### PR TITLE
[feat] Flip working directory: run Claude from business repo, load vip as additionalDirectory

### DIFF
--- a/.claude/skills/ads/SKILL.md
+++ b/.claude/skills/ads/SKILL.md
@@ -15,7 +15,9 @@ Create ads, generate creative variations, review for compliance, and check ad ac
 
 **NEVER search the filesystem. NEVER use Explore or Task agents to find repos. NEVER scan ~/Documents/GitHub/.**
 
-Do this instead — one step:
+**CWD-first:** If `reference/core/` exists in CWD, you're already in the business repo — use it.
+
+If CWD is NOT a business repo:
 
 ```bash
 cat ~/.config/vip/local.yaml 2>/dev/null

--- a/.claude/skills/end/SKILL.md
+++ b/.claude/skills/end/SKILL.md
@@ -53,11 +53,11 @@ A quick `/end` (user says "just commit and close") can be steps 1-3 and 6. But i
 
 ## Step 1: Find the Business Repo
 
-Read `~/.config/vip/local.yaml` for `default_repo` (primary). If not found, optionally check additional working directories as a fallback for a folder containing `reference/core/`.
+**CWD-first:** If `reference/core/` exists in CWD, you're already in the business repo — use it. Otherwise, read `~/.config/vip/local.yaml` for `default_repo` as fallback.
 
 **If no repo found:** Skip to a simple close. No business repo means no git activity to scan.
 
-**Do not ask the user to pick a repo.** /end is a quick close, not a triage. Use the default. If the user worked in a different repo today, they can say so.
+**Do not ask the user to pick a repo.** /end is a quick close, not a triage. Use CWD or the default. If the user worked in a different repo today, they can say so.
 
 ---
 

--- a/.claude/skills/help/SKILL.md
+++ b/.claude/skills/help/SKILL.md
@@ -58,7 +58,7 @@ Answer questions, troubleshoot issues, explain philosophy, suggest next steps.
 
 | Question | Answer |
 |----------|--------|
-| Start Claude in a folder? | `cd ~/vip && claude` — Claude sees files in that folder |
+| Start Claude in a folder? | `cd ~/Documents/GitHub/[your-business] && claude` — Claude sees files in that folder. vip is loaded automatically via `settings.local.json` additionalDirectories. |
 | When use slash commands? | For structured tasks: `/start`, `/think`, `/ads`, `/vsl` |
 | Drag files in? | Drag from Finder into Terminal, path appears |
 | Voice input? | [Wispr Flow](https://ref.wisprflow.ai/main) (affiliate link) |

--- a/.claude/skills/help/references/skills-guide.md
+++ b/.claude/skills/help/references/skills-guide.md
@@ -10,12 +10,12 @@ Skills are specialized workflows. Each one does something specific. This guide h
 **Use when:** Beginning a session, unsure what to do next, want Claude to figure out your state.
 
 **What it does:**
-- Pulls latest vip updates
-- Loads your business repo automatically
+- Pulls latest vip updates (via canonical VIP resolution)
+- Verifies your business repo and vip are connected
 - Checks your setup completeness
 - Routes you to the right skill
 
-**Daily habit:** Always start sessions with `/start`.
+**Daily habit:** Always start sessions with `/start`. You should already be in your business repo folder (`cd ~/Documents/GitHub/[your-business] && claude`).
 
 ---
 

--- a/.claude/skills/help/references/terminal-basics.md
+++ b/.claude/skills/help/references/terminal-basics.md
@@ -50,28 +50,28 @@ You can change which folder you're "in" by typing commands.
 `cd` stands for "change directory" (directory = folder).
 
 ```bash
-cd ~/Documents/GitHub/vip
+cd ~/Documents/GitHub/my-business
 ```
 
-This tells Terminal: "Go to the vip folder inside GitHub inside Documents inside my home folder."
+This tells Terminal: "Go to the my-business folder inside GitHub inside Documents inside my home folder."
 
 **The `~` symbol means "my home folder."**
 
-After running this, you're now "in" the vip folder. If you type `claude`, Claude starts with access to everything in that folder.
+After running this, you're now "in" your business repo folder. If you type `claude`, Claude starts with access to everything in that folder. The vip engine is loaded automatically as a read-only additional directory via `.claude/settings.local.json`.
 
 ---
 
 ## What "Start Claude in a Folder" Means
 
-When someone says "start Claude in vip," they mean:
+When someone says "start Claude in your business repo," they mean:
 
 1. Open Terminal
-2. Type `cd ~/Documents/GitHub/vip` and press Enter
+2. Type `cd ~/Documents/GitHub/[your-business]` and press Enter
 3. Type `claude` and press Enter
 
-Now Claude is running AND it can see all the files in vip.
+Now Claude is running AND it can see all the files in your business repo. The vip engine is loaded automatically as an additional directory via `.claude/settings.local.json`.
 
-**Why this matters:** Claude Code can only see files in folders you give it access to. If you start Claude in vip, it sees vip. If you start elsewhere, it doesn't.
+**Why this matters:** Claude Code can only see files in folders you give it access to. Starting in your business repo means Claude sees your reference files directly. vip (the engine with skills) is added automatically so you don't need to worry about it.
 
 ---
 
@@ -79,16 +79,16 @@ Now Claude is running AND it can see all the files in vip.
 
 Every session:
 ```bash
-cd ~/Documents/GitHub/vip
+cd ~/Documents/GitHub/[your-business]
 claude
 /start
 ```
 
 That's it. Three lines. Copy and paste them if needed.
 
-1. `cd ~/Documents/GitHub/vip` - Go to the vip folder
-2. `claude` - Start Claude Code
-3. `/start` - Tell Claude to load your business repo and get ready
+1. `cd ~/Documents/GitHub/[your-business]` - Go to your business repo folder
+2. `claude` - Start Claude Code (vip engine loads automatically via `settings.local.json`)
+3. `/start` - Tell Claude to check your setup and get ready
 
 ---
 
@@ -100,7 +100,7 @@ You can drag things from Finder (Mac) or Explorer (Windows) directly into Termin
 
 **Drag a folder:** Its path appears. Useful for sharing paths.
 
-**Power user tip:** You can add extra directories with `/add-dir`, but the standard workflow is to start in vip and run `/start`.
+**Power user tip:** You can add extra directories with `/add-dir`. The standard workflow is to start in your business repo and run `/start`. The vip engine is loaded automatically.
 
 **Optional /add-dir example (power users):**
 1. Type `/add-dir ` (with the space)
@@ -157,7 +157,7 @@ Press Ctrl + C to cancel the current operation.
 
 Most of the time, you'll just use:
 ```bash
-cd ~/Documents/GitHub/vip
+cd ~/Documents/GitHub/[your-business]
 claude
 /start
 ```

--- a/.claude/skills/help/references/troubleshooting.md
+++ b/.claude/skills/help/references/troubleshooting.md
@@ -102,6 +102,24 @@ If you don't have a `.claude/settings.local.json` in your business repo, run `/s
 
 ---
 
+## "Cannot edit files outside allowed directories"
+
+This is common in sandboxed tools (like Conductor workspaces). It means Claude can only edit files inside the current workspace folder.
+
+**What this means in plain English:** Claude is working in one folder "bubble" and can't directly write to files outside that bubble with the normal write tool.
+
+**Important context:** In a regular terminal Claude session (not sandboxed by an IDE/workspace tool), Claude will often prompt for permission and continue. This error is most common in stricter sandboxed environments.
+
+**Fix options:**
+1. **Best:** Start Claude in the repo you want to edit (or switch workspace to that repo)
+2. **Fallback:** Use terminal commands to write files in the target path
+
+**Recommended for beginners:** Use option 1 whenever possible. It's easier to review and less error-prone.
+
+**If you're in Conductor:** open a workspace rooted at the target repo, then re-run `/setup` or `/start`.
+
+---
+
 ## Context Feels "Off" or Claude Forgot Things
 
 Claude's context decays as conversations get longer. The CLAUDE.md instructions fade.

--- a/.claude/skills/help/references/troubleshooting.md
+++ b/.claude/skills/help/references/troubleshooting.md
@@ -77,19 +77,28 @@ Same as the 404 error above. You need access first.
 
 If slash commands like `/start` or `/ads` aren't recognized:
 
-**Check 1: Are you in vip?**
+**Check 1: Is vip loaded as an additional directory?**
 ```bash
-pwd
-ls .claude/skills
+cat .claude/settings.local.json
 ```
 
-If not in vip, skills won't be available.
+You should see vip listed under `permissions.additionalDirectories`. If not, vip skills won't be available.
 
-**Check 2: Did you start in vip?**
+**Check 2: Did you start in your business repo?**
 
