### PR TITLE
Harden /think codify and /start status truth

### DIFF
--- a/.claude/scripts/decision_lifecycle_audit.sh
+++ b/.claude/scripts/decision_lifecycle_audit.sh
@@ -1,0 +1,315 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: decision_lifecycle_audit.sh [--repo PATH] [--format text|json] [--stale-days N]
+
+Audits decision lifecycle state using frontmatter-only parsing.
+
+Options:
+  --repo PATH        Business repo path (default: current directory)
+  --format FORMAT    Output format: text|json (default: text)
+  --stale-days N     Accepted stale threshold in days (default: 14)
+  -h, --help         Show this help
+EOF
+}
+
+repo="."
+format="text"
+stale_days=14
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --repo)
+      repo="${2:-}"
+      shift 2
+      ;;
+    --format)
+      format="${2:-}"
+      shift 2
+      ;;
+    --stale-days)
+      stale_days="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+case "$format" in
+  text|json) ;;
+  *)
+    echo "Invalid format: $format (expected text or json)" >&2
+    exit 2
+    ;;
+esac
+
+case "$stale_days" in
+  ''|*[!0-9]*)
+    echo "Invalid --stale-days: $stale_days" >&2
+    exit 2
+    ;;
+esac
+
+for cmd in awk git date; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "Missing required command: $cmd" >&2
+    exit 3
+  fi
+done
+
+if ! repo_abs=$(cd "$repo" 2>/dev/null && pwd); then
+  echo "Repo path not found: $repo" >&2
+  exit 3
+fi
+
+if ! git -C "$repo_abs" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "Not a git repository: $repo_abs" >&2
+  exit 3
+fi
+
+decisions_dir="$repo_abs/decisions"
+reference_dir="$repo_abs/reference"
+
+iso_to_epoch() {
+  local iso="$1"
+
+  if [ -z "$iso" ]; then
+    return 1
+  fi
+
+  if epoch=$(date -j -f "%Y-%m-%d" "$iso" "+%s" 2>/dev/null); then
+    printf "%s" "$epoch"
+    return 0
+  fi
+
+  if epoch=$(date -d "$iso" "+%s" 2>/dev/null); then
+    printf "%s" "$epoch"
+    return 0
+  fi
+
+  return 1
+}
+
+cutoff_date() {
+  local days="$1"
+
+  if cutoff=$(date -u -v-"${days}"d "+%Y-%m-%d" 2>/dev/null); then
+    printf "%s" "$cutoff"
+    return 0
+  fi
+
+  if cutoff=$(date -u -d "${days} days ago" "+%Y-%m-%d" 2>/dev/null); then
+    printf "%s" "$cutoff"
+    return 0
+  fi
+
+  return 1
+}
+
+is_iso_date() {
+  case "$1" in
+    ????-??-??) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+json_escape() {
+  printf "%s" "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
+}
+
+if ! cutoff=$(cutoff_date "$stale_days"); then
+  echo "Unable to compute stale cutoff date" >&2
+  exit 3
+fi
+
+now_iso=$(date -u "+%Y-%m-%d")
+if ! now_epoch=$(iso_to_epoch "$now_iso"); then
+  now_epoch=""
+fi
+
+tmp_records=$(mktemp)
+trap 'rm -f "$tmp_records"' EXIT
+
+total=0
+codified=0
+accepted=0
+proposed=0
+needs_review=0
+action_needed=0
+stale_orphaned=0
+invalid_or_missing=0
+parse_errors=0
+
+if [ -d "$decisions_dir" ]; then
+  for decision_file in "$decisions_dir"/*.md; do
+    [ -f "$decision_file" ] || continue
+    total=$((total + 1))
+
+    if ! parsed=$(awk '
+      NR==1 && $0=="---" { fm=1; next }
+      fm && $0=="---" { exit }
+      fm && /^status:[[:space:]]*/ {
+        st=$0
+        sub(/^status:[[:space:]]*/, "", st)
+        gsub(/[[:space:]]+$/, "", st)
+        gsub(/^["'"'"']|["'"'"']$/, "", st)
+        status=st
+      }
+      fm && /^date:[[:space:]]*/ {
+        d=$0
+        sub(/^date:[[:space:]]*/, "", d)
+        gsub(/[[:space:]]+$/, "", d)
+        gsub(/^["'"'"']|["'"'"']$/, "", d)
+        datev=d
+      }
+      END { print status "\t" datev }
+    ' "$decision_file"); then
+      parse_errors=$((parse_errors + 1))
+      continue
+    fi
+
+    status=${parsed%%$'\t'*}
+    date_value=${parsed#*$'\t'}
+    file_rel="decisions/$(basename "$decision_file")"
+
+    bucket=""
+    confidence="low"
+    evidence_commits=0
+    age_days=""
+
+    if is_iso_date "$date_value" && [ -n "${now_epoch:-}" ]; then
+      if decision_epoch=$(iso_to_epoch "$date_value"); then
+        age_days=$(( (now_epoch - decision_epoch) / 86400 ))
+      fi
+    fi
+
+    case "$status" in
+      codified)
+        codified=$((codified + 1))
+        bucket="codified"
+        confidence="high"
+        ;;
+      proposed)
+        proposed=$((proposed + 1))
+        bucket="proposed"
+        confidence="medium"
+        ;;
+      accepted)
+        accepted=$((accepted + 1))
+
+        if is_iso_date "$date_value" && [ -d "$reference_dir" ]; then
+          evidence_commits=$(git -C "$repo_abs" log --since="${date_value} 00:00:00" --pretty=format:%H -- "$reference_dir" 2>/dev/null | awk 'NF { c++ } END { print c + 0 }')
+        elif [ -d "$reference_dir" ]; then
+          evidence_commits=$(git -C "$repo_abs" log --since="30 days ago" --pretty=format:%H -- "$reference_dir" 2>/dev/null | awk 'NF { c++ } END { print c + 0 }')
+        fi
+
+        if [ "$evidence_commits" -gt 0 ]; then
+          bucket="needs_review"
+          needs_review=$((needs_review + 1))
+          # Reference commit evidence is directional, not proof of codification.
+          confidence="medium"
+        elif is_iso_date "$date_value" && [ "$date_value" \< "$cutoff" ]; then
+          bucket="stale_orphaned"
+          stale_orphaned=$((stale_orphaned + 1))
+          confidence="medium"
+        else
+          bucket="action_needed"
+          action_needed=$((action_needed + 1))
+          if is_iso_date "$date_value"; then
+            confidence="medium"
+          else
+            confidence="low"
+          fi
+        fi
+        ;;
+      *)
+        invalid_or_missing=$((invalid_or_missing + 1))
+        bucket="invalid_or_missing"
+        confidence="low"
+        ;;
+    esac
+
+    [ -n "$status" ] || status="(missing)"
+    [ -n "$date_value" ] || date_value="(missing)"
+    [ -n "$age_days" ] || age_days="(unknown)"
+
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+      "$file_rel" "$status" "$date_value" "$bucket" "$confidence" "$evidence_commits" "$age_days" \
+      >> "$tmp_records"
+  done
+fi
+
+if [ "$parse_errors" -gt 0 ]; then
+  echo "Frontmatter parsing failed for $parse_errors decision file(s)" >&2
+  exit 4
+fi
+
+if [ "$format" = "json" ]; then
+  printf '{\n'
+  printf '  "summary": {\n'
+  printf '    "total": %s,\n' "$total"
+  printf '    "codified": %s,\n' "$codified"
+  printf '    "accepted": %s,\n' "$accepted"
+  printf '    "proposed": %s,\n' "$proposed"
+  printf '    "needs_review": %s,\n' "$needs_review"
+  printf '    "action_needed": %s,\n' "$action_needed"
+  printf '    "stale_orphaned": %s,\n' "$stale_orphaned"
+  printf '    "invalid_or_missing": %s,\n' "$invalid_or_missing"
+  printf '    "stale_days": %s,\n' "$stale_days"
+  printf '    "cutoff_date": "%s"\n' "$(json_escape "$cutoff")"
+  printf '  },\n'
+  printf '  "records": [\n'
+
+  first=1
+  while IFS=$'\t' read -r file_rel status date_value bucket confidence evidence_commits age_days; do
+    [ -n "$file_rel" ] || continue
+    if [ "$first" -eq 0 ]; then
+      printf ',\n'
+    fi
+    first=0
+
+    printf '    {"file":"%s","status":"%s","date":"%s","bucket":"%s","confidence":"%s","evidence_commits":%s,"age_days":"%s"}' \
+      "$(json_escape "$file_rel")" \
+      "$(json_escape "$status")" \
+      "$(json_escape "$date_value")" \
+      "$(json_escape "$bucket")" \
+      "$(json_escape "$confidence")" \
+      "$evidence_commits" \
+      "$(json_escape "$age_days")"
+  done < "$tmp_records"
+
+  printf '\n  ]\n'
+  printf '}\n'
+  exit 0
+fi
+
+printf 'SUMMARY|total=%s|codified=%s|accepted=%s|proposed=%s|needs_review=%s|action_needed=%s|stale_orphaned=%s|invalid_or_missing=%s|cutoff=%s\n' \
+  "$total" "$codified" "$accepted" "$proposed" "$needs_review" "$action_needed" "$stale_orphaned" "$invalid_or_missing" "$cutoff"
+
+while IFS=$'\t' read -r file_rel status date_value bucket confidence evidence_commits age_days; do
+  [ -n "$file_rel" ] || continue
+  printf 'RECORD|file=%s|status=%s|date=%s|bucket=%s|confidence=%s|evidence_commits=%s|age_days=%s\n' \
+    "$file_rel" "$status" "$date_value" "$bucket" "$confidence" "$evidence_commits" "$age_days"
+done < "$tmp_records"
+
+printf '\n'
+printf '%s decisions need review\n' "$needs_review"
+printf '%s look implemented but are not marked codified\n' "$needs_review"
+printf '%s still need codification\n' "$action_needed"
+printf '%s appear stale\n' "$stale_orphaned"
+if [ "$invalid_or_missing" -gt 0 ]; then
+  printf '%s have invalid or missing status frontmatter\n' "$invalid_or_missing"
+fi
+
+exit 0

