### PR TITLE
[atom] _envelope + domain (check live, buy deferred)

### DIFF
--- a/.claude/skills/site/scripts/.gitignore
+++ b/.claude/skills/site/scripts/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.pytest_cache/

--- a/.claude/skills/site/scripts/_envelope.py
+++ b/.claude/skills/site/scripts/_envelope.py
@@ -1,0 +1,85 @@
+"""Shared envelope primitives for /site atoms.
+
+Lifted from `dmthepm/companyctx`'s schema.py. The shape is the contract:
+every atom emits exactly one Envelope-shape JSON document on stdout. Agents
+branch on `error.code` (a closed Literal per atom). Humans read `error.message`
+and act on `error.suggestion`.
+
+Each atom defines its own concrete Envelope class binding:
+    - `data` to its result Pydantic model
+    - `error` to a per-atom EnvelopeError subclass with a closed `code` Literal
+
+This module exports only the shared building blocks. Atom-specific shapes live
+in the atom file (e.g. `domain.py`).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+SCHEMA_VERSION = "0.1.0"
+
+EnvelopeStatus = Literal["ok", "partial", "degraded"]
+ProviderStatus = Literal["ok", "degraded", "failed", "not_configured"]
+
+
+class ProviderRunMetadata(BaseModel):
+    """Per-provider provenance row. Attach one per upstream call."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    status: ProviderStatus
+    latency_ms: int
+    error: str | None = None
+    provider_version: str
+    cost_incurred: int = 0
+    """Cost charged by this attempt, in US cents. Free providers stay 0."""
+
+
+def validate_status_consistency(envelope: BaseModel) -> BaseModel:
+    """Status ⟺ error invariant. Call from each atom's @model_validator(mode="after")."""
+    status = getattr(envelope, "status", None)
+    err = getattr(envelope, "error", None)
+    if status == "ok" and err is not None:
+        raise ValueError('status="ok" must not include an error')
+    if status != "ok" and err is None:
+        raise ValueError('status!="ok" requires a structured error')
+    return envelope
+
+
+def emit(envelope: BaseModel) -> int:
+    """Print envelope to stdout as indented JSON. Returns POSIX exit code.
+
+    Exit codes:
+        ok       → 0
+        partial  → 0   (data returned with caveats; not an operational failure)
+        degraded → 1   (operational failure; agent should branch on error.code)
+    """
+    sys.stdout.write(envelope.model_dump_json(indent=2) + "\n")
+    sys.stdout.flush()
+
+    status = getattr(envelope, "status", None)
+    if status in ("ok", "partial"):
+        return 0
+    return 1
+
+
+def log(msg: str) -> None:
+    """Write a log line to stderr. Stdout is reserved for the envelope JSON."""
+    sys.stderr.write(msg + "\n")
+    sys.stderr.flush()
+
+
+__all__ = [
+    "SCHEMA_VERSION",
+    "EnvelopeStatus",
+    "ProviderStatus",
+    "ProviderRunMetadata",
+    "validate_status_consistency",
+    "emit",
+    "log",
+]

