### PR TITLE
[add] Task tracking options and decisions-as-anchors pattern

### DIFF
--- a/.claude/skills/help/SKILL.md
+++ b/.claude/skills/help/SKILL.md
@@ -35,6 +35,7 @@ Comprehensive help for Main Branch. Answer questions, troubleshoot issues, expla
 | "What are the two repos?" / "What's vip?" | [two-repos.md](references/two-repos.md) |
 | "Why this approach?" / "How does this help me?" | [philosophy.md](references/philosophy.md) |
 | "How do I use /think?" / "Research and decisions" | [the-think-cycle.md](references/the-think-cycle.md) |
+| "How do I track tasks?" / "Where did I leave off?" | [task-tracking-options.md](references/task-tracking-options.md) |
 | "command not found" / errors / MCP issues | [troubleshooting.md](references/troubleshooting.md) |
 | "How do I set up Apify?" / MCP setup | [troubleshooting.md](references/troubleshooting.md) or route to `/content` |
 | "How do I get started?" / setup | Route to `/setup` or `/start` |
@@ -82,6 +83,7 @@ Load these as needed based on the question:
 - [philosophy.md](references/philosophy.md) - Vision, compound knowledge, why this works
 - [terminal-basics.md](references/terminal-basics.md) - Terminal 101 for complete beginners
 - [the-think-cycle.md](references/the-think-cycle.md) - The core loop that makes everything work
+- [task-tracking-options.md](references/task-tracking-options.md) - How to track work across sessions
 - [two-repos.md](references/two-repos.md) - Engine + data model explained
 - [troubleshooting.md](references/troubleshooting.md) - Error fixes, MCP setup, session resuming
 - Route to `/setup` or `/start` for setup questions

--- a/.claude/skills/help/references/philosophy.md
+++ b/.claude/skills/help/references/philosophy.md
@@ -80,6 +80,25 @@ Each gets its own repo. Same skills, different data, different outputs.
 
 ---
 
+## Conversations Are Disposable
+
+Counterintuitive but critical: **if you're using the system correctly, conversations become disposable.**
+
+The instinct to "save everything" is fear of losing context. That fear is the symptom — you haven't extracted what matters.
+
+**In a good session, value migrates to files:**
+- Insight? → `research/`
+- Decision? → `decisions/`
+- Truth changed? → `reference/`
+
+The conversation is scaffolding. The building stands without it.
+
+**The test:** Feel the urge to save a conversation? Stop. Ask: "What actually mattered?" Put that in the right file. Let the rest go.
+
+**For tracking work across sessions:** See [task-tracking-options.md](task-tracking-options.md).
+
+---
+
 ## The Endgame
 
 Over time, your reference becomes a comprehensive, accurate representation of your business. Every ad, email, piece of content draws from this truth.