--- a/.claude/scripts/test-decision-lifecycle-wiring.sh
+++ b/.claude/scripts/test-decision-lifecycle-wiring.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+START_FILE="$ROOT_DIR/.claude/skills/start/references/readiness-assessment.md"
+END_FILE="$ROOT_DIR/.claude/skills/end/SKILL.md"
+
+fail=0
+
+assert_contains() {
+  local file="$1"
+  local pattern="$2"
+  local label="$3"
+
+  if grep -q "$pattern" "$file"; then
+    printf 'PASS: %s\n' "$label"
+  else
+    printf 'FAIL: %s\n' "$label"
+    fail=1
+  fi
+}
+
+assert_contains "$START_FILE" ".claude/scripts/decision_lifecycle_audit.sh" "/start references shared lifecycle script path"
+assert_contains "$END_FILE" ".claude/scripts/decision_lifecycle_audit.sh" "/end references shared lifecycle script path"
+assert_contains "$START_FILE" "bash \"\\\$AUDIT_SCRIPT\" --repo" "/start executes shared lifecycle script"
+assert_contains "$END_FILE" "bash \"\\\$AUDIT_SCRIPT\" --repo" "/end executes shared lifecycle script"
+
+if [ "$fail" -ne 0 ]; then
+  exit 1
+fi
+
+printf 'PASS: shared lifecycle script wiring is present in /start and /end\n'

