### PR TITLE
[atom] dns.ensure — CF zone + NS swap, idempotent (live-tested on thelastbill.com)

### DIFF
--- a/.claude/skills/site/scripts/dns.py
+++ b/.claude/skills/site/scripts/dns.py
@@ -1,0 +1,598 @@
+#!/usr/bin/env python3
+"""dns.py — DNS operations atom.
+
+Subcommand:
+    ensure   Idempotent: ensure a Cloudflare zone exists for <domain>, swap
+             nameservers at the registrar if needed (Porkbun-registered only),
+             poll until propagation confirmed.
+
+Invocation: `python3 dns.py ensure <domain> [--registrar cloudflare|porkbun]`
+Output: companyctx-shape envelope JSON on stdout, logs on stderr.
+
+Live integration with Cloudflare and Porkbun is wired but deferred to the
+first real-project domain (per #94: no money on junk fixtures, no zones
+created against test domains we don't own).
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Literal
+
+import click
+import requests
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _envelope import (  # noqa: E402
+    SCHEMA_VERSION,
+    EnvelopeStatus,
+    ProviderRunMetadata,
+    emit,
+    log,
+    validate_status_consistency,
+)
+
+CF_API_BASE = "https://api.cloudflare.com/client/v4"
+PORKBUN_API_BASE = "https://porkbun.com/api/json/v3"
+CF_NS_SUFFIX = ".ns.cloudflare.com"
+
+# Loose domain validator. Real validation happens upstream on first API call.
+_DOMAIN_RE = re.compile(r"^(?=.{1,253}$)([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,}$")
+
+# ---------------------------------------------------------------------------
+# Envelope shape
+# ---------------------------------------------------------------------------
+
+DnsEnsureErrorCode = Literal[
+    "invalid_domain",
+    "cf_account_id_missing",
+    "cf_unauthenticated",
+    "cf_rate_limited",
+    "cf_request_failed",
+    "zone_already_exists",  # 1097: zone owned by another CF account
+    "registrar_required",  # need NS swap but no registrar specified/detected
+    "registrar_unsupported",
+    "porkbun_unauthenticated",
+    "porkbun_ns_update_failed",
+    "dig_unavailable",
+    "propagation_timeout",
+    "network_timeout",
+]
+
+
+class DnsEnsureError(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    code: DnsEnsureErrorCode
+    message: str
+    suggestion: str | None = None
+
+
+class DnsEnsureData(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    domain: str
+    zone_id: str | None = None
+    ns_pair: list[str] = Field(default_factory=list)
+    zone_created_now: bool = False
+    registrar: Literal["cloudflare", "porkbun"] | None = None
+    ns_swap_performed: bool = False
+    propagated: bool = False
+    propagation_seconds: int | None = None
+
+
+class DnsEnsureEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    schema_version: Literal["0.1.0"] = SCHEMA_VERSION
+    status: EnvelopeStatus
+    data: DnsEnsureData
+    provenance: dict[str, ProviderRunMetadata] = Field(default_factory=dict)
+    error: DnsEnsureError | None = None
+
+    @model_validator(mode="after")
+    def _v(self) -> DnsEnsureEnvelope:
+        return validate_status_consistency(self)  # type: ignore[return-value]
+
+
+# ---------------------------------------------------------------------------
+# CF API helpers
+# ---------------------------------------------------------------------------
+
+
+class CfResult(BaseModel):
+    """Internal: a Cloudflare API response normalized for atom consumption."""
+
+    model_config = ConfigDict(extra="forbid")
+    ok: bool
+    latency_ms: int
+    status_code: int
+    payload: dict | list | None = None
+    error_code: int | None = None
+    error_message: str | None = None
+
+
+def _cf_call(method: str, path: str, token: str, json_body: dict | None = None) -> CfResult:
+    url = f"{CF_API_BASE}{path}"
+    headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+    start = time.monotonic()
+    try:
+        resp = requests.request(method, url, headers=headers, json=json_body, timeout=30)
+    except requests.Timeout:
+        return CfResult(
+            ok=False,
+            latency_ms=int((time.monotonic() - start) * 1000),
+            status_code=0,
+            error_message="timeout",
+        )
+    except requests.RequestException as exc:
+        return CfResult(
+            ok=False,
+            latency_ms=int((time.monotonic() - start) * 1000),
+            status_code=0,
+            error_message=f"request_exception: {exc.__class__.__name__}",
+        )
+
+    latency_ms = int((time.monotonic() - start) * 1000)
+    try:
+        body = resp.json()
+    except ValueError:
+        return CfResult(
+            ok=False,
+            latency_ms=latency_ms,
+            status_code=resp.status_code,
+            error_message="non_json_response",
+        )
+
+    success = bool(body.get("success", False))
+    errors = body.get("errors") or []
+    err_code = errors[0].get("code") if errors else None
+    err_msg = errors[0].get("message") if errors else None
+    return CfResult(
+        ok=success,
+        latency_ms=latency_ms,
+        status_code=resp.status_code,
+        payload=body.get("result"),
+        error_code=err_code,
+        error_message=err_msg,
+    )
+
+
+def _cf_classify_error(result: CfResult) -> tuple[DnsEnsureErrorCode, str]:
+    """Map a failed CF response to a closed-enum error code + suggestion."""
+    if result.error_message == "timeout":
+        return "network_timeout", "Cloudflare API timed out. Retry; check connectivity."
+    if result.status_code == 401 or result.error_code in (10000, 10001):
+        return (
+            "cf_unauthenticated",
+            "Verify CLOUDFLARE_API_TOKEN has Zone:Edit + DNS:Edit + Pages:Edit.",
+        )
+    if result.status_code == 429:
+        return "cf_rate_limited", "Cloudflare rate-limited the request. Back off and retry."
+    if result.error_code == 1097:
+        return (
+            "zone_already_exists",
+            "Zone exists in another Cloudflare account. Manual cleanup required at "
+            "dash.cloudflare.com before retrying.",
+        )
+    return (
+        "cf_request_failed",
+        f"Cloudflare API rejected: {result.error_message or 'unknown'} "
+        f"(http {result.status_code}, code {result.error_code}).",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Porkbun NS update helper
+# ---------------------------------------------------------------------------
+
+
+def _porkbun_update_ns(
+    domain: str, nameservers: list[str], api_key: str, secret_key: str
+) -> tuple[bool, int, str | None]:
+    url = f"{PORKBUN_API_BASE}/domain/updateNs/{domain}"
+    body = {
+        "apikey": api_key,
+        "secretapikey": secret_key,
+        "ns": nameservers,
+    }
+    start = time.monotonic()
+    try:
+        resp = requests.post(url, json=body, timeout=30)
+    except requests.Timeout:
+        return False, int((time.monotonic() - start) * 1000), "timeout"
+    except requests.RequestException as exc:
+        return False, int((time.monotonic() - start) * 1000), f"request_exception: {exc!s}"
+
+    latency_ms = int((time.monotonic() - start) * 1000)
+    try:
+        body_json = resp.json()
+    except ValueError:
+        return False, latency_ms, f"non_json_response: http {resp.status_code}"
+
+    status = body_json.get("status")
+    if status != "SUCCESS":
+        return False, latency_ms, body_json.get("message", "unknown_error")
+    return True, latency_ms, None
+
+
+# ---------------------------------------------------------------------------
+# Propagation polling
+# ---------------------------------------------------------------------------
+
+
+def _dig_ns(domain: str) -> tuple[list[str] | None, str | None]:
+    """Query 1.1.1.1 for the domain's NS records. Returns (ns_list, error)."""
+    dig_bin = shutil.which("dig")
+    if not dig_bin:
+        return None, "dig_unavailable"
+    try:
+        proc = subprocess.run(
+            [dig_bin, "+short", "NS", domain, "@1.1.1.1"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except subprocess.TimeoutExpired:
+        return None, "dig_timeout"
+    if proc.returncode != 0:
+        return None, f"dig_exit_{proc.returncode}"
+    lines = [ln.strip().rstrip(".").lower() for ln in proc.stdout.splitlines() if ln.strip()]
+    return lines, None
+
+
+def _wait_for_propagation(
+    domain: str, expected_ns: list[str], timeout_seconds: int
+) -> tuple[bool, int, str | None]:
+    """Poll dig +short NS until expected_ns appear. Returns (propagated, elapsed_s, error)."""
+    expected_lower = {ns.lower().rstrip(".") for ns in expected_ns}
+    start = time.monotonic()
+    while True:
+        observed, err = _dig_ns(domain)
+        if err == "dig_unavailable":
+            return False, int(time.monotonic() - start), "dig_unavailable"
+        if observed and expected_lower.issubset(set(observed)):
+            return True, int(time.monotonic() - start), None
+        elapsed = int(time.monotonic() - start)
+        if elapsed >= timeout_seconds:
+            return False, elapsed, "timeout"
+        log(f"  [{elapsed:>4}s] NS observed: {observed or '(none)'} — waiting for {sorted(expected_lower)}")
+        time.sleep(min(30, max(5, timeout_seconds // 30)))
+
+
+# ---------------------------------------------------------------------------
+# Registrar selection
+# ---------------------------------------------------------------------------
+
+
+def _detect_registrar(explicit: str | None) -> tuple[str | None, DnsEnsureError | None]:
+    if explicit:
+        return explicit, None
+    if os.environ.get("CLOUDFLARE_API_TOKEN_REGISTRAR"):
+        return "cloudflare", None
+    if os.environ.get("PORKBUN_API_KEY") and os.environ.get("PORKBUN_SECRET_KEY"):
+        return "porkbun", None
+    return None, DnsEnsureError(
+        code="registrar_required",
+        message="Cannot determine registrar; pass --registrar or set CF/Porkbun env vars.",
+        suggestion=(
+            "Pass --registrar=cloudflare or --registrar=porkbun. "
+            "Or set CLOUDFLARE_API_TOKEN_REGISTRAR (CF-registered) or "
+            "PORKBUN_API_KEY+PORKBUN_SECRET_KEY (Porkbun-registered) in ~/.config/vip/env.sh."
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+@click.group()
+def cli() -> None:
+    """dns.py — DNS operations atom."""
+
+
+@cli.command("ensure")
+@click.argument("domain")
+@click.option(
+    "--registrar",
+    type=click.Choice(["cloudflare", "porkbun"]),
+    default=None,
+    help="Where the domain is registered. Auto-detected from env if omitted.",
+)
+@click.option(
+    "--timeout-seconds",
+    default=600,
+    show_default=True,
+    type=int,
+    help="Max wait for NS propagation before returning propagation_timeout.",
+)
+@click.option(
+    "--skip-propagation-poll",
+    is_flag=True,
+    help="Skip the propagation poll. Use only if a downstream caller will poll itself.",
+)
+def ensure(
+    domain: str, registrar: str | None, timeout_seconds: int, skip_propagation_poll: bool
+) -> None:
+    """Ensure DOMAIN has a Cloudflare zone with NS pointing at CF.
+
+    Idempotent: existing zones are reused; existing CF nameservers are not re-pushed.
+    """
+    domain = domain.strip().lower().rstrip(".")
+    provenance: dict[str, ProviderRunMetadata] = {}
+
+    if not _DOMAIN_RE.match(domain):
+        env = DnsEnsureEnvelope(
+            status="degraded",
+            data=DnsEnsureData(domain=domain),
+            error=DnsEnsureError(
+                code="invalid_domain",
+                message=f"Domain {domain!r} doesn't look like a valid apex.",
+                suggestion="Pass a registrable apex like 'example.com' (no scheme, no path).",
+            ),
+        )
+        sys.exit(emit(env))
+
+    cf_token = os.environ.get("CLOUDFLARE_API_TOKEN")
+    cf_account_id = os.environ.get("CF_ACCOUNT_ID")
+
+    if not cf_token:
+        env = DnsEnsureEnvelope(
+            status="degraded",
+            data=DnsEnsureData(domain=domain),
+            error=DnsEnsureError(
+                code="cf_unauthenticated",
+                message="CLOUDFLARE_API_TOKEN not set.",
+                suggestion=(
+                    "Add CLOUDFLARE_API_TOKEN to ~/.config/vip/env.sh with Zone:Edit + "
+                    "DNS:Edit permissions."
+                ),
+            ),
+        )
+        sys.exit(emit(env))
+
+    if not cf_account_id:
+        env = DnsEnsureEnvelope(
+            status="degraded",
+            data=DnsEnsureData(domain=domain),
+            error=DnsEnsureError(
+                code="cf_account_id_missing",
+                message="CF_ACCOUNT_ID not set.",
+                suggestion=(
+                    "Add CF_ACCOUNT_ID to ~/.config/vip/env.sh "
+                    "(find it at dash.cloudflare.com → right sidebar of any zone)."
+                ),
+            ),
+        )
+        sys.exit(emit(env))
+
+    selected_registrar, reg_err = _detect_registrar(registrar)
+    if reg_err is not None:
+        env = DnsEnsureEnvelope(
+            status="degraded",
+            data=DnsEnsureData(domain=domain),
+            error=reg_err,
+        )
+        sys.exit(emit(env))
+
+    # Step 1: look up existing zone
+    log(f"Looking up Cloudflare zone for {domain}...")
+    lookup = _cf_call(
+        "GET", f"/zones?name={domain}&account.id={cf_account_id}", cf_token
+    )
+    provenance["cf_zone_lookup"] = ProviderRunMetadata(
+        status="ok" if lookup.ok else "failed",
+        latency_ms=lookup.latency_ms,
+        error=None if lookup.ok else (lookup.error_message or "unknown"),
+        provider_version="cloudflare-api-v4",
+    )
+    if not lookup.ok:
+        code, suggestion = _cf_classify_error(lookup)
+        env = DnsEnsureEnvelope(
+            status="degraded",
+            data=DnsEnsureData(domain=domain, registrar=selected_registrar),  # type: ignore[arg-type]
+            provenance=provenance,
+            error=DnsEnsureError(code=code, message=lookup.error_message or "lookup_failed", suggestion=suggestion),
+        )
+        sys.exit(emit(env))
+
+    zones = lookup.payload if isinstance(lookup.payload, list) else []
+    zone_id: str | None = None
+    ns_pair: list[str] = []
+    zone_created_now = False
+
+    if zones:
+        zone = zones[0]
+        zone_id = zone.get("id")
+        ns_pair = list(zone.get("name_servers") or [])
+        log(f"Zone exists: id={zone_id}, ns={ns_pair}")
+    else:
+        # Step 2: create zone
+        log(f"Creating Cloudflare zone for {domain}...")
+        create = _cf_call(
+            "POST",
+            "/zones",
+            cf_token,
+            json_body={"name": domain, "account": {"id": cf_account_id}},
+        )
+        provenance["cf_zone_create"] = ProviderRunMetadata(
+            status="ok" if create.ok else "failed",
+            latency_ms=create.latency_ms,
+            error=None if create.ok else (create.error_message or "unknown"),
+            provider_version="cloudflare-api-v4",
+        )
+        if not create.ok:
+            code, suggestion = _cf_classify_error(create)
+            env = DnsEnsureEnvelope(
+                status="degraded",
+                data=DnsEnsureData(domain=domain, registrar=selected_registrar),  # type: ignore[arg-type]
+                provenance=provenance,
+                error=DnsEnsureError(
+                    code=code, message=create.error_message or "create_failed", suggestion=suggestion
+                ),
+            )
+            sys.exit(emit(env))
+
+        zone = create.payload if isinstance(create.payload, dict) else {}
+        zone_id = zone.get("id")
+        ns_pair = list(zone.get("name_servers") or [])
+        zone_created_now = True
+        log(f"Zone created: id={zone_id}, ns={ns_pair}")
+
+    if not ns_pair or not all(ns.endswith(CF_NS_SUFFIX) for ns in ns_pair):
+        env = DnsEnsureEnvelope(
+            status="degraded",
+            data=DnsEnsureData(
+                domain=domain,
+                zone_id=zone_id,
+                ns_pair=ns_pair,
+                zone_created_now=zone_created_now,
+                registrar=selected_registrar,  # type: ignore[arg-type]
+            ),
+            provenance=provenance,
+            error=DnsEnsureError(
+                code="cf_request_failed",
+                message="Cloudflare returned no nameservers for the zone.",
+                suggestion="Check the zone in dash.cloudflare.com; it may be in a non-standard plan/state.",
+            ),
+        )
+        sys.exit(emit(env))
+
+    # Step 3: NS swap if registrar is porkbun
+    ns_swap_performed = False
+    if selected_registrar == "porkbun":
+        pb_key = os.environ.get("PORKBUN_API_KEY")
+        pb_secret = os.environ.get("PORKBUN_SECRET_KEY")
+        if not pb_key or not pb_secret:
+            env = DnsEnsureEnvelope(
+                status="degraded",
+                data=DnsEnsureData(
+                    domain=domain,
+                    zone_id=zone_id,
+                    ns_pair=ns_pair,
+                    zone_created_now=zone_created_now,
+                    registrar="porkbun",
+                ),
+                provenance=provenance,
+                error=DnsEnsureError(
+                    code="porkbun_unauthenticated",
+                    message="PORKBUN_API_KEY/PORKBUN_SECRET_KEY not set.",
+                    suggestion="Add PORKBUN_API_KEY and PORKBUN_SECRET_KEY to ~/.config/vip/env.sh.",
+                ),
+            )
+            sys.exit(emit(env))
+
+        log(f"Updating Porkbun nameservers for {domain} → {ns_pair}")
+        ok, lat, err = _porkbun_update_ns(domain, ns_pair, pb_key, pb_secret)
+        provenance["porkbun_update_ns"] = ProviderRunMetadata(
+            status="ok" if ok else "failed",
+            latency_ms=lat,
+            error=err,
+            provider_version="porkbun-api-v3",
+        )
+        if not ok:
+            env = DnsEnsureEnvelope(
+                status="degraded",
+                data=DnsEnsureData(
+                    domain=domain,
+                    zone_id=zone_id,
+                    ns_pair=ns_pair,
+                    zone_created_now=zone_created_now,
+                    registrar="porkbun",
+                ),
+                provenance=provenance,
+                error=DnsEnsureError(
+                    code="porkbun_ns_update_failed",
+                    message=f"Porkbun rejected NS update: {err or 'unknown'}",
+                    suggestion="Verify the domain is in the Porkbun account whose API keys you supplied.",
+                ),
+            )
+            sys.exit(emit(env))
+        ns_swap_performed = True
+
+    # Step 4: propagation poll
+    propagated = False
+    propagation_seconds: int | None = None
+    if not skip_propagation_poll:
+        log(f"Polling NS propagation (timeout {timeout_seconds}s)...")
+        propagated, elapsed, prop_err = _wait_for_propagation(
+            domain, ns_pair, timeout_seconds
+        )
+        propagation_seconds = elapsed
+        provenance["dns_propagation_poll"] = ProviderRunMetadata(
+            status="ok" if propagated else "failed",
+            latency_ms=elapsed * 1000,
+            error=prop_err,
+            provider_version="dig+1.1.1.1",
+        )
+        if prop_err == "dig_unavailable":
+            env = DnsEnsureEnvelope(
+                status="degraded",
+                data=DnsEnsureData(
+                    domain=domain,
+                    zone_id=zone_id,
+                    ns_pair=ns_pair,
+                    zone_created_now=zone_created_now,
+                    registrar=selected_registrar,  # type: ignore[arg-type]
+                    ns_swap_performed=ns_swap_performed,
+                    propagated=False,
+                    propagation_seconds=elapsed,
+                ),
+                provenance=provenance,
+                error=DnsEnsureError(
+                    code="dig_unavailable",
+                    message="`dig` binary not on PATH; cannot poll propagation.",
+                    suggestion="brew install bind (provides dig). Or pass --skip-propagation-poll.",
+                ),
+            )
+            sys.exit(emit(env))
+        if not propagated:
+            env = DnsEnsureEnvelope(
+                status="degraded",
+                data=DnsEnsureData(
+                    domain=domain,
+                    zone_id=zone_id,
+                    ns_pair=ns_pair,
+                    zone_created_now=zone_created_now,
+                    registrar=selected_registrar,  # type: ignore[arg-type]
+                    ns_swap_performed=ns_swap_performed,
+                    propagated=False,
+                    propagation_seconds=elapsed,
+                ),
+                provenance=provenance,
+                error=DnsEnsureError(
+                    code="propagation_timeout",
+                    message=f"NS did not propagate to Cloudflare within {timeout_seconds}s.",
+                    suggestion=(
+                        "Check the registrar dashboard — NS update may be queued. "
+                        "Re-run `dns.py ensure` once the registrar shows the new NS."
+                    ),
+                ),
+            )
+            sys.exit(emit(env))
+
+    env = DnsEnsureEnvelope(
+        status="ok",
+        data=DnsEnsureData(
+            domain=domain,
+            zone_id=zone_id,
+            ns_pair=ns_pair,
+            zone_created_now=zone_created_now,
+            registrar=selected_registrar,  # type: ignore[arg-type]
+            ns_swap_performed=ns_swap_performed,
+            propagated=propagated,
+            propagation_seconds=propagation_seconds,
+        ),
+        provenance=provenance,
+    )
+    sys.exit(emit(env))
+
+
+if __name__ == "__main__":
+    cli()

--- a/.claude/skills/site/scripts/dns.py
+++ b/.claude/skills/site/scripts/dns.py
@@ -40,7 +40,7 @@ from _envelope import (  # noqa: E402
 )
 
 CF_API_BASE = "https://api.cloudflare.com/client/v4"
-PORKBUN_API_BASE = "https://porkbun.com/api/json/v3"
+PORKBUN_API_BASE = "https://api.porkbun.com/api/json/v3"
 CF_NS_SUFFIX = ".ns.cloudflare.com"
 
 # Loose domain validator. Real validation happens upstream on first API call.
@@ -162,14 +162,27 @@ def _cf_call(method: str, path: str, token: str, json_body: dict | None = None) 
     )
 
 
+# CF error codes that indicate auth problems regardless of HTTP status.
+# 10000 / 10001 — generic auth token error in body
+# 6003 / 6111 — malformed Authorization header (HTTP 400 path)
+# 9106 / 9107 — missing X-Auth-Email / X-Auth-Key (legacy auth path)
+# 9109 — token format OK but invalid/revoked (HTTP 403 path)
+_CF_AUTH_ERROR_CODES = frozenset({10000, 10001, 6003, 6111, 9106, 9107, 9109})
+
+
 def _cf_classify_error(result: CfResult) -> tuple[DnsEnsureErrorCode, str]:
     """Map a failed CF response to a closed-enum error code + suggestion."""
     if result.error_message == "timeout":
         return "network_timeout", "Cloudflare API timed out. Retry; check connectivity."
-    if result.status_code == 401 or result.error_code in (10000, 10001):
+    if (
+        result.status_code == 401
+        or (result.error_code is not None and result.error_code in _CF_AUTH_ERROR_CODES)
+    ):
         return (
             "cf_unauthenticated",
-            "Verify CLOUDFLARE_API_TOKEN has Zone:Edit + DNS:Edit + Pages:Edit.",
+            "Verify CLOUDFLARE_API_TOKEN exists, isn't revoked, and has "
+            "Zone:Edit + DNS:Edit + Pages:Edit scopes. Create at "
+            "https://dash.cloudflare.com/profile/api-tokens.",
         )
     if result.status_code == 429:
         return "cf_rate_limited", "Cloudflare rate-limited the request. Back off and retry."

--- a/.claude/skills/site/scripts/domain.py
+++ b/.claude/skills/site/scripts/domain.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import subprocess
 import sys
 import time
@@ -35,7 +36,7 @@ from _envelope import (  # noqa: E402
     validate_status_consistency,
 )
 
-DOMAIN_CHECK_BIN = "/opt/homebrew/bin/domain-check"
+DOMAIN_CHECK_BIN = shutil.which("domain-check") or "/opt/homebrew/bin/domain-check"
 
 # ---------------------------------------------------------------------------
 # domain check

--- a/.claude/skills/site/scripts/setup_creds.sh
+++ b/.claude/skills/site/scripts/setup_creds.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# setup_creds.sh — write Cloudflare credentials into ~/.config/vip/env.sh.
+#
+# Prompts for an API token (hidden input) + account ID (visible), then writes
+# CLOUDFLARE_API_TOKEN, CLOUDFLARE_API_TOKEN_REGISTRAR, and CF_ACCOUNT_ID to
+# ~/.config/vip/env.sh with chmod 600. Idempotent — re-running replaces
+# existing values for these three vars without duplicating lines.
+#
+# Token must have these scopes on the account that will own paidup.us:
+#   Cloudflare Registrar:Edit
+#   Zone:Read, Zone:Edit
+#   DNS:Read, DNS:Edit
+#   Cloudflare Pages:Edit
+# Pin Account Resources to the single account (not "All accounts") so the
+# token can't drift to the wrong place.
+#
+# Create at: https://dash.cloudflare.com/profile/api-tokens
+
+set -euo pipefail
+
+ENV_FILE="$HOME/.config/vip/env.sh"
+
+mkdir -p "$(dirname "$ENV_FILE")"
+touch "$ENV_FILE"
+chmod 600 "$ENV_FILE"
+
+cat <<'EOF'
+
+=== Cloudflare credentials setup for /site atoms ===
+
+Writes to: ~/.config/vip/env.sh (chmod 600, owner-only)
+Vars set:  CLOUDFLARE_API_TOKEN, CLOUDFLARE_API_TOKEN_REGISTRAR, CF_ACCOUNT_ID
+
+Existing values for these three vars will be replaced (idempotent).
+Token input is hidden; nothing is echoed back to the terminal.
+
+EOF
+
+# --- Token (hidden) ---
+printf 'Paste CF API token (input hidden, hit Enter when done): '
+IFS= read -rs CF_TOKEN
+echo
+CF_TOKEN="$(printf '%s' "$CF_TOKEN" | tr -d '[:space:]')"
+
+if [[ ${#CF_TOKEN} -lt 20 ]]; then
+  echo "ERROR: token looks too short (got ${#CF_TOKEN} chars). Aborting; nothing written." >&2
+  exit 1
+fi
+
+# --- Account ID (visible — not secret) ---
+printf 'Paste CF_ACCOUNT_ID (visible, 32 hex chars): '
+IFS= read -r CF_ACCT
+CF_ACCT="$(printf '%s' "$CF_ACCT" | tr -d '[:space:]')"
+
+if [[ ! "$CF_ACCT" =~ ^[a-f0-9]{32}$ ]]; then
+  echo "ERROR: account ID should be 32 lowercase hex chars; got '${CF_ACCT}'." >&2
+  echo "       Find it in dash.cloudflare.com → click any zone → right sidebar." >&2
+  exit 1
+fi
+
+# --- Idempotent var update (replace existing line; otherwise append) ---
+update_var() {
+  local var="$1"
+  local val="$2"
+  if grep -q "^export ${var}=" "$ENV_FILE"; then
+    awk -v var="$var" -v val="$val" '
+      $0 ~ "^export " var "=" { printf "export %s=\"%s\"\n", var, val; next }
+      { print }
+    ' "$ENV_FILE" > "${ENV_FILE}.tmp" && mv "${ENV_FILE}.tmp" "$ENV_FILE"
+  else
+    printf 'export %s="%s"\n' "$var" "$val" >> "$ENV_FILE"
+  fi
+}
+
+update_var CLOUDFLARE_API_TOKEN           "$CF_TOKEN"
+update_var CLOUDFLARE_API_TOKEN_REGISTRAR "$CF_TOKEN"
+update_var CF_ACCOUNT_ID                  "$CF_ACCT"
+
+chmod 600 "$ENV_FILE"
+
+# --- Verify, redacted ---
+echo
+echo "=== ~/.config/vip/env.sh (relevant lines, redacted) ==="
+if grep -qE "^export (CLOUDFLARE_API_TOKEN|CLOUDFLARE_API_TOKEN_REGISTRAR|CF_ACCOUNT_ID)=" "$ENV_FILE"; then
+  grep -E "^export (CLOUDFLARE_API_TOKEN|CLOUDFLARE_API_TOKEN_REGISTRAR|CF_ACCOUNT_ID)=" "$ENV_FILE" \
+    | sed -E 's/=("[^"]+"|[^[:space:]]+)/=<set>/'
+else
+  echo "WARNING: nothing matched after write — file may have unexpected format." >&2
+fi
+
+cat <<'EOF'
+
+Next:
+  source ~/.config/vip/env.sh
+  python3 .claude/skills/site/scripts/verify_live.py
+
+Expected: 3/4 → 4/4 once Porkbun keys land. CF auth + zone lookup should
+flip green immediately. Token + account never printed; safe to scroll back.
+EOF

--- a/.claude/skills/site/scripts/setup_creds.sh
+++ b/.claude/skills/site/scripts/setup_creds.sh
@@ -6,7 +6,8 @@
 # ~/.config/vip/env.sh with chmod 600. Idempotent — re-running replaces
 # existing values for these three vars without duplicating lines.
 #
-# Token must have these scopes on the account that will own paidup.us:
+# Token must have these scopes on the account that owns the chassis assets
+# (registrar domains + Pages projects + DNS zones):
 #   Cloudflare Registrar:Edit
 #   Zone:Read, Zone:Edit
 #   DNS:Read, DNS:Edit

--- a/.claude/skills/site/scripts/test_atoms.py
+++ b/.claude/skills/site/scripts/test_atoms.py
@@ -20,13 +20,18 @@ from pydantic import ValidationError
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from _envelope import SCHEMA_VERSION, ProviderRunMetadata, validate_status_consistency
+from unittest.mock import patch
+
+import dns as dns_module
 from dns import (
     CfResult,
     DnsEnsureData,
     DnsEnsureEnvelope,
     DnsEnsureError,
+    PORKBUN_API_BASE,
     _cf_classify_error,
     _detect_registrar,
+    _porkbun_update_ns,
 )
 from domain import (
     DomainBuyData,
@@ -318,6 +323,97 @@ def test_cf_classify_generic_failure() -> None:
     code, suggestion = _cf_classify_error(result)
     assert code == "cf_request_failed"
     assert "9999" in suggestion or "500" in suggestion
+
+
+# CF auth-error code coverage — all five flavors map to cf_unauthenticated.
+# (Verified against Cloudflare's published error codes: 9106/9107 legacy,
+# 9109 invalid/revoked, 6003/6111 malformed Authorization header.)
+@pytest.mark.parametrize(
+    "http_status,cf_code",
+    [
+        (403, 9109),  # token format OK but invalid/revoked
+        (403, 9106),  # missing X-Auth-Email (legacy auth)
+        (403, 9107),  # missing X-Auth-Key (legacy auth)
+        (400, 6003),  # malformed Authorization header
+        (400, 6111),  # malformed Authorization header variant
+    ],
+)
+def test_cf_classify_auth_error_codes(http_status: int, cf_code: int) -> None:
+    """All five auth-error code paths map to cf_unauthenticated."""
+    result = CfResult(
+        ok=False,
+        latency_ms=80,
+        status_code=http_status,
+        error_code=cf_code,
+        error_message="auth_problem",
+    )
+    code, suggestion = _cf_classify_error(result)
+    assert code == "cf_unauthenticated", f"http {http_status} + code {cf_code} → {code}"
+    assert "CLOUDFLARE_API_TOKEN" in suggestion
+    assert "scopes" in suggestion.lower() or "scope" in suggestion.lower()
+
+
+# ---------------------------------------------------------------------------
+# Porkbun host pinned (regression test for the audit-caught bug)
+# ---------------------------------------------------------------------------
+
+
+def test_porkbun_api_base_pinned_to_correct_host() -> None:
+    """Regression: Porkbun's documented API host is api.porkbun.com (not porkbun.com).
+
+    porkbun.com/api/json/v3/* returns HTTP 403; api.porkbun.com/api/json/v3/* works.
+    Audited live before this test was written.
+    """
+    assert PORKBUN_API_BASE == "https://api.porkbun.com/api/json/v3"
+
+
+def test_porkbun_update_ns_url_construction() -> None:
+    """The actual HTTP call hits api.porkbun.com, not porkbun.com.
+
+    Mocks `requests.post` at the dns module level and asserts the URL passed.
+    Catches a future regression where someone shortens the base back to porkbun.com.
+    """
+    fake_response = type(
+        "FakeResp",
+        (),
+        {
+            "status_code": 200,
+            "json": lambda self: {"status": "SUCCESS"},
+        },
+    )()
+
+    with patch.object(dns_module.requests, "post", return_value=fake_response) as mock_post:
+        ok, _, err = _porkbun_update_ns(
+            "example.com",
+            ["walt.ns.cloudflare.com", "sara.ns.cloudflare.com"],
+            "fake_key",
+            "fake_secret",
+        )
+        assert ok is True
+        assert err is None
+        called_url = mock_post.call_args.args[0] if mock_post.call_args.args else mock_post.call_args.kwargs["url"]
+        assert called_url.startswith("https://api.porkbun.com/api/json/v3/"), (
+            f"Porkbun URL must start with api.porkbun.com — got {called_url}"
+        )
+        assert "example.com" in called_url
+        assert "domain/updateNs" in called_url
+
+
+def test_porkbun_update_ns_failure_returns_message() -> None:
+    """Porkbun status != SUCCESS surfaces the message verbatim for diagnosis."""
+    fake_response = type(
+        "FakeResp",
+        (),
+        {
+            "status_code": 200,
+            "json": lambda self: {"status": "ERROR", "message": "invalid api key"},
+        },
+    )()
+
+    with patch.object(dns_module.requests, "post", return_value=fake_response):
+        ok, _, err = _porkbun_update_ns("example.com", ["a", "b"], "k", "s")
+        assert ok is False
+        assert err == "invalid api key"
 
 
 def test_detect_registrar_explicit_wins() -> None:

--- a/.claude/skills/site/scripts/test_atoms.py
+++ b/.claude/skills/site/scripts/test_atoms.py
@@ -20,6 +20,14 @@ from pydantic import ValidationError
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from _envelope import SCHEMA_VERSION, ProviderRunMetadata, validate_status_consistency
+from dns import (
+    CfResult,
+    DnsEnsureData,
+    DnsEnsureEnvelope,
+    DnsEnsureError,
+    _cf_classify_error,
+    _detect_registrar,
+)
 from domain import (
     DomainBuyData,
     DomainBuyEnvelope,
@@ -192,6 +200,158 @@ def test_provider_run_metadata_is_frozen() -> None:
     pr = ProviderRunMetadata(status="ok", latency_ms=100, provider_version="v1")
     with pytest.raises(ValidationError):
         pr.latency_ms = 200  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# DnsEnsureEnvelope
+# ---------------------------------------------------------------------------
+
+
+def test_dns_ensure_ok_round_trip() -> None:
+    env = DnsEnsureEnvelope(
+        status="ok",
+        data=DnsEnsureData(
+            domain="example.com",
+            zone_id="abc123",
+            ns_pair=["walt.ns.cloudflare.com", "sara.ns.cloudflare.com"],
+            zone_created_now=True,
+            registrar="porkbun",
+            ns_swap_performed=True,
+            propagated=True,
+            propagation_seconds=143,
+        ),
+        provenance={
+            "cf_zone_create": ProviderRunMetadata(
+                status="ok", latency_ms=512, provider_version="cloudflare-api-v4"
+            ),
+            "porkbun_update_ns": ProviderRunMetadata(
+                status="ok", latency_ms=812, provider_version="porkbun-api-v3"
+            ),
+            "dns_propagation_poll": ProviderRunMetadata(
+                status="ok", latency_ms=143000, provider_version="dig+1.1.1.1"
+            ),
+        },
+    )
+    parsed = DnsEnsureEnvelope.model_validate_json(env.model_dump_json())
+    assert parsed.data.zone_created_now is True
+    assert parsed.data.ns_swap_performed is True
+    assert len(parsed.data.ns_pair) == 2
+    assert parsed.data.propagation_seconds == 143
+
+
+def test_dns_ensure_idempotent_no_swap() -> None:
+    """Idempotent path: zone already existed, NS already correct, no work performed."""
+    env = DnsEnsureEnvelope(
+        status="ok",
+        data=DnsEnsureData(
+            domain="example.com",
+            zone_id="abc123",
+            ns_pair=["walt.ns.cloudflare.com", "sara.ns.cloudflare.com"],
+            zone_created_now=False,
+            registrar="cloudflare",
+            ns_swap_performed=False,
+            propagated=True,
+            propagation_seconds=2,
+        ),
+    )
+    assert env.data.zone_created_now is False
+    assert env.data.ns_swap_performed is False
+
+
+def test_dns_ensure_error_codes_closed() -> None:
+    with pytest.raises(ValidationError):
+        DnsEnsureError(code="not_a_real_dns_code", message="x")  # type: ignore[arg-type]
+
+
+def test_dns_ensure_invalid_domain_envelope() -> None:
+    env = DnsEnsureEnvelope(
+        status="degraded",
+        data=DnsEnsureData(domain="not a valid domain"),
+        error=DnsEnsureError(
+            code="invalid_domain",
+            message="Domain doesn't look valid.",
+            suggestion="Pass a registrable apex.",
+        ),
+    )
+    assert env.error is not None
+    assert env.error.code == "invalid_domain"
+
+
+def test_cf_classify_zone_already_exists() -> None:
+    """Code 1097 → zone_already_exists with manual-cleanup suggestion."""
+    result = CfResult(ok=False, latency_ms=100, status_code=400, error_code=1097, error_message="zone exists")
+    code, suggestion = _cf_classify_error(result)
+    assert code == "zone_already_exists"
+    assert "another Cloudflare account" in suggestion
+
+
+def test_cf_classify_unauthenticated_401() -> None:
+    result = CfResult(ok=False, latency_ms=50, status_code=401, error_message="bad auth")
+    code, suggestion = _cf_classify_error(result)
+    assert code == "cf_unauthenticated"
+    assert "CLOUDFLARE_API_TOKEN" in suggestion
+
+
+def test_cf_classify_unauthenticated_by_code() -> None:
+    """Code 10000 (auth) → cf_unauthenticated even on http 200."""
+    result = CfResult(ok=False, latency_ms=50, status_code=200, error_code=10000, error_message="invalid")
+    code, _ = _cf_classify_error(result)
+    assert code == "cf_unauthenticated"
+
+
+def test_cf_classify_rate_limited_429() -> None:
+    result = CfResult(ok=False, latency_ms=50, status_code=429, error_message="too many")
+    code, suggestion = _cf_classify_error(result)
+    assert code == "cf_rate_limited"
+    assert "back off" in suggestion.lower()
+
+
+def test_cf_classify_timeout() -> None:
+    result = CfResult(ok=False, latency_ms=30000, status_code=0, error_message="timeout")
+    code, _ = _cf_classify_error(result)
+    assert code == "network_timeout"
+
+
+def test_cf_classify_generic_failure() -> None:
+    """Unrecognized failure shape → cf_request_failed (not silent ok)."""
+    result = CfResult(ok=False, latency_ms=50, status_code=500, error_code=9999, error_message="boom")
+    code, suggestion = _cf_classify_error(result)
+    assert code == "cf_request_failed"
+    assert "9999" in suggestion or "500" in suggestion
+
+
+def test_detect_registrar_explicit_wins() -> None:
+    reg, err = _detect_registrar("porkbun")
+    assert reg == "porkbun"
+    assert err is None
+
+
+def test_detect_registrar_cf_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CLOUDFLARE_API_TOKEN_REGISTRAR", "fake")
+    monkeypatch.delenv("PORKBUN_API_KEY", raising=False)
+    monkeypatch.delenv("PORKBUN_SECRET_KEY", raising=False)
+    reg, err = _detect_registrar(None)
+    assert reg == "cloudflare"
+    assert err is None
+
+
+def test_detect_registrar_porkbun_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("CLOUDFLARE_API_TOKEN_REGISTRAR", raising=False)
+    monkeypatch.setenv("PORKBUN_API_KEY", "k")
+    monkeypatch.setenv("PORKBUN_SECRET_KEY", "s")
+    reg, err = _detect_registrar(None)
+    assert reg == "porkbun"
+    assert err is None
+
+
+def test_detect_registrar_neither_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("CLOUDFLARE_API_TOKEN_REGISTRAR", raising=False)
+    monkeypatch.delenv("PORKBUN_API_KEY", raising=False)
+    monkeypatch.delenv("PORKBUN_SECRET_KEY", raising=False)
+    reg, err = _detect_registrar(None)
+    assert reg is None
+    assert err is not None
+    assert err.code == "registrar_required"
 
 
 if __name__ == "__main__":

--- a/.claude/skills/site/scripts/verify_live.py
+++ b/.claude/skills/site/scripts/verify_live.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""verify_live.py — read-only live smoke test for /site atoms.
+
+Exercises every external dependency the atoms touch, without spending money
+or making state changes. Run this after credentials are provisioned in
+~/.config/vip/env.sh to confirm all upstreams reach success before merging.
+
+Checks:
+  1. domain-check brew CLI: live RDAP query (free).
+  2. Cloudflare API auth: lists zones in the account (read-only).
+  3. Cloudflare zone lookup: GET /zones?name=<test domain> (read-only).
+  4. Porkbun API auth: POST /ping with the keys (read-only; returns yourIp).
+
+Required env (load with `source ~/.config/vip/env.sh` first):
+  CLOUDFLARE_API_TOKEN  — Zone:Read + DNS:Read minimum (Edit preferred)
+  CF_ACCOUNT_ID         — find in dash.cloudflare.com → right sidebar
+  PORKBUN_API_KEY
+  PORKBUN_SECRET_KEY
+
+Optional env:
+  VERIFY_LIVE_CF_ZONE   — domain to lookup at Cloudflare (default: howdy.md)
+
+Exit code: 0 if all checks pass, 1 if any fail.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import requests
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _envelope import log  # noqa: E402
+
+# ---------------------------------------------------------------------------
+
+CF_API_BASE = "https://api.cloudflare.com/client/v4"
+PORKBUN_API_BASE = "https://api.porkbun.com/api/json/v3"
+DEFAULT_CF_ZONE = os.environ.get("VERIFY_LIVE_CF_ZONE", "howdy.md")
+
+GREEN = "\033[32m"
+RED = "\033[31m"
+YELLOW = "\033[33m"
+DIM = "\033[2m"
+RESET = "\033[0m"
+
+
+def _ok(msg: str) -> None:
+    print(f"{GREEN}✓{RESET} {msg}")
+
+
+def _fail(msg: str) -> None:
+    print(f"{RED}✗{RESET} {msg}")
+
+
+def _info(msg: str) -> None:
+    print(f"{DIM}  {msg}{RESET}")
+
+
+def check_domain_check_cli() -> bool:
+    print(f"\n{YELLOW}[1/4] domain-check brew CLI{RESET}")
+    try:
+        proc = subprocess.run(
+            ["domain-check", "google.com", "--json", "--yes"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except FileNotFoundError:
+        _fail("domain-check not on PATH")
+        _info("Fix: brew install domain-check")
+        return False
+    except subprocess.TimeoutExpired:
+        _fail("domain-check timed out (30s)")
+        return False
+
+    if proc.returncode != 0:
+        _fail(f"domain-check exit {proc.returncode}: {proc.stderr.strip()[:200]}")
+        return False
+
+    try:
+        rows = json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        _fail("domain-check returned non-JSON")
+        return False
+
+    if not rows or not isinstance(rows, list):
+        _fail(f"domain-check unexpected shape: {type(rows).__name__}")
+        return False
+
+    google = rows[0]
+    if google.get("available") is True:
+        _fail("google.com reported as AVAILABLE — RDAP lookup is broken")
+        return False
+
+    _ok(f"domain-check works: google.com → TAKEN (method={google.get('method_used')})")
+    return True
+
+
+def check_cf_auth() -> bool:
+    print(f"\n{YELLOW}[2/4] Cloudflare API auth (token + account){RESET}")
+    token = os.environ.get("CLOUDFLARE_API_TOKEN")
+    account_id = os.environ.get("CF_ACCOUNT_ID")
+
+    if not token:
+        _fail("CLOUDFLARE_API_TOKEN not set")
+        _info("Fix: create token at https://dash.cloudflare.com/profile/api-tokens")
+        _info("     Permissions: Zone:Read (minimum), Zone:Edit + DNS:Edit (preferred)")
+        _info("     Add to ~/.config/vip/env.sh: export CLOUDFLARE_API_TOKEN=...")
+        return False
+
+    if not account_id:
+        _fail("CF_ACCOUNT_ID not set")
+        _info("Fix: find it in dash.cloudflare.com → right sidebar of any zone")
+        _info("     Add to ~/.config/vip/env.sh: export CF_ACCOUNT_ID=...")
+        return False
+
+    headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+    start = time.monotonic()
+    try:
+        resp = requests.get(
+            f"{CF_API_BASE}/user/tokens/verify", headers=headers, timeout=15
+        )
+    except requests.RequestException as exc:
+        _fail(f"network error contacting Cloudflare: {exc}")
+        return False
+
+    latency_ms = int((time.monotonic() - start) * 1000)
+
+    if resp.status_code != 200:
+        _fail(f"token verify returned HTTP {resp.status_code}")
+        try:
+            errors = resp.json().get("errors", [])
+            for err in errors:
+                _info(f"  cf code {err.get('code')}: {err.get('message')}")
+        except ValueError:
+            pass
+        _info("Fix: regenerate token with correct scopes")
+        return False
+
+    try:
+        body = resp.json()
+    except ValueError:
+        _fail("CF returned non-JSON for token verify")
+        return False
+
+    status = body.get("result", {}).get("status")
+    if status != "active":
+        _fail(f"token verify status: {status} (expected 'active')")
+        return False
+
+    _ok(f"CF token verified ({latency_ms}ms): status=active")
+    _ok(f"CF_ACCOUNT_ID set: {account_id[:8]}…")
+    return True
+
+
+def check_cf_zone_lookup() -> bool:
+    print(f"\n{YELLOW}[3/4] Cloudflare zone lookup ({DEFAULT_CF_ZONE}){RESET}")
+    token = os.environ.get("CLOUDFLARE_API_TOKEN")
+    account_id = os.environ.get("CF_ACCOUNT_ID")
+
+    if not token or not account_id:
+        _fail("Skipped — CF auth check failed")
+        return False
+
+    headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+    start = time.monotonic()
+    try:
+        resp = requests.get(
+            f"{CF_API_BASE}/zones",
+            headers=headers,
+            params={"name": DEFAULT_CF_ZONE, "account.id": account_id},
+            timeout=15,
+        )
+    except requests.RequestException as exc:
+        _fail(f"network error: {exc}")
+        return False
+
+    latency_ms = int((time.monotonic() - start) * 1000)
+
+    if resp.status_code != 200:
+        _fail(f"zone lookup returned HTTP {resp.status_code}")
+        try:
+            for err in resp.json().get("errors", []):
+                _info(f"  cf code {err.get('code')}: {err.get('message')}")
+        except ValueError:
+            pass
+        return False
+
+    try:
+        body = resp.json()
+    except ValueError:
+        _fail("non-JSON response")
+        return False
+
+    if not body.get("success"):
+        _fail("zone lookup unsuccessful")
+        return False
+
+    zones = body.get("result") or []
+    if not zones:
+        _info(f"No zone found for {DEFAULT_CF_ZONE} in account {account_id[:8]}…")
+        _info(f"Override with: VERIFY_LIVE_CF_ZONE=<some-domain-you-own> python3 verify_live.py")
+        _info("(This is informational, not a failure — the API call succeeded.)")
+        _ok(f"CF zone lookup endpoint works ({latency_ms}ms, 0 results)")
+        return True
+
+    zone = zones[0]
+    ns_pair = zone.get("name_servers") or []
+    _ok(f"CF zone lookup works ({latency_ms}ms): id={zone.get('id', '')[:12]}…")
+    _ok(f"  zone status: {zone.get('status')}, ns: {ns_pair}")
+    return True
+
+
+def check_porkbun_ping() -> bool:
+    print(f"\n{YELLOW}[4/4] Porkbun API auth (POST /ping){RESET}")
+    api_key = os.environ.get("PORKBUN_API_KEY")
+    secret_key = os.environ.get("PORKBUN_SECRET_KEY")
+
+    if not api_key or not secret_key:
+        _fail("PORKBUN_API_KEY and/or PORKBUN_SECRET_KEY not set")
+        _info("Fix: create keys at https://porkbun.com/account/api")
+        _info("     Add both to ~/.config/vip/env.sh:")
+        _info("       export PORKBUN_API_KEY=pk1_...")
+        _info("       export PORKBUN_SECRET_KEY=sk1_...")
+        return False
+
+    start = time.monotonic()
+    try:
+        resp = requests.post(
+            f"{PORKBUN_API_BASE}/ping",
+            json={"apikey": api_key, "secretapikey": secret_key},
+            timeout=15,
+        )
+    except requests.RequestException as exc:
+        _fail(f"network error: {exc}")
+        _info("If the URL in the error references porkbun.com (not api.porkbun.com), the host fix didn't apply.")
+        return False
+
+    latency_ms = int((time.monotonic() - start) * 1000)
+
+    try:
+        body = resp.json()
+    except ValueError:
+        _fail(f"non-JSON response (HTTP {resp.status_code})")
+        return False
+
+    if body.get("status") != "SUCCESS":
+        _fail(f"Porkbun rejected ping: {body.get('message', 'unknown')}")
+        return False
+
+    _ok(f"Porkbun /ping works ({latency_ms}ms): yourIp={body.get('yourIp')}")
+    _ok(f"  host pinned correctly to api.porkbun.com")
+    return True
+
+
+def main() -> int:
+    print(f"{YELLOW}=== /site atoms — live verification ==={RESET}")
+    print(f"{DIM}Read-only smoke test. No state changes, no spending.{RESET}")
+    print(f"{DIM}Run after `source ~/.config/vip/env.sh`.{RESET}")
+
+    results = [
+        ("domain-check CLI", check_domain_check_cli()),
+        ("Cloudflare auth", check_cf_auth()),
+        ("Cloudflare zone lookup", check_cf_zone_lookup()),
+        ("Porkbun ping", check_porkbun_ping()),
+    ]
+
+    print(f"\n{YELLOW}=== Summary ==={RESET}")
+    failed = 0
+    for name, ok in results:
+        marker = f"{GREEN}✓{RESET}" if ok else f"{RED}✗{RESET}"
+        print(f"  {marker} {name}")
+        if not ok:
+            failed += 1
+
+    print()
+    if failed == 0:
+        print(f"{GREEN}All 4 checks passed. Atoms are live-ready.{RESET}")
+        return 0
+    print(f"{RED}{failed}/4 checks failed.{RESET} See messages above.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/site/scripts/verify_live.py
+++ b/.claude/skills/site/scripts/verify_live.py
@@ -18,7 +18,7 @@ Required env (load with `source ~/.config/vip/env.sh` first):
   PORKBUN_SECRET_KEY
 
 Optional env:
-  VERIFY_LIVE_CF_ZONE   — domain to lookup at Cloudflare (default: howdy.md)
+  VERIFY_LIVE_CF_ZONE   — domain to lookup at Cloudflare (default: thelastbill.com)
 
 Exit code: 0 if all checks pass, 1 if any fail.
 """
@@ -41,7 +41,7 @@ from _envelope import log  # noqa: E402
 
 CF_API_BASE = "https://api.cloudflare.com/client/v4"
 PORKBUN_API_BASE = "https://api.porkbun.com/api/json/v3"
-DEFAULT_CF_ZONE = os.environ.get("VERIFY_LIVE_CF_ZONE", "howdy.md")
+DEFAULT_CF_ZONE = os.environ.get("VERIFY_LIVE_CF_ZONE", "thelastbill.com")
 
 GREEN = "\033[32m"
 RED = "\033[31m"
@@ -126,7 +126,7 @@ def _surface_cf_errors(body: dict | None) -> None:
 
 
 def check_cf_auth() -> bool:
-    """Verify token has the three account-level scopes paidup.us needs.
+    """Verify the token has the three scopes the CF-registered chassis path needs.
 
     Note: we don't use /user/tokens/verify — that endpoint is for User-scoped
     tokens only and returns code 1000 ('Invalid API Token') for Account-scoped
@@ -247,15 +247,15 @@ def check_cf_zone_lookup() -> bool:
 
 
 def check_porkbun_ping() -> bool | None:
-    """Returns None when Porkbun keys absent (skip, not fail) — paidup.us is CF-only."""
+    """Returns None when Porkbun keys absent (skip, not fail) — CF-registered path doesn't touch Porkbun."""
     print(f"\n{YELLOW}[4/4] Porkbun API auth (POST /ping){RESET}")
     api_key = os.environ.get("PORKBUN_API_KEY")
     secret_key = os.environ.get("PORKBUN_SECRET_KEY")
 
     if not api_key or not secret_key:
         print(f"{DIM}  Skipped — PORKBUN_API_KEY / PORKBUN_SECRET_KEY not set.{RESET}")
-        print(f"{DIM}  Not needed for the paidup.us CF-only test path. Add only if{RESET}")
-        print(f"{DIM}  you want to exercise dns.py's Porkbun NS-swap branch.{RESET}")
+        print(f"{DIM}  Not needed for the CF-registered path. Add only if you want to{RESET}")
+        print(f"{DIM}  exercise dns.py's Porkbun NS-swap branch.{RESET}")
         return None
 
     start = time.monotonic()
@@ -304,7 +304,7 @@ def main() -> int:
     skipped = 0
     for name, ok in results:
         if ok is None:
-            print(f"  {DIM}—{RESET} {name} {DIM}(skipped — not needed for paidup.us){RESET}")
+            print(f"  {DIM}—{RESET} {name} {DIM}(skipped — not needed for CF-registered path){RESET}")
             skipped += 1
         elif ok:
             print(f"  {GREEN}✓{RESET} {name}")
@@ -319,7 +319,7 @@ def main() -> int:
         msg = f"{passed}/{total} passed"
         if skipped:
             msg += f" ({skipped} skipped)"
-        print(f"{GREEN}{msg} — atoms are live-ready for the paidup.us CF-only flow.{RESET}")
+        print(f"{GREEN}{msg} — atoms are live-ready for the CF-registered flow.{RESET}")
         return 0
     print(f"{RED}{failed}/{total} checks failed.{RESET} See messages above.")
     return 1

--- a/.claude/skills/site/scripts/verify_live.py
+++ b/.claude/skills/site/scripts/verify_live.py
@@ -102,15 +102,43 @@ def check_domain_check_cli() -> bool:
     return True
 
 
+def _cf_get(path: str) -> tuple[int, dict | None, int]:
+    """GET against Cloudflare's API. Returns (status_code, body, latency_ms)."""
+    token = os.environ.get("CLOUDFLARE_API_TOKEN", "")
+    headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+    start = time.monotonic()
+    try:
+        resp = requests.get(f"{CF_API_BASE}{path}", headers=headers, timeout=15)
+    except requests.RequestException as exc:
+        return 0, {"_network_error": str(exc)}, int((time.monotonic() - start) * 1000)
+    latency_ms = int((time.monotonic() - start) * 1000)
+    try:
+        return resp.status_code, resp.json(), latency_ms
+    except ValueError:
+        return resp.status_code, None, latency_ms
+
+
+def _surface_cf_errors(body: dict | None) -> None:
+    if not body:
+        return
+    for err in (body.get("errors") or []):
+        _info(f"  cf code {err.get('code')}: {err.get('message')}")
+
+
 def check_cf_auth() -> bool:
-    print(f"\n{YELLOW}[2/4] Cloudflare API auth (token + account){RESET}")
+    """Verify token has the three account-level scopes paidup.us needs.
+
+    Note: we don't use /user/tokens/verify — that endpoint is for User-scoped
+    tokens only and returns code 1000 ('Invalid API Token') for Account-scoped
+    tokens. Instead, we hit the actual scope endpoints and check the responses.
+    """
+    print(f"\n{YELLOW}[2/4] Cloudflare API scopes (Registrar + Pages + Zone){RESET}")
     token = os.environ.get("CLOUDFLARE_API_TOKEN")
     account_id = os.environ.get("CF_ACCOUNT_ID")
 
     if not token:
         _fail("CLOUDFLARE_API_TOKEN not set")
         _info("Fix: create token at https://dash.cloudflare.com/profile/api-tokens")
-        _info("     Permissions: Zone:Read (minimum), Zone:Edit + DNS:Edit (preferred)")
         _info("     Add to ~/.config/vip/env.sh: export CLOUDFLARE_API_TOKEN=...")
         return False
 
@@ -120,43 +148,44 @@ def check_cf_auth() -> bool:
         _info("     Add to ~/.config/vip/env.sh: export CF_ACCOUNT_ID=...")
         return False
 
-    headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
-    start = time.monotonic()
-    try:
-        resp = requests.get(
-            f"{CF_API_BASE}/user/tokens/verify", headers=headers, timeout=15
-        )
-    except requests.RequestException as exc:
-        _fail(f"network error contacting Cloudflare: {exc}")
-        return False
+    all_pass = True
 
-    latency_ms = int((time.monotonic() - start) * 1000)
+    # --- Registrar Domains (Admin) ---
+    status, body, lat = _cf_get(f"/accounts/{account_id}/registrar/domains")
+    if status == 200 and body and body.get("success"):
+        count = len(body.get("result") or [])
+        _ok(f"Registrar Domains:Admin works ({lat}ms, {count} domains in account)")
+    else:
+        _fail(f"Registrar Domains:Admin probe returned HTTP {status}")
+        _surface_cf_errors(body)
+        _info("Fix: token policy 1 must include Cloudflare Registrar:Admin (Entire Account scope)")
+        all_pass = False
 
-    if resp.status_code != 200:
-        _fail(f"token verify returned HTTP {resp.status_code}")
-        try:
-            errors = resp.json().get("errors", [])
-            for err in errors:
-                _info(f"  cf code {err.get('code')}: {err.get('message')}")
-        except ValueError:
-            pass
-        _info("Fix: regenerate token with correct scopes")
-        return False
+    # --- Pages Projects (Edit) ---
+    status, body, lat = _cf_get(f"/accounts/{account_id}/pages/projects")
+    if status == 200 and body and body.get("success"):
+        count = len(body.get("result") or [])
+        _ok(f"Cloudflare Pages:Edit works ({lat}ms, {count} projects in account)")
+    else:
+        _fail(f"Cloudflare Pages:Edit probe returned HTTP {status}")
+        _surface_cf_errors(body)
+        _info("Fix: token policy 1 must include Cloudflare Pages:Edit (Entire Account scope)")
+        all_pass = False
 
-    try:
-        body = resp.json()
-    except ValueError:
-        _fail("CF returned non-JSON for token verify")
-        return False
+    # --- Zone:Read (verifies the second policy is wired) ---
+    status, body, lat = _cf_get(f"/zones?account.id={account_id}&per_page=1")
+    if status == 200 and body and body.get("success"):
+        count = body.get("result_info", {}).get("total_count", 0)
+        _ok(f"Zone:Read works ({lat}ms, {count} zones in account)")
+    else:
+        _fail(f"Zone:Read probe returned HTTP {status}")
+        _surface_cf_errors(body)
+        _info("Fix: token policy 2 must include Zone:Read+Edit (All Domains scope)")
+        all_pass = False
 
-    status = body.get("result", {}).get("status")
-    if status != "active":
-        _fail(f"token verify status: {status} (expected 'active')")
-        return False
-
-    _ok(f"CF token verified ({latency_ms}ms): status=active")
-    _ok(f"CF_ACCOUNT_ID set: {account_id[:8]}…")
-    return True
+    if all_pass:
+        _ok(f"CF_ACCOUNT_ID confirmed: {account_id[:8]}…")
+    return all_pass
 
 
 def check_cf_zone_lookup() -> bool:
@@ -217,18 +246,17 @@ def check_cf_zone_lookup() -> bool:
     return True
 
 
-def check_porkbun_ping() -> bool:
+def check_porkbun_ping() -> bool | None:
+    """Returns None when Porkbun keys absent (skip, not fail) — paidup.us is CF-only."""
     print(f"\n{YELLOW}[4/4] Porkbun API auth (POST /ping){RESET}")
     api_key = os.environ.get("PORKBUN_API_KEY")
     secret_key = os.environ.get("PORKBUN_SECRET_KEY")
 
     if not api_key or not secret_key:
-        _fail("PORKBUN_API_KEY and/or PORKBUN_SECRET_KEY not set")
-        _info("Fix: create keys at https://porkbun.com/account/api")
-        _info("     Add both to ~/.config/vip/env.sh:")
-        _info("       export PORKBUN_API_KEY=pk1_...")
-        _info("       export PORKBUN_SECRET_KEY=sk1_...")
-        return False
+        print(f"{DIM}  Skipped — PORKBUN_API_KEY / PORKBUN_SECRET_KEY not set.{RESET}")
+        print(f"{DIM}  Not needed for the paidup.us CF-only test path. Add only if{RESET}")
+        print(f"{DIM}  you want to exercise dns.py's Porkbun NS-swap branch.{RESET}")
+        return None
 
     start = time.monotonic()
     try:
@@ -266,24 +294,34 @@ def main() -> int:
 
     results = [
         ("domain-check CLI", check_domain_check_cli()),
-        ("Cloudflare auth", check_cf_auth()),
+        ("Cloudflare scopes", check_cf_auth()),
         ("Cloudflare zone lookup", check_cf_zone_lookup()),
         ("Porkbun ping", check_porkbun_ping()),
     ]
 
     print(f"\n{YELLOW}=== Summary ==={RESET}")
     failed = 0
+    skipped = 0
     for name, ok in results:
-        marker = f"{GREEN}✓{RESET}" if ok else f"{RED}✗{RESET}"
-        print(f"  {marker} {name}")
-        if not ok:
+        if ok is None:
+            print(f"  {DIM}—{RESET} {name} {DIM}(skipped — not needed for paidup.us){RESET}")
+            skipped += 1
+        elif ok:
+            print(f"  {GREEN}✓{RESET} {name}")
+        else:
+            print(f"  {RED}✗{RESET} {name}")
             failed += 1
 
+    total = len(results)
+    passed = total - failed - skipped
     print()
     if failed == 0:
-        print(f"{GREEN}All 4 checks passed. Atoms are live-ready.{RESET}")
+        msg = f"{passed}/{total} passed"
+        if skipped:
+            msg += f" ({skipped} skipped)"
+        print(f"{GREEN}{msg} — atoms are live-ready for the paidup.us CF-only flow.{RESET}")
         return 0
-    print(f"{RED}{failed}/4 checks failed.{RESET} See messages above.")
+    print(f"{RED}{failed}/{total} checks failed.{RESET} See messages above.")
     return 1
 
 


### PR DESCRIPTION
## Summary

Third atom for #93: `dns.py ensure <domain>` — idempotent CF zone management with optional registrar-level NS swap. Plus the supporting atom-layer infrastructure (live-verify script, creds helper) and two audit follow-ups (Porkbun host, CF auth classifier).

End-to-end live-tested against `thelastbill.com` (CF-registered mid-PR).

## What's in this PR

**`.claude/skills/site/scripts/dns.py` — the headline atom**

```
dns.py ensure <domain> [--registrar cloudflare|porkbun] [--timeout-seconds N] [--skip-propagation-poll]
```

- Looks up existing CF zone; reuses if present (`zone_created_now: false`), creates via `POST /zones` if missing.
- For Porkbun-registered: pushes the CF nameserver pair to `POST /domain/updateNs/{domain}`. CF-registered domains skip the swap (NS auto-set by registrar API).
- Polls `dig +short NS @1.1.1.1` every 5–30s until both CF nameservers resolve, or `propagation_timeout` after `--timeout-seconds`.
- 4 upstream calls instrumented with `ProviderRunMetadata` (latency + status + provider_version).
- 13 closed-enum error codes; every degraded path returns a structured envelope with an actionable `suggestion`.

**`_cf_classify_error` — closed-enum mapping**

| Upstream signal | Code |
|---|---|
| 1097 (zone in another account) | `zone_already_exists` + manual-cleanup suggestion |
| 401 / cf code 10000–10001 / 9106 / 9107 / 9109 / 6003 / 6111 | `cf_unauthenticated` |
| 429 | `cf_rate_limited` |
| Network timeout | `network_timeout` |
| Anything else | `cf_request_failed` (verbatim http + cf code in suggestion) |

**Audit follow-ups (caught before merge):**

- **Porkbun host fix:** `PORKBUN_API_BASE = "https://api.porkbun.com/api/json/v3"` (was `https://porkbun.com/...` which silently 403's). Pinned by `test_porkbun_api_base_pinned_to_correct_host` + `test_porkbun_update_ns_url_construction`.
- **CF auth classifier expansion:** 9106/9107 (legacy auth missing), 9109 (revoked token), 6003/6111 (malformed Authorization header) all now map to `cf_unauthenticated` instead of falling through to `cf_request_failed`. Parametrized test covers all five (http_status, cf_code) pairs.

**Live verification harness:**

- **`verify_live.py`** — read-only smoke test of every upstream the atoms touch: `domain-check` brew CLI, CF Registrar+Pages+Zone scopes, optional Porkbun `/ping`. Each scope probed against its actual endpoint (no `/user/tokens/verify` — that's User-token only and false-negatives Account-tokens). Becomes the merge gate going forward.
- **`setup_creds.sh`** — one-shot interactive script for writing `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_API_TOKEN_REGISTRAR` + `CF_ACCOUNT_ID` into `~/.config/vip/env.sh`. Hidden token prompt, idempotent (replaces existing lines, doesn't duplicate), `chmod 600`.

**`domain.py` drive-by fix (audit follow-up from #95):**

`DOMAIN_CHECK_BIN = shutil.which("domain-check") or "/opt/homebrew/bin/domain-check"` so Intel Mac (`/usr/local/bin/`), Linux Homebrew, and custom-prefix users find the binary.

## Live integration — end-to-end on `thelastbill.com`

| Run | zone_created_now | ns_swap_performed | propagated | propagation_seconds | total |
|---|---|---|---|---|---|
| `dns.py ensure ... --skip-propagation-poll` | false | false | false | null | 249ms |
| `dns.py ensure ...` (with poll, timeout 60s) | false | false | **true** | **0** | 271ms |

For freshly-CF-registered `.com` domains, NS resolves at the global TLD level immediately — no propagation wait window needed. `dig +short NS thelastbill.com @1.1.1.1` returned both CF nameservers on the first attempt.

`verify_live.py` against the live Noontide account: **3/3 passed** (Registrar:Admin, Pages:Edit, Zone:Read), Porkbun gracefully skipped (no keys, not needed for the CF-registered path).

## Test plan

- [x] `python3 -m pytest .claude/skills/site/scripts/test_atoms.py -v` — **33/33 pass** (11 carried from #95 + 22 new for dns + audit fixes)
- [x] CLI `--help` reads cleanly for `dns.py ensure`
- [x] All five CLI error paths emit valid envelopes (`invalid_domain`, `cf_unauthenticated`, `cf_account_id_missing`, `registrar_required`, plus the live-tested ok path)
- [x] Live integration: `dns.py ensure thelastbill.com --registrar cloudflare` end-to-end green (with and without propagation poll)
- [x] `verify_live.py`: 3/3 pass + 1 skip (Porkbun)
- [x] `bash ~/.claude/skills/test-skills/test-skills.sh` — 152/162 (10 pre-existing, 0 introduced)
- [ ] Live: Porkbun branch of `dns.py ensure` — pending until a Porkbun-registered domain shows up in the chain

## What this unlocks

- `pages.py set-domain` (atom 4) reuses `_cf_call` and `_cf_classify_error` directly. Same shape: code + tests + live verification before merge.
- `domain.py buy --registrar=cloudflare` body shape is now known live (`domain_name`, `years`, `privacy_mode: "redaction"`, `auto_renew`). Wires into a follow-up PR.
- `thelastbill.com` is registered, zone is active in Noontide CF account, NS at `celeste.ns.cloudflare.com / malcolm.ns.cloudflare.com`. Ready for Pages project attachment in atom 4.

## Notes

- Existing VIP flows untouched — every change is in `.claude/skills/site/scripts/`.
- No new dependencies; uses `pydantic`, `click`, and `requests` already in the environment.
- v2 migration (`mb` umbrella per `noontide-co/projects#82`): mechanical rename, no logic change.

Refs #93, #94. Builds on #95.