### PR TITLE
Add Conductor setup documentation to help skill

### DIFF
--- a/.claude/skills/help/SKILL.md
+++ b/.claude/skills/help/SKILL.md
@@ -41,6 +41,7 @@ Answer questions, troubleshoot issues, explain philosophy, suggest next steps.
 | Better outputs, quality, what next | [making-outputs-better.md](references/making-outputs-better.md) |
 | Content strategy, pillars, platforms, newsletter, content plan | [content-strategy-help.md](references/content-strategy-help.md) |
 | Subagents, parallel, agents, context window, tokens | [working-with-agents.md](references/working-with-agents.md) |
+| Conductor, workspace, PA config, pre-agent, skills not showing (Conductor) | [conductor-setup.md](references/conductor-setup.md) |
 | Contribute, contributor | [becoming-contributor.md](references/becoming-contributor.md) |
 
 ---
@@ -79,3 +80,5 @@ Answer questions, troubleshoot issues, explain philosophy, suggest next steps.
 | How do I recover after compaction? | Point Claude at recent files: "look at my last 3 decisions" or "read the commits from today." Or just run /start — it scans your folders and rebuilds context automatically. You can also open files yourself in Cursor, Warp, VS Code, or any text editor. |
 | Is this system finished? | Still new and actively being tuned. We're building around Claude Code, minimizing commands you need to learn while giving you real power. There's progressive discovery in /think — the more you use it, the more it reveals. You might find workflows we haven't documented yet. Post them in Skool. |
 | Where can I see my files? | Open your business repo folder in Finder, Cursor, Warp, VS Code, or any text editor. They're regular .md files on your hard drive. GitHub Desktop also shows them with version history. |
+| Skills not showing in Conductor? | Conductor workspaces are isolated — they don't know where vip is. You need a Pre-Agent (PA) config script that creates bridge symlinks and `settings.local.json` before Claude starts. See [conductor-setup.md](references/conductor-setup.md) for the script and setup steps. |
+| What's a PA config? | Pre-Agent config — a script Conductor runs before Claude starts in a workspace. Used to set up vip bridge links so skills appear. One-time setup per workspace. |

