### PR TITLE
Add /content skill family for organic content creation

### DIFF
--- a/.claude/skills/content/SKILL.md
+++ b/.claude/skills/content/SKILL.md
@@ -1,0 +1,434 @@
+---
+name: content
+description: |
+  Mine competitor content and generate organic scripts for Reels, TikTok, and carousels. Use when:
+  (1) User wants to research competitor Instagram/TikTok content
+  (2) User says "mine", "competitors", "organic", "reels", "tiktok"
+  (3) User needs scripts for talking-head videos (not ads)
+  (4) User wants carousel copy for Instagram
+  (5) User needs captions for static posts
+
+  Supports modes: full flow (mine -> script), mine-only, video, carousel, static.
+---
+
+# Content
+
+Mine competitor content, extract winning concepts, generate scripts in your voice.
+
+**Need help?** Type `/help` + your question anytime.
+
+---
+
+## How It Differs from Ad Skills
+
+| Aspect | /ad-video-scripts | /content |
+|--------|-------------------|----------|
+| **Purpose** | Paid traffic conversion | Organic reach and engagement |
+| **Tone** | Direct response, urgency | Authentic, value-first |
+| **CTA** | Hard (link in bio, buy now) | Soft (follow, save, comment) |
+| **Framework** | AIDA, PAS | Hook-Retain-Reward |
+| **Goal** | Clicks and conversions | Views, saves, follows |
+
+---
+
+## Modes
+
+### `/content` (Full Flow - Default)
+
+Mine competitors -> pick concepts -> generate scripts.
+
+```
+Mine -> Select -> Generate -> Output
+```
+
+### `/content mine`
+
+Research competitor content only. Saves to `research/`.
+
+### `/content video "concept"`
+
+Generate Reels/TikTok script from a concept.
+
+### `/content carousel "concept"`
+
+Generate multi-slide carousel copy from a concept.
+
+### `/content static "concept"`
+
+Generate single-post caption from a concept.
+
+---
+
+## Reference Required
+
+Business repo must have these files:
+
+| File | What It Contains |
+|------|------------------|
+| `reference/core/offer.md` | What you sell (for CTA context) |
+| `reference/core/audience.md` | Who watches your content |
+| `reference/core/voice.md` | How you sound on camera |
+
+**Optional but recommended:**
+
+| File | Purpose |
+|------|---------|
+| `reference/competitors/handles.md` | List of competitor handles to mine |
+| `reference/proof/angles/*.md` | Proven angles to adapt |
+
+If core files are missing, prompt user to create them first or run `/setup`.
+
+---
+
+## Full Flow Walkthrough
+
+### Step 1: Identify Competitors
+
+Check for `reference/competitors/handles.md`:
+
+```markdown
+# Competitor Handles
+
+## Primary Competitors (same niche)
+- @competitor1
+- @competitor2
+
+## Adjacent Creators (similar audience)
+- @adjacent1
+- @adjacent2
+
+## Aspirational (bigger accounts to study)
+- @aspirational1
+```
+
+If file missing, ask:
+
+> "Who are 3-5 creators making content for your audience? These can be:
+> - Direct competitors
+> - Adjacent creators (similar audience, different offer)
+> - Bigger accounts you admire"
+
+### Step 2: Mine Content
+
+**Data extraction approach:**
+
+For Instagram mining, use Apify MCP if available:
+- Instagram Profile Scraper actor
+- Extracts posts with engagement metrics
+- Returns structured JSON
+
+If Apify unavailable, ask user to share:
+- Screenshots of top posts
+- URLs to high-performing content
+- Notes on what they observed
+
+**Filter for winners:**
+
+Sort by engagement rate (likes + comments / followers). Top 10-20% are winners.
+
+**Server-side sorting (replaces Sort Feed extension):**
+
+```python
+# Sort posts by engagement, no Chrome extension needed
+sorted_posts = sorted(posts, key=lambda p: p['likes'] + p['comments'], reverse=True)
+top_performers = sorted_posts[:int(len(sorted_posts) * 0.2)]  # Top 20%
+```
+
+### Step 3: Extract Concepts
+
+For each winning post, extract:
+
+| Element | What to Capture |
+|---------|-----------------|
+| **Hook** | First line/first 3 seconds |
+| **Topic** | Core subject matter |
+| **Structure** | How content is organized |
+| **Angle** | Emotional entry point |
+| **Format** | Talking head, carousel, text, etc. |
+
+### Step 4: Adapt to User's Brand
+
+Map competitor concepts to user's:
+- Offer (what relates to their product)
+- Audience (what resonates with their people)
+- Voice (how they would say it)
+
+### Step 5: Generate Scripts
+
+Based on content type:
+- **Talking head** -> Use video framework
+- **Carousel** -> Use carousel framework
+- **Single post** -> Use static framework
+
+### Step 6: Save Output
+
+Save mining results to:
+```
+research/YYYY-MM-DD-competitor-mine.md
+```
+
+Save generated scripts to:
+```
+outputs/content-scripts/YYYY-MM-DD-[concept-slug].md
+```
+
+---
+
+## Mine Mode
+
+Research competitor content without generating scripts.
+
+### Workflow
+
+1. Identify competitors (file or ask)
+2. Gather content data (Apify or manual)
+3. Sort by engagement (server-side)
+4. Extract top concepts
+5. Save to research file
+
+### Output Location
+
+```
+research/YYYY-MM-DD-competitor-mine.md
+```
+
+### Template
+
+See [references/mining-template.md](references/mining-template.md)
+
+### Exit Criteria
+
+Mining is complete when:
+- [ ] Competitors identified
+- [ ] Content data gathered
+- [ ] Sorted by performance
+- [ ] Top 10-20 concepts extracted
+- [ ] Saved to research/
+
+---
+
+## Video Mode
+
+Generate Reels/TikTok scripts from concepts.
+
+### Input
+
+Either:
+- A concept from mining session
+- User-provided topic
+- Reference to research file
+
+### Framework Selection
+
+Detect or ask for framework:
+
+| Framework | Structure | When to Use |
+|-----------|-----------|-------------|
+| **Educational** | Hook -> Tips -> Takeaway | How-to, lists, advice |
+| **Story-based** | Hook -> Trigger -> Outcome -> Result | Personal narrative |
+| **Transformation** | Before -> Turning Point -> After | Journey, case study |
+| **Problem-Solution** | Hook -> Problem -> Solution -> CTA | PAS for organic |
+
+User can specify: `/content video "topic" --framework story`
+
+### Hook-Retain-Reward Structure
+
+Every video script follows:
+
+1. **Hook** (0-3 seconds): Stop the scroll
+2. **Retain** (3-45 seconds): Deliver value, maintain attention
+3. **Reward** (last 5-15 seconds): Payoff + soft CTA
+
+See [references/organic-frameworks.md](references/organic-frameworks.md) for detailed breakdown.
+
+### Output
+
+See [references/video-script-template.md](references/video-script-template.md)
+
+---
+
+## Carousel Mode
+
+Generate multi-slide Instagram carousels.
+
+### Input
+
+Either:
+- A concept from mining session
+- User-provided topic
+- Number of slides (default: 7-10)
+
+### Structure
+
+| Slide | Purpose |
+|-------|---------|
+| 1 | Hook slide (stops scroll) |
+| 2-8 | Value slides (one idea per slide) |
+| 9 | Summary or recap |
+| 10 | CTA slide |
+
+### Output
+
+See [references/carousel-template.md](references/carousel-template.md)
+
+---
+
+## Static Mode
+
+Generate single-post captions.
+
+### Input
+
+- Topic or angle
+- Image context (what the image shows)
+- Desired length (short/medium/long)
+
+### Structure
+
+1. **Hook** (first line visible before "more")
+2. **Body** (value or story)
+3. **CTA** (soft: save, comment, follow)
+4. **Hashtags** (optional, user preference)
+
+### Output
+
+See [references/static-template.md](references/static-template.md)
+
+---
+
+## Voice Adaptation
+
+When generating, always:
+
+1. Read `reference/core/voice.md`
+2. Match tone markers (casual, professional, energetic, etc.)
+3. Use vocabulary from voice file
+4. Avoid phrases marked as "never say"
+
+### Authenticity Checklist
+
+- [ ] Sounds like the creator, not a copywriter
+- [ ] Uses contractions naturally
+- [ ] Matches their energy level
+- [ ] Includes their verbal quirks
+- [ ] Avoids AI tells ("dive into", "unlock", "game-changer")
+
+---
+
+## CTA Softness
+
+Organic content uses soft CTAs:
+
+| Hard (Avoid) | Soft (Use) |
+|--------------|-----------|
+| "Link in bio to buy" | "Save this for later" |
+| "Sign up now" | "Follow for more like this" |
+| "Limited time offer" | "Comment [word] if you want the full breakdown" |
+| "Don't miss out" | "Share with someone who needs this" |
+
+**Exception:** If user's voice file shows they use harder CTAs successfully, match their style.
+
+---
+
+## Integration with /think
+
+When user wants to save winning angles to reference:
+
+> "Want to save these winning concepts to your angles folder? I can route to `/think codify` to add them to `reference/proof/angles/`."
+
+This keeps codification logic in one place.
+
+---
+
+## Quality Checklist
+
+Before outputting any script:
+
+**Content:**
+- [ ] Hook stops scroll (first 3 seconds/first line)
+- [ ] One clear idea per piece
+- [ ] Value delivered before any ask
+- [ ] Soft CTA appropriate to platform
+
+**Voice:**
+- [ ] Sounds like the creator
+- [ ] Matches their energy
+- [ ] Uses their vocabulary
+- [ ] No AI tells
+
+**Platform:**
+- [ ] Appropriate length for format
+- [ ] Structure matches content type
+- [ ] Optimized for the algorithm (retention, saves)
+
+---
+
+## Examples
+
+### Example 1: Full Flow
+
+```
+User: /content
+
+Claude: Let me check for your competitor list...
+[Reads reference/competitors/handles.md]
+
+Found 5 competitors. Want me to mine their top-performing content?
+
+User: Yes
+
+Claude: [Uses Apify or asks for data]
+[Extracts top 10 concepts]
+
+Here are the winning concepts:
+1. "The one thing successful [audience] do differently" (Story)
+2. "Stop doing [common mistake]" (Problem-Solution)
+3. "3 tools I use every day for [outcome]" (Educational)
+...
+
+Which concepts resonate? I'll generate scripts in your voice.
+
+User: 1 and 4
+
+Claude: [Reads voice.md, generates scripts]
+[Saves to outputs/content-scripts/]
+```
+
+### Example 2: Video Only
+
+```
+User: /content video "how I structure my morning routine"
+
+Claude: What framework fits this best?
+- Educational (tips and steps)
+- Story-based (your journey)
+- Transformation (before/after)
+
+User: Story-based
+
+Claude: [Generates script using story framework]
+[Saves to outputs/content-scripts/]
+```
+
+### Example 3: Mine Only
+
+```
+User: /content mine
+
+Claude: [Gathers competitor data]
+[Extracts concepts]
+[Saves to research/2026-01-19-competitor-mine.md]
+
+Mining complete. 12 winning concepts extracted.
+Run `/content video` or `/content carousel` to generate from these.
+```
+
+---
+
+## References
+
+- [references/organic-frameworks.md](references/organic-frameworks.md) - Content structure frameworks
+- [references/mining-template.md](references/mining-template.md) - Template for mining output
+- [references/video-script-template.md](references/video-script-template.md) - Reels/TikTok template
+- [references/carousel-template.md](references/carousel-template.md) - Carousel slide template
+- [references/static-template.md](references/static-template.md) - Single post template

