### PR TITLE
Add content strategy layer across all skills

### DIFF
--- a/.claude/reference/domain-rubrics/community.md
+++ b/.claude/reference/domain-rubrics/community.md
@@ -16,6 +16,8 @@ Guide for structuring `reference/domain/` folder for community-based businesses 
 ```
 reference/
 └── domain/
+    ├── content-strategy.md   # Pillars, platforms, cadence, metrics
+    │
     ├── classroom/
     │   ├── modules.md        # Course modules and lessons
     │   └── resources.md      # Downloads, templates, tools
@@ -143,6 +145,35 @@ reference/
 
 ---
 
+### content-strategy.md
+
+**Purpose:** Strategic backbone for all content creation. Defines pillars, platforms, cadence, and metrics. Consumed by `/organic`, `/ads`, and `/newsletter` (coming soon).
+
+**Required sections:**
+- Content Pillars (3-5 themes with sub-topics)
+- Platform Strategy (priority-ordered platforms with format and cadence)
+- Content Mix (ratios: educational / entertaining / community / promotional)
+- Weekly Cadence (day-by-day template)
+- Metrics (PRP benchmarks, review cadence)
+
+**Optional sections (populate over time):**
+- Repurposing Flow
+- Content Genotype Defaults
+- Framework Library
+- Hooks Library
+
+**How it gets built:** Through `/think` cycles, not upfront. `/setup` scaffolds an empty template. Users fill sections through research, experimentation, and iteration.
+
+**How pillars are derived:**
+Each pillar must pass three tests:
+1. **Soul test** — Does this connect to why you exist?
+2. **Offer test** — Does this lead toward your mechanism?
+3. **Audience test** — Does your audience care?
+
+Pillars emerge from the intersection of soul.md + offer.md + audience.md. If a pillar fails any test, it is either the wrong pillar or the wrong business.
+
+---
+
 ## Optional Extensions
 
 | Folder | Use Case |
@@ -161,8 +192,9 @@ reference/
 | `core/audience.md` | `funnel/stages.md` |
 | `core/voice.md` | — |
 | `proof/testimonials.md` | — |
+| — | `content-strategy.md` |
 
-**The relationship:** `core/offer.md` summarizes the transformation. `domain/classroom/` is the delivery. `domain/membership/` is the access structure.
+**The relationship:** `core/offer.md` summarizes the transformation. `domain/classroom/` is the delivery. `domain/membership/` is the access structure. `domain/content-strategy.md` is the distribution backbone — it connects ALL core files (soul for pillar derivation, offer for promotional content, audience for topic relevance, voice for content tone).
 
 ---
 
@@ -216,9 +248,13 @@ When running `/think` to analyze Skool performance:
 
 | Skill | What It Reads |
 |-------|---------------|
+| `/think` | Writes to `content-strategy.md` during codify phase |
+| `/organic` | `content-strategy.md` for pillar alignment, platform format |
+| `/ads` | `content-strategy.md` for topic selection, funnel mapping |
+| `/newsletter` | `content-strategy.md` for pillar topics, repurposing flow (coming soon) |
 | `/vsl skool` | `funnel/stages.md`, `membership/benefits.md` |
 
 ---
 
-*Rubric version: 1.1*
-*Last updated: 2026-01-23*
+*Rubric version: 1.2*
+*Last updated: 2026-01-29*

--- a/.claude/skills/ads/SKILL.md
+++ b/.claude/skills/ads/SKILL.md
@@ -59,8 +59,11 @@ Before creating ads, the business repo must have:
 | `reference/core/audience.md` | Who buys, their pains, desires |
 | `reference/proof/testimonials.md` | Testimonials with names and outcomes |
 | `reference/proof/angles/*.md` | Different messaging entry points |
+| `reference/domain/content-strategy.md` | Content pillars, platform strategy (optional -- improves topic selection) |
 
 If reference files are missing, ask user to create them first.
+
+**Content funnel awareness:** Ads are the "immediate ROI" pillar of the two-pillar value prop (ads + content). In the content pipeline, ads drive newsletter signups, newsletter nurtures, Skool trial converts, revenue follows. If `content-strategy.md` exists, use content pillars to inform angle selection, metrics to understand what performs organically (ads amplify top-performing organic content), and funnel mapping to determine whether ads should target awareness, consideration, or conversion.
 
 ---
 

--- a/.claude/skills/help/SKILL.md
+++ b/.claude/skills/help/SKILL.md
@@ -37,6 +37,7 @@ Answer questions, troubleshoot issues, explain philosophy, suggest next steps.
 | Skool, community | [skool-help.md](references/skool-help.md) |
 | Wiki, atomic notes, publish, WikiLinks | Route to `/wiki` |
 | Better outputs, quality, what next | [making-outputs-better.md](references/making-outputs-better.md) |
+| Content strategy, pillars, platforms, newsletter, content plan | [content-strategy-help.md](references/content-strategy-help.md) |
 | Contribute, contributor | [becoming-contributor.md](references/becoming-contributor.md) |
 
 ---
@@ -57,3 +58,7 @@ Answer questions, troubleshoot issues, explain philosophy, suggest next steps.
 | When use slash commands? | For structured tasks: `/start`, `/think`, `/ads`, `/vsl` |
 | Drag files in? | Drag from Finder into Terminal, path appears |
 | Voice input? | [Wispr Flow](https://ref.wisprflow.ai/main) (affiliate link) |
+| What is content-strategy.md? | Your distribution backbone -- pillars, platforms, cadence. Built through `/think`, consumed by `/organic` and `/ads`. Lives in `reference/domain/`. |
+| How do I build a content strategy? | Run `/think`. Start by deriving 3-5 pillars from your soul.md + offer.md + audience.md. Then choose platforms, set cadence, and fill in over time. |
+| How do pillars work? | Each pillar is a content theme that passes three tests: Soul test (connects to why), Offer test (leads to mechanism), Audience test (they care). 3-5 pillars cover your content universe. |
+| What's the content pipeline? | Newsletter-first: write one keystone piece weekly, then `/organic` adapts it for social platforms, `/ads` amplifies top performers. One idea, many formats. |

--- a/.claude/skills/help/references/content-strategy-help.md
+++ b/.claude/skills/help/references/content-strategy-help.md
@@ -1,0 +1,151 @@
+# Content Strategy Help
+
+Answers to common questions about content-strategy.md and the content pipeline.
+
+---
+
+## What is content-strategy.md?
+
+Your distribution backbone. It defines:
+- **What** you talk about (content pillars)
+- **Where** you publish (platform strategy)
+- **When** you publish (weekly cadence)
+- **How much** of each type (content mix ratios)
+- **What works** (hooks library, framework library, metrics)
+
+It is a reference file that skills read when generating content. Without it, skills still work -- they just lack strategic alignment.
+
+---
+
+## Where does it live?
+
+```
+reference/
+└── domain/
+    └── content-strategy.md
+```
+
+It lives in `reference/domain/`, not `reference/core/`. Core files (soul, offer, audience, voice) are required for every business. Content strategy is domain-level -- it emerges over time through `/think` cycles, not at setup.
+
+**Why domain and not core?** You need to have your core reference solid before a content strategy makes sense. You also need some real content experience (what platforms you like, what topics land, what hooks work) before you can codify a strategy. It is emergent, not foundational.
+
+---
+
+## How does it relate to other reference files?
+
+| File | Answers | Relationship to Content Strategy |
+|------|---------|----------------------------------|
+| soul.md | WHY you exist | Pillars must connect to your soul (Soul test) |
+| offer.md | WHAT you sell | Pillars must lead toward your mechanism (Offer test) |
+| audience.md | WHO you serve | Pillars must address what your audience cares about (Audience test) |
+| voice.md | HOW you sound | Content tone and personality come from voice |
+| content-strategy.md | WHERE and WHEN | Distribution strategy informed by all four core files |
+
+Content strategy sits downstream of all four core files. If your core changes, your content strategy may need updating too.
+
+---
+
+## How do I build it?
+
+You build content-strategy.md through `/think` cycles, not all at once. The recommended path:
+
+1. **Start with pillars.** Run `/think` and say "I want to build my content strategy." Claude will guide you to derive 3-5 pillars from your soul.md + offer.md + audience.md.
+
+2. **Choose platforms.** Research where your audience actually is. Decide which platforms to prioritize. Codify into the Platform Strategy section.
+
+3. **Set a cadence.** Decide how often you publish, on which days, in what formats. Start simple -- you can always add more.
+
+4. **Fill in over time.** The Hooks Library, Framework Library, and Metrics sections grow as you create content and learn what works. They are not filled upfront.
+
+Each step is a `/think` cycle: research, decide, codify into content-strategy.md.
+
+---
+
+## What are the 9 sections?
+
+| Section | What It Contains | When It Gets Filled |
+|---------|-----------------|---------------------|
+| **Content Pillars** | 3-5 themes with sub-topics | First `/think` cycle |
+| **Platform Strategy** | Priority-ordered platforms with format, cadence, purpose | Early -- after choosing platforms |
+| **Content Mix** | Ratios: educational / entertaining / community / promotional | Early -- starting suggestion 50/25/15/10 |
+| **Weekly Cadence** | Day-by-day plan for what content type and platform | After platforms and pillars are set |
+| **Repurposing Flow** | Keystone piece to derivative content flow | After you have a keystone format (usually newsletter) |
+| **Content Genotype Defaults** | Preferred formats, durations, hook styles, variables to test | After some content creation experience |
+| **Metrics** | PRP benchmarks per platform, review cadence | After 2-4 weeks of publishing |
+| **Framework Library** | Proven frameworks extracted via mining | Grows over time from `/organic` mining |
+| **Hooks Library** | Hooks that work, organized by type | Grows over time from what performs |
+
+You do not need all 9 sections filled to start creating content. Pillars + Platform Strategy + Content Mix is enough to begin.
+
+---
+
+## How do skills use it?
+
+| Skill | How It Reads content-strategy.md |
+|-------|----------------------------------|
+| `/organic` | Suggests topics aligned to defined pillars. Uses platform format from Platform Strategy. Pulls hooks from Hooks Library. |
+| `/ads` | Uses pillars to inform angle selection. Uses metrics to identify top organic performers for paid amplification. |
+| `/newsletter` | Uses pillars for topic selection. Uses Repurposing Flow to map newsletter to derivative content. (Coming soon.) |
+| `/think` | Writes to content-strategy.md during the codify phase. This is the primary tool for building and updating the file. |
+
+If content-strategy.md does not exist, all skills work exactly as they did before. The integration is additive -- it improves output quality but is never required.
+
+---
+
+## What is the two-pillar value prop?
+
+Main Branch delivers two kinds of value:
+
+1. **Ads that convert** -- immediate ROI through `/ads` and `/vsl`. Reference files make ads specific, compliant, and high-converting.
+
+2. **Content that runs itself** -- long game through content strategy, `/organic`, and eventually `/newsletter`. One keystone piece (newsletter) gets adapted across platforms automatically.
+
+Both pillars are powered by the same reference files. The better your reference, the better both your ads and your content.
+
+---
+
+## What is the newsletter-first waterfall?
+
+The content pipeline flows from one keystone piece to many derivatives:
+
+```
+Newsletter (keystone, weekly)
+    |
+    v
+/organic --> Platform-adapted social content
+    |         (Reels, TikTok, carousels, threads)
+    v
+/ads --> Paid amplification of top performers
+    |
+    v
+/think --> Performance analysis, strategy updates
+    |       (what worked? update hooks library, metrics)
+    v
+Loop back to newsletter
+```
+
+**Why newsletter-first?** Writing one thoughtful piece per week is sustainable. AI adapts it for every platform. You never open a social media app to post -- the system handles distribution.
+
+**What if I do not have a newsletter yet?** You can still use `/organic` to create standalone content. The newsletter is the ideal keystone, but it is not required. Use `/think` to build your content strategy now; add the newsletter when you are ready.
+
+---
+
+## Common Questions
+
+**Q: Do I need content-strategy.md to use /organic?**
+No. `/organic` works without it. But with it, your content is strategically aligned instead of ad hoc.
+
+**Q: Can I skip straight to content-strategy.md without core reference?**
+Not recommended. Your pillars derive from soul + offer + audience. Without those, your pillars will be generic. Build core reference first.
+
+**Q: How often should I update content-strategy.md?**
+- Hooks Library and Framework Library: weekly (as you discover what works)
+- Metrics: monthly (review performance)
+- Pillars: quarterly (or when your offer fundamentally changes)
+- Platform Strategy: when you add or drop a platform
+
+**Q: What if I only do ads, not content?**
+Content-strategy.md is optional. If you only use `/ads` and `/vsl`, you do not need it. It becomes valuable when you start doing organic content or a newsletter.
+
+**Q: Is /newsletter available yet?**
+Not yet. It is coming soon and requires newsletter infrastructure (Beehiiv or similar). For now, use `/think` to build your content strategy and `/organic` to create social content. When `/newsletter` launches, your content-strategy.md will already be ready for it.

--- a/.claude/skills/organic/SKILL.md
+++ b/.claude/skills/organic/SKILL.md
@@ -114,6 +114,8 @@ This is why mining lives in `/think` — it's research that feeds your evergreen
 
 Requires `reference/core/voice.md`, `audience.md`, `offer.md`.
 
+**Optional but recommended:** `reference/domain/content-strategy.md` — If present, /organic reads content pillars to align generated content and platform strategy for format selection. Works perfectly without it.
+
 Search all working directories for `reference/core/`. If not found, ask user or run `/setup`.
 
 Missing files? See [references/first-time-setup.md](references/first-time-setup.md).
@@ -158,8 +160,10 @@ Which works better for you?
 Check for existing mined concepts, pick one, generate scripts.
 
 ```
-Check research/ -> Select concept -> Generate -> Output
+Check research/ -> Check content-strategy.md (if exists, suggest pillar-aligned topic) -> Select concept -> Generate -> Output
 ```
+
+If content-strategy.md exists and has pillars defined, suggest topics aligned to those pillars when the user has no specific concept in mind.
 
 If no mining exists, prompt: "No mined concepts found. Want to mine competitors first? That's `/think` — should I switch you over?"
 
@@ -196,6 +200,7 @@ Campaign name is REQUIRED. Ask user if not provided. Examples: `january-hooks`, 
 2. Check `outputs/*-organic-*/` — What scripts exist?
 3. Don't suggest re-mining same handles from today
 4. Recommend generating from existing mining if concepts unused
+5. Check `reference/domain/content-strategy.md` — What pillars are defined? What platform is the target?
 
 **Example context-aware response:**
 ```
