### PR TITLE
Add auto-pull to all skills + clarify GitHub Desktop

### DIFF
--- a/.claude/skills/ad-review/SKILL.md
+++ b/.claude/skills/ad-review/SKILL.md
@@ -7,6 +7,16 @@ description: Multi-lens compliance and quality review for ads before shipping. U
 
 Review ads through 6 compliance and quality lenses before shipping.
 
+## Pull Latest Updates (Always)
+
+```bash
+cd ~/vip 2>/dev/null && git pull origin main 2>/dev/null && cd - >/dev/null || true
+```
+
+If updates pulled: briefly note "Pulled latest vip updates." then continue silently.
+
+---
+
 ## When to Use
 
 - Before launching a new ad batch

--- a/.claude/skills/ad-static/SKILL.md
+++ b/.claude/skills/ad-static/SKILL.md
@@ -7,6 +7,16 @@ description: Create static/image ads with copy and AI image prompts. Use when as
 
 Create static/image ads with copy (multiple styles) + AI image prompts.
 
+## Pull Latest Updates (Always)
+
+```bash
+cd ~/vip 2>/dev/null && git pull origin main 2>/dev/null && cd - >/dev/null || true
+```
+
+If updates pulled: briefly note "Pulled latest vip updates." then continue silently.
+
+---
+
 ## Reference Required
 
 Before creating ads, the business repo must have these files in `reference/`:

--- a/.claude/skills/ad-video-scripts/SKILL.md
+++ b/.claude/skills/ad-video-scripts/SKILL.md
@@ -7,6 +7,16 @@ description: Write high-converting video ad scripts for Meta ads. Use when asked
 
 Creates diverse video ad scripts using a systematic 6-step process.
 
+## Pull Latest Updates (Always)
+
+```bash
+cd ~/vip 2>/dev/null && git pull origin main 2>/dev/null && cd - >/dev/null || true
+```
+
+If updates pulled: briefly note "Pulled latest vip updates." then continue silently.
+
+---
+
 ## Reference Required
 
 Business repo must have these files in `reference/`:

--- a/.claude/skills/b2b-killer-vsl/SKILL.md
+++ b/.claude/skills/b2b-killer-vsl/SKILL.md
@@ -15,6 +15,16 @@ description: |
 
 Creates conversion-focused Video Sales Letter scripts using Jeremy Haynes' 7-step framework.
 
+## Pull Latest Updates (Always)
+
+```bash
+cd ~/vip 2>/dev/null && git pull origin main 2>/dev/null && cd - >/dev/null || true
+```
+
+If updates pulled: briefly note "Pulled latest vip updates." then continue silently.
+
+---
+
 ## CRITICAL RULE: Never Invent Facts
 
 **Before writing ANY VSL, you must verify you have explicit confirmation for every claim.**

--- a/.claude/skills/deck/SKILL.md
+++ b/.claude/skills/deck/SKILL.md
@@ -7,6 +7,16 @@ description: Create branded presentations from your business context. Use when a
 
 Create branded PowerPoint presentations using your business context and visual identity.
 
+## Pull Latest Updates (Always)
+
+```bash
+cd ~/vip 2>/dev/null && git pull origin main 2>/dev/null && cd - >/dev/null || true
+```
+
+If updates pulled: briefly note "Pulled latest vip updates." then continue silently.
+
+---
+
 ## Overview
 
 This skill is a fork of Anthropic's PPTX skill, enhanced with:

--- a/.claude/skills/enrich/SKILL.md
+++ b/.claude/skills/enrich/SKILL.md
@@ -30,6 +30,16 @@ Add context to an existing Main Branch business repo.
 
 ## Workflow
 
+### 0. Pull Latest Updates (Always)
+
+```bash
+cd ~/vip 2>/dev/null && git pull origin main 2>/dev/null && cd - >/dev/null || true
+```
+
+If updates pulled: briefly note "Pulled latest vip updates." then continue silently.
+
+---
+
 ### 1. Verify Repo Structure
 
 Check that standard folders exist:

--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -70,6 +70,20 @@ After setup, teach users: "Use `/think` to research topics and make decisions. Y
 
 ## Workflow
 
+### Pull Latest Updates (Always)
+
+**Before anything else, ensure vip is up to date:**
+
+```bash
+# If vip is an added directory or we can find it
+cd ~/vip 2>/dev/null && git pull origin main 2>/dev/null && cd - >/dev/null || true
+```
+
+If updates pulled: briefly note "Pulled latest vip updates." then continue.
+If offline or already current: continue silently.
+
+---
+
 ### CRITICAL: Check Location First
 
 **Before doing ANYTHING, verify we're NOT in the vip (engine) repository:**

--- a/.claude/skills/skool-manager/SKILL.md
+++ b/.claude/skills/skool-manager/SKILL.md
@@ -15,6 +15,16 @@ description: |
 
 Draft and post community responses with Chrome MCP.
 