--- a/.claude/skills/end/SKILL.md
+++ b/.claude/skills/end/SKILL.md
@@ -33,6 +33,7 @@ This is not an audit. It is a thoughtful friend helping you close the session.
 ```
 1. Find the business repo
 2. Scan today's activity
+2b. Decision lifecycle reconciliation (shared audit script)
 3. Session summary
 4. Final thought capture (optional)
 5. Crystallize (spawns dedicated agent if meaningful activity detected)
@@ -95,6 +96,74 @@ Report: "Offers affected: community, newsletter" (or "Brand-level changes only" 
 **If git log fails** (no commits today, repo issues): Fall back to `git status` and `ls -lt` to find recently modified files. Don't block on this.
 
 **If nothing happened today:** Say so briefly. "Quiet day -- no changes detected. Want to close out?" Skip to Step 6.
+
+---
+
+## Step 2b: Decision Lifecycle Reconciliation
+
+Run the shared lifecycle audit script so `/end` uses the same decision buckets as `/start`.
+
+```bash
+# Resolve vip script path (settings.local.json first, then ~/.config/vip/local.yaml)
+AUDIT_SCRIPT=$(python3 -c "
+import json, os
+path = '.claude/settings.local.json'
+target = ''
+try:
+    with open(path) as f:
+        dirs = json.load(f).get('permissions', {}).get('additionalDirectories', [])
+    for d in dirs:
+        candidate = os.path.join(d, '.claude/scripts/decision_lifecycle_audit.sh')
+        if os.path.isfile(candidate):
+            target = candidate
+            break
+except Exception:
+    pass
+print(target)
+" 2>/dev/null)
+
+if [ -z "$AUDIT_SCRIPT" ] && [ -f "$HOME/.config/vip/local.yaml" ]; then
+  vip_path=$(awk -F': *' '/^vip_path:/ {print $2; exit}' "$HOME/.config/vip/local.yaml" | tr -d '"')
+  [ -n "$vip_path" ] && AUDIT_SCRIPT="$vip_path/.claude/scripts/decision_lifecycle_audit.sh"
+fi
+
+if [ -n "$AUDIT_SCRIPT" ] && [ -f "$AUDIT_SCRIPT" ]; then
+  bash "$AUDIT_SCRIPT" --repo "[repo-path]" --format text
+else
+  echo "Decision lifecycle audit script not found; fallback to strict status counts."
+  codified=0
+  accepted=0
+  invalid_or_missing=0
+
+  for f in [repo-path]/decisions/*.md; do
+    [ -f "$f" ] || continue
+    status=$(awk 'NR==1&&$0=="---"{fm=1;next} fm&&$0=="---"{exit} fm&&/^status:[[:space:]]*/{val=$0; sub(/^status:[[:space:]]*/, "", val); gsub(/[[:space:]]+$/, "", val); print val; exit}' "$f")
+    case "$status" in
+      codified) codified=$((codified + 1)) ;;
+      accepted) accepted=$((accepted + 1)) ;;
+      proposed) ;;
+      *) invalid_or_missing=$((invalid_or_missing + 1)) ;;
+    esac
+  done
+
+  printf "Decisions: %s codified, %s accepted\n" "$codified" "$accepted"
+  [ "$invalid_or_missing" -gt 0 ] && printf "Decisions with invalid/missing status: %s\n" "$invalid_or_missing"
+fi
+```
+
+**Expected buckets from the shared script:**
+- `needs_review` — accepted decisions with implementation evidence
+- `action_needed` — accepted decisions with no evidence and not stale
+- `stale_orphaned` — accepted decisions past stale threshold with weak/no evidence
+- `invalid_or_missing` — missing/invalid lifecycle frontmatter (never guess)
+
+**Manual confirmation rule (non-negotiable):**
+- Never auto-flip to `codified` from evidence alone.
+- If `needs_review > 0`, offer: "I found [N] accepted decisions with implementation evidence. Want to review and mark any as codified now?"
+- For each file, require explicit user confirmation before editing `status: accepted` -> `status: codified`.
+- After each edit, read the file back and confirm there is exactly one `status:` field and it is `codified`.
+
+If the user declines, leave statuses unchanged and continue to Step 3.
 
 ---
 

--- a/.claude/skills/start/references/readiness-assessment.md
+++ b/.claude/skills/start/references/readiness-assessment.md
@@ -162,71 +162,65 @@ Compare actual .md file count (excluding README.md) against angles README if it 
 
 **Flag:** `! 3 files vs 5 in README` (inline next to angles row)
 
-### Check D: Decision Codification Rate (scripted pass)
+### Check D: Decision Lifecycle Audit (shared script)
 
 ```bash