--- a/.claude/skills/content/references/carousel-template.md
+++ b/.claude/skills/content/references/carousel-template.md
@@ -1,0 +1,498 @@
+# Carousel Template
+
+Template for multi-slide Instagram carousels. Optimized for swipe-through engagement and saves.
+
+---
+
+## Output Format
+
+Save carousels to: `outputs/content-scripts/YYYY-MM-DD-[concept-slug]-carousel.md`
+
+Example: `outputs/content-scripts/2026-01-19-content-mistakes-carousel.md`
+
+---
+
+## File Structure
+
+```markdown
+---
+type: content-script
+format: carousel
+date: YYYY-MM-DD
+slides: [number]
+concept_source: [mined | user-provided | reference-angle]
+status: draft
+---
+
+# [Concept Title] Carousel
+
+Generated: YYYY-MM-DD
+Slides: [X]
+Concept: [Brief description]
+
+---
+
+## Slide 1: Hook
+
+**Text:**
+[Main text - large, attention-grabbing]
+
+**Subtext (optional):**
+[Smaller supporting text]
+
+**Visual notes:**
+[Background color, image suggestion, text placement]
+
+---
+
+## Slide 2: [Section title]
+
+**Text:**
+[Main point for this slide]
+
+**Subtext (optional):**
+[Supporting detail]
+
+**Visual notes:**
+[Design guidance]
+
+---
+
+[Continue for all slides]
+
+---
+
+## Slide [Last]: CTA
+
+**Text:**
+[Call to action]
+
+**Subtext:**
+[What to do next]
+
+**Visual notes:**
+[Include handle, any branding]
+
+---
+
+## Caption
+
+[Full Instagram caption to accompany carousel]
+
+## Hashtags
+#tag1 #tag2 #tag3
+
+---
+```
+
+---
+
+## Carousel Structure
+
+Standard 7-10 slide format:
+
+| Slide | Purpose | What to Include |
+|-------|---------|-----------------|
+| 1 | Hook | Bold statement, question, or promise |
+| 2 | Context/Setup | Why this matters, brief intro |
+| 3-7 | Value | One idea per slide, numbered if list |
+| 8-9 | Summary/Bridge | Recap or "here's the thing" |
+| 10 | CTA | What to do next |
+
+---
+
+## Slide Copy Guidelines
+
+### Character Limits
+
+- **Headline text:** 5-10 words max
+- **Body text:** 20-30 words max per slide
+- **Readable at glance:** If it takes more than 2 seconds to read, it's too long
+
+### Typography Hierarchy
+
+1. **Headline:** Large, bold, first thing seen
+2. **Body:** Smaller, supporting the headline
+3. **Accent:** Numbers, emojis, or highlights
+
+---
+
+## Example: Educational List (10 slides)
+
+```markdown
+---
+type: content-script
+format: carousel
+date: 2026-01-19
+slides: 10
+concept_source: mined
+status: draft
+---
+
+# 5 Content Mistakes Carousel
+
+Generated: 2026-01-19
+Slides: 10
+Concept: Common content creation mistakes with fixes
+
+---
+
+## Slide 1: Hook
+
+**Text:**
+5 content mistakes
+that are killing your reach
+
+**Subtext:**
+(and what to do instead)
+
+**Visual notes:**
+Bold text, dark background, maybe a "stop" or warning element
+
+---
+
+## Slide 2: Setup
+
+**Text:**
+I made all of these.
+
+For two years.
+
+Then I fixed them.
+
+**Subtext:**
+Here's what I learned.
+
+**Visual notes:**
+Clean, personal, transition slide
+
+---
+
+## Slide 3: Mistake 1
+
+**Text:**
+Mistake #1
+No hook
+
+**Subtext:**
+If you don't stop the scroll in 1 second,
+nothing else matters.
+
+**Visual notes:**
+Number prominent, text secondary
+
+---
+
+## Slide 4: Fix 1
+
+**Text:**
+The fix:
+
+Lead with the payoff.
+Not the context.
+
+**Subtext:**
+Hook = promise of value
+
+**Visual notes:**
+Lighter/different color to signal "fix"
+
+---
+
+## Slide 5: Mistake 2
+
+**Text:**
+Mistake #2
+Too many ideas
+
+**Subtext:**
+One post trying to do everything
+does nothing.
+
+**Visual notes:**
+Return to "mistake" design
+
+---
+
+## Slide 6: Fix 2
+
+**Text:**
+The fix:
+
+1 post = 1 idea
+
+Save the rest for tomorrow.
+
+**Visual notes:**
+"Fix" design treatment
+
+---
+
+## Slide 7: Mistake 3
+
+**Text:**
+Mistake #3
+No CTA
+
+**Subtext:**
+If you don't tell them what to do,
+they'll do nothing.
+
+**Visual notes:**
+"Mistake" design
+
+---
+
+## Slide 8: Fix 3
+
+**Text:**
+The fix:
+
+End every post with ONE clear ask.
+
+Save. Follow. Comment. Share.
+
+**Visual notes:**
+"Fix" design
+
+---
+
+## Slide 9: Summary
+
+**Text:**
+The formula:
+
+Hook that stops.
+One idea that lands.
+CTA that converts.
+
+**Visual notes:**
+Clean, memorable, quotable
+
+---
+
+## Slide 10: CTA
+
+**Text:**
+Save this.
+Share it with a creator friend.
+
+**Subtext:**
+Follow @handle for more
+
+**Visual notes:**
+Include branding, handle prominent
+
+---
+
+## Caption
+
+These three mistakes kept me stuck for years.
+
+The third one is sneaky - you think the content speaks for itself.
+
+It doesn't.
+
+Every piece of content needs a job.
+And the CTA is how you tell the reader what that job is.
+
+Which mistake are you most guilty of? (Comment below - I'm curious)
+
+Save this for your next content audit.
+
+## Hashtags
+#contentcreation #creatoreconomy #contentmarketing #instagramtips #socialmediatips
+```
+
+---
+
+## Example: Story/Journey (8 slides)
+
+```markdown
+---
+type: content-script
+format: carousel
+date: 2026-01-19
+slides: 8
+concept_source: user-provided
+status: draft
+---
+
+# My Content Journey Carousel
+
+Generated: 2026-01-19
+Slides: 8
+Concept: Before/after of content strategy transformation
+
+---
+
+## Slide 1: Hook
+
+**Text:**
+6 months ago vs. today
+
+**Subtext:**
+What changed when I stopped chasing views
+
+**Visual notes:**
+Split design or transformation visual
+
+---
+
+## Slide 2: Before
+
+**Text:**
+6 months ago:
+
+Posting 3x/day
+Copying every trend
+Zero engagement
+
+**Visual notes:**
+"Before" treatment - maybe grayed/faded
+
+---
+
+## Slide 3: The Breaking Point
+
+**Text:**
+I had 10,000 followers.
+
+And zero customers.
+
+**Visual notes:**
+Stark, honest, emotional beat
+
+---
+
+## Slide 4: The Question
+
+**Text:**
+I asked myself:
+
+"What do I actually want
+people to DO?"
+
+**Visual notes:**
+Centered, impactful, turning point
+
+---
+
+## Slide 5: The Shift
+
+**Text:**
+I stopped making content
+for the algorithm.
+
+Started making content
+for my customer.
+
+**Visual notes:**
+Transition design
+
+---
+
+## Slide 6: After
+
+**Text:**
+Today:
+
+Posting 3x/week
+Half the views
+10x the DMs
+
+**Visual notes:**
+"After" treatment - brighter/cleaner
+
+---
+
+## Slide 7: The Lesson
+
+**Text:**
+Views are vanity.
+Sales are sanity.
+
+**Visual notes:**
+Quotable, shareable
+
+---
+
+## Slide 8: CTA
+
+**Text:**
+Save this if you needed
+to hear it today.
+
+**Subtext:**
+Follow @handle for more
+
+**Visual notes:**
+CTA with branding
+
+---
+
+## Caption
+
+I used to measure success by the wrong things.
+
+Likes. Views. Posting every single day.
+
+Then I looked at my revenue. And realized none of it was translating.
+
+The shift wasn't about working harder. It was about working smarter.
+
+Are you creating for the algorithm or for your customer?
+
+(Save this for when you need a reminder)
+```
+
+---
+
+## Design Principles
+
+### Swipe Motivation
+
+Each slide should make them want to see the next:
+- End slides with incomplete thoughts
+- Use "..." or arrows to imply continuation
+- Number slides to show progression
+
+### Visual Consistency
+
+- Same color palette throughout
+- Consistent text placement
+- Repeated design elements
+- Brand recognition by slide 3
+
+### Save-Worthiness
+
+Carousels get saved when they:
+- Contain reference-able information
+- Summarize complex topics
+- Feel like a "mini guide"
+- Have that "I'll need this later" quality
+
+---
+
+## Carousel Types
+
+| Type | Slides | Best For |
+|------|--------|----------|
+| List/Tips | 7-10 | How-to, numbered advice |
+| Story | 6-8 | Journey, transformation |
+| Myth-Busting | 8-10 | Debunking, corrections |
+| Comparison | 6-8 | This vs That, Before/After |
+| Mini-Guide | 10+ | Deep dives, tutorials |
+
+---
+
+## Caption Guidelines
+
+Carousel captions should:
+
+1. **Expand on slide content** - Don't just repeat
+2. **Add context** - Personal story, why this matters
+3. **Ask a question** - Drive comments
+4. **End with CTA** - Save, share, or follow
+
+Length: 100-300 words (longer captions perform well on carousels)