--- a/.claude/skills/help/references/conductor-setup.md
+++ b/.claude/skills/help/references/conductor-setup.md
@@ -1,0 +1,148 @@
+# Conductor Setup
+
+How to get Main Branch skills working in Conductor workspaces.
+
+---
+
+## Why Skills Don't Show Up in Conductor
+
+Conductor creates isolated workspaces. Each workspace is its own folder — it doesn't automatically know where vip lives on your machine.
+
+Main Branch skills live in the **vip repo** (the engine). For Claude to discover them in a Conductor workspace, two things need to exist:
+
+1. **`settings.local.json`** — tells Claude where vip is (file access)
+2. **Bridge symlinks** — make Claude discover skills as if they're local (skill dropdown)
+
+Without these, Claude opens in your workspace and sees no skills. No `/start`, no `/ads`, nothing.
+
+---
+
+## The Fix: Pre-Agent (PA) Config Script
+
+Conductor has a **Pre-Agent config** — a script that runs before Claude starts in a workspace. This is where you set up the vip connection.
+
+### The Script
+
+```bash
+for skill in ads end help organic pull setup site start think vsl wiki; do
+  target="/absolute/path/to/vip/.claude/skills/$skill"
+  link=".claude/skills/$skill"
+  [ -d "$target" ] && [ ! -e "$link" ] && ln -s "$target" "$link" || true
+done
+mkdir -p .claude
+cat > .claude/settings.local.json << 'EOF'
+{
+  "permissions": {
+    "additionalDirectories": [
+      "/absolute/path/to/vip"
+    ]
+  }
+}
+EOF
+exit
+```
+
+**Replace `/absolute/path/to/vip`** with the actual path to your vip clone. Common locations:
+
+| OS | Typical Path |
+|----|-------------|
+| Mac (GitHub Desktop) | `~/Documents/GitHub/mb-vip` or `~/Documents/GitHub/vip` |
+| Mac (manual clone) | `~/projects/vip` or wherever you cloned it |
+| Linux | `~/repos/vip` or `~/Documents/GitHub/vip` |
+
+### What Each Part Does
+
+1. **The `for` loop** — Creates symlinks from the workspace's `.claude/skills/` to each vip skill directory. The `[ ! -e "$link" ]` guard means it won't overwrite existing local skills.
+
+2. **`settings.local.json`** — Tells Claude that vip is an additional directory it can read from. This gives Claude access to lenses, compliance docs, and reference files inside vip.
+
+3. **`exit`** — Closes the Claude session so it restarts fresh with skills loaded. Skills are only discovered at startup — adding symlinks mid-session doesn't make them appear.
+
+### Finding Your vip Path
+
+If you're not sure where vip is:
+
+```bash
+# Check if you cloned it with GitHub Desktop
+ls ~/Documents/GitHub/mb-vip 2>/dev/null && echo "Found: ~/Documents/GitHub/mb-vip"
+ls ~/Documents/GitHub/vip 2>/dev/null && echo "Found: ~/Documents/GitHub/vip"
+
+# Or search for it
+find ~/ -name "CLAUDE.md" -path "*/vip/*" -maxdepth 4 2>/dev/null
+```
+
+---
+
+## Setting Up the PA Config
+
+### Step by Step
+
+1. **Open Conductor**
+2. **Create or select a workspace** for your business repo
+3. **Find the PA (Pre-Agent) config** for that workspace
+4. **Paste the script above** (with your actual vip path)
+5. **Start the agent** — the script runs first, creates the links, then exits
+6. **Start the agent again** — now skills show up in the dropdown
+
+### Per-Workspace
+
+The PA config is per-workspace. If you create a new workspace, you need to add the script there too. Same script, same vip path.
+
+---
+
+## Troubleshooting
+
+### Skills still don't appear after running the script
+
+1. **Did Claude restart?** The script ends with `exit`. Start a new session — skills only load at startup.
+2. **Is the vip path correct?** Check that the path in the script actually contains `.claude/skills/start/SKILL.md`.
+3. **Are symlinks created?** Run `ls -la .claude/skills/` — you should see arrows (`->`) pointing to vip.
+
+### "Cannot edit files outside allowed directories"
+
+This is Conductor's sandbox. The PA script handles this by using `ln -s` (which creates links inside the workspace). The `settings.local.json` grants read access to vip. If you still hit this error during a session, it means you're trying to write to a path outside the workspace — which is expected. Your business files should be inside the workspace.
+
+### Symlinks show as broken
+
+The vip path in the script doesn't match where vip actually lives. Verify:
+
+```bash
+ls /absolute/path/to/vip/.claude/skills/start/SKILL.md
+```
+
+If that file doesn't exist, your path is wrong.
+
+### New skills added to vip don't appear
+
+When Devon adds new skills to vip, your PA script's skill list may be outdated. Update the `for skill in ...` line to include the new skill name. Or replace it with a dynamic version:
+
+```bash
+for d in /absolute/path/to/vip/.claude/skills/*/; do
+  [ -d "$d" ] || continue
+  skill=$(basename "$d")
+  link=".claude/skills/$skill"
+  [ -e "$link" ] || ln -s "$d" "$link"
+done
+```
+
+This automatically picks up any new skills from vip.
+
+---
+
+## Why Not Just Use Terminal?
+
+You can. Running `cd ~/Documents/GitHub/my-business && claude` in a regular terminal works perfectly — `/setup` and `/start` handle all the vip linkage automatically.
+
+Conductor adds value when you want to run **multiple agents in parallel** on different tasks. The tradeoff is the one-time PA config setup per workspace.
+
+---
+
+## Quick Reference
+
+| What | Where |
+|------|-------|
+| PA config script | Conductor workspace settings |
+| vip path | Your local vip clone (e.g., `~/Documents/GitHub/mb-vip`) |
+| Bridge links | `.claude/skills/` in the workspace (symlinks to vip) |
+| File access | `.claude/settings.local.json` → `additionalDirectories` |
+| Skills load | Only at Claude startup (not mid-session) |

--- a/.claude/skills/help/references/troubleshooting.md
+++ b/.claude/skills/help/references/troubleshooting.md
@@ -132,6 +132,24 @@ claude
 
 ---
 
+## Conductor: Skills Not Showing
+
+Conductor workspaces are isolated — Claude doesn't know where vip is unless you tell it.
+
+**The fix:** Add a Pre-Agent (PA) config script to your workspace. This runs before Claude starts and creates the bridge links + `settings.local.json` that skills need.
+
+See [conductor-setup.md](conductor-setup.md) for the full script and setup walkthrough.
+
+**Quick version:**
+1. Find your vip path (e.g., `~/Documents/GitHub/mb-vip`)
+2. Add the PA config script to your Conductor workspace
+3. The script creates symlinks + settings, then exits
+4. Start the agent again — skills appear
+
+**After fixing:** Skills only load at startup. If you added bridge links mid-session, you need to restart Claude.
+
+---
+
 ## "Cannot edit files outside allowed directories"
 
 This is common in sandboxed tools (like Conductor workspaces). It means Claude can only edit files inside the current workspace folder.


### PR DESCRIPTION
## Summary

Added comprehensive documentation for Conductor users who need to configure skill discovery in isolated workspaces. Includes the PA (Pre-Agent) config script, troubleshooting, and integrated help routing.

- New `conductor-setup.md` reference with full script and setup walkthrough
- Added topic router entry for Conductor/workspace/PA config keywords
- Expanded troubleshooting section with dedicated Conductor entry
- Added Quick Answers for Conductor skill discovery issues

This helps Conductor users self-serve when asking `/help` about why skills aren't showing in their workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)