### PR TITLE
[fix] Grok SDK docs — LiveSearch deprecated, subagent recipe, grok-3 refs

### DIFF
--- a/.claude/skills/think/references/grok-social.md
+++ b/.claude/skills/think/references/grok-social.md
@@ -23,6 +23,8 @@ Real-time social intelligence from X/Twitter using xAI's Grok API.
 
 **The REST API does not support X search. You must use the Python SDK with grok-4.** See [grok-setup.md](grok-setup.md) for the full REST vs SDK explanation and setup instructions.
 
+**DEPRECATED (Feb 2026):** The `SearchParameters` / `x_source()` API (aka "Live Search") has been removed server-side. Using `search_parameters=SearchParameters(sources=[x_source()])` returns `UNIMPLEMENTED: "Live search is deprecated"`. Use the Agent Tools API (`tools=[x_search()]`) instead — see code below.
+
 ---
 
 ## When to Use
@@ -103,15 +105,25 @@ When you pass `x_search()`, the model gets access to:
 | `x_semantic_search` | Semantic/contextual search |
 | `x_thread_fetch` | Fetch full thread from a post |
 
-### Search Parameters
+### x_search() Parameters
 
-The model can use these internally when searching:
+You CAN control these directly when creating the tool:
 
-- **Date filtering:** `from_date`, `to_date` (ISO8601 format: "2026-01-01")
-- **Handle exclusion:** `excluded_handles` (list of handles to skip)
-- **Result limits:** Typically returns 10-20 relevant posts
+```python
+import datetime
+from xai_sdk.tools import x_search
 
-**Note:** You don't control these directly — the model decides based on your prompt. You can influence by being specific: "What have people said about X in the last week, excluding @spamaccount?"
+tool = x_search(
+    from_date=datetime.datetime(2026, 2, 1),      # Optional: start date
+    to_date=datetime.datetime(2026, 2, 15),        # Optional: end date
+    allowed_x_handles=["xai", "elonmusk"],         # Optional: limit to these handles
+    excluded_x_handles=["spambot"],                # Optional: exclude these handles
+    enable_image_understanding=True,                # Optional: analyze images in posts
+    enable_video_understanding=True,                # Optional: analyze videos in posts
+)
+```
+
+**Note:** `allowed_x_handles` and `excluded_x_handles` are mutually exclusive. The model still autonomously decides WHEN to search — you control the scope/filters.
 
 ### Example with Streaming
 
@@ -140,14 +152,39 @@ def research_topic(topic: str):
 
     result = []
     for response, chunk in chat.stream():
-        if chunk.token:
-            result.append(chunk.token)
-            print(chunk.token, end="", flush=True)
+        if chunk.content:
+            result.append(chunk.content)
+            print(chunk.content, end="", flush=True)
 
     return "".join(result)
 
 research_topic("Skool communities")
 ```
+
+### Subagent Prompt Recipe
+
+When spawning a Claude Code subagent for Grok X research, include this exact recipe in the prompt. Subagents cannot reverse-engineer the SDK — they need the code:
+
+```
+GROK X SEARCH RECIPE — use this exact pattern, do not try alternatives:
+
+from xai_sdk import Client
+from xai_sdk.tools import x_search
+from xai_sdk.chat import user
+
+client = Client()
+chat = client.chat.create(model="grok-4", tools=[x_search()])
+chat.append(user("YOUR QUERY HERE"))
+response = chat.sample()
+
+response.content has the full X search results with citations
+
+DO NOT use SearchParameters, x_source(), or the xai_sdk.search module — deprecated.
+DO NOT try the REST API — it does not support X search.
+DO NOT try to reverse-engineer the SDK — use exactly this pattern.
+```
+
+**Why this matters:** The SDK contains two search APIs. The deprecated one (`SearchParameters`/`x_source()`) is more discoverable via introspection. Without this recipe, agents burn all turns trying the wrong API.
 
 ---
 

--- a/.claude/skills/think/references/research-architecture.md
+++ b/.claude/skills/think/references/research-architecture.md
@@ -182,10 +182,12 @@ If !APIFY_AVAILABLE:
 
 **Critical:** The xAI REST API does NOT support X search (the `search` parameter is ignored, returns `num_sources_used: 0`). Live X search requires the Python SDK (`xai_sdk`) which uses gRPC and server-side tool execution. See `grok-social.md` for full details.
 
+**Also deprecated (Feb 2026):** The SDK's `SearchParameters`/`x_source()` approach returns `UNIMPLEMENTED`. Only `tools=[x_search()]` works. When spawning subagents for X research, include the exact code recipe — see [grok-social.md](grok-social.md) subagent recipe section.
+
 **Routing:**
 ```
 If GROK_AVAILABLE (Python SDK with xai_sdk):