--- a/.claude/skills/site/scripts/domain.py
+++ b/.claude/skills/site/scripts/domain.py
@@ -1,0 +1,429 @@
+#!/usr/bin/env python3
+"""domain.py — domain operations atom.
+
+Subcommands:
+    check  Wraps the `domain-check` brew CLI (RDAP, no auth) for availability lookups.
+    buy    Registers via Cloudflare Registrar (default) or Porkbun (legacy/lifecycle).
+           [Code lands here; live integration deferred to first real-project domain.]
+
+Invocation: `python3 domain.py <subcommand> [args]`
+Output: companyctx-shape envelope JSON on stdout, logs on stderr.
+Exit code: 0 on ok|partial, 1 on degraded.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Literal
+
+import click
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+# Allow `python3 path/to/domain.py` when run directly (script lookup).
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _envelope import (  # noqa: E402
+    SCHEMA_VERSION,
+    EnvelopeStatus,
+    ProviderRunMetadata,
+    emit,
+    log,
+    validate_status_consistency,
+)
+
+DOMAIN_CHECK_BIN = "/opt/homebrew/bin/domain-check"
+
+# ---------------------------------------------------------------------------
+# domain check
+# ---------------------------------------------------------------------------
+
+DomainCheckErrorCode = Literal[
+    "domain_check_unavailable",
+    "domain_check_failed",
+    "tld_not_supported",
+    "invalid_name",
+    "network_timeout",
+]
+
+
+class DomainCheckError(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    code: DomainCheckErrorCode
+    message: str
+    suggestion: str | None = None
+
+
+class DomainCheckResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    domain: str
+    available: bool
+    method_used: str | None = None
+
+
+class DomainCheckData(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    name: str
+    tlds_checked: list[str]
+    results: list[DomainCheckResult]
+    available: list[str] = Field(default_factory=list)
+
+
+class DomainCheckEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    schema_version: Literal["0.1.0"] = SCHEMA_VERSION
+    status: EnvelopeStatus
+    data: DomainCheckData
+    provenance: dict[str, ProviderRunMetadata] = Field(default_factory=dict)
+    error: DomainCheckError | None = None
+
+    @model_validator(mode="after")
+    def _v(self) -> DomainCheckEnvelope:
+        return validate_status_consistency(self)  # type: ignore[return-value]
+
+
+def _run_domain_check(domains: list[str]) -> tuple[list[dict], int, str | None]:
+    """Run the brew `domain-check` CLI in JSON mode. Returns (rows, latency_ms, error)."""
+    start = time.monotonic()
+    try:
+        proc = subprocess.run(
+            [DOMAIN_CHECK_BIN, *domains, "--json", "--batch", "--yes"],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+    except FileNotFoundError:
+        return [], int((time.monotonic() - start) * 1000), "binary_missing"
+    except subprocess.TimeoutExpired:
+        return [], int((time.monotonic() - start) * 1000), "timeout"
+
+    latency_ms = int((time.monotonic() - start) * 1000)
+
+    if proc.returncode != 0:
+        return [], latency_ms, f"exit_{proc.returncode}: {proc.stderr.strip()[:200]}"
+
+    try:
+        rows = json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        return [], latency_ms, f"json_parse: {exc}"
+
+    if not isinstance(rows, list):
+        return [], latency_ms, f"unexpected_shape: {type(rows).__name__}"
+
+    return rows, latency_ms, None
+
+
+@click.group()
+def cli() -> None:
+    """domain.py — domain operations atom."""
+
+
+@cli.command("check")
+@click.argument("name")
+@click.option(
+    "--tlds",
+    default=".com,.co,.xyz",
+    show_default=True,
+    help="Comma-separated TLDs to check (with or without leading dot).",
+)
+@click.option(
+    "--full-domain",
+    is_flag=True,
+    help="Treat NAME as a fully qualified domain; ignore --tlds.",
+)
+def check(name: str, tlds: str, full_domain: bool) -> None:
+    """Check availability for NAME across one or more TLDs (RDAP via domain-check)."""
+    name = name.strip().lower()
+    if not name:
+        env = DomainCheckEnvelope(
+            status="degraded",
+            data=DomainCheckData(name=name, tlds_checked=[], results=[]),
+            error=DomainCheckError(
+                code="invalid_name",
+                message="Empty name argument.",
+                suggestion="Pass a domain stem (e.g. 'mybrand') or a full domain with --full-domain.",
+            ),
+        )
+        sys.exit(emit(env))
+
+    if full_domain:
+        if "." not in name:
+            env = DomainCheckEnvelope(
+                status="degraded",
+                data=DomainCheckData(name=name, tlds_checked=[], results=[]),
+                error=DomainCheckError(
+                    code="invalid_name",
+                    message=f"--full-domain set but {name!r} has no TLD.",
+                    suggestion="Pass a fully qualified domain like 'example.com', or drop --full-domain to use --tlds.",
+                ),
+            )
+            sys.exit(emit(env))
+        domains = [name]
+        tlds_checked = [name.split(".", 1)[1]]
+    else:
+        tld_list = [t.strip().lstrip(".") for t in tlds.split(",") if t.strip()]
+        if not tld_list:
+            env = DomainCheckEnvelope(
+                status="degraded",
+                data=DomainCheckData(name=name, tlds_checked=[], results=[]),
+                error=DomainCheckError(
+                    code="tld_not_supported",
+                    message="No TLDs supplied to --tlds.",
+                    suggestion="Pass a comma-separated list like '.com,.co,.xyz'.",
+                ),
+            )
+            sys.exit(emit(env))
+        domains = [f"{name}.{tld}" for tld in tld_list]
+        tlds_checked = tld_list
+
+    rows, latency_ms, err = _run_domain_check(domains)
+
+    if err == "binary_missing":
+        env = DomainCheckEnvelope(
+            status="degraded",
+            data=DomainCheckData(name=name, tlds_checked=tlds_checked, results=[]),
+            provenance={
+                "domain_check": ProviderRunMetadata(
+                    status="not_configured",
+                    latency_ms=latency_ms,
+                    error="binary_missing",
+                    provider_version="domain-check",
+                )
+            },
+            error=DomainCheckError(
+                code="domain_check_unavailable",
+                message=f"`domain-check` binary not found at {DOMAIN_CHECK_BIN}.",
+                suggestion="brew install domain-check",
+            ),
+        )
+        sys.exit(emit(env))
+
+    if err == "timeout":
+        env = DomainCheckEnvelope(
+            status="degraded",
+            data=DomainCheckData(name=name, tlds_checked=tlds_checked, results=[]),
+            provenance={
+                "domain_check": ProviderRunMetadata(
+                    status="failed",
+                    latency_ms=latency_ms,
+                    error="timeout",
+                    provider_version="domain-check",
+                )
+            },
+            error=DomainCheckError(
+                code="network_timeout",
+                message="domain-check did not return within 60s.",
+                suggestion="Retry with fewer TLDs, or check your network connection.",
+            ),
+        )
+        sys.exit(emit(env))
+
+    if err is not None:
+        env = DomainCheckEnvelope(
+            status="degraded",
+            data=DomainCheckData(name=name, tlds_checked=tlds_checked, results=[]),
+            provenance={
+                "domain_check": ProviderRunMetadata(
+                    status="failed",
+                    latency_ms=latency_ms,
+                    error=err,
+                    provider_version="domain-check",
+                )
+            },
+            error=DomainCheckError(
+                code="domain_check_failed",
+                message=f"domain-check failed: {err}",
+                suggestion="Run with --debug locally and report the failure shape.",
+            ),
+        )
+        sys.exit(emit(env))
+
+    # Parse rows. Each row: {"domain": "...", "available": bool, "method_used": "..."}
+    results = []
+    available = []
+    for row in rows:
+        domain = row.get("domain", "")
+        avail = bool(row.get("available", False))
+        method = row.get("method_used")
+        results.append(DomainCheckResult(domain=domain, available=avail, method_used=method))
+        if avail:
+            available.append(domain)
+
+    env = DomainCheckEnvelope(
+        status="ok",
+        data=DomainCheckData(
+            name=name,
+            tlds_checked=tlds_checked,
+            results=results,
+            available=available,
+        ),
+        provenance={
+            "domain_check": ProviderRunMetadata(
+                status="ok",
+                latency_ms=latency_ms,
+                provider_version="domain-check",
+            )
+        },
+    )
+    sys.exit(emit(env))
+
+
+# ---------------------------------------------------------------------------
+# domain buy (code only — live integration deferred to real-project domain)
+# ---------------------------------------------------------------------------
+
+DomainBuyErrorCode = Literal[
+    "domain_unavailable",
+    "already_owned",
+    "registrar_unauthenticated",
+    "price_exceeds_ceiling",
+    "tld_not_supported",
+    "rate_limited",
+    "network_timeout",
+    "registrar_rejected",
+    "registrar_unsupported",
+    "no_registrar_configured",
+    "user_declined",
+]
+
+
+class DomainBuyError(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    code: DomainBuyErrorCode
+    message: str
+    suggestion: str | None = None
+
+
+class DomainBuyData(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    domain: str
+    registrar: Literal["cloudflare", "porkbun"] | None = None
+    price_usd: float | None = None
+    purchased: bool = False
+    already_owned: bool = False
+    expiry: str | None = None  # ISO date string
+    years: int = 1
+
+
+class DomainBuyEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    schema_version: Literal["0.1.0"] = SCHEMA_VERSION
+    status: EnvelopeStatus
+    data: DomainBuyData
+    provenance: dict[str, ProviderRunMetadata] = Field(default_factory=dict)
+    error: DomainBuyError | None = None
+
+    @model_validator(mode="after")
+    def _v(self) -> DomainBuyEnvelope:
+        return validate_status_consistency(self)  # type: ignore[return-value]
+
+
+def _select_registrar(explicit: str | None) -> tuple[str | None, DomainBuyError | None]:
+    """Pick a registrar based on explicit flag and env vars. Returns (registrar, error)."""
+    if explicit:
+        return explicit, None
+    if os.environ.get("CLOUDFLARE_API_TOKEN_REGISTRAR"):
+        return "cloudflare", None
+    if os.environ.get("PORKBUN_API_KEY") and os.environ.get("PORKBUN_SECRET_KEY"):
+        return "porkbun", None
+    return None, DomainBuyError(
+        code="no_registrar_configured",
+        message="No registrar credentials found.",
+        suggestion=(
+            "Add CLOUDFLARE_API_TOKEN_REGISTRAR (preferred) or "
+            "PORKBUN_API_KEY + PORKBUN_SECRET_KEY to ~/.config/vip/env.sh"
+        ),
+    )
+
+
+@cli.command("buy")
+@click.argument("name")
+@click.option(
+    "--registrar",
+    type=click.Choice(["cloudflare", "porkbun"]),
+    default=None,
+    help="Override registrar selection. Default: env-detected (cloudflare > porkbun).",
+)
+@click.option("--years", default=1, show_default=True, type=int)
+@click.option(
+    "--max-price",
+    default=30.0,
+    show_default=True,
+    type=float,
+    help="Refuse to register if listed price exceeds this ceiling (USD).",
+)
+@click.option(
+    "--yes",
+    "assume_yes",
+    is_flag=True,
+    help="Skip the confirmation prompt. Required for non-interactive use.",
+)
+def buy(name: str, registrar: str | None, years: int, max_price: float, assume_yes: bool) -> None:
+    """Register a domain. NAME must be a full domain (e.g. 'mybrand.com').
+
+    NOTE: live registrar calls are not yet wired. This command currently
+    validates inputs, selects a registrar, and emits a structured
+    `registrar_unsupported` error. The actual API integration lands
+    against the first real-project domain (no junk asset purchases).
+    """
+    name = name.strip().lower()
+
+    if "." not in name:
+        env = DomainBuyEnvelope(
+            status="degraded",
+            data=DomainBuyData(domain=name, years=years),
+            error=DomainBuyError(
+                code="tld_not_supported",
+                message=f"buy expects a full domain; got {name!r} with no TLD.",
+                suggestion="Pass a fully qualified domain like 'example.com'.",
+            ),
+        )
+        sys.exit(emit(env))
+
+    selected, err = _select_registrar(registrar)
+    if err is not None:
+        env = DomainBuyEnvelope(
+            status="degraded",
+            data=DomainBuyData(domain=name, years=years),
+            error=err,
+        )
+        sys.exit(emit(env))
+
+    # Cost-spending atoms require explicit confirmation.
+    if not assume_yes:
+        log(
+            f"About to register {name} at {selected} for {years}yr (max ${max_price:.2f}). "
+            "Pass --yes to proceed."
+        )
+        env = DomainBuyEnvelope(
+            status="degraded",
+            data=DomainBuyData(domain=name, registrar=selected, years=years),  # type: ignore[arg-type]
+            error=DomainBuyError(
+                code="user_declined",
+                message="Registration requires --yes confirmation.",
+                suggestion=f"Re-run with --yes if you actually want to spend money on {name}.",
+            ),
+        )
+        sys.exit(emit(env))
+
+    # Registrar API integration not yet wired (V1 scope: code lands, live test deferred).
+    env = DomainBuyEnvelope(
+        status="degraded",
+        data=DomainBuyData(domain=name, registrar=selected, years=years),  # type: ignore[arg-type]
+        error=DomainBuyError(
+            code="registrar_unsupported",
+            message=f"Registrar API for {selected!r} not yet wired in this build.",
+            suggestion=(
+                "Live registration is deferred to the first real-project domain. "
+                "Wire the API call before invoking with --yes against a real name."
+            ),
+        ),
+    )
+    sys.exit(emit(env))
+
+
+if __name__ == "__main__":
+    cli()

--- a/.claude/skills/site/scripts/test_atoms.py
+++ b/.claude/skills/site/scripts/test_atoms.py
@@ -1,0 +1,198 @@
+"""Atom envelope round-trip + invariant tests.
+
+Run with: `python3 -m pytest .claude/skills/site/scripts/test_atoms.py -v`
+or directly:  `python3 .claude/skills/site/scripts/test_atoms.py`
+
+These tests exercise the schema contract — not network calls. Live integration
+tests for `domain.py check` are run manually (see issue #93). Live `domain.py
+buy` is deferred to the first real-project domain.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _envelope import SCHEMA_VERSION, ProviderRunMetadata, validate_status_consistency
+from domain import (
+    DomainBuyData,
+    DomainBuyEnvelope,
+    DomainBuyError,
+    DomainCheckData,
+    DomainCheckEnvelope,
+    DomainCheckError,
+    DomainCheckResult,
+)
+
+
+# ---------------------------------------------------------------------------
+# DomainCheckEnvelope
+# ---------------------------------------------------------------------------
+
+
+def test_domain_check_ok_round_trip() -> None:
+    env = DomainCheckEnvelope(
+        status="ok",
+        data=DomainCheckData(
+            name="example",
+            tlds_checked=["com", "co"],
+            results=[
+                DomainCheckResult(domain="example.com", available=False, method_used="bootstrap"),
+                DomainCheckResult(domain="example.co", available=True, method_used="whois"),
+            ],
+            available=["example.co"],
+        ),
+        provenance={
+            "domain_check": ProviderRunMetadata(
+                status="ok",
+                latency_ms=412,
+                provider_version="domain-check",
+            )
+        },
+    )
+    payload = env.model_dump_json()
+    parsed = DomainCheckEnvelope.model_validate_json(payload)
+    assert parsed.status == "ok"
+    assert parsed.error is None
+    assert parsed.data.available == ["example.co"]
+    assert parsed.schema_version == SCHEMA_VERSION
+
+
+def test_domain_check_degraded_requires_error() -> None:
+    with pytest.raises(ValidationError, match="status!=.ok. requires a structured error"):
+        DomainCheckEnvelope(
+            status="degraded",
+            data=DomainCheckData(name="x", tlds_checked=[], results=[]),
+        )
+
+
+def test_domain_check_ok_rejects_error() -> None:
+    with pytest.raises(ValidationError, match='status="ok" must not include an error'):
+        DomainCheckEnvelope(
+            status="ok",
+            data=DomainCheckData(name="x", tlds_checked=[], results=[]),
+            error=DomainCheckError(code="invalid_name", message="x"),
+        )
+
+
+def test_domain_check_error_code_is_closed() -> None:
+    """Closed enum: only listed codes accepted."""
+    with pytest.raises(ValidationError):
+        DomainCheckError(code="not_a_real_code", message="x")  # type: ignore[arg-type]
+
+
+def test_domain_check_extra_fields_rejected() -> None:
+    """extra='forbid' on every model — schema drift is loud."""
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "status": "ok",
+        "data": {
+            "name": "x",
+            "tlds_checked": [],
+            "results": [],
+            "available": [],
+            "surprise_field": "drift",
+        },
+        "provenance": {},
+        "error": None,
+    }
+    with pytest.raises(ValidationError):
+        DomainCheckEnvelope.model_validate(payload)
+
+
+# ---------------------------------------------------------------------------
+# DomainBuyEnvelope
+# ---------------------------------------------------------------------------
+
+
+def test_domain_buy_ok_round_trip() -> None:
+    env = DomainBuyEnvelope(
+        status="ok",
+        data=DomainBuyData(
+            domain="example.com",
+            registrar="cloudflare",
+            price_usd=10.45,
+            purchased=True,
+            already_owned=False,
+            expiry="2027-04-27",
+            years=1,
+        ),
+        provenance={
+            "cloudflare_registrar": ProviderRunMetadata(
+                status="ok",
+                latency_ms=1845,
+                provider_version="cf-registrar-beta-2026-04-15",
+                cost_incurred=1045,
+            )
+        },
+    )
+    parsed = DomainBuyEnvelope.model_validate_json(env.model_dump_json())
+    assert parsed.data.purchased is True
+    assert parsed.data.registrar == "cloudflare"
+    assert parsed.provenance["cloudflare_registrar"].cost_incurred == 1045
+
+
+def test_domain_buy_already_owned_is_ok_status() -> None:
+    """already_owned is a *data field*, not an error — atom is idempotent."""
+    env = DomainBuyEnvelope(
+        status="ok",
+        data=DomainBuyData(
+            domain="example.com",
+            registrar="cloudflare",
+            already_owned=True,
+            purchased=False,
+            expiry="2027-04-27",
+            years=1,
+        ),
+    )
+    assert env.error is None
+    assert env.data.already_owned is True
+
+
+def test_domain_buy_user_declined_is_degraded() -> None:
+    env = DomainBuyEnvelope(
+        status="degraded",
+        data=DomainBuyData(domain="example.com", years=1),
+        error=DomainBuyError(
+            code="user_declined",
+            message="Registration requires --yes confirmation.",
+            suggestion="Re-run with --yes",
+        ),
+    )
+    assert env.error is not None
+    assert env.error.code == "user_declined"
+
+
+def test_domain_buy_error_code_is_closed() -> None:
+    with pytest.raises(ValidationError):
+        DomainBuyError(code="something_not_in_the_enum", message="x")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# validate_status_consistency (shared)
+# ---------------------------------------------------------------------------
+
+
+def test_validate_status_consistency_partial_requires_error() -> None:
+    with pytest.raises(ValidationError, match="status!=.ok. requires a structured error"):
+        DomainCheckEnvelope(
+            status="partial",
+            data=DomainCheckData(name="x", tlds_checked=[], results=[]),
+        )
+
+
+def test_provider_run_metadata_is_frozen() -> None:
+    """Provenance rows are immutable — no after-the-fact mutation."""
+    pr = ProviderRunMetadata(status="ok", latency_ms=100, provider_version="v1")
+    with pytest.raises(ValidationError):
+        pr.latency_ms = 200  # type: ignore[misc]
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

First two atoms toward [#93](https://github.com/mainbranch-ai/vip/issues/93)'s V1 atom layer, scoped per [#94](https://github.com/mainbranch-ai/vip/issues/94)'s onboarding brief. Shape-proving PR — if the envelope survives first contact with `domain-check`, the remaining atoms (`dns.py`, `pages.py`, `pages_gen.py`) follow the same pattern.

- `_envelope.py` — shared primitives lifted from `dmthepm/companyctx/schema.py` (SCHEMA_VERSION, status/provider literals, `ProviderRunMetadata`, `validate_status_consistency`, `emit`/`log` stdout/stderr split).
- `domain.py check` — wraps `/opt/homebrew/bin/domain-check` (RDAP, no auth, no money). Live-tested.
- `domain.py buy` — code complete with registrar selection (CF default, Porkbun fallback) and `--yes` confirmation gate. Live registrar API integration deliberately deferred to the first real-project domain per #94 (no junk fixtures, no money without explicit confirmation).
- `test_atoms.py` — 11 schema-contract tests, all passing.

## Live integration tested

```bash
python3 .claude/skills/site/scripts/domain.py check google --tlds .com
# → status: ok, available: false, exit 0

python3 .claude/skills/site/scripts/domain.py check noontide-atom-test-2026-04-27 --tlds .xyz,.com,.co
# → status: ok, all three available, exit 0

# error paths exercised:
python3 .claude/skills/site/scripts/domain.py check foo --tlds ""              # tld_not_supported
python3 .claude/skills/site/scripts/domain.py check foo --full-domain          # invalid_name
python3 .claude/skills/site/scripts/domain.py buy x.xyz                        # no_registrar_configured
CLOUDFLARE_API_TOKEN_REGISTRAR=fake python3 ... buy x.xyz                      # user_declined
CLOUDFLARE_API_TOKEN_REGISTRAR=fake python3 ... buy x.xyz --yes                # registrar_unsupported
```

All five degraded paths emit valid envelopes with closed-enum error codes and actionable `suggestion` strings.

## Schema contract enforced by tests

- `extra='forbid'` on every model (schema drift is loud).
- `status="ok"` ⟺ `error is None`; `status!="ok"` requires structured error.
- Closed-enum error codes per atom (Pydantic Literal); unknown codes rejected.
- `ProviderRunMetadata` is frozen — no after-the-fact mutation.
- `already_owned` is a *data* field on buy, not an error code (idempotent semantics).

## What's deferred (and why)

`domain.py buy` returns `registrar_unsupported` until the first real-project domain lands. Per #94: no money on junk fixtures; the chassis is offer-agnostic so first real `buy` registers a real lander asset, not a test domain. Wiring CF Registrar API + Porkbun API behind the existing scaffold is mechanical — it lands in a follow-up PR scoped to the real project.

## Test plan

- [x] `python3 -m pytest .claude/skills/site/scripts/test_atoms.py -v` — 11/11 pass
- [x] Live `domain.py check` against taken + free names — both return correct envelope
- [x] All five `domain.py` error paths emit valid envelopes
- [x] `bash ~/.claude/skills/test-skills/test-skills.sh` — 152/162 (10 pre-existing, none introduced by this PR)
- [ ] Live `domain.py buy` integration — deferred to first real-project domain

## What this unlocks

- Shape is proven; remaining V1 atoms (`dns.py`, `pages.py`, `pages_gen.py`) reuse `_envelope.py` and the same per-atom Error/Data/Envelope pattern.
- `/site setup` (#89) can call `python3 ./scripts/domain.py check` from the buy-new domain branch as soon as it's wired.

Refs #93, #94.

🤖 Generated with [Claude Code](https://claude.com/claude-code)