--- a/.claude/skills/content/references/mining-template.md
+++ b/.claude/skills/content/references/mining-template.md
@@ -1,0 +1,257 @@
+# Competitor Content Mining Template
+
+Use this template when saving mining research to `research/YYYY-MM-DD-competitor-mine.md`.
+
+---
+
+## Frontmatter
+
+```yaml
+---
+type: research
+date: YYYY-MM-DD
+source: competitor-mine
+status: draft
+competitors_analyzed:
+  - "@handle1"
+  - "@handle2"
+linked_decisions: []
+---
+```
+
+---
+
+## Template
+
+```markdown
+---
+type: research
+date: YYYY-MM-DD
+source: competitor-mine
+status: draft
+competitors_analyzed:
+  - "@handle1"
+  - "@handle2"
+linked_decisions: []
+---
+
+# Competitor Content Mining
+
+Mining date: YYYY-MM-DD
+Competitors analyzed: X accounts
+Posts reviewed: X total
+Top performers extracted: X concepts
+
+---
+
+## Competitors Analyzed
+
+### @handle1
+- **Niche:** [Their specific focus]
+- **Follower count:** [Approximate]
+- **Post frequency:** [Daily/3x week/etc.]
+- **Primary format:** [Reels/Carousels/Mixed]
+- **Why included:** [Direct competitor / Adjacent / Aspirational]
+
+### @handle2
+- **Niche:** [Their specific focus]
+- **Follower count:** [Approximate]
+- **Post frequency:** [Daily/3x week/etc.]
+- **Primary format:** [Reels/Carousels/Mixed]
+- **Why included:** [Direct competitor / Adjacent / Aspirational]
+
+[Repeat for each competitor]
+
+---
+
+## Data Collection Method
+
+[How data was gathered]
+
+- [ ] Apify Instagram Profile Scraper
+- [ ] Manual review of top posts
+- [ ] Screenshots provided by user
+- [ ] Other: [specify]
+
+**Time period:** [Last 30 days / Last 90 days / etc.]
+
+**Engagement threshold:** [Top 20% by engagement rate / etc.]
+
+---
+
+## Top Performing Concepts
+
+### Concept 1: [Title/Theme]
+
+**Source:** @handle - [Post date or link]
+
+**Engagement:**
+- Likes: X
+- Comments: X
+- Engagement rate: X%
+
+**Hook:**
+> "[Exact hook text or first 3 seconds transcribed]"
+
+**Format:** [Talking head / Carousel / Text overlay / etc.]
+
+**Topic:** [Core subject matter]
+
+**Angle:** [Emotional entry point - curiosity, pain, desire, identity]
+
+**Structure:**
+1. [Hook approach]
+2. [Middle content approach]
+3. [Ending/CTA approach]
+
+**Why it worked:**
+[Analysis of what made this perform]
+
+**Adaptation potential:** [High / Medium / Low]
+[Notes on how to adapt for user's brand]
+
+---
+
+### Concept 2: [Title/Theme]
+
+[Same structure as above]
+
+---
+
+### Concept 3: [Title/Theme]
+
+[Same structure as above]
+
+---
+
+[Continue for 10-20 concepts]
+
+---
+
+## Patterns Observed
+
+### Content Patterns
+
+| Pattern | Frequency | Example |
+|---------|-----------|---------|
+| [Pattern 1] | [How often seen] | [Brief example] |
+| [Pattern 2] | [How often seen] | [Brief example] |
+| [Pattern 3] | [How often seen] | [Brief example] |
+
+### Hook Patterns
+
+Most effective hook types observed:
+
+1. **[Hook type]** - [Why it works in this niche]
+2. **[Hook type]** - [Why it works in this niche]
+3. **[Hook type]** - [Why it works in this niche]
+
+### Format Distribution
+
+| Format | % of Top Performers |
+|--------|---------------------|
+| Talking head | X% |
+| Carousel | X% |
+| Text overlay | X% |
+| B-roll + voiceover | X% |
+| Other | X% |
+
+### Posting Insights
+
+- **Best performing days:** [If observable]
+- **Caption length trend:** [Short / Medium / Long]
+- **CTA style:** [What CTAs top performers use]
+- **Hashtag usage:** [Heavy / Light / None]
+
+---
+
+## Gaps and Opportunities
+
+### What competitors are NOT doing:
+
+1. [Gap 1]
+2. [Gap 2]
+3. [Gap 3]
+
+### Underserved angles in the niche:
+
+1. [Angle 1]
+2. [Angle 2]
+
+### Differentiation opportunities:
+
+1. [How user can stand out]
+2. [Unique perspective user has]
+
+---
+
+## Synthesis
+
+### One-Sentence Summary
+[Distilled insight from this mining session - 20 words max]
+
+### Key Findings (5-10 bullets)
+- [Finding 1]
+- [Finding 2]
+- [Finding 3]
+- [Finding 4]
+- [Finding 5]
+
+### Top 5 Concepts to Adapt
+
+| Priority | Concept | Adaptation Idea |
+|----------|---------|-----------------|
+| 1 | [Concept title] | [How to make it yours] |
+| 2 | [Concept title] | [How to make it yours] |
+| 3 | [Concept title] | [How to make it yours] |
+| 4 | [Concept title] | [How to make it yours] |
+| 5 | [Concept title] | [How to make it yours] |
+
+### Implications for Reference Files
+
+| File | Potential Update |
+|------|------------------|
+| reference/proof/angles/*.md | [New angles discovered] |
+| reference/core/voice.md | [Voice patterns to adopt/avoid] |
+| reference/competitors/handles.md | [New competitors to add] |
+
+### Next Steps
+
+- [ ] Generate scripts from concepts 1, 2, 3
+- [ ] Save winning angles to reference
+- [ ] [Other actions]
+
+---
+
+## Raw Data (Optional)
+
+If extracted via Apify or other tools, include raw JSON or CSV here for reference.
+
+```json
+[Raw data if available]
+```
+```
+
+---
+
+## Usage Notes
+
+### When to Mine
+
+- Starting a new content strategy
+- Content feels stale, need fresh ideas
+- Entering a new platform
+- Quarterly refresh of angles
+
+### How Often
+
+- **Full mining session:** Monthly or quarterly
+- **Quick check:** Weekly scan of top performers
+- **Reactive mining:** When a competitor goes viral
+
+### What to Do After
+
+1. Review concepts with user
+2. Select 3-5 to adapt
+3. Generate scripts via `/content video` or `/content carousel`
+4. (Optional) Codify winning angles via `/think codify`

