### PR TITLE
[update] Consolidate outputs/ — kill content/ refs, standardize frontmatter

### DIFF
--- a/.claude/skills/ads/SKILL.md
+++ b/.claude/skills/ads/SKILL.md
@@ -278,6 +278,18 @@ Campaign Batch 001
 4. **Write ALL image prompts first** (Part 1)
 5. **Write ALL ad copy second** (Part 2)
 6. **Cold traffic language check:** Every hook must pass the 3-second comprehension test — no insider jargon, no assumed context. Translate community language to customer language. See Joel's cold traffic guidance in [references/one-liner-methodology.md](references/one-liner-methodology.md).
+
+Each batch file should start with:
+```yaml
+---
+type: output
+format: static-ad
+date: YYYY-MM-DD
+status: draft
+platform: meta
+---
+```
+
 7. Save to `outputs/YYYY-MM-DD-static-ads-[offer]-{campaign}/static-ads-batch-001.md` (include offer slug in multi-offer mode; omit `[offer]-` in single-offer mode)
 8. Tell user: "Copy saved. Running automatic post-generation pipeline..."
 9. Run the **Automatic Post-Generation Pipeline** (see below). This handles git commit, compliance review, and image generation automatically.
@@ -361,10 +373,10 @@ Every variation **MUST** include at least one specific element:
 ```markdown
 ---
 type: output
-subtype: creative-variations
+format: creative-variations
 date: YYYY-MM-DD
 status: draft
-review_status: null
+platform: meta
 ---
 
 # Creative Variations: {Campaign Name}
@@ -426,6 +438,18 @@ Create diverse spoken-word scripts for camera delivery.
 4. **Generate Ads:** 15-30 scripts across all avatars
 5. **Optimize for Spoken:** ~5th grade reading level, contractions, fragments
 6. Ask for campaign name (required)
+
+Each batch file should start with:
+```yaml
+---
+type: output
+format: video-ad-script
+date: YYYY-MM-DD
+status: draft
+platform: meta
+---
+```
+
 7. **Save Output:** `outputs/YYYY-MM-DD-video-ads-[offer]-{campaign}/video-ads-batch-001.md` (include offer slug in multi-offer mode; omit `[offer]-` in single-offer mode)
 8. Tell user: "Video scripts saved. Running automatic post-generation pipeline..."
 9. Run the **Automatic Post-Generation Pipeline** (see below). This handles git commit and compliance review automatically. (No image generation for video scripts.)

--- a/.claude/skills/ads/references/one-liner-methodology.md
+++ b/.claude/skills/ads/references/one-liner-methodology.md
@@ -267,10 +267,10 @@ The file should include:
 ```markdown
 ---
 type: output
-subtype: creative-variations
+format: creative-variations
 date: YYYY-MM-DD
 status: draft
-review_status: null
+platform: meta
 ---
 
 # One-Liners: {Campaign Name}

--- a/.claude/skills/ads/references/static-output-template.md
+++ b/.claude/skills/ads/references/static-output-template.md
@@ -12,6 +12,14 @@ Use this structure for campaign batch outputs.
 ---
 
 ```markdown
+---
+type: output
+format: static-ad
+date: YYYY-MM-DD
+status: draft
+platform: meta
+---
+
 # Campaign Batch {number} — {Campaign Name}
 
 Generated: {date}

--- a/.claude/skills/end/SKILL.md
+++ b/.claude/skills/end/SKILL.md
@@ -83,7 +83,7 @@ git diff --name-only --diff-filter=AM HEAD@{6am}..HEAD 2>/dev/null
 | Research files created | New files in `research/` |
 | Decisions made | New or modified files in `decisions/` |
 | Reference files updated | Modified files in `reference/` |
-| Outputs generated | New files in `outputs/` or `content/` |
+| Outputs generated | New files in `outputs/` |
 | Uncommitted changes | `git status --short` output |
 
 **Multi-offer detection (skip if no `offers/` folder — single-offer mode, everything reads from `core/`):** If `reference/offers/` exists, note which offers had files changed:

--- a/.claude/skills/organic/SKILL.md
+++ b/.claude/skills/organic/SKILL.md
@@ -234,6 +234,17 @@ Generate single-post caption from a concept.
 
 **Output path (all script modes):** `outputs/YYYY-MM-DD-organic-[offer]-{campaign}/organic-batch-001.md` (include offer slug in multi-offer mode; omit `[offer]-` in single-offer mode)
 
+**Output frontmatter:**
+```yaml
+---
+type: output
+format: video | carousel | static
+date: YYYY-MM-DD
+status: draft
+platform: instagram | tiktok
+---
+```
+
 Campaign name is REQUIRED. Ask user if not provided. Examples: `january-hooks`, `transformation-series`, `pain-point-reels`.
 
 ---

--- a/.claude/skills/organic/references/carousel-template.md
+++ b/.claude/skills/organic/references/carousel-template.md
@@ -16,7 +16,7 @@ Example: `outputs/organic-scripts/2026-01-19-content-mistakes-carousel.md`
 
 ```markdown
 ---