-# Decision truth metrics from anchored frontmatter (strict status enum)
-cutoff=$(date -u -v-14d +%Y-%m-%d 2>/dev/null || date -u -d '14 days ago' +%Y-%m-%d)
+# Resolve vip script path (settings.local.json first, then ~/.config/vip/local.yaml)
+AUDIT_SCRIPT=$(python3 -c "
+import json, os
+path = '.claude/settings.local.json'
+target = ''
+try:
+    with open(path) as f:
+        dirs = json.load(f).get('permissions', {}).get('additionalDirectories', [])
+    for d in dirs:
+        candidate = os.path.join(d, '.claude/scripts/decision_lifecycle_audit.sh')
+        if os.path.isfile(candidate):
+            target = candidate
+            break
+except Exception:
+    pass
+print(target)
+" 2>/dev/null)
 
-codified=0
-accepted=0
-accepted_stale=0
-invalid_or_missing=0
+if [ -z "$AUDIT_SCRIPT" ] && [ -f "$HOME/.config/vip/local.yaml" ]; then
+  vip_path=$(awk -F': *' '/^vip_path:/ {print $2; exit}' "$HOME/.config/vip/local.yaml" | tr -d '"')
+  [ -n "$vip_path" ] && AUDIT_SCRIPT="$vip_path/.claude/scripts/decision_lifecycle_audit.sh"
+fi
 
-for f in [repo-path]/decisions/*.md; do
-  [ -f "$f" ] || continue
+if [ -n "$AUDIT_SCRIPT" ] && [ -f "$AUDIT_SCRIPT" ] && bash "$AUDIT_SCRIPT" --repo "[repo-path]" --format text; then
+  : # Shared script output includes machine-friendly summary + human bucket lines
+else
+  echo "Decision lifecycle audit unavailable; falling back to strict frontmatter counts."
+  codified=0
+  accepted=0
+  invalid_or_missing=0
 
-  parsed=$(awk '
-    NR==1 && $0=="---" { fm=1; next }
-    fm && $0=="---" { exit }
-    fm && /^status:[[:space:]]*/ {
-      status=$0
-      sub(/^status:[[:space:]]*/, "", status)
-      gsub(/[[:space:]]+$/, "", status)
-    }
-    fm && /^date:[[:space:]]*/ {
-      dt=$0
-      sub(/^date:[[:space:]]*/, "", dt)
-      gsub(/[[:space:]]+$/, "", dt)
-    }
-    END { print status "\t" dt }
-  ' "$f")
+  for f in [repo-path]/decisions/*.md; do
+    [ -f "$f" ] || continue
+    status=$(awk 'NR==1&&$0=="---"{fm=1;next} fm&&$0=="---"{exit} fm&&/^status:[[:space:]]*/{val=$0; sub(/^status:[[:space:]]*/, "", val); gsub(/[[:space:]]+$/, "", val); print val; exit}' "$f")
+    case "$status" in
+      codified) codified=$((codified + 1)) ;;
+      accepted) accepted=$((accepted + 1)) ;;
+      proposed) ;;
+      *) invalid_or_missing=$((invalid_or_missing + 1)) ;;
+    esac
+  done
 