--- a/.claude/skills/content/references/organic-frameworks.md
+++ b/.claude/skills/content/references/organic-frameworks.md
@@ -1,0 +1,421 @@
+# Organic Content Frameworks
+
+Structures for Reels, TikTok, and carousels. These differ from paid ad frameworks - organic prioritizes value and engagement over direct conversion.
+
+---
+
+## Core Principle: Hook-Retain-Reward
+
+Every piece of organic content follows this structure:
+
+```
+HOOK (0-3 seconds)
+Stop the scroll. Create curiosity or recognition.
+
+RETAIN (3-45 seconds)
+Deliver value. Maintain attention through the middle.
+
+REWARD (final 5-15 seconds)
+Payoff the hook. Soft CTA.
+```
+
+**Why this works:** Algorithms favor watch time and saves. Content that delivers value gets pushed to more people.
+
+---
+
+## Framework 1: Educational
+
+**Structure:** Hook -> Tips/Steps -> Takeaway
+
+**Best for:** How-to content, lists, advice, tutorials
+
+### Components
+
+| Section | Purpose | Example |
+|---------|---------|---------|
+| **Hook** | Promise specific value | "3 things I wish I knew before starting my business" |
+| **Setup** | Brief context (optional) | "After 5 years of trial and error..." |
+| **Tips 1-3** | One clear idea per beat | "First: Don't wait until you're ready" |
+| **Takeaway** | Summarize or add perspective | "The real secret? Just start." |
+| **CTA** | Soft engagement ask | "Save this for when you need a reminder" |
+
+### Timing (30-60 seconds)
+
+```
+Hook:     3 seconds
+Setup:    5 seconds (optional)
+Tip 1:    8 seconds
+Tip 2:    8 seconds
+Tip 3:    8 seconds
+Takeaway: 5 seconds
+CTA:      3 seconds
+```
+
+### Example Script
+
+```
+HOOK:
+"3 mistakes killing your content (and what to do instead)"
+
+RETAIN:
+Mistake one: Posting without a hook.
+Every scroll is a decision. Give them a reason to stop.
+
+Mistake two: Trying to say too much.
+One idea per post. That's it. Save the rest for tomorrow.
+
+Mistake three: Skipping the CTA.
+If you don't tell them what to do, they'll do nothing.
+
+REWARD:
+The fix? Hook. One idea. Clear ask. Repeat.
+
+CTA:
+Save this. You'll need it.
+```
+
+---
+
+## Framework 2: Story-Based
+
+**Structure:** Hook -> Trigger Event -> Journey -> Outcome -> Result
+
+**Best for:** Personal narratives, lessons learned, case studies
+
+### Components
+
+| Section | Purpose | Example |
+|---------|---------|---------|
+| **Hook** | Tease the transformation | "This one decision changed everything" |
+| **Trigger** | What happened to start the journey | "Three years ago, I got fired" |
+| **Journey** | The struggle or process | "I tried everything. Nothing worked until..." |
+| **Outcome** | What you discovered/did | "Then I realized I was solving the wrong problem" |
+| **Result** | Where you are now | "Now I run a business I actually love" |
+| **CTA** | Invite engagement | "Comment if you've been there" |
+
+### Timing (45-90 seconds)
+
+```
+Hook:     3 seconds
+Trigger:  10 seconds
+Journey:  20-40 seconds
+Outcome:  10 seconds
+Result:   5 seconds
+CTA:      3 seconds
+```
+
+### Example Script
+
+```
+HOOK:
+"The hardest lesson I learned building my business"
+
+TRIGGER:
+Two years ago, I hit rock bottom.
+Revenue was up, but I was miserable.
+Working 80-hour weeks. Missing everything that mattered.
+
+JOURNEY:
+I tried time management apps. Delegation frameworks.
+Productivity systems from every guru on the internet.
+Nothing changed.
+
+OUTCOME:
+Then I realized: I wasn't overworked.
+I was doing the wrong work.
+Building someone else's version of success.
+
+RESULT:
+Now I make half what I used to.
+And I've never been happier.
+
+CTA:
+Has anyone else been through this? Drop a comment.
+```
+
+---
+
+## Framework 3: Transformation
+
+**Structure:** Before -> Turning Point -> After
+
+**Best for:** Journey content, case studies, before/after reveals
+
+### Components
+
+| Section | Purpose | Example |
+|---------|---------|---------|
+| **Hook** | Tease the gap | "6 months ago vs today" |
+| **Before** | Where you/they started | "I was posting every day with zero engagement" |
+| **Turning Point** | What changed | "Then I stopped chasing views and started this instead" |
+| **After** | Where you/they are now | "Now my content actually converts" |
+| **Bridge** | How they can do it too | "Here's what I changed..." |
+| **CTA** | Soft ask | "Follow for more breakdowns like this" |
+
+### Timing (30-60 seconds)
+
+```
+Hook:           3 seconds
+Before:         10 seconds
+Turning Point:  10 seconds
+After:          10 seconds
+Bridge:         10 seconds
+CTA:            3 seconds
+```
+
+### Example Script
+
+```
+HOOK:
+"What changed when I stopped trying to go viral"
+
+BEFORE:
+Six months ago, I was obsessed with views.
+Posting three times a day.
+Copying trends. Chasing algorithms.
+My content was everywhere. My business? Nowhere.
+
+TURNING POINT:
+Then I asked myself one question:
+"What do I actually want people to DO?"
+Not watch. DO.
+
+AFTER:
+Now I post half as much.
+Get fewer views.
+And my DMs are full of people ready to buy.
+
+BRIDGE:
+The shift? I stopped making content for the algorithm.
+Started making content for my actual customer.
+
+CTA:
+Save this if you needed to hear it.
+```
+
+---
+
+## Framework 4: Problem-Solution (PAS for Organic)
+
+**Structure:** Hook (Problem) -> Agitate -> Solution -> Proof
+
+**Best for:** Pain point content, myth-busting, "stop doing this"
+
+### Components
+
+| Section | Purpose | Example |
+|---------|---------|---------|
+| **Hook** | Name the problem | "This 'advice' is ruining your content" |
+| **Problem** | Describe the pain | "You've heard you need to post every day" |
+| **Agitate** | Make it worse | "So you burn out. Quality drops. Engagement tanks." |
+| **Solution** | Present the fix | "Here's what actually works..." |
+| **Proof** | Why this works | "I tested this for 90 days..." |
+| **CTA** | Engagement ask | "Comment 'LESS' if you're trying this" |
+
+### Timing (30-45 seconds)
+
+```
+Hook:     3 seconds
+Problem:  8 seconds
+Agitate:  8 seconds
+Solution: 10 seconds
+Proof:    8 seconds
+CTA:      3 seconds
+```
+
+### Example Script
+
+```
+HOOK:
+"Stop batching your content. Seriously."
+
+PROBLEM:
+Everyone says batch create a month of content at once.
+Sounds efficient, right?
+
+AGITATE:
+But here's what happens:
+Week one content is fire.
+Week four? Generic. Disconnected. Stale.
+Because you're not in the same headspace you were when you wrote it.
+
+SOLUTION:
+Instead: Create same-day.
+Not more content. Better content.
+Content that matches your energy RIGHT NOW.
+
+PROOF:
+My engagement went up 40% when I stopped batching.
+Because the content felt real. Because it was.
+
+CTA:
+Try it for one week. Comment and let me know what happens.
+```
+
+---
+
+## Framework 5: Contrarian/Hot Take
+
+**Structure:** Hook (Bold Claim) -> Evidence -> Reframe -> New Perspective
+
+**Best for:** Challenging conventional wisdom, standing out, sparking discussion
+
+### Components
+
+| Section | Purpose | Example |
+|---------|---------|---------|
+| **Hook** | Make bold claim | "Consistency is overrated" |
+| **Evidence** | Support the claim | "I've seen creators post daily and fail..." |
+| **Reframe** | Shift perspective | "It's not about frequency. It's about..." |
+| **New Perspective** | What to do instead | "Focus on resonance, not routine" |
+| **CTA** | Invite debate | "Agree or disagree? Comment below" |
+
+### Timing (30-45 seconds)
+
+```
+Hook:            3 seconds
+Evidence:        10 seconds
+Reframe:         10 seconds
+New Perspective: 10 seconds
+CTA:             3 seconds
+```
+
+### Example Script
+
+```
+HOOK:
+"Niching down is bad advice. Here's why."
+
+EVIDENCE:
+I followed the niche-down playbook for two years.
+Picked one topic. One format. One audience.
+Know what happened? I got bored. My content got boring.
+And my growth flatlined.
+
+REFRAME:
+The real rule isn't "niche down."
+It's "be known for something."
+
+NEW PERSPECTIVE:
+You can talk about multiple things.
+As long as they all point back to your core perspective.
+Your ANGLE is your niche. Not your topic.
+
+CTA:
+Hot take or truth? Tell me in the comments.
+```
+
+---
+
+## Choosing the Right Framework
+
+| Content Type | Best Framework |
+|--------------|----------------|
+| How-to, tutorial | Educational |
+| Personal story | Story-Based |
+| Before/after, case study | Transformation |
+| Myth-busting, "stop doing X" | Problem-Solution |
+| Bold opinion, debate starter | Contrarian |
+
+---
+
+## Hook Formulas
+
+Strong hooks create curiosity or recognition. Use these patterns:
+
+### Curiosity Hooks
+
+- "The one thing [successful people] do that you don't"
+- "This changed everything for me"
+- "Nobody talks about this, but..."
+- "I was today years old when I learned..."
+- "Here's why [common advice] is wrong"
+
+### Recognition Hooks
+
+- "POV: You just realized [relatable thing]"
+- "When [specific situation] happens and you [relatable response]"
+- "You're not [negative label]. You're just [reframe]"
+- "[Number] signs you're actually [positive identity]"
+
+### Controversy Hooks
+
+- "Unpopular opinion: [bold claim]"
+- "Stop [common behavior]. Here's why."
+- "[Common advice] is ruining your [outcome]"
+- "I'm going to get hate for this, but..."
+
+### Story Hooks
+
+- "The day I [pivotal moment]"
+- "I almost [gave up/quit/failed], then this happened"
+- "Nobody knew this about me until now"
+- "This is the story I never told"
+
+---
+
+## Retention Techniques
+
+Keep viewers watching through the middle:
+
+### Pattern Interrupts
+
+Change the visual or vocal pattern every 5-8 seconds:
+- Change camera angle
+- Add text overlay
+- Shift energy/tone
+- Use jump cuts
+
+### Open Loops
+
+Create mini-cliffhangers:
+- "But that's not the crazy part..."
+- "And then I made a mistake..."
+- "Wait, it gets better..."
+
+### Value Stacking
+
+Each beat should feel like its own payoff:
+- "First... Second... But here's the real secret..."
+- Give 80% of value before asking for anything
+
+---
+
+## Soft CTAs for Organic
+
+Organic content uses soft CTAs that prioritize engagement over conversion:
+
+| Hard CTA (Avoid) | Soft CTA (Use) |
+|------------------|----------------|
+| "Link in bio to buy" | "Save this for later" |
+| "Sign up now" | "Follow for more like this" |
+| "Limited time offer" | "Comment [word] if you want more" |
+| "Don't miss out" | "Share with someone who needs this" |
+| "DM me to work together" | "Tag a friend who's going through this" |
+
+**Exception:** If the user's voice file shows they successfully use harder CTAs, match their style.
+
+---
+
+## Platform-Specific Notes
+
+### Instagram Reels
+
+- Optimal length: 15-30 seconds (up to 60 for story content)
+- First frame matters (appears in grid)
+- Captions should complement, not repeat
+- Save-worthy content gets boosted
+
+### TikTok
+
+- Can go longer (60-90 seconds) if retention stays high
+- Hook must work with sound off
+- Trends can be adapted but not required
+- Stitch/duet opportunities increase reach
+
+### Both Platforms
+
+- Watch time > views
+- Saves > likes
+- Comments > shares (for engagement signal)
+- Reply to comments quickly (boosts distribution)

