### PR TITLE
Add deck skill for branded presentation generation

### DIFF
--- a/.claude/skills/deck/SKILL.md
+++ b/.claude/skills/deck/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: deck
+description: Create branded presentations from your business context. Use when asked to create slides, decks, presentations, or teaching materials. Reads brand guide and assets from your repo, outputs .pptx files matching your visual identity.
+---
+
+# Presentation Creator
+
+Create branded PowerPoint presentations using your business context and visual identity.
+
+## Overview
+
+This skill is a fork of Anthropic's PPTX skill, enhanced with:
+- **Brand-aware generation** — Reads your style guide from `context/brand/`
+- **Asset integration** — Uses your logos, textures, and decorative elements
+- **Gemini integration** for AI image generation (optional)
+
+## Context Required
+
+Before creating presentations, the business repo should have:
+
+| File | What It Contains |
+|------|------------------|
+| `context/brand/visual-style.md` | Visual identity, color palettes, typography |
+| `context/brand/assets/logo/` | Logo variants for different backgrounds |
+| `context/brand/assets/textures/` | Background textures, overlays |
+| `context/brand/assets/decorative/` | Decorative elements, dividers |
+
+If brand context is missing, ask the user to create it or offer to help define their visual identity.
+
+## Reading Brand Context
+
+**Always read the user's style guide first** before creating any presentation:
+
+```
+context/brand/visual-style.md
+```
+
+If no style guide exists, offer to help create one using the template at:
+```
+templates/modules/brand-style-template.md
+```
+
+## Workflows
+
+### Creating a New Presentation
+
+1. **Read brand context**: Read user's `context/brand/visual-style.md`
+2. **Plan content**: Create outline with slide-by-slide breakdown
+3. **Choose theme**: Based on user's defined themes (if multiple exist)
+4. **Generate assets**: If AI images needed, use Gemini integration
+5. **Build slides**: Use html2pptx workflow from base skill
+6. **Validate**: Generate thumbnails, check brand consistency
+
+### Using the html2pptx Workflow
+
+See [`html2pptx.md`](html2pptx.md) for detailed instructions.
+
+**Brand-aware additions:**
+- Use colors from user's style guide
+- Use brand fonts (fallback to web-safe equivalents)
+- Include logo per user's placement guidelines
+- Apply textures/overlays as defined in brand
+
+## Design Principles
+
+### Reading User's Palette
+
+Extract colors from `context/brand/visual-style.md`:
+- Background colors (primary, secondary)
+- Text colors (primary, muted, accent)
+- Accent colors (success, warning, error, links)
+- Chart colors (series colors for data viz)
+
+### Typography
+
+**Always use web-safe fonts for PowerPoint compatibility:**
+- **Headers**: Arial Black, Impact, Trebuchet MS
+- **Body**: Verdana, Tahoma, Arial
+- **Code/Data**: Courier New (monospace)
+
+If user specifies custom fonts, note they may not render on all machines.
+
+### Visual Elements
+
+Read from user's brand guide:
+- Background textures/overlays
+- Decorative elements (dividers, frames)
+- Logo placement rules
+- Glow/shadow effects
+
+## Gemini Integration (Optional)
+
+For AI-generated images, set `GEMINI_API_KEY` in environment.
+
+See project `.env.example` for setup instructions.
+
+## Dependencies
+
+Same as base PPTX skill:
+- markitdown (text extraction)
+- pptxgenjs (PowerPoint generation)
+- playwright (HTML rendering)
+- sharp (image processing)
+- LibreOffice (PDF conversion)
+- Poppler (PDF to images)
+
+## Base Skill Documentation
+
+For complete PPTX creation, editing, and analysis workflows, see:
+- [`html2pptx.md`](html2pptx.md) - HTML to PowerPoint conversion
+- [`ooxml.md`](ooxml.md) - OOXML format reference
+
+---
+
+*Forked from [anthropics/skills/pptx](https://github.com/anthropics/skills/tree/main/skills/pptx)*

--- a/.claude/skills/deck/html2pptx.md
+++ b/.claude/skills/deck/html2pptx.md
@@ -1,0 +1,148 @@
+# HTML to PowerPoint Guide
+
+Convert HTML slides to PowerPoint presentations with accurate positioning.
+
+**Full reference**: See [anthropics/skills/pptx/html2pptx.md](https://github.com/anthropics/skills/blob/main/skills/pptx/html2pptx.md)
+
+---
+
+## Quick Start
+
+### 1. Create HTML Slide
+
+```html
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+body {
+  width: 720pt; height: 405pt; margin: 0; padding: 0;
+  background: #121212;  /* Use brand background color */
+  font-family: Verdana, sans-serif;
+  color: #f0f0f0;       /* Use brand text color */
+  display: flex;
+}
+h1 { color: #4ade80; font-size: 48pt; }  /* Use brand accent */
+</style>
+</head>
+<body>
+  <div style="margin: 40pt;">
+    <h1>Slide Title</h1>
+    <p>Content goes here</p>
+  </div>
+</body>
+</html>
+```
+
+### 2. Convert to PowerPoint
+
+```javascript
+const pptxgen = require('pptxgenjs');
+const html2pptx = require('./html2pptx');
+
+const pptx = new pptxgen();
+pptx.layout = 'LAYOUT_16x9';
+
+const { slide } = await html2pptx('slide1.html', pptx);
+await pptx.writeFile('output.pptx');
+```
+
+---
+
+## Using Brand Colors
+
+Read colors from the user's `context/brand/visual-style.md` and create a colors object:
+
+```javascript
+// Example: Extract from user's style guide
+const BRAND_COLORS = {
+  bgPrimary: "0a0f0a",    // From style guide
+  bgSecondary: "121212",
+  textPrimary: "f0fdf4",
+  textMuted: "86efac",
+  accent1: "4ade80",
+  accent2: "22d3ee",
+  accent3: "f59e0b",
+  warning: "f87171"
+};
+```
+
+**CRITICAL**: No `#` prefix in PptxGenJS colors!
+
+### Chart Colors
+
+```javascript
+// Single series - use primary accent
+chartColors: ["4ade80"]
+
+// Multiple series - use accent palette
+chartColors: ["4ade80", "22d3ee", "f59e0b", "f87171"]
+```
+
+### Web-Safe Fonts
+
+```javascript
+// Headers
+fontFace: "Impact"  // or "Arial Black", "Trebuchet MS"
+
+// Body
+fontFace: "Verdana"  // or "Tahoma", "Arial"
+
+// Code/Data
+fontFace: "Courier New"
+```
+
+---
+
+## Critical Rules
+
+### Text Must Be in Tags
+
+- ✅ `<div><p>Text</p></div>`
+- ❌ `<div>Text</div>` — Text will NOT appear
+
+### No Manual Bullets
+
+- ✅ Use `<ul>` and `<ol>`
+- ❌ Never use •, -, * symbols
+
+### Web-Safe Fonts Only
+
+- ✅ Arial, Verdana, Georgia, Courier New, Impact
+- ❌ Segoe UI, Roboto, SF Pro
+
+### Colors Without Hash
+
+- ✅ `color: "4ade80"`
+- ❌ `color: "#4ade80"` — Causes corruption
+
+---
+
+## Workflow
+
+1. **Read user's style guide** from `context/brand/visual-style.md`
+2. **Create HTML slides** with brand colors/fonts
+3. **Rasterize gradients/icons** to PNG using Sharp FIRST
+4. **Convert with html2pptx**
+5. **Add charts/tables** using PptxGenJS
+6. **Generate thumbnails** to validate
+7. **Iterate** until visually correct
+
+---
+
+## Dependencies
+
+```bash
+# Required
+npm install -g pptxgenjs playwright sharp
+
+# For text extraction
+pip install "markitdown[pptx]"
+
+# For PDF conversion
+brew install libreoffice poppler  # macOS
+```
+
+---
+
+*See full documentation at [anthropics/skills](https://github.com/anthropics/skills)*

--- a/.claude/skills/deck/ooxml.md
+++ b/.claude/skills/deck/ooxml.md
@@ -1,0 +1,51 @@
+# Office Open XML Technical Reference
+
+This document provides technical details for working with PowerPoint's OOXML format.
+
+**Full reference**: See [anthropics/skills/pptx/ooxml.md](https://github.com/anthropics/skills/blob/main/skills/pptx/ooxml.md)
+
+## Quick Reference
+
+### File Structure
+
+A .pptx file is a ZIP archive containing:
+
+```
+presentation.pptx/
+├── [Content_Types].xml      # Content type declarations
+├── _rels/
+│   └── .rels               # Package relationships
+├── docProps/
+│   ├── app.xml             # Application properties
+│   └── core.xml            # Core metadata
+└── ppt/
+    ├── presentation.xml    # Main presentation data
+    ├── slides/             # Individual slides
+    │   ├── slide1.xml
+    │   └── slide2.xml
+    ├── slideLayouts/       # Layout templates
+    ├── slideMasters/       # Master templates
+    ├── theme/              # Theme data
+    └── media/              # Images and media
+```
+
+### Key Operations
+
+**Unpack**: `python ooxml/scripts/unpack.py <file.pptx> <output_dir>`
+
+**Validate**: `python ooxml/scripts/validate.py <dir> --original <file.pptx>`
+
+**Pack**: `python ooxml/scripts/pack.py <input_dir> <output.pptx>`
+
+### Common Tasks
+
+| Task | Approach |
+|------|----------|
+| Add slide | Create XML, update relationships |
+| Edit text | Modify `<a:t>` elements in slide XML |
+| Change colors | Update `<a:srgbClr>` values |
+| Add image | Copy to media/, add relationship, reference in slide |
+
+---
+
+*For complete OOXML documentation, refer to the Anthropic skills repository.*

--- a/.claude/skills/deck/svg-guide.md
+++ b/.claude/skills/deck/svg-guide.md
@@ -1,0 +1,191 @@
+# SVG Generation Guide
+
+Guidelines for generating SVG graphics for Main Branch presentations.
+
+---
+
+## Why This Guide Exists
+
+AI-generated SVGs often have issues:
+- Incorrect viewBox dimensions
+- Missing xmlns declaration
+- Broken paths
+- Unsupported features
+
+This guide ensures consistent, valid SVGs.
+
+---
+
+## SVG Template
+
+Always start with this structure:
+
+```xml
+<svg xmlns="http://www.w3.org/2000/svg"
+     viewBox="0 0 WIDTH HEIGHT"
+     width="WIDTH"
+     height="HEIGHT">
+  <!-- Content here -->
+</svg>
+```
+
+**Required attributes:**
+- `xmlns` — Always include
+- `viewBox` — Define coordinate system
+- `width/height` — Explicit dimensions
+
+---
+
+## Main Branch SVG Colors
+
+Use brand colors from the style guide:
+
+```xml
+<!-- Backgrounds -->
+<rect fill="#0a0f0a"/>  <!-- Terminal Black -->
+<rect fill="#121212"/>  <!-- Pure Dark -->
+
+<!-- Accents -->
+<path fill="#4ade80"/>  <!-- Canopy Green -->
+<path fill="#22d3ee"/>  <!-- Cyan Glow -->
+<path fill="#f59e0b"/>  <!-- Amber LED -->
+
+<!-- Text -->
+<text fill="#f0fdf4"/>  <!-- Soft White -->
+<text fill="#86efac"/>  <!-- Muted Green -->
+```
+
+---
+
+## Glow Effects
+
+For CRT-style glow, use filters:
+
+```xml
+<defs>
+  <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+    <feGaussianBlur in="SourceGraphic" stdDeviation="4" result="blur"/>
+    <feMerge>
+      <feMergeNode in="blur"/>
+      <feMergeNode in="SourceGraphic"/>
+    </feMerge>
+  </filter>
+</defs>
+
+<circle cx="50" cy="50" r="10" fill="#22d3ee" filter="url(#glow)"/>
+```
+
+---
+
+## Circuit Trace Pattern
+
+For decorative circuit lines:
+
+```xml
+<path d="M0 50 L100 50 L100 100"
+      stroke="#22d3ee"
+      stroke-width="2"
+      fill="none"
+      stroke-linecap="round"/>
+
+<!-- With nodes (LED points) -->
+<circle cx="100" cy="50" r="4" fill="#f59e0b"/>
+```
+
+---
+
+## Tree/Branch Shapes
+
+For organic branch shapes:
+
+```xml
+<!-- Simplified branch path -->
+<path d="M50 100
+         Q50 70 40 50
+         Q30 30 20 10
+         M50 70
+         Q60 50 80 40"
+      stroke="#4ade80"
+      stroke-width="3"
+      fill="none"
+      stroke-linecap="round"/>
+```
+
+---
+
+## Rasterizing SVGs
+
+**Always rasterize SVGs to PNG before using in PowerPoint.**
+
+PowerPoint's SVG support is inconsistent. Rasterize with Sharp:
+
+```javascript
+const sharp = require('sharp');
+
+async function svgToPng(svgPath, pngPath, width = 1000) {
+  await sharp(svgPath)
+    .resize(width)
+    .png()
+    .toFile(pngPath);
+}
+
+// Usage
+await svgToPng('circuit-trace.svg', 'circuit-trace.png', 800);
+```
+
+---
+
+## Common Issues & Fixes
+
+### Issue: SVG not rendering
+
+**Fix**: Ensure `xmlns` is present:
+```xml
+<svg xmlns="http://www.w3.org/2000/svg" ...>
+```
+
+### Issue: Wrong size in PowerPoint
+
+**Fix**: Set explicit width/height, not just viewBox:
+```xml
+<svg viewBox="0 0 100 100" width="100" height="100">
+```
+
+### Issue: Gradients not showing
+
+**Fix**: Rasterize to PNG. PowerPoint gradient support is limited.
+
+### Issue: Filters not working
+
+**Fix**: Rasterize to PNG. Complex filters don't convert well.
+
+---
+
+## SVG Validation Checklist
+
+Before using an SVG:
+
+- [ ] Has `xmlns="http://www.w3.org/2000/svg"`
+- [ ] Has valid `viewBox`
+- [ ] Has explicit `width` and `height`
+- [ ] All paths are closed or properly stroked
+- [ ] Colors use hex format (#rrggbb)
+- [ ] No external references (fonts, images)
+- [ ] Tested render in browser
+
+---
+
+## When to Use SVG vs PNG
+
+| Use SVG | Use PNG |
+|---------|---------|
+| Source assets | Final presentation |
+| Scalable icons | Complex illustrations |
+| Simple shapes | Photos/textures |
+| Version control | AI-generated images |
+
+**Rule**: Keep SVG as source, rasterize to PNG for PowerPoint.
+
+---
+
+*Last updated: 2026-01-14*

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,20 @@
+# Main Branch Premium Environment Configuration
+# Copy this file to .env and fill in your values
+
+# ===========================================
+# AI Image Generation (Optional)
+# ===========================================
+
+# Gemini API Key for AI image generation in deck skill
+# Get yours at: https://makersuite.google.com/app/apikey
+GEMINI_API_KEY=your-gemini-api-key-here
+
+# ===========================================
+# Future Integrations
+# ===========================================
+
+# Anthropic API (if using API skills directly)
+# ANTHROPIC_API_KEY=your-anthropic-api-key-here
+
+# OpenAI API (for DALL-E image generation alternative)
+# OPENAI_API_KEY=your-openai-api-key-here

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 # Environment
 .env
 .env.local
+WARP.md

--- a/docs/deck-skill-setup.md
+++ b/docs/deck-skill-setup.md
@@ -1,0 +1,138 @@
+# Deck Skill Setup Guide
+
+How to use the `/deck` skill for creating Main Branch presentations.
+
+---
+
+## Prerequisites
+
+### 1. Install Dependencies
+
+```bash
+# Node.js packages (global)
+npm install -g pptxgenjs playwright sharp react react-dom react-icons
+
+# Python packages
+pip install "markitdown[pptx]" defusedxml
+
+# System tools (macOS)
+brew install libreoffice poppler
+
+# System tools (Linux)
+sudo apt-get install libreoffice poppler-utils
+```
+
+### 2. Configure Environment (Optional)
+
+For AI image generation with Gemini:
+
+```bash
+# Copy the example env file
+cp .env.example .env
+
+# Edit and add your Gemini API key
+# Get one at: https://makersuite.google.com/app/apikey
+```
+
+---
+
+## Usage
+
+### Basic Presentation
+
+```
+Create a 5-slide presentation about [topic]
+```
+
+The skill will:
+1. Read the Main Branch style guide
+2. Create HTML slides with brand styling
+3. Convert to PowerPoint
+4. Generate thumbnails for validation
+
+### With AI Images
+
+```
+Create a presentation about [topic] with AI-generated images
+```
+
+Requires `GEMINI_API_KEY` in your `.env` file.
+
+### Using a Template
+
+```
+Create a presentation using template.pptx as a base
+```
+
+---
+
+## Customization
+
+### Brand Assets
+
+Place your assets in `.claude/skills/deck/assets/`:
+
+```
+assets/
+├── logo/
+│   ├── tree-circuit-dark.png
+│   ├── tree-circuit-light.png
+│   └── tree-mark-only.png
+├── textures/
+│   ├── crt-scanlines.png
+│   └── terminal-grain.png
+└── decorative/
+    └── circuit-traces.svg
+```
+
+### Style Guide
+
+Edit `.claude/skills/deck/main-branch-style.md` to customize:
+- Color palette
+- Typography
+- Layout templates
+- Visual elements
+
+---
+
+## Troubleshooting
+
+### "pptxgenjs not found"
+
+```bash
+npm install -g pptxgenjs
+```
+
+### "LibreOffice not found"
+
+```bash
+# macOS
+brew install libreoffice
+
+# Linux
+sudo apt-get install libreoffice
+```
+
+### Colors look wrong
+
+Remember: PptxGenJS requires hex colors WITHOUT the `#` prefix.
+
+```javascript
+// ✅ Correct
+color: "4ade80"
+
+// ❌ Wrong (causes file corruption)
+color: "#4ade80"
+```
+
+---
+
+## Resources
+
+- [Main Branch Style Guide](/.claude/skills/deck/main-branch-style.md)
+- [Anthropic PPTX Skill](https://github.com/anthropics/skills/tree/main/skills/pptx)
+- [PptxGenJS Documentation](https://gitbrent.github.io/PptxGenJS/)
+
+---
+
+*Last updated: 2026-01-14*

--- a/templates/modules/brand-style-template.md
+++ b/templates/modules/brand-style-template.md
@@ -1,0 +1,397 @@
+# Visual Style Guide Template
+
+**Usage**: Copy this file to your business repo at `context/brand/visual-style.md` and customize for your brand.
+
+This template is populated with Main Branch's style as an example. Replace all sections with your own brand details.
+
+---
+
+## Brand Overview
+
+> **Replace this section with your brand info**
+
+**[Brand Name]** — [What you do in one line]
+
+**Positioning**: "[Your tagline]"
+
+**Core metaphor**: [What visual metaphor represents your brand?]
+
+**Voice**: [Describe your brand voice]
+
+---
+
+## Style Identity
+
+> **Replace with your style description**
+
+Give your style a name and describe it as a fusion of influences.
+
+**Example (Main Branch):**
+
+*Style: "Terminal Forest"* — A fusion of retro terminal aesthetics, organic growth imagery, and modern dark mode.
+
+---
+
+## Two Themes
+
+| Theme | Background | Accent | Use Case |
+|-------|------------|--------|----------|
+| **Editorial/Dark** | #0a0f0a (near-black green) | Cyan glow, green highlights | Brand storytelling, launches |
+| **Teaching/Neutral** | #1a1a2e (dark navy) | Amber LEDs, warm accents | Curriculum, tutorials |
+
+---
+
+## Color Palette
+
+### Primary Colors
+
+```
+DARK BACKGROUNDS
+├── #0a0f0a  "Terminal Black"    Primary background (green-tinted black)
+├── #121212  "Pure Dark"         Alternative background
+├── #1a1a2e  "Navy Dark"         Teaching theme background
+└── #0d1117  "GitHub Dark"       Code block backgrounds
+
+LIGHT TEXT
+├── #f0fdf4  "Soft White"        Primary text (slight green tint)
+├── #e2e8f0  "Cool Gray"         Secondary text
+├── #86efac  "Muted Green"       Tertiary text, labels
+└── #64748b  "Slate"             Disabled, placeholder text
+```
+
+### Accent Colors
+
+```
+GREENS (Tree Canopy)
+├── #4ade80  "Canopy Green"      Primary accent, success states
+├── #22c55e  "Terminal Green"    Active states, highlights
+├── #16a34a  "Forest Green"      Darker green for contrast
+└── #166534  "Deep Forest"       Shadows, depth
+
+AMBERS (Circuit LEDs)
+├── #f59e0b  "Amber LED"         Warning, attention, nodes
+├── #fbbf24  "Bright Amber"      Hover states
+├── #d97706  "Dark Amber"        Pressed states
+└── #92400e  "Burnt Amber"       Shadows
+
+CYANS (Terminal Glow)
+├── #22d3ee  "Cyan Glow"         Links, interactive elements
+├── #06b6d4  "Bright Cyan"       Hover states
+├── #0891b2  "Dark Cyan"         Pressed states
+└── #155e75  "Deep Cyan"         Shadows
+
+REDS (Errors/Emphasis)
+├── #f87171  "Coral Red"         Errors, warnings, emphasis
+├── #ef4444  "Bright Red"        Critical alerts
+└── #dc2626  "Dark Red"          Pressed states
+```
+
+### Semantic Colors
+
+```
+SUCCESS     #4ade80  Canopy Green
+WARNING     #f59e0b  Amber LED
+ERROR       #f87171  Coral Red
+INFO        #22d3ee  Cyan Glow
+LINK        #22d3ee  Cyan Glow
+ACTIVE      #22c55e  Terminal Green
+MUTED       #64748b  Slate
+```
+
+---
+
+## Typography
+
+### Font Stack (Web-Safe Only)
+
+```
+DISPLAY/HEADERS
+├── Primary:    "Impact" or "Arial Black"
+├── Fallback:   "Trebuchet MS", "Helvetica", sans-serif
+└── Use:        Slide titles, section headers
+
+BODY TEXT
+├── Primary:    "Verdana" or "Tahoma"
+├── Fallback:   "Arial", "Helvetica", sans-serif
+└── Use:        Paragraphs, lists, descriptions
+
+MONOSPACE (Code/Data)
+├── Primary:    "Courier New"
+├── Fallback:   "Lucida Console", monospace
+└── Use:        Code snippets, file paths, technical data, stats
+```
+
+### Type Scale
+
+```
+SLIDE TITLES       48-64pt    Impact/Arial Black, bold
+SECTION HEADERS    32-40pt    Trebuchet MS, bold
+SUBHEADERS         24-28pt    Verdana, bold
+BODY LARGE         18-20pt    Verdana, regular
+BODY STANDARD      14-16pt    Verdana, regular
+CAPTIONS           11-12pt    Verdana, regular
+CODE               14pt       Courier New, regular
+```
+
+### Typography Rules
+
+1. **Never use more than 2 fonts per slide**
+2. **Headers always bold**, body rarely bold
+3. **Monospace for any technical content** (paths, code, commands)
+4. **High contrast**: Light text on dark backgrounds only
+5. **Letter spacing**: Slightly increased for headers (+0.5-1pt)
+
+---
+
+## Visual Elements
+
+### The Logo
+
+Three variants available:
+
+| Variant | File | Use Case |
+|---------|------|----------|
+| **Full Dark** | `tree-circuit-dark.png` | Dark backgrounds, primary use |
+| **Full Light** | `tree-circuit-light.png` | Light backgrounds (rare) |
+| **Mark Only** | `tree-mark-only.png` | Favicons, small spaces |
+
+**Logo anatomy:**
+- Lush green tree canopy (organic, alive)
+- White/cyan circuit traces for trunk and roots (structure, system)
+- Amber/orange LED nodes at branch points (activity, data flow)
+- Soft cyan glow halo (CRT aesthetic)
+
+**Logo placement:**
+- Title slides: Centered, large
+- Content slides: Bottom-right corner, small
+- Teaching slides: Top-left corner, small
+
+### CRT Texture Overlay
+
+Apply subtle scanline texture for terminal aesthetic:
+- Horizontal lines at 2-3px intervals
+- 5-10% opacity (very subtle)
+- Use on hero slides and section dividers
+- Skip on content-heavy slides for readability
+
+### Circuit Traces
+
+Decorative lines suggesting data flow:
+- Use as section dividers
+- Connect related concepts visually
+- Animate in videos (optional)
+- Colors: Cyan (#22d3ee) or white at 30-50% opacity
+
+### Glow Effects
+
+Terminal-style glow on key elements:
+- Apply to logo
+- Apply to important numbers/stats
+- Use box-shadow with blur: `0 0 20px rgba(34, 211, 238, 0.3)`
+- Don't overuse — 1-2 glowing elements per slide max
+
+---
+
+## Slide Layouts
+
+### Title Slide
+
+```
+┌─────────────────────────────────────────┐
+│                                         │
+│              [LOGO]                     │
+│                                         │
+│         PRESENTATION TITLE              │
+│           Subtitle text                 │
+│                                         │
+│                                         │
+│   ══════════════════════════════════    │  ← circuit trace divider
+│                                         │
+└─────────────────────────────────────────┘
+Background: #0a0f0a with subtle CRT texture
+```
+
+### Section Divider
+
+```
+┌─────────────────────────────────────────┐
+│                                         │
+│                                         │
+│                                         │
+│          SECTION TITLE                  │
+│      ────────────────────               │
+│                                         │
+│                                         │
+│                                    [MB] │  ← small logo
+└─────────────────────────────────────────┘
+Background: #0a0f0a
+Accent: Cyan glow on title
+```
+
+### Content Slide (Two-Column)
+
+```
+┌─────────────────────────────────────────┐
+│  SLIDE TITLE                            │
+│  ═══════════════════════════════════    │
+│                                         │
+│  ┌──────────────┐  ┌──────────────────┐ │
+│  │              │  │                  │ │
+│  │   TEXT       │  │    VISUAL        │ │
+│  │   CONTENT    │  │    (chart/image) │ │
+│  │              │  │                  │ │
+│  └──────────────┘  └──────────────────┘ │
+│                                    [MB] │
+└─────────────────────────────────────────┘
+Split: 40% text / 60% visual
+```
+
+### Quote Slide
+
+```
+┌─────────────────────────────────────────┐
+│                                         │
+│                                         │
+│     "Quote text goes here in large      │
+│      italic type with quotes."          │
+│                                         │
+│                    — Attribution        │
+│                                         │
+│                                         │
+│                                    [MB] │
+└─────────────────────────────────────────┘
+Quote color: #4ade80 (Canopy Green)
+Attribution: #86efac (Muted Green)
+```
+
+### Data/Stats Slide
+
+```
+┌─────────────────────────────────────────┐
+│  SLIDE TITLE                            │
+│  ═══════════════════════════════════    │
+│                                         │
+│   ┌─────┐   ┌─────┐   ┌─────┐          │
+│   │ 20  │   │  2  │   │ 10x │          │
+│   │hours│   │hours│   │ ROI │          │
+│   └─────┘   └─────┘   └─────┘          │
+│    Before    After    Result            │
+│                                         │
+│                                    [MB] │
+└─────────────────────────────────────────┘
+Numbers: Large (48-64pt), Monospace, Cyan glow
+Labels: Small (14pt), Muted Green
+```
+
+---
+
+## Chart Styling
+
+### Colors for Charts
+
+```javascript
+// Single series
+chartColors: ["4ade80"]  // Canopy Green
+
+// Multiple series
+chartColors: ["4ade80", "22d3ee", "f59e0b", "f87171"]
+// Green, Cyan, Amber, Coral
+
+// Pie charts
+chartColors: ["4ade80", "22d3ee", "f59e0b", "86efac", "0891b2"]
+```
+
+### Chart Rules
+
+1. **Dark background for chart area** (#121212 or transparent)
+2. **Light gridlines** at 10-20% opacity
+3. **No 3D effects** — flat design only
+4. **Axis labels in Muted Green** (#86efac)
+5. **Data labels in Soft White** (#f0fdf4)
+
+---
+
+## Image Guidelines
+
+### AI Image Prompts (for Gemini/Midjourney)
+
+When generating images for Main Branch materials:
+
+**Style keywords:**
+- "dark background, near-black"
+- "terminal aesthetic, CRT glow"
+- "organic and digital fusion"
+- "circuit board traces"
+- "bonsai tree, pine tree"
+- "soft cyan and green glow"
+- "retro futurism"
+
+**Avoid:**
+- Bright backgrounds
+- Corporate stock photo style
+- Geometric patterns (use organic shapes)
+- Pure white elements
+
+### Screenshot Treatment
+
+When including screenshots:
+1. Add subtle border (#22d3ee at 50% opacity)
+2. Apply slight corner radius (8-12px)
+3. Add drop shadow for depth
+4. Consider CRT texture overlay on decorative screenshots
+
+---
+
+## Animation Guidelines (for Video)
+
+### Transitions
+
+- **Preferred**: Fade, dissolve (0.3-0.5s)
+- **Accent**: Slide from left (data flow direction)
+- **Avoid**: Spin, flip, bounce, or playful transitions
+
+### Element Animation
+
+- **Text**: Fade in, slight upward motion
+- **Charts**: Draw on, bars grow upward
+- **Circuit traces**: Draw along path (like data flowing)
+- **Logo**: Fade in with subtle glow pulse
+
+---
+
+## Do's and Don'ts
+
+### Do
+
+- ✅ Use dark backgrounds consistently
+- ✅ Apply CRT texture on hero/divider slides
+- ✅ Use monospace for technical content
+- ✅ Include logo on every slide (small, corner)
+- ✅ Use high contrast (light on dark)
+- ✅ Apply glow effects sparingly
+
+### Don't
+
+- ❌ Use light/white backgrounds
+- ❌ Use more than 2 fonts per slide
+- ❌ Overuse glow effects (max 1-2 per slide)
+- ❌ Use geometric patterns (stay organic)
+- ❌ Use corporate stock imagery
+- ❌ Use low contrast text
+
+---
+
+## Assets Checklist
+
+Before creating a presentation, ensure you have:
+
+- [ ] Logo variants (dark, light, mark)
+- [ ] CRT scanline texture
+- [ ] Circuit trace SVG/PNG
+- [ ] Brand color hex codes
+- [ ] Font files (if custom, otherwise web-safe)
+
+---
+
+*Last updated: 2026-01-14*
+*Style version: 1.0*


### PR DESCRIPTION
## Summary

- Adds `/deck` skill for creating PowerPoint presentations with automatic brand styling
- Fork of Anthropic's PPTX skill, enhanced to read brand context from user repos
- Includes Gemini integration for AI-generated images (optional)
- Provides brand style template for users to define their visual identity

## What's Included

| File | Purpose |
|------|---------|
| `.claude/skills/deck/SKILL.md` | Main skill definition with workflows |
| `.claude/skills/deck/html2pptx.md` | HTML to PPTX conversion reference |
| `.claude/skills/deck/ooxml.md` | Office Open XML format guide |
| `.claude/skills/deck/svg-guide.md` | SVG support documentation |
| `docs/deck-skill-setup.md` | Setup instructions for dependencies |
| `templates/modules/brand-style-template.md` | Template for defining brand visual identity |
| `.env.example` | Environment variable configuration template |

## How It Works

1. User defines their brand in `context/brand/visual-style.md` (using template)
2. Skill reads brand colors, typography, logos, textures
3. Generates slides using html2pptx workflow with brand styling
4. Outputs `.pptx` files matching user's visual identity

## Dependencies

- Node: pptxgenjs, playwright, sharp
- Python: markitdown, defusedxml
- System: LibreOffice, Poppler

## Test plan

- [ ] Run `/deck` in a repo with brand context configured
- [ ] Verify output matches brand colors/typography
- [ ] Test without Gemini API key (should gracefully skip AI images)
- [ ] Test brand-style-template copy workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)