### PR TITLE
[fix] add .gitignore entries for vip bridge links

### DIFF
--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -154,6 +154,8 @@ User started Claude in their business repo. Confirm and configure vip:
 
    **Never use:** `cat > ~/.config/vip/local.yaml`
 
+   Then update `.gitignore` to exclude bridge links (see `auto-heal.md` Step 2.5 for the canonical script — marker-based, per-skill entries, idempotent).
+
    > "Configured. vip is now linked for file access, and compatibility bridge links are in place for skill discovery."
 
 3. **If vip loaded:** Check compatibility symlinks exist (without clobbering local files):
@@ -203,6 +205,8 @@ User started Claude in the engine folder. Guide them to the new workflow:
      [ -e "$REPO_PATH/.claude/$parent/$base" ] || ln -s "$p" "$REPO_PATH/.claude/$parent/$base"
    done
    ```
+   Then update `.gitignore` in the business repo to exclude bridge links (see `auto-heal.md` Step 2.5 for the canonical script).
+
    If direct write is blocked by sandbox boundaries, use the write-boundary decision flow above (ask first, then use terminal commands only if user agrees).
 
 3. **If NO repo exists:** Create one:
@@ -244,17 +248,18 @@ User started Claude in the engine folder. Guide them to the new workflow:
         [ -e "$REPO_PATH/.claude/$parent/$base" ] || ln -s "$p" "$REPO_PATH/.claude/$parent/$base"
       done
       ```
-   d. Update `~/.config/vip/local.yaml` with a **merge** (never overwrite):
+   d. Update `.gitignore` in the new repo to exclude bridge links (see `auto-heal.md` Step 2.5 for the canonical script).
+   e. Update `~/.config/vip/local.yaml` with a **merge** (never overwrite):
       - Read existing file first
       - Preserve existing/unknown keys
       - Set/update `vip_path`
       - Add new repo to `recent_repos` (prepend + dedupe)
       - Keep `user.*` if present; ask only when missing
       - Ask before changing `default_repo` if one already exists
-   e. **Set the business repo as the target for all file writes:**
+   f. **Set the business repo as the target for all file writes:**
       From this point forward, write all files to `~/Documents/GitHub/[business-name]/` NOT to the current directory.
       If direct writes are blocked by workspace limits, use explicit terminal commands with full paths (after user approval via the decision flow above).
-   f. Confirm:
+   g. Confirm:
       > "Created [business-name] and configured vip. Next time:
       > ```
       > cd ~/Documents/GitHub/[business-name]

--- a/.claude/skills/setup/references/repo-scaffolding.md
+++ b/.claude/skills/setup/references/repo-scaffolding.md
@@ -134,8 +134,30 @@ cat > .gitignore << 'EOF'
 EOF
 ```
 
+**Then add VIP bridge link entries** (dynamic, based on which vip skills exist):
+
+```bash
+GITIGNORE="$REPO_PATH/.gitignore"
+
+if ! grep -q "VIP BRIDGE LINKS" "$GITIGNORE" 2>/dev/null; then
+  cat >> "$GITIGNORE" << 'GITIGNORE_BLOCK'
+
+# === VIP BRIDGE LINKS (machine-local, do not commit) ===
+.claude/lenses/
+.claude/reference/
+GITIGNORE_BLOCK
+
+  # Add each vip skill symlink individually (preserves custom skill tracking)
+  for d in "$VIP_PATH"/.claude/skills/*/; do
+    [ -d "$d" ] || continue
+    n=$(basename "$d")
+    echo ".claude/skills/$n" >> "$GITIGNORE"
+  done
+fi
+```
+
 **Why `.claude/settings.local.json` is git-ignored:** Claude Code auto-ignores this file, but we add it explicitly for safety. It contains machine-specific absolute paths to vip (`additionalDirectories`) that differ per computer.
 
-**Do not ignore `.claude/skills/` globally:** This folder is where repo-specific local skills live. Ignoring it would block project-level custom skills. If you create compatibility links to vip skill folders, keep those links uncommitted via local Git excludes (`.git/info/exclude`) rather than broad `.gitignore` rules.
+**Why per-skill entries (not `.claude/skills/`):** Users have custom skills (deck, pr-review, etc.) that ARE tracked in git. Ignoring the whole folder would hide those. We only ignore the vip-linked symlinks. `.claude/lenses/` and `.claude/reference/` are blanket-ignored because they're 100% vip content — no user files live there.
 
 **Why `.vip/local.yaml` is git-ignored:** It stores session state like `current_offer` -- which offer you're working on right now. This is per-machine, per-session. The git-tracked `.vip/config.yaml` holds team/business settings that should be shared.

--- a/.claude/skills/start/references/auto-heal.md
+++ b/.claude/skills/start/references/auto-heal.md
@@ -79,6 +79,37 @@ done
 
 ---
 
+## Step 2.5: Update .gitignore
+
+Bridge links are machine-local symlinks — they must not be committed. After creating links, ensure `.gitignore` covers them.
+
+```bash
+GITIGNORE="$REPO_PATH/.gitignore"
+
+# Add marker + entries if not already present
+if ! grep -q "VIP BRIDGE LINKS" "$GITIGNORE" 2>/dev/null; then
+  cat >> "$GITIGNORE" << 'GITIGNORE_BLOCK'
+
+# === VIP BRIDGE LINKS (machine-local, do not commit) ===
+.claude/lenses/
+.claude/reference/
+GITIGNORE_BLOCK
+
+  # Add each vip skill symlink individually (preserves custom skill tracking)
+  for d in "$VIP_PATH"/.claude/skills/*/; do
+    [ -d "$d" ] || continue
+    n=$(basename "$d")
+    echo ".claude/skills/$n" >> "$GITIGNORE"
+  done
+fi
+```
+
+**Why per-skill entries (not `.claude/skills/`):** Users have custom skills (deck, pr-review, etc.) that ARE tracked. Ignoring the whole folder would hide those. We only ignore the vip-linked ones.
+
+**Idempotent:** The marker check (`VIP BRIDGE LINKS`) prevents duplicate entries on repeated heals.
+
+---
+
 ## Step 3: Verify
 
 ```bash


### PR DESCRIPTION
Bridge symlinks are machine-local and must not be committed. This adds per-skill .gitignore entries across setup, auto-heal, and scaffolding workflows.

**Key changes:**
- Step 2.5 in auto-heal.md: canonical gitignore script with marker-based idempotency
- repo-scaffolding.md: integrated bridge link entries after initial .gitignore creation
- setup/SKILL.md: references to auto-heal Step 2.5 after each bridge link creation point

Per-skill entries preserve custom skill tracking (.claude/lenses/ and .claude/reference/ are blanket-ignored as 100% vip content).

📌 Generated with Claude Code