### PR TITLE
Self-heal stale tool status across start/think

### DIFF
--- a/.claude/skills/ads/SKILL.md
+++ b/.claude/skills/ads/SKILL.md
@@ -79,7 +79,7 @@ Check for Meta ad account access on first /ads invocation when topic is ads-rela
 ```
 1. Read .vip/config.yaml → tools.pipeboard
 2. If status: true → note available, skip detection
-3. If status: false AND last_checked < 30 days → skip
+3. If status: false AND last_checked is valid and <30 days old → skip
 4. If status: null OR missing OR stale false:
    a. Check for mcp__pipeboard__* tools in session
    b. If found: probe with get_ad_accounts (lightweight)
@@ -87,6 +87,8 @@ Check for Meta ad account access on first /ads invocation when topic is ads-rela
    d. If not found or probe fails: write status: false to config
 5. Never block on detection failure
 ```
+
+`stale false` means: `status: false` and `last_checked` is missing, invalid, or >=30 days old.
 
 ### Config Update (REQUIRED after detection)
 

--- a/.claude/skills/ads/references/pipeboard-integration.md
+++ b/.claude/skills/ads/references/pipeboard-integration.md
@@ -185,7 +185,7 @@ Triggered lazily at /think or /ads when topic is ads-related:
 ```
 1. Read .vip/config.yaml → tools.pipeboard
 2. If status: true → use it, skip detection
-3. If status: false AND last_checked < 30 days → skip
+3. If status: false AND last_checked is valid and <30 days old → skip
 4. If status: null OR missing OR stale false:
    a. Check for mcp__pipeboard__* tools in session
    b. If found: probe with get_ad_accounts (lightweight)
@@ -193,6 +193,8 @@ Triggered lazily at /think or /ads when topic is ads-related:
    d. If not found or probe fails: write status: false to config
 5. Never block on detection failure
 ```
+
+`stale false` means: `status: false` and `last_checked` is missing, invalid, or >=30 days old.
 
 ---
 

--- a/.claude/skills/setup/references/repo-scaffolding.md
+++ b/.claude/skills/setup/references/repo-scaffolding.md
@@ -98,6 +98,50 @@ mcps:
     required_for: [organic, think]  # Handles web scraping AND YouTube transcripts
     setup_guide: ".claude/skills/organic/references/apify-setup.md"
 
+# === TOOL STATUS CACHE (self-healing) ===
+# /start and /think update these over time.
+# Rule: every tool entry keeps status + notes + last_checked.
+tools:
+  apify:
+    status: null
+    notes: "unknown"
+    last_checked: null
+  gemini:
+    status: null
+    notes: "unknown"
+    last_checked: null
+  grok:
+    status: null
+    notes: "unknown"
+    last_checked: null
+  whisper:
+    status: null
+    notes: "unknown"
+    last_checked: null
+  nanobanana:
+    status: null
+    notes: "unknown"
+    last_checked: null
+  markitdown:
+    status: null
+    notes: "unknown"
+    last_checked: null
+  pandoc:
+    status: null
+    notes: "unknown"
+    last_checked: null
+  marker:
+    status: null
+    notes: "unknown"
+    last_checked: null
+  pipeboard:
+    status: null
+    method: mcp
+    tier: null
+    notes: "unknown"
+    last_checked: null
+    weekly_calls_used: 0
+
 # === CONTENT ===
 content:
   default_channels: []

--- a/.claude/skills/start/SKILL.md
+++ b/.claude/skills/start/SKILL.md
@@ -352,19 +352,19 @@ fi
 
 ---
 
-## Step 0.75: MCP Pre-Flight (Not Research Tools)
+## Step 0.75: MCP Pre-Flight (Not Full Research Detection)
 
 Check for MCPs required by skills user might invoke. See [mcp-preflight.md](references/mcp-preflight.md).
 
-**Research tool detection happens in /think** — deferred to when user actually needs research. This keeps /start fast and avoids checking tools user might not use this session.
+**Full research tool detection still happens in /think** — deferred to when user actually needs research. This keeps /start fast and avoids checking tools user might not use this session.
 
 **What /start DOES check:**
 - MCPs that skills depend on (Apify for /organic, etc.)
 - Critical blockers (missing config, broken paths)
 
