### PR TITLE
[add] One-liner ads mode to /ads skill

### DIFF
--- a/.claude/skills/ads/SKILL.md
+++ b/.claude/skills/ads/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: ads
-description: Create and review Meta/Facebook/Instagram ads. Routes to static image ads (copy + AI image prompts), video scripts (15-30 spoken-word scripts), or multi-lens compliance review. Use when asked to create ads, write ad copy, generate image prompts, write video scripts, or review ads for compliance. Say "/ads" or ask for "static ads", "video scripts", or "ad review".
+description: Create and review Meta/Facebook/Instagram ads. Routes to static image ads (copy + AI image prompts), video scripts (15-30 spoken-word scripts), one-liners (30 diversified lines for Andromeda), or multi-lens compliance review. Use when asked to create ads, write ad copy, generate image prompts, write video scripts, one-liners, or review ads for compliance. Say "/ads" or ask for "static ads", "video scripts", "one-liners", or "ad review".
 ---
 
 # Ads Skill
 
-Create static ads, video scripts, or review ads for compliance.
+Create static ads, video scripts, one-liners, or review ads for compliance.
 
 ## Triage
 
@@ -15,9 +15,10 @@ Determine mode from user request:
 |------|----------|--------|
 | **Static** | "static ads", "image ads", "primaries", "headlines", "image prompts" | 5-6 concepts, each with 5 primaries + 5 headlines + 3 image prompts |
 | **Video** | "video scripts", "ad scripts", "spoken word", "camera scripts" | 15-30 diverse scripts for spoken delivery |
+| **One-Liner** | "one-liners", "30 one-liners", "Andromeda", "diversified static copy" | 30 diversified one-liners for static image ads |
 | **Review** | "review", "check", "audit", "compliance", "before launch" | P1/P2/P3 report across 6 lenses |
 
-If unclear, ask: "Do you want static image ads, video scripts, or a compliance review?"
+If unclear, ask: "Do you want static image ads, video scripts, one-liners, or a compliance review?"
 
 ---
 
@@ -93,6 +94,57 @@ Campaign Batch 001
 | Interrupt | Pattern interrupt, scroll-stopping |
 
 See [references/static-output-template.md](references/static-output-template.md) for full output format.
+
+---
+
+## Mode: One-Liner
+
+Generate 30 punchy, truly diversified one-liners for static image ads that feed Meta's Andromeda algorithm.
+
+### Why This Mode Exists
+
+Meta's Andromeda algorithm (July 2025) rewards TRUE creative diversification - not surface variations. 30 one-liners = 30 different psychological conversations, each anchored in offer-specific details.
+
+### 6-Step Process
+
+1. **Core Outcome:** Single transformation every buyer achieves
+2. **Extract Specifics:** Roles, timelines, niche pains, value props, failed alternatives, proof points
+3. **Reasons to Buy:** 15-20 fundamentally different reasons (the protein supplement exercise)
+4. **Hook Categories:** Ensure variety across problem agitation, emotional state, transformation, contrarian, identity callout, etc.
+5. **Generate:** 30 one-liners, each with at least one specific anchor
+6. **Output:** Simple numbered list, ready to copy
+
+### The Anchor Rule (Non-Negotiable)
+
+Every one-liner **MUST** include at least one specific element:
+- A specific role, outcome, or company (DevOps Engineer, AWS, 60k)
+- A specific niche pain (service desk 2+ years, no CS degree)
+- A specific value prop (mock interviews with Principal Engineers)
+- A specific timeline or proof point (8 weeks, 500+ community)
+
+**The Specificity Test:** If this one-liner could sell a gym membership, a life coaching program, or a generic course - it fails. Rewrite it.
+
+### Input Modes
+
+| Mode | How to Detect | What to Pull |
+|------|---------------|--------------|
+| **Has business repo** | Reference files exist | `reference/core/offer.md`, `reference/core/audience.md`, `reference/core/voice.md`, testimonials |
+| **No repo** | Nothing found | Ask user for materials |
+
+### Output Format
+
+Simple numbered list. One per line. Ready to copy.
+
+```
+1. [one-liner]
+2. [one-liner]
+...
+30. [one-liner]
+```
+
+See [references/one-liner-methodology.md](references/one-liner-methodology.md) for the complete 6-step process, hook categories, and quality checklist.
+
+See [references/one-liner-examples.md](references/one-liner-examples.md) for real examples by offer type.
 
 ---
 

--- a/.claude/skills/ads/references/one-liner-examples.md
+++ b/.claude/skills/ads/references/one-liner-examples.md
@@ -1,0 +1,165 @@
+# One-Liner Examples
+
+Real examples organized by offer type. Use for pattern recognition, not copying.
+
+---
+
+## Barber Business Coaching ($77/month)
+
+**Core outcome:** Barbers making $10K+/month working fewer hours
+
+**Reasons to buy:**
+
+| # | Reason | Psychological Driver |
+|---|--------|---------------------|
+| 1 | Income plateau | Frustration, stuck |
+| 2 | Skills vs. system | Reframe, insight |
+| 3 | No time freedom | Burnout, escape |
+| 4 | Vacation impossible | Life quality |
+| 5 | Hours vs. income | Efficiency desire |
+| 6 | Trading time | Business model |
+| 7 | Full chair, empty bank | Confusion |
+| 8 | Hard work not paying | Unfairness |
+| 9 | Competitor comparison | Envy, curiosity |
+| 10 | Identity/pride | Recognition |
+
+**One-liners:**
+
+```
+1. If you're a barber stuck at $4K a month no matter how hard you grind, this was built for you.
+
+2. You're good at cutting hair. You're broke anyway. The problem isn't your skills. It's your system.
+
+3. If your business stops when you stop, you don't own a business. You own a job.
+
+4. The reason you can't take a vacation is fixable. For $77/month.
+
+5. Making $10K/month is great. Doing it in half the hours is better.
+
+6. Still trading time for money? There's a reason the best barbers don't.
+
+7. Your chair is full. Your bank account isn't. Something's broken.
+
+8. If you're working 60 hours a week and still stressed about rent, the problem isn't effort.
+
+9. The barber down the street makes twice what you do. He's not twice as talented.
+
+10. Built for barbers who are done being the hardest worker in the room with the smallest check.
+```
+
+**Patterns used:**
+- If [identity] + [pain], [promise] (#1)
+- [Affirm]. [Negate]. [Reframe]. (#2)
+- [Reframe their reality] (#3)
+- [Pain is fixable]. [Price]. (#4)
+- [Good]. [Better]. (#5)
+- [Question]. [Answer]. (#6)
+- [Observation]. [Conclusion]. (#7)
+- [Situation]. [Insight]. (#8)
+- [Comparison]. [Twist]. (#9)
+- [Identity call-out] (#10)
+
+---
+
+## Credit Repair ($5 entry)
+
+**Core outcome:** Credit score high enough to get approved
+
+**Reasons to buy:**
+
+| # | Reason | Trigger Moment |
+|---|--------|----------------|
+| 1 | Apartment denial | Just got denied |
+| 2 | Car financing | Dealership ran credit |
+| 3 | DIY failure | Tried fixing it themselves |
+
+**One-liners:**
+
+```
+1. If you just got denied for an apartment because of your credit, start here for $5.
+
+2. If the dealership ran your credit and everything changed, start here for $5.
+
+3. If you've tried fixing your credit yourself and got nowhere, try $5 credit repair.
+```
+
+**Why these work:**
+- Specific trigger moment (not generic "bad credit")
+- Low entry point removes friction
+- Meets them in the exact moment of pain
+
+---
+
+## Autism Parent Program
+
+**Core outcome:** Clear home plan for raising neurodivergent children
+
+**Reasons to buy:**
+
+| # | Reason | Psychological Driver |
+|---|--------|---------------------|
+| 1 | Need real plan | Structure, control |
+| 2 | Want clarity | Overwhelm, direction |
+
+**One-liners:**
+
+```
+1. If you're a mom of an autistic child ages 2-12 and want a real home plan, we built this for you.
+
+2. If you're raising an autistic or neurodivergent child and want clarity on what to focus on, we built this for you.
+```
+
+**Why these work:**
+- Ultra-specific identity (mom, ages 2-12)
+- Specific desire (real home plan, clarity on focus)
+- "Built for you" ending
+
+---
+
+## Pattern Analysis
+
+### What makes these work:
+
+| Element | Generic (weak) | Specific (strong) |
+|---------|----------------|-------------------|
+| Identity | "business owners" | "barbers" |
+| Pain | "struggling financially" | "stuck at $4K a month" |
+| Trigger | "need help with credit" | "just got denied for an apartment" |
+| Price | "affordable" | "$5" / "$77/month" |
+| Age/stage | "parents of kids" | "mom of an autistic child ages 2-12" |
+| Timeline | "eventually" | "8 weeks" / "2 years stuck" |
+| Outcome | "success" | "specific job title or result" |
+
+### Sentence rhythm:
+
+Short. Punchy. Fragments work.
+
+- "You're good at cutting hair." (6 words)
+- "You're broke anyway." (3 words)
+- "The problem isn't your skills." (5 words)
+- "It's your system." (3 words)
+
+### Endings that work:
+
+| Type | Example |
+|------|---------|
+| Built for you | "...this was built for you." |
+| Low price | "...start here for $5." |
+| Reframe | "...you don't own a business. You own a job." |
+| Implied promise | "...that's what happens when you stop guessing." |
+| Identity | "...built for barbers who are done trading time for money." |
+
+### Hook category variety:
+
+Don't use the same pattern 30 times. Mix:
+
+- Problem Agitation
+- Emotional State
+- Situational Context
+- Transformation
+- Contrarian
+- Curiosity Gap
+- Reframe
+- Identity
+- Comparison
+- Urgency/Timing

--- a/.claude/skills/ads/references/one-liner-methodology.md
+++ b/.claude/skills/ads/references/one-liner-methodology.md
@@ -345,3 +345,18 @@ Before outputting the 30 one-liners, verify:
 - [ ] Tone matches brand (direct? conversational? anti-hype?)
 - [ ] No forbidden words used
 - [ ] Preferred vocabulary applied where natural
+
+---
+
+## Step 7: Compliance Check (Recommended)
+
+One-liners are hooks. Aggressive claims sneak in here. Before finalizing:
+
+> "These one-liners are ready. Want me to run them through `/ads review` to check for FTC and Meta compliance issues?"
+
+Common one-liner compliance flags:
+- Income/outcome claims ("$10K months", "6-figure")
+- Implied guarantees ("never worry about X again")
+- Unsubstantiated comparisons ("better than", "fastest")
+
+A quick review catches issues before the copy goes to creative.

--- a/.claude/skills/ads/references/one-liner-methodology.md
+++ b/.claude/skills/ads/references/one-liner-methodology.md
@@ -1,0 +1,347 @@
+# One-Liner Methodology
+
+Reference for generating 30 diversified one-liners for static image ads that feed Meta's Andromeda algorithm.
+
+---
+
+## Why Diversification Matters
+
+Meta's Andromeda algorithm (July 2025) rewards TRUE creative diversification - not surface variations.
+
+**Surface variations (Andromeda penalizes this):**
+- "Struggling with lead generation? We can help."
+- "Need more leads? We've got solutions."
+- "Lead generation problems? We solve them."
+
+All three are the SAME psychological conversation. Different words, same message. Andromeda sees this as ONE ad, not three.
+
+**True diversification (Andromeda rewards this):**
+- **Referral Dependency:** "If you're still waiting for referrals to grow, that's why you're stuck at the same revenue."
+- **Time Freedom:** "Spending 20+ hours a week on marketing when you should be doing what you do best?"
+- **Competitive Pressure:** "Watching competitors with less experience win deals because they have better marketing?"
+- **Revenue Predictability:** "Tired of the feast-or-famine cycle where you never know if you'll make payroll?"
+
+Each is a DIFFERENT reason to buy. Different psychological driver. Different market segment. Different conversation.
+
+**Your job:** 30 one-liners = 30 different psychological conversations, each anchored in offer-specific details.
+
+---
+
+## Input Modes
+
+| Mode | How to Detect | What to Pull |
+|------|---------------|--------------|
+| **Has business repo** | Reference files exist | `reference/core/offer.md`, `reference/core/audience.md`, `reference/core/voice.md` (if exists), testimonials |
+| **Alternate structure** | Systems files exist | `systems/01-the-offer.md`, `systems/02-the-customer.md` |
+| **No repo** | Nothing found | Ask user for materials |
+
+If no reference files exist, ask: "Do you have a business repo set up, or should I work from materials you provide?"
+
+**Important:** Check for testimonials to understand results, but do NOT quote them directly in one-liners.
+
+**Voice (optional but recommended):** If `voice.md` exists, extract tone markers, words to use/avoid, and personality traits. One-liners should sound like the brand.
+
+---
+
+## 6-Step Process
+
+```
+Step 1: Core Outcome -> Step 2: Extract Specifics -> Step 3: Reasons to Buy -> Step 4: Hook Categories -> Step 5: Generate -> Step 6: Output
+```
+
+---
+
+### Step 1: Core Outcome
+
+Identify the single transformation every buyer achieves.
+
+Not features. Not process. The ONE result.
+
+> "What does every successful buyer walk away with?"
+
+| Offer Type | Core Outcome |
+|------------|--------------|
+| DevOps bootcamp | Regular people landing DevOps/Cloud Engineer jobs at companies like AWS |
+| Barber coaching | Barbers making $10K+/month working fewer hours |
+| Credit repair | Credit score high enough to get approved |
+| Fitness coaching | Busy professionals losing 20+ lbs without giving up their lifestyle |
+
+This outcome is the THROUGHLINE - but each one-liner approaches it from a different angle/reason.
+
+---
+
+### Step 2: Extract Specifics (REQUIRED)
+
+**This step prevents generic one-liners.** Before writing anything, extract the concrete details that make this offer UNIQUE.
+
+Fill out this table from reference files, testimonials, and offer details:
+
+| Category | What to Extract | Examples |
+|----------|-----------------|----------|
+| **Roles/Outcomes** | Job titles, results, companies | DevOps Engineer, Systems Engineer, AWS, Home Office, 60k+ |
+| **Timelines** | How fast people get results | 8 weeks, 6 months, within a year |
+| **Niche Pains** | Pains SPECIFIC to this audience | Stuck on service desk 2+ years, no CS degree, failing technical rounds, 40k ceiling |
+| **Value Props** | What makes THIS offer different | Mock interviews with Principal Engineers, 4-phase system, 500+ community, live mentoring |
+| **Failed Alternatives** | What they've tried that didn't work | YouTube tutorials, cheap Udemy courses, self-study, random bootcamps |
+| **Proof Points** | Numbers, stats, community size | 39 success stories, 5-stage interview prep, production-grade projects |
+
+**Example for a DevOps bootcamp:**
+
+| Category | Specifics Extracted |
+|----------|---------------------|
+| Roles/Outcomes | DevOps Engineer, Cloud Engineer, Systems Engineer, Platform Engineer, AWS, Home Office, 60k-100k |
+| Timelines | 8 weeks to job, 6 months to transform, hired within a year |
+| Niche Pains | Stuck on service desk 2+ years, no CS degree, failing technical rounds, 40k ceiling, wrong degree, retail/admin jobs |
+| Value Props | Mock interviews harder than real ones, live mentoring with Principal Engineers, 4-phase system, production-grade ECS project, CV grilling, 500+ community |
+| Failed Alternatives | YouTube tutorials, cheap courses, self-study with no structure, bootcamps with no job support |
+| Proof Points | Members hired at AWS, Home Office; 8 weeks to first offer; interview prep so hard the real thing feels easy |
+
+**Example for a barber coaching program:**
+
+| Category | Specifics Extracted |
+|----------|---------------------|
+| Roles/Outcomes | $10K+/month, 6-figure barber, shop owner, multiple chairs |
+| Timelines | 90 days to $10K months, doubled revenue in 6 months |
+| Niche Pains | Stuck at $4K/month, can't take vacation, 60-hour weeks, full chair but empty bank, trading time for money |
+| Value Props | Pricing system, rebooking scripts, client retention playbook, weekly calls with 6-figure barbers |
+| Failed Alternatives | Instagram marketing courses, generic business coaches, trying to figure it out alone |
+| Proof Points | Barbers hitting $15K months, cutting hours in half, taking first vacation in years |
+
+**These become your REQUIRED ANCHORS for Step 5.**
+
+---
+
+### Step 3: Reasons to Buy (The Protein Supplement Exercise)
+
+**List 15-20 fundamentally DIFFERENT reasons someone would buy this offer.**
+
+**The Protein Supplement Example:**
+
+Same product (protein powder) -> 6 completely different conversations:
+
+| Reason | Psychological Driver | One-Liner |
+|--------|---------------------|-----------|
+| Muscle building | Gains, achievement | "You're serious about gains. This protein maximizes muscle synthesis." |
+| Busy professional | Time scarcity | "No time for meal prep? Get complete nutrition in 30 seconds." |
+| Weight loss | Control, cravings | "Stay full longer and crush cravings with high-quality protein." |
+| Health conscious | Identity, purity | "Clean ingredients, no fillers, just pure nutrition." |
+| Performance athlete | Competition, recovery | "Recover faster and perform better." |
+| Budget-conscious | Value, smart spending | "Premium nutrition without the premium price tag." |
+
+**Each reason represents:**
+- A different person (or the same person in a different mindset)
+- A different psychological driver
+- A different pain point or desire
+- A different trigger moment
+
+**Brainstorm categories:**
+
+| Category | Questions to Ask |
+|----------|-----------------|
+| Functional benefits | What does it save? (time, money, effort) |
+| Emotional benefits | What do they feel? (confidence, peace, pride) |
+| Identity shifts | Who do they become? How do others see them? |
+| Pains to escape | What specific situations hurt? |
+| Fears driving action | What happens if they don't act? |
+| Desires pulling them | What does life look like after? |
+| Trigger moments | What specific events make them ready? |
+| Past failures | What have they tried that didn't work? |
+| Competitive pressure | What are peers doing that they're not? |
+| Life circumstances | Stage of life, family, career context? |
+
+**You need at least 15 distinct reasons before writing one-liners.**
+
+---
+
+### Step 4: Hook Categories
+
+Ensure variety by using different hook TYPES. Don't write 30 "If you're..." one-liners.
+
+| Category | Pattern | Example |
+|----------|---------|---------|
+| **Problem Agitation** | Identify and amplify specific pain | "Stuck on service desk for 2 years while others get promoted to Cloud Engineer." |
+| **Emotional State** | Meet them in their feeling | "If you're tired of applying to DevOps jobs and hearing nothing back..." |
+| **Situational Context** | Specific circumstance | "If you're a barber stuck at $4K/month no matter how hard you grind..." |
+| **Transformation** | Paint the after | "From service desk to Systems Engineer at AWS. That's not a fantasy - it's a system." |
+| **Contrarian** | Challenge conventional wisdom | "You don't need a CS degree to land a DevOps job. You need a system." |
+| **Curiosity Gap** | Create information gap | "The reason you keep failing technical interviews has nothing to do with your knowledge." |
+| **Reframe** | Shift perspective | "You don't have a skills problem. You have a structure problem." |
+| **Identity** | Call out who they are | "Built for career switchers who are done watching others break into tech." |
+| **Comparison** | Before/after or vs competitors | "Still watching YouTube tutorials while others are getting hired at AWS?" |
+| **Urgency/Timing** | Why now matters | "The tech job market has changed. This is how you catch up." |
+| **Direct Identity Callout** | Lead with who they are + situation + direct invitation | "If you're a mom of an autistic child ages 2-12 and want a real home plan, we built this for you." |
+
+**Aim for variety across categories.** If you notice you're repeating the same structure, switch categories.
+
+#### Direct Identity Callout (High-Performer)
+
+**Use this pattern for 8-10 of your 30 one-liners.** This format consistently outperforms observational hooks because it makes the reader immediately self-select.
+
+**Pattern:**
+```
+If you're a [specific identity] + [specific situation/pain/desire], [direct close].
+```
+
+**The power is in the first part** - not just "parent" but "working mom" or "mom of a child ages 2-12." Stack specificity:
+- Role/identity: "working mom", "barber stuck at $4K/month", "service desk engineer"
+- Situation modifier: "ages 2-12", "trying to support at home", "with no CS degree"
+- Pain or desire: "want a real home plan", "ready to break into DevOps"
+
+**Close variations:**
+- "we built this for you"
+- "this is for you"
+- "you're in the right place"
+- "this was made for you"
+
+**Examples:**
+- "If you're a working mom trying to support your autistic child at home, we built this for you."
+- "If you're a barber doing 60-hour weeks and still stuck at $4K/month, this was made for you."
+- "If you're on service desk with no CS degree but ready to break into DevOps, you're in the right place."
+
+---
+
+### Step 5: Generate One-Liners
+
+Write 30 one-liners. Each must:
+
+1. **Address a different reason to buy** (from Step 3)
+2. **Use variety of hook types** (from Step 4)
+3. **Include at least one SPECIFIC ANCHOR** (from Step 2)
+4. **Meet them where they are** - their situation, their pain, their desire
+5. **Match brand voice** (if voice.md exists) - use preferred words, avoid forbidden words, match tone
+
+#### THE ANCHOR RULE (MANDATORY)
+
+Every one-liner **MUST** include at least one specific element from Step 2:
+
+- A specific role, outcome, or company (DevOps Engineer, AWS, 60k)
+- A specific niche pain (service desk 2+ years, no CS degree, failing technical rounds)
+- A specific value prop (mock interviews with Principal Engineers, 4-phase system)
+- A specific timeline or proof point (8 weeks, 500+ community)
+
+**THE SPECIFICITY TEST:**
+
+> If this one-liner could sell a gym membership, a life coaching program, or a generic course - it fails. Rewrite it.
+
+**Bad (too generic):**
+- "You're not dumb. You just haven't found the right path."
+- "You have the motivation. You're missing the roadmap."
+- "If you feel behind, you're not. You just need to start."
+
+These could be for ANYTHING. They fail.
+
+**Good (anchored to offer):**
+- "You're not 'not technical enough.' Half the people landing DevOps jobs here started in retail."
+- "You'll outwork anyone. Point that at the 4-phase system and you're interviewing at AWS in months."
+- "Feeling behind at 27? The guy who just got hired at AWS felt the same way 8 weeks ago."
+
+These can ONLY be for this offer. They pass.
+
+#### Patterns that work (mix them up):
+
+| Pattern | Example |
+|---------|---------|
+| If [identity] + [niche pain], [specific outcome] | "If you've been stuck on service desk for 2 years, this is how people get to AWS in 8 weeks." |
+| [Affirm]. [Negate]. [Specific reframe]. | "You're technical enough. You're stuck anyway. The problem isn't skills - it's the 5-stage interview you haven't prepped for." |
+| [Niche situation] + [Specific outcome contrast] | "Still on service desk after 2 years. Others are at AWS after 8 weeks. The difference is the system." |
+| [Specific pain is fixable]. [Value prop]. | "The reason you keep failing technical interviews is fixable. Mock interviews with Principal Engineers." |
+| [Challenge belief with specific proof] | "You don't need a CS degree. The guy who just got hired at AWS didn't have one either." |
+| [Failed alternative] -> [Specific value prop] | "YouTube taught you Docker. It won't prep you for the 5-stage AWS interview." |
+| [Niche trigger] + [Specific timeline] | "Just got passed over for promotion again? People in your situation are Cloud Engineers within 6 months." |
+
+See [one-liner-examples.md](one-liner-examples.md) for more patterns and real examples.
+
+---
+
+### Step 6: Output
+
+Simple numbered list. One per line. Ready to copy.
+
+```
+1. [one-liner]
+2. [one-liner]
+3. [one-liner]
+...
+30. [one-liner]
+```
+
+No explanations. No categories. Just the list.
+
+After the list, optionally note which reasons/hook types were used for the client's reference.
+
+---
+
+## What NOT to Do
+
+| Don't | Why | Example |
+|-------|-----|---------|
+| **Write generic affirmations** | Could be for any offer | BAD: "You're not behind. You just haven't started." |
+| **Use vague value props** | "The right system" means nothing | BAD: "You need the right roadmap." |
+| **Use client quotes as one-liners** | Testimonials are proof, not hooks | BAD: `"The AWS interview felt easier than the prep." - Eid` |
+| **List features without context** | Features don't stop the scroll | BAD: "Weekly calls, CV reviews, mock interviews. $199/month." |
+| **Write surface variations** | Andromeda penalizes this | BAD: Three versions of "stuck in your career? we help" |
+| **Use buzzwords** | "Accountability" and "roadmap" are empty | BAD: "You're missing accountability - not motivation." |
+| **Write yes/no questions** | Binary "no" kills the hook | BAD: "Want to make more money?" |
+| **Skip the anchor check** | Generic one-liners waste ad spend | ALWAYS verify against Step 2 specifics |
+
+---
+
+## Clarifying Questions (No Repo Mode)
+
+If user provides materials but gaps exist, ask:
+
+| Gap | Question |
+|-----|----------|
+| No outcomes | "What specific results do people get? (Job titles, salaries, companies, timelines)" |
+| No niche pains | "What are the top 3 frustrations specific to YOUR audience? Not 'feeling stuck' but 'stuck at 40k ceiling' or 'failing technical interviews'" |
+| No value props | "What do you offer that's different? What would someone miss if they tried to do this alone?" |
+| No failed alternatives | "What have they tried before that didn't work? (YouTube, other courses, self-study)" |
+| No price | "What's the price point?" |
+| No timelines | "How fast do people typically see results?" |
+
+Don't ask all at once. Ask what's missing after reviewing their materials.
+
+---
+
+## Recovery from Compaction
+
+If context was compacted mid-task, check:
+
+1. **What step were we on?** (Core Outcome, Extract Specifics, Reasons, Hook Categories, Generating, Output)
+2. **Do we have the Specifics table?** This is critical - regenerate if missing
+3. **How many one-liners done?** Check if partial list was output
+4. **Resume:** Continue from last completed step
+
+```bash
+# Check for recent output in business repo
+ls -lt outputs/*.md 2>/dev/null | head -3
+```
+
+Then confirm: "I see we were generating one-liners. Continue from #[X]?"
+
+---
+
+## Quality Check Before Submitting
+
+Before outputting the 30 one-liners, verify:
+
+**Specificity (MOST IMPORTANT):**
+- [ ] Every one-liner includes at least one specific anchor from Step 2
+- [ ] No one-liner could work for a gym, diet, or generic self-help program
+- [ ] Niche pains are specific (not "feeling stuck" but "stuck on service desk for 2 years")
+- [ ] Outcomes are specific (not "success" but "DevOps Engineer at AWS")
+
+**Diversification:**
+- [ ] Each one-liner addresses a DIFFERENT reason to buy
+- [ ] Used variety of hook types (not all "If you're..." patterns)
+- [ ] No surface variations (same message, different words)
+
+**Formatting:**
+- [ ] No client quotes used as one-liners
+- [ ] No feature lists
+- [ ] Short, punchy sentences
+
+**Voice (if voice.md exists):**
+- [ ] Tone matches brand (direct? conversational? anti-hype?)
+- [ ] No forbidden words used
+- [ ] Preferred vocabulary applied where natural

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -221,7 +221,7 @@ Research files also add: `linked_decisions: []`
 | `/start` | Entry point — detects state, routes to right skill |
 | `/setup` | Bootstrap new repo with correct structure |
 | `/think` | Research → decide → codify into reference |
-| `/ads` | Static ads, video scripts, or compliance review |
+| `/ads` | Static ads, video scripts, one-liners, or compliance review |
 | `/vsl` | VSL scripts (Skool 18-section or B2B Haynes 7-step) |
 | `/content` | Mine competitors, generate organic scripts |
 | `/skool-manager` | Community engagement via Chrome |


### PR DESCRIPTION
## Summary

Promotes Joel's one-liner methodology from noontide-projects PR #10 into the VIP `/ads` skill.

- Adds one-liner mode routing to `/ads/SKILL.md`
- Creates `references/one-liner-methodology.md` (6-step Andromeda diversification process)
- Creates `references/one-liner-examples.md` (DevOps bootcamp and barber coaching examples)
- Includes Step 7 compliance check recommendation (suggest `/ads review` after generation)

## Origin

Joel submitted this as a standalone `/one-liner-ads` skill. Per skill architecture rules:
- Ads-related → `/ads`
- Organic-related → `/organic`
- VSL → `/vsl`

One-liner static image ads belong in `/ads`. Moved here as a mode rather than standalone skill.

## Test plan

- [ ] Invoke `/ads` and ask for one-liners
- [ ] Verify routing detects "one-liners", "30 one-liners", "Andromeda", "static copy"
- [ ] Verify 6-step process executes correctly
- [ ] Verify Step 7 suggests compliance review

🤖 Generated with [Claude Code](https://claude.com/claude-code)