### PR TITLE
[update] Wiki skill personalization and improved setup flow

### DIFF
--- a/.claude/skills/wiki/SKILL.md
+++ b/.claude/skills/wiki/SKILL.md
@@ -93,12 +93,22 @@ First-time wiki setup. Creates repo, configures hosting, deploys.
    | Twitter/X handle | No | skip |
    | GitHub username | No | skip |
    | Website URLs | No | skip (comma-separated) |
+   | Welcome page title | No | `Welcome` |
+   | Welcome heading | No | `Welcome to my wiki` |
+   | Welcome intro | No | Based on tagline |
 
    Update template files with user's info:
    - `src/config.ts` or `astro.config.mjs` — name, tagline, social links
    - `src/components/Header.astro` — brand name
    - `src/pages/index.astro` — meta author, structured data
+   - `src/content/notes/my-working-notes.md` — welcome page content
    - Replace any hardcoded "Devon Meadows" references
+
+   **Replace avatar with generic placeholder:**
+   - Delete `public/avatar.jpg` (Devon's photo)
+   - Create initials-based or generic placeholder, OR
+   - Leave avatar.jpg as a simple placeholder icon
+   - User can replace later (see `references/customization.md`)
 
 5. **Clean install option** — ask:
    > "Include sample notes? (recommended for first-time users) [Y/n]"

--- a/.claude/skills/wiki/SKILL.md
+++ b/.claude/skills/wiki/SKILL.md
@@ -115,10 +115,14 @@ First-time wiki setup. Creates repo, configures hosting, deploys.
 
    If declined:
    ```bash
-   # Keep what-is-commune.md (linked from footer "Powered by Commune")
-   find src/content/notes -name "*.md" ! -name "what-is-commune.md" -delete
+   rm -f src/content/notes/*.md
    rm -f src/content/updates/*.md
    ```
+
+   **Update footer link** (always, for clean install):
+   - Change `src/components/Footer.astro` "Powered by Commune" link
+   - From: `/notes/what-is-commune/`
+   - To: `https://devonmeadows.com/` (external, target="_blank")
 
 6. Configure domain in `astro.config.mjs`
 7. Install and test: `pnpm install && pnpm dev`

--- a/.claude/skills/wiki/SKILL.md
+++ b/.claude/skills/wiki/SKILL.md
@@ -8,8 +8,9 @@ description: |
   (4) Converting Gemini/GPT deep research into wiki format
   (5) Pulling upstream template updates from Devon
   (6) Generating "Recent Updates" notes from Git history
+  (7) Adding a custom domain after initial setup
 
-  Triggered by: /wiki, "add a note", "publish wiki", "create wiki", "update my wiki template"
+  Triggered by: /wiki, "add a note", "publish wiki", "create wiki", "update my wiki template", "add domain to wiki"
 ---
 
 # Wiki Skill
@@ -70,6 +71,7 @@ cat ~/.mainbranch/wiki.json 2>/dev/null || echo "No wiki configured yet"
 | `research` | Convert Gemini/GPT research to wiki | After deep research |
 | `update` | Pull upstream template changes | When fixes released |
 | `recent` | Generate "Recent Updates" from Git | Weekly or on threshold |
+| `domain-setup` | Add custom domain to existing wiki | After initial setup |
 
 ---
 
@@ -183,6 +185,32 @@ Generate "Recent Updates" note from Git history.
 2. Categorize: new notes, updated notes, research added
 3. Generate update note — see [references/updates-template.md](references/updates-template.md)
 4. Save to `src/content/updates/YYYY-MM-DD.md`
+
+---
+
+## Mode: domain-setup
+
+Add a custom domain to an existing wiki. Use this if you skipped custom domain during initial setup.
+
+**Usage:** `/wiki domain-setup`
+
+**Steps:**
+1. Read config: `cat ~/.mainbranch/wiki.json`
+2. Ask user for domain name
+3. Check if domain is already on Cloudflare:
+   - **YES:** Workers & Pages → project → Custom domains → Set up a custom domain → Enter domain
+   - **NO:** Guide user to either:
+     - Add domain to Cloudflare (Account home → Domains → Onboard) then configure, OR
+     - Add CNAME record at registrar pointing to `[project].pages.dev`
+4. Update config with new domain:
+   ```bash
+   jq '.domain = "newdomain.com"' ~/.mainbranch/wiki.json > tmp && mv tmp ~/.mainbranch/wiki.json
+   ```
+5. Update `astro.config.mjs` site URL if needed
+
+See [references/cloudflare-pages-setup.md](references/cloudflare-pages-setup.md) for detailed dashboard steps.
+
+**Exit:** "Custom domain configured. DNS may take up to 24-48 hours to propagate."
 
 ---
 

--- a/.claude/skills/wiki/SKILL.md
+++ b/.claude/skills/wiki/SKILL.md
@@ -157,8 +157,8 @@ Create a new atomic note following evergreen note principles.
 6. Suggest WikiLinks: `grep -r "concept" "$WIKI_REPO/src/content/notes/" --include="*.md" -l`
 
 **Frontmatter validation:**
-- Valid `status` values: `seed`, `growing`, `evergreen`
-- Do NOT use `draft` — causes Astro build failure
+- Valid `status` values: `draft`, `live`, `updated`
+- Valid `visibility` values: `public`, `private`, `draft`
 
 **Exit:** "Note created. Run `/wiki publish` to deploy, or continue editing."
 

--- a/.claude/skills/wiki/SKILL.md
+++ b/.claude/skills/wiki/SKILL.md
@@ -3,14 +3,14 @@ name: wiki
 description: |
   Create and maintain personal wikis using Commune Wiki architecture. Use when:
   (1) Setting up a new wiki from the commune-wiki template
-  (2) Adding atomic notes with proper frontmatter and WikiLinks
-  (3) Publishing changes (git commit + push for auto-deploy)
-  (4) Converting Gemini/GPT deep research into wiki format
-  (5) Pulling upstream template updates from Devon
-  (6) Generating "Recent Updates" notes from Git history
-  (7) Adding a custom domain after initial setup
+  (2) Personalizing wiki (name, avatar, social links, domain)
+  (3) Adding atomic notes with proper frontmatter and WikiLinks
+  (4) Publishing changes (git commit + push for auto-deploy)
+  (5) Converting Gemini/GPT deep research into wiki format
+  (6) Pulling upstream template updates from Devon
+  (7) Generating "Recent Updates" notes from Git history
 
-  Triggered by: /wiki, "add a note", "publish wiki", "create wiki", "update my wiki template", "add domain to wiki"
+  Triggered by: /wiki, "add a note", "publish wiki", "create wiki", "configure wiki", "personalize wiki"
 ---
 
 # Wiki Skill
@@ -65,85 +65,50 @@ cat ~/.mainbranch/wiki.json 2>/dev/null || echo "No wiki configured yet"
 
 | Mode | What It Does | When to Use |
 |------|--------------|-------------|
-| `setup` | Clone template, configure, deploy to CF Pages | First time |
+| `setup` | Clone template, deploy to CF Pages | First time (quick) |
+| `configure` | Personalize wiki (name, social, domain, etc.) | After setup |
 | `add` | Create atomic note with frontmatter | Daily note-taking |
 | `publish` | Git commit + push (auto-deploy) | After any changes |
 | `research` | Convert Gemini/GPT research to wiki | After deep research |
 | `update` | Pull upstream template changes | When fixes released |
 | `recent` | Generate "Recent Updates" from Git | Weekly or on threshold |
-| `domain-setup` | Add custom domain to existing wiki | After initial setup |
 
 ---
 
 ## Mode: setup
 
-First-time wiki setup. Creates repo, configures hosting, deploys.
+Quick first-time wiki setup. Installs default template and deploys. Run `/wiki configure` after to personalize.
 
 **Steps:**
-1. Create GitHub repo: `gh repo create [user]/[wiki] --private --clone`
-2. Add upstream: `git remote add upstream https://github.com/noontide-co/commune-wiki.git`
-3. Merge template: `git fetch upstream && git merge upstream/main --allow-unrelated-histories`
-4. **Personalize wiki** — prompt user for:
-
-   | Prompt | Required | Default |
-   |--------|----------|---------|
-   | Display name | Yes | — |
-   | Short name (mobile) | No | First word of display name |
-   | Tagline | No | `{display name}'s Notes` |
-   | Twitter/X handle | No | skip |
-   | GitHub username | No | skip |
-   | Website URLs | No | skip (comma-separated) |
-   | Welcome page title | No | `Welcome` |
-   | Welcome heading | No | `Welcome to my wiki` |
-   | Welcome intro | No | Based on tagline |
-
-   Update template files with user's info:
-   - `src/config.ts` or `astro.config.mjs` — name, tagline, social links
-   - `src/components/Header.astro` — brand name
-   - `src/pages/index.astro` — meta author, structured data
-   - `src/content/notes/my-working-notes.md` — welcome page content
-   - Replace any hardcoded "Devon Meadows" references
-
-   **Replace avatar with generic placeholder:**
-   - Delete `public/avatar.jpg` (Devon's photo)
-   - Create initials-based or generic placeholder, OR
-   - Leave avatar.jpg as a simple placeholder icon
-   - User can replace later (see `references/customization.md`)
-
-5. **Clean install option** — ask:
-   > "Include sample notes? (recommended for first-time users) [Y/n]"
-
-   If declined:
-   ```bash
-   rm -f src/content/notes/*.md
-   rm -f src/content/updates/*.md
-   ```
-
-   **Update footer link** (always, for clean install):
+1. Ask: Repo name? Location?
+2. Create GitHub repo: `gh repo create [user]/[wiki] --private --clone`
+3. Add upstream: `git remote add upstream https://github.com/noontide-co/commune-wiki.git`
+4. Merge template: `git fetch upstream && git merge upstream/main --allow-unrelated-histories`
+5. **Update footer link:**
    - Change `src/components/Footer.astro` "Powered by Commune" link
-   - From: `/notes/what-is-commune/`
    - To: `https://devonmeadows.com/` (external, target="_blank")
-
-6. Configure domain in `astro.config.mjs`
-7. Install and test: `pnpm install && pnpm dev`
-8. Deploy to Cloudflare Pages — see [references/cloudflare-pages-setup.md](references/cloudflare-pages-setup.md)
+6. Ask: Domain? (use `[project].pages.dev` or custom)
+7. Update `astro.config.mjs` with site URL
+8. Install and build: `pnpm install && pnpm build`
+9. Deploy to Cloudflare Pages — see [references/cloudflare-pages-setup.md](references/cloudflare-pages-setup.md)
 
    **First-time GitHub app install:** If you've never connected Cloudflare to GitHub, you'll need to install the Cloudflare Pages GitHub app first. See the reference for details.
 
-9. Save config:
-   ```bash
-   mkdir -p ~/.mainbranch
-   cat > ~/.mainbranch/wiki.json << 'EOF'
-   {
-     "wiki_repo": "/path/to/wiki",
-     "hosting": "cloudflare",
-     "domain": "yourdomain.com",
-     "cf_project": "your-project-name"
-   }
-   EOF
-   ```
+10. Commit and push: `git add -A && git commit -m "Initial wiki setup" && git push`
+11. Save config:
+    ```bash
+    mkdir -p ~/.mainbranch
+    cat > ~/.mainbranch/wiki.json << 'EOF'
+    {
+      "wiki_repo": "/path/to/wiki",
+      "hosting": "cloudflare",
+      "domain": "yourdomain.com",
+      "cf_project": "your-project-name"
+    }
+    EOF
+    ```
 
-**Exit:** Config saved, wiki live at user's domain. See [references/customization.md](references/customization.md) for how to update settings later.
+**Exit:** "Wiki deployed! Run `/wiki configure` to personalize (name, avatar, social links, etc.)"
 
 ---
 
@@ -236,29 +201,57 @@ Generate "Recent Updates" note from Git history.
 
 ---
 
-## Mode: domain-setup
+## Mode: configure
 
-Add a custom domain to an existing wiki. Use this if you skipped custom domain during initial setup.
+Personalize your wiki after setup. All customization in one place.
 
-**Usage:** `/wiki domain-setup`
+**Usage:** `/wiki configure`
+
+**Prompts:**
+
+| Setting | Required | Default |
+|---------|----------|---------|
+| Display name | Yes | — |
+| Short name (mobile) | No | First word of display name |
+| Tagline | No | `{display name}'s Notes` |
+| Twitter/X handle | No | skip |
+| GitHub username | No | skip |
+| Website URLs | No | skip (comma-separated) |
+| Welcome page title | No | `Welcome` |
+| Welcome heading | No | `Welcome to my wiki` |
+| Welcome intro | No | Based on tagline |
+| Custom domain | No | keep current |
+| Delete sample notes | No | keep samples |
 
 **Steps:**
 1. Read config: `cat ~/.mainbranch/wiki.json`
-2. Ask user for domain name
-3. Check if domain is already on Cloudflare:
-   - **YES:** Workers & Pages → project → Custom domains → Set up a custom domain → Enter domain
-   - **NO:** Guide user to either:
-     - Add domain to Cloudflare (Account home → Domains → Onboard) then configure, OR
-     - Add CNAME record at registrar pointing to `[project].pages.dev`
-4. Update config with new domain:
+2. Show current settings, ask what to change
+3. Update files based on selections:
+   - `src/components/Header.astro` — display name, short name, avatar alt
+   - `src/pages/index.astro` — meta author, structured data, tagline
+   - `src/pages/notes/[...slug].astro` — author meta
+   - `src/pages/research/[...slug].astro` — footer attribution
+   - `src/content/notes/my-working-notes.md` — welcome page content
+   - `astro.config.mjs` — site URL (if domain changed)
+   - Replace any "Devon Meadows" references with user's name
+
+4. **If custom domain requested:**
+   - Guide through Cloudflare custom domain setup
+   - See [references/cloudflare-pages-setup.md](references/cloudflare-pages-setup.md)
+   - Update config with new domain
+
+5. **If delete sample notes:**
    ```bash
-   jq '.domain = "newdomain.com"' ~/.mainbranch/wiki.json > tmp && mv tmp ~/.mainbranch/wiki.json
+   rm -f src/content/notes/*.md
+   rm -f src/content/updates/*.md
    ```
-5. Update `astro.config.mjs` site URL if needed
+   Then create fresh `my-working-notes.md` with user's welcome content.
 
-See [references/cloudflare-pages-setup.md](references/cloudflare-pages-setup.md) for detailed dashboard steps.
+6. Rebuild and push: `pnpm build && git add -A && git commit -m "[configure] Personalize wiki" && git push`
 
-**Exit:** "Custom domain configured. DNS may take up to 24-48 hours to propagate."
+**Exit:** "Wiki personalized! Changes will deploy in ~90 seconds."
+
+See [references/customization.md](references/customization.md) for manual edits.
 
 ---
 

--- a/.claude/skills/wiki/SKILL.md
+++ b/.claude/skills/wiki/SKILL.md
@@ -50,9 +50,9 @@ The skill reads `~/.mainbranch/wiki.json` to find your wiki repo location.
 ## Prerequisites
 
 Before using this skill:
-1. **GitHub account** with SSH keys configured
-2. **Cloudflare account** (free tier works)
-3. **Wiki repo** cloned locally (created via `/wiki setup` or manually)
+1. **GitHub CLI** (`gh`) installed and authenticated
+2. **pnpm** installed (`npm install -g pnpm`)
+3. **Cloudflare account** (free tier works) — can create during setup via `wrangler login`
 
 Check for existing config:
 ```bash
@@ -77,38 +77,142 @@ cat ~/.mainbranch/wiki.json 2>/dev/null || echo "No wiki configured yet"
 
 ## Mode: setup
 
-Quick first-time wiki setup. Installs default template and deploys. Run `/wiki configure` after to personalize.
+Quick first-time wiki setup. Installs default template and deploys via wrangler CLI. Run `/wiki configure` after to personalize.
 
 **Steps:**
-1. Ask: Repo name? Location?
-2. Create GitHub repo: `gh repo create [user]/[wiki] --private --clone`
-3. Add upstream: `git remote add upstream https://github.com/noontide-co/commune-wiki.git`
-4. Merge template: `git fetch upstream && git merge upstream/main --allow-unrelated-histories`
-5. **Update footer link:**
-   - Change `src/components/Footer.astro` "Powered by Commune" link
-   - To: `https://devonmeadows.com/` (external, target="_blank")
-6. Ask: Domain? (use `[project].pages.dev` or custom)
-7. Update `astro.config.mjs` with site URL
-8. Install and build: `pnpm install && pnpm build`
-9. Deploy to Cloudflare Pages — see [references/cloudflare-pages-setup.md](references/cloudflare-pages-setup.md)
 
-   **First-time GitHub app install:** If you've never connected Cloudflare to GitHub, you'll need to install the Cloudflare Pages GitHub app first. See the reference for details.
+### 1. Ask: Repo name? Location?
+Default: `wiki` in home directory (`~/wiki`)
 
-10. Commit and push: `git add -A && git commit -m "Initial wiki setup" && git push`
-11. Save config:
-    ```bash
-    mkdir -p ~/.mainbranch
-    cat > ~/.mainbranch/wiki.json << 'EOF'
-    {
-      "wiki_repo": "/path/to/wiki",
-      "hosting": "cloudflare",
-      "domain": "yourdomain.com",
-      "cf_project": "your-project-name"
-    }
-    EOF
-    ```
+### 2. Check GitHub CLI
+```bash
+gh auth status
+```
+If not authenticated, guide user to run `gh auth login`.
 
-**Exit:** "Wiki deployed! Run `/wiki configure` to personalize (name, avatar, social links, etc.)"
+### 3. Create GitHub repo and clone
+```bash
+gh repo create [user]/[wiki] --private --clone
+cd [wiki]
+```
+If repo exists but not cloned: `git clone https://github.com/[user]/[wiki].git`
+
+### 4. Add upstream and merge template
+```bash
+git remote add upstream https://github.com/noontide-co/commune-wiki.git
+git fetch upstream
+git merge upstream/main --allow-unrelated-histories -m "Initial wiki from commune-wiki template"
+```
+
+### 5. Apply Windows compatibility fixes (Windows only)
+On Windows, fix path handling in `astro.backlinks.ts`:
+
+```bash
+# Add fileURLToPath import
+sed -i "s/import path from 'node:path';/import path from 'node:path';\nimport { fileURLToPath } from 'node:url';/" astro.backlinks.ts
+
+# Fix the dist path line
+sed -i "s/path.join(dir.pathname,/path.join(fileURLToPath(dir),/" astro.backlinks.ts
+```
+
+Or manually edit `astro.backlinks.ts`:
+- Add import: `import { fileURLToPath } from 'node:url';`
+- Change: `path.join(dir.pathname, 'backlinks.json')` → `path.join(fileURLToPath(dir), 'backlinks.json')`
+
+### 6. Install dependencies and build
+```bash
+pnpm install
+pnpm build
+```
+
+**If build fails with sitemap error:** Temporarily comment out the sitemap integration in `astro.config.mjs`, rebuild, then uncomment after first deploy.
+
+### 7. Commit and push
+```bash
+git add -A
+git commit -m "Initial wiki setup"
+```
+
+**Check branch name** (Git may default to `master`):
+```bash
+git branch --show-current
+```
+
+If branch is `master`, rename to `main`:
+```bash
+git branch -m master main
+```
+
+Then push:
+```bash
+git push -u origin main
+```
+
+### 8. Check Cloudflare authentication
+```bash
+npx wrangler whoami
+```
+
+**If not logged in:** Run `npx wrangler login` — opens browser for OAuth. User can create a Cloudflare account during this flow if they don't have one (free tier works).
+
+### 9. Create Pages project and deploy
+```bash
+npx wrangler pages project create [wiki] --production-branch main
+npx wrangler pages deploy dist --project-name [wiki]
+```
+
+Wrangler outputs the URL (e.g., `https://wiki-abc.pages.dev`). Note this URL.
+
+### 10. Update site URL and redeploy
+Edit `astro.config.mjs`:
+```javascript
+site: 'https://[your-url].pages.dev',
+```
+
+Then rebuild and deploy:
+```bash
+pnpm build
+git add -A && git commit -m "[update] Set site URL" && git push
+npx wrangler pages deploy dist --project-name [wiki]
+```
+
+### 11. Save config
+```bash
+mkdir -p ~/.mainbranch
+cat > ~/.mainbranch/wiki.json << 'EOF'
+{
+  "wiki_repo": "/absolute/path/to/wiki",
+  "hosting": "cloudflare",
+  "domain": "your-url.pages.dev",
+  "cf_project": "wiki"
+}
+EOF
+```
+
+### 12. Ask: Set up auto-deploy?
+
+Prompt user: "Would you like to set up auto-deploy so `git push` automatically deploys your wiki?"
+
+**If yes:** Guide through Cloudflare dashboard:
+1. Open https://dash.cloudflare.com
+2. Workers & Pages → click project name
+3. Settings tab → Builds & deployments
+4. Click "Connect to Git"
+5. Authorize GitHub if prompted
+6. Select the wiki repository
+7. Build settings:
+   - Build command: `pnpm build`
+   - Build output directory: `dist`
+8. Save
+
+After setup, every `git push` triggers automatic deploy (~90 seconds).
+
+**If no:** Remind user they can deploy manually anytime with:
+```bash
+pnpm build && npx wrangler pages deploy dist --project-name [wiki]
+```
+
+**Exit:** "Wiki deployed at https://[url].pages.dev! Run `/wiki configure` to personalize (name, avatar, social links, etc.)"
 
 ---
 
@@ -213,14 +317,10 @@ Personalize your wiki after setup. All customization in one place.
 |---------|----------|---------|
 | Display name | Yes | — |
 | Short name (mobile) | No | First word of display name |
-| Tagline | No | `{display name}'s Notes` |
 | Avatar image | No | drag & drop to replace |
 | Twitter/X handle | No | skip |
 | GitHub username | No | skip |
 | Website URLs | No | skip (comma-separated) |
-| Welcome page title | No | `Welcome` |
-| Welcome heading | No | `Welcome to my wiki` |
-| Welcome intro | No | Based on tagline |
 | Custom domain | No | keep current |
 | Delete sample notes | No | keep samples |
 
@@ -229,10 +329,11 @@ Personalize your wiki after setup. All customization in one place.
 2. Show current settings, ask what to change
 3. Update files based on selections:
    - `src/components/Header.astro` — display name, short name, avatar alt
-   - `src/pages/index.astro` — meta author, structured data, tagline
+   - `src/components/Footer.astro` — update "Powered by Commune" link to `https://devonmeadows.com/` (external, target="_blank")
+   - `src/pages/index.astro` — meta author, structured data
    - `src/pages/notes/[...slug].astro` — author meta
    - `src/pages/research/[...slug].astro` — footer attribution
-   - `src/content/notes/my-working-notes.md` — welcome page content
+   - `src/content/notes/my-working-notes.md` — social links
    - `astro.config.mjs` — site URL (if domain changed)
    - Replace any "Devon Meadows" references with user's name
 
@@ -240,8 +341,18 @@ Personalize your wiki after setup. All customization in one place.
    - Prompt: "Drag and drop your avatar image here (or paste path):"
    - User drags image into terminal → path is pasted
    - Copy to wiki: `cp "[path]" "$WIKI_REPO/public/avatar.jpg"`
+   - Generate favicon from avatar (uses sharp, already a dependency):
+     ```bash
+     cd "$WIKI_REPO" && node -e "
+       const sharp = require('sharp');
+       sharp('public/avatar.jpg')
+         .resize(32, 32)
+         .png()
+         .toFile('public/favicon-32x32.png');
+     "
+     ```
    - Supported formats: .jpg, .png, .webp (rename to avatar.jpg)
-   - Recommended: 200x200px square crop
+   - Recommended: square image (will be cropped/resized)
 
 5. **If custom domain requested:**
    - Guide through Cloudflare custom domain setup
@@ -253,7 +364,7 @@ Personalize your wiki after setup. All customization in one place.
    rm -f src/content/notes/*.md
    rm -f src/content/updates/*.md
    ```
-   Then create fresh `my-working-notes.md` with user's welcome content.
+   Then create fresh `my-working-notes.md` with default welcome content and social links.
 
 7. Rebuild and push: `pnpm build && git add -A && git commit -m "[configure] Personalize wiki" && git push`
 
@@ -355,6 +466,33 @@ Live at: https://yourdomain.com
 
 **"No wiki configured"**
 Run `/wiki setup` first.
+
+**Build failing on Windows with path error (`C:\C:\Users\...`)**
+The `astro.backlinks.ts` file needs a Windows path fix. Add this import:
+```javascript
+import { fileURLToPath } from 'node:url';
+```
+And change:
+```javascript
+// Before
+const distPath = path.join(dir.pathname, 'backlinks.json');
+// After
+const distPath = path.join(fileURLToPath(dir), 'backlinks.json');
+```
+
+**Build failing with sitemap "reduce" error**
+Temporarily disable sitemap in `astro.config.mjs`:
+```javascript
+integrations: [
+  tailwind({ applyBaseStyles: false }),
+  backlinks(),
+  // sitemap({ ... }),  // Comment out temporarily
+],
+```
+Re-enable after first successful deploy.
+
+**"Not logged in" with wrangler**
+Run `npx wrangler login` — opens browser for Cloudflare OAuth. You can create a free account during this flow.
 
 **Build failing**
 - Check build command is `pnpm build` (not `npm run build`)

--- a/.claude/skills/wiki/SKILL.md
+++ b/.claude/skills/wiki/SKILL.md
@@ -52,7 +52,7 @@ The skill reads `~/.mainbranch/wiki.json` to find your wiki repo location.
 Before using this skill:
 1. **GitHub CLI** (`gh`) installed and authenticated
 2. **pnpm** installed (`npm install -g pnpm`)
-3. **Cloudflare account** (free tier works) — can create during setup via `wrangler login`
+3. **Cloudflare account** (free tier works) — can create during setup
 
 Check for existing config:
 ```bash
@@ -148,35 +148,51 @@ Then push:
 git push -u origin main
 ```
 
-### 8. Check Cloudflare authentication
-```bash
-npx wrangler whoami
-```
+### 8. Ensure Cloudflare account exists
 
-**If not logged in:** Run `npx wrangler login` — opens browser for OAuth. User can create a Cloudflare account during this flow if they don't have one (free tier works).
+If user doesn't have a Cloudflare account, guide them to create one:
+1. Go to https://dash.cloudflare.com
+2. Click "Sign up" and create free account
 
-### 9. Create Pages project and deploy
-```bash
-npx wrangler pages project create [wiki] --production-branch main
-npx wrangler pages deploy dist --project-name [wiki]
-```
+### 9. Create Pages project via dashboard (enables auto-deploy)
 
-Wrangler outputs the URL (e.g., `https://wiki-abc.pages.dev`). Note this URL.
+Guide user through Cloudflare dashboard — this creates a Git-connected project with auto-deploy:
 
-### 10. Update site URL and redeploy
-Edit `astro.config.mjs`:
+1. Go to https://dash.cloudflare.com
+2. Left sidebar: **Workers & Pages**
+3. Click **"Create application"** (blue button, top right)
+4. **IMPORTANT:** Click the small link at the bottom: **"Pages: Get started"** (NOT the Worker option)
+5. Select **"Connect to Git"**
+6. Authorize GitHub if prompted, select the wiki repository
+7. Configure build settings:
+   - Project name: `wiki` (or preferred name)
+   - Production branch: `main`
+   - Build command: `pnpm build`
+   - Build output directory: `dist`
+8. Click **"Save and Deploy"**
+
+First build takes ~1-2 minutes. Watch progress on screen.
+
+### 10. Note the deployed URL
+
+After deploy completes, Cloudflare shows the URL (e.g., `https://wiki-abc.pages.dev`).
+
+Ask user: "What URL did Cloudflare assign? (shown on success screen)"
+
+### 11. Update site URL and push
+
+Edit `astro.config.mjs` with the actual URL:
 ```javascript
-site: 'https://[your-url].pages.dev',
+site: 'https://[actual-url].pages.dev',
 ```
 
-Then rebuild and deploy:
+Then commit and push — this triggers auto-deploy:
 ```bash
 pnpm build
 git add -A && git commit -m "[update] Set site URL" && git push
-npx wrangler pages deploy dist --project-name [wiki]
 ```
 
-### 11. Save config
+### 12. Save config
 ```bash
 mkdir -p ~/.mainbranch
 cat > ~/.mainbranch/wiki.json << 'EOF'
@@ -189,30 +205,7 @@ cat > ~/.mainbranch/wiki.json << 'EOF'
 EOF
 ```
 
-### 12. Ask: Set up auto-deploy?
-
-Prompt user: "Would you like to set up auto-deploy so `git push` automatically deploys your wiki?"
-
-**If yes:** Guide through Cloudflare dashboard:
-1. Open https://dash.cloudflare.com
-2. Workers & Pages → click project name
-3. Settings tab → Builds & deployments
-4. Click "Connect to Git"
-5. Authorize GitHub if prompted
-6. Select the wiki repository
-7. Build settings:
-   - Build command: `pnpm build`
-   - Build output directory: `dist`
-8. Save
-
-After setup, every `git push` triggers automatic deploy (~90 seconds).
-
-**If no:** Remind user they can deploy manually anytime with:
-```bash
-pnpm build && npx wrangler pages deploy dist --project-name [wiki]
-```
-
-**Exit:** "Wiki deployed at https://[url].pages.dev! Run `/wiki configure` to personalize (name, avatar, social links, etc.)"
+**Exit:** "Wiki deployed at https://[url].pages.dev with auto-deploy enabled! Every `git push` will automatically deploy. Run `/wiki configure` to personalize (name, avatar, social links, etc.)"
 
 ---
 

--- a/.claude/skills/wiki/SKILL.md
+++ b/.claude/skills/wiki/SKILL.md
@@ -83,10 +83,39 @@ First-time wiki setup. Creates repo, configures hosting, deploys.
 1. Create GitHub repo: `gh repo create [user]/[wiki] --private --clone`
 2. Add upstream: `git remote add upstream https://github.com/noontide-co/commune-wiki.git`
 3. Merge template: `git fetch upstream && git merge upstream/main --allow-unrelated-histories`
-4. Configure `astro.config.mjs` (title, domain)
-5. Install and test: `pnpm install && pnpm dev`
-6. Deploy to Cloudflare Pages — see [references/cloudflare-pages-setup.md](references/cloudflare-pages-setup.md)
-7. Save config:
+4. **Personalize wiki** — prompt user for:
+
+   | Prompt | Required | Default |
+   |--------|----------|---------|
+   | Display name | Yes | — |
+   | Short name (mobile) | No | First word of display name |
+   | Tagline | No | `{display name}'s Notes` |
+   | Twitter/X handle | No | skip |
+   | GitHub username | No | skip |
+   | Website URLs | No | skip (comma-separated) |
+
+   Update template files with user's info:
+   - `src/config.ts` or `astro.config.mjs` — name, tagline, social links
+   - `src/components/Header.astro` — brand name
+   - `src/pages/index.astro` — meta author, structured data
+   - Replace any hardcoded "Devon Meadows" references
+
+5. **Clean install option** — ask:
+   > "Include sample notes? (recommended for first-time users) [Y/n]"
+
+   If declined:
+   ```bash
+   rm -f src/content/notes/*.md
+   rm -f src/content/updates/*.md
+   ```
+
+6. Configure domain in `astro.config.mjs`
+7. Install and test: `pnpm install && pnpm dev`
+8. Deploy to Cloudflare Pages — see [references/cloudflare-pages-setup.md](references/cloudflare-pages-setup.md)
+
+   **First-time GitHub app install:** If you've never connected Cloudflare to GitHub, you'll need to install the Cloudflare Pages GitHub app first. See the reference for details.
+
+9. Save config:
    ```bash
    mkdir -p ~/.mainbranch
    cat > ~/.mainbranch/wiki.json << 'EOF'
@@ -99,7 +128,7 @@ First-time wiki setup. Creates repo, configures hosting, deploys.
    EOF
    ```
 
-**Exit:** Config saved, wiki live at user's domain.
+**Exit:** Config saved, wiki live at user's domain. See [references/customization.md](references/customization.md) for how to update settings later.
 
 ---
 
@@ -294,6 +323,7 @@ Live at: https://yourdomain.com
 ## References
 
 - [references/cloudflare-pages-setup.md](references/cloudflare-pages-setup.md) — Dashboard walkthrough
+- [references/customization.md](references/customization.md) — Update avatar, name, social links after setup
 - [references/hosting-recommendation.md](references/hosting-recommendation.md) — Why Cloudflare
 - [references/note-template.md](references/note-template.md) — Atomic note guidelines
 - [references/research-format.md](references/research-format.md) — Deep research conversion

--- a/.claude/skills/wiki/SKILL.md
+++ b/.claude/skills/wiki/SKILL.md
@@ -9,8 +9,9 @@ description: |
   (5) Pulling upstream template updates from Devon
   (6) Generating "Recent Updates" notes from Git history
   (7) Adding a custom domain after initial setup
+  (8) Checking deployment status after publish
 
-  Triggered by: /wiki, "add a note", "publish wiki", "create wiki", "update my wiki template", "add domain to wiki"
+  Triggered by: /wiki, "add a note", "publish wiki", "create wiki", "update my wiki template", "add domain to wiki", "check deploy status"
 ---
 
 # Wiki Skill
@@ -72,6 +73,7 @@ cat ~/.mainbranch/wiki.json 2>/dev/null || echo "No wiki configured yet"
 | `update` | Pull upstream template changes | When fixes released |
 | `recent` | Generate "Recent Updates" from Git | Weekly or on threshold |
 | `domain-setup` | Add custom domain to existing wiki | After initial setup |
+| `deploy-status` | Check Cloudflare deployment status | After publish |
 
 ---
 
@@ -133,7 +135,7 @@ Commit changes and push to trigger auto-deploy.
 3. Generate commit message if not provided (analyze changed files)
 4. Commit and push: `git add -A && git commit -m "[type] Message" && git push`
 
-**Exit:** "Pushed to GitHub. Cloudflare Pages will auto-deploy in ~90 seconds."
+**Exit:** "Pushed to GitHub. Cloudflare Pages will auto-deploy in ~90 seconds. Run `/wiki deploy-status` to verify."
 
 ---
 
@@ -211,6 +213,31 @@ Add a custom domain to an existing wiki. Use this if you skipped custom domain d
 See [references/cloudflare-pages-setup.md](references/cloudflare-pages-setup.md) for detailed dashboard steps.
 
 **Exit:** "Custom domain configured. DNS may take up to 24-48 hours to propagate."
+
+---
+
+## Mode: deploy-status
+
+Check Cloudflare Pages deployment status. Useful after `/wiki publish` to verify deployment succeeded.
+
+**Usage:** `/wiki deploy-status`
+
+**Prerequisites:** Requires wrangler CLI (one-time setup):
+```bash
+pnpm add -g wrangler  # Install globally
+wrangler login        # Authenticate with Cloudflare
+```
+
+**Steps:**
+1. Read config: `cat ~/.mainbranch/wiki.json | jq -r '.cf_project'`
+2. List recent deployments:
+   ```bash
+   wrangler pages deployment list --project-name="$CF_PROJECT"
+   ```
+3. Show deployment status (Success, Failed, In Progress)
+4. If failed, show error details and suggest checking Cloudflare dashboard
+
+**Exit:** Display latest deployment status with timestamp and URL.
 
 ---
 

--- a/.claude/skills/wiki/SKILL.md
+++ b/.claude/skills/wiki/SKILL.md
@@ -9,9 +9,8 @@ description: |
   (5) Pulling upstream template updates from Devon
   (6) Generating "Recent Updates" notes from Git history
   (7) Adding a custom domain after initial setup
-  (8) Checking deployment status after publish
 
-  Triggered by: /wiki, "add a note", "publish wiki", "create wiki", "update my wiki template", "add domain to wiki", "check deploy status"
+  Triggered by: /wiki, "add a note", "publish wiki", "create wiki", "update my wiki template", "add domain to wiki"
 ---
 
 # Wiki Skill
@@ -73,7 +72,6 @@ cat ~/.mainbranch/wiki.json 2>/dev/null || echo "No wiki configured yet"
 | `update` | Pull upstream template changes | When fixes released |
 | `recent` | Generate "Recent Updates" from Git | Weekly or on threshold |
 | `domain-setup` | Add custom domain to existing wiki | After initial setup |
-| `deploy-status` | Check Cloudflare deployment status | After publish |
 
 ---
 
@@ -135,7 +133,7 @@ Commit changes and push to trigger auto-deploy.
 3. Generate commit message if not provided (analyze changed files)
 4. Commit and push: `git add -A && git commit -m "[type] Message" && git push`
 
-**Exit:** "Pushed to GitHub. Cloudflare Pages will auto-deploy in ~90 seconds. Run `/wiki deploy-status` to verify."
+**Exit:** "Pushed to GitHub. Cloudflare Pages will auto-deploy in ~90 seconds. Check status: https://dash.cloudflare.com → Workers & Pages → [project-name]"
 
 ---
 
@@ -213,31 +211,6 @@ Add a custom domain to an existing wiki. Use this if you skipped custom domain d
 See [references/cloudflare-pages-setup.md](references/cloudflare-pages-setup.md) for detailed dashboard steps.
 
 **Exit:** "Custom domain configured. DNS may take up to 24-48 hours to propagate."
-
----
-
-## Mode: deploy-status
-
-Check Cloudflare Pages deployment status. Useful after `/wiki publish` to verify deployment succeeded.
-
-**Usage:** `/wiki deploy-status`
-
-**Prerequisites:** Requires wrangler CLI (one-time setup):
-```bash
-pnpm add -g wrangler  # Install globally
-wrangler login        # Authenticate with Cloudflare
-```
-
-**Steps:**
-1. Read config: `cat ~/.mainbranch/wiki.json | jq -r '.cf_project'`
-2. List recent deployments:
-   ```bash
-   wrangler pages deployment list --project-name="$CF_PROJECT"
-   ```
-3. Show deployment status (Success, Failed, In Progress)
-4. If failed, show error details and suggest checking Cloudflare dashboard
-
-**Exit:** Display latest deployment status with timestamp and URL.
 
 ---
 

--- a/.claude/skills/wiki/SKILL.md
+++ b/.claude/skills/wiki/SKILL.md
@@ -146,6 +146,10 @@ Create a new atomic note following evergreen note principles.
 5. Apply evergreen principles: atomic, concept-oriented, densely linked
 6. Suggest WikiLinks: `grep -r "concept" "$WIKI_REPO/src/content/notes/" --include="*.md" -l`
 
+**Frontmatter validation:**
+- Valid `status` values: `seed`, `growing`, `evergreen`
+- Do NOT use `draft` — causes Astro build failure
+
 **Exit:** "Note created. Run `/wiki publish` to deploy, or continue editing."
 
 ---

--- a/.claude/skills/wiki/SKILL.md
+++ b/.claude/skills/wiki/SKILL.md
@@ -115,7 +115,8 @@ First-time wiki setup. Creates repo, configures hosting, deploys.
 
    If declined:
    ```bash
-   rm -f src/content/notes/*.md
+   # Keep what-is-commune.md (linked from footer "Powered by Commune")
+   find src/content/notes -name "*.md" ! -name "what-is-commune.md" -delete
    rm -f src/content/updates/*.md
    ```
 

--- a/.claude/skills/wiki/SKILL.md
+++ b/.claude/skills/wiki/SKILL.md
@@ -214,6 +214,7 @@ Personalize your wiki after setup. All customization in one place.
 | Display name | Yes | — |
 | Short name (mobile) | No | First word of display name |
 | Tagline | No | `{display name}'s Notes` |
+| Avatar image | No | drag & drop to replace |
 | Twitter/X handle | No | skip |
 | GitHub username | No | skip |
 | Website URLs | No | skip (comma-separated) |
@@ -235,19 +236,26 @@ Personalize your wiki after setup. All customization in one place.
    - `astro.config.mjs` — site URL (if domain changed)
    - Replace any "Devon Meadows" references with user's name
 
-4. **If custom domain requested:**
+4. **If avatar image provided:**
+   - Prompt: "Drag and drop your avatar image here (or paste path):"
+   - User drags image into terminal → path is pasted
+   - Copy to wiki: `cp "[path]" "$WIKI_REPO/public/avatar.jpg"`
+   - Supported formats: .jpg, .png, .webp (rename to avatar.jpg)
+   - Recommended: 200x200px square crop
+
+5. **If custom domain requested:**
    - Guide through Cloudflare custom domain setup
    - See [references/cloudflare-pages-setup.md](references/cloudflare-pages-setup.md)
    - Update config with new domain
 
-5. **If delete sample notes:**
+6. **If delete sample notes:**
    ```bash
    rm -f src/content/notes/*.md
    rm -f src/content/updates/*.md
    ```
    Then create fresh `my-working-notes.md` with user's welcome content.
 
-6. Rebuild and push: `pnpm build && git add -A && git commit -m "[configure] Personalize wiki" && git push`
+7. Rebuild and push: `pnpm build && git add -A && git commit -m "[configure] Personalize wiki" && git push`
 
 **Exit:** "Wiki personalized! Changes will deploy in ~90 seconds."
 

--- a/.claude/skills/wiki/references/cloudflare-pages-setup.md
+++ b/.claude/skills/wiki/references/cloudflare-pages-setup.md
@@ -1,167 +1,121 @@
 # Cloudflare Pages Setup
 
-One-time setup for auto-deploy. After this, every `git push` deploys automatically.
+Deploy your wiki to Cloudflare Pages using the wrangler CLI.
 
 **Stuck?** Drag a screenshot into chat for help.
 
 ---
 
-## What's a CLI?
+## CLI Deployment (Default)
 
-CLI = Command Line Interface. It's the terminal/command prompt where you type commands.
+### 1. Check wrangler authentication
 
-**UI (dashboard)** = Click buttons in a browser
-**CLI (terminal)** = Type commands like `git push`
-
-After this one-time UI setup, you'll work entirely in the CLI. That's where I can help you directly — no more dashboard needed.
-
----
-
-## Quick Path
-
-```
-Workers & Pages → Create application → "Looking to deploy Pages? Get started" (bottom link!)
-→ Import an existing Git repository → Select repo → Fill build settings → Save and Deploy
+```bash
+npx wrangler whoami
 ```
 
----
+**If not logged in:**
+```bash
+npx wrangler login
+```
+Opens browser for OAuth. You can create a free Cloudflare account during this flow.
 
-## Step-by-Step
+### 2. Create Pages project
 
-### 1. Navigate to Pages
+```bash
+npx wrangler pages project create [project-name] --production-branch main
+```
 
-Left sidebar: **Build** → **Compute & AI** → **Workers & Pages**
+This creates an empty project at `https://[project-name].pages.dev`.
 
-### 2. Create Application
+### 3. Deploy
 
-Click **"Create application"** (blue, top right)
+```bash
+npx wrangler pages deploy dist --project-name [project-name]
+```
 
----
+Wrangler outputs the URL. Note this for your `astro.config.mjs`.
 
-⚠️ **WARNING: Worker vs Page Confusion**
+### 4. Subsequent deploys
 
-The default screen is **Workers** (wrong!). You need **Pages**.
+After any changes:
+```bash
+pnpm build
+npx wrangler pages deploy dist --project-name [project-name]
+```
 
-Look for the small link at the **BOTTOM** of the page:
-> "Looking to deploy Pages? **Get started**"
-
-Click **"Get started"** to switch to the Pages flow.
-
-If you miss this, you'll create a Worker instead of a Page — it won't work and you'll have to delete it and start over.
-
----
-
-### 3. Choose Import Method
-
-Select: **"Import an existing Git repository"** → **Get started**
-
-### 4. Connect GitHub
-
-⚠️ **First time connecting Cloudflare to GitHub?** You'll need to install the Cloudflare Pages GitHub app:
-1. Click **"Connect GitHub"** button
-2. Authorize Cloudflare to access your GitHub account
-3. Choose **"Only select repositories"** and pick your wiki repo
-4. Click **"Install & Authorize"**
-
-**Already connected?** Continue below:
-
-- Make sure you're on the **GitHub** tab (not GitLab)
-- Select your GitHub account from dropdown
-- Find and click your wiki repo (e.g., `my-wiki`)
-- Click **"Begin setup"**
-
-*Repo not showing?* Click "configure repository access for the Cloudflare Pages app on GitHub" to add it.
-
-### 5. Build Settings
-
-| Field | Value |
-|-------|-------|
-| Project name | (auto-filled from repo) |
-| Production branch | `main` |
-| Framework preset | `Astro` or `None` |
-| **Build command** | `pnpm build` |
-| **Build output directory** | `dist` |
-
-Advanced settings (optional, leave defaults):
-- Root directory: `/`
-- Environment variables: none needed
-
-### 6. Deploy
-
-Click **"Save and Deploy"**
-
-First build takes ~1-2 minutes. Watch progress on screen.
-
-**Build stages you'll see:**
-1. Initializing build environment
-2. Cloning git repository
-3. Building application
-4. Deploying to Cloudflare's global network
-
-**Success screen shows:**
-- "Your project is deployed to Region: Earth"
-- Link to your site: `[project-name].pages.dev`
-- Next steps (you can ignore these)
+Or set up auto-deploy (below) so `git push` deploys automatically.
 
 ---
 
-## You're Done with the Dashboard!
+## Auto-Deploy Setup (Optional)
 
-Once you see the success screen, **you never need to open this dashboard again**.
+Connect GitHub so every `git push` deploys automatically. One-time dashboard setup.
 
-From now on:
-- Edit files locally
-- `git add . && git commit -m "message" && git push`
-- Cloudflare automatically rebuilds and deploys
+### Quick Path
 
-I can help you with everything from the terminal now. The dashboard was just the one-time connection step.
+```
+dash.cloudflare.com → Workers & Pages → [your project] → Settings → Builds & deployments → Connect to Git
+```
+
+### Step-by-Step
+
+1. Go to https://dash.cloudflare.com
+2. Left sidebar: **Workers & Pages**
+3. Click your project name
+4. **Settings** tab → **Builds & deployments**
+5. Click **"Connect to Git"**
+6. Authorize GitHub if prompted
+7. Select your repository
+8. Build settings:
+   - Build command: `pnpm build`
+   - Build output directory: `dist`
+9. **Save**
+
+Now every `git push` triggers automatic deploy.
 
 ---
 
 ## Custom Domain (Optional)
 
-Skip this if you're fine with `[project].pages.dev` for now. **You can add a domain later anytime with `/wiki domain-setup`.**
+Skip this if `[project].pages.dev` works for now.
 
 ### Check: Is your domain already on Cloudflare?
 
-Go to Account home → Domains. Is your domain listed there?
+Go to Account home → Domains.
 
-**YES → Easy path:**
+**YES (domain on Cloudflare) → Easy:**
 1. Workers & Pages → your project → **Custom domains** tab
 2. **"Set up a custom domain"**
 3. Enter your domain
 4. CF auto-configures DNS — done!
 
-**NO → Two options:**
+**NO (domain external) → Two options:**
 
 *Option 1: Add domain to Cloudflare (recommended)*
 1. Account home → Domains → **"Onboard a domain"**
-2. Enter your domain, follow steps to change nameservers at your registrar
+2. Change nameservers at your registrar (instructions provided)
 3. Wait for DNS propagation (up to 24-48 hours)
 4. Then follow "YES" path above
 
 *Option 2: Keep domain external*
-- Manually add CNAME record at your registrar pointing to `[project].pages.dev`
+- Add CNAME record at your registrar pointing to `[project].pages.dev`
 - Less integrated, SSL may have issues
 
 ---
 
 ## Common Issues
 
-**Created a Worker instead of a Page?**
-Symptoms: "Missing entry point" error, or project appears under Workers instead of Pages.
-Fix:
-1. Go to Workers & Pages → find your project
-2. Click it → Settings → scroll to bottom → **Delete**
-3. Start over from Step 2, but this time click the **"Pages: Get started"** link at the bottom
+**"Not logged in" error**
+Run `npx wrangler login` and complete OAuth in browser.
 
-**Repo not showing when connecting GitHub?**
-Click "configure repository access for the Cloudflare Pages app on GitHub" and add your repo.
+**Build failing with path error on Windows**
+See Troubleshooting in main skill file for `astro.backlinks.ts` fix.
 
-**Direct upload project can't add Git?**
-Delete project (Settings → Delete), recreate via this flow.
+**Build failing with sitemap error**
+Temporarily comment out sitemap in `astro.config.mjs`, deploy, then re-enable.
 
-**Build failing?**
-- Check Build command is `pnpm build` (not `npm run build`)
-- Check Build output directory is `dist` (not `public` or `/`)
+**Build failing in general**
+- Check build command is `pnpm build`
+- Check output directory is `dist`
 - Check for frontmatter errors — `status` must be `draft`, `live`, or `updated`

--- a/.claude/skills/wiki/references/cloudflare-pages-setup.md
+++ b/.claude/skills/wiki/references/cloudflare-pages-setup.md
@@ -1,121 +1,106 @@
 # Cloudflare Pages Setup
 
-Deploy your wiki to Cloudflare Pages using the wrangler CLI.
+Deploy your wiki to Cloudflare Pages with Git-connected auto-deploy.
 
 **Stuck?** Drag a screenshot into chat for help.
 
 ---
 
-## CLI Deployment (Default)
+## Create Git-Connected Project (Recommended)
 
-### 1. Check wrangler authentication
+This method enables auto-deploy — every `git push` automatically deploys.
 
-```bash
-npx wrangler whoami
-```
+### 1. Open Cloudflare Dashboard
 
-**If not logged in:**
-```bash
-npx wrangler login
-```
-Opens browser for OAuth. You can create a free Cloudflare account during this flow.
+Go to https://dash.cloudflare.com (create free account if needed)
 
-### 2. Create Pages project
+### 2. Navigate to Workers & Pages
 
-```bash
-npx wrangler pages project create [project-name] --production-branch main
-```
+Left sidebar: **Workers & Pages**
 
-This creates an empty project at `https://[project-name].pages.dev`.
+### 3. Create Application
 
-### 3. Deploy
+Click **"Create application"** (blue button, top right)
 
-```bash
-npx wrangler pages deploy dist --project-name [project-name]
-```
+### 4. Choose Pages (NOT Workers!)
 
-Wrangler outputs the URL. Note this for your `astro.config.mjs`.
+⚠️ **IMPORTANT:** The default screen shows Workers. Look for the small link at the **BOTTOM**:
 
-### 4. Subsequent deploys
+> "Looking to deploy Pages? **Get started**"
 
-After any changes:
-```bash
-pnpm build
-npx wrangler pages deploy dist --project-name [project-name]
-```
+Click **"Get started"** to switch to Pages.
 
-Or set up auto-deploy (below) so `git push` deploys automatically.
+### 5. Connect to Git
+
+Select **"Connect to Git"** → **Get started**
+
+### 6. Authorize GitHub
+
+- Click **"Connect GitHub"** if first time
+- Authorize Cloudflare to access your GitHub
+- Choose **"Only select repositories"** and pick your wiki repo
+- Click **"Install & Authorize"**
+
+If already connected, just select your wiki repo and click **"Begin setup"**
+
+### 7. Configure Build Settings
+
+| Field | Value |
+|-------|-------|
+| Project name | `wiki` (or preferred name) |
+| Production branch | `main` |
+| Build command | `pnpm build` |
+| Build output directory | `dist` |
+
+### 8. Deploy
+
+Click **"Save and Deploy"**
+
+First build takes ~1-2 minutes. Success screen shows your URL (e.g., `wiki-abc.pages.dev`).
 
 ---
 
-## Auto-Deploy Setup (Optional)
+## After Setup
 
-Connect GitHub so every `git push` deploys automatically. One-time dashboard setup.
+Every `git push` to main automatically deploys (~90 seconds).
 
-### Quick Path
-
-```
-dash.cloudflare.com → Workers & Pages → [your project] → Settings → Builds & deployments → Connect to Git
-```
-
-### Step-by-Step
-
-1. Go to https://dash.cloudflare.com
-2. Left sidebar: **Workers & Pages**
-3. Click your project name
-4. **Settings** tab → **Builds & deployments**
-5. Click **"Connect to Git"**
-6. Authorize GitHub if prompted
-7. Select your repository
-8. Build settings:
-   - Build command: `pnpm build`
-   - Build output directory: `dist`
-9. **Save**
-
-Now every `git push` triggers automatic deploy.
+No need for manual deploys or wrangler CLI.
 
 ---
 
 ## Custom Domain (Optional)
 
-Skip this if `[project].pages.dev` works for now.
+### Domain already on Cloudflare?
 
-### Check: Is your domain already on Cloudflare?
-
-Go to Account home → Domains.
-
-**YES (domain on Cloudflare) → Easy:**
 1. Workers & Pages → your project → **Custom domains** tab
 2. **"Set up a custom domain"**
-3. Enter your domain
-4. CF auto-configures DNS — done!
+3. Enter your domain — CF auto-configures DNS
 
-**NO (domain external) → Two options:**
+### Domain not on Cloudflare?
 
 *Option 1: Add domain to Cloudflare (recommended)*
 1. Account home → Domains → **"Onboard a domain"**
-2. Change nameservers at your registrar (instructions provided)
+2. Change nameservers at your registrar
 3. Wait for DNS propagation (up to 24-48 hours)
-4. Then follow "YES" path above
+4. Then add custom domain above
 
-*Option 2: Keep domain external*
-- Add CNAME record at your registrar pointing to `[project].pages.dev`
-- Less integrated, SSL may have issues
+*Option 2: External domain*
+- Add CNAME record at registrar pointing to `[project].pages.dev`
 
 ---
 
 ## Common Issues
 
-**"Not logged in" error**
-Run `npx wrangler login` and complete OAuth in browser.
+**Created a Worker instead of a Page?**
+Delete it (Settings → Delete) and start over. Make sure to click "Pages: Get started" link.
 
-**Build failing with path error on Windows**
-See Troubleshooting in main skill file for `astro.backlinks.ts` fix.
+**Repo not showing?**
+Click "configure repository access for the Cloudflare Pages app on GitHub" and add your repo.
 
-**Build failing with sitemap error**
-Temporarily comment out sitemap in `astro.config.mjs`, deploy, then re-enable.
+**Build failing?**
+- Build command must be `pnpm build`
+- Output directory must be `dist`
+- Check for frontmatter errors in notes
 
-**Build failing in general**
-- Check build command is `pnpm build`
-- Check output directory is `dist`
-- Check for frontmatter errors — `status` must be `draft`, `live`, or `updated`
+**Build failing with path error on Windows?**
+The `astro.backlinks.ts` needs a fix. See Troubleshooting in main skill file.

--- a/.claude/skills/wiki/references/cloudflare-pages-setup.md
+++ b/.claude/skills/wiki/references/cloudflare-pages-setup.md
@@ -164,4 +164,4 @@ Delete project (Settings → Delete), recreate via this flow.
 **Build failing?**
 - Check Build command is `pnpm build` (not `npm run build`)
 - Check Build output directory is `dist` (not `public` or `/`)
-- Check for frontmatter errors — `status` must be `seed`, `growing`, or `evergreen` (not `draft`)
+- Check for frontmatter errors — `status` must be `draft`, `live`, or `updated`

--- a/.claude/skills/wiki/references/cloudflare-pages-setup.md
+++ b/.claude/skills/wiki/references/cloudflare-pages-setup.md
@@ -36,10 +36,20 @@ Left sidebar: **Build** → **Compute & AI** → **Workers & Pages**
 
 Click **"Create application"** (blue, top right)
 
-**CRITICAL:** Default screen is Workers. Look for small link at bottom:
+---
+
+⚠️ **WARNING: Worker vs Page Confusion**
+
+The default screen is **Workers** (wrong!). You need **Pages**.
+
+Look for the small link at the **BOTTOM** of the page:
 > "Looking to deploy Pages? **Get started**"
 
-Click **"Get started"** to switch to Pages flow.
+Click **"Get started"** to switch to the Pages flow.
+
+If you miss this, you'll create a Worker instead of a Page — it won't work and you'll have to delete it and start over.
+
+---
 
 ### 3. Choose Import Method
 
@@ -47,12 +57,20 @@ Select: **"Import an existing Git repository"** → **Get started**
 
 ### 4. Connect GitHub
 
-- Click **GitHub** tab
+⚠️ **First time connecting Cloudflare to GitHub?** You'll need to install the Cloudflare Pages GitHub app:
+1. Click **"Connect GitHub"** button
+2. Authorize Cloudflare to access your GitHub account
+3. Choose **"Only select repositories"** and pick your wiki repo
+4. Click **"Install & Authorize"**
+
+**Already connected?** Continue below:
+
+- Make sure you're on the **GitHub** tab (not GitLab)
 - Select your GitHub account from dropdown
-- Find and click your wiki repo (e.g., `devon-wiki`)
+- Find and click your wiki repo (e.g., `my-wiki`)
 - Click **"Begin setup"**
 
-*Repo not showing? Click "configure repository access for the Cloudflare Pages app on GitHub"*
+*Repo not showing?* Click "configure repository access for the Cloudflare Pages app on GitHub" to add it.
 
 ### 5. Build Settings
 
@@ -130,12 +148,20 @@ Go to Account home → Domains. Is your domain listed there?
 
 ## Common Issues
 
-**Ended up in Workers flow?**
-Look for "Looking to deploy Pages? Get started" link at bottom. Easy to miss.
+**Created a Worker instead of a Page?**
+Symptoms: "Missing entry point" error, or project appears under Workers instead of Pages.
+Fix:
+1. Go to Workers & Pages → find your project
+2. Click it → Settings → scroll to bottom → **Delete**
+3. Start over from Step 2, but this time click the **"Pages: Get started"** link at the bottom
+
+**Repo not showing when connecting GitHub?**
+Click "configure repository access for the Cloudflare Pages app on GitHub" and add your repo.
 
 **Direct upload project can't add Git?**
 Delete project (Settings → Delete), recreate via this flow.
 
 **Build failing?**
-Check Build command is `pnpm build` (not `npm run build`).
-Check Build output directory is `dist` (not `public` or `/`).
+- Check Build command is `pnpm build` (not `npm run build`)
+- Check Build output directory is `dist` (not `public` or `/`)
+- Check for frontmatter errors — `status` must be `seed`, `growing`, or `evergreen` (not `draft`)

--- a/.claude/skills/wiki/references/cloudflare-pages-setup.md
+++ b/.claude/skills/wiki/references/cloudflare-pages-setup.md
@@ -102,7 +102,7 @@ I can help you with everything from the terminal now. The dashboard was just the
 
 ## Custom Domain (Optional)
 
-Skip this if you're fine with `[project].pages.dev` for now.
+Skip this if you're fine with `[project].pages.dev` for now. **You can add a domain later anytime with `/wiki domain-setup`.**
 
 ### Check: Is your domain already on Cloudflare?
 

--- a/.claude/skills/wiki/references/customization.md
+++ b/.claude/skills/wiki/references/customization.md
@@ -26,6 +26,12 @@ Your intro text here.
 
 ## Avatar
 
+**Via `/wiki configure`:**
+- When prompted, drag and drop your image into the terminal
+- The file path gets pasted automatically
+- Image is copied to your wiki's `public/avatar.jpg`
+
+**Manual:**
 1. Replace `public/avatar.jpg` (or `.png`) with your image
 2. Recommended size: 200x200px, square crop
 3. Run `/wiki publish` to deploy

--- a/.claude/skills/wiki/references/customization.md
+++ b/.claude/skills/wiki/references/customization.md
@@ -4,6 +4,26 @@ After initial setup, you can update any of these settings manually.
 
 ---
 
+## Welcome Page
+
+Edit `src/content/notes/my-working-notes.md`:
+
+```markdown
+---
+title: Welcome
+created: "2026-01-23"
+visibility: public
+status: live
+summary: Your tagline here
+---
+
+# Your Heading
+
+Your intro text here.
+```
+
+---
+
 ## Avatar
 
 1. Replace `public/avatar.jpg` (or `.png`) with your image

--- a/.claude/skills/wiki/references/customization.md
+++ b/.claude/skills/wiki/references/customization.md
@@ -1,0 +1,69 @@
+# Customize Your Wiki
+
+After initial setup, you can update any of these settings manually.
+
+---
+
+## Avatar
+
+1. Replace `public/avatar.jpg` (or `.png`) with your image
+2. Recommended size: 200x200px, square crop
+3. Run `/wiki publish` to deploy
+
+---
+
+## Display Name / Tagline
+
+Edit `src/config.ts` (or `astro.config.mjs` depending on template version):
+
+```ts
+export const SITE = {
+  author: "Your Name",
+  description: "Your Name's Notes",  // tagline
+  // ...
+}
+```
+
+---
+
+## Social Links
+
+Edit `src/config.ts`:
+
+```ts
+export const SOCIAL = {
+  twitter: "yourhandle",        // without @
+  github: "yourusername",
+  websites: [                   // array of URLs
+    "https://yoursite.com",
+    "https://yourother.site"
+  ],
+}
+```
+
+Leave empty string `""` or remove the line to hide a social link.
+
+---
+
+## Site URL / Domain
+
+Edit `astro.config.mjs`:
+
+```js
+export default defineConfig({
+  site: "https://yourdomain.com",
+  // ...
+})
+```
+
+If changing domains, also update your Cloudflare Pages custom domain settings.
+See `/wiki domain-setup` for help.
+
+---
+
+## After Any Changes
+
+Run `/wiki publish` to deploy your updates.
+
+Changes typically go live within 90 seconds.
+Check status: https://dash.cloudflare.com → Workers & Pages → [project-name]

--- a/.claude/skills/wiki/references/note-template.md
+++ b/.claude/skills/wiki/references/note-template.md
@@ -57,18 +57,6 @@ Links create **associative connections**, not hierarchies.
 
 ---
 
-## Word Count Targets
-
-| Status | Target | Max | Description |
-|--------|--------|-----|-------------|
-| **seed** | 50-150 | 200 | Rough capture, needs work |
-| **growing** | 100-200 | 300 | Being developed, iterating |
-| **evergreen** | 150-250 | 350 | Stable, refined, heavily linked |
-
-Only exceed 350 words with explicit justification.
-
----
-
 ## Frontmatter Template
 
 ```yaml
@@ -76,7 +64,7 @@ Only exceed 350 words with explicit justification.
 title: "Note Title as Concept Statement"
 created: 2026-01-21
 visibility: public
-status: seed | growing | evergreen
+status: draft | live | updated
 summary: "1-2 sentence summary for previews and hover cards"
 tags: [topic1, topic2]
 aliases: ["alternative name", "shorthand"]
@@ -87,7 +75,7 @@ aliases: ["alternative name", "shorthand"]
 - `title` — Concept-oriented statement
 - `created` — Date created
 - `visibility` — public, private, or draft
-- `status` — seed, growing, or evergreen
+- `status` — draft, live, or updated
 - `summary` — 1-2 sentences for previews
 
 **Optional fields:**
@@ -167,7 +155,7 @@ Write like yourself, not like generic AI.
 title: "Externalizing thought builds cognitive scaffold"
 created: 2026-01-21
 visibility: public
-status: evergreen
+status: live
 summary: "Writing ideas down frees working memory and reveals gaps in thinking."
 tags: [thinking, writing, cognition]
 ---
@@ -189,14 +177,13 @@ The best thinkers aren't those with better memories—they're those who external
 
 ## Quality Checklist
 
-Before marking note as `evergreen`:
+Before marking note as `live`:
 
 - [ ] Title is concept-oriented (not event-based or vague)
 - [ ] Content is atomic — one complete idea
-- [ ] Word count is 150-250 words (max 350 with justification)
 - [ ] Minimum 3 WikiLinks included
 - [ ] Link density ~1 per 30-50 words
 - [ ] Summary field is 1-2 sentences
 - [ ] No preamble — opens with core claim
 - [ ] Voice is direct, not generic AI
-- [ ] Status reflects actual state (seed → growing → evergreen)
+- [ ] Status reflects actual state (draft → live → updated)

--- a/decisions/2026-01-23-wiki-skill-improvements.md
+++ b/decisions/2026-01-23-wiki-skill-improvements.md
@@ -74,6 +74,14 @@ In `add` mode, mention valid status values:
 - Valid: `seed`, `growing`, `evergreen`
 - Invalid: `draft` (causes build failure)
 
+#### 5. Add `/wiki domain-setup` Mode
+
+New mode for adding custom domain after initial setup:
+- Reads existing config
+- Guides user through Cloudflare custom domain setup
+- Updates config and astro.config.mjs with new domain
+- References existing cloudflare-pages-setup.md for dashboard steps
+
 ### Deferred
 
 - **Avatar customization** — Adds complexity, users can manually edit
@@ -98,7 +106,9 @@ All changes align with skill-creator guidelines:
 - [ ] Update `.claude/skills/wiki/SKILL.md` setup mode with clean install option
 - [ ] Update `.claude/skills/wiki/SKILL.md` setup mode with CF warning
 - [ ] Update `.claude/skills/wiki/SKILL.md` add mode with frontmatter note
+- [x] Add `.claude/skills/wiki/SKILL.md` domain-setup mode
 - [ ] Update `.claude/skills/wiki/references/cloudflare-pages-setup.md` with stronger warnings
+- [x] Add note to CF reference about `/wiki domain-setup`
 - [ ] Test full setup flow after changes
 
 ## Approval

--- a/decisions/2026-01-23-wiki-skill-improvements.md
+++ b/decisions/2026-01-23-wiki-skill-improvements.md
@@ -82,13 +82,12 @@ New mode for adding custom domain after initial setup:
 - Updates config and astro.config.mjs with new domain
 - References existing cloudflare-pages-setup.md for dashboard steps
 
-#### 6. Add `/wiki deploy-status` Mode
+#### 6. Add Dashboard Link to `/wiki publish` Output
 
-New mode for checking Cloudflare deployment status after publish:
-- Requires wrangler CLI (optional dependency, one-time setup)
-- Uses `wrangler pages deployment list` to show recent deployments
-- Shows status (Success, Failed, In Progress) with timestamp
-- Updated `/wiki publish` exit message to reference this command
+Instead of a separate mode, simply include the Cloudflare dashboard link in the publish exit message:
+- No extra dependencies (no wrangler needed)
+- User can click through to check deployment status
+- Simpler UX than a separate command
 
 ### Deferred
 
@@ -115,8 +114,7 @@ All changes align with skill-creator guidelines:
 - [ ] Update `.claude/skills/wiki/SKILL.md` setup mode with CF warning
 - [ ] Update `.claude/skills/wiki/SKILL.md` add mode with frontmatter note
 - [x] Add `.claude/skills/wiki/SKILL.md` domain-setup mode
-- [x] Add `.claude/skills/wiki/SKILL.md` deploy-status mode
-- [x] Update `/wiki publish` exit message to reference deploy-status
+- [x] Add dashboard link to `/wiki publish` exit message
 - [ ] Update `.claude/skills/wiki/references/cloudflare-pages-setup.md` with stronger warnings
 - [x] Add note to CF reference about `/wiki domain-setup`
 - [ ] Test full setup flow after changes

--- a/decisions/2026-01-23-wiki-skill-improvements.md
+++ b/decisions/2026-01-23-wiki-skill-improvements.md
@@ -82,6 +82,14 @@ New mode for adding custom domain after initial setup:
 - Updates config and astro.config.mjs with new domain
 - References existing cloudflare-pages-setup.md for dashboard steps
 
+#### 6. Add `/wiki deploy-status` Mode
+
+New mode for checking Cloudflare deployment status after publish:
+- Requires wrangler CLI (optional dependency, one-time setup)
+- Uses `wrangler pages deployment list` to show recent deployments
+- Shows status (Success, Failed, In Progress) with timestamp
+- Updated `/wiki publish` exit message to reference this command
+
 ### Deferred
 
 - **Avatar customization** — Adds complexity, users can manually edit
@@ -107,6 +115,8 @@ All changes align with skill-creator guidelines:
 - [ ] Update `.claude/skills/wiki/SKILL.md` setup mode with CF warning
 - [ ] Update `.claude/skills/wiki/SKILL.md` add mode with frontmatter note
 - [x] Add `.claude/skills/wiki/SKILL.md` domain-setup mode
+- [x] Add `.claude/skills/wiki/SKILL.md` deploy-status mode
+- [x] Update `/wiki publish` exit message to reference deploy-status
 - [ ] Update `.claude/skills/wiki/references/cloudflare-pages-setup.md` with stronger warnings
 - [x] Add note to CF reference about `/wiki domain-setup`
 - [ ] Test full setup flow after changes

--- a/decisions/2026-01-23-wiki-skill-improvements.md
+++ b/decisions/2026-01-23-wiki-skill-improvements.md
@@ -124,17 +124,15 @@ All changes align with skill-creator guidelines:
 
 ## Action Items
 
-- [x] Update `.claude/skills/wiki/SKILL.md` setup mode with personalization prompts
-- [x] Update `.claude/skills/wiki/SKILL.md` setup mode with clean install option
 - [x] Update `.claude/skills/wiki/SKILL.md` setup mode with CF warning (GitHub app install note)
 - [x] Update `.claude/skills/wiki/SKILL.md` add mode with frontmatter note
-- [x] Add `.claude/skills/wiki/SKILL.md` domain-setup mode
 - [x] Add dashboard link to `/wiki publish` exit message
 - [x] Create `.claude/skills/wiki/references/customization.md` for post-setup edits
 - [x] Update `.claude/skills/wiki/references/cloudflare-pages-setup.md` with stronger warnings
-- [x] Add note to CF reference about `/wiki domain-setup`
-- [ ] Test full setup flow after changes
+- [x] Restructure: simplified setup (no prompts) + `/wiki configure` for all personalization
+- [x] Footer "Powered by Commune" links to devonmeadows.com even in fresh setup
+- [x] Test full setup flow (joedefilippo wiki deployed to CF Pages)
 
-## Approval
+## Status
 
-Awaiting user approval before implementation.
+Implemented and tested. Ready for PR.

--- a/decisions/2026-01-23-wiki-skill-improvements.md
+++ b/decisions/2026-01-23-wiki-skill-improvements.md
@@ -48,6 +48,10 @@ Update these files with user's identity:
 
 Created `references/customization.md` with instructions for updating all settings after setup.
 
+**Added from testing:**
+- Welcome page prompts (title, heading, intro text)
+- Generic avatar placeholder instead of Devon's photo
+
 #### 2. Add Clean Install Option
 
 After template merge, ask:

--- a/decisions/2026-01-23-wiki-skill-improvements.md
+++ b/decisions/2026-01-23-wiki-skill-improvements.md
@@ -1,7 +1,7 @@
 ---
 type: decision
 date: 2026-01-23
-status: proposed
+status: accepted
 linked_research: ["2026-01-23-wiki-skill-improvements-mining.md"]
 github_issue: 39
 ---
@@ -123,11 +123,11 @@ All changes align with skill-creator guidelines:
 - [x] Update `.claude/skills/wiki/SKILL.md` setup mode with personalization prompts
 - [x] Update `.claude/skills/wiki/SKILL.md` setup mode with clean install option
 - [x] Update `.claude/skills/wiki/SKILL.md` setup mode with CF warning (GitHub app install note)
-- [ ] Update `.claude/skills/wiki/SKILL.md` add mode with frontmatter note
+- [x] Update `.claude/skills/wiki/SKILL.md` add mode with frontmatter note
 - [x] Add `.claude/skills/wiki/SKILL.md` domain-setup mode
 - [x] Add dashboard link to `/wiki publish` exit message
 - [x] Create `.claude/skills/wiki/references/customization.md` for post-setup edits
-- [ ] Update `.claude/skills/wiki/references/cloudflare-pages-setup.md` with stronger warnings
+- [x] Update `.claude/skills/wiki/references/cloudflare-pages-setup.md` with stronger warnings
 - [x] Add note to CF reference about `/wiki domain-setup`
 - [ ] Test full setup flow after changes
 

--- a/decisions/2026-01-23-wiki-skill-improvements.md
+++ b/decisions/2026-01-23-wiki-skill-improvements.md
@@ -27,15 +27,26 @@ Implement Phase 1 and Phase 2 improvements to the wiki skill setup flow.
 
 #### 1. Add Personalization Prompts to Setup
 
-After template merge, prompt user:
-- **Display name** (required) — Used in site header, meta tags, footer
-- **Short name** (optional) — For mobile display, defaults to first name
+After template merge, prompt user for:
+
+| Prompt | Required | Default |
+|--------|----------|---------|
+| Display name | Yes | — |
+| Short name (mobile) | No | First word of display name |
+| Tagline | No | `{display name}'s Notes` |
+| Twitter/X handle | No | skip |
+| GitHub username | No | skip |
+| Website URLs | No | skip (comma-separated) |
 
 Update these files with user's identity:
-- `astro.config.mjs` — site title
+- `src/config.ts` or `astro.config.mjs` — name, tagline, social links
 - `src/components/Header.astro` — brand name
 - `src/pages/index.astro` — meta author, structured data
 - Any hardcoded "Devon Meadows" references
+
+**Deferred to manual:** Avatar upload — too complex, provide instructions instead.
+
+Created `references/customization.md` with instructions for updating all settings after setup.
 
 #### 2. Add Clean Install Option
 
@@ -109,12 +120,13 @@ All changes align with skill-creator guidelines:
 
 ## Action Items
 
-- [ ] Update `.claude/skills/wiki/SKILL.md` setup mode with personalization prompts
-- [ ] Update `.claude/skills/wiki/SKILL.md` setup mode with clean install option
-- [ ] Update `.claude/skills/wiki/SKILL.md` setup mode with CF warning
+- [x] Update `.claude/skills/wiki/SKILL.md` setup mode with personalization prompts
+- [x] Update `.claude/skills/wiki/SKILL.md` setup mode with clean install option
+- [x] Update `.claude/skills/wiki/SKILL.md` setup mode with CF warning (GitHub app install note)
 - [ ] Update `.claude/skills/wiki/SKILL.md` add mode with frontmatter note
 - [x] Add `.claude/skills/wiki/SKILL.md` domain-setup mode
 - [x] Add dashboard link to `/wiki publish` exit message
+- [x] Create `.claude/skills/wiki/references/customization.md` for post-setup edits
 - [ ] Update `.claude/skills/wiki/references/cloudflare-pages-setup.md` with stronger warnings
 - [x] Add note to CF reference about `/wiki domain-setup`
 - [ ] Test full setup flow after changes

--- a/decisions/2026-01-23-wiki-skill-improvements.md
+++ b/decisions/2026-01-23-wiki-skill-improvements.md
@@ -1,0 +1,106 @@
+---
+type: decision
+date: 2026-01-23
+status: proposed
+linked_research: ["2026-01-23-wiki-skill-improvements-mining.md"]
+github_issue: 39
+---
+
+# Decision: Wiki Skill Setup Improvements
+
+## Context
+
+GitHub Issue #39 identifies friction in the `/wiki setup` flow based on first-run testing. This decision captures the approved changes to address those issues.
+
+## Research
+
+See `research/2026-01-23-wiki-skill-improvements-mining.md` for full analysis of:
+- Mined transcripts from contributor testing
+- Devon's skill-creator guidelines
+- Current skill architecture
+
+## Decision
+
+Implement Phase 1 and Phase 2 improvements to the wiki skill setup flow.
+
+### Approved Changes
+
+#### 1. Add Personalization Prompts to Setup
+
+After template merge, prompt user:
+- **Display name** (required) — Used in site header, meta tags, footer
+- **Short name** (optional) — For mobile display, defaults to first name
+
+Update these files with user's identity:
+- `astro.config.mjs` — site title
+- `src/components/Header.astro` — brand name
+- `src/pages/index.astro` — meta author, structured data
+- Any hardcoded "Devon Meadows" references
+
+#### 2. Add Clean Install Option
+
+After template merge, ask:
+> "Include sample notes? (recommended for first-time wiki users) [Y/n]"
+
+If user declines:
+```bash
+rm -f src/content/notes/*.md
+rm -f src/content/updates/*.md
+# Keep research/ empty by default
+```
+
+#### 3. Improve Cloudflare Pages Guidance
+
+Update `references/cloudflare-pages-setup.md`:
+
+**A) Add first-time GitHub app installation step:**
+- Before "Connect GitHub", add explicit section for first-time users
+- Steps: Install Cloudflare Pages GitHub app → Authorize → Select repositories
+- Move this from troubleshooting footnote to primary flow
+
+**B) Add Worker vs Page warning:**
+- Add explicit **WARNING** callout about Worker vs Page confusion
+- Clarify "GitHub tab" selection step (user saw GitHub in multiple places)
+- Add troubleshooting entry: "Created a Worker instead of a Page? Delete and recreate."
+
+Update SKILL.md setup mode:
+- Add inline warning before CF dashboard step
+- Reference the "Get started" link at bottom explicitly
+- Note that first-time users need to install GitHub app
+
+#### 4. Add Frontmatter Validation Note
+
+In `add` mode, mention valid status values:
+- Valid: `seed`, `growing`, `evergreen`
+- Invalid: `draft` (causes build failure)
+
+### Deferred
+
+- **Avatar customization** — Adds complexity, users can manually edit
+- **Deployment verification** — `wrangler` CLI dependency not worth it
+- **Plausible analytics** — Comment out in template, separate concern
+
+## Rationale
+
+1. **Personalization prompts** — Users expect wiki to feel like theirs immediately
+2. **Clean install** — Power users want blank slate; beginners benefit from examples (default: include)
+3. **CF guidance** — The Worker vs Page confusion is the #1 setup failure
+4. **Frontmatter validation** — Prevents cryptic Astro build errors
+
+All changes align with skill-creator guidelines:
+- Keep SKILL.md under 500 lines (currently 291, adding ~50)
+- Focused improvements, not feature bloat
+- Reference files handle detailed documentation
+
+## Action Items
+
+- [ ] Update `.claude/skills/wiki/SKILL.md` setup mode with personalization prompts
+- [ ] Update `.claude/skills/wiki/SKILL.md` setup mode with clean install option
+- [ ] Update `.claude/skills/wiki/SKILL.md` setup mode with CF warning
+- [ ] Update `.claude/skills/wiki/SKILL.md` add mode with frontmatter note
+- [ ] Update `.claude/skills/wiki/references/cloudflare-pages-setup.md` with stronger warnings
+- [ ] Test full setup flow after changes
+
+## Approval
+
+Awaiting user approval before implementation.

--- a/research/2026-01-23-wiki-skill-improvements-mining.md
+++ b/research/2026-01-23-wiki-skill-improvements-mining.md
@@ -1,0 +1,225 @@
+---
+type: research
+date: 2026-01-23
+source: mining
+status: complete
+linked_decisions: ["2026-01-23-wiki-skill-improvements.md"]
+---
+
+# Wiki Skill Improvements Research
+
+Mining first-run testing feedback and contributor guidance to identify wiki skill improvements.
+
+## Sources Mined
+
+1. **GitHub Issue #39** — Detailed problem statement from @joedef after first-run testing
+2. **Devon's contributor guidance transcript** — How to approach skill modifications using /think and skill-creator guidelines
+3. **Joe's test drive transcript** — 1-hour raw session showing setup friction points in real time
+
+---
+
+## Key Findings
+
+### 1. GitHub → Cloudflare Connection Unclear
+
+**Problem:** Two distinct issues caused setup friction:
+
+**A) First-time GitHub app installation not called out**
+
+User had never connected Cloudflare to GitHub before. The setup assumes the Cloudflare Pages GitHub app is already installed, but first-time users must:
+1. Install the Cloudflare Pages GitHub app on their GitHub account
+2. Authorize it
+3. Select which repositories it can access (all or specific)
+
+**Current state:** The reference buries this as a troubleshooting footnote: "*Repo not showing? Click 'configure repository access'*" — but this is a REQUIRED first-time step, not an edge case.
+
+**B) Worker vs Page confusion**
+
+User accidentally created a Worker instead of a Page because Cloudflare dashboard defaults to Workers.
+
+**Evidence from Joe's transcript:**
+> "Missing Entry Point to Worker Script or to Assets Directory. This means that CloudFlare created a Workers Project instead of a Pages Project. It's a common mistake, the UI defaults to Workers."
+
+**Current state:** The `cloudflare-pages-setup.md` reference does mention this but it's easy to miss during setup.
+
+**Proposed fix:**
+- Add explicit "First time? Install the Cloudflare Pages GitHub app" step BEFORE selecting repo
+- Add explicit warning about Worker vs Page, make the distinction impossible to miss
+
+---
+
+### 2. Branding Not Customized During Setup
+
+**Problem:** Site deploys with Devon's name and likeness. User had to manually request changes.
+
+**Evidence from Joe's transcript:**
+> "On deployment, the site was still customized with Devin's name and likeness had to manually request, request changes for rebrand"
+> "not super clear to me right now that I'm working on my local repository... it has your name as the site"
+> "maybe this is part of, the setup process. You know, let them, let them customize. Or that could be another skill, wiki, customize."
+
+**Current state:** Setup flow does NOT prompt for user identity. Template ships with Devon's branding.
+
+**Proposed fix:** Add personalization prompts during setup — display name, short name for mobile, then auto-update:
+- `src/components/Header.astro` — brand name, avatar alt text
+- `src/pages/index.astro` — meta tags, structured data, author
+- `src/pages/notes/[...slug].astro` — author meta
+- `src/pages/research/[...slug].astro` — footer attribution
+- `src/pages/updates/*.astro` — site name
+- `public/robots.txt` — domain reference
+- `astro.config.mjs` — site URL
+
+---
+
+### 3. No Clean Installation Option
+
+**Problem:** Sample notes included by default with no option to start fresh.
+
+**Evidence from Joe's transcript:**
+> "It also installed with a good amount of existing notes and pages, which were very interesting. But I would also like the option to have a clean installation."
+
+**Current state:** Template merges all sample content automatically.
+
+**Proposed fix:** After merging template, ask:
+> "Include sample notes? (recommended for first-time users) [Y/n]"
+
+If declined:
+```bash
+rm -f src/content/notes/*.md
+rm -f src/content/updates/*.md
+```
+
+---
+
+### 4. Deployment Status Unclear
+
+**Problem:** Skill says "live" before Cloudflare actually finishes deploying.
+
+**Evidence from Joe's transcript:**
+> "it says it's live, right? But it's not live yet, right? It's just kicking off the job to deploy"
+> "Definitely we need to ping, I think, CloudFlare. If, if there is a deployment problem, we need to know about it. And we shouldn't say that it's live, like, until it's actually live."
+
+**Current state:** `publish` mode says "Cloudflare Pages will auto-deploy in ~90 seconds" without verification.
+
+**Proposed fix:** Either:
+- A) Add caveat: "Deployment triggered. Check Cloudflare dashboard if issues."
+- B) Add optional verification step using `wrangler` CLI (more complex)
+
+Given skill-creator guidelines favoring simplicity, option A is preferred.
+
+---
+
+### 5. Frontmatter Validation Gap
+
+**Problem:** Joe's note had `draft` in frontmatter where it needed `seed` — caused Cloudflare build failure.
+
+**Evidence from Joe's transcript:**
+> "deployment failed. invalid content entry... invalid enum value and it has to do with I guess this atomic note... Seed versus draft."
+
+**Current state:** `add` mode doesn't validate frontmatter values against Astro collection schema.
+
+**Proposed fix:** Add validation note to `add` mode:
+- Valid status values: `seed`, `growing`, `evergreen`
+- Invalid: `draft` (common mistake)
+
+---
+
+### 6. Windows Path Bugs
+
+**Evidence from Joe's transcript:**
+> "Windows Path Bug. Alright, so just so the transcript catches this, we want to open an issue that includes, uh, but there's a Windows Path Bug in Astro.Backlinks."
+
+**Assessment:** This is a template/Astro issue, not a skill issue. Should be tracked separately in commune-wiki repo.
+
+---
+
+## Skill-Creator Guidelines to Apply
+
+From Devon's contributor guidance:
+> "make sure to invoke the official Anthropic skill creator skill prior to adding to the skills. Because it, it defines, like, how skills should be, and it has all these suggestions about, like, how, how long they are, how to make reference files, what to put where, router stuff, brevity."
+
+Key guidelines from research:
+
+1. **Brevity under 500 lines** — Current SKILL.md is 291 lines, room for additions
+2. **Light-touch integration** — Don't bloat; keep changes focused
+3. **Natural language invocation** — Already good
+4. **Progressive context loading** — Reference files already separated
+5. **Recovery patterns** — Consider adding if setup fails mid-way
+
+---
+
+## Implementation Assessment
+
+### Phase 1: Quick Wins (High Priority)
+
+| Change | Effort | Impact |
+|--------|--------|--------|
+| Add Workers vs Pages warning to setup | Low | High |
+| Add personalization prompts to setup | Medium | High |
+| Update CF setup reference with clearer steps | Low | Medium |
+| Add frontmatter validation note to `add` mode | Low | Low |
+
+### Phase 2: Clean Install (Medium Priority)
+
+| Change | Effort | Impact |
+|--------|--------|--------|
+| Add sample notes prompt | Low | Medium |
+| Implement content deletion when declined | Low | Medium |
+
+### Phase 3: Polish (Low Priority)
+
+| Change | Effort | Impact |
+|--------|--------|--------|
+| Avatar customization option | Medium | Low |
+| Deployment verification | High | Low |
+| Handle Plausible analytics domain | Low | Low |
+
+---
+
+## Proposed Updated Setup Flow
+
+1. Check prerequisites (gh auth, pnpm)
+2. Ask: Repo name? Location?
+3. Create GitHub repo and clone
+4. Add upstream, fetch, merge template
+5. **NEW:** Ask: Include sample notes? [Y/n]
+6. **NEW:** Ask: Your display name? Short name (mobile)?
+7. **NEW:** Update branding in template files
+8. Ask: Domain type? (pages.dev or custom)
+9. Update astro.config.mjs with site URL
+10. pnpm install && pnpm build (verify locally)
+11. **IMPROVED:** Guide through CF Pages with stronger Worker vs Page warnings
+12. Save config
+13. First push to trigger deploy
+
+---
+
+## Files to Modify
+
+| File | Changes |
+|------|---------|
+| `.claude/skills/wiki/SKILL.md` | Add personalization prompts, clean install option, frontmatter validation |
+| `.claude/skills/wiki/references/cloudflare-pages-setup.md` | Strengthen Workers vs Pages warning, clarify GitHub tab selection |
+
+---
+
+## Open Questions
+
+1. **Avatar handling** — Should we prompt for avatar upload/URL, or leave for manual customization?
+   - **Recommendation:** Skip for now. Add `/wiki customize` skill later if demand exists.
+
+2. **Plausible analytics** — Template hardcodes `devonmeadows.com`. Remove or prompt?
+   - **Recommendation:** Comment out by default, add note to customize manually.
+
+3. **Deployment verification** — Should we use `wrangler pages deployment list` to verify?
+   - **Recommendation:** No, adds complexity. Just improve messaging.
+
+---
+
+## Summary
+
+The wiki skill works but has setup friction that can be resolved through:
+1. Better Cloudflare guidance (Worker vs Page warning)
+2. Personalization prompts (display name, clean install option)
+3. Minor validation improvements (frontmatter status values)
+
+Changes align with skill-creator guidelines: focused, brief additions that improve UX without bloating the skill.


### PR DESCRIPTION
## Summary

Implements issue #39 - Improve /wiki setup flow with personalization and clearer Cloudflare guidance.

**Changes:**
- Added personalization prompts (display name, avatar)
- Clean install option (remove sample notes)
- Improved Cloudflare Pages vs Workers warnings
- Added `/wiki configure` mode for post-setup changes
- Avatar drag-and-drop support
- Dashboard-first deploy approach

## Files Changed
- `.claude/skills/wiki/SKILL.md` - Main skill updates
- `.claude/skills/wiki/references/cloudflare-pages-setup.md` - CF warnings
- `.claude/skills/wiki/references/customization.md` - New reference
- `decisions/2026-01-23-wiki-skill-improvements.md`
- `research/2026-01-23-wiki-skill-improvements-mining.md`

## Test Plan
- [x] Run regression tests
- [ ] Test wiki setup flow with new prompts
- [ ] Verify CF Pages guidance is clear

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)