-type: content-script
+type: output
 format: carousel
 date: YYYY-MM-DD
 slides: [number]
@@ -121,7 +121,7 @@ Standard 7-10 slide format:
 
 ```markdown
 ---
-type: content-script
+type: output
 format: carousel
 date: 2026-01-19
 slides: 10
@@ -310,7 +310,7 @@ Save this for your next content audit.
 
 ```markdown
 ---
-type: content-script
+type: output
 format: carousel
 date: 2026-01-19
 slides: 8

--- a/.claude/skills/organic/references/static-template.md
+++ b/.claude/skills/organic/references/static-template.md
@@ -16,7 +16,7 @@ Example: `outputs/organic-scripts/2026-01-19-content-tip-static.md`
 
 ```markdown
 ---
-type: content-script
+type: output
 format: static
 date: YYYY-MM-DD
 length: [short | medium | long]
@@ -100,7 +100,7 @@ End with a soft engagement ask:
 
 ```markdown
 ---
-type: content-script
+type: output
 format: static
 date: 2026-01-19
 length: short
@@ -151,7 +151,7 @@ Minimalist graphic with text reading "Your content isn't boring. Your hooks are.
 
 ```markdown
 ---
-type: content-script
+type: output
 format: static
 date: 2026-01-19
 length: medium
@@ -220,7 +220,7 @@ Creator sitting at a minimal desk workspace, looking relaxed while working on co
 
 ```markdown
 ---
-type: content-script
+type: output
 format: static
 date: 2026-01-19
 length: long

--- a/.claude/skills/organic/references/video-script-template.md
+++ b/.claude/skills/organic/references/video-script-template.md
@@ -16,7 +16,7 @@ Example: `outputs/organic-scripts/2026-01-19-morning-routine-story.md`
 
 ```markdown
 ---
-type: content-script
+type: output
 format: video
 date: YYYY-MM-DD
 framework: [educational | story | transformation | problem-solution | contrarian]
@@ -91,7 +91,7 @@ Concept: [Brief description of the core idea]
 
 ```markdown
 ---
-type: content-script
+type: output
 format: video
 date: 2026-01-19
 framework: educational
@@ -150,7 +150,7 @@ Save this for your next content day.
 
 ```markdown
 ---
-type: content-script
+type: output
 format: video
 date: 2026-01-19
 framework: story
@@ -224,7 +224,7 @@ What changed for you?
 
 ```markdown
 ---
-type: content-script
+type: output
 format: video
 date: 2026-01-19
 framework: transformation

--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -384,7 +384,7 @@ See **[references/context-gathering.md](references/context-gathering.md)** for:
 # Always create:
 mkdir -p .vip
 mkdir -p reference/core reference/brand reference/proof/angles reference/domain