--- a/.claude/skills/content/references/static-template.md
+++ b/.claude/skills/content/references/static-template.md
@@ -1,0 +1,389 @@
+# Static Post Template
+
+Template for single-post captions. Optimized for feed posts with images or graphics.
+
+---
+
+## Output Format
+
+Save static posts to: `outputs/content-scripts/YYYY-MM-DD-[concept-slug]-static.md`
+
+Example: `outputs/content-scripts/2026-01-19-content-tip-static.md`
+
+---
+
+## File Structure
+
+```markdown
+---
+type: content-script
+format: static
+date: YYYY-MM-DD
+length: [short | medium | long]
+concept_source: [mined | user-provided | reference-angle]
+status: draft
+---
+
+# [Concept Title] Static Post
+
+Generated: YYYY-MM-DD
+Length: [Short/Medium/Long]
+Concept: [Brief description]
+
+---
+
+## Image Context
+
+[Description of the image/graphic this caption accompanies]
+
+---
+
+## Caption
+
+[Full caption text]
+
+---
+
+## Hashtags
+#tag1 #tag2 #tag3
+
+---
+
+## Alt Text
+[Accessibility description of the image]
+
+---
+```
+
+---
+
+## Caption Length Guidelines
+
+| Length | Word Count | Best For |
+|--------|------------|----------|
+| Short | 20-50 words | Single insight, quote, quick tip |
+| Medium | 50-150 words | Story snippet, expanded tip, personal share |
+| Long | 150-300+ words | Mini-essay, deep reflection, story |
+
+---
+
+## Caption Structure
+
+### Hook Line (CRITICAL)
+
+The first line appears before "...more" - it must stop the scroll.
+
+- **Character limit:** ~125 characters before truncation
+- **Purpose:** Create curiosity or recognition
+- **Test:** Would you tap "more" to read this?
+
+### Body
+
+Expand on the hook. Options:
+
+- Story (brief narrative arc)
+- List (numbered or bulleted points)
+- Reflection (personal insight)
+- Value (actionable advice)
+
+### CTA
+
+End with a soft engagement ask:
+
+- Question to answer in comments
+- Save/share suggestion
+- Tag someone prompt
+
+---
+
+## Example: Short Caption
+
+```markdown
+---
+type: content-script
+format: static
+date: 2026-01-19
+length: short
+concept_source: user-provided
+status: draft
+---
+
+# Quick Content Tip Static Post
+
+Generated: 2026-01-19
+Length: Short
+Concept: Single actionable content tip
+
+---
+
+## Image Context
+
+Graphic with text: "Your content isn't boring. Your hooks are."
+
+---
+
+## Caption
+
+The content isn't the problem.
+
+The first line is.
+
+If they don't stop scrolling, the rest doesn't matter.
+
+What hook stopped YOU today? Drop it below.
+
+---
+
+## Hashtags
+#contentcreator #hooktips #instagramgrowth #contentmarketing #creatoreconomy
+
+---
+
+## Alt Text
+Minimalist graphic with text reading "Your content isn't boring. Your hooks are." on a neutral background.
+
+---
+```
+
+---
+
+## Example: Medium Caption
+
+```markdown
+---
+type: content-script
+format: static
+date: 2026-01-19
+length: medium
+concept_source: mined
+status: draft
+---
+
+# Content Consistency Static Post
+
+Generated: 2026-01-19
+Length: Medium
+Concept: Reframing consistency advice
+
+---
+
+## Image Context
+
+Photo of creator at desk, casual/authentic vibe. Or graphic with pull quote.
+
+---
+
+## Caption
+
+"Just be consistent."
+
+The advice everyone gives. That nobody explains.
+
+Here's what consistency actually means:
+
+It's not posting every day.
+It's not never missing a week.
+It's not sacrificing quality for quantity.
+
+Consistency is about PRESENCE.
+
+Showing up regularly enough that your audience remembers you exist.
+
+For some people, that's daily.
+For others, that's twice a week.
+For others, that's three bangers a month.
+
+The "right" frequency is whatever you can sustain.
+
+For a year.
+Without burning out.
+Without resenting your content.
+
+What's YOUR sustainable consistency?
+
+---
+
+## Hashtags
+#contentconsistency #creatorlife #contentcreation #sustainablecreator #contentadvice
+
+---
+
+## Alt Text
+Creator sitting at a minimal desk workspace, looking relaxed while working on content.
+
+---
+```
+
+---
+
+## Example: Long Caption (Story)
+
+```markdown
+---
+type: content-script
+format: static
+date: 2026-01-19
+length: long
+concept_source: user-provided
+status: draft
+---
+
+# Business Lesson Story Static Post
+
+Generated: 2026-01-19
+Length: Long
+Concept: Personal story with lesson
+
+---
+
+## Image Context
+
+Candid photo of creator, or carousel cover that invites reading the caption.
+
+---
+
+## Caption
+
+Two years ago, I almost quit.
+
+Not because of money. Revenue was actually up.
+
+But I was miserable.
+
+Working 70-hour weeks on a business I'd built to have freedom.
+Missing dinners. Missing weekends. Missing the point.
+
+I remember sitting in my office at 11pm on a Tuesday, thinking:
+"This isn't what I signed up for."
+
+So I made a decision that felt crazy at the time.
+
+I cut my revenue goal in half.
+
+Not because I couldn't hit the higher number.
+Because hitting it was costing me everything else.
+
+I restructured around margin, not scale.
+Raised prices. Dropped clients. Said no more than yes.
+
+The first month was terrifying.
+The third month was liberating.
+Six months in, I made MORE money working LESS hours.
+
+But here's the real lesson:
+
+I had to give myself permission to want something different.
+
+The hustle narrative is so loud. Grow. Scale. More.
+
+But nobody asks: More of what? At what cost?
+
+If you're grinding toward something that doesn't feel right, this is your permission slip.
+
+Define YOUR version of success.
+Then build toward that.
+
+Nothing else matters.
+
+What would change if you gave yourself that permission?
+
+---
+
+## Hashtags
+#businesslessons #entrepreneurlife #sustainablebusiness #worklifebalance #businessowner #solopreneur
+
+---
+
+## Alt Text
+Candid portrait photo of creator looking thoughtful, natural lighting, authentic expression.
+
+---
+```
+
+---
+
+## Hook Patterns for Static Posts
+
+Since the hook is critical, here are proven patterns:
+
+### Curiosity Hooks
+- "The one thing nobody tells you about [topic]"
+- "This changed everything."
+- "I was wrong about [common belief]"
+
+### Confession Hooks
+- "I have a confession."
+- "I need to be honest about something."
+- "Here's what I've never shared..."
+
+### Contrast Hooks
+- "What they tell you: [advice]. What actually works: [truth]"
+- "[Common belief] is a lie."
+- "Stop doing [X]. Start doing [Y]."
+
+### Story Hooks
+- "Two years ago, I [pivotal moment]"
+- "I'll never forget the day..."
+- "This is the story I've been afraid to tell."
+
+### Direct Value Hooks
+- "Save this for later:"
+- "The cheat code for [outcome]:"
+- "If you're struggling with [problem], read this."
+
+---
+
+## Image-Caption Relationship
+
+The caption and image should complement, not compete:
+
+| Image Type | Caption Approach |
+|------------|------------------|
+| Text graphic with tip | Caption expands on the tip |
+| Photo of you | Caption tells a personal story |
+| Quote graphic | Caption adds context or story behind quote |
+| Behind-the-scenes | Caption shares the lesson from the moment |
+| Aesthetic shot | Caption provides substance (image is the hook) |
+
+---
+
+## Soft CTAs for Static Posts
+
+| Goal | CTA Example |
+|------|-------------|
+| Comments | "What's your take? Comment below." |
+| Saves | "Save this for when you need it." |
+| Shares | "Tag someone who needs to hear this." |
+| DMs | "DM me [word] and I'll send you [resource]." |
+| Follows | "Follow for more like this." |
+
+Choose ONE CTA per post. Multiple asks = no action.
+
+---
+
+## Hashtag Strategy
+
+**Quantity:** 5-15 hashtags (debate exists, test for your account)
+
+**Mix:**
+- 2-3 broad (high volume, high competition)
+- 3-5 medium (your niche)
+- 2-3 specific (your sub-niche)
+
+**Placement:**
+- In caption (more casual)
+- First comment (cleaner look)
+- Either works - consistency matters more than placement
+
+---
+
+## Voice Checklist
+
+Before finalizing:
+
+- [ ] First line would make YOU tap "more"
+- [ ] Reads in the creator's voice (not generic)
+- [ ] Uses their vocabulary
+- [ ] One clear CTA (not multiple asks)
+- [ ] No AI tells
+- [ ] Caption enhances the image (not redundant)