@@ -280,6 +285,19 @@ See [references/organic-frameworks.md](references/organic-frameworks.md) for sof
 ## Integration with /think
 
 To save winning angles: route to `/think codify` → `reference/proof/angles/`.
+
+---
+
+## Content Strategy Integration
+
+If `reference/domain/content-strategy.md` exists, /organic uses it to improve output:
+
+- **Pillar alignment:** Suggest topics from defined pillars when user has no specific concept
+- **Platform format:** Default to the format matching the target platform from platform strategy
+- **Content mix:** Track which pillar types have been generated recently to maintain ratio balance
+- **Hooks library:** Pull proven hooks from the hooks library section if populated
+
+If content-strategy.md does not exist, /organic works exactly as before -- from mined concepts or user-provided topics. No warnings, no degradation.
 
 ---
 

--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -204,6 +204,7 @@ Full structure:
 │   │   ├── testimonials.md
 │   │   └── angles/        # Proven messaging entry points
 │   └── domain/            # Business-type specific
+│       └── content-strategy.md  # Content pillars, platforms, cadence
 │
 ├── research/              # Dated investigations
 │   └── YYYY-MM-DD-topic-[source].md
@@ -341,13 +342,16 @@ Use templates from `references/templates.md`.
 3. `reference/core/voice.md` — How you sound
 4. `reference/proof/testimonials.md` — Social proof
 5. `reference/proof/angles/` — Messaging entry points
