### PR TITLE
Integrate Claude's new tasks feature into /think

### DIFF
--- a/.claude/skills/think/SKILL.md
+++ b/.claude/skills/think/SKILL.md
@@ -79,7 +79,9 @@ Every research output needs:
 
 Present options with pros/cons. Document choice and rationale.
 
-### 6. Action Items
+### 6. Action Items + Tasks
+
+List action items in the decision file AND create Claude tasks:
 
 ```markdown
 ## Action Items
@@ -87,9 +89,22 @@ Present options with pros/cons. Document choice and rationale.
 - [ ] Create reference/proof/angles/risk-reversal.md
 ```
 
+**Create tasks for execution tracking:**
+```
+TaskCreate: "Update offer.md with guarantee section"
+TaskCreate: "Create risk-reversal.md angle file"
+```
+
+Tasks provide:
+- Spinner showing current work
+- Dependencies between items
+- Session-level progress tracking
+
 ### 7. Checkpoint
 
 > "Ready to update reference files now, or save for later?"
+>
+> "I've created tasks for each action item. Want to work through them now?"
 
 ### 8. Codify
 
@@ -133,25 +148,60 @@ See [references/codify-phase.md](references/codify-phase.md) for full workflow.
 
 ---
 
-## Decisions as Task Anchors
+## Task Tracking Layers
 
-For substantial work, create decision file early with `status: proposed`. The file becomes your task tracker:
+Three levels of task tracking, each with a purpose:
+
+| Layer | Scope | Persists | Use For |
+|-------|-------|----------|---------|
+| **Claude tasks** | Current session | Session | Execution tracking, spinners |
+| **Decision files** | Project | Forever | Rationale, anchor for work |
+| **GitHub issues** | Roadmap | Forever | Cross-session, team visibility |
+
+### Decision Files as Anchors
+
+For substantial work, create decision file early with `status: proposed`:
 
 1. `proposed` - Drafted, exploring
 2. `accepted` - Decision made
 3. `codified` - Applied to reference files
 
-Check `decisions/` to see where you left off.
+### Claude Tasks for Execution
+
+When a decision has action items, create Claude tasks:
+- Use `TaskCreate` for each action item
+- Use `TaskUpdate` to mark progress
+- Use `TaskList` to see what's left
+
+### GitHub Issues for Roadmap
+
+For work that spans sessions or needs team visibility:
+- Create issue: `gh issue create --repo [repo] --title "..." --body "..."`
+- Link to decision file in issue body
+- Close issue when decision is codified
+
+Check `decisions/` and `TaskList` to see where you left off.
 
 ---
 
 ## Recovery
 
-If conversation compacted, check recent files:
+If conversation compacted, check multiple sources:
 
+**1. Claude tasks (current session):**
+```
+TaskList
+```
+
+**2. Recent files:**
 ```bash
 ls -lt research/*.md 2>/dev/null | head -5
 grep -l "status: proposed\|status: accepted" decisions/*.md 2>/dev/null
+```
+
+**3. GitHub issues (if using):**
+```bash
+gh issue list --assignee @me --state open
 ```
 
 Then confirm: "I see you were working on [topic]. Continue from here?"

--- a/.claude/skills/think/SKILL.md
+++ b/.claude/skills/think/SKILL.md
@@ -79,9 +79,9 @@ Every research output needs:
 
 Present options with pros/cons. Document choice and rationale.
 
-### 6. Action Items + Tasks
+### 6. Action Items
 
-List action items in the decision file AND create Claude tasks:
+List action items in the decision file:
 
 ```markdown
 ## Action Items
@@ -89,22 +89,11 @@ List action items in the decision file AND create Claude tasks:
 - [ ] Create reference/proof/angles/risk-reversal.md
 ```
 
-**Create tasks for execution tracking:**
-```
-TaskCreate: "Update offer.md with guarantee section"
-TaskCreate: "Create risk-reversal.md angle file"
-```
-
-Tasks provide:
-- Spinner showing current work
-- Dependencies between items
-- Session-level progress tracking
+Optionally create Claude tasks for execution tracking. See [decide-phase.md](references/decide-phase.md).
 
 ### 7. Checkpoint
 
 > "Ready to update reference files now, or save for later?"
->
-> "I've created tasks for each action item. Want to work through them now?"
 
 ### 8. Codify
 
@@ -150,37 +139,16 @@ See [references/codify-phase.md](references/codify-phase.md) for full workflow.
 
 ## Task Tracking Layers
 
-Three levels of task tracking, each with a purpose:
+| Layer | Scope | Use For |
+|-------|-------|---------|
+| **Claude tasks** | Session | Execution tracking, spinners |
+| **Decision files** | Forever | Rationale, anchor for work |
+| **GitHub issues** | Forever | Cross-session, team visibility |
 