-**What /start DOES NOT check:**
-- Research tools (Gemini, Grok, whisper, etc.) — /think handles these
-- Document tools (markitdown, pandoc, marker) — /think handles these
+**What /start DOES NOT do here:**
+- Full research tool scan (Gemini, Grok, whisper, etc.) — /think handles this
+- Full document tool scan (markitdown, pandoc, marker) — /think handles this
 
 **Why defer:** Most sessions don't use all tools. Checking everything upfront wastes time and clutters the greeting. /think detects tools when user's intent requires them and surfaces setup options at the right moment.
 
@@ -372,9 +372,21 @@ If user's stated intent involves research, route to /think — it will handle to
 
 ---
 
+## Step 0.8: Tool Status Audit (Lightweight Self-Heal)
+
+Run a lightweight `.vip/config.yaml` audit before readiness to repair stale `status: false` entries and normalize missing `last_checked` values.
+
+- Re-probe only stale false entries (missing/invalid/old `last_checked`)
+- Write updates immediately when status or metadata is repaired
+- Notify only when status changes (`false → true` or `true → false`)
+
+See [tool-status-audit.md](references/tool-status-audit.md) for the full procedure and messaging rules.
+
+---
+
 ## Step 0.9: Readiness Assessment
 
-**Run AFTER MCP pre-flight, BEFORE routing.** Scores reference files, checks session state, and gates routing so users don't jump into output skills with thin context.
+**Run AFTER MCP pre-flight and tool-status audit, BEFORE routing.** Scores reference files, checks session state, and gates routing so users don't jump into output skills with thin context.
 
 See [readiness-assessment.md](references/readiness-assessment.md) for complete scoring rubric, session state checks, soul health check, skill-specific requirements, and display format.
 

--- a/.claude/skills/start/references/config-system.md
+++ b/.claude/skills/start/references/config-system.md
@@ -149,6 +149,7 @@ Key fields:
 - `session.auto_load_reference` → Load core/ automatically
 - `session.show_context_tips` → Team default for tips
 - `mcps` → Required MCP servers for this business
+- `tools` → Cached tool status (`status`, `notes`, `last_checked`) for self-healing detection in `/start` and `/think`
 - `infrastructure` → Shared team resources (Railway, Postiz, etc.)
 - `skills` → Team defaults for skill behavior
 

--- a/.claude/skills/start/references/tool-status-audit.md
+++ b/.claude/skills/start/references/tool-status-audit.md
@@ -1,0 +1,42 @@
+# Tool Status Audit
+
+Lightweight self-healing pass run during `/start` before readiness scoring.
+
+---
+
+## Goal
+
+Repair stale false negatives in `.vip/config.yaml` without running a full research tool scan.
+
+---
+
+## Audit Flow
+
+1. Read `.vip/config.yaml` `tools` section
+2. For each tool entry:
+   - If `status: false` and stale (`last_checked` missing, invalid, or older than 30 days), re-probe
+   - If entry exists and `last_checked` is missing, add `last_checked: [today]`
+3. Write config updates immediately
+4. Notify only on state changes:
+   - `false → true`: "Found [tool] installed — updated your config."
+   - `true → false`: "Warning: [tool] was previously available but is now missing."
+5. If no status changes, stay silent
+
+---
+
+## Scope Boundary
+
+- This is not full `/think` tool detection.
+- Only stale false entries are probed.
+- `status: true` entries are not routinely re-probed here.
+- Full detection and tool surfacing remain in `/think`.
+
+Use probe methods defined in `/think` (`Gemini`, `Grok`, `whisper`, document tools, and lazy `Pipeboard` handling).
+
+---
+
+## See Also
+
+- [SKILL.md](../SKILL.md)
+- [mcp-preflight.md](mcp-preflight.md)
+- [../../think/references/tool-status-self-healing.md](../../think/references/tool-status-self-healing.md)

--- a/.claude/skills/think/SKILL.md
+++ b/.claude/skills/think/SKILL.md
@@ -87,7 +87,7 @@ Tool status persists in `.vip/config.yaml` under `tools:`. Read config first, on
 
 ### Staleness Check
 
-If `status: false` and `last_checked` is >30 days ago, re-probe. User may have installed it since then.
+Treat `status: false` as stale when `last_checked` is missing, invalid, or older than 30 days. Re-probe stale false entries.
 
 ### Detection Flow
 
@@ -95,14 +95,13 @@ On first /think invocation each session:
 
 ```
 1. Read .vip/config.yaml → tools section
-2. Build list of tools needing detection:
-   - status: null or missing → detect
-   - status: false AND last_checked >= 30 days → re-detect
-   - status: true OR (false AND recent) → skip
-3. Run detection for unknowns (see methods below)
-4. WRITE config updates immediately (use Edit tool)
+2. Detect unknown tools and re-detect stale false entries
+3. Normalize metadata (`last_checked`) on existing tool entries missing it
+4. WRITE config updates immediately (status + notes + last_checked for touched entries)
 5. Report once (experience-appropriate)
 ```
