### PR TITLE
[fix] preserve local custom skills in vip bridge

### DIFF
--- a/.claude/skills/help/references/troubleshooting.md
+++ b/.claude/skills/help/references/troubleshooting.md
@@ -75,18 +75,50 @@ Same as the 404 error above. You need access first.
 
 ## Skills Not Working
 
-If slash commands like `/start` or `/ads` aren't recognized:
+If slash commands like `/start` or `/ads` aren't showing in the dropdown:
 
-**Check 1: Is vip loaded as an additional directory?**
+**Check 1: Does the local bridge exist?**
+```bash
+test -e .claude/skills/start && echo "START_BRIDGE_OK"
+```
+
+If missing, add compatibility links (without replacing local folders):
+```bash
+# Get vip path from settings
+VIP_PATH=$(python3 -c "
+import json, os
+with open('.claude/settings.local.json') as f:
+    dirs = json.load(f).get('permissions', {}).get('additionalDirectories', [])
+for d in dirs:
+    if os.path.isfile(os.path.join(d, '.claude/skills/start/SKILL.md')):
+        print(d); break
+")
+
+# Create bridge links only for missing entries
+mkdir -p .claude/skills .claude/lenses .claude/reference
+for d in "$VIP_PATH"/.claude/skills/*; do
+  [ -d "$d" ] || continue
+  n=$(basename "$d")
+  [ -e ".claude/skills/$n" ] || ln -s "$d" ".claude/skills/$n"
+done
+for p in "$VIP_PATH"/.claude/lenses/* "$VIP_PATH"/.claude/reference/*; do
+  [ -e "$p" ] || continue
+  base=$(basename "$p")
+  parent=$(basename "$(dirname "$p")")
+  [ -e ".claude/$parent/$base" ] || ln -s "$p" ".claude/$parent/$base"
+done
+```
+
+**Why this bridge?** It preserves project-local custom skills in `.claude/skills/` while adding missing vip entries when discovery is inconsistent.
+
+**Check 2: Is vip loaded as an additional directory?**
 ```bash
 cat .claude/settings.local.json
 ```
 
-You should see vip listed under `permissions.additionalDirectories`. If not, vip skills won't be available.
+You should see vip listed under `permissions.additionalDirectories`. If not, run `/setup`.
 
-**Check 2: Did you start in your business repo?**
-
-You should start Claude in your business repo folder. The vip engine is loaded automatically via `.claude/settings.local.json` additionalDirectories.
+**Check 3: Did you start in your business repo?**
 
 ```bash
 cd ~/Documents/GitHub/[your-business]
@@ -94,11 +126,9 @@ claude
 /start
 ```
 
-**Check 3: Does `settings.local.json` exist?**
+**Check 4: None of the above?** Run `/setup` — it creates `settings.local.json` and missing bridge links.
 
-If you don't have a `.claude/settings.local.json` in your business repo, run `/setup` to create one, or manually create it with the path to vip.
-
-**Best practice:** Always start in your business repo, run `/start`. vip is loaded automatically via `settings.local.json`.
+**After fixing:** Close and reopen Claude (`Ctrl+C`, then `claude`) for skill changes to take effect.
 
 ---
 