-mkdir -p research decisions outputs content/drafts content/scheduled content/published
+mkdir -p research decisions outputs
 ```
 
 **Multi-offer only (if user has multiple offers from Step 2.5):**
@@ -434,12 +434,7 @@ Full structure (single-offer):
 ├── decisions/             # Dated choices with rationale
 │   └── YYYY-MM-DD-topic.md
 │
-├── content/               # Content lifecycle
-│   ├── drafts/            # WIP content
-│   ├── scheduled/         # Queued for posting
-│   └── published/         # Archive
-│
-└── outputs/               # Generated assets
+└── outputs/               # All generated content (lifecycle via frontmatter status)
     └── YYYY-MM-DD-batch-name/
 ```
 

--- a/.claude/skills/start/references/triage-agent.md
+++ b/.claude/skills/start/references/triage-agent.md
@@ -84,7 +84,7 @@ Gather these in main and pass as structured text in each agent's prompt:
 | Past triage file names | `ls research/*-start-triage.md 2>/dev/null` | ~5 lines | Agent 3 |
 | Past crystallize file names | `ls research/*-end-of-day-crystallize.md 2>/dev/null` | ~5 lines | Agent 3 |
 | `current_offer` | From `.vip/local.yaml` | 1 line | All 3 agents |
-| Content pipeline listing | `ls content/drafts/ content/scheduled/ 2>/dev/null` | ~10 lines | Agent 2 |
+| Output lifecycle listing | `grep -rl "status: draft\|status: scheduled" outputs/ 2>/dev/null` | ~10 lines | Agent 2 |
 
 **What agents read themselves (in their own context, NOT in main):**
 - soul.md, offer.md, audience.md, voice.md — Agent 1 reads all, Agent 3 reads soul
@@ -203,14 +203,12 @@ and first 10 lines of each.]
 
 [Research files with linked_decisions: []. Include filename and date.]
 
-=== CONTENT PIPELINE STATE ===
+=== OUTPUT LIFECYCLE STATE ===
 
-[Contents of content/drafts/, content/scheduled/, content/published/
-or "No content/ folder" if missing]
-
-=== RECENT OUTPUTS ===
-
-[Most recent 5 items in outputs/]
+[Files in outputs/ grouped by frontmatter status: draft, scheduled, published, final.
+Use: grep -rl "status: draft" outputs/ 2>/dev/null
+or "No outputs with lifecycle status" if none have status field.
+Also list most recent 5 items in outputs/.]
 
 === CONTENT STRATEGY ===
 
@@ -232,15 +230,15 @@ Analyze these dimensions:
    some research is exploratory. But research older than 14 days without a
    decision may be going stale.
 
-3. **Content pipeline state:** Anything in drafts? Scheduled? When was last
-   content published? Is there a gap between reference readiness and content
-   output?
+3. **Output lifecycle state:** Any outputs with status: draft? Scheduled?
+   When was the last output published? Is there a gap between reference
+   readiness and output generation?
 
 4. **Output recency:** When was the last batch generated? What type?
    Long gap between reference updates and output generation = missed opportunity.
 
 5. **Velocity pattern:** What's the ratio of enrichment work (research/,
-   reference/ changes) to output work (outputs/, content/)? All enrichment
+   reference/ changes) to output work (outputs/)? All enrichment
    with no output = stuck in thinking. All output with no enrichment =
    running on stale context.
 

--- a/.claude/skills/vsl/SKILL.md
+++ b/.claude/skills/vsl/SKILL.md
@@ -165,6 +165,17 @@ Campaign name is REQUIRED. Ask user if not provided. Examples: `skool-about`, `a
 
 ## Output Format
 
+**Output frontmatter:**
+```yaml
+---
+type: output
+format: vsl
+date: YYYY-MM-DD
+status: final
+platform: skool | website
+---
+```
+
 Both frameworks produce scripts with:
 - Header: Target audience, transformation, runtime estimate
 - Sections with timestamps/chapter markers

--- a/README.md
+++ b/README.md
@@ -226,8 +226,7 @@ your-business/
 │       └── content-strategy.md <- Pillars, platforms, cadence
 ├── research/              <- Your investigations
 ├── decisions/             <- Your choices
-├── content/               <- Content lifecycle
-└── outputs/               <- Generated content
+└── outputs/               <- All generated content (lifecycle via frontmatter status)
 ```
 
 You fill in the reference files. Claude reads them when generating.

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -199,12 +199,7 @@ your-business/
 ├── decisions/                   # DATED — Choices with rationale
 │   └── YYYY-MM-DD-slug.md
 │
