### PR TITLE
Validate config paths before presenting repo options

### DIFF
--- a/.claude/skills/start/SKILL.md
+++ b/.claude/skills/start/SKILL.md
@@ -104,16 +104,21 @@ for d in . ~/Documents/GitHub/vip ~/vip; do [ -d "$d/.claude/skills" ] && git -C
 
 ```
 1. Read ~/.config/vip/local.yaml
-   ├── Found? → Get default_repo + user identity
-   │            Validate path exists and has reference/core/
-   │            ├── Valid? → STILL ASK (see below)
-   │            └── Invalid? → Clear config, fall to discovery
+   ├── Found? → Get default_repo + recent_repos + user identity
+   │            Validate ALL paths (see Path Validation below)
+   │            ├── All valid? → Present valid options
+   │            ├── Some invalid? → Attempt recovery, prune dead paths
+   │            └── All invalid? → Clear config, fall to discovery
    └── Missing? → Fall to discovery
 
 2. If repo found, read [repo]/.vip/config.yaml
    ├── Found? → Get team settings, MCP requirements
    └── Missing? → Use defaults, offer to create later
 ```
+
+### Path Validation (Before Presenting Options)
+
+**Validate EVERY path in config before showing it to the user.** Never present a dead path as an option. For each path in `default_repo` and `recent_repos`, check `test -d "[path]/reference/core"`. If invalid, attempt recovery (check sibling folders for a renamed repo) and auto-prune dead entries. See [config-system.md](references/config-system.md) for the full recovery algorithm.
 
 ### CRITICAL: Always Offer Switch Option
 

--- a/.claude/skills/start/references/config-system.md
+++ b/.claude/skills/start/references/config-system.md
@@ -186,11 +186,49 @@ Config is always optional. Skills work without it.
 ```
 1. Try local.yaml → missing? → discovery
 2. Try repo config → missing? → use defaults
-3. Path invalid? → clear config, rediscover
+3. Path invalid? → attempt recovery, then clear and rediscover
 4. Parse error? → warn, clear, rediscover
 ```
 
 **Principle:** Config is a speed optimization, not a requirement.
+
+---
+
+## Config Hygiene (Stale Path Handling)
+
+Users rename folders, move repos, or clone to new locations. Config paths go stale. `/start` must handle this gracefully — a normie user won't know to say "fix my config."
+
+### Validation Rule
+
+**Before presenting ANY repo as a numbered option, verify the path exists:**
+
+```bash
+test -d "[path]/reference/core" && echo "valid" || echo "invalid"
+```
+
+Never show a dead path. Never load a dead path and show "0/18 EMPTY" for a repo that simply moved.
+
+### Recovery Algorithm
+
+When a config path is invalid:
+
+1. **Check parent directory** — if the parent exists, the folder was likely renamed
+2. **Scan siblings** — look for `reference/core/` in adjacent folders
+3. **If match found** — tell the user: "Looks like **[old-name]** moved to **[new-name]**. Updating your config."
+4. **If no match** — silently drop the stale entry from the list
+
+### Auto-Prune
+
+After validation, if any paths were removed or updated, write the cleaned `local.yaml` immediately. Removing dead paths is housekeeping — no confirmation needed. Adding or changing the default repo still requires user confirmation.
+
+### Common Scenarios
+
+| What Happened | What User Sees | What /start Does |
+|---------------|---------------|-------------------|
+| Folder renamed | Nothing broken | Detects new name, updates config, presents correct option |
+| Folder deleted | Fewer options | Prunes dead entry, shows only valid repos |
+| Folder moved to new parent | "Switch to different repo" | Can't auto-detect across parents — user provides new path, config updates |
+| Clone to new machine | Empty config | Normal discovery flow — no stale paths to worry about |
 
 ---
 


### PR DESCRIPTION
## Summary

- Validates ALL paths in `default_repo` and `recent_repos` before presenting them as numbered options
- Adds stale path recovery: when a folder was renamed, searches sibling directories for the repo and offers to update config
- Auto-prunes dead entries from `local.yaml` (housekeeping, no confirmation needed)
- Prevents the confusing "0/18 EMPTY" result when a user simply renamed their repo folder

## What changed

| File | Change |
|------|--------|
| `start/SKILL.md` | Added Path Validation section with link to detailed algorithm in config-system.md |
| `start/references/config-system.md` | Added Config Hygiene section: validation rule, recovery algorithm, auto-prune, scenario table |

## Test plan

- [ ] 162/162 tests passing
- [ ] Rename a business repo folder, run `/start`, verify it detects the rename and offers to fix config
- [ ] Delete a repo, run `/start`, verify stale entry is dropped and valid repos still shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)