-  status=${parsed%%$'\t'*}
-  dt=${parsed#*$'\t'}
-
-  case "$status" in
-    codified)
-      codified=$((codified + 1))
-      ;;
-    accepted)
-      accepted=$((accepted + 1))
-      case "$dt" in
-        ????-??-??)
-          if [ "$dt" \< "$cutoff" ]; then
-            accepted_stale=$((accepted_stale + 1))
-          fi
-          ;;
-      esac
-      ;;
-    proposed)
-      ;;
-    *)
-      invalid_or_missing=$((invalid_or_missing + 1))
-      ;;
-  esac
-done
-
-printf "Decisions: %s codified, %s accepted\n" "$codified" "$accepted"
-[ "$accepted_stale" -gt 0 ] && printf "Accepted stale >14d: %s\n" "$accepted_stale"
-[ "$invalid_or_missing" -gt 0 ] && printf "Decisions with invalid/missing status: %s\n" "$invalid_or_missing"
+  printf "Decisions: %s codified, %s accepted\n" "$codified" "$accepted"
+  [ "$invalid_or_missing" -gt 0 ] && printf "Decisions with invalid/missing status: %s\n" "$invalid_or_missing"
+fi
 ```
 
-Count decisions from frontmatter `status:` truth, not body-text proxies. Accept only `proposed|accepted|codified` as valid status values.
-Parser rules: only read between the opening and closing `---` frontmatter delimiters, ignore body `status:` text, and count missing/invalid status values in `invalid_or_missing` instead of guessing.
+Use `.claude/scripts/decision_lifecycle_audit.sh` as the single source of truth for lifecycle classification in both `/start` and `/end`.
+The script parses frontmatter only (between `---` delimiters), ignores body `status:` text, classifies accepted decisions into `needs_review|action_needed|stale_orphaned`, and reports invalid/missing status explicitly.
+Never auto-flip statuses from evidence alone. Status changes remain manual-confirmed.
 
 **Flag:** `Decisions: X codified, Y accepted` (below file scores)
-**Staleness flag:** `Accepted stale >14d: Z` (below file scores, only when `Z > 0`)
+**Flag:** `Needs review: N` (accepted with implementation evidence)
+**Flag:** `Action needed: A` (accepted with no evidence and not stale)
+**Flag:** `Stale/orphaned: S` (accepted, stale threshold crossed, weak/no evidence)
+**Flag:** `Decisions with invalid/missing status: I` (only when `I > 0`)
 
 ### Check E: Naming Convention Spot-Check (1 call)
 
@@ -496,13 +490,15 @@ Health flags from Section 3 appear alongside structural scores. File-level flags
 > - soul.md — status: draft (you marked this unfinished)
 > - audience.md — stale (41d since last update)
 > - Decisions: 8 codified, 55 accepted
-> - Accepted stale >14d: 22
+> - Needs review: 4
+> - Action needed: 2
+> - Stale/orphaned: 1
 >
 > Pick option 1 for deeper analysis."
 
 **Advanced — flags on one line:**
 
-> "**18/18** — flags: soul.md draft, audience.md stale (41d), 8 codified + 55 accepted, 22 accepted stale >14d. Option 1 for details."
+> "**18/18** — flags: soul.md draft, audience.md stale (41d), 8 codified + 55 accepted, 4 need review, 2 action needed, 1 stale/orphaned. Option 1 for details."
 
 **When GOOD/FULL with both gaps AND flags:**
 
@@ -514,7 +510,9 @@ Health flags from Section 3 appear alongside structural scores. File-level flags
 > **Flags:**
 > - offer.md — stale (35d)
 > - Decisions: 3 codified, 9 accepted
-> - Accepted stale >14d: 4
+> - Needs review: 2
+> - Action needed: 1
+> - Stale/orphaned: 1
 >
 > Pick option 1 for deeper analysis."
 

--- a/.claude/skills/start/references/readiness-assessment.md
+++ b/.claude/skills/start/references/readiness-assessment.md
@@ -162,7 +162,7 @@ Compare actual .md file count (excluding README.md) against angles README if it 
 
 **Flag:** `! 3 files vs 5 in README` (inline next to angles row)
 
-### Check D: Decision Codification Rate (1 call)
+### Check D: Decision Codification Rate (scripted pass)
 
 ```bash
 # Decision truth metrics from anchored frontmatter (strict status enum)
