### PR TITLE
[fix] harden /start auto-heal and align workflow docs

### DIFF
--- a/.claude/skills/help/SKILL.md
+++ b/.claude/skills/help/SKILL.md
@@ -58,7 +58,7 @@ Answer questions, troubleshoot issues, explain philosophy, suggest next steps.
 
 | Question | Answer |
 |----------|--------|
-| Start Claude in a folder? | `cd ~/Documents/GitHub/[your-business] && claude` — Claude sees files in that folder. vip is loaded automatically via `settings.local.json` additionalDirectories. |
+| Start Claude in a folder? | `cd ~/Documents/GitHub/[your-business] && claude` — Claude sees files in that folder. vip is linked via `settings.local.json`, with bridge links as a compatibility fallback for skill discovery. |
 | When use slash commands? | For structured tasks: `/start`, `/think`, `/ads`, `/vsl` |
 | Drag files in? | Drag from Finder into Terminal, path appears |
 | Voice input? | [Wispr Flow](https://ref.wisprflow.ai/main) (affiliate link) |

--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -154,7 +154,7 @@ User started Claude in their business repo. Confirm and configure vip:
 
    **Never use:** `cat > ~/.config/vip/local.yaml`
 
-   > "Configured. vip skills will load automatically in future sessions."
+   > "Configured. vip is now linked for file access, and compatibility bridge links are in place for skill discovery."
 
 3. **If vip loaded:** Check compatibility symlinks exist (without clobbering local files):
    ```bash

--- a/.claude/skills/setup/references/claude-md-guide.md
+++ b/.claude/skills/setup/references/claude-md-guide.md
@@ -41,6 +41,8 @@ This repo contains your **business data**. It's powered by **vip** (the engine).
 - Data (this repo): Contains your business context. You own and edit this.
 - Skills read from your `reference/` and output to your `outputs/`
 
+**If `/start` isn't available:** Skills may need bridge links. Find the vip path from `.claude/settings.local.json` (the `additionalDirectories` array), then read `[vip-path]/.claude/skills/start/references/auto-heal.md` and follow the repair steps. After repair, tell the user to restart Claude.
+
 ---
 
 ## Folder Structure

--- a/.claude/skills/start/SKILL.md
+++ b/.claude/skills/start/SKILL.md
@@ -7,7 +7,7 @@ description: "Main entry point for Main Branch. Detects state and routes to the 
 
 Single entry point for Main Branch. Detect user state, context level, experience — route to the right skill.
 
-**Recommended workflow:** Start Claude in your business repo, run `/start`. It handles everything. Skills load automatically from vip via `additionalDirectories`.
+**Recommended workflow:** Start Claude in your business repo, run `/start`. It handles everything. vip is loaded through `additionalDirectories`, with bridge links as a compatibility fallback for skill discovery.
 
 ---
 
@@ -258,6 +258,16 @@ No repo selection needed. Confirm briefly and move on:
 
 > "Working in **[repo-name]**."
 
+### Canonical Repo Variable (Required)
+
+After repo detection/selection, set one canonical variable and use it everywhere:
+
+```bash
+REPO_PATH="[absolute-path-to-selected-business-repo]"
+```
+
+**Rule:** All business-repo operations must target `REPO_PATH` (not implicit CWD). This is critical when `/start` is invoked from vip and the selected repo is elsewhere.
+
 If `~/.config/vip/local.yaml` doesn't have this repo saved, offer to save:
 
 > "Want me to save [repo-name] as your default? (faster startup next time)"
@@ -278,43 +288,30 @@ user:
 
 ### Verify vip Is Loaded (Config + Compatibility Links)
 
-After detecting the business repo, confirm vip is accessible and `/start` bridge exists:
+After detecting the business repo, confirm vip is accessible and `/start` bridge exists in the selected repo (`REPO_PATH`):
 
 ```bash
-# 1. Check additionalDirectories config
-VIP_PATH=$(test -f ".claude/settings.local.json" && python3 -c "
+# 1. Resolve vip path from selected repo's settings.local.json
+VIP_PATH=$(test -f "$REPO_PATH/.claude/settings.local.json" && REPO_PATH="$REPO_PATH" python3 -c "
 import json, os
-with open('.claude/settings.local.json') as f:
+with open(os.path.join(os.environ['REPO_PATH'], '.claude/settings.local.json')) as f:
     dirs = json.load(f).get('permissions', {}).get('additionalDirectories', [])
 for d in dirs:
     if os.path.isfile(os.path.join(d, '.claude/skills/start/SKILL.md')):
         print(d); break
 " 2>/dev/null)
 
-# 2. Check /start bridge exists in local .claude/skills
-test -e ".claude/skills/start" && echo "START_BRIDGE_OK"
+# 2. Check /start bridge exists in selected repo
+test -e "$REPO_PATH/.claude/skills/start" && echo "START_BRIDGE_OK"
 ```
 
 **If `additionalDirectories` missing:** Run `/setup` to configure.
 
-**If bridge links missing** (but `additionalDirectories` exists): Repair without replacing local folders:
-```bash
-mkdir -p .claude/skills .claude/lenses .claude/reference
+**If bridge links missing** (but `additionalDirectories` exists): run the canonical repair from [auto-heal.md](references/auto-heal.md), targeting `REPO_PATH`.
 
-for d in "$VIP_PATH"/.claude/skills/*; do
-  [ -d "$d" ] || continue
-  n=$(basename "$d")
-  [ -e ".claude/skills/$n" ] || ln -s "$d" ".claude/skills/$n"
-done
+Tell the user: "Repaired missing vip bridge links in **[repo-name]**. Local custom skills are preserved."
 
-for p in "$VIP_PATH"/.claude/lenses/* "$VIP_PATH"/.claude/reference/*; do
-  [ -e "$p" ] || continue
-  base=$(basename "$p")
-  parent=$(basename "$(dirname "$p")")
-  [ -e ".claude/$parent/$base" ] || ln -s "$p" ".claude/$parent/$base"
-done
-```
-Tell the user: "Repaired missing vip bridge links. Local custom skills are preserved."
+**If `/start` was invoked from vip:** always run this verification block for the selected `REPO_PATH` before routing. This is the migration safety net for existing users.
 
 **Why both are needed:**
 - `additionalDirectories` = file access (read reference files, compliance docs)
@@ -324,10 +321,14 @@ Tell the user: "Repaired missing vip bridge links. Local custom skills are prese
 
 ## Step 0.5: Pull Business Repo Updates
 
-Once business repo is confirmed, pull its latest updates. Since CWD IS the business repo, just pull directly:
+Once business repo is confirmed, pull its latest updates from `REPO_PATH`:
 
 ```bash
-git pull origin main 2>&1
+if git -C "$REPO_PATH" remote get-url origin >/dev/null 2>&1; then
+  git -C "$REPO_PATH" pull origin main 2>&1
+else
+  echo "NO_REMOTE"
+fi
 ```
 
 **Handle the result:**
@@ -336,7 +337,7 @@ git pull origin main 2>&1
 |--------|-------------|
 | "Already up to date." | Say nothing |
 | "Updating..." / files changed | "Pulled latest updates for [repo-name]." |
-| "fatal: 'origin' does not appear to be a git repo" | Say nothing — local-only repo, no remote configured |
+| "NO_REMOTE" | Say nothing — local-only repo, no remote configured |
 | Any other error | Show the warning below |
 
 **If pull fails (and repo has a remote):**
@@ -415,7 +416,7 @@ Adapt display to `user.experience` level (beginner = full breakdown, advanced = 
 After loading core context, check for multi-offer:
 
 ```bash
-ls reference/offers/*/offer.md 2>/dev/null
+find "$REPO_PATH/reference/offers" -mindepth 2 -maxdepth 2 -name "offer.md" 2>/dev/null
 ```
 
 **If no offers/ folder:** Single-offer mode. Skip to Step 2. Everything reads from `core/`.

--- a/.claude/skills/start/references/auto-heal.md
+++ b/.claude/skills/start/references/auto-heal.md
@@ -1,0 +1,124 @@
+# Auto-Heal: Bridge Link Recovery
+
+When a user launches Claude in their business repo and skills aren't showing, this file provides the self-repair logic. It's readable via `additionalDirectories` file access even when skills aren't discoverable.
+
+---
+
+## When This Runs
+
+This runs in two places:
+
+1. **Bootstrap path:** business repo `CLAUDE.md` points here when `/start` is missing.
+2. **Main `/start` path:** when `/start` is invoked from vip, it resolves a selected business repo and runs this repair against that repo.
+
+---
+
+## Step 0: Set target repo
+
+Always target the business repo explicitly:
+
+```bash
+REPO_PATH="[absolute-path-to-business-repo]"
+test -d "$REPO_PATH" || echo "BAD_REPO_PATH"
+```
+
+If running directly inside the business repo, set:
+
+```bash
+REPO_PATH="$PWD"
+```
+
+---
+
+## Step 1: Find vip path
+
+```bash
+VIP_PATH=$(REPO_PATH="$REPO_PATH" python3 -c "
+import json, os
+with open(os.path.join(os.environ['REPO_PATH'], '.claude/settings.local.json')) as f:
+    dirs = json.load(f).get('permissions', {}).get('additionalDirectories', [])
+for d in dirs:
+    if os.path.isfile(os.path.join(d, '.claude/skills/start/SKILL.md')):
+        print(d); break
+" 2>/dev/null)
+echo "VIP_PATH=$VIP_PATH"
+```
+
+If empty: `settings.local.json` is missing or doesn't point to vip. Tell the user to run `/setup` from vip, or manually create `REPO_PATH/.claude/settings.local.json`:
+
+```json
+{
+  "permissions": {
+    "additionalDirectories": ["/absolute/path/to/vip"]
+  }
+}
+```
+
+---
+
+## Step 2: Create bridge links
+
+```bash
+mkdir -p "$REPO_PATH/.claude/skills" "$REPO_PATH/.claude/lenses" "$REPO_PATH/.claude/reference"
+
+# Per-skill symlinks (preserves local custom skills)
+for d in "$VIP_PATH"/.claude/skills/*/; do
+  [ -d "$d" ] || continue
+  n=$(basename "$d")
+  [ -e "$REPO_PATH/.claude/skills/$n" ] || ln -s "$d" "$REPO_PATH/.claude/skills/$n"
+done
+
+# Per-entry lenses and reference
+for p in "$VIP_PATH"/.claude/lenses/* "$VIP_PATH"/.claude/reference/*; do
+  [ -e "$p" ] || continue
+  base=$(basename "$p")
+  parent=$(basename "$(dirname "$p")")
+  [ -e "$REPO_PATH/.claude/$parent/$base" ] || ln -s "$p" "$REPO_PATH/.claude/$parent/$base"
+done
+```
+
+---
+
+## Step 3: Verify
+
+```bash
+test -e "$REPO_PATH/.claude/skills/start" && echo "HEAL_OK" || echo "HEAL_FAILED"
+```
+
+---
+
+## Step 4: Tell the user
+
+If HEAL_OK:
+> "I've set up the skill bridge links. **Please restart Claude** (Ctrl+C, then `claude`) — skills like `/start` will appear in the dropdown on next launch."
+
+If HEAL_FAILED:
+> "Auto-repair failed. Check that vip is cloned locally and the path in `.claude/settings.local.json` is correct."
+
+---
+
+## Why this is needed
+
+`additionalDirectories` in `settings.local.json` grants file access to vip but doesn't reliably trigger skill discovery in Claude Code v2.1.39. Bridge links (symlinks from `.claude/skills/[name]` to vip skill directories) make Claude discover skills as if they're local. This is a compatibility layer — if Anthropic fixes discovery from additional directories, these links become redundant but harmless.
+
+---
+
+## What the links look like
+
+```
+business-repo/.claude/
+├── settings.local.json                              # Real file (canonical)
+├── skills/                                          # Real directory
+│   ├── start -> /path/to/vip/.claude/skills/start   # Symlink (bridge)
+│   ├── ads -> /path/to/vip/.claude/skills/ads       # Symlink (bridge)
+│   ├── my-local-skill/                              # Real dir (preserved)
+│   └── ...
+├── lenses/                                          # Real directory
+│   ├── ftc-compliance.md -> /path/to/vip/...        # Symlink (bridge)
+│   └── ...
+└── reference/                                       # Real directory
+    ├── compliance -> /path/to/vip/...               # Symlink (bridge)
+    └── ...
+```
+
+Local custom skills are never overwritten — the `[ -e ] || ln -s` guard skips anything that already exists.

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ That is it. You are ready to generate.
 
 ## What Are Skills?
 
-Skills are pre-built commands that do specific jobs.
+Skills are pre-built workflows you invoke with slash prompts (for example, `/start`, `/ads`, `/think`).
 
 Instead of figuring out how to prompt Claude, you just type a command like `/ads` and Claude knows exactly what to do.
 

--- a/docs/BEGINNER-SETUP.md
+++ b/docs/BEGINNER-SETUP.md
@@ -61,7 +61,7 @@ claude
 /start
 ```
 
-`/start` detects your business repo and routes you to the right skill. vip skills load automatically.
+`/start` detects your business repo and routes you to the right skill. vip is linked automatically via `settings.local.json` plus compatibility bridge links when needed.
 
 When you're done for the day:
 


### PR DESCRIPTION
This hardens `/start` when invoked from vip by making business-repo operations explicitly `REPO_PATH`-targeted and by using a canonical `auto-heal.md` reference for bridge-link repair. It also updates business-repo pull and multi-offer detection examples to avoid CWD/glob edge cases. I added a bootstrap fallback in the CLAUDE.md guide for cases where `/start` is missing in business repos. Finally, I tightened beginner/help/setup wording so docs no longer imply `additionalDirectories` alone guarantees skill discovery.