--- a/.claude/skills/content/references/video-script-template.md
+++ b/.claude/skills/content/references/video-script-template.md
@@ -1,0 +1,313 @@
+# Video Script Template
+
+Template for Reels and TikTok scripts. Optimized for talking-head, camera-facing delivery.
+
+---
+
+## Output Format
+
+Save scripts to: `outputs/content-scripts/YYYY-MM-DD-[concept-slug].md`
+
+Example: `outputs/content-scripts/2026-01-19-morning-routine-story.md`
+
+---
+
+## File Structure
+
+```markdown
+---
+type: content-script
+format: video
+date: YYYY-MM-DD
+framework: [educational | story | transformation | problem-solution | contrarian]
+duration: [15s | 30s | 45s | 60s | 90s]
+concept_source: [mined | user-provided | reference-angle]
+status: draft
+---
+
+# [Concept Title] Video Scripts
+
+Generated: YYYY-MM-DD
+Framework: [Framework name]
+Target duration: [X seconds]
+Concept: [Brief description of the core idea]
+
+---
+
+## Script 1: [Variation name]
+
+### HOOK (0-3 seconds)
+[Text - spoken word, exactly as delivered]
+
+### RETAIN (3-X seconds)
+[Body content - the value/story/teaching]
+
+### REWARD (final 5-15 seconds)
+[Payoff + soft CTA]
+
+---
+
+### Delivery Notes
+- **Energy:** [High / Conversational / Intimate / Intense]
+- **Pacing:** [Fast / Medium / Slow]
+- **Visual suggestion:** [Direct to camera / Walking / Sitting / B-roll option]
+
+### Caption
+[Instagram/TikTok caption to accompany]
+
+### Hashtags (optional)
+#tag1 #tag2 #tag3
+
+---
+
+## Script 2: [Variation name]
+
+[Same structure]
+
+---
+
+## Script 3: [Variation name]
+
+[Same structure]
+
+---
+```
+
+---
+
+## Duration Guidelines
+
+| Length | Best For | Hook Time | Body Time | Reward Time |
+|--------|----------|-----------|-----------|-------------|
+| 15s | Quick tip, single point | 2s | 10s | 3s |
+| 30s | Standard educational | 3s | 20s | 7s |
+| 45s | Story or multiple tips | 3s | 35s | 7s |
+| 60s | In-depth story | 3s | 45s | 12s |
+| 90s | Complex story/tutorial | 5s | 70s | 15s |
+
+---
+
+## Example: Educational (30 seconds)
+
+```markdown
+---
+type: content-script
+format: video
+date: 2026-01-19
+framework: educational
+duration: 30s
+concept_source: mined
+status: draft
+---
+
+# 3 Content Mistakes Video Scripts
+
+Generated: 2026-01-19
+Framework: Educational
+Target duration: 30 seconds
+Concept: Common content creation mistakes and how to fix them
+
+---
+
+## Script 1: Direct delivery
+
+### HOOK (0-3 seconds)
+3 content mistakes that are killing your engagement.
+
+### RETAIN (3-23 seconds)
+Mistake one: No hook.
+Every scroll is a decision. Give them a reason to stop.
+
+Mistake two: Too many ideas.
+One post. One idea. That's it.
+
+Mistake three: No CTA.
+If you don't tell them what to do, they'll do nothing.
+
+### REWARD (23-30 seconds)
+The fix? Hook. One idea. Clear ask.
+
+Save this if you needed that reminder.
+
+---
+
+### Delivery Notes
+- **Energy:** Conversational but confident
+- **Pacing:** Medium - pause between mistakes
+- **Visual suggestion:** Direct to camera, can use finger counts for "1, 2, 3"
+
+### Caption
+The third one is the one most people skip.
+
+Which mistake are you guilty of? (I'm definitely a recovering #2)
+
+Save this for your next content day.
+```
+
+---
+
+## Example: Story-Based (60 seconds)
+
+```markdown
+---
+type: content-script
+format: video
+date: 2026-01-19
+framework: story
+duration: 60s
+concept_source: user-provided
+status: draft
+---
+
+# Business Pivot Story Video Scripts
+
+Generated: 2026-01-19
+Framework: Story-Based
+Target duration: 60 seconds
+Concept: Personal story about pivoting business approach
+
+---
+
+## Script 1: Vulnerable version
+
+### HOOK (0-3 seconds)
+The hardest lesson I learned building my business.
+
+### RETAIN (3-50 seconds)
+Two years ago, I hit rock bottom.
+
+Revenue was up. But I was miserable.
+80-hour weeks. Missing everything that mattered.
+
+I tried every productivity hack.
+Time blocking. Delegation. Systems.
+Nothing changed.
+
+Then I realized something.
+I wasn't overworked.
+I was doing the wrong work.
+
+Building someone else's version of success.
+Chasing a number instead of a feeling.
+
+So I burned it down. Not the business. The approach.
+
+### REWARD (50-60 seconds)
+Now I make half what I used to.
+And I've never been happier.
+
+If you're grinding toward something that doesn't feel right...
+Maybe it's not about working harder.
+
+Comment if you've been there.
+
+---
+
+### Delivery Notes
+- **Energy:** Intimate, reflective, building to realization
+- **Pacing:** Slower in the middle, speeds up at realization
+- **Visual suggestion:** Sitting down, conversational, maybe looking away at key moments
+
+### Caption
+I used to measure success by the wrong things.
+
+Revenue. Followers. Being "busy."
+
+Now I measure it by how I feel on Sunday nights.
+
+What changed for you?
+```
+
+---
+
+## Example: Transformation (45 seconds)
+
+```markdown
+---
+type: content-script
+format: video
+date: 2026-01-19
+framework: transformation
+duration: 45s
+concept_source: mined
+status: draft
+---
+
+# Content Strategy Shift Video Scripts
+
+Generated: 2026-01-19
+Framework: Transformation
+Target duration: 45 seconds
+Concept: Before/after of content strategy change
+
+---
+
+## Script 1: Contrast focused
+
+### HOOK (0-3 seconds)
+What changed when I stopped trying to go viral.
+
+### RETAIN (3-38 seconds)
+BEFORE:
+Six months ago, I was obsessed with views.
+Posting three times a day.
+Copying trends. Chasing algorithms.
+
+My content was everywhere.
+My business? Nowhere.
+
+TURNING POINT:
+Then I asked one question:
+What do I actually want people to DO?
+Not watch. Do.
+
+AFTER:
+Now I post half as much.
+Get fewer views.
+And my DMs are full of people ready to buy.
+
+### REWARD (38-45 seconds)
+The shift?
+I stopped making content for the algorithm.
+Started making content for my actual customer.
+
+Save this if you needed to hear it.
+
+---
+
+### Delivery Notes
+- **Energy:** Starts frustrated, ends confident
+- **Pacing:** Fast in "before," slows at turning point
+- **Visual suggestion:** Can use split screen visual or just delivery shift
+
+### Caption
+Views are vanity. Sales are sanity.
+
+I learned this the hard way.
+```
+
+---
+
+## Voice Checklist
+
+Before finalizing any script, verify:
+
+- [ ] Sounds like the creator (not a copywriter)
+- [ ] Uses their vocabulary (from voice.md)
+- [ ] Matches their energy level
+- [ ] Uses contractions naturally
+- [ ] No AI tells ("dive into", "unlock", "game-changer", "journey")
+- [ ] Avoids phrases from their "never say" list
+
+---
+
+## Adaptation Notes
+
+When adapting a mined concept:
+
+1. **Keep the structure** - The framework that worked
+2. **Change the specifics** - Examples, numbers, personal details
+3. **Add their voice** - Vocabulary, energy, quirks
+4. **Relate to their offer** - How does this connect to what they sell?
+
+Never copy hooks verbatim. Adapt the PATTERN, not the words.