@@ -223,7 +223,7 @@ printf "Decisions: %s codified, %s accepted\n" "$codified" "$accepted"
 ```
 
 Count decisions from frontmatter `status:` truth, not body-text proxies. Accept only `proposed|accepted|codified` as valid status values.
-Parser behavior should follow `2026-02-28-frontmatter-status-detection-fallback-policy.md`.
+Parser rules: only read between the opening and closing `---` frontmatter delimiters, ignore body `status:` text, and count missing/invalid status values in `invalid_or_missing` instead of guessing.
 
 **Flag:** `Decisions: X codified, Y accepted` (below file scores)
 **Staleness flag:** `Accepted stale >14d: Z` (below file scores, only when `Z > 0`)

--- a/.claude/skills/start/references/readiness-assessment.md
+++ b/.claude/skills/start/references/readiness-assessment.md
@@ -82,8 +82,14 @@ If no commits in 7+ days, note the gap -- this feeds into the soul health check 
 ### Open Decisions
 
 ```bash
-# Decisions with status: proposed or accepted (not yet codified)
-grep -rl "status: proposed\|status: accepted" decisions/ 2>/dev/null
+# Decisions with frontmatter status: proposed or accepted (anchored parse)
+for f in [repo-path]/decisions/*.md; do
+  [ -f "$f" ] || continue
+  status=$(awk 'NR==1&&$0=="---"{fm=1;next} fm&&$0=="---"{exit} fm&&/^status:[[:space:]]*/{val=$0; sub(/^status:[[:space:]]*/, "", val); gsub(/[[:space:]]+$/, "", val); print val; exit}' "$f")
+  case "$status" in
+    proposed|accepted) echo "$f" ;;
+  esac
+done 2>/dev/null
 ```
 
 For each found, read the frontmatter to extract the topic. Present as:
@@ -159,12 +165,68 @@ Compare actual .md file count (excluding README.md) against angles README if it 
 ### Check D: Decision Codification Rate (1 call)
 
 ```bash