--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -123,6 +123,27 @@ User started Claude in their business repo. Confirm and configure vip:
    }
    ```
 
+   **Create compatibility symlinks for skill discovery** (without replacing local folders):
+   ```bash
+   VIP_PATH="/absolute/path/to/vip"
+   mkdir -p .claude/skills .claude/lenses .claude/reference
+
+   # Link each vip skill folder only if missing (preserves local custom skills)
+   for d in "$VIP_PATH"/.claude/skills/*; do
+     [ -d "$d" ] || continue
+     n=$(basename "$d")
+     [ -e ".claude/skills/$n" ] || ln -s "$d" ".claude/skills/$n"
+   done
+
+   # Bridge lenses/reference similarly without overwriting local files
+   for p in "$VIP_PATH"/.claude/lenses/* "$VIP_PATH"/.claude/reference/*; do
+     [ -e "$p" ] || continue
+     base=$(basename "$p")
+     parent=$(basename "$(dirname "$p")")
+     [ -e ".claude/$parent/$base" ] || ln -s "$p" ".claude/$parent/$base"
+   done
+   ```
+
    Update `~/.config/vip/local.yaml` with a **merge** (never overwrite):
    - Read existing file first (if present)
    - Preserve unknown keys
@@ -135,7 +156,12 @@ User started Claude in their business repo. Confirm and configure vip:
 
    > "Configured. vip skills will load automatically in future sessions."
 
-3. **If vip loaded:** Confirm and continue.
+3. **If vip loaded:** Check compatibility symlinks exist (without clobbering local files):
+   ```bash
+   # At minimum, /start must be discoverable
+   test -e ".claude/skills/start" && echo "START_BRIDGE_OK"
+   ```
+   If missing, recreate missing links using the loop above. Never replace the entire `.claude/skills` directory.
 
 ---
 
@@ -159,7 +185,24 @@ User started Claude in the engine folder. Guide them to the new workflow:
    > ```
    > Want me to configure vip as an additional directory there first?"
 
-   If yes, write `.claude/settings.local.json` in the business repo.
+   If yes, write `.claude/settings.local.json` in the business repo AND create compatibility links:
+   ```bash
+   VIP_PATH="/absolute/path/to/vip"
+   REPO_PATH="[repo-path]"
+   mkdir -p "$REPO_PATH"/.claude/skills "$REPO_PATH"/.claude/lenses "$REPO_PATH"/.claude/reference
+   # settings.local.json (write via tool or bash)
+   for d in "$VIP_PATH"/.claude/skills/*; do
+     [ -d "$d" ] || continue
+     n=$(basename "$d")
+     [ -e "$REPO_PATH/.claude/skills/$n" ] || ln -s "$d" "$REPO_PATH/.claude/skills/$n"
+   done
+   for p in "$VIP_PATH"/.claude/lenses/* "$VIP_PATH"/.claude/reference/*; do
+     [ -e "$p" ] || continue
+     base=$(basename "$p")
+     parent=$(basename "$(dirname "$p")")
+     [ -e "$REPO_PATH/.claude/$parent/$base" ] || ln -s "$p" "$REPO_PATH/.claude/$parent/$base"
+   done
+   ```
    If direct write is blocked by sandbox boundaries, use the write-boundary decision flow above (ask first, then use terminal commands only if user agrees).
 
 3. **If NO repo exists:** Create one:
@@ -171,13 +214,35 @@ User started Claude in the engine folder. Guide them to the new workflow:
       mkdir -p ~/Documents/GitHub/[business-name]
       cd ~/Documents/GitHub/[business-name] && git init
       ```
-   c. Create `.claude/settings.local.json` in the NEW repo:
+   c. Create `.claude/settings.local.json` AND compatibility links in the NEW repo:
+      ```bash
+      VIP_PATH="/absolute/path/to/vip"
+      mkdir -p ~/Documents/GitHub/[business-name]/.claude/skills \
+               ~/Documents/GitHub/[business-name]/.claude/lenses \
+               ~/Documents/GitHub/[business-name]/.claude/reference
+      ```
+      Write `settings.local.json`:
       ```json
       {
         "permissions": {
           "additionalDirectories": ["/absolute/path/to/vip"]
         }
       }
+      ```
+      Create compatibility links without replacing local directories:
+      ```bash
+      REPO_PATH=~/Documents/GitHub/[business-name]
+      for d in "$VIP_PATH"/.claude/skills/*; do
+        [ -d "$d" ] || continue
+        n=$(basename "$d")
+        [ -e "$REPO_PATH/.claude/skills/$n" ] || ln -s "$d" "$REPO_PATH/.claude/skills/$n"
+      done
+      for p in "$VIP_PATH"/.claude/lenses/* "$VIP_PATH"/.claude/reference/*; do
+        [ -e "$p" ] || continue
+        base=$(basename "$p")
+        parent=$(basename "$(dirname "$p")")
+        [ -e "$REPO_PATH/.claude/$parent/$base" ] || ln -s "$p" "$REPO_PATH/.claude/$parent/$base"
+      done
       ```
    d. Update `~/.config/vip/local.yaml` with a **merge** (never overwrite):
       - Read existing file first

--- a/.claude/skills/setup/references/repo-scaffolding.md
+++ b/.claude/skills/setup/references/repo-scaffolding.md
@@ -136,4 +136,6 @@ EOF
 
 **Why `.claude/settings.local.json` is git-ignored:** Claude Code auto-ignores this file, but we add it explicitly for safety. It contains machine-specific absolute paths to vip (`additionalDirectories`) that differ per computer.
 
+**Do not ignore `.claude/skills/` globally:** This folder is where repo-specific local skills live. Ignoring it would block project-level custom skills. If you create compatibility links to vip skill folders, keep those links uncommitted via local Git excludes (`.git/info/exclude`) rather than broad `.gitignore` rules.
+
 **Why `.vip/local.yaml` is git-ignored:** It stores session state like `current_offer` -- which offer you're working on right now. This is per-machine, per-session. The git-tracked `.vip/config.yaml` holds team/business settings that should be shared.

--- a/.claude/skills/start/SKILL.md
+++ b/.claude/skills/start/SKILL.md
@@ -276,23 +276,49 @@ user:
 
 **If user.name or user.experience missing:** Ask once, save for future sessions.
 
-### Verify vip Is Loaded
+### Verify vip Is Loaded (Config + Compatibility Links)
 
-After detecting the business repo, confirm vip is accessible as an additional directory:
+After detecting the business repo, confirm vip is accessible and `/start` bridge exists:
 
 ```bash
-# Check if vip skills are discoverable
-test -f ".claude/settings.local.json" && python3 -c "
+# 1. Check additionalDirectories config
+VIP_PATH=$(test -f ".claude/settings.local.json" && python3 -c "
 import json, os
 with open('.claude/settings.local.json') as f:
     dirs = json.load(f).get('permissions', {}).get('additionalDirectories', [])
 for d in dirs:
     if os.path.isfile(os.path.join(d, '.claude/skills/start/SKILL.md')):
-        print('VIP_LOADED'); break
-" 2>/dev/null
+        print(d); break
+" 2>/dev/null)
+
+# 2. Check /start bridge exists in local .claude/skills
+test -e ".claude/skills/start" && echo "START_BRIDGE_OK"
 ```
 
-**If vip not loaded:** Skills won't be available. Offer to run `/setup` to configure `additionalDirectories`.
+**If `additionalDirectories` missing:** Run `/setup` to configure.
+
+**If bridge links missing** (but `additionalDirectories` exists): Repair without replacing local folders:
+```bash
+mkdir -p .claude/skills .claude/lenses .claude/reference
+
+for d in "$VIP_PATH"/.claude/skills/*; do
+  [ -d "$d" ] || continue
+  n=$(basename "$d")
+  [ -e ".claude/skills/$n" ] || ln -s "$d" ".claude/skills/$n"
+done
+
+for p in "$VIP_PATH"/.claude/lenses/* "$VIP_PATH"/.claude/reference/*; do
+  [ -e "$p" ] || continue
+  base=$(basename "$p")
+  parent=$(basename "$(dirname "$p")")
+  [ -e ".claude/$parent/$base" ] || ln -s "$p" ".claude/$parent/$base"
+done
+```
+Tell the user: "Repaired missing vip bridge links. Local custom skills are preserved."
+
+**Why both are needed:**
+- `additionalDirectories` = file access (read reference files, compliance docs)
+- Bridge links = compatibility fallback for skill discovery in environments where settings-based discovery is inconsistent
 
 ---
 

--- a/.claude/skills/start/references/config-system.md
+++ b/.claude/skills/start/references/config-system.md
@@ -33,6 +33,27 @@ Created by `/setup`. Tells Claude Code to load vip as a read-only additional dir
 
 **Auto git-ignored** by Claude Code (like `.claude/settings.local.json` is always local). Contains machine-specific absolute paths — never commit this.
 
+### .claude/ bridge links (compatibility fallback)
+
+`additionalDirectories` is the canonical config for loading vip. In some environments/versions, skill discovery can still be inconsistent. Compatibility links in local `.claude/` provide a fallback without changing user workflow.
+
+```
+business-repo/.claude/
+├── settings.local.json       # real file (auto git-ignored)
+├── skills/                   # real local folder (for project custom skills)
+│   ├── start -> /path/to/vip/.claude/skills/start
+│   ├── ads   -> /path/to/vip/.claude/skills/ads
+│   └── ... (only missing entries linked)
+├── lenses/                   # real local folder; missing vip entries linked
+└── reference/                # real local folder; missing vip entries linked
+```
+
+Created by `/setup` as a compatibility layer. `/start` can auto-repair missing links.
+
+**Both are needed:**
+- `additionalDirectories` = file access (reading reference files across repos)
+- Bridge links = compatibility fallback for skill discovery in affected environments
+
 ---
 
 ## Environment Variables (~/.config/vip/env.sh)


### PR DESCRIPTION
This updates setup/start compatibility bridging so local repo skills are never overwritten. Instead of symlinking the entire .claude/skills directory, setup and start now create missing per-skill links only. Troubleshooting and config docs were updated to match the same non-destructive flow. This preserves project-local custom skills while still repairing vip skill discovery when needed.