### PR TITLE
Add Skool surfaces congruence checks across all content skills

### DIFF
--- a/.claude/reference/domain-rubrics/community.md
+++ b/.claude/reference/domain-rubrics/community.md
@@ -24,7 +24,8 @@ reference/
     │
     ├── funnel/
     │   ├── stages.md         # Awareness → Member journey
-    │   └── touchpoints.md    # Key conversion moments
+    │   ├── touchpoints.md    # Key conversion moments
+    │   └── skool-surfaces.md # Live about page + pricing card copy
     │
     └── membership/
         ├── pricing.md        # Pricing model (whatever structure you use)
@@ -103,6 +104,21 @@ reference/
 - Sales pages
 - Checkout flow
 - Onboarding sequence
+
+---
+
+### funnel/skool-surfaces.md
+
+**Purpose:** Live copy from Skool about page and pricing cards. Content-generating skills (`/ads`, `/organic`, `/vsl`, `/site`) check this for congruence — ensuring all customer-facing surfaces speak the same language.
+
+**Required sections:**
+- About page copy (verbatim, with character count)
+- Pricing card bullets (all tiers)
+- Key claims extracted for congruence checks
+- Congruence rules
+- Update trigger (when to refresh this file)
+
+**Update when:** About page copy changes, pricing tiers change, or new claims are added to any Skool surface.
 
 ---
 
@@ -253,6 +269,9 @@ When running `/think` to analyze Skool performance:
 | `/ads` | `content-strategy.md` for topic selection, funnel mapping |
 | `/newsletter` | `content-strategy.md` for pillar topics, repurposing flow (coming soon) |
 | `/vsl skool` | `funnel/stages.md`, `membership/benefits.md` |
+| `/ads` (congruence) | `funnel/skool-surfaces.md` for ad-to-landing alignment |
+| `/organic` (congruence) | `funnel/skool-surfaces.md` for content-to-landing alignment |
+| `/site` (congruence) | `funnel/skool-surfaces.md` for site-to-Skool alignment |
 
 ---
 

--- a/.claude/skills/ads/SKILL.md
+++ b/.claude/skills/ads/SKILL.md
@@ -121,10 +121,13 @@ Before creating ads, the business repo must have:
 | `reference/proof/angles/*.md` | Different messaging entry points | Yes (at least 1) |
 | `reference/brand/visual-style.md` | Colors, typography, mood, prompt fragments | Optional (affects image gen) |
 | `reference/domain/content-strategy.md` | Content pillars, platform strategy | Optional (improves topic selection) |
+| `reference/domain/funnel/skool-surfaces.md` | Live Skool about page + pricing card copy | Optional (congruence check) |
 
 If required files are missing, Step 0 pre-flight catches this and routes appropriately.
 
 **Content funnel awareness:** Ads are the "immediate ROI" pillar of the two-pillar value prop (ads + content). In the content pipeline, ads drive newsletter signups, newsletter nurtures, Skool trial converts, revenue follows. If `content-strategy.md` exists, use content pillars to inform angle selection, metrics to understand what performs organically (ads amplify top-performing organic content), and funnel mapping to determine whether ads should target awareness, consideration, or conversion.
+
+**Skool surface congruence:** If `reference/domain/funnel/skool-surfaces.md` exists, check it before finalizing any batch. Ad copy must not promise anything not visible on the Skool about page or pricing cards. Pricing mentioned in ads must match current tier structure. Language and framing should echo (not contradict) the about page positioning. The about page is the FIXED surface — ads are the VARIABLE surface.
 
 ---
 
@@ -434,7 +437,7 @@ Each compliance agent receives:
 - **Business context** (only what that lens needs):
   - FTC: offer.md, testimonials.md, typicality.md
   - Meta Policy: offer.md
-  - Copy Quality: offer.md, audience.md
+  - Copy Quality: offer.md, audience.md, skool-surfaces.md (if exists)
   - Voice Auth: voice.md
   - Substantiation: offer.md, testimonials.md, typicality.md
   - Visual Standards: (no extra context needed — evaluates image prompts)
@@ -578,6 +581,7 @@ Before saving any batch, verify:
 | **Angle diversity** | Each concept uses a genuinely different psychological entry point |
 | **Voice match** | Copy matches `voice.md` tone (if available) |
 | **Compliance** | No banned claims, proper testimonial attribution |
+| **Skool congruence** | Claims match live about page + pricing cards (if `skool-surfaces.md` exists) |
 
 ---
 

--- a/.claude/skills/organic/SKILL.md
+++ b/.claude/skills/organic/SKILL.md
@@ -116,6 +116,8 @@ Requires `reference/core/voice.md`, `audience.md`, `offer.md`.
 
 **Optional but recommended:** `reference/domain/content-strategy.md` — If present, /organic reads content pillars to align generated content and platform strategy for format selection. Works perfectly without it.
 