-If you started in your business repo, close and re-run Claude from the vip folder, then run `/start`.
+You should start Claude in your business repo folder. The vip engine is loaded automatically via `.claude/settings.local.json` additionalDirectories.
 
-**Best practice:** Always start in vip, run `/start`. It resolves your business repo via `~/.config/vip/local.yaml`.
+```bash
+cd ~/Documents/GitHub/[your-business]
+claude
+/start
+```
+
+**Check 3: Does `settings.local.json` exist?**
+
+If you don't have a `.claude/settings.local.json` in your business repo, run `/setup` to create one, or manually create it with the path to vip.
+
+**Best practice:** Always start in your business repo, run `/start`. vip is loaded automatically via `settings.local.json`.
 
 ---
 
@@ -162,6 +171,7 @@ cat ~/.config/vip/local.yaml
 
 Should show:
 ```yaml
+vip_path: /Users/yourname/Documents/GitHub/vip
 default_repo: /Users/yourname/Documents/GitHub/your-business
 recent_repos:
   - /Users/yourname/Documents/GitHub/your-business
@@ -185,7 +195,7 @@ cat /path/to/your/repo/.vip/config.yaml
 | No `.vip/config.yaml` in repo | Run `/start` — it will offer to create config for faster startups |
 
 **Migration from old system:**
-If you have an old `~/.claude/settings.json` with `business_repo_path`, `/start` will detect it and offer to migrate to the new config system.
+If you have an old `~/.claude/settings.json` with `business_repo_path`, `/start` will detect it and offer to migrate to the new config system. The new architecture uses `.claude/settings.local.json` (in your business repo) to load vip as an additional directory.
 
 ---
 
@@ -218,12 +228,37 @@ rm ~/.config/vip/local.yaml
 
 You shouldn't have any uncommitted changes in vip.
 
-If you do:
+If you do, resolve them using the canonical VIP resolution to find your vip path:
 ```bash