-├── content/                     # CONTENT PIPELINE — Draft to published
-│   ├── drafts/                  # Work in progress
-│   ├── scheduled/               # Ready to publish
-│   └── published/               # Archive of published content
-│
-└── outputs/                     # OUTPUT — Generated content
+└── outputs/                     # All generated content — lifecycle via frontmatter status
     └── YYYY-MM-DD-batch-name/
 ```
 
@@ -535,18 +530,19 @@ These are destinations the pipeline drives traffic to, not recurring content ite
 
 The pipeline is designed so the creator **never opens a social app to post**. AI handles adaptation and distribution. The creator's energy stays in thinking and writing -- not scrolling. Audience feedback (metrics, comments, engagement) flows back through /think into content-strategy.md, closing the loop without requiring the creator to be on-platform.
 
-### Content Folder State Machine
+### Output Lifecycle (Frontmatter-Based)
 
-The `content/` folder is the designed lifecycle pipeline for distribution automation. It is scaffolded by `/setup` but not yet written to by skills. Currently, skills write generated assets to `outputs/`. The `content/` pipeline is where content will move through states once distribution automation (e.g., Postiz integration, `/newsletter`) is built.
+All generated content lives in `outputs/`. Lifecycle is tracked via the `status` field in YAML frontmatter, not folder moves:
 
-```
-content/
-├── drafts/       → Work in progress
-├── scheduled/    → Approved, ready to publish (manual or automated move)
-└── published/    → Archive of published content (moved after publish)
-```
+- `status: draft` — Work in progress
+- `status: scheduled` — Approved, ready to publish
+- `status: published` — Live on platform
+- `status: final` — Complete, no publishing lifecycle (VSL scripts, reviewed ad batches)
 
-Today: skills write to `outputs/`. The move from drafts to scheduled to published can be manual or automated (via Postiz or similar infrastructure -- out of scope for engine, documented here as architectural pattern).
+To find all drafts: `grep -rl "^status: draft" outputs/ --include="*.md"`
+To find scheduled content: `grep -rl "^status: scheduled" outputs/ --include="*.md"`
+
+This replaces the previous folder-move lifecycle pattern where files moved between subdirectories.
 
 ### Skill Connections to Content Pipeline
 
@@ -747,7 +743,7 @@ Content strategy links back to the decisions that informed pillar choices, creat
 | Research | `YYYY-MM-DD-slug.md` | `2026-01-10-competitor-analysis.md` |
 | Decisions | `YYYY-MM-DD-slug.md` | `2026-01-11-pricing-strategy.md` |
 | Output batches | `YYYY-MM-DD-batch-name/` | `2026-01-15-january-launch/` |
-| Content drafts | `descriptive.md` | `newsletter-2026-02-03.md` |
+| Output drafts | `YYYY-MM-DD-descriptive.md` | `2026-02-03-newsletter-issue.md` |
 | Typicality data | `typicality.md` | `reference/proof/typicality.md` |
 
 ### Why Dates in Filenames


### PR DESCRIPTION
## Summary

- Removes all references to `content/` as a write target across skills and docs, replacing with single `outputs/` folder where lifecycle is tracked via frontmatter `status` field (draft/scheduled/published/final) instead of folder moves
- Standardizes output frontmatter (`type: output`, `format:`, `date:`, `status:`, `platform:`) across all generation skills (ads, organic, vsl)
- Updates triage agent to use grep-based output lifecycle detection instead of content/ pipeline listing

## Test plan

- [x] Ran test-skills.sh: 149/162 passed, 3 expected failures (tests 23-25 check for removed `content/` dirs — fixed in separate noontide-projects PR), 10 pre-existing failures
- [x] Verified `grep -ri "content/" --include="*.md"` returns zero hits for write-target references
- [x] Confirmed all output templates include standard frontmatter block

🤖 Generated with [Claude Code](https://claude.com/claude-code)