-  → Use x_search() tool with grok-3 model
+  → Use x_search() tool with grok-4 model
   → Model autonomously calls x_keyword_search, x_semantic_search, etc.
   → Save to: research/YYYY-MM-DD-topic-x-social.md
 

--- a/.claude/skills/think/references/research-routing-quick-ref.md
+++ b/.claude/skills/think/references/research-routing-quick-ref.md
@@ -9,7 +9,7 @@ Fast lookup table for routing research requests in /think skill.
 | User Says | Route To | Requires | Fallback |
 |-----------|----------|----------|----------|
 | YouTube URL, "transcribe video" | Apify YouTube | `mcp__apify__*` | Ask for manual transcript |
-| "what are people saying", "X sentiment" | Grok X search | `XAI_API_KEY` OR `mcp__xai__*` | WebSearch site:x.com |
+| "what are people saying", "X sentiment" | Grok X search | `XAI_API_KEY` + `xai_sdk` package | WebSearch site:x.com |
 | Quick research, fact-checking | Gemini Flash (Tier 1) | `GOOGLE_API_KEY` | WebSearch + synthesis |
 | "deep dive", "comprehensive research" | Gemini Deep (Tier 2) | `GOOGLE_API_KEY` | Tier 1 or WebSearch |
 | Local file path, "transcribe recording" | whisper-mcp | `mcp__whisper__*` | CLI fallback |
@@ -31,8 +31,8 @@ Fast lookup table for routing research requests in /think skill.
 # Check for Apify (YouTube, Instagram)
 if mcp__apify__* exists: APIFY=true
 
-# Check for Grok (X/Twitter)
-if $XAI_API_KEY set OR mcp__xai__* exists: GROK=true
+# Check for Grok (X/Twitter) — requires Python SDK, not just API key
+if $XAI_API_KEY set AND xai_sdk package installed: GROK=true
 
 # Check for Gemini (deep research)
 if $GOOGLE_API_KEY set: GEMINI=true


### PR DESCRIPTION
## Summary

Fixed outdated Grok SDK documentation after xAI deprecated the SearchParameters/x_source() API (LiveSearch) server-side in Feb 2026. Only `tools=[x_search()]` works now. Added exact code recipe for subagents to prevent them from discovering and trying the deprecated API.

## Changes

- **grok-social.md**: Deprecation warning in CRITICAL section, x_search() parameters with working example, streaming fix (chunk.token→chunk.content), subagent prompt recipe with DO/DON'T rules
- **research-architecture.md**: Fixed grok-3→grok-4 model ref, added deprecation note with cross-reference to subagent recipe
- **research-routing-quick-ref.md**: Clarified SDK requirement (+ xai_sdk package, not just API key), fixed detection logic (AND not OR)

All changes are documentation/reference updates. No code behavior changes.

## Notes for Reviewers

The subagent recipe is critical because the SDK contains two search APIs:
- Deprecated: SearchParameters/x_source() — more discoverable via introspection
- Working: tools=[x_search()] — requires explicit code

Without this recipe, subagents burn all turns trying the wrong API.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)