--- a/.claude/skills/help/SKILL.md
+++ b/.claude/skills/help/SKILL.md
@@ -42,6 +42,7 @@ Comprehensive help for Main Branch. Answer questions, troubleshoot issues, expla
 | "How do I get started?" / setup | [getting-started.md](references/getting-started.md) |
 | "Which skill should I use?" | [skills-guide.md](references/skills-guide.md) |
 | "How do I migrate from GPT?" | [gpt-migration.md](references/gpt-migration.md) |
+| Content questions / "Reels" / "TikTok" / "organic" | [content-help.md](references/content-help.md) |
 | Skool-specific questions | [skool-help.md](references/skool-help.md) |
 | "How do I make outputs better?" / "What next?" | [making-outputs-better.md](references/making-outputs-better.md) |
 | "Can I contribute?" | [becoming-contributor.md](references/becoming-contributor.md) |
@@ -147,6 +148,7 @@ Load these as needed based on the question:
 - [getting-started.md](references/getting-started.md) - Setup guide
 - [skills-guide.md](references/skills-guide.md) - When to use which skill
 - [gpt-migration.md](references/gpt-migration.md) - Bringing GPT knowledge over
+- [content-help.md](references/content-help.md) - Organic content creation (Reels, TikTok, carousels)
 - [skool-help.md](references/skool-help.md) - Skool community specifics
 - [making-outputs-better.md](references/making-outputs-better.md) - Improving quality, next steps
 - [becoming-contributor.md](references/becoming-contributor.md) - Contributing back to Main Branch

--- a/.claude/skills/help/references/content-help.md
+++ b/.claude/skills/help/references/content-help.md
@@ -1,0 +1,211 @@
+# Content Skill Help
+
+Help for the `/content` skill - mining competitors and generating organic content scripts.
+
+---
+
+## What is /content?
+
+The `/content` skill helps you:
+
+1. **Mine competitor content** - Find what's working for others in your niche
+2. **Extract winning concepts** - Identify hooks, structures, and angles that perform
+3. **Generate scripts** - Create Reels, TikTok, and carousel content in your voice
+
+It's for **organic content** (free reach), not **paid ads** (use `/ad-video-scripts` for ads).
+
+---
+
+## When to Use /content
+
+Use `/content` when you want to:
+
+- Research what's working for competitors
+- Get ideas for Reels or TikTok videos
+- Create carousel content
+- Write captions for static posts
+- Find proven angles to adapt
+
+---
+
+## Modes
+
+### Full Flow: `/content`
+
+The complete workflow:
+1. Identify competitors
+2. Mine their top content
+3. Extract winning concepts
+4. Generate scripts in your voice
+
+### Mine Only: `/content mine`
+
+Just research, no script generation:
+- Extracts competitor content data
+- Identifies top performers
+- Saves research to `research/` folder
+- Use when you want ideas but will generate later
+
+### Video: `/content video "topic"`
+
+Generate a Reels/TikTok script:
+- From a mined concept
+- From a topic you provide
+- Applies your voice from `reference/core/voice.md`
+
+### Carousel: `/content carousel "topic"`
+
+Generate multi-slide carousel:
+- 7-10 slides by default
+- Hook slide, value slides, CTA slide
+- Ready to design
+
+### Static: `/content static "topic"`
+
+Generate single-post caption:
+- Hook line, body, soft CTA
+- Matches your voice
+- Hashtag suggestions included
+
+---
+
+## How It Differs from /ad-video-scripts
+
+| Aspect | /ad-video-scripts | /content |
+|--------|-------------------|----------|
+| **Purpose** | Paid traffic conversion | Organic reach |
+| **Tone** | Direct response, urgency | Value-first, authentic |
+| **CTA** | Hard (buy now, link in bio) | Soft (save, follow, comment) |
+| **Framework** | AIDA, PAS | Hook-Retain-Reward |
+| **Goal** | Clicks and sales | Views, saves, follows |
+
+**Rule of thumb:**
+- Spending money to show it? → `/ad-video-scripts`
+- Posting to your feed? → `/content`
+
+---
+
+## Required Reference Files
+
+The skill needs these files in your business repo:
+
+| File | Required? | Purpose |
+|------|-----------|---------|
+| `reference/core/offer.md` | Yes | Context for CTAs |
+| `reference/core/audience.md` | Yes | Who you're creating for |
+| `reference/core/voice.md` | Yes | How you sound on camera |
+| `reference/competitors/handles.md` | No | List of competitors to mine |
+
+If missing core files, run `/setup` first.
+
+---
+
+## Common Questions
+
+### "How do I know which competitors to mine?"
+
+Look for:
+- **Direct competitors** - Same offer, same audience
+- **Adjacent creators** - Similar audience, different offer
+- **Aspirational accounts** - Bigger creators you admire
+
+You want 3-5 accounts minimum. Save them in `reference/competitors/handles.md`.
+
+### "What makes content 'top performing'?"
+
+Engagement rate = (likes + comments) / followers
+
+Top 10-20% by engagement rate are "winners" worth studying.
+
+### "Can I use the exact hooks I find?"
+
+No. Adapt the PATTERN, not the words.
+
+**Example:**
+- Competitor hook: "3 things I wish I knew before starting my agency"
+- Your adaptation: "3 things I wish I knew before my first launch"
+
+Same structure. Different words. Your topic.
+
+### "How is voice applied?"
+
+The skill reads `reference/core/voice.md` and:
+- Matches your tone (casual, professional, energetic)
+- Uses your vocabulary
+- Avoids your "never say" phrases
+- Adds your verbal quirks
+
+The more detailed your voice file, the better the output.
+
+### "What if my content feels generic?"
+
+Usually means:
+1. Voice file is too thin → Run `/enrich` to add more
+2. Topic is too broad → Be more specific
+3. Missing personal examples → Add stories to your reference
+
+### "Can I save winning angles I discover?"
+
+Yes. Route to `/think codify` to add them to `reference/proof/angles/`.
+
+This makes them available for future generations across all skills.
+
+---
+
+## Workflow Example
+
+```
+1. /content mine
+   → Competitor data extracted
+   → Top 15 concepts identified
+   → Saved to research/
+
+2. Review concepts with Claude
+   → Select 5 to adapt
+
+3. /content video "concept 1"
+   → Script generated in your voice
+   → Saved to outputs/
+
+4. Repeat for carousel, static as needed
+
+5. (Optional) /think codify
+   → Save best angles to reference
+```
+
+---
+
+## Troubleshooting
+
+### "Apify isn't working"
+
+The skill can work without Apify. Share:
+- Screenshots of top posts
+- URLs to content you want to study
+- Notes on what you observed
+
+### "Output doesn't sound like me"
+
+Check `reference/core/voice.md`:
+- Is it detailed enough?
+- Does it have examples of how you talk?
+- Does it list phrases to avoid?
+
+Run `/enrich` to add more voice context.
+
+### "I don't know what to create about"
+
+Run `/content mine` first. Let competitor research inspire topics.
+
+Or run `/think research "content ideas for [your niche]"` to brainstorm.
+
+---
+
+## Related Skills
+
+| Skill | When to Use Instead |
+|-------|---------------------|
+| `/ad-video-scripts` | Paid video ads |
+| `/ad-static` | Paid image ads |
+| `/think` | Researching content strategy |
+| `/enrich` | Adding more voice/context |