+**Congruence check:** If `reference/domain/funnel/skool-surfaces.md` exists, read it. Organic content should echo the same positioning and claims visible on the Skool about page and pricing cards. No contradictions between organic and the landing experience.
+
 Search all working directories for `reference/core/`. If not found, ask user or run `/setup`.
 
 Missing files? See [references/first-time-setup.md](references/first-time-setup.md).
@@ -308,6 +310,8 @@ If content-strategy.md does not exist, /organic works exactly as before -- from 
 **Voice:** Sounds like creator. Matches energy. Uses vocabulary. No AI tells.
 
 **Platform:** Appropriate length. Correct structure. Optimized for retention/saves.
+
+**Skool congruence:** If `skool-surfaces.md` exists, claims and positioning match live about page + pricing cards.
 
 ---
 

--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -346,6 +346,7 @@ Use templates from `references/templates.md`.
 5. `reference/proof/angles/` — Messaging entry points
 6. `reference/brand/visual-style.md` — Visual brand identity (colors, typography, mood, image prompt fragments)
 7. `reference/domain/content-strategy.md` — Content pillars, platforms, cadence (template for community businesses)
+8. `reference/domain/funnel/skool-surfaces.md` — Live Skool about page + pricing card copy (community businesses with Skool)
 
 > **Note:** content-strategy.md and visual-style.md start as templates and get filled through `/think` cycles. Not required at setup — scaffolded with placeholder sections.
 
@@ -361,7 +362,7 @@ Use answers + audience data to generate a starter `visual-style.md` from the tem
 Based on business type, create domain-specific folders:
 
 **E-commerce:** `reference/domain/products/`, `reference/domain/fulfillment/`
-**Community:** `reference/domain/classroom/`, `reference/domain/membership/`, `reference/domain/funnel/`, `reference/domain/content-strategy.md`
+**Community:** `reference/domain/classroom/`, `reference/domain/membership/`, `reference/domain/funnel/`, `reference/domain/content-strategy.md`, `reference/domain/funnel/skool-surfaces.md`
 
 See `vip/.claude/reference/domain-rubrics/` for full specifications.
 

--- a/.claude/skills/site/SKILL.md
+++ b/.claude/skills/site/SKILL.md
@@ -98,6 +98,7 @@ cat ~/.mainbranch/sites.json 2>/dev/null || echo "NO_CONFIG"
 | `reference/proof/testimonials.md` | Approved testimonials | Recommended |
 | `reference/proof/angles/*.md` | Messaging entry points | Optional |
 | `reference/domain/content-strategy.md` | Pillars, platforms, CTA destinations | Optional |
+| `reference/domain/funnel/skool-surfaces.md` | Live Skool about page + pricing copy | Optional (congruence) |
 
 If required files are missing, stop and route to `/think codify`:
 
@@ -353,6 +354,7 @@ See [references/section-patterns.md](references/section-patterns.md) for detaile
 - Pain points from `audience.md` — their words, not generic
 - Testimonials from `testimonials.md` only — never fabricate
 - CTAs from `offer.md` — specific action, not generic "Learn More"
+- If site drives traffic to Skool, cross-reference `skool-surfaces.md` for messaging consistency between the landing page and the Skool about page
 
 ### Design Guidelines
 

--- a/.claude/skills/think/SKILL.md
+++ b/.claude/skills/think/SKILL.md
@@ -203,6 +203,7 @@ ls reference/domain/content-strategy.md 2>/dev/null
 | Accepted decision, unchecked items | "Decision [topic] has action items. Ready to codify?" |
 | content-strategy.md exists but empty/thin | "Your content strategy file is a skeleton. Want to fill it in? We can derive pillars from your soul.md + offer.md + audience.md." |
 | content-strategy.md missing (community biz) | "You don't have a content strategy yet. Want to build one? It'll define your pillars, platforms, and cadence." |
+| skool-surfaces.md missing (community biz with live Skool) | "Your Skool about page and pricing card copy aren't in reference yet. Want to add them? Skills check this for congruence." |
 | Nothing in progress | "What are you trying to figure out?" |
 
 **The goal is reference files.** Research and decisions are waypoints. Keep asking: "What needs to happen to get this into reference?"