--- a/.claude/skills/help/references/task-tracking-options.md
+++ b/.claude/skills/help/references/task-tracking-options.md
@@ -1,0 +1,213 @@
+# Task Tracking Options
+
+How to track ongoing work across sessions. Pick one approach and commit.
+
+---
+
+## The Core Insight
+
+**If you need to "save the conversation," you didn't extract what mattered.**
+
+The system is designed so valuable outputs become files:
+- Insight? → `research/`
+- Decision? → `decisions/`
+- Truth changed? → `reference/`
+
+When you do this, conversations become disposable. The value lives in files.
+
+---
+
+## The Spectrum
+
+| Approach | Token Cost | Setup | Best For |
+|----------|------------|-------|----------|
+| **decisions/** as anchors | Lowest | None | People who think in choices |
+| **GitHub Issues** | Low | `gh` CLI | Developers, CLI-native |
+| **focus.md** file | Low | Create file | One status file preference |
+| **External (Linear/Notion)** | Highest | MCP setup | Teams, complex workflows |
+
+**Pick one.** Record your preference in CLAUDE.md so `/start` knows.
+
+---
+
+## Option 1: Decisions as Task Anchors (Recommended)
+
+Use decision files for substantial work. The file IS your task tracker.
+
+**How it works:**
+
+```markdown
+---
+type: decision
+status: proposed  # ← This is your progress indicator
+---
+
+# Decision: New Pricing Strategy
+
+## Action Items
+
+- [ ] Research competitor pricing
+- [ ] Update reference/core/offer.md
+- [ ] Create new angle in proof/angles/
+
+## Other actions
+
+- [ ] Set up Stripe tiers
+- [ ] Update sales page
+```
+
+**Status progression:**
+- `proposed` → I'm working on this
+- `accepted` → Decision made, executing
+- `codified` → Done, reference updated
+
+**Why it works:**
+- No separate system to maintain
+- Rationale captured alongside tasks
+- Check `decisions/` folder to see where you left off
+- Natural audit trail
+
+**Best for:** Strategic work, anything where "why" matters.
+
+---
+
+## Option 2: GitHub Issues
+
+Native task management in your repo. Claude can read/write via `gh` CLI.
+
+**Setup:**
+```bash
+# Ensure gh is authenticated
+gh auth status
+```
+
+**Usage:**
+```bash
+# Create issue
+gh issue create --title "Implement new pricing" --body "Tasks: ..."
+
+# List open issues
+gh issue list
+
+# Close when done
+gh issue close 123
+```
+
+**Why it works:**
+- Native to repo (no external tool)
+- `gh` CLI uses minimal tokens
+- Labels, milestones, assignments
+- Works across devices via GitHub
+
+**Best for:** Developers, CLI-native users, detailed task breakdown.
+
+---
+
+## Option 3: focus.md File
+
+Single lightweight file showing current state.
+
+**Create:** `reference/focus.md`
+
+```markdown
+# Current Focus
+
+## Priority
+[One sentence: what you're trying to accomplish]
+
+## Next Actions
+- [ ] Action 1
+- [ ] Action 2
+- [ ] Action 3
+
+## Blockers
+- [Thing preventing progress]
+
+## Session Notes
+[Quick thoughts — delete after acting on them]
+
+---
+*Last updated: 2026-01-21*
+```
+
+**Why it works:**
+- One file to check
+- Lightweight (~20 lines)
+- `/start` can scan it quickly
+
+**Best for:** People who want a single "where am I?" file.
+
+**Warning:** Easy to let this go stale. Update it or delete it.
+
+---
+
+## Option 4: External Tools (Linear, Notion, etc.)
+
+Full project management via MCP.
+
+**Setup:** Configure MCP server for your tool.
+
+**Token cost:** Highest — each query/update costs tokens.
+
+**Why use it:**
+- Team collaboration
+- Complex workflows
+- Visual boards, timelines
+- Integrations with other tools
+
+**Best for:** Teams, complex multi-person projects.
+
+**Trade-off:** More UX, more tokens. Only worth it if you need the features.
+
+---
+
+## Recording Your Preference
+
+Add to your business repo's CLAUDE.md:
+
+```markdown
+## Workflow Preferences
+
+**Task tracking:** decisions/ as anchors
+```
+
+Or:
+```markdown
+## Workflow Preferences
+
+**Task tracking:** GitHub Issues
+```
+
+This tells `/start` how to help you pick up where you left off.
+
+---
+
+## What NOT to Do
+
+**Don't save entire conversations.**
+
+- Full of noise (tangents, corrections, false starts)
+- Not synthesized — Claude has to sift through it
+- Goes stale immediately
+- Eats tokens on context that isn't actionable
+- Doesn't scale
+
+**The fix:** When a conversation has value, extract it into the right file type. Let the conversation go.
+
+---
+
+## Quick Decision Guide
+
+**"I have a big strategic choice to make"** → Decision file
+
+**"I have 10 small tasks"** → GitHub Issues or focus.md
+
+**"My team needs to see progress"** → External tool
+
+**"I just want to not forget where I was"** → focus.md or check recent `decisions/`
+
+---
+
+## Next Step
+
+Pick one approach. Add your preference to CLAUDE.md. Use it consistently for a week. Adjust if needed.

--- a/.claude/skills/help/references/the-think-cycle.md
+++ b/.claude/skills/help/references/the-think-cycle.md
@@ -1,6 +1,6 @@
 # The /think Cycle
 
-The heart of Main Branch. Your project management solution for running anything.
+The heart of Main Branch. Research, decisions, and reference files ARE your project management.
 
 ---
 
@@ -123,6 +123,56 @@ If you can't summarize it, you don't understand it yet.
 **Codify:** Execute migration, update reference files.
 
 **Result:** Documented process AND knowledge now in Main Branch.
+
+---
+
+## Decisions as Task Anchors
+
+For substantial work, **create a decision file early** — even before you've fully decided.
+
+**How it works:**
+
+| Status | Meaning |
+|--------|---------|
+| `proposed` | I'm working on this, exploring options |
+| `accepted` | Decision made, now executing |
+| `codified` | Done — reference files updated |
+
+**The decision file becomes your task tracker:**
+- `## Action Items` = Your task list (with checkboxes)
+- `## Other actions` = Non-reference tasks
+- `## Review Date` = When to revisit
+
+**Example workflow:**
+
+1. Start a big project → Create `decisions/2026-01-21-new-pricing-strategy.md` with `status: proposed`
+2. Research, think, iterate → Update the file as you learn
+3. Make the call → Change to `status: accepted`, finalize action items
+4. Execute → Check off action items as you complete them
+5. Finish → Change to `status: codified`
+
+**Why this works:**
+- Progress is visible in the file itself
+- Rationale is captured as you go
+- Next session, check your `decisions/` folder — you know exactly where you left off
+- No separate task manager needed
+
+**For smaller tasks:** Just do them. Decision files are for substantial work where the "why" matters.
+
+---
+
+## Task Tracking Options
+
+Different people prefer different approaches. See [task-tracking-options.md](task-tracking-options.md) for the full spectrum:
+
+| Approach | Best For |
+|----------|----------|
+| **decisions/** as anchors | People who think in choices |
+| **GitHub Issues** | Developers, CLI-native users |
+| **focus.md** file | People who want one status file |
+| **External tools** | Teams, complex workflows |
+
+Pick one and commit. The system adapts.
 
 ---
 

--- a/.claude/skills/setup/references/claude-md-guide.md
+++ b/.claude/skills/setup/references/claude-md-guide.md
@@ -123,6 +123,14 @@ This repo contains your **business data**. It's powered by **vip** (the engine).
 | **On-demand** | research/, decisions/ | When reasoning about choices |
 | **Deep reference** | reference/brand/, reference/proof/ | When writing copy |
 | **Domain** | reference/domain/ | When business-type matters |
+
+---
+
+## Workflow Preferences
+
+**Task tracking:** [decisions/ | GitHub Issues | focus.md | External: ___]
+
+This tells `/start` how you prefer to track ongoing work.
 ```
 
 ---
@@ -140,6 +148,7 @@ This repo contains your **business data**. It's powered by **vip** (the engine).
 
 ### Should Have (if exists)
 - Key decisions index
+- Workflow preferences (task tracking approach)
 - Best sellers / top products
 - Current strategy
 - Known gaps

--- a/.claude/skills/think/SKILL.md
+++ b/.claude/skills/think/SKILL.md
@@ -332,6 +332,30 @@ Research File → Decision File → Reference Files
 
 ---
 
+## Decisions as Task Anchors
+
+For substantial work, **create a decision file early** — even before you've fully decided. The decision file becomes your task tracker.
+
+**How it works:**
+
+1. Start project → Create `decisions/YYYY-MM-DD-topic.md` with `status: proposed`
+2. Research and iterate → Update the file as you learn
+3. Make the call → Change to `status: accepted`
+4. Execute → Check off action items as you complete them
+5. Finish → Change to `status: codified`
+
+**Why this works:**
+- Progress is visible in the file
+- Rationale captured as you go
+- Next session: check `decisions/` to see where you left off
+- No separate task manager needed
+
+**The `## Other actions` section** captures non-reference tasks (set up Stripe, update sales page, etc.).
+
+**For smaller tasks:** Just do them. Decision files are for substantial work where the "why" matters.
+
+---
+
 ## When NOT to Use
 
 - Quick factual questions (just ask)


### PR DESCRIPTION
- Add task-tracking-options.md: comprehensive guide to tracking work
- Add "Conversations Are Disposable" to philosophy.md
- Add "Decisions as Task Anchors" to /think skill and think-cycle help
- Add workflow preferences to CLAUDE.md template guide
- Update /help router for task tracking questions

Inspired by community feedback on conversation persistence.