--- a/.claude/skills/help/references/skills-guide.md
+++ b/.claude/skills/help/references/skills-guide.md
@@ -87,6 +87,26 @@ See [the-think-cycle.md](the-think-cycle.md) for deep dive.
 
 ---
 
+### /content - Organic Content
+**Use when:** Creating Reels, TikTok, or carousel content (not paid ads).
+
+**What it does:**
+- Mines competitor content for winning concepts
+- Extracts hooks, structures, and angles that perform
+- Generates scripts in your voice
+- Supports video, carousel, and static formats
+
+**Modes:**
+- `/content` - Full flow (mine -> select -> generate)
+- `/content mine` - Research competitors only
+- `/content video "topic"` - Generate Reels/TikTok script
+- `/content carousel "topic"` - Generate carousel slides
+- `/content static "topic"` - Generate post caption
+
+**Key difference from /ad-video-scripts:** Organic uses soft CTAs (save, follow) while ads use hard CTAs (buy, sign up).
+
+---
+
 ### /ad-review - Compliance Check
 **Use when:** Before running ads, want to check for issues.
 
@@ -132,9 +152,12 @@ What do you need?
 ├── Research or decide something?
 │   └── /think
 │
-├── Create ad copy?
+├── Create ad copy? (paid)
 │   ├── Image ads → /ad-static
 │   └── Video scripts → /ad-video-scripts
+│
+├── Create organic content? (free reach)
+│   └── /content (Reels, TikTok, carousels)
 │
 ├── Check ads before running?
 │   └── /ad-review

--- a/.claude/skills/start/SKILL.md
+++ b/.claude/skills/start/SKILL.md
@@ -8,7 +8,7 @@ description: |
   (4) User seems lost or unsure which skill to use
 
   Routes to: /setup (new users), /enrich (add context), /think (research/decide),
-  /ad-static, /ad-video-scripts, /ad-review, /skool-manager, /skool-vsl-scripts
+  /ad-static, /ad-video-scripts, /ad-review, /content, /skool-manager, /skool-vsl-scripts
 ---
 
 # Start
@@ -38,6 +38,7 @@ Single entry point for Main Branch. Detect user state, route to the right skill.
 │   ├── "research" / "decide" ────────→ /think
 │   ├── "ads" / "copy" ───────────────→ /ad-static or /ad-video-scripts
 │   ├── "review" / "compliance" ──────→ /ad-review
+│   ├── "content" / "organic" ────────→ /content
 │   ├── "skool" / "community" ────────→ /skool-manager
 │   ├── "vsl" / "sales video" ────────→ /skool-vsl-scripts
 │   ├── "help" / questions ───────────→ /help
@@ -147,6 +148,7 @@ If user is ready to work, ask or infer intent:
 > - **Research a topic** → `/think`
 > - **Create ad copy** → `/ad-static` (images) or `/ad-video-scripts` (video)
 > - **Review ads for compliance** → `/ad-review`
+> - **Create organic content** → `/content` (Reels, TikTok, carousels)
 > - **Manage Skool community** → `/skool-manager`
 > - **Write a VSL script** → `/skool-vsl-scripts`
 > - **Add more context** → `/enrich`
@@ -191,6 +193,7 @@ Quick overview to give before routing:
 | `/ad-static` | Generate image ad copy | Need Meta ad copy |
 | `/ad-video-scripts` | Generate video ad scripts | Need 15-60s video scripts |
 | `/ad-review` | Check ads for compliance | Before running ads |
+| `/content` | Mine competitors, generate organic scripts | Reels, TikTok, carousels |
 | `/skool-manager` | Manage community engagement | Daily Skool tasks |
 | `/skool-vsl-scripts` | Write video sales letters | Need VSL for about page |
 
@@ -207,8 +210,9 @@ Use these to auto-detect what user wants:
 | "add", "update", "more context", "new testimonials" | `/enrich` |
 | "research", "decide", "figure out", "explore" | `/think` |
 | "ads", "copy", "static", "image ads", "primaries" | `/ad-static` |
-| "video", "scripts", "hooks", "ugc" | `/ad-video-scripts` |
+| "video ads", "ad scripts", "hooks", "ugc" | `/ad-video-scripts` |
 | "review", "compliance", "ftc", "check" | `/ad-review` |
+| "content", "reels", "tiktok", "organic", "mine", "competitors", "carousel" | `/content` |
 | "skool", "community", "posts", "respond" | `/skool-manager` |
 | "vsl", "sales video", "about page video" | `/skool-vsl-scripts` |
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Once set up, you can:
 - Research topics and document decisions
 - Generate batches of ad copy in your voice
 - Create video scripts for Meta ads
+- Mine competitor content and create organic Reels/TikTok/carousels
 - Write VSL scripts for your community
 - Review ads for compliance before you run them
 - Manage Skool community engagement
@@ -167,6 +168,7 @@ No prompt engineering. No explaining what you want. Just type the command.
 | `/ad-static` | Create static image ad copy for Meta |
 | `/ad-video-scripts` | Write 15-60 second video ad scripts |
 | `/ad-review` | Check ads for FTC and Meta compliance |
+| `/content` | Mine competitors, create Reels/TikTok/carousel scripts |
 | `/skool-vsl-scripts` | Write video sales letter scripts |
 | `/skool-manager` | Respond to Skool community posts |
 

--- a/docs/BEGINNER-SETUP.md
+++ b/docs/BEGINNER-SETUP.md
@@ -96,6 +96,19 @@ Same engine + different data = outputs tailored to each business.
 
 ---
 
+## What You Can Do
+
+Once set up, type these commands:
+
+- `/think` - Research and make decisions
+- `/ad-static` - Generate image ad copy
+- `/ad-video-scripts` - Create video ad scripts
+- `/content` - Mine competitors, create Reels/TikTok/carousels
+- `/ad-review` - Check ads for compliance
+- `/help` - Get answers to any question
+
+---
+
 ## Getting Help
 
 - **Stuck?** Post in Skool with a screenshot. Tag @Devon.


### PR DESCRIPTION
## Summary

- Adds `/content` skill with modes: mine, video, carousel, static
- Creates 5 reference files for organic content frameworks and templates
- Updates `/start`, `/help`, README, and BEGINNER-SETUP with new skill routing
- Implements Hook-Retain-Reward framework for organic (vs AIDA/PAS for paid ads)

Closes #9

## Files Added

| File | Purpose |
|------|---------|
| `.claude/skills/content/SKILL.md` | Main skill with mode routing |
| `references/organic-frameworks.md` | 5 content frameworks with timing |
| `references/mining-template.md` | Competitor research output template |
| `references/video-script-template.md` | Reels/TikTok script template |
| `references/carousel-template.md` | Multi-slide carousel template |
| `references/static-template.md` | Single-post caption template |
| `.claude/skills/help/references/content-help.md` | Help documentation |

## Integration Points

- Routes from `/start` via keywords: content, reels, tiktok, organic, mine, competitors, carousel
- Integrates with `/think codify` for saving winning angles
- Reads voice from `reference/core/voice.md` for adaptation
- Supports Apify MCP for Instagram data extraction (with manual fallback)

## Test plan

- [ ] Run `/content` and verify mode detection
- [ ] Run `/content mine` and confirm research file saves to `research/`
- [ ] Run `/content video "topic"` and confirm script generation
- [ ] Verify `/start` routes correctly on "organic content" keyword
- [ ] Verify `/help content` returns help documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)