+6. `reference/domain/content-strategy.md` — Content pillars, platforms, cadence (template for community businesses)
+
+> **Note:** content-strategy.md starts as an empty template and gets filled through `/think` cycles. Not required at setup — scaffolded with placeholder sections.
 
 ### 6. Apply Domain Rubric
 
 Based on business type, create domain-specific folders:
 
 **E-commerce:** `reference/domain/products/`, `reference/domain/fulfillment/`
-**Community:** `reference/domain/classroom/`, `reference/domain/membership/`, `reference/domain/funnel/`
+**Community:** `reference/domain/classroom/`, `reference/domain/membership/`, `reference/domain/funnel/`, `reference/domain/content-strategy.md`
 
 See `vip/.claude/reference/domain-rubrics/` for full specifications.
 
@@ -470,8 +474,10 @@ Once setup is complete, tell the user:
 >
 > **Key skills to try:**
 > - `/think` — Research topics, make decisions, update reference
+> - `/think` — Build your content strategy (pillars, platforms, cadence) — start here after core reference is solid
 > - `/ads` — Generate image ads, video scripts, or review for compliance
 > - `/vsl` — Write video sales letters (Skool or B2B)
+> - `/organic` — Create social content aligned to your content pillars
 > - `/help` — Get answers anytime you're stuck
 >
 > **The core loop:** Use `/think` regularly. Research → Decide → Codify. This is how your reference files get smarter over time.