-| Layer | Scope | Persists | Use For |
-|-------|-------|----------|---------|
-| **Claude tasks** | Current session | Session | Execution tracking, spinners |
-| **Decision files** | Project | Forever | Rationale, anchor for work |
-| **GitHub issues** | Roadmap | Forever | Cross-session, team visibility |
+Decision files are the anchor — create early with `status: proposed`, update to `accepted`, then `codified`.
 
-### Decision Files as Anchors
-
-For substantial work, create decision file early with `status: proposed`:
-
-1. `proposed` - Drafted, exploring
-2. `accepted` - Decision made
-3. `codified` - Applied to reference files
-
-### Claude Tasks for Execution
-
-When a decision has action items, create Claude tasks:
-- Use `TaskCreate` for each action item
-- Use `TaskUpdate` to mark progress
-- Use `TaskList` to see what's left
-
-### GitHub Issues for Roadmap
-
-For work that spans sessions or needs team visibility:
-- Create issue: `gh issue create --repo [repo] --title "..." --body "..."`
-- Link to decision file in issue body
-- Close issue when decision is codified
-
-Check `decisions/` and `TaskList` to see where you left off.
+See [decide-phase.md](references/decide-phase.md) for task creation patterns.
+See [recovery.md](references/recovery.md) for resuming sessions.
 
 ---
 

--- a/.claude/skills/think/references/decide-phase.md
+++ b/.claude/skills/think/references/decide-phase.md
@@ -108,25 +108,18 @@ Other actions:
 
 **Be specific:** "Update offer.md" is bad. "Update offer.md — Add 30-day guarantee section after pricing" is good.
 
-### Claude Tasks for Execution
+### Claude Tasks for Execution (Optional)
 
-After listing action items, create Claude tasks to track execution:
+For complex action items, optionally create Claude tasks for execution tracking:
 
 ```
 TaskCreate: "Update offer.md with guarantee section"
 TaskCreate: "Create risk-reversal.md angle file"
-TaskCreate: "Update voice.md vocabulary"
 ```
 
-This gives you:
-- Spinner showing current work ("Updating offer.md...")
-- Progress tracking via `TaskList`
-- Clear completion markers
+Tasks provide spinners, progress tracking via `TaskList`, and completion markers. Mark complete with `TaskUpdate: taskId=X, status=completed`.
 
-As you complete each item, mark the task complete:
-```
-TaskUpdate: taskId=1, status=completed
-```
+**Note:** Tasks are session-scoped and ephemeral. The decision file is the permanent anchor — tasks just help track execution within a session.
 
 ---
 

--- a/.claude/skills/think/references/decide-phase.md
+++ b/.claude/skills/think/references/decide-phase.md
@@ -108,6 +108,26 @@ Other actions:
 
 **Be specific:** "Update offer.md" is bad. "Update offer.md — Add 30-day guarantee section after pricing" is good.
 
+### Claude Tasks for Execution
+
+After listing action items, create Claude tasks to track execution:
+
+```
+TaskCreate: "Update offer.md with guarantee section"
+TaskCreate: "Create risk-reversal.md angle file"
+TaskCreate: "Update voice.md vocabulary"
+```
+
+This gives you:
+- Spinner showing current work ("Updating offer.md...")
+- Progress tracking via `TaskList`
+- Clear completion markers
+
+As you complete each item, mark the task complete:
+```
+TaskUpdate: taskId=1, status=completed
+```
+
 ---
 
 ## Decisions as Task Anchors

--- a/.claude/skills/think/references/recovery.md
+++ b/.claude/skills/think/references/recovery.md
@@ -21,16 +21,26 @@ That's it. The skill handles the rest.
 
 When resuming a `/think` session:
 
-### 1. Check Recent Files
+### 1. Check Multiple Sources
 
-Look for context in the user's repo:
+**Claude tasks (current session):**
+```
+TaskList
+```
+Shows any in-progress tasks from this session.
 
+**Recent files in user's repo:**
 ```bash
 # Recent research files
 ls -lt research/*.md 2>/dev/null | head -5
 
 # In-progress decisions
 grep -l "status: proposed\|status: accepted" decisions/*.md 2>/dev/null
+```
+
+**GitHub issues (if using):**
+```bash
+gh issue list --assignee @me --state open --limit 5
 ```
 
 ### 2. Read Relevant File(s)


### PR DESCRIPTION
## Summary
- Adds Task Tracking Layers section explaining three levels: Claude tasks (session), decision files (project), GitHub issues (roadmap)
- Updates decide phase to create Claude tasks for action item execution
- Updates recovery workflow to check TaskList alongside files and GitHub issues

## Test plan
- [x] Run `/think` and verify tasks are created for action items
- [x] Use TaskList to verify session-level tracking
- [x] Test recovery scenario checking all three sources

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)