### PR TITLE
[docs] align user guidance with vip linkage + bridge fallback

### DIFF
--- a/.claude/skills/help/SKILL.md
+++ b/.claude/skills/help/SKILL.md
@@ -59,7 +59,7 @@ Answer questions, troubleshoot issues, explain philosophy, suggest next steps.
 | Question | Answer |
 |----------|--------|
 | Start Claude in a folder? | `cd ~/Documents/GitHub/[your-business] && claude` — Claude sees files in that folder. vip is linked via `settings.local.json`, with bridge links as a compatibility fallback for skill discovery. |
-| When use slash commands? | For structured tasks: `/start`, `/think`, `/ads`, `/vsl` |
+| When use skill prompts? | For structured tasks: `/start`, `/think`, `/ads`, `/vsl` |
 | Drag files in? | Drag from Finder into Terminal, path appears |
 | Voice input? | [Wispr Flow](https://ref.wisprflow.ai/main) (affiliate link) |
 | What is content-strategy.md? | Your distribution backbone -- pillars, platforms, cadence. Built through `/think`, consumed by `/organic` and `/ads`. Lives in `reference/domain/`. |

--- a/.claude/skills/help/references/terminal-basics.md
+++ b/.claude/skills/help/references/terminal-basics.md
@@ -57,7 +57,7 @@ This tells Terminal: "Go to the my-business folder inside GitHub inside Document
 
 **The `~` symbol means "my home folder."**
 
-After running this, you're now "in" your business repo folder. If you type `claude`, Claude starts with access to everything in that folder. The vip engine is loaded automatically as a read-only additional directory via `.claude/settings.local.json`.
+After running this, you're now "in" your business repo folder. If you type `claude`, Claude starts with access to everything in that folder. vip is linked through `.claude/settings.local.json`, with bridge links as a compatibility fallback for skill discovery.
 
 ---
 
@@ -69,9 +69,9 @@ When someone says "start Claude in your business repo," they mean:
 2. Type `cd ~/Documents/GitHub/[your-business]` and press Enter
 3. Type `claude` and press Enter
 
-Now Claude is running AND it can see all the files in your business repo. The vip engine is loaded automatically as an additional directory via `.claude/settings.local.json`.
+Now Claude is running AND it can see all the files in your business repo. vip is linked via `.claude/settings.local.json` (and bridge links when needed).
 
-**Why this matters:** Claude Code can only see files in folders you give it access to. Starting in your business repo means Claude sees your reference files directly. vip (the engine with skills) is added automatically so you don't need to worry about it.
+**Why this matters:** Claude Code can only see files in folders you give it access to. Starting in your business repo means Claude sees your reference files directly. vip (the engine with skills) is linked by setup so you don't have to wire this manually.
 
 ---
 
@@ -87,7 +87,7 @@ claude
 That's it. Three lines. Copy and paste them if needed.
 
 1. `cd ~/Documents/GitHub/[your-business]` - Go to your business repo folder
-2. `claude` - Start Claude Code (vip engine loads automatically via `settings.local.json`)
+2. `claude` - Start Claude Code (vip linkage comes from `.claude/settings.local.json`)
 3. `/start` - Tell Claude to check your setup and get ready
 
 ---
@@ -100,7 +100,7 @@ You can drag things from Finder (Mac) or Explorer (Windows) directly into Termin
 
 **Drag a folder:** Its path appears. Useful for sharing paths.
 
-**Power user tip:** You can add extra directories with `/add-dir`. The standard workflow is to start in your business repo and run `/start`. The vip engine is loaded automatically.
+**Power user tip:** You can add extra directories with `/add-dir`. The standard workflow is still: start in your business repo and run `/start`.
 
 **Optional /add-dir example (power users):**
 1. Type `/add-dir ` (with the space)

--- a/.claude/skills/help/references/troubleshooting.md
+++ b/.claude/skills/help/references/troubleshooting.md
@@ -75,7 +75,7 @@ Same as the 404 error above. You need access first.
 
 ## Skills Not Working
 
-If slash commands like `/start` or `/ads` aren't showing in the dropdown:
+If skill prompts like `/start` or `/ads` aren't showing in the dropdown:
 
 **Check 1: Does the local bridge exist?**
 ```bash

--- a/.claude/skills/help/references/two-repos.md
+++ b/.claude/skills/help/references/two-repos.md
@@ -36,15 +36,16 @@ This is what makes your outputs sound like YOU.
 ## How They Work Together
 
 ```
-your-business/                    vip/ (loaded via settings.local.json)
+your-business/                    vip/ (linked from business repo)
 ├── Your offer                    ├── Skills
 ├── Your audience                 ├── Templates
 ├── Your voice                    ├── Frameworks
 ├── .claude/settings.local.json   └── (shared, read-only)
+├── .claude/skills/* (bridge links)
 └── (yours, you own it)
 ```
 
-You start Claude in your business repo. The vip engine is loaded automatically as a read-only additional directory via `.claude/settings.local.json`. The engine reads your business data and generates content that sounds like you.
+You start Claude in your business repo. `/setup` connects vip through `.claude/settings.local.json` for file access, and adds bridge links when needed for skill discovery. The engine then reads your business data and generates content that sounds like you.
 
 **Same engine + different data = different outputs for each business.**
 

--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -649,7 +649,7 @@ Once setup is complete, tell the user:
 > claude
 > /start
 > ```
-> Skills load automatically from vip via `additionalDirectories` — no need to touch the vip folder.
+> vip linkage is managed by setup (`settings.local.json` + compatibility bridge links) — no need to touch the vip folder.
 >
 > **Key skills to try:**
 > - `/think` — Research topics, make decisions, update reference

--- a/.claude/skills/setup/references/claude-md-guide.md
+++ b/.claude/skills/setup/references/claude-md-guide.md
@@ -34,7 +34,7 @@ This repo contains your **business data**. It's powered by **vip** (the engine).
 **Setup:**
 1. Clone vip: `git clone https://github.com/mainbranch-ai/vip.git`
 2. Start Claude in THIS folder (your business repo) and run `/start`
-3. vip loads automatically via `.claude/settings.local.json` additionalDirectories
+3. vip is linked via `.claude/settings.local.json` (with bridge links as compatibility fallback)
 
 **How it works:**
 - Engine (vip): Contains skills, lenses, frameworks. You pull updates but never edit.

--- a/.claude/skills/setup/references/templates.md
+++ b/.claude/skills/setup/references/templates.md
@@ -582,7 +582,7 @@ It uses [vip](https://github.com/mainbranch-ai/vip) as the **engine** — skills
 
 2. **Start Claude in this folder** (your business repo) and run `/start`
 
-3. **vip loads automatically** via `.claude/settings.local.json` additionalDirectories
+3. **vip is linked** via `.claude/settings.local.json` (bridge links handle skill discovery fallback)
 
 ### How It Works
 

--- a/.claude/skills/start/SKILL.md
+++ b/.claude/skills/start/SKILL.md
@@ -516,7 +516,7 @@ If user already stated intent, route directly without asking.
 
 "Help" or confused → route to `/help`. Give quick overview first:
 
-> "1. **vip** = engine (skills, loaded automatically). 2. **Your repo** = data (offer, audience, voice).
+> "1. **vip** = engine (skills + frameworks, linked via setup). 2. **Your repo** = data (offer, audience, voice).
 > Daily: `cd your-business-repo && claude` then `/start`.
 > For detailed help: `/help` + your question."
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ That is it. You are ready to generate.
 
 Skills are pre-built workflows you invoke with slash prompts (for example, `/start`, `/ads`, `/think`).
 
-Instead of figuring out how to prompt Claude, you just type a command like `/ads` and Claude knows exactly what to do.
+Instead of figuring out how to prompt Claude, you invoke a skill with a slash prompt like `/ads` and Claude knows exactly what to do.
 
 **Example:**
 
@@ -158,13 +158,13 @@ You type:
 
 Claude reads your business files, then generates 5-6 complete ad concepts. Each concept includes headlines, primary text, and image prompts. All in your voice.
 
-No prompt engineering. No explaining what you want. Just type the command.
+No prompt engineering. No explaining what you want. Just run the skill.
 
 ---
 
 ## Available Skills
 
-| Command | What It Does |
+| Skill | What It Does |
 |---------|-------------|
 | `/start` | Main entry point — figures out what you need and routes you there |
 | `/setup` | Set up your business repo (run this first if you're new) |
@@ -252,7 +252,7 @@ Post in the Main Branch group. Tag @Devon for technical questions.
 **Common issues:**
 - "404 error" or "Repository not found" — You need access first. Share your GitHub username with Devon.
 - "Claude does not see my files" — Make sure you started Claude in your business repo folder and ran `/start`
-- "Skills are not working" — Check that `.claude/settings.local.json` exists in your business repo with vip in `additionalDirectories`. Run `/setup` to fix.
+- "Skills are not working" — Check that `.claude/settings.local.json` exists and run `/start` once to auto-repair missing bridge links. If still broken, run `/setup`.
 - "Output sounds generic" — Add more detail to your reference files, especially voice.md
 - "I edited vip but can't push" — That's expected. vip is read-only. Your business data goes in YOUR repo.
 
@@ -262,7 +262,7 @@ Post in the Main Branch group. Tag @Devon for technical questions.
 
 **Do I need to know how to code?**
 
-No. You just type commands and answer questions.
+No. You invoke skills with slash prompts and answer questions.
 
 **What if I have multiple products under one brand?**
 

--- a/docs/BEGINNER-SETUP.md
+++ b/docs/BEGINNER-SETUP.md
@@ -61,7 +61,7 @@ claude
 /start
 ```
 
-`/start` detects your business repo and routes you to the right skill. vip is linked automatically via `settings.local.json` plus compatibility bridge links when needed.
+`/start` detects your business repo and routes you to the right skill. vip linkage is configured by setup via `settings.local.json`, plus compatibility bridge links when needed.
 
 When you're done for the day:
 

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -472,7 +472,7 @@ Skills should load context progressively:
 
 1. Clone vip locally
 2. Create or clone your business repo
-3. Run `/setup` to configure vip as an additional directory (writes `.claude/settings.local.json`)
+3. Run `/setup` to configure vip linkage (writes `.claude/settings.local.json` and compatibility links when needed)
 4. Start Claude in your business repo and run `/start`
 
 ### In Practice
@@ -481,12 +481,13 @@ Skills should load context progressively:
 Claude Code Session:
 ├── Primary (CWD): ~/projects/my-business/
 │   ├── .claude/settings.local.json  ← additionalDirectories points to vip
+│   ├── .claude/skills/*             ← bridge links for skill discovery fallback
 │   ├── reference/
 │   ├── outputs/
 │   └── ...
 │
 └── Additional directory (read-only): ~/Documents/GitHub/vip/
-    ├── .claude/skills/              ← skills discovered automatically
+    ├── .claude/skills/              ← canonical skill source
     ├── .claude/lenses/
     └── ...
 ```
@@ -828,6 +829,6 @@ Client repos (BDC, autism-rewired) are separate — can be handed off independen
 5. **File linking** — Research links to decisions, decisions link to context
 6. **Progressive loading** — Context tiers for token efficiency
 7. **Compliance layers** — Planning, review, and data layers
-8. **Multi-repo workflow** — Engine as additional directory, business repo as primary
+8. **Multi-repo workflow** — Engine linked via additional directory + bridge fallback, business repo as primary
 9. **Content pipeline** — Newsletter-first waterfall: keystone → organic → ads → learn
 10. **Multi-offer support** — Cascading path resolution for businesses with multiple products under one brand


### PR DESCRIPTION
Manual language-consistency sweep across user-facing docs and skill prompts after the workflow flip. This removes stale wording that implied `additionalDirectories` alone guarantees skill discovery and replaces it with explicit linkage + compatibility-bridge framing. It also standardizes beginner-facing phrasing around skills/slash prompts and updates architecture/help text to match current behavior. No functional code changes; documentation and operator guidance only.