+## Pull Latest Updates (Always)
+
+```bash
+cd ~/vip 2>/dev/null && git pull origin main 2>/dev/null && cd - >/dev/null || true
+```
+
+If updates pulled: briefly note "Pulled latest vip updates." then continue silently.
+
+---
+
 ## Prerequisites
 
 - Claude in Chrome extension installed and connected

--- a/.claude/skills/skool-vsl-scripts/SKILL.md
+++ b/.claude/skills/skool-vsl-scripts/SKILL.md
@@ -7,6 +7,16 @@ description: Write high-converting Video Sales Letter (VSL) scripts using a prov
 
 Creates complete Video Sales Letter scripts using an 18-section conversion framework.
 
+## Pull Latest Updates (Always)
+
+```bash
+cd ~/vip 2>/dev/null && git pull origin main 2>/dev/null && cd - >/dev/null || true
+```
+
+If updates pulled: briefly note "Pulled latest vip updates." then continue silently.
+
+---
+
 ## Reference Required
 
 Business repo must have these files in `reference/`:

--- a/.claude/skills/start/SKILL.md
+++ b/.claude/skills/start/SKILL.md
@@ -22,6 +22,8 @@ Single entry point for Main Branch. Detect user state, route to the right skill.
 ```
 /start
 │
+├── Pull latest vip updates ──────────→ (always, silently)
+│
 ├── In vip (engine) repo? ─────────→ STOP — need user's business repo
 │   (.claude/skills/ exists)
 │
@@ -42,6 +44,30 @@ Single entry point for Main Branch. Detect user state, route to the right skill.
 │
 └── "help" / confused? ─────────────→ Explain concepts
 ```
+
+---
+
+## Step -1: Pull Latest Updates (Always Do This)
+
+**Before anything else, ensure vip has the latest skills:**
+
+```bash
+# Find vip directory and pull updates
+# If we're in vip:
+if [ -f ".claude/skills/start/SKILL.md" ]; then
+  git pull origin main 2>/dev/null || true
+fi
+
+# If vip is an added directory, find and pull it:
+# (Claude Code shows added directories - pull from there if found)
+```
+
+**If updates were pulled:**
+> "Pulled latest updates from vip."
+
+**If already up to date or offline:** Continue silently (don't block on network issues).
+
+This ensures users always have the latest skills without needing to remember to pull manually.
 
 ---
 

--- a/.claude/skills/think/SKILL.md
+++ b/.claude/skills/think/SKILL.md
@@ -15,6 +15,14 @@ description: |
 
 Structured workflow for research, decisions, and codifying knowledge.
 
+## Pull Latest Updates (Always)
+
+```bash
+cd ~/vip 2>/dev/null && git pull origin main 2>/dev/null && cd - >/dev/null || true
+```
+
+If updates pulled: briefly note "Pulled latest vip updates." then continue silently.
+
 ---
 
 ## When to Use

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ This is a private repository. You need access before you can clone it.
 | Claude Code | Terminal app that runs skills | See install commands below |
 | Chrome Extension | Lets Claude see your web pages (optional) | [claude.ai/chrome](https://claude.ai/chrome) |
 
+*GitHub Desktop is strongly recommended for beginners. If you're comfortable with git, you can use terminal commands instead.*
+
 **Install Claude Code:**
 
 Mac:

--- a/docs/BEGINNER-SETUP.md
+++ b/docs/BEGINNER-SETUP.md
@@ -37,7 +37,7 @@ You need a paid Claude subscription (Pro at $20/month or Max at $100-200/month) 
 
 ## Install These Tools
 
-### 1. GitHub Desktop (Required)
+### 1. GitHub Desktop (Strongly Recommended for Beginners)
 
 GitHub Desktop lets you clone repositories and see when updates are available â€” all without touching the terminal.
 
@@ -49,6 +49,8 @@ GitHub Desktop lets you clone repositories and see when updates are available â€
 - Visual indicator when there are updates to pull
 - No need to remember git commands
 - Works the same on Mac and Windows
+
+**Already comfortable with git?** You can skip GitHub Desktop and use terminal commands instead. But for most people new to this, GitHub Desktop makes life easier.
 
 ### 2. Claude Code (Required)
 


### PR DESCRIPTION
## Summary

- Clarified GitHub Desktop is "strongly recommended" (not required) for beginners
- Added auto-pull to ALL 11 skills so users always run latest versions

## Skills Updated

- /start, /setup, /enrich
- /ad-static, /ad-video-scripts, /ad-review
- /think
- /skool-manager, /skool-vsl-scripts
- /b2b-killer-vsl, /deck

## How Auto-Pull Works

Each skill runs `git pull origin main` on vip before doing anything.
Fails silently on network issues so users are never blocked.