-grep -rl "What Changes" [repo-path]/decisions/ 2>/dev/null | wc -l
+# Decision truth metrics from anchored frontmatter (strict status enum)
+cutoff=$(date -u -v-14d +%Y-%m-%d 2>/dev/null || date -u -d '14 days ago' +%Y-%m-%d)
+
+codified=0
+accepted=0
+accepted_stale=0
+invalid_or_missing=0
+
+for f in [repo-path]/decisions/*.md; do
+  [ -f "$f" ] || continue
+
+  parsed=$(awk '
+    NR==1 && $0=="---" { fm=1; next }
+    fm && $0=="---" { exit }
+    fm && /^status:[[:space:]]*/ {
+      status=$0
+      sub(/^status:[[:space:]]*/, "", status)
+      gsub(/[[:space:]]+$/, "", status)
+    }
+    fm && /^date:[[:space:]]*/ {
+      dt=$0
+      sub(/^date:[[:space:]]*/, "", dt)
+      gsub(/[[:space:]]+$/, "", dt)
+    }
+    END { print status "\t" dt }
+  ' "$f")
+
+  status=${parsed%%$'\t'*}
+  dt=${parsed#*$'\t'}
+
+  case "$status" in
+    codified)
+      codified=$((codified + 1))
+      ;;
+    accepted)
+      accepted=$((accepted + 1))
+      case "$dt" in
+        ????-??-??)
+          if [ "$dt" \< "$cutoff" ]; then
+            accepted_stale=$((accepted_stale + 1))
+          fi
+          ;;
+      esac
+      ;;
+    proposed)
+      ;;
+    *)
+      invalid_or_missing=$((invalid_or_missing + 1))
+      ;;
+  esac
+done
+
+printf "Decisions: %s codified, %s accepted\n" "$codified" "$accepted"
+[ "$accepted_stale" -gt 0 ] && printf "Accepted stale >14d: %s\n" "$accepted_stale"
+[ "$invalid_or_missing" -gt 0 ] && printf "Decisions with invalid/missing status: %s\n" "$invalid_or_missing"
 ```
 
-Count decisions with "What Changes" section vs total. Pipeline health signal.
+Count decisions from frontmatter `status:` truth, not body-text proxies. Accept only `proposed|accepted|codified` as valid status values.
+Parser behavior should follow `2026-02-28-frontmatter-status-detection-fallback-policy.md`.
 
-**Flag:** `Decisions: X/Y codified` (below file scores)
+**Flag:** `Decisions: X codified, Y accepted` (below file scores)
+**Staleness flag:** `Accepted stale >14d: Z` (below file scores, only when `Z > 0`)
 
 ### Check E: Naming Convention Spot-Check (1 call)
 
@@ -433,13 +495,14 @@ Health flags from Section 3 appear alongside structural scores. File-level flags
 > **Flags:**
 > - soul.md — status: draft (you marked this unfinished)
 > - audience.md — stale (41d since last update)
-> - Decisions: 8/63 codified
+> - Decisions: 8 codified, 55 accepted
+> - Accepted stale >14d: 22
 >
 > Pick option 1 for deeper analysis."
 
 **Advanced — flags on one line:**
 
-> "**18/18** — flags: soul.md draft, audience.md stale (41d), 8/63 decisions codified. Option 1 for details."
+> "**18/18** — flags: soul.md draft, audience.md stale (41d), 8 codified + 55 accepted, 22 accepted stale >14d. Option 1 for details."
 
 **When GOOD/FULL with both gaps AND flags:**
 
@@ -450,7 +513,8 @@ Health flags from Section 3 appear alongside structural scores. File-level flags
 >
 > **Flags:**
 > - offer.md — stale (35d)
-> - Decisions: 3/12 codified
+> - Decisions: 3 codified, 9 accepted
+> - Accepted stale >14d: 4
 >
 > Pick option 1 for deeper analysis."
 

--- a/.claude/skills/think/references/codify-phase.md
+++ b/.claude/skills/think/references/codify-phase.md
@@ -19,8 +19,9 @@ Apply decisions to reference files. Merges research findings and decisions into 
 2. **Identify what changes** — Read the `## What Changes` section (or infer from `## Decision` and `## Consequences` if What Changes is missing). Identify which reference files are affected and what the key changes are.
 3. **Propose edits** — For each affected reference file, read it, then propose the specific update to the user.
 4. **Apply with confirmation** — After user confirms, apply each update. Preserve existing content.