-cd ~/Documents/GitHub/vip
-git status
-git checkout .  # Discards local changes
-git pull origin main
+# Canonical vip resolution (settings.local.json first — no extra deps)
+VIP_PATH=$(python3 -c "
+import json, os
+try:
+    with open('.claude/settings.local.json') as f:
+        dirs = json.load(f).get('permissions', {}).get('additionalDirectories', [])
+    for d in dirs:
+        if os.path.isfile(os.path.join(d, '.claude/skills/start/SKILL.md')):
+            print(d); break
+except: print('')
+" 2>/dev/null)
+
+# Fallback: check ~/.config/vip/local.yaml (needs PyYAML)
+if [ -z "$VIP_PATH" ] || [ ! -f "$VIP_PATH/.claude/skills/start/SKILL.md" ]; then
+  VIP_PATH=$(python3 -c "
+import os
+try:
+    import yaml
+    with open(os.path.expanduser('~/.config/vip/local.yaml')) as f:
+        print(yaml.safe_load(f).get('vip_path', ''))
+except: print('')
+" 2>/dev/null)
+fi
+
+# Then clean and pull (WARNING: discards any local changes in vip)
+if [ -n "$VIP_PATH" ] && [ -f "$VIP_PATH/.claude/skills/start/SKILL.md" ]; then
+  git -C "$VIP_PATH" checkout .
+  git -C "$VIP_PATH" pull origin main
+fi
 ```
 
-**Note:** vip is read-only. Any changes you made there should move to your business repo.
+**Warning:** `git checkout .` discards all uncommitted changes in vip. This is safe because vip is read-only — you shouldn't have local changes there. If you do, move them to your business repo first.

--- a/.claude/skills/help/references/two-repos.md
+++ b/.claude/skills/help/references/two-repos.md
@@ -36,14 +36,15 @@ This is what makes your outputs sound like YOU.
 ## How They Work Together
 
 ```
-vip/                          your-business/
-├── Skills                    ├── Your offer
-├── Templates                 ├── Your audience
-├── Frameworks                ├── Your voice
-└── (shared, read-only)       └── (yours, you own it)
+your-business/                    vip/ (loaded via settings.local.json)
+├── Your offer                    ├── Skills
+├── Your audience                 ├── Templates
+├── Your voice                    ├── Frameworks
+├── .claude/settings.local.json   └── (shared, read-only)
+└── (yours, you own it)
 ```
 
-The engine (vip) reads your business data and generates content that sounds like you.
+You start Claude in your business repo. The vip engine is loaded automatically as a read-only additional directory via `.claude/settings.local.json`. The engine reads your business data and generates content that sounds like you.
 
 **Same engine + different data = different outputs for each business.**
 

--- a/.claude/skills/organic/SKILL.md
+++ b/.claude/skills/organic/SKILL.md
@@ -32,8 +32,33 @@ Detect if user is in the right place:
 ## Pull Latest Updates (Always)
 
 ```bash
-# Pull vip updates (checks common locations)
-for d in . ~/Documents/GitHub/vip ~/vip; do [ -d "$d/.claude/skills" ] && git -C "$d" pull origin main 2>/dev/null && break; done || true
+# Canonical vip resolution (settings.local.json first — no extra deps)
+VIP_PATH=$(python3 -c "
+import json, os
+try:
+    with open('.claude/settings.local.json') as f:
+        dirs = json.load(f).get('permissions', {}).get('additionalDirectories', [])
+    for d in dirs:
+        if os.path.isfile(os.path.join(d, '.claude/skills/start/SKILL.md')):
+            print(d); break
+except: print('')
+" 2>/dev/null)
+
+# Fallback: check ~/.config/vip/local.yaml (needs PyYAML)
+if [ -z "$VIP_PATH" ] || [ ! -f "$VIP_PATH/.claude/skills/start/SKILL.md" ]; then
+  VIP_PATH=$(python3 -c "
+import os
+try:
+    import yaml
+    with open(os.path.expanduser('~/.config/vip/local.yaml')) as f:
+        print(yaml.safe_load(f).get('vip_path', ''))
+except: print('')
+" 2>/dev/null)
+fi
+
+# Pull if found and valid
+[ -n "$VIP_PATH" ] && [ -f "$VIP_PATH/.claude/skills/start/SKILL.md" ] && \
+  git -C "$VIP_PATH" pull origin main 2>&1
 ```
 
 If updates pulled: briefly note "Pulled latest vip updates." then continue silently.
@@ -137,7 +162,7 @@ Requires `reference/core/voice.md` (always core), plus resolved `offer.md` and `
 
 **Congruence check:** If `reference/domain/funnel/skool-surfaces.md` exists, read it. Organic content should echo the same positioning and claims visible on the Skool about page and pricing cards. No contradictions between organic and the landing experience.
 
-Resolve the business repo via `~/.config/vip/local.yaml` (default_repo). If missing, check additional working directories as a fallback, then ask the user or run `/setup`.
+**CWD-first:** If `reference/core/` exists in CWD, you're already in the business repo. Otherwise, resolve via `~/.config/vip/local.yaml` (`default_repo`). If missing, ask the user or run `/setup`.
 
 Missing files? See [references/first-time-setup.md](references/first-time-setup.md).
 

--- a/.claude/skills/pull/SKILL.md
+++ b/.claude/skills/pull/SKILL.md
@@ -5,18 +5,66 @@ description: Quick pull latest vip updates from GitHub. Use when user wants to u
 
 # Pull
 
-Pull latest updates from GitHub.
+Pull latest vip engine updates from GitHub.
 
 ---
 
 ## What It Does
 
+Resolves the vip path and pulls updates there — NOT from the current working directory (which is your business repo).
+
+### Step 1: Resolve VIP Path
+
 ```bash
-git pull origin main
+# Canonical vip resolution (settings.local.json first — no extra deps)
+VIP_PATH=$(python3 -c "
+import json, os
+try:
+    with open('.claude/settings.local.json') as f:
+        dirs = json.load(f).get('permissions', {}).get('additionalDirectories', [])
+    for d in dirs:
+        if os.path.isfile(os.path.join(d, '.claude/skills/start/SKILL.md')):
+            print(d); break
+except: print('')
+" 2>/dev/null)
+
+# Fallback: check ~/.config/vip/local.yaml (needs PyYAML)
+if [ -z "$VIP_PATH" ] || [ ! -f "$VIP_PATH/.claude/skills/start/SKILL.md" ]; then
+  VIP_PATH=$(python3 -c "
+import os
+try:
+    import yaml
+    with open(os.path.expanduser('~/.config/vip/local.yaml')) as f:
+        print(yaml.safe_load(f).get('vip_path', ''))
+except: print('')
+" 2>/dev/null)
+fi
 ```
 
-**Updated:** "Pulled latest. Changes: [list]"
+### Step 2: Pull VIP
 
-**Current:** "Already up to date."
+```bash
+# Pull if found and valid
+[ -n "$VIP_PATH" ] && [ -f "$VIP_PATH/.claude/skills/start/SKILL.md" ] && \
+  git -C "$VIP_PATH" pull origin main 2>&1
+```
 
-**Error:** "Couldn't pull: [error]. Try again later."
+### Step 3: Pull Business Repo (if it has a remote)
+
+```bash
+git pull origin main 2>&1
+```
+
+### Handling Results
+
+**VIP updated:** "Pulled latest engine updates. Changes: [list]"
+
+**VIP current:** "Engine already up to date."
+
+**VIP path not found:** "Couldn't find vip. Run `/setup` to configure your vip path, or check `~/.config/vip/local.yaml`."
+
+**Business repo updated:** "Also pulled updates for [repo-name]."
+
+**Business repo current or local-only:** Say nothing.
+
+**Error:** "Couldn't pull: [error]. Try: Open GitHub Desktop → select vip → click 'Fetch origin'."

--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -17,84 +17,184 @@ Get a new user fully configured with Claude Code and their business repo.
 
 ## Workflow
 
-### Pull Latest Updates (Always)
+### Pull Latest Engine Updates (Always)
 
 **Before anything else, ensure vip is up to date:**
 
 ```bash
-# Pull vip updates (checks common locations)
-for d in . ~/Documents/GitHub/vip ~/vip; do [ -d "$d/.claude/skills" ] && git -C "$d" pull origin main 2>/dev/null && break; done || true
+# Canonical vip resolution (settings.local.json first — no extra deps)
+VIP_PATH=$(python3 -c "
+import json, os
+try:
+    with open('.claude/settings.local.json') as f:
+        dirs = json.load(f).get('permissions', {}).get('additionalDirectories', [])
+    for d in dirs:
+        if os.path.isfile(os.path.join(d, '.claude/skills/start/SKILL.md')):
+            print(d); break
+except: print('')
+" 2>/dev/null)
+
+# Fallback: check ~/.config/vip/local.yaml (needs PyYAML)
+if [ -z "$VIP_PATH" ] || [ ! -f "$VIP_PATH/.claude/skills/start/SKILL.md" ]; then
+  VIP_PATH=$(python3 -c "
+import os
+try:
+    import yaml
+    with open(os.path.expanduser('~/.config/vip/local.yaml')) as f:
+        print(yaml.safe_load(f).get('vip_path', ''))
+except: print('')
+" 2>/dev/null)
+fi
+
+# Pull if found and valid
+[ -n "$VIP_PATH" ] && [ -f "$VIP_PATH/.claude/skills/start/SKILL.md" ] && \
+  git -C "$VIP_PATH" pull origin main 2>&1
 ```
 
-If updates pulled: briefly note "Pulled latest vip updates." then continue.
+If updates pulled: briefly note "Pulled latest engine updates." then continue.
+If vip not found: note it — will be configured during setup.
 If offline or already current: continue silently.
 
 ---
 
-### Check Location — Create Business Repo if Needed (CRITICAL: DO THIS FIRST)
+### Check Location and Configure vip (CRITICAL: DO THIS FIRST)
 
 **This must happen BEFORE context gathering.** If the conversation compacts later, the essential config is already saved.
 
-**Check if we're in the vip (engine) repository:**
+**Detect where we are:**
 
 ```bash
-# If this succeeds, we're in vip
-ls .claude/skills/setup/SKILL.md 2>/dev/null
+# Check CWD for business repo fingerprint
+test -d "reference/core" && echo "IS_BUSINESS_REPO"
+
+# Check CWD for vip fingerprint
+test -f ".claude/skills/setup/SKILL.md" && echo "IS_VIP"
 ```
 
-**If we're in vip, CREATE the business repo for them:**
+---
 
-> "You're in vip — that's the engine. Let me create your business repo."
+#### Case 1: CWD IS the Business Repo (Happy Path)
 
-1. **Ask for business name:**
-   > "What do you want to call your business folder? (e.g., 'my-agency', 'acme-coaching')"
+User started Claude in their business repo. Confirm and configure vip:
 
-2. **Create the folder and init git:**
+> "You're in your business repo — perfect."
+
+1. **Check if vip is already configured:**
    ```bash
-   mkdir -p ~/Documents/GitHub/[business-name]
-   cd ~/Documents/GitHub/[business-name] && git init
+   test -f ".claude/settings.local.json" && python3 -c "
+   import json, os
+   with open('.claude/settings.local.json') as f:
+       dirs = json.load(f).get('permissions', {}).get('additionalDirectories', [])
+   for d in dirs:
+       if os.path.isfile(os.path.join(d, '.claude/skills/start/SKILL.md')):
+           print('VIP_LOADED'); break
+   " 2>/dev/null
    ```
 
-3. **IMMEDIATELY save to machine-local settings:**
+2. **If vip NOT loaded:** Ask for vip path and configure:
+   > "Where is your vip folder? (usually `~/Documents/GitHub/vip`)"
 
-   This ensures `/start` can find the business repo in future sessions.
+   Create `.claude/settings.local.json` (auto git-ignored by Claude Code):
+   ```json
+   {
+     "permissions": {
+       "additionalDirectories": ["/absolute/path/to/vip"]
+     }
+   }
+   ```
 
-   Create/update `~/.config/vip/local.yaml`:
+   Save to `~/.config/vip/local.yaml`:
    ```bash
    mkdir -p ~/.config/vip
    ```
-
    ```yaml
-   # ~/.config/vip/local.yaml
-   # Machine AND user specific — NOT git-tracked
-   default_repo: /Users/[username]/Documents/GitHub/[business-name]
+   vip_path: /absolute/path/to/vip
+   default_repo: /absolute/path/to/this-repo
    recent_repos:
-     - /Users/[username]/Documents/GitHub/[business-name]
-
-   # User identity lives here (allows multi-user on same repo)
+     - /absolute/path/to/this-repo
    user:
      name: "[User's name]"
-     experience: beginner  # beginner | intermediate | advanced
+     experience: beginner
    ```
 
-   Use the actual expanded path (not ~). Ask user for their name and experience level.
+   > "Configured. vip skills will load automatically in future sessions."
 
-4. **Optional (power users): add as a working directory** if you want manual browsing. Not required for `/start`.
+3. **If vip loaded:** Confirm and continue.
+
+---
+
+#### Case 2: CWD IS vip (Old Workflow — Migration)
+
+User started Claude in the engine folder. Guide them to the new workflow:
+
+> "You're in vip — that's the engine. The recommended workflow is now to run Claude from your business repo instead. Let me set that up."
+
+1. **Check if business repo exists:**
+   ```bash
+   cat ~/.config/vip/local.yaml 2>/dev/null
    ```
-   /add-dir ~/Documents/GitHub/[business-name]
-   ```
 
-5. **Set the business repo as the target for all file writes:**
-   From this point forward, write all files to `~/Documents/GitHub/[business-name]/` NOT to the current directory.
+2. **If repo exists:** Guide user to switch:
+   > "Found your repo at [path]. Close this session, then:
+   > ```
+   > cd [path]
+   > claude
+   > /start
+   > ```
+   > Want me to configure vip as an additional directory there first?"
 
-6. **Confirm the setup is saved:**
-   > "Created [business-name] and saved the path. From now on, just run `/start` in vip and it'll load your business repo automatically.
-   >
-   > **Reminder:** If you ever get confused or the conversation compacts, type `/help` + your question. It has comprehensive answers about how everything works."
+   If yes, write `.claude/settings.local.json` in the business repo (using Bash since it's outside CWD).
 
-7. **Continue with setup** — proceed to Step 0 (Chrome extension) and beyond.
+3. **If NO repo exists:** Create one:
+   > "Let me create your business repo first."
 
-**If NOT in vip:** You're already in the user's business repo. Check if vip path is configured, continue normally.
+   a. Ask for business name
+   b. Create the folder and init git:
+      ```bash
+      mkdir -p ~/Documents/GitHub/[business-name]
+      cd ~/Documents/GitHub/[business-name] && git init
+      ```
+   c. Create `.claude/settings.local.json` in the NEW repo:
+      ```json
+      {
+        "permissions": {
+          "additionalDirectories": ["/absolute/path/to/vip"]
+        }
+      }
+      ```
+   d. Save to `~/.config/vip/local.yaml`:
+      ```yaml
+      vip_path: /absolute/path/to/vip
+      default_repo: /absolute/path/to/new-repo
+      recent_repos:
+        - /absolute/path/to/new-repo
+      user:
+        name: "[User's name]"
+        experience: beginner
+      ```
+   e. **Set the business repo as the target for all file writes:**
+      From this point forward, write all files to `~/Documents/GitHub/[business-name]/` NOT to the current directory.
+   f. Confirm:
+      > "Created [business-name] and configured vip. Next time:
+      > ```
+      > cd ~/Documents/GitHub/[business-name]
+      > claude
+      > /start
+      > ```"
+
+4. **Continue with setup** — proceed to Step 0 (Chrome extension) and beyond.
+
+---
+
+#### Case 3: CWD is Neither
+
+User is in some other directory. Ask what they want:
+
+> "This doesn't look like a business repo or vip. Options:
+>
+> 1. Create a new business repo here
+> 2. Tell me where your existing repo is
+> 3. Start fresh (`/setup` will create everything)"
 
 ---
 
@@ -146,7 +246,7 @@ Don't block setup on this. Continue and mention it at the end.
 
 **IMPORTANT:** If user has a Skool community, choose **Community/Skool** even if they also do coaching, courses, or services outside Skool. The community is the hub — other offerings feed into it.
 
-Read the appropriate rubric from `vip/.claude/reference/domain-rubrics/`.
+Read the appropriate rubric from `.claude/reference/domain-rubrics/ (in vip)`.
 
 ### 2.5: Offer Structure
 
@@ -160,7 +260,7 @@ After business type, determine offer structure:
 - Ask: "What should we call each offer? Short slugs work best (e.g., 'community', 'newsletter', 'done-for-you')"
 - Ask: "How do these relate? Is there a natural progression — like a free tier that feeds into a paid one?" (This builds `product-ladder.md`)
 - Store offer names for Step 4 folder creation
-- Note: The multi-offer rubric lives at `vip/.claude/reference/domain-rubrics/multi-offer.md` — read it if the user has multiple offers
+- Note: The multi-offer rubric lives at `.claude/reference/domain-rubrics/multi-offer.md` (in vip) — read it if the user has multiple offers
 
 **Multi-business check (brief, not interrogating):**
 > "Are any other business repos relevant right now? If you run completely separate brands, they each get their own repo. We're setting up this one."
@@ -343,7 +443,7 @@ Use templates from `references/templates.md`.
 2. "What are your brand colors?" (hex codes or descriptions)
 3. "What photography style fits?" (lifestyle/product/abstract/editorial)
 
-Use answers + audience data to generate a starter `visual-style.md` from the template at `vip/templates/modules/brand-style-template.md`. This file is consumed by `/ads` (image prompts), `/site` (CSS/design tokens), and `/organic` (visual consistency).
+Use answers + audience data to generate a starter `visual-style.md` from the template at `templates/modules/brand-style-template.md` (in vip). This file is consumed by `/ads` (image prompts), `/site` (CSS/design tokens), and `/organic` (visual consistency).
 
 ### 6. Apply Domain Rubric
 
@@ -352,7 +452,7 @@ Based on business type, create domain-specific folders:
 **E-commerce:** `reference/domain/products/`, `reference/domain/fulfillment/`
 **Community:** `reference/domain/classroom/`, `reference/domain/membership/`, `reference/domain/funnel/`, `reference/domain/content-strategy.md`, `reference/domain/funnel/skool-surfaces.md`
 
-See `vip/.claude/reference/domain-rubrics/` for full specifications.
+See `.claude/reference/domain-rubrics/ (in vip)` for full specifications.
 
 ### 7. Draft CLAUDE.md
 
@@ -465,10 +565,11 @@ Once setup is complete, tell the user:
 >
 > **Daily workflow:**
 > ```
-> cd ~/Documents/GitHub/vip
+> cd ~/Documents/GitHub/[business-name]
 > claude
 > /start
 > ```
+> Skills load automatically from vip via `additionalDirectories` — no need to touch the vip folder.
 >
 > **Key skills to try:**
 > - `/think` — Research topics, make decisions, update reference

--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -19,23 +19,23 @@ Get a new user fully configured with Claude Code and their business repo.
 
 ### CRITICAL: Write Boundaries in Sandboxed Environments
 
-Some tools (like Conductor and sandboxed IDEs) may only allow direct file writes inside the current workspace folder. If you see:
+Some tools (especially workspace-isolated apps, like Conductor workspaces) may only allow direct file writes inside the current workspace folder. If you see:
 
 > "Cannot edit files outside allowed directories"
 
-In a regular terminal Claude session, this is less common because Claude can often request permission and continue. In sandboxed tools, these limits are stricter.
+In a regular terminal `claude` session, this is less common because Claude can often request permission and continue. In restricted workspace tools, limits are usually stricter.
 
 Do **not** silently switch strategies. Ask the user first, in beginner language:
 
-> "This app is only letting me edit files in this one folder right now.
+> "This app is only letting me edit files in this one workspace folder.
 >
-> I can do one of two things:
-> 1. Switch to the target repo workspace (cleanest)
-> 2. Stay here and use terminal commands to write files there
+> Since this is first-time setup, switching workspaces mid-chat can be confusing. The easiest options are:
+> 1. Continue here and I use terminal commands to create/update files in your target repo path
+> 2. Stop here, open Terminal in the target repo folder, run `claude`, then run `/setup` again
 >
-> Option 1 is easier to review. Which do you want?"
+> If you already have a workspace open for that repo, we can use that too. Which option do you want?"
 
-If they choose option 2, proceed. If not, stop and wait.
+For first-time setup, do not default to "switch workspace now." Prefer option 1 or 2 unless the user already has the target repo workspace ready.
 
 ### Pull Latest Engine Updates (Always)
 
@@ -188,6 +188,7 @@ User started Claude in the engine folder. Guide them to the new workflow:
       - Ask before changing `default_repo` if one already exists
    e. **Set the business repo as the target for all file writes:**
       From this point forward, write all files to `~/Documents/GitHub/[business-name]/` NOT to the current directory.
+      If direct writes are blocked by workspace limits, use explicit terminal commands with full paths (after user approval via the decision flow above).
    f. Confirm:
       > "Created [business-name] and configured vip. Next time:
       > ```

--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -17,6 +17,26 @@ Get a new user fully configured with Claude Code and their business repo.
 
 ## Workflow
 
+### CRITICAL: Write Boundaries in Sandboxed Environments
+
+Some tools (like Conductor and sandboxed IDEs) may only allow direct file writes inside the current workspace folder. If you see:
+
+> "Cannot edit files outside allowed directories"
+
+In a regular terminal Claude session, this is less common because Claude can often request permission and continue. In sandboxed tools, these limits are stricter.
+
+Do **not** silently switch strategies. Ask the user first, in beginner language:
+
+> "This app is only letting me edit files in this one folder right now.
+>
+> I can do one of two things:
+> 1. Switch to the target repo workspace (cleanest)
+> 2. Stay here and use terminal commands to write files there
+>
+> Option 1 is easier to review. Which do you want?"
+
+If they choose option 2, proceed. If not, stop and wait.
+
 ### Pull Latest Engine Updates (Always)
 
 **Before anything else, ensure vip is up to date:**
@@ -103,19 +123,15 @@ User started Claude in their business repo. Confirm and configure vip:
    }
    ```
 
-   Save to `~/.config/vip/local.yaml`:
-   ```bash
-   mkdir -p ~/.config/vip
-   ```
-   ```yaml
-   vip_path: /absolute/path/to/vip
-   default_repo: /absolute/path/to/this-repo
-   recent_repos:
-     - /absolute/path/to/this-repo
-   user:
-     name: "[User's name]"
-     experience: beginner
-   ```
+   Update `~/.config/vip/local.yaml` with a **merge** (never overwrite):
+   - Read existing file first (if present)
+   - Preserve unknown keys
+   - Set/update `vip_path`
+   - Add this repo to `recent_repos` (prepend + dedupe)
+   - Keep `user.*` if present; ask only when missing
+   - If `default_repo` is already set to a different repo, ask before changing it
+
+   **Never use:** `cat > ~/.config/vip/local.yaml`
 
    > "Configured. vip skills will load automatically in future sessions."
 
@@ -143,7 +159,8 @@ User started Claude in the engine folder. Guide them to the new workflow:
    > ```
    > Want me to configure vip as an additional directory there first?"
 
-   If yes, write `.claude/settings.local.json` in the business repo (using Bash since it's outside CWD).
+   If yes, write `.claude/settings.local.json` in the business repo.
+   If direct write is blocked by sandbox boundaries, use the write-boundary decision flow above (ask first, then use terminal commands only if user agrees).
 
 3. **If NO repo exists:** Create one:
    > "Let me create your business repo first."
@@ -162,16 +179,13 @@ User started Claude in the engine folder. Guide them to the new workflow:
         }
       }
       ```
-   d. Save to `~/.config/vip/local.yaml`:
-      ```yaml
-      vip_path: /absolute/path/to/vip
-      default_repo: /absolute/path/to/new-repo
-      recent_repos:
-        - /absolute/path/to/new-repo
-      user:
-        name: "[User's name]"
-        experience: beginner
-      ```
+   d. Update `~/.config/vip/local.yaml` with a **merge** (never overwrite):
+      - Read existing file first
+      - Preserve existing/unknown keys
+      - Set/update `vip_path`
+      - Add new repo to `recent_repos` (prepend + dedupe)
+      - Keep `user.*` if present; ask only when missing
+      - Ask before changing `default_repo` if one already exists
    e. **Set the business repo as the target for all file writes:**
       From this point forward, write all files to `~/Documents/GitHub/[business-name]/` NOT to the current directory.
    f. Confirm:

--- a/.claude/skills/setup/references/claude-md-guide.md
+++ b/.claude/skills/setup/references/claude-md-guide.md
@@ -33,8 +33,8 @@ This repo contains your **business data**. It's powered by **vip** (the engine).
 
 **Setup:**
 1. Clone vip: `git clone https://github.com/mainbranch-ai/vip.git`
-2. Start Claude in the vip folder and run `/start`
-3. Work in THIS repo as your primary data directory
+2. Start Claude in THIS folder (your business repo) and run `/start`
+3. vip loads automatically via `.claude/settings.local.json` additionalDirectories
 
 **How it works:**
 - Engine (vip): Contains skills, lenses, frameworks. You pull updates but never edit.

--- a/.claude/skills/setup/references/repo-scaffolding.md
+++ b/.claude/skills/setup/references/repo-scaffolding.md
@@ -104,6 +104,9 @@ cat > .gitignore << 'EOF'
 .env
 *.env.local
 
+# Machine-local settings (absolute paths, not shared)
+.claude/settings.local.json
+
 # Session state (not shared between machines)
 .vip/local.yaml
 
@@ -115,5 +118,7 @@ cat > .gitignore << 'EOF'
 .idea/
 EOF
 ```
+
+**Why `.claude/settings.local.json` is git-ignored:** Claude Code auto-ignores this file, but we add it explicitly for safety. It contains machine-specific absolute paths to vip (`additionalDirectories`) that differ per computer.
 
 **Why `.vip/local.yaml` is git-ignored:** It stores session state like `current_offer` -- which offer you're working on right now. This is per-machine, per-session. The git-tracked `.vip/config.yaml` holds team/business settings that should be shared.

--- a/.claude/skills/setup/references/repo-scaffolding.md
+++ b/.claude/skills/setup/references/repo-scaffolding.md
@@ -2,6 +2,21 @@
 
 Detailed instructions for creating the business repo's configuration files, environment setup, and gitignore.
 
+## Machine-Local Config Safety (`~/.config/vip/local.yaml`)
+
+When updating `local.yaml`, always use **read → merge → write**:
+- Read existing file first
+- Preserve unknown keys
+- Add/refresh only the keys needed (`vip_path`, `recent_repos`, optional `default_repo`, `user.*`)
+- Ask before changing `default_repo` if one already exists
+
+**Never overwrite the whole file with:**
+```bash
+cat > ~/.config/vip/local.yaml
+```
+
+That can silently delete user settings.
+
 ## API Key Environment (Progressive Setup)
 
 Create the env.sh template for optional research tools. This lives outside git repos for security.

--- a/.claude/skills/setup/references/templates.md
+++ b/.claude/skills/setup/references/templates.md
@@ -580,9 +580,9 @@ It uses [vip](https://github.com/mainbranch-ai/vip) as the **engine** — skills
    git clone https://github.com/mainbranch-ai/vip.git
    ```
 
-2. **Start Claude in the vip folder** and run `/start`
+2. **Start Claude in this folder** (your business repo) and run `/start`
 
-3. **Work in this repo** as your primary data directory
+3. **vip loads automatically** via `.claude/settings.local.json` additionalDirectories
 
 ### How It Works
 

--- a/.claude/skills/site/SKILL.md
+++ b/.claude/skills/site/SKILL.md
@@ -26,8 +26,33 @@ Say `/site` again after compaction, context loss, or switching focus. It reloads
 ## Pull Latest Updates
 
 ```bash
-# Pull vip updates (checks common locations)
-for d in . ~/Documents/GitHub/vip ~/vip; do [ -d "$d/.claude/skills" ] && git -C "$d" pull origin main 2>/dev/null && break; done || true
+# Canonical vip resolution (settings.local.json first — no extra deps)
+VIP_PATH=$(python3 -c "
+import json, os
+try:
+    with open('.claude/settings.local.json') as f:
+        dirs = json.load(f).get('permissions', {}).get('additionalDirectories', [])
+    for d in dirs:
+        if os.path.isfile(os.path.join(d, '.claude/skills/start/SKILL.md')):
+            print(d); break
+except: print('')
+" 2>/dev/null)
+
+# Fallback: check ~/.config/vip/local.yaml (needs PyYAML)
+if [ -z "$VIP_PATH" ] || [ ! -f "$VIP_PATH/.claude/skills/start/SKILL.md" ]; then
+  VIP_PATH=$(python3 -c "
+import os
+try:
+    import yaml
+    with open(os.path.expanduser('~/.config/vip/local.yaml')) as f:
+        print(yaml.safe_load(f).get('vip_path', ''))
+except: print('')
+" 2>/dev/null)
+fi
+
+# Pull if found and valid
+[ -n "$VIP_PATH" ] && [ -f "$VIP_PATH/.claude/skills/start/SKILL.md" ] && \
+  git -C "$VIP_PATH" pull origin main 2>&1
 ```
 
 ---

--- a/.claude/skills/start/SKILL.md
+++ b/.claude/skills/start/SKILL.md
@@ -7,13 +7,15 @@ description: "Main entry point for Main Branch. Detects state and routes to the 
 
 Single entry point for Main Branch. Detect user state, context level, experience — route to the right skill.
 
-**Recommended workflow:** Always start Claude in vip, run `/start`. It handles everything.
+**Recommended workflow:** Start Claude in your business repo, run `/start`. It handles everything. Skills load automatically from vip via `additionalDirectories`.
 
 ---
 
-## CRITICAL: Always Ask Which Repo
+## CRITICAL: Repo Selection Rules
 
-**Even if config exists with a saved default, ALWAYS ask the user which repo before proceeding.** List ALL validated repos from `recent_repos`, not just the default:
+**CWD-first wins.** If `reference/core/` exists in CWD, the user is already in their business repo — no selection needed. Just confirm: "Working in **[repo-name]**."
+
+**Only ask which repo when CWD is NOT a business repo** (fallback to config). In that case, list ALL validated repos from `recent_repos`:
 
 > "Found your repos:
 >
@@ -32,9 +34,11 @@ Single entry point for Main Branch. Detect user state, context level, experience
 >
 > (hit a number)"
 
-**DO NOT skip this question.** Users have multiple repos. The saved default is a suggestion, not automatic.
+**DO NOT skip this question when in fallback mode.** Users have multiple repos. The saved default is a suggestion, not automatic.
 
-**Only exception:** User explicitly ran `/start [repo-name]` with a specific path.
+**Exceptions (skip selection entirely):**
+- CWD has `reference/core/` — user chose their repo by cd'ing into it
+- User explicitly ran `/start [repo-name]` with a specific path
 
 **After user selects a repo:** If the selected repo is not the current `default_repo`, ask: "Want me to save [repo-name] as your default? (faster startup next time)" If yes, update `default_repo` in `~/.config/vip/local.yaml`.
 
@@ -55,18 +59,24 @@ Apply to: business repo selection, skill routing, any multiple choice.
 │
 ├── Check context level ──────────────→ Fresh? Full load. Heavy? Warn user.
 │
-├── Pull engine updates ──────────────→ (vip, always, silently)
+├── Detect business repo ─────────────→ CWD-first detection (see Step 0)
+│   ├── CWD has reference/core/? ─────→ This IS the repo. Proceed.
+│   ├── CWD has .claude/skills/? ─────→ User is in vip (old workflow). Trigger migration.
+│   └── Neither? ────────────────────→ Check config, then ask user.
+│
+├── Pull engine updates ──────────────→ Resolve vip path, pull THAT dir (not CWD)
 │
 ├── Load config ──────────────────────→ See [config-system.md](references/config-system.md)
-│   ├── ~/.config/vip/local.yaml ─────→ Default repo + user identity (name, experience)
+│   ├── ~/.config/vip/local.yaml ─────→ vip_path + default_repo + user identity
 │   └── [repo]/.vip/config.yaml ──────→ Team settings, MCP requirements
+│
+├── Verify vip loaded ────────────────→ Check additionalDirectories has vip
+│   └── Missing? ────────────────────→ Offer to run /setup to configure
 │
 ├── MCP pre-flight ───────────────────→ See [mcp-preflight.md](references/mcp-preflight.md)
 │   └── Missing required MCP? ────────→ Offer setup or skip
 │
-├── Find business repo ───────────────→ (from config OR discovery)
-│
-├── No business repo configured? ─────→ /setup (creates repo, saves path)
+├── No business repo found? ──────────→ /setup (creates repo, saves path)
 │
 ├── Pull business repo updates ───────→ (your repo, silently)
 │
@@ -102,13 +112,38 @@ Apply to: business repo selection, skill routing, any multiple choice.
 
 ---
 
-## Step -1: Pull Updates
+## Step -1: Pull Engine Updates
 
-Pull vip updates. **Do NOT silently swallow failures.** Users on stale code get broken features.
+Pull vip updates. CWD is the business repo — resolve vip path first. **Do NOT silently swallow failures.** Users on stale code get broken features.
 
 ```bash
-# Pull vip updates — capture result
-git pull origin main 2>&1
+# Canonical vip resolution (settings.local.json first — no extra deps)
+VIP_PATH=$(python3 -c "
+import json, os
+try:
+    with open('.claude/settings.local.json') as f:
+        dirs = json.load(f).get('permissions', {}).get('additionalDirectories', [])
+    for d in dirs:
+        if os.path.isfile(os.path.join(d, '.claude/skills/start/SKILL.md')):
+            print(d); break
+except: print('')
+" 2>/dev/null)
+
+# Fallback: check ~/.config/vip/local.yaml (needs PyYAML)
+if [ -z "$VIP_PATH" ] || [ ! -f "$VIP_PATH/.claude/skills/start/SKILL.md" ]; then
+  VIP_PATH=$(python3 -c "
+import os
+try:
+    import yaml
+    with open(os.path.expanduser('~/.config/vip/local.yaml')) as f:
+        print(yaml.safe_load(f).get('vip_path', ''))
+except: print('')
+" 2>/dev/null)
+fi
+
+# Pull if found and valid
+[ -n "$VIP_PATH" ] && [ -f "$VIP_PATH/.claude/skills/start/SKILL.md" ] && \
+  git -C "$VIP_PATH" pull origin main 2>&1
 ```
 
 **Handle the result:**
@@ -116,8 +151,9 @@ git pull origin main 2>&1
 | Result | What to say |
 |--------|-------------|
 | "Already up to date." | Say nothing |
-| "Updating..." / files changed | "Pulled latest updates." |
-| Any error (auth, network, not a repo) | Show the warning below |
+| "Updating..." / files changed | "Pulled latest engine updates." |
+| VIP_PATH empty (not found) | "Couldn't find vip. Run `/setup` to configure, or check `~/.config/vip/local.yaml`." |
+| Any error (auth, network) | Show the warning below |
 
 **If pull fails, show this warning immediately:**
 
@@ -135,59 +171,58 @@ git pull origin main 2>&1
 
 ---
 
-## Step 0: Load Config and Find Business Repo
+## Step 0: Detect Business Repo (CWD-First)
 
-### Config Reading Flow
+The user starts Claude in their business repo. Check CWD first before falling back to config.
+
+### CWD Detection (Primary — Fast Path)
+
+```
+1. Check CWD for business repo fingerprint:
+   test -d "reference/core"
+   ├── YES → This IS the business repo. Use CWD. Skip to config loading.
+   └── NO → Continue to step 2.
+
+2. Check CWD for vip fingerprint (old workflow):
+   test -f ".claude/skills/start/SKILL.md"
+   ├── YES → User is in vip (old workflow). Trigger migration guidance.
+   └── NO → Continue to step 3.
+
+3. Fall back to config:
+   Read ~/.config/vip/local.yaml → default_repo + recent_repos
+   ├── Found valid repo(s)? → Present options (see below)
+   └── Nothing valid? → Discovery or /setup
+```
+
+**Migration guidance (step 2 — user is in vip):**
+
+> "It looks like you're running Claude inside the vip engine folder. The recommended workflow is now to run Claude from your business repo instead.
+>
+> 1. **Quick switch:** Close this session, `cd [their-repo-path]` then `claude` then `/start`
+> 2. **Need setup help?** `/setup` will configure everything
+> 3. **Continue here anyway** (some features may need manual paths)"
+>
+> If `~/.config/vip/local.yaml` has `default_repo`, show that path in option 1.
+
+### Config Loading
+
+Once business repo is identified (from CWD or config), load settings:
 
 ```
 1. Read ~/.config/vip/local.yaml
-   ├── Found? → Get default_repo + recent_repos + user identity
-   │            Validate ALL paths (see Path Validation below)
-   │            ├── All valid? → Present valid options
-   │            ├── Some invalid? → Attempt recovery, prune dead paths
-   │            └── All invalid? → Clear config, fall to discovery
-   └── Missing? → Fall to discovery
+   ├── Found? → Get vip_path + default_repo + recent_repos + user identity
+   └── Missing? → Acceptable if CWD is the repo; config gets created by /setup
 
-2. If repo found, read [repo]/.vip/config.yaml
+2. Read [repo]/.vip/config.yaml
    ├── Found? → Get team settings, MCP requirements
    └── Missing? → Use defaults, offer to create later
 ```
 
-### Path Validation (Before Presenting Options)
+### Multi-Repo Selection (When CWD Is NOT a Business Repo)
+
+If CWD detection fails (step 3 above), present options from config:
 
 **Validate EVERY path in config before showing it to the user.** Never present a dead path as an option. For each path in `default_repo` and `recent_repos`, check `test -d "[path]/reference/core"`. If invalid, attempt recovery (check sibling folders for a renamed repo) and auto-prune dead entries. See [config-system.md](references/config-system.md) for the full recovery algorithm.
-
-### CRITICAL: Always Offer Switch Option
-
-**Even with valid config, ALWAYS list ALL validated repos from `recent_repos` as numbered options** (see top-level "Always Ask Which Repo" section for templates). Never show just the default — users switch repos and shouldn't have to type paths.
-
-**Why:** Users may have multiple business repos. The saved default is a convenience, not a lock-in. Skipping this question traps users in one repo.
-
-**Only skip the question if:** User explicitly said `/start [repo-name]` with a specific repo.
-
-**Shortcut:** If user says `/start [repo-name]` or mentions a specific repo, validate that path directly with Read. If valid, confirm with user and proceed.
-
-**Config path (fast):** Check `~/.config/vip/local.yaml` for `default_repo` and `user.*`. See [config-system.md](references/config-system.md).
-
-**Why fallback glob can fail:** If additional working directories are present, they may point at subdirectories (like `decisions/` or `research/`), not the parent repo. When using this fallback, walk up to find `reference/core/`.
-
-**Discovery algorithm (when no config):** Use fallbacks in order. Additional working directories are optional.
-
-1. **If additional working directories exist, extract parent paths**
-   - Look at env info for "Additional working directories"
-   - For each path, walk up to find a folder containing `reference/core/`
-   - Example: if `main-branch/decisions` is listed, check `main-branch/reference/core/`
-
-2. **Use bash to find repos** (if step 1 fails)
-   ```bash
-   find ~/Documents/GitHub -maxdepth 3 -type d -name "reference" -exec test -d "{}/core" \; -print 2>/dev/null
-   ```
-
-3. **Ask the user** (if nothing found)
-
-**Verify with Read, not Glob:** Once you have a candidate path, use `Read` on `[path]/reference/core/soul.md` to confirm it's a business repo. (Don't check `core/offer.md` — in multi-offer repos, the primary offer details live in `offers/[name]/offer.md` instead. `soul.md` is always in `core/`.)
-
-**Skip vip** — any path containing `.claude/skills/` is the engine, not a business repo.
 
 **ALWAYS present numbered options** — even with ONE repo found:
 
@@ -204,15 +239,33 @@ git pull origin main 2>&1
 
 **NONE found:** Ask user for path, or route to `/setup`.
 
-### After User Selects Repo
+**Discovery algorithm (when no config):** Use fallbacks in order:
 
-**Offer to save to config:**
+1. **Scan additionalDirectories** for paths containing `reference/core/`
+2. **Use bash to find repos** (if step 1 fails)
+   ```bash
+   find ~/Documents/GitHub -maxdepth 3 -type d -name "reference" -exec test -d "{}/core" \; -print 2>/dev/null
+   ```
+3. **Ask the user** (if nothing found)
+
+**Verify with Read, not Glob:** Use `Read` on `[path]/reference/core/soul.md` to confirm it's a business repo. `soul.md` is always in `core/` (even multi-offer repos).
+
+**Skip vip** — any path containing `.claude/skills/start/SKILL.md` is the engine, not a business repo.
+
+### When CWD IS the Business Repo (Happy Path)
+
+No repo selection needed. Confirm briefly and move on:
+
+> "Working in **[repo-name]**."
+
+If `~/.config/vip/local.yaml` doesn't have this repo saved, offer to save:
 
 > "Want me to save [repo-name] as your default? (faster startup next time)"
 
 If yes, update `~/.config/vip/local.yaml`:
 
 ```yaml
+vip_path: /path/to/vip
 default_repo: /full/path/to/repo
 recent_repos:
   - /full/path/to/repo
@@ -223,14 +276,32 @@ user:
 
 **If user.name or user.experience missing:** Ask once, save for future sessions.
 
+### Verify vip Is Loaded
+
+After detecting the business repo, confirm vip is accessible as an additional directory:
+
+```bash
+# Check if vip skills are discoverable
+test -f ".claude/settings.local.json" && python3 -c "
+import json, os
+with open('.claude/settings.local.json') as f:
+    dirs = json.load(f).get('permissions', {}).get('additionalDirectories', [])
+for d in dirs:
+    if os.path.isfile(os.path.join(d, '.claude/skills/start/SKILL.md')):
+        print('VIP_LOADED'); break
+" 2>/dev/null
+```
+
+**If vip not loaded:** Skills won't be available. Offer to run `/setup` to configure `additionalDirectories`.
+
 ---
 
 ## Step 0.5: Pull Business Repo Updates
 
-Once business repo is confirmed, pull its latest updates:
+Once business repo is confirmed, pull its latest updates. Since CWD IS the business repo, just pull directly:
 
 ```bash
-cd [repo-path] && git pull origin main 2>&1
+git pull origin main 2>&1
 ```
 
 **Handle the result:**
@@ -418,8 +489,8 @@ If user already stated intent, route directly without asking.
 
 "Help" or confused → route to `/help`. Give quick overview first:
 
-> "1. **vip** = engine (skills). 2. **Your repo** = data (offer, audience, voice).
-> Daily: `cd vip && claude` then `/start`.
+> "1. **vip** = engine (skills, loaded automatically). 2. **Your repo** = data (offer, audience, voice).
+> Daily: `cd your-business-repo && claude` then `/start`.
 > For detailed help: `/help` + your question."
 
 ---

--- a/.claude/skills/start/references/config-system.md
+++ b/.claude/skills/start/references/config-system.md
@@ -1,6 +1,6 @@
 # Config System
 
-Three-file system: personal settings, team settings, and API keys — each in the right place.
+Four-file system: vip linkage, personal settings, team settings, and API keys — each in the right place.
 
 ---
 
@@ -8,14 +8,30 @@ Three-file system: personal settings, team settings, and API keys — each in th
 
 | File | Location | Purpose | Git-tracked? |
 |------|----------|---------|--------------|
-| `local.yaml` | `~/.config/vip/` | User identity + which repo is default | No |
+| `settings.local.json` | `[repo]/.claude/` | Links vip as additionalDirectory | No (auto git-ignored by Claude Code) |
+| `local.yaml` | `~/.config/vip/` | User identity + vip_path + default repo | No |
 | `env.sh` | `~/.config/vip/` | API keys for optional research tools | No |
 | `config.yaml` | `[repo]/.vip/` | Team/business settings, MCP requirements | Yes |
 
 **Key split:**
+- **Settings** = "Where is vip?" (per-repo, per-machine — `.claude/settings.local.json`)
 - **Local** = "Who am I? What repo do I want?" (per-person, per-machine)
 - **Env** = "What API keys do I have?" (per-person, sourced by shell)
 - **Repo** = "How does this business/team operate?" (shared)
+
+### .claude/settings.local.json (vip linkage)
+
+Created by `/setup`. Tells Claude Code to load vip as a read-only additional directory:
+
+```json
+{
+  "permissions": {
+    "additionalDirectories": ["/absolute/path/to/vip"]
+  }
+}
+```
+
+**Auto git-ignored** by Claude Code (like `.claude/settings.local.json` is always local). Contains machine-specific absolute paths — never commit this.
 
 ---
 
@@ -74,6 +90,7 @@ cat ~/.config/vip/local.yaml 2>/dev/null
 ```yaml
 # NOTE: All paths MUST be absolute. Never use ~ (tools don't expand it).
 # /start writes absolute paths automatically when saving config.
+vip_path: /absolute/path/to/vip
 default_repo: /absolute/path/to/my-business
 recent_repos:
   - /absolute/path/to/my-business

--- a/.claude/skills/start/references/config-system.md
+++ b/.claude/skills/start/references/config-system.md
@@ -198,6 +198,23 @@ If yes → Create `.vip/config.yaml` with defaults from `/setup`.
 
 **Rule:** Never write silently. Confirm changes that affect future sessions.
 
+### Safe Write Pattern (CRITICAL)
+
+When updating `~/.config/vip/local.yaml`:
+
+1. Read the existing file first
+2. Merge changes into existing keys (do not replace whole file)
+3. Preserve unknown keys for forward compatibility
+4. Ask before changing `default_repo` if one already exists
+5. Write the merged result
+
+**Never use full-file overwrite commands like:**
+```bash
+cat > ~/.config/vip/local.yaml
+```
+
+That pattern can silently delete fields (like `user.*`, `vip_path`, or future keys).
+
 ---
 
 ## Fallback Chain

--- a/.claude/skills/think/SKILL.md
+++ b/.claude/skills/think/SKILL.md
@@ -41,8 +41,33 @@ Both are work. Enriching the core levels up everything downstream.
 ## Pull Latest Updates
 
 ```bash
-# Pull vip updates (checks common locations)
-for d in . ~/Documents/GitHub/vip ~/vip; do [ -d "$d/.claude/skills" ] && git -C "$d" pull origin main 2>/dev/null && break; done || true
+# Canonical vip resolution (settings.local.json first — no extra deps)
+VIP_PATH=$(python3 -c "
+import json, os
+try:
+    with open('.claude/settings.local.json') as f:
+        dirs = json.load(f).get('permissions', {}).get('additionalDirectories', [])
+    for d in dirs:
+        if os.path.isfile(os.path.join(d, '.claude/skills/start/SKILL.md')):
+            print(d); break
+except: print('')
+" 2>/dev/null)
+
+# Fallback: check ~/.config/vip/local.yaml (needs PyYAML)
+if [ -z "$VIP_PATH" ] || [ ! -f "$VIP_PATH/.claude/skills/start/SKILL.md" ]; then
+  VIP_PATH=$(python3 -c "
+import os
+try:
+    import yaml
+    with open(os.path.expanduser('~/.config/vip/local.yaml')) as f:
+        print(yaml.safe_load(f).get('vip_path', ''))
+except: print('')
+" 2>/dev/null)
+fi
+
+# Pull if found and valid
+[ -n "$VIP_PATH" ] && [ -f "$VIP_PATH/.claude/skills/start/SKILL.md" ] && \
+  git -C "$VIP_PATH" pull origin main 2>&1
 ```
 
 ---

--- a/.claude/skills/vsl/SKILL.md
+++ b/.claude/skills/vsl/SKILL.md
@@ -12,8 +12,33 @@ Routes to the right framework based on your offer type.
 ## Pull Latest Updates
 
 ```bash
-# Pull vip updates (checks common locations)
-for d in . ~/Documents/GitHub/vip ~/vip; do [ -d "$d/.claude/skills" ] && git -C "$d" pull origin main 2>/dev/null && break; done || true
+# Canonical vip resolution (settings.local.json first — no extra deps)
+VIP_PATH=$(python3 -c "
+import json, os
+try:
+    with open('.claude/settings.local.json') as f:
+        dirs = json.load(f).get('permissions', {}).get('additionalDirectories', [])
+    for d in dirs:
+        if os.path.isfile(os.path.join(d, '.claude/skills/start/SKILL.md')):
+            print(d); break
+except: print('')
+" 2>/dev/null)
+
+# Fallback: check ~/.config/vip/local.yaml (needs PyYAML)
+if [ -z "$VIP_PATH" ] || [ ! -f "$VIP_PATH/.claude/skills/start/SKILL.md" ]; then
+  VIP_PATH=$(python3 -c "
+import os
+try:
+    import yaml
+    with open(os.path.expanduser('~/.config/vip/local.yaml')) as f:
+        print(yaml.safe_load(f).get('vip_path', ''))
+except: print('')
+" 2>/dev/null)
+fi
+
+# Pull if found and valid
+[ -n "$VIP_PATH" ] && [ -f "$VIP_PATH/.claude/skills/start/SKILL.md" ] && \
+  git -C "$VIP_PATH" pull origin main 2>&1
 ```
 
 ---

--- a/.claude/skills/wiki/SKILL.md
+++ b/.claude/skills/wiki/SKILL.md
@@ -22,8 +22,33 @@ Create and maintain personal wikis with atomic notes, WikiLinks, and auto-deploy
 ## Pull Latest Updates (Always)
 
 ```bash
-# Pull vip updates (checks common locations)
-for d in . ~/Documents/GitHub/vip ~/vip; do [ -d "$d/.claude/skills" ] && git -C "$d" pull origin main 2>/dev/null && break; done || true
+# Canonical vip resolution (settings.local.json first — no extra deps)
+VIP_PATH=$(python3 -c "
+import json, os
+try:
+    with open('.claude/settings.local.json') as f:
+        dirs = json.load(f).get('permissions', {}).get('additionalDirectories', [])
+    for d in dirs:
+        if os.path.isfile(os.path.join(d, '.claude/skills/start/SKILL.md')):
+            print(d); break
+except: print('')
+" 2>/dev/null)
+
+# Fallback: check ~/.config/vip/local.yaml (needs PyYAML)
+if [ -z "$VIP_PATH" ] || [ ! -f "$VIP_PATH/.claude/skills/start/SKILL.md" ]; then
+  VIP_PATH=$(python3 -c "
+import os
+try:
+    import yaml
+    with open(os.path.expanduser('~/.config/vip/local.yaml')) as f:
+        print(yaml.safe_load(f).get('vip_path', ''))
+except: print('')
+" 2>/dev/null)
+fi
+
+# Pull if found and valid
+[ -n "$VIP_PATH" ] && [ -f "$VIP_PATH/.claude/skills/start/SKILL.md" ] && \
+  git -C "$VIP_PATH" pull origin main 2>&1
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -95,45 +95,49 @@ https://github.com/mainbranch-ai/vip
 
 Choose where to save it (remember the location!). Click **Clone**.
 
-### Step 2: Open Terminal in the vip Folder
+### Step 2: First Session (Run From vip)
+
+Open a terminal in the **vip** folder you just cloned:
 
 **Mac:**
 ```bash
-cd ~/path/to/vip
+cd ~/Documents/GitHub/vip
 ```
 
 **Windows (Git Bash):**
 ```bash
-cd /c/Users/YourName/path/to/vip
+cd /c/Users/YourName/Documents/GitHub/vip
 ```
 
-### Step 3: Run Claude Code
-
-In your terminal, type:
+Run Claude and type `/setup`:
 ```bash
 claude
 ```
 
-The first time, you will authenticate with your Anthropic account.
+`/setup` creates your business repo and configures everything. The first time, you will also authenticate with your Anthropic account.
 
-### Step 4: Start Setup
+### Step 3: Complete /setup (Share Business Context)
 
-Once Claude is running, type:
-```
-/start
-```
-
-This walks you through everything. Just answer the questions.
-
-### Step 5: Tell Claude About Your Business
-
-Claude will ask you to share:
+During `/setup`, Claude will ask you to share:
 - Your offer (what you sell)
 - Your audience (who buys)
 - Your voice (how you sound)
 - Testimonials (proof it works)
 
 You can paste text, share URLs, or upload files. Claude organizes it all for you.
+
+### Step 4: Daily Workflow (After Setup)
+
+After setup, work from your **business repo** (not vip):
+```bash
+cd ~/Documents/GitHub/[your-business]
+claude
+/start
+```
+
+### Step 5: Start Generating
+
+Use `/start` to route to the right workflow (`/think`, `/ads`, `/organic`, etc.).
 
 That is it. You are ready to generate.
 
@@ -247,8 +251,8 @@ Post in the Main Branch group. Tag @Devon for technical questions.
 
 **Common issues:**
 - "404 error" or "Repository not found" — You need access first. Share your GitHub username with Devon.
-- "Claude does not see my files" — Make sure you started Claude in the vip folder and ran `/start`
-- "Skills are not working" — Make sure you ran `claude` from inside the vip folder, then run `/start`
+- "Claude does not see my files" — Make sure you started Claude in your business repo folder and ran `/start`
+- "Skills are not working" — Check that `.claude/settings.local.json` exists in your business repo with vip in `additionalDirectories`. Run `/setup` to fix.
 - "Output sounds generic" — Add more detail to your reference files, especially voice.md
 - "I edited vip but can't push" — That's expected. vip is read-only. Your business data goes in YOUR repo.
 

--- a/docs/BEGINNER-SETUP.md
+++ b/docs/BEGINNER-SETUP.md
@@ -34,33 +34,34 @@ irm https://claude.ai/install.ps1 | iex
 
 In GitHub Desktop: **File → Clone Repository → GitHub.com tab → select `mainbranch-ai/vip`**
 
-### 4. Open Terminal in vip Folder
+### 4. First Session (One-Time Setup)
+
+Open Terminal in the **vip** folder and run Claude:
 
 **Mac:** Open Terminal, type `cd `, drag the vip folder from Finder into Terminal, press Enter.
 
 **Windows:** Right-click inside the vip folder → "Open in Terminal"
 
-### 5. Start Claude
-
 ```bash
 claude
 ```
 
-Then type `/start` and follow the prompts.
+Then type `/setup`. It will:
+- Create your business repo
+- Configure vip as the skill source
+- Walk you through adding your business context
 
----
+### 5. Daily Workflow (After Setup)
 
-## Daily Workflow (After Setup)
-
-Every time you use Main Branch:
+After the first session, you work from your **business repo** (not vip):
 
 ```bash
-cd ~/Documents/GitHub/vip
+cd ~/Documents/GitHub/[your-business]
 claude
 /start
 ```
 
-`/start` loads your business repo and routes you to the right skill.
+`/start` detects your business repo and routes you to the right skill. vip skills load automatically.
 
 When you're done for the day:
 

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -472,21 +472,22 @@ Skills should load context progressively:
 
 1. Clone vip locally
 2. Create or clone your business repo
-3. Start Claude in the vip folder and run `/start`
-4. `/start` resolves your business repo from `~/.config/vip/local.yaml` and skills use absolute paths
+3. Run `/setup` to configure vip as an additional directory (writes `.claude/settings.local.json`)
+4. Start Claude in your business repo and run `/start`
 
 ### In Practice
 
 ```
 Claude Code Session:
-├── Primary: ~/vip/
-│   ├── .claude/skills/
-│   ├── .claude/lenses/
+├── Primary (CWD): ~/projects/my-business/
+│   ├── .claude/settings.local.json  ← additionalDirectories points to vip
+│   ├── reference/
+│   ├── outputs/
 │   └── ...
 │
-└── Business repo (resolved by /start via ~/.config/vip/local.yaml): ~/projects/my-business/
-    ├── reference/
-    ├── outputs/
+└── Additional directory (read-only): ~/Documents/GitHub/vip/
+    ├── .claude/skills/              ← skills discovered automatically
+    ├── .claude/lenses/
     └── ...
 ```
 


### PR DESCRIPTION
## Summary

Completes the architectural migration to flip the working directory from vip (engine) to business repo (data). Users now start Claude in their business repo with vip loaded automatically via `.claude/settings.local.json` `additionalDirectories`. This separates concerns: engine files are read-only in vip, all data (reference, research, decisions) lives in the user's business repo.

## Key Changes

- **All skills updated:** CWD-first business repo detection + canonical VIP resolution routine (settings.local.json first, yaml fallback)
- **`/setup` completely rewritten:** Three cases (CWD is business repo, CWD is vip/migration, CWD is neither) with proper initialization
- **`/start` fully migrated:** Detection flow, config loading, repo selection, vip verification all updated
- **Documentation refreshed:** First session starts in vip (one-time), daily workflow runs from business repo
- **All 11 review findings resolved:** Bootstrap flow, PyYAML dependency flipped, hardcoded paths replaced, migration guidance added

## Test Plan

- New user: bootstrap from vip, run `/setup`, switch to business repo
- Existing user: switch to business repo, run `/start`, confirm CWD-first detection
- Missing config: run `/setup` to create `.claude/settings.local.json`
- `/pull` behavior: resolve vip correctly, pull both repos
- Skill-specific CWD: `/ads`, `/end`, `/organic` all detect business repo first

---

🤖 Generated with Claude Code