@@ -304,7 +305,7 @@ Optionally create Claude tasks for execution tracking. See [decide-phase.md](ref
 
 Apply action items to reference files. Mark decision as codified.
 
-**Codify targets include:** `reference/core/*.md`, `reference/proof/angles/*.md`, `reference/proof/testimonials.md`, **`reference/domain/content-strategy.md`** (pillars, hooks library, framework library, metrics).
+**Codify targets include:** `reference/core/*.md`, `reference/proof/angles/*.md`, `reference/proof/testimonials.md`, **`reference/domain/content-strategy.md`** (pillars, hooks library, framework library, metrics), `reference/domain/funnel/skool-surfaces.md` (live Skool copy — update when about page or pricing changes).
 
 ---
 

--- a/.claude/skills/vsl/SKILL.md
+++ b/.claude/skills/vsl/SKILL.md
@@ -52,8 +52,11 @@ If unclear, ask: "Is this for a Skool/membership community ($47-$497/month) or a
 | `reference/core/offer.md` | What you sell, price, inclusions, guarantee |
 | `reference/core/audience.md` | Who buys, their pains, objections |
 | `reference/proof/testimonials.md` | Success stories with specifics |
+| `reference/domain/funnel/skool-surfaces.md` | Live Skool about page + pricing copy (congruence) |
 
 **If missing:** Ask user to provide or run `/think` first.
+
+**Skool VSL congruence:** When writing a Skool VSL, load `skool-surfaces.md` if it exists. The VSL script must not contradict or overpromise beyond what the about page and pricing cards state. Pricing, benefit claims, and positioning in the VSL should align with the live surfaces the viewer will see after clicking through.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,7 @@ Skills read from `reference/`, output to `outputs/`. Some skills (`/wiki`, `/sit
 | `audience.md` | WHO buys — real people, not avatars |
 | `voice.md` | HOW you sound — tone, phrases, personality |
 | `content-strategy.md` | HOW you distribute — pillars, platforms, cadence, metrics (domain -- emerges through /think, not required at setup) |
+| `skool-surfaces.md` | WHAT cold traffic sees — live Skool about page + pricing card copy (domain/funnel -- congruence anchor for ads, organic, VSLs) |
 
 These live in `reference/core/` and are required for all businesses. `content-strategy.md` lives in `reference/domain/` and is built over time.
 
@@ -190,7 +191,7 @@ Skills load reference progressively to stay token-efficient:
 |------|------|-------------|
 | **Always** | CLAUDE.md | Every session |
 | **Core** | reference/core/*.md | When generating |
-| **On-demand** | research/, decisions/, content-strategy.md | When reasoning about choices or generating content |
+| **On-demand** | research/, decisions/, content-strategy.md, skool-surfaces.md | When reasoning about choices or generating content |
 | **Deep reference** | reference/brand/, reference/proof/ | When writing copy |
 | **Domain** | reference/domain/ | When business-type matters |
 

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -304,6 +304,7 @@ Skills expect business context in standardized locations:
 | Testimonials | `reference/proof/testimonials.md` | Recommended |
 | Typicality | `reference/proof/typicality.md` | For outcome claims |
 | Content Strategy | `reference/domain/content-strategy.md` | Recommended for /organic, /newsletter |
+| Skool Surfaces | `reference/domain/funnel/skool-surfaces.md` | When generating ads, organic, VSLs, or site copy (congruence) |
 | Site config | `~/.mainbranch/sites.json` | When building/publishing with /site |
 
 Skills should fail gracefully with clear errors if required context is missing.
@@ -442,7 +443,7 @@ Skills should load context progressively:
 |------|------|------|------------|
 | **Always** | CLAUDE.md | Every session | Low |
 | **Just-in-time** | reference/core/*.md | When generating | Medium |
-| **On-demand** | research/, decisions/, content-strategy.md | When reasoning or generating content | Medium |
+| **On-demand** | research/, decisions/, content-strategy.md, skool-surfaces.md | When reasoning or generating content | Medium |
 | **Deep reference** | reference/proof/, lenses/ | When reviewing | High |
 
 **Why this matters:** Token efficiency. Don't load everything upfront. Load what's needed when it's needed.


### PR DESCRIPTION
## Summary

- All content-generating skills now check `reference/domain/funnel/skool-surfaces.md` for congruence with live Skool about page and pricing card copy
- Ensures ads, organic content, VSLs, and site copy never contradict what cold traffic sees on Skool
- 20 edits across 9 files: 6 skills, 1 domain rubric, CLAUDE.md, system-architecture.md

## Files Changed

| File | Edits |
|------|-------|
| `ads/SKILL.md` | Reference table, congruence paragraph, quality checklist, lens context |
| `organic/SKILL.md` | First-time setup note, quality checklist |
| `vsl/SKILL.md` | Reference table, Skool VSL congruence guidance |
| `site/SKILL.md` | Reference table, copy guidelines cross-reference |
| `think/SKILL.md` | Codify targets, active guidance for missing file |
| `setup/SKILL.md` | Priority order, domain rubric path |
| `community.md` (rubric) | Tree entry, file spec section, skills table |
| `CLAUDE.md` | Core reference table, reference tiers |
| `system-architecture.md` | Context discovery, context tiers |

## Test plan

- [ ] Run `/ads` on a community business repo with `skool-surfaces.md` present — verify congruence check fires
- [ ] Run `/ads` on a business repo WITHOUT `skool-surfaces.md` — verify no errors, graceful skip
- [ ] Run `/think` on a community business — verify active guidance detects missing `skool-surfaces.md`
- [ ] Run `/setup` for Community/Skool type — verify `skool-surfaces.md` appears in domain scaffold
- [ ] Verify all reference table additions are syntactically correct markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)