-5. **Mark complete** — Update decision status from `accepted` to `codified`
-6. **Report changes** — Summary of what was updated
+5. **Atomic finalize pass** — In the SAME edit pass as the final reference file update, flip the source decision from `status: accepted` to `status: codified`. This is the most likely dropped step; treat it as part of the final edit unit, never a follow-up.
+6. **Verify read-back** — Re-open the source decision file and confirm frontmatter contains exactly one `status:` field and that it is `codified`.
+7. **Report changes** — Summary of what was updated
 
 ---
 
@@ -41,8 +42,9 @@ Or naturally: "/think apply the pricing decision to reference files"
 3. **Add, don't replace** — New content supplements, doesn't overwrite
 4. **Mark additions** — Use date comments for traceability: `<!-- Added 2026-01-17 -->`
 5. **Confirm before large changes** — If changing >30% of a file, ask first
-6. **Atomic updates** — Complete all or none
+6. **Atomic updates** — Complete all or none. The decision status flip (`accepted` -> `codified`) is part of the same atomic unit as the final reference-file edit.
 7. **Write in enduring language** — Reference files should read like they've always been true, not like reactions to specific events. Core beliefs are timeless truths. If a line references a specific tool, session, bug, or conversation — it belongs in an evolution marker or decision file, not in the reference itself. Test: would someone reading this in 6 months with no context understand it? If not, rewrite until they would.
+8. **One status field only** — Never add `codified: true` or any parallel lifecycle field. Decision lifecycle state must live only in `status:` using `proposed|accepted|codified`.
 
 ---
 
@@ -232,4 +234,5 @@ Codification is complete when:
 
 - All changes described in the decision have been applied to reference files
 - Source decision status changed from `accepted` to `codified`
+- Verification read-back confirms frontmatter has exactly one `status:` field and it is `codified`
 - User confirms the reference file updates capture the decision

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -253,6 +253,8 @@ model: opus-4.5 | sonnet-4  # when relevant
 
 Research files also add: `linked_decisions: []`
 
+Decision lifecycle metrics must use `.claude/scripts/decision_lifecycle_audit.sh` (shared by `/start` and `/end`), not ad-hoc `grep`/`awk` rewrites in skill prose.
+
 ---
 
 ## Skills


### PR DESCRIPTION
Phase 1 lifecycle hardening only, with zero new dependencies. In /think codify-phase, decision status flip is atomic with the final reference edit, requires mandatory read-back verification, and enforces a single lifecycle field via status. In /start readiness-assessment, open decision and codification metrics now use anchored frontmatter awk parsing with strict proposed|accepted|codified status handling, replacing body-text proxies and adding accepted >14d staleness visibility. Deferred intentionally in this PR: /end reconciliation, hooks, and frontmatter-mcp.