### PR TITLE
[fix] Make /setup create business repo automatically instead of stopping

### DIFF
--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -84,47 +84,39 @@ If offline or already current: continue silently.
 
 ---
 
-### CRITICAL: Check Location First
+### Check Location — Create Business Repo if Needed
 
-**Before doing ANYTHING, verify we're NOT in the vip (engine) repository:**
+**Check if we're in the vip (engine) repository:**
 
 ```bash
-# If this succeeds, we're in vip — STOP
+# If this succeeds, we're in vip
 ls .claude/skills/setup/SKILL.md 2>/dev/null
 ```
 
-**If we're in vip, STOP and tell the user:**
+**If we're in vip, CREATE the business repo for them:**
 
-> "Hold on — you're in the **vip** repository. That's the engine, not your business repo.
->
-> I cannot create your business files here because:
-> 1. You only have read-only access to vip (you can't push changes)
-> 2. Your business data needs its own separate repository
->
-> **Here's what to do:**
->
-> 1. Create a folder for your business:
->    ```bash
->    mkdir ~/my-business-name
->    cd ~/my-business-name
->    git init
->    ```
->
-> 2. Start Claude in that folder:
->    ```bash
->    claude
->    ```
->
-> 3. Add vip as an additional directory so you still have skills:
->    ```
->    /add-dir ~/vip
->    ```
->
-> 4. Run `/setup` again
->
-> Need more help? See `docs/BEGINNER-SETUP.md` in the vip repo."
+> "You're in vip — that's the engine. Let me create your business repo."
 
-**Do not proceed if we're in vip.**
+1. **Ask for business name:**
+   > "What do you want to call your business folder? (e.g., 'my-agency', 'acme-coaching')"
+
+2. **Create the folder and init git:**
+   ```bash
+   mkdir -p ~/[business-name]
+   cd ~/[business-name] && git init
+   ```
+
+3. **Add it as a working directory:**
+   ```
+   /add-dir ~/[business-name]
+   ```
+
+4. **Set the business repo as the target for all file writes:**
+   From this point forward, write all files to `~/[business-name]/` NOT to the current directory.
+
+5. **Continue with setup** — proceed to Step 0 (Chrome extension) and beyond.
+
+**If NOT in vip:** You're already in the user's business repo. Continue normally.
 
 ---
 
@@ -179,7 +171,11 @@ See **[references/context-gathering.md](references/context-gathering.md)** for:
 - Completeness criteria
 
 **Opening prompt:**
-> Dump everything about this business — sales pages, offer details, testimonials, notes, whatever exists. Paste text, share file paths, or give me URLs to fetch. I'll sort it into the right files.
+> Dump everything about this business — sales pages, offer details, testimonials, notes, whatever exists.
+>
+> **Pro tip:** You can drag screenshots directly into this terminal window and I'll read them. If you have a Skool community, screenshot your about page, classroom, pricing — drag them all in. Fastest way to get me up to speed.
+>
+> Paste text, share file paths, give me URLs to fetch, or drag in images. I'll sort it all into the right files.
 
 **After each batch, assess gaps:**
 > "Got it. I still need [X, Y, Z] to complete your reference files. Can you share those?"

--- a/.claude/skills/start/SKILL.md
+++ b/.claude/skills/start/SKILL.md
@@ -24,8 +24,7 @@ Single entry point for Main Branch. Detect user state, route to the right skill.
 │
 ├── Pull latest vip updates ──────────→ (always, silently)
 │
-├── In vip (engine) repo? ─────────→ STOP — need user's business repo
-│   (.claude/skills/ exists)
+├── In vip + needs setup? ────────────→ /setup (creates repo automatically)
 │
 ├── No business repo? ──────────────→ /setup
 │   (no reference/ folder)
@@ -71,33 +70,20 @@ This ensures users always have the latest skills without needing to remember to 
 
 ---
 
-## Step 0: Check Location (CRITICAL)
+## Step 0: Check Location
 
-**Before doing anything else, check if we're in the vip (engine) repo:**
+**Check if we're in the vip (engine) repo:**
 
 ```bash
-# If this succeeds, we're in vip — don't write here
+# If this succeeds, we're in vip
 ls .claude/skills/start/SKILL.md 2>/dev/null
 ```
 
-**If we're in vip:**
+**If we're in vip AND user needs setup:** Route to `/setup`.
 
-> "You're currently in the **vip** repository — that's the engine.
->
-> I can't save your business files here because:
-> 1. You only have read-only access (you can't push changes)
-> 2. Your business data should live in YOUR OWN separate repo
->
-> **To fix this:**
-> - Create a new folder for your business (e.g., `~/my-business`)
-> - Run `claude` from that folder
-> - Use `/add-dir` to add vip so you still have access to skills
->
-> Or if you already have a business repo, navigate there first.
->
-> Need help? See `docs/BEGINNER-SETUP.md` in this repo."
+The `/setup` skill will handle creating their business repo automatically — it asks for a business name, creates the folder, and continues. No manual steps needed.
 
-**Do not proceed with setup or file creation if we're in vip.**
+**If we're in vip AND user already has a business repo:** Ask them to add it via `/add-dir` or navigate there.
 
 ---
 


### PR DESCRIPTION
PROBLEM:
- Previous change added "STOP" guards that told users to manually create folders
- This broke the flow — /setup is supposed to DO everything for users

FIX:
- /setup now CREATES the business repo when run from vip
  - Asks for business name
  - Creates ~/[business-name]/ folder
  - Inits git
  - Adds via /add-dir
  - Continues with setup
- /start routes to /setup instead of stopping

ALSO ADDED:
- Screenshot tip in /setup: "drag screenshots directly into terminal"
- Especially useful for Skool users to quickly dump about page, classroom, etc.