+
+For full self-healing contract (stale semantics, status-change messaging, and true-tool degradation handling), see [tool-status-self-healing.md](references/tool-status-self-healing.md).
 
 ### Detection Methods
 
@@ -157,17 +156,14 @@ tools:
   gemini:
     status: true              # ← detection result
     notes: "GOOGLE_API_KEY verified"
-    last_checked: 2026-02-03  # ← today's date
-  pipeboard:
-    status: true              # true | false | null
-    method: mcp               # always mcp for Pipeboard
-    tier: free                # free | pro (self-reported)
-    notes: "meta-ads MCP configured via remote URL"
-    last_checked: 2026-02-10
-    weekly_calls_used: 0      # lightweight tracking (Phase 1.5)
+    last_checked: 2026-03-02  # ← today's date
+  whisper:
+    status: true
+    notes: "mlx_whisper verified"
+    last_checked: 2026-03-02
 ```
 
-**Do not skip this step.** Config updates prevent re-probing next session.
+**Do not skip this step.** Config updates prevent re-probing next session. Use the self-healing contract in [tool-status-self-healing.md](references/tool-status-self-healing.md).
 
 ### Reporting by Experience
 

--- a/.claude/skills/think/references/tool-status-self-healing.md
+++ b/.claude/skills/think/references/tool-status-self-healing.md
@@ -1,0 +1,91 @@
+# Tool Status Self-Healing
+
+Operational contract for tool status in `.vip/config.yaml`.
+
+---
+
+## Staleness Definition
+
+A tool entry is **stale false** when all are true:
+
+- `status: false`
+- `last_checked` is missing, invalid, or older than 30 days
+
+Only stale false entries are re-probed during routine audits.
+
+---
+
+## Detection Contract (/think)
+
+On first `/think` invocation each session:
+
+1. Read `.vip/config.yaml` `tools` section
+2. Build detection list:
+   - `status: null` or missing → detect
+   - `status: false` + stale false → re-detect
+   - `status: true` or recent false → skip
+3. Normalize metadata:
+   - Add `last_checked: [today]` to any existing tool entry missing it
+4. Run probe methods from `SKILL.md`
+5. Write updates immediately
+
+Every touched entry must include:
+- `status`
+- `notes`
+- `last_checked`
+
+---
+
+## Status-Change Messaging
+
+Do not hide state flips:
+
+- `false → true`:
+  - "Found [tool] installed and working — updated `.vip/config.yaml`."
+- `true → false`:
+  - "Warning: [tool] was previously available but is not detected now. I updated `.vip/config.yaml` so this doesn't fail silently."
+
+If status does not change, use normal experience-level reporting.
+
+---
+
+## Degradation Rule for `status: true`
+
+If a tool marked `status: true` fails at use time (missing command, missing MCP tool, auth failure):
+
+1. Re-probe that tool immediately
+2. Update config to `status: false`, set `last_checked: [today]`, add explanatory notes
+3. Warn the user in the same turn
+
+Never let a previously-true tool fail silently.
+
+---
+
+## Example Normalized Shape
+
+```yaml
+tools:
+  gemini:
+    status: true
+    notes: "GOOGLE_API_KEY verified"
+    last_checked: 2026-03-02
+  whisper:
+    status: false
+    notes: "No CLI or MCP tool detected"
+    last_checked: 2026-03-02
+  pipeboard:
+    status: null
+    method: mcp
+    tier: null
+    notes: "unknown"
+    last_checked: null
+    weekly_calls_used: 0
+```
+
+---
+
+## See Also
+
+- [SKILL.md](../SKILL.md)
+- [tool-surfacing.md](tool-surfacing.md)
+- [local-transcription.md](local-transcription.md)


### PR DESCRIPTION
This PR adds config self-healing for tool status drift so stale false entries are re-probed and missing last_checked metadata is normalized. It introduces a lightweight /start tool-status audit, keeps /think config-first detection concise, and moves detailed self-healing contracts into dedicated reference files to preserve behavior while reducing SKILL.md bloat. It also adds a tools status cache block to setup scaffolding and documents the tools cache in config-system guidance. Finally, it aligns /ads Pipeboard stale handling language so invalid or missing last_checked is treated as stale.