--- a/.claude/skills/setup/references/templates.md
+++ b/.claude/skills/setup/references/templates.md
@@ -297,6 +297,174 @@ status: active
 
 ---
 
+## reference/domain/content-strategy.md
+
+```markdown
+---
+type: reference
+status: draft
+---
+
+# Content Strategy
+
+## Content Pillars
+<!-- 3-5 pillars derived from soul.md + offer.md + audience.md -->
+<!-- Each pillar must pass the triple test:
+     1. Soul test — Does this connect to why you exist?
+     2. Offer test — Does this lead toward your mechanism?
+     3. Audience test — Does your audience care about this?
+-->
+
+### Pillar 1: [Name]
+- **Theme:** [What this pillar covers]
+- **Sub-topics:** [Specific angles within this pillar]
+- **Connection:** [How it maps to offer/audience/soul]
+
+### Pillar 2: [Name]
+- **Theme:**
+- **Sub-topics:**
+- **Connection:**
+
+### Pillar 3: [Name]
+- **Theme:**
+- **Sub-topics:**
+- **Connection:**
+
+<!-- Add more pillars as needed — 3-5 is the sweet spot -->
+
+---
+
+## Platform Strategy
+<!-- Priority-ordered platforms with format, cadence, purpose, funnel role -->
+<!-- Start with 1-2 platforms. Add more only after consistency. -->
+
+| Platform | Format | Cadence | Purpose | Funnel Role |
+|----------|--------|---------|---------|-------------|
+| [e.g., Newsletter] | [Long-form] | [Weekly] | [Keystone content] | [Nurture] |
+| [e.g., Instagram] | [Reels, carousels] | [3x/week] | [Discovery] | [Awareness] |
+| [e.g., YouTube] | [Short-form] | [2x/week] | [Authority] | [Consideration] |
+
+---
+
+## Content Mix
+<!-- Ratios across content types -->
+<!-- Starting suggestion: 50 / 25 / 15 / 10 — adjust based on performance -->
+
+| Type | Target % | Description |
+|------|----------|-------------|
+| Educational | 50% | Teaches concepts, frameworks, how-tos |
+| Entertaining | 25% | Stories, personality, relatable moments |
+| Community | 15% | Engagement, questions, member spotlights |
+| Promotional | 10% | Direct offers, CTAs, launches |
+
+---
+
+## Weekly Cadence
+<!-- Day-by-day plan: what content type, which platform -->
+<!-- This is a starting template — iterate based on what works -->
+
+| Day | Content Type | Platform | Pillar | Notes |
+|-----|-------------|----------|--------|-------|
+| Mon | | | | |
+| Tue | | | | |
+| Wed | | | | |
+| Thu | | | | |
+| Fri | | | | |
+| Sat | | | | |
+| Sun | | | | |
+
+---
+
+## Repurposing Flow
+<!-- Keystone piece -> derivative flow -->
+<!-- The goal: create once, distribute everywhere -->
+
+```
+[Keystone piece, e.g., Newsletter]
+    |
+    ├── [Derivative 1, e.g., 3 social posts]
+    ├── [Derivative 2, e.g., 1 short-form video]
+    ├── [Derivative 3, e.g., Community discussion thread]
+    └── [Derivative 4, e.g., Email teaser]
+```
+
+---
+
+## Content Genotype Defaults
+<!-- Your preferred content DNA — the defaults AI uses when generating -->
+<!-- Variables to test next are tracked here so /think can run experiments -->
+
+| Variable | Current Default | Notes |
+|----------|----------------|-------|
+| Hook style | [e.g., question, bold claim, story] | |
+| Content format | [e.g., talking head, text overlay] | |
+| Duration | [e.g., 30-60 sec for reels] | |
+| CTA style | [e.g., soft, direct, community-invite] | |
+| Tone | [Reference voice.md] | |
+
+**Variables to test next:**
+<!-- Track what you want to experiment with -->
+- [ ] [e.g., Try controversial hooks vs educational hooks]
+- [ ] [e.g., Test 15-sec vs 60-sec format]
+
+---
+
+## Metrics
+<!-- PRP (per-piece performance) benchmarks per platform -->
+<!-- Updated through /think cycles analyzing performance data -->
+
+### Platform Benchmarks
+
+| Platform | Metric | Current Benchmark | Target | Last Updated |
+|----------|--------|-------------------|--------|--------------|
+| | Views | | | |
+| | Engagement rate | | | |
+| | Click-through | | | |
+
+### Review Cadence
+
+- **Weekly:** Check per-piece performance, update hooks library
+- **Monthly:** Review pillar performance, adjust content mix
+- **Quarterly:** Full strategy review — pillars still relevant? Platforms still right?
+
+---
+
+## Framework Library
+<!-- Proven content frameworks extracted via /think mining -->
+<!-- Each framework includes structure + when to use + example -->
+
+<!-- Example:
+### [Framework Name]
+- **Structure:** [Step-by-step pattern]
+- **When to use:** [What pillar/content type this fits]
+- **Example:** [Brief reference to a piece that used this]
+- **Source:** [Mined from competitor X / discovered through testing]
+-->
+
+---
+
+## Hooks Library
+<!-- Populated over time from what works -->
+<!-- Organized by hook type for quick reference during content creation -->
+
+### Question Hooks
+<!-- e.g., "What if everything you knew about X was wrong?" -->
+
+### Bold Claim Hooks
+<!-- e.g., "Most people fail at X because they skip this one step" -->
+
+### Story Hooks
+<!-- e.g., "Last Tuesday a member told me something that changed how I think about X" -->
+
+### Contrarian Hooks
+<!-- e.g., "Stop doing X. Here's what to do instead." -->
+
+### Data Hooks
+<!-- e.g., "97% of people who try X never see results. Here's why." -->
+```
+
+---
+
 ## decisions/YYYY-MM-DD-topic.md
 
 ```markdown

--- a/.claude/skills/start/SKILL.md
+++ b/.claude/skills/start/SKILL.md
@@ -69,6 +69,8 @@ Apply to: business repo selection, skill routing, any multiple choice.
 │   ├── "ads" / "copy" ───────────────→ /ads (triages to static/video/review)
 │   ├── "vsl" / "sales video" ────────→ /vsl (triages to skool/b2b)
 │   ├── "content" / "organic" ────────→ /organic
+│   ├── "newsletter" / "email" ───────→ /newsletter (coming soon — route to /think for now)
+│   ├── "content strategy" / "pillars"→ /think
 │   ├── "wiki" / "notes" ─────────────→ /wiki
 │   ├── "help" / questions ───────────→ /help
 │   └── unclear ──────────────────────→ Show options + mention /help
@@ -273,9 +275,10 @@ If user is ready to work, ask or infer intent. **Use numbered options:**
 > 2. Create ads (image or video) → `/ads`
 > 3. Write a VSL script → `/vsl`
 > 4. Create organic content → `/organic`
-> 5. Work on my wiki → `/wiki`
-> 6. Add more context → `/think codify`
-> 7. Get help → `/help`
+> 5. Write a newsletter → `/newsletter` (coming soon — use `/think` for now)
+> 6. Work on my wiki → `/wiki`
+> 7. Add more context → `/think codify`
+> 8. Get help → `/help`
 >
 > (hit a number to reply, or just tell me what you need)"
 
@@ -335,6 +338,7 @@ Read `user.experience` from `~/.config/vip/local.yaml` (defaults to `beginner` i
 | `/ads` | Generate image ads, video scripts, or review for compliance |
 | `/vsl` | Write video sales letters (Skool or B2B frameworks) |
 | `/organic` | Mine competitors, generate organic scripts |
+| `/newsletter` | Generate weekly newsletter from thinking work (coming soon) |
 | `/wiki` | Create atomic notes, publish wiki |
 
 ---
@@ -349,6 +353,8 @@ Use these to auto-detect what user wants:
 | "new", "first time", "get started", "set up" | `/setup` |
 | "add", "update", "more context", "new testimonials", "enrich" | `/think codify` |
 | "research", "decide", "figure out", "explore", "mine", "mining", "transcribe" | `/think` |
+| "content strategy", "pillars", "platforms", "cadence", "content plan" | `/think` |
+| "newsletter", "email", "beehiiv", "weekly email" | `/newsletter` (coming soon — route to `/think` for now) |
 | "ads", "copy", "static", "image ads", "video ads", "review", "compliance" | `/ads` |
 | "vsl", "sales video", "about page video", "b2b video" | `/vsl` |
 | "content", "reels", "tiktok", "organic", "mine", "competitors", "carousel" | `/organic` |

--- a/.claude/skills/think/SKILL.md
+++ b/.claude/skills/think/SKILL.md
@@ -29,7 +29,7 @@ Before diving in, know which mode you're in:
 
 | Mode | You're doing | Examples |
 |------|--------------|----------|
-| **Enriching the core** | Pulling insights → reference files | Mining videos, making decisions, updating offer.md |
+| **Enriching the core** | Pulling insights → reference files | Mining videos, making decisions, updating offer.md, **building content-strategy.md** |
 | **Creating for the world** | Reference files → output | Ads, scripts, courses, code, posts |
 
 `/think` is for **enriching the core**. When you're ready to create, use `/ads`, `/organic`, `/vsl`, or just ask.
@@ -124,6 +124,7 @@ Detect mode from user's natural language:
 | "decide", "we chose", "document decision" | Decide | [decide-phase.md](references/decide-phase.md) |
 | "codify", "apply", "update reference files" | Codify | [codify-phase.md](references/codify-phase.md) |
 | "add context", "enrich", "I have new info" | Codify | [codify-phase.md](references/codify-phase.md) |
+| "content strategy", "pillars", "what platforms", "content plan", "cadence" | Full Flow (codify to content-strategy.md) | [codify-phase.md](references/codify-phase.md) |
 | "where was I", "continue", "pick up" | Recovery | [recovery.md](references/recovery.md) |
 
 If unclear, ask: "Are you exploring a question, documenting a decision, or updating reference files?"
@@ -186,6 +187,8 @@ On every `/think` invocation, detect state and guide the next step:
 # Check for work in progress
 ls -lt research/*.md 2>/dev/null | head -3
 grep -l "status: proposed\|status: accepted" decisions/*.md 2>/dev/null
+# Also check content strategy state
+ls reference/domain/content-strategy.md 2>/dev/null
 ```
 
 | If you find... | Then... |
@@ -193,6 +196,8 @@ grep -l "status: proposed\|status: accepted" decisions/*.md 2>/dev/null
 | Recent research, no decision | "You have research on [topic]. Ready to make a decision?" |
 | Proposed decision | "Decision [topic] is proposed. Ready to accept it?" |
 | Accepted decision, unchecked items | "Decision [topic] has action items. Ready to codify?" |
+| content-strategy.md exists but empty/thin | "Your content strategy file is a skeleton. Want to fill it in? We can derive pillars from your soul.md + offer.md + audience.md." |
+| content-strategy.md missing (community biz) | "You don't have a content strategy yet. Want to build one? It'll define your pillars, platforms, and cadence." |
 | Nothing in progress | "What are you trying to figure out?" |
 
 **The goal is reference files.** Research and decisions are waypoints. Keep asking: "What needs to happen to get this into reference?"
@@ -278,6 +283,8 @@ Optionally create Claude tasks for execution tracking. See [decide-phase.md](ref
 ### 8. Codify
 
 Apply action items to reference files. Mark decision as codified.
+
+**Codify targets include:** `reference/core/*.md`, `reference/proof/angles/*.md`, `reference/proof/testimonials.md`, **`reference/domain/content-strategy.md`** (pillars, hooks library, framework library, metrics).
 
 ---
 

--- a/.claude/skills/think/references/codify-phase.md
+++ b/.claude/skills/think/references/codify-phase.md
@@ -144,6 +144,40 @@ After codifying, show summary:
 
 ---
 
+## Content Strategy Updates
+
+When codifying decisions about content pillars, platform selection, cadence, or content performance, update `reference/domain/content-strategy.md`. Sections to update:
+
+| Decision About | Update Section |
+|----------------|----------------|
+| New pillar discovered | **Content Pillars** — add pillar with sub-topics and three tests (soul, offer, audience) |
+| Platform added or removed | **Platform Strategy** — update priority-ordered platform list |
+| Winning hook identified | **Hooks Library** — add hook with context and performance |
+| New framework extracted | **Framework Library** — add framework with source and transfer notes |
+| New benchmark established | **Metrics** — update PRP benchmarks or review cadence |
+| Content mix ratio adjusted | **Content Mix** — update ratios based on performance data |
+| Cadence changed | **Weekly Cadence** — update day-by-day plan |
+
+**How /think cycles update content-strategy.md:**
+
+```
+Research: "Which platforms does my audience use?"
+  → Decide: Platform strategy (Instagram Reels + newsletter)
+    → Codify: Update Platform Strategy section in content-strategy.md
+
+Research: "What content themes drive engagement?"
+  → Decide: Three pillars (transformation stories, tactical tips, community wins)
+    → Codify: Update Content Pillars section in content-strategy.md
+
+Mining: Competitor content analysis
+  → Extract: Framework (hook pattern, emotional arc)
+    → Codify: Add to Framework Library + Hooks Library in content-strategy.md
+```
+
+If `content-strategy.md` does not exist and the user is codifying content-related decisions, suggest creating it: "This looks like content strategy work. Want to create `reference/domain/content-strategy.md` to store this?"
+
+---
+
 ## Exit Criteria
 
 Codification is complete when:

--- a/.claude/skills/think/references/research-phase.md
+++ b/.claude/skills/think/references/research-phase.md
@@ -51,6 +51,23 @@ Detailed workflow for research mode in `/think`.
 
 ---
 
+## Content Strategy Research Routing
+
+When the user's research topic involves content pillars, platform selection, content cadence, or content performance, check `reference/domain/content-strategy.md` first. If it exists, read it to understand current strategy before researching.
+
+**Trigger topics:** content pillars, which platforms, content plan, cadence, content mix, repurposing, hooks, content frameworks, content metrics, newsletter strategy
+
+**Research flow for content strategy topics:**
+1. Read existing `reference/domain/content-strategy.md` (if present) to understand current state
+2. Read `reference/core/soul.md` + `offer.md` + `audience.md` for pillar derivation context
+3. Conduct research (web, mining, competitor analysis)
+4. Synthesize into a research file as usual
+5. In the **Implications for Reference Files** section, note which sections of `content-strategy.md` should be updated
+
+If `content-strategy.md` does not exist, the research output should recommend creating it as an action item.
+
+---
+
 ## Sources to Check
 
 1. **Codebase** — Existing reference files, past decisions, research

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,8 @@
 - **Synthesize research** into evergreen reference
 - **Control** exactly what informs every output
 
+Two pillars power every business: **ads that convert** (immediate ROI) and **content that runs itself** (long game). Both are driven by the same reference files -- your offer, audience, voice, and proof inform everything from a static ad to a newsletter-first content pipeline.
+
 This engagement is the learning. Articulating your offer, audience, angles — you understand your business more deeply than passive memory allows.
 
 **Reference files as reconnection:** The act of writing and refining reference files isn't just documentation — it's identity work. It keeps you associated with WHY you do this, not dissociated into pure execution.
@@ -52,6 +54,10 @@ You're a thoughtful friend helping them build their business, not a task executo
 - If the think cycle feels like pushing, they might have the wrong offer
 - The goal is they stay *associated*, not dissociated into execution mode
 
+**Connect to content strategy:**
+- If they have reference files but no content strategy, suggest building one through /think
+- If they're creating content without a plan, route to /think to build content-strategy.md first
+
 ---
 
 ## When to Route
@@ -63,13 +69,15 @@ Take inventory. Notice what's missing. Proactively suggest skills they haven't i
 | Lost, confused, returning | `/start` |
 | Brand new, need repo setup | `/setup` |
 | Exploring, researching, deciding | `/think` |
+| Building content pillars, planning platforms | `/think` |
 | Ready to create paid ads | `/ads` |
 | Need a sales video script | `/vsl` |
 | Want organic content (reels, tiktok) | `/organic` |
+| Want to write a newsletter | `/newsletter` (coming soon -- use `/think` for now) |
 | Building a wiki or notes | `/wiki` |
 | Asking questions, troubleshooting | `/help` |
 
-**Quick triggers:** "research/decide" → `/think` · "ads/copy" → `/ads` · "organic/reels" → `/organic` · "help/stuck" → `/help`
+**Quick triggers:** "research/decide" → `/think` · "ads/copy" → `/ads` · "organic/reels" → `/organic` · "newsletter/email" → `/newsletter` · "content strategy/pillars" → `/think` · "help/stuck" → `/help`
 
 ---
 
@@ -88,6 +96,7 @@ vip (ENGINE)                          your-repo (DATA)
                                       │   ├── brand/
                                       │   ├── proof/
                                       │   └── domain/
+                                      │       └── content-strategy.md
                                       ├── research/
                                       ├── decisions/
                                       └── outputs/
@@ -105,8 +114,9 @@ Skills read from `reference/`, output to `outputs/`. Same engine + different dat
 | `offer.md` | WHAT you sell — price, mechanism, benefits |
 | `audience.md` | WHO buys — real people, not avatars |
 | `voice.md` | HOW you sound — tone, phrases, personality |
+| `content-strategy.md` | HOW you distribute — pillars, platforms, cadence, metrics (domain -- emerges through /think, not required at setup) |
 
-These live in `reference/core/` and are required for all businesses.
+These live in `reference/core/` and are required for all businesses. `content-strategy.md` lives in `reference/domain/` and is built over time.
 
 ---
 
@@ -130,7 +140,7 @@ Not everyone goes all the way. Most stay at Phase 2. The path exists for those w
 
 | Mode | Direction | Skills |
 |------|-----------|--------|
-| **Enriching the core** | Insights → reference files | `/think` |
+| **Enriching the core** | Insights → reference files (including content-strategy.md — your distribution backbone) | `/think` |
 | **Creating for the world** | Reference files → output | `/ads`, `/vsl`, `/organic` |
 
 ---
@@ -177,7 +187,7 @@ Skills load reference progressively to stay token-efficient:
 |------|------|-------------|
 | **Always** | CLAUDE.md | Every session |
 | **Core** | reference/core/*.md | When generating |
-| **On-demand** | research/, decisions/ | When reasoning about choices |
+| **On-demand** | research/, decisions/, content-strategy.md | When reasoning about choices or generating content |
 | **Deep reference** | reference/brand/, reference/proof/ | When writing copy |
 | **Domain** | reference/domain/ | When business-type matters |
 
@@ -224,6 +234,7 @@ Research files also add: `linked_decisions: []`
 | `/organic` | Mine competitors, generate organic scripts |
 | `/wiki` | Personal wiki with atomic notes |
 | `/help` | Answer questions, troubleshoot, explain |
+| `/newsletter` | Generate weekly newsletter from thinking work (coming soon) |
 | `/pull` | Quick update vip (auto in /start) |
 
 ---

--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -29,7 +29,7 @@ The core insight — from Tony Robbins' interview with Alex Hormozi — is that 
 | Magic passive memory | Active management |
 | Start fresh every chat | `/start` loads your context |
 | Generic outputs | Business-specific |
-| Content treadmill | Think cycle (research → decide → codify) |
+| Content treadmill | Newsletter-first, AI-adapted distribution |
 | Rent infrastructure | Own it (portable files) |
 
 ---
@@ -38,7 +38,7 @@ The core insight — from Tony Robbins' interview with Alex Hormozi — is that 
 
 | Mode | What Happens |
 |------|--------------|
-| **Enriching the core** | Research what interests you → extract → codify into reference |
+| **Enriching the core** | Research what interests you → extract → codify into reference → build content strategy |
 | **Creating for the world** | Generate content, ads, scripts — all informed by reference |
 
 **The test:** If the think cycle feels like pushing, you have the wrong offer. If it feels like pull, you're in the right place.

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -11,8 +11,9 @@ Main Branch operates on a fundamental separation:
 ```
 ENGINE (vip)     +     DATA (your business repo)     =     OUTPUT
 ├── Skills                             ├── Reference                       ├── Ads
-├── Lenses                             ├── Research                        ├── Scripts
-└── Frameworks                         ├── Decisions                       └── Outputs
+├── Lenses                             │   (incl. content-strategy.md)     ├── Scripts
+└── Frameworks                         ├── Research                        ├── Content
+                                       ├── Decisions                       └── Outputs
                                        └── Compliance
 ```
 
@@ -156,6 +157,8 @@ outputs/
 
 Outputs inform new research. What worked? What didn't? This becomes new research, which informs new decisions, which updates context.
 
+In the Generate step, the **newsletter is the keystone piece** -- long-form thinking that gets adapted into platform-specific content by /organic and amplified by /ads. In the Learn step, performance data flows back into `content-strategy.md` -- updating the hooks library, metrics benchmarks, and pillar effectiveness.
+
 ---
 
 ## Folder Structure: Business Repos
@@ -176,12 +179,18 @@ your-business/
 │   │   └── angles/              # Messaging entry points
 │   │       └── [angle-name].md
 │   └── domain/                  # Business-type specific
+│       └── content-strategy.md  # Pillars, platforms, cadence, metrics
 │
 ├── research/                    # DATED — Point-in-time exploration
 │   └── YYYY-MM-DD-slug.md
 │
 ├── decisions/                   # DATED — Choices with rationale
 │   └── YYYY-MM-DD-slug.md
+│
+├── content/                     # CONTENT PIPELINE — Draft to published
+│   ├── drafts/                  # Work in progress
+│   ├── scheduled/               # Ready to publish
+│   └── published/               # Archive of published content
 │
 └── outputs/                     # OUTPUT — Generated content
     └── YYYY-MM-DD-batch-name/
@@ -290,6 +299,7 @@ Skills expect business context in standardized locations:
 | Angles | `reference/proof/angles/*.md` | At least one |
 | Testimonials | `reference/proof/testimonials.md` | Recommended |
 | Typicality | `reference/proof/typicality.md` | For outcome claims |
+| Content Strategy | `reference/domain/content-strategy.md` | Recommended for /organic, /newsletter |
 
 Skills should fail gracefully with clear errors if required context is missing.
 
@@ -423,7 +433,7 @@ Skills should load context progressively:
 |------|------|------|------------|
 | **Always** | CLAUDE.md | Every session | Low |
 | **Just-in-time** | reference/core/*.md | When generating | Medium |
-| **On-demand** | research/, decisions/ | When reasoning | Medium |
+| **On-demand** | research/, decisions/, content-strategy.md | When reasoning or generating content | Medium |
 | **Deep reference** | reference/proof/, lenses/ | When reviewing | High |
 
 **Why this matters:** Token efficiency. Don't load everything upfront. Load what's needed when it's needed.
@@ -459,6 +469,54 @@ When you invoke `/ads`:
 2. Skill reads context from my-business/reference/
 3. Output goes to my-business/outputs/
 4. Review uses lenses from vip
+
+---
+
+## Content Pipeline Architecture
+
+The content pipeline follows a **newsletter-first waterfall**: one keystone piece becomes many platform-adapted outputs.
+
+```
+/think → research, decisions, content-strategy.md
+    │
+    ▼
+/newsletter → keystone long-form (weekly email)
+    │
+    ▼
+/organic → platform-adapted social (reels, tiktok, carousels)
+    │
+    ▼
+/ads → paid amplification of top performers
+    │
+    ▼
+/think → performance analysis, strategy updates → content-strategy.md
+```
+
+### Energy-Protected Audience Feedback Loop
+
+The pipeline is designed so the creator **never opens a social app to post**. AI handles adaptation and distribution. The creator's energy stays in thinking and writing -- not scrolling. Audience feedback (metrics, comments, engagement) flows back through /think into content-strategy.md, closing the loop without requiring the creator to be on-platform.
+
+### Content Folder State Machine
+
+Content moves through three states:
+
+```
+content/
+├── drafts/       → Work in progress (skill output lands here)
+├── scheduled/    → Approved, ready to publish (manual or automated move)
+└── published/    → Archive of published content (moved after publish)
+```
+
+Skills write to `content/drafts/`. The move from drafts to scheduled to published can be manual or automated (via Postiz or similar infrastructure -- out of scope for engine, documented here as architectural pattern).
+
+### Skill Connections to Content Pipeline
+
+| Skill | Pipeline Role |
+|-------|---------------|
+| `/think` | Builds content-strategy.md, analyzes performance |
+| `/newsletter` | Generates keystone long-form (coming soon) |
+| `/organic` | Adapts keystone into platform-specific formats |
+| `/ads` | Amplifies top-performing organic content |
 
 ---
 
@@ -504,6 +562,18 @@ Decisions note what context they updated:
 
 This creates a traceable chain: Research → Decision → Context → Output
 
+### Decision → Content Strategy
+
+Decisions about content pillars, platforms, or cadence update content-strategy.md:
+
+```markdown
+## Action Items
+- [x] Add "transformation stories" pillar to reference/domain/content-strategy.md
+- [x] Update platform strategy with Instagram Reels cadence
+```
+
+Content strategy links back to the decisions that informed pillar choices, creating the same traceable chain.
+
 ---
 
 ## Naming Conventions
@@ -511,9 +581,11 @@ This creates a traceable chain: Research → Decision → Context → Output
 | Content Type | Format | Example |
 |--------------|--------|---------|
 | Core context | `slug.md` | `offer.md`, `audience.md`, `voice.md` |
+| Content strategy | `slug.md` | `content-strategy.md` |
 | Research | `YYYY-MM-DD-slug.md` | `2026-01-10-competitor-analysis.md` |
 | Decisions | `YYYY-MM-DD-slug.md` | `2026-01-11-pricing-strategy.md` |
 | Output batches | `YYYY-MM-DD-batch-name/` | `2026-01-15-january-launch/` |
+| Content drafts | `descriptive.md` | `newsletter-2026-02-03.md` |
 | Typicality data | `typicality.md` | `reference/proof/typicality.md` |
 
 ### Why Dates in Filenames
@@ -596,3 +668,4 @@ Client repos (BDC, autism-rewired) are separate — can be handed off independen
 6. **Progressive loading** — Context tiers for token efficiency
 7. **Compliance layers** — Planning, review, and data layers
 8. **Multi-repo workflow** — Engine as additional directory, business repo as primary
+9. **Content pipeline** — Newsletter-first waterfall: keystone → organic → ads → learn


### PR DESCRIPTION
## Summary

- Integrates `content-strategy.md` as a new reference file concept across the entire vip engine (14 files)
- Adds newsletter-first waterfall architecture and content pipeline documentation to `system-architecture.md`
- Establishes two-pillar value prop (ads + content) across CLAUDE.md, philosophy.md, ads, organic, and help skills
- Creates full 9-section content-strategy.md template in setup/references/templates.md
- Updates community domain rubric with pillar derivation (triple test: soul/offer/audience)
- All changes are additive — no existing functionality removed or broken

## Files Changed (14)

**System docs (3):** CLAUDE.md, docs/system-architecture.md, docs/philosophy.md
**Setup + rubric (3):** setup/SKILL.md, setup/references/templates.md, domain-rubrics/community.md
**Think family (3):** think/SKILL.md, think/references/codify-phase.md, think/references/research-phase.md
**Start + Help (3):** start/SKILL.md, help/SKILL.md, help/references/content-strategy-help.md (NEW)
**Organic + Ads (2):** organic/SKILL.md, ads/SKILL.md

## Review notes

- Skill-creator review: All 6 criteria PASS. setup/SKILL.md at 496/500 lines (tight but under limit)
- Structural regression: All 14 files validated. Cross-reference integrity confirmed.
- `/newsletter` is consistently marked "coming soon" everywhere with `/think` fallback

## Test plan

- [ ] Run `/start` — verify content strategy routing appears in intent keywords
- [ ] Run `/think` with "content strategy" — verify routing to codify target
- [ ] Run `/organic` — verify content-strategy.md is listed as optional reference
- [ ] Run `/ads` — verify content-strategy.md appears in reference table
- [ ] Run `/help` with "content strategy" — verify routing to content-strategy-help.md
- [ ] Run `/setup` on a test repo — verify content-strategy.md template scaffolded

🤖 Generated with [Claude Code](https://claude.com/claude-code)