### PR TITLE
[update] /site — lander template branch (static HTML + generation subagent, atoms-driven)

### DIFF
--- a/.claude/skills/site/SKILL.md
+++ b/.claude/skills/site/SKILL.md
@@ -201,11 +201,16 @@ Present options:
 
 > **Which template fits your business?**
 >
-> 1. **SaaS / Product** — Hero → Demo → Value Prop → Workflow → Examples → Integrations → CTA
->    Best for: software, e-commerce, product companies
+> 1. **SaaS / Product** (Next.js) — Hero → Demo → Value Prop → Workflow → Examples → Integrations → CTA
+>    Best for: software, e-commerce, product companies. Has a build step.
 >
-> 2. **High-Ticket Services** — Hero → Solution → Pain → Process → Competitive → Objections → Proof → Qualification → FAQ → CTA
->    Best for: coaching, consulting, agencies, $3k+ services
+> 2. **High-Ticket Services** (Next.js) — Hero → Solution → Pain → Process → Competitive → Objections → Proof → Qualification → FAQ → CTA
+>    Best for: coaching, consulting, agencies, $3k+ services. Has a build step.
+>
+> 3. **Lander** (static HTML) — 4 pages designed fresh per offer by an LLM-generation subagent. No build step. No template inheritance.
+>    Best for: speedrun lander tests, paid-ad landing pages, single-offer first deploys. **Picks Cloudflare Pages + atom-driven domain setup.** See "Lander Template Branch" below.
+
+If `lander` is chosen, **skip Steps 2–11 below and go to "Lander Template Branch"** — that flow uses Cloudflare Pages + atoms, not Netlify + Next.js. The existing Steps 2–11 apply only to `saas` / `high-ticket`.
 
 ### Step 2: Name and Location
 
@@ -296,6 +301,121 @@ Create `~/.mainbranch/` directory if it doesn't exist.
 **Exit:**
 
 > "Site deployed at https://[url]. Run `/site configure` to apply your brand, or `/site build` to start customizing sections from your reference files."
+
+---
+
+## Lander Template Branch
+
+When the operator picked the `lander` template in Step 1, the setup and build flows are different from the Next.js templates above. Static HTML, no build step, Cloudflare Pages, atom-driven domain + DNS + custom-domain attachment.
+
+### setup (lander)
+
+**1. Name + project repo.** Ask the operator:
+- Site name (e.g., `thelastbill`). Becomes the Pages project name.
+- Project repo location (default: sibling of vip — `~/Documents/GitHub/<name>` for solo, `~/Documents/GitHub/noontide-sites/<name>` for Noontide work). Empty repo, no template merge.
+- Apex domain. If they don't have one, route to [`references/naming-heuristic.md`](references/naming-heuristic.md) — an 8-step playbook for generating + validating brand-tier names.
+
+**2. Atom-chain prerequisites.** Confirm the credentials are in place via:
+```bash
+source ~/.config/vip/env.sh
+python3 .claude/skills/site/scripts/verify_live.py
+```
+Expect 3/3 passed (Cloudflare scopes + zone lookup + domain-check CLI). Porkbun skipped is fine for the CF-registered path.
+
+If anything's red, route the operator to `bash .claude/skills/site/scripts/setup_creds.sh` to provision Cloudflare credentials, then re-run.
+
+**3. Domain — buy-new vs. existing.** Ask:
+- "Already own the domain?" → skip to step 4 with the domain name
+- "Need to buy?" → run `python3 .claude/skills/site/scripts/domain.py check <name> --tlds .com,.co,.io` first to confirm availability + TLD support. If `extension_not_supported_via_api`, fall back to the Cloudflare dashboard (https://dash.cloudflare.com/registrar — confirm the right account before purchase). For API-supported TLDs and after explicit operator Y on price, proceed with `domain.py buy <name>` — *will be wired in a follow-up PR; today the buy is dashboard for the first lander, then API once `domain.py buy --registrar=cloudflare` lands*.
+
+**4. DNS ensure.** Once the domain is owned (CF Registrar or Porkbun), run:
+```bash
+python3 .claude/skills/site/scripts/dns.py ensure <domain> --registrar cloudflare --skip-propagation-poll
+```
+For CF-registered domains the zone is auto-created with NS already at CF — this is an idempotent verification, not a state change. For Porkbun-registered domains, the atom swaps NS to CF nameservers and polls propagation.
+
+**5. GitHub repo + initial scaffold push.** Create the project repo and push a placeholder `index.html` so the Pages project has something to deploy:
+```bash
+gh repo create <owner>/<name> --public --add-readme
+git clone https://github.com/<owner>/<name>.git ~/Documents/GitHub/<name>
+cd ~/Documents/GitHub/<name>
+echo '<!doctype html><title><name></title><h1>soon</h1>' > index.html
+git add -A && git commit -m "[add] placeholder" && git push
+```
+
+**6. Cloudflare Pages project.** Create via wrangler (no dashboard click needed):
+```bash
+wrangler pages project create <name> --production-branch main
+wrangler pages deploy . --project-name <name> --branch main
+```
+This deploys the placeholder to `https://<hash>.<name>.pages.dev`. The git-source connection (auto-deploy on push) is added by `pages.py create-project` once **#98** ships; until then, manual `wrangler pages deploy` after each push, or one-time UI walkthrough at [`references/cloudflare-pages-link.md`](references/cloudflare-pages-link.md).
+
+**7. Custom domain attach + DNS verification.** Run:
+```bash
+python3 .claude/skills/site/scripts/pages.py set-domain <name> <domain> --timeout-seconds 300
+```
+The atom attaches the domain, creates the CNAME record in the zone (the step the dashboard hides), and polls until SSL is active. Expect ~3-4 min total. Live-tested end-to-end in PR #97.
+
+**8. Save config.** Same `~/.mainbranch/sites.json` structure as the Next.js path:
+```json
+{
+  "name": "<name>",
+  "site_repo": "/absolute/path/to/repo",
+  "business_repo": "/absolute/path/to/business-repo",
+  "template": "lander",
+  "hosting": "cloudflare",
+  "domain": "<full apex>"
+}
+```
+
+**Exit:**
+> "Lander chassis ready at https://<domain>. Placeholder deployed; run `/site build --one-shot` to generate the actual lander from your offer + audience specs."
+
+### build --one-shot (lander)
+
+This is the load-bearing mode — where Claude (the operator's running session) spawns a subagent that generates fresh HTML/CSS/SVG for this offer. No template inheritance. No placeholder tokens. No Anthropic SDK call. The subagent is a Claude Code subagent, spawned via the `Agent` tool.
+
+**1. Resolve offer context.** Use the existing offer-context resolution above (lines 116–145). At minimum: `offer.md` + `audience.md` paths + the active offer slug.
+
+**2. Load the system prompt.** Read [`references/lander-generation-system.md`](references/lander-generation-system.md) verbatim. This is the load-bearing artifact — the full hard-constraints + soft-brief framing for the generation subagent. Pass it as the subagent's system prompt unmodified.
+
+**3. Build the user message.** Compose:
+- Resolved `offer.md` content
+- Resolved `audience.md` content
+- Optional `voice.md` snippets (anchor phrases, named enemies, "never say" list)
+- Reference URLs — defaults: `https://howdy.md`, `https://thelastbill.com`. Operator can pass `--reference URL` to add or replace
+- Project repo absolute path (where the subagent writes via `Write`)
+- Soft directive: *"Generate fresh HTML/CSS/SVG for this offer. The reference URLs are taste anchors, not templates — read them for polish level, then design something that fits **this** offer. Surprise me."*
+
+Anti-patterns to avoid in your own framing of the user message: see [`references/anti-patterns.md`](references/anti-patterns.md). The big ones: don't lock typography or colors, don't enumerate available sections, don't ask the subagent to "make it look like Howdy," don't suppress variance.
+
+**4. Spawn the subagent.** Invoke the `Agent` tool with `subagent_type=general-purpose`, the system prompt from step 2, and the user message from step 3. The subagent has `Write` access; it will write files directly to the project repo path.
+
+**5. Validate the output.** After the subagent returns, run these checks against the project repo:
+
+- **Required files present:** `index.html`, `how-it-works/index.html`, two more page directories with `index.html`, `privacy/index.html`, `terms/index.html`, `_headers`, `_redirects`, `robots.txt`, `sitemap.xml`, `og.svg`, `favicon.svg`. Each missing file = a fix request to the subagent.
+- **Footer presence:** `grep -L "Noontide Collective LLC" *.html **/*.html` should return nothing (or only files where `offer.md` declared a different parent entity — check the override).
+- **OG render:** `python3 .claude/skills/site/scripts/og_render.py render <repo>/og.svg <repo>/og.png`. Envelope must return `status: ok` with `width: 1200, height: 630`. Failure → fix request to subagent (likely `og.svg` viewBox is wrong).
+- **Lighthouse smoke (optional, V1.1):** `npx lighthouse http://localhost:8000 --only-categories=performance --form-factor=mobile` against a local `python3 -m http.server` running in the project repo. Score ≥ 90 = pass.
+
+**6. Commit + push (operator's call).** Once validation is green, summarize for the operator:
+- Files written
+- Hero artifact picked
+- Color palette
+- Two page choices
+- Suggested commit message: `"[add] one-shot lander generation for <offer>"`
+
+Operator runs `git add -A && git commit && git push`. Cloudflare auto-deploys (after #98) or operator runs `wrangler pages deploy` manually.
+
+**Variance test (acceptance criterion):** Running `/site build --one-shot` twice on the same offer must produce visually different output. If it doesn't, the soft brief was too prescriptive — re-read [`references/anti-patterns.md`](references/anti-patterns.md).
+
+### What's NOT in the lander branch
+
+- No `pnpm install`, no `pnpm build`. Static HTML only.
+- No `site-config.ts` pattern. Each lander generates its own one-off structure.
+- No section-types menu (the Next.js section catalog at lines 381–399 doesn't apply).
+- No `configure` mode separate from `build --one-shot` — the generation subagent reads voice.md / offer.md directly and bakes the brand decisions into the output.
+- No Anthropic API key. No `pages_gen.py` Python wrapper. The generation runs inside the operator's Claude Code session via the `Agent` tool.
 
 ---
 
@@ -544,6 +664,15 @@ cd [site_repo] && git status && git log --oneline -5
 ---
 
 ## References
+
+**Lander branch (static HTML, Cloudflare Pages, atom-driven):**
+
+- [references/lander-generation-system.md](references/lander-generation-system.md) — Load-bearing system prompt for the `--one-shot` generation subagent. Hard constraints + soft brief + reference handling rules.
+- [references/anti-patterns.md](references/anti-patterns.md) — What NOT to bake into prompts (over-prescription, hex-locked critique, "make it look like X", template tokens). Read before extending the system prompt.
+- [references/naming-heuristic.md](references/naming-heuristic.md) — 8-step playbook for picking a brand-tier domain when the operator hits "I need a domain."
+- [references/cloudflare-pages-link.md](references/cloudflare-pages-link.md) — Dashboard walkthrough for the one-time CF Pages Git connect (fallback path; default uses `wrangler pages project create`).
+
+**Next.js branch (saas / high-ticket templates):**
 
 - [references/frontend-design.md](references/frontend-design.md) — Typography, color, motion, anti-AI-slop standards
 - [references/section-patterns.md](references/section-patterns.md) — How reference files map to page sections

--- a/.claude/skills/site/references/anti-patterns.md
+++ b/.claude/skills/site/references/anti-patterns.md
@@ -1,0 +1,72 @@
+# Anti-Patterns — What NOT to Bake Into Lander Generation
+
+Lessons from prior failed prompt attempts. Each pattern below was tried, produced bad output, and is now explicitly avoided. The lander generation system prompt (`lander-generation-system.md`) is shaped around these.
+
+## 1. Over-prescription
+
+**Pattern:** The prompt specifies typography (`font-family: Inter, sans-serif`), exact hex colors (`#0a0a0a` background, `#fafafa` text, `#3b82f6` CTA), section structure (`hero → 3-up features → testimonial carousel → pricing table → CTA`), spacing scale, even shadow values.
+
+**Result:** Every output looks like every other output. The LLM has nothing to decide; it slot-fills. The lander becomes indistinguishable from a generic SaaS template, regardless of offer.
+
+**Fix in `lander-generation-system.md`:** Specify structural constraints (4 pages, SEO, footer, mobile-first, perf budget). Leave aesthetic decisions — palette, typography, section order, hero artifact — to the LLM with reference URLs as taste signal.
+
+## 2. Hex-locked color critique
+
+**Pattern:** Reviewing a generated lander, telling the LLM "the CTA needs to be `#10b981` and the heading should be `#0f172a` not `#1e293b`."
+
+**Result:** The LLM stops making aesthetic judgments. Future runs default to "ask the operator for hex codes." The agent loses the ability to pick a palette that fits the offer's voice.
+
+**Fix:** Critique by describing the *quality* you want ("the CTA needs more grounded weight; right now it floats"), not the value. Let the LLM translate quality → hex.
+
+## 3. "Make it look like Howdy"
+
+**Pattern:** Pointing at a successful lander and saying "make this offer's lander look like that."
+
+**Result:** Surface-copying. The LLM lifts colors, layouts, fonts. The new lander reads as derivative — and worse, it doesn't fit the new offer's tone (a billing tool's lander shouldn't feel like a spiritual coach's).
+
+**Fix:** Reference URLs are **polish anchors**, not templates. The system prompt explicitly says: "read them for polish level, not structure to copy." The user message frames them as "here's the level of intentionality we want; now design something fresh that fits **this** offer."
+
+## 4. Templated placeholder tokens (`{BRAND_NAME}`, `{HERO_HEADLINE}`)
+
+**Pattern:** Defining a template repo with placeholder tokens and instructing the LLM to fill them in.
+
+**Result:** The LLM operates as a mail-merge engine. Output structure is locked to whatever the template authors imagined. Aesthetic invention is impossible — the template predetermined every section, every copy slot, every interactive element.
+
+**Fix:** No template repo. The chassis ships zero source files for the LLM to inherit from. The LLM generates fresh HTML/CSS/SVG per offer, with reference URLs as taste anchors only. If two runs on the same offer produce identical output, the chassis is broken.
+
+## 5. Over-enumerating "available sections"
+
+**Pattern:** "Choose from these section types: hero-left-image, hero-right-image, three-up-grid, four-up-grid, testimonial-quote-block, testimonial-carousel, pricing-table-3-tier, faq-accordion, cta-banner..."
+
+**Result:** The LLM picks from a menu instead of inventing. The lander reads as assembled rather than designed. Same problem as #1 (over-prescription) but applied at the section level.
+
+**Fix:** The system prompt names the four pages and a few decision points (which two extra pages this offer needs, what the hero artifact should be). It does not enumerate component types. The LLM decides what each page contains.
+
+## 6. Building in fallbacks for "if the LLM gets confused"
+
+**Pattern:** "If you're not sure what to do for the hero, default to a centered headline with a CTA button below."
+
+**Result:** The LLM uses the fallback every time, because it's the safe option. The "default" becomes the actual.
+
+**Fix:** No fallbacks. If the LLM doesn't have enough to make a confident aesthetic choice, the prompt sends it to look at reference URLs and the offer's voice. The output should be a confident decision, not a hedged middle.
+
+## 7. Suppressing variance ("be consistent across runs")
+
+**Pattern:** "Make sure that if I run this twice, I get similar output."
+
+**Result:** The LLM clamps to the safe default. Variance is the feature — different runs produce visually distinct output that all fit the offer. The chassis is supposed to surprise.
+
+**Fix:** The system prompt explicitly tests for variance: *"If two runs on the same offer produce visually identical output, you've been too conservative."* The skill's acceptance criteria include "running --one-shot twice on the same spec produces visually different output."
+
+---
+
+## How to write a critique that doesn't break the chassis
+
+When you don't like a generated lander:
+
+- **Describe the quality, not the value.** "The hero feels too cold for an emotional offer" → not → "change `#0a0a0a` to `#1c1917`."
+- **Name the missing thing, not the present thing.** "There's no signature visual; the hero is just text" → not → "remove the gradient."
+- **Ask for a different decision, not a different parameter.** "Pick a different hero artifact — a receipt, not a stamp" → not → "change `<svg viewBox='0 0 100 100'>` to `<svg viewBox='0 0 200 200'>`."
+- **Re-run before iterating.** Sometimes the first generation is conservative. A re-run often produces a sharper take. Iterate by re-running, not by directing.
+
+The chassis only works when the LLM is making aesthetic decisions. Every constraint we add is a decision we're taking away. Add only the structural ones (file presence, footer, perf, SEO, OG dimensions) — leave the rest open.

--- a/.claude/skills/site/references/lander-generation-system.md
+++ b/.claude/skills/site/references/lander-generation-system.md
@@ -1,0 +1,141 @@
+# Lander Generation — System Prompt
+
+This file is the **load-bearing artifact** for `/site build --one-shot`. The skill loads this content as the system prompt for the lander-generation subagent. Edit with care: the constraints below define the chassis.
+
+The skill also passes the resolved `offer.md` + `audience.md` + reference URLs as the user message. The subagent generates HTML/CSS/SVG with the `Write` tool into the project repo. The skill validates the output afterward (file presence, footer, OG render).
+
+---
+
+## Role
+
+You are a freelance designer-developer hired for a single landing page. The operator has handed you an offer spec + audience research + a few reference URLs for taste. You ship a fresh design that fits **this offer**, not a generic template. You write static HTML, CSS, and inline SVG directly to the project repo via the `Write` tool. You do not render images, run builds, or call APIs — the skill validates your output and renders OG separately.
+
+## Hard constraints — non-negotiable
+
+These are structural, not aesthetic. Aesthetic decisions are yours.
+
+### Files required at the repo root (write all of these)
+
+| Path | Purpose |
+|---|---|
+| `index.html` | Home / hero / primary CTA |
+| `how-it-works/index.html` | Process or mechanism page |
+| Two more pages, your pick from: `proof/`, `pricing/`, `start/`, `faq/` | Pick the two that match this offer's pull |
+| `privacy/index.html` | Placeholder privacy policy (boilerplate fine) |
+| `terms/index.html` | Placeholder terms (boilerplate fine) |
+| `_headers` | Cloudflare Pages: security + cache headers |
+| `_redirects` | Empty starter; comment the format |
+| `robots.txt` | Allow all + sitemap link |
+| `sitemap.xml` | Lists every page above |
+| `og.svg` | 1200x630 viewBox; hero text ≤2 lines + one signature visual + wordmark; **nothing else** |
+| `favicon.svg` | Single brandmark; works at 16px |
+
+`og.png` is rendered from your `og.svg` by the skill after you finish. Do not generate it.
+
+### Page structure rules
+
+- 4 main pages max (privacy + terms don't count)
+- URL-readable paths (`how-it-works/`, not `page-2/`)
+- Every page has a `<title>` (under 60 chars), `<meta name="description">` (under 160 chars), canonical link, OG + Twitter Card meta, viewport, charset
+- Every page ends with the **Noontide footer** (see below) as the last visible element
+- Mobile-first responsive — design for 375px first, scale up
+- Semantic HTML: `<header>`, `<main>`, `<section>`, `<footer>`. No div soup.
+- JSON-LD: at minimum, an `Organization` block on `/`. If you ship `/faq/`, add `FAQPage`. If pricing, `Product` or `Offer`.
+
+### Performance budget
+
+- Total page weight < 300KB on `/` (HTML + CSS + inline SVG combined)
+- Hero (above-fold) renders < 80KB
+- Defer below-fold images; lazy-load anything optional
+- No external fonts unless you've weighed the cost — system fonts and `font-display: swap` for self-hosted .woff2 are both fine
+- No JS frameworks. Tiny vanilla JS for one or two interactions is fine. No build step.
+
+### The Noontide footer
+
+Last visible element on every `.html` page. Default content:
+
+```html
+<footer class="site-footer">
+  <p>
+    A product of <strong>Noontide Collective LLC</strong> ·
+    <a href="/privacy/">Privacy</a> ·
+    <a href="/terms/">Terms</a> ·
+    <a href="mailto:hello@noontide.co">Contact</a>
+  </p>
+</footer>
+```
+
+If `offer.md` declares a different parent entity (e.g., `entity: DM-LLC` and `contact: dm@example.com`), substitute. Otherwise use the default verbatim. The skill will grep every page for "Noontide Collective LLC" or the declared replacement — missing footers fail validation.
+
+### What NOT to ship
+
+- Tracking pixels (Meta Pixel, GA, etc.) unless `offer.md` explicitly declares them
+- External CDN scripts beyond fonts (no Tailwind CDN, no Bootstrap CDN, no analytics)
+- Lorem ipsum — every line of copy comes from the offer/audience material or is a coherent original line you wrote
+- Stock photos. SVG illustrations or geometric shapes only
+- Accordion-of-FAQs without considered ordering — if FAQ ships, the order matters
+- A "Connect with us on social" section unless the offer declares social presence
+
+## Soft brief — your creative call
+
+Within the constraints above, every other decision is yours. Specifically:
+
+- **Hero artifact.** Pick the right object for this offer. A receipt for a billing service. A waveform for an audio product. A knot for a coaching practice. A stamp, a key, a bell, a letter, a gear, a leaf — whatever fits. Inline SVG, hand-drawn feel preferred over geometric perfection.
+- **Color palette.** Derived from the offer's voice and audience. The offer + audience material gives you direction. Pick 1 anchor neutral, 1 accent, 1 highlight. Not more.
+- **Typography.** One sans for body, one display for hero — or just one humanist sans for both. Self-hosted or system. Match the offer's energy, not a SaaS-template default.
+- **Hero copy.** Two lines max, ideally one. Compresses the offer's transformation, not the feature list.
+- **Section order.** Decide what belongs on `/` and what gets its own page. Don't force a "hero → features → testimonials → pricing → CTA" template if it doesn't fit.
+- **Microinteractions.** One or two small interactions are welcome — a hover state with character, an SVG that responds to scroll, a subtle stagger on the hero. Not required.
+- **Voice in copy.** Adopt the operator's voice from `audience.md` and any voice cues. If it sounds like every-other-SaaS-page, rewrite.
+
+## Reference URLs
+
+The user message includes 1–N reference URLs (default list: `https://howdy.md`, `https://thelastbill.com`). These are **taste anchors, not templates**:
+
+- Read them for polish level, not structure to copy
+- Notice the level of intentionality (custom illustration, considered typography, single signature artifact)
+- Notice what they DON'T do (no stock photo, no generic SaaS hero, no testimonial logo bar)
+- Now design something that **fits this offer**, at that polish level
+
+If two runs on the same offer produce visually identical output, you've been too conservative. The chassis is supposed to surprise.
+
+## OG image rules
+
+The OG image (`og.svg`, rendered to `og.png` post-step) is the page-as-thumbnail. It will be seen at 200px wide in iMessage previews, social cards, and Slack unfurls. Constraints:
+
+- 1200x630 viewBox (canonical OG dimensions)
+- Hero text: maximum 2 lines, large enough to read at 200px wide. Often this is just the offer's transformation phrase.
+- One signature visual: the same hero artifact you used on `/`, or a related one
+- Wordmark (the brand name, small, well-placed)
+- **Nothing else.** No bullet list, no CTA button, no logo bar, no testimonials, no body copy
+- Inline SVG; no external image references
+
+Test: would someone glancing at this thumbnail at 200px know what the page is about in one second? If not, simplify.
+
+## Output format
+
+Use the `Write` tool to write each file directly to the project repo path provided in the user message. Group writes logically (HTML page, then its inline assets if any). When done, return a brief summary:
+
+```
+Wrote 11 files to <repo_path>:
+  index.html, how-it-works/index.html, faq/index.html, pricing/index.html,
+  privacy/index.html, terms/index.html, _headers, _redirects, robots.txt,
+  sitemap.xml, og.svg, favicon.svg
+Hero artifact: <one-line description>
+Palette: <three-color description>
+```
+
+Do not commit, push, or render OG. The skill handles all of that after validating your output.
+
+## Self-checks before returning
+
+Run these mentally before signaling done:
+
+- [ ] Footer present on every `.html` page (the validation grep will catch you)
+- [ ] All required files written
+- [ ] No tracking pixels, no external CDN scripts, no stock photos
+- [ ] Mobile layout works (visualize at 375px)
+- [ ] OG.svg has hero text ≤ 2 lines + one visual + wordmark, nothing more
+- [ ] Two runs on the same input would produce visually different output (you didn't pick the safe default)
+
+Fail any of those, fix before returning.

--- a/.claude/skills/site/references/naming-heuristic.md
+++ b/.claude/skills/site/references/naming-heuristic.md
@@ -1,0 +1,101 @@
+# Domain Naming Heuristic
+
+A repeatable playbook for picking a brand-tier domain when the operator hits "I need a domain." Use this when the offer doesn't already have a name. Run via `domain.py check` and validate the top picks with `domain-check --info` before purchase.
+
+The goal is a `.com` (or `.co`, `.app`, `.io`) that reads as a confident standalone brand — not a generic descriptor or a clever-but-forgettable pun. Spend 15 minutes here; the name will outlive the lander by years.
+
+---
+
+## Step 1 — Map the category's existing brand patterns
+
+List the top 5–10 names in the offer's category. Look for naming patterns:
+
+- **Descriptive** ("Quickbooks", "Mailchimp"): tells you what it does
+- **Compound noun** ("Notion", "Linear", "Figma"): coined word that sounds like something
+- **Action verb** ("Spotify", "Shopify"): does-something-y
+- **Object/artifact** ("Slack", "Stripe", "Honey"): a thing in the world
+- **Person/place** ("Wendy's", "Asana"): named after someone or somewhere
+
+Note which patterns dominate. Those are saturated; you want a different territory.
+
+## Step 2 — Identify underused naming territories
+
+Among the patterns NOT dominant in the category, which would actually fit the offer's voice? A coaching offer in a sea of "Coach.io" / "TrainerOS" can be named after an object — a knot, a compass, a lantern. A billing tool in a sea of "BillRunner" / "PayPilot" can be named after a moment — `thelastbill`.
+
+The territory should feel surprising-but-right when you say it out loud. If it's just surprising, it'll feel arbitrary. If it's just right, it'll feel like every other brand in the category.
+
+## Step 3 — Pick 4–6 brand directions in those territories
+
+Each direction is a *concept* you'll mine for candidates. Examples:
+
+- **Direction A:** A small, intimate household object (relevant if the offer is about quiet daily practice)
+- **Direction B:** A moment in a transformation (relevant if the offer ends a struggle — `thelastbill`, `firstdraft`)
+- **Direction C:** A craft or trade verb (relevant if the offer is about workmanship — `forge`, `lathe`)
+- **Direction D:** A natural pattern (relevant if the offer is about emergence — `pollen`, `tide`, `bloom`)
+
+Don't workshop the directions to death. 4–6 candidates, 2 minutes each.
+
+## Step 4 — Generate 5–8 candidates per direction
+
+For each direction, ride the concept into adjacent words. If the direction is "small intimate household object," candidates might be: `bell`, `latch`, `pin`, `match`, `wick`, `kettle`, `spoon`, `notebook`. Don't filter yet — quantity over quality at this stage.
+
+End of step 4: ~30 candidate names.
+
+## Step 5 — Run `domain.py check` across multi-TLD
+
+For each candidate, check availability across the relevant TLDs. The default chassis priority:
+
+```bash
+python3 .claude/skills/site/scripts/domain.py check <candidate> \
+  --tlds .com,.co,.io,.app,.ai,.dev
+```
+
+For thematic offers, also try category-specific TLDs:
+
+- Coaching/community → `.coach`, `.club`, `.studio`
+- Software/tooling → `.app`, `.dev`, `.tools`
+- Editorial/publishing → `.md`, `.press`, `.weekly`
+- Local/place → `.us`, `.la`, `.nyc`
+
+Many premium TLDs are dashboard-only at Cloudflare today (`.us`, `.co`, `.io` returned `extension_not_supported_via_api` in earlier probes). Note which require dashboard purchase vs. API.
+
+## Step 6 — Mine the strong root
+
+If a candidate stem is strong but the exact `.com` is taken, try variations:
+
+- **Prefix:** `the-`, `get-`, `use-`, `with-` (`thelastbill`, `getlatch`)
+- **Suffix:** `-app`, `-hq`, `-co`, `-studio`, `-club`
+- **Compound:** combine two words from your candidate list (`bell` + `forge` = `bellforge`)
+- **Slight alteration:** `notebok`, `notebok.io`, `noteboox` (last resort — risks looking misspelled)
+
+Re-run `domain.py check` on variations.
+
+## Step 7 — Retry UNKNOWNs after 30 seconds
+
+`domain-check` occasionally returns transient UNKNOWN states for less-common TLDs. If a candidate you care about returns UNKNOWN, retry once after 30 seconds before assuming it's unavailable. The provider WHOIS path is sometimes rate-limited.
+
+## Step 8 — Validate the final 3 with `domain-check --info`
+
+For your top three candidates, run a richer query that surfaces parked / squatted / offer-for-sale states:
+
+```bash
+domain-check <candidate>.com --info
+```
+
+Watch for:
+
+- "Parked by speculator with offer-for-sale page" — technically available via aftermarket but at $500–$5000+
+- "Active site, content unrelated" — domain is owned but unused; can't acquire without negotiation
+- "Truly available" — clean RDAP/WHOIS path, ready for `domain.py buy`
+
+Pick the one with the cleanest history + the strongest fit. Two-name shortlists tend to deadlock; three-name shortlists usually have a clear winner once you read the real WHOIS.
+
+---
+
+## When to skip this heuristic
+
+- The offer already has a brand name in `offer.md` (the operator decided weeks ago; respect that decision)
+- The offer is a sub-product under an existing brand (use `<existing-brand>.<sub>.com` or a subdirectory; not a new domain)
+- The operator has emotional attachment to a specific name and is past the "ready to consider alternatives" phase
+
+The heuristic exists for the case where the operator is starting fresh and wants a confident answer in 15 minutes. Honor the offer when there's already an answer.


### PR DESCRIPTION
## Summary

Step 2 of the V1 chassis sequence per the [stacked-skill decision](https://github.com/noontide-co/noontide-ops/blob/dmthepm/launch-site-skill/decisions/2026-04-27-lander-chassis-as-stacked-skill.md). Composes the already-shipped atoms (#95–#97, #100) and adds the load-bearing piece: a generation **subagent** spawned inside the running Claude Code session via the `Agent` tool.

**No code, no atoms.** Skill prose + reference files only. The atom layer is done.

**No Anthropic SDK, no API key, no template repo, no `pages_gen.py`.** Claude Code is the LLM. The skill instructs the operator's session to spawn an `Agent`-tool subagent with system prompt + offer/audience/reference-URL inputs; subagent generates fresh HTML/CSS/SVG via the `Write` tool; skill validates output afterward (`og_render.py` + footer grep + file-presence checks).

## What's added

### Three reference files (the load-bearing artifacts)

| File | Lines | Purpose |
|---|---|---|
| `references/lander-generation-system.md` | 141 | The system prompt for the `--one-shot` subagent. Hard constraints (4 pages, SEO, footer, OG content rules, perf budget, mobile-first, static HTML only) + soft brief framing + reference-URL handling + self-checks. Loaded verbatim. |
| `references/anti-patterns.md` | 72 | Seven failure modes from prior prompt iterations: over-prescription, hex-locked critique, "make it look like Howdy," placeholder tokens, over-enumerated section types, fallback baking, variance suppression. Each named with the fix. Generic — no source naming. |
| `references/naming-heuristic.md` | 101 | Eight-step playbook for picking a brand-tier domain. Map category patterns → identify underused territories → 4–6 directions → 5–8 candidates each → `domain.py check` across multi-TLD → mine the strong root → retry UNKNOWNs → validate with `domain-check --info`. |

### `SKILL.md` edits (+129 lines)

- **Step 1 template menu** adds `lander` as option 3, with "static HTML, no build step, designed fresh per offer" framing. Routes the operator to the new branch section (skipping Steps 2–11, which apply only to Next.js templates).

- **New "Lander Template Branch" section** between `Mode: setup` and `Mode: configure`:

  **`setup (lander)` — 8-step flow** composing the atoms:

  | Step | Atom / tool |
  |---|---|
  | 1 | Operator inputs (name, repo location, domain) — routes to `naming-heuristic.md` if no domain |
  | 2 | `verify_live.py` preflight (Cloudflare scopes + zone lookup + domain-check) |
  | 3 | `domain.py check / buy` (or dashboard for non-API TLDs like `.us`) |
  | 4 | `dns.py ensure` |
  | 5 | `gh repo create` + push placeholder `index.html` |
  | 6 | `wrangler pages project create` + `wrangler pages deploy` (no dashboard click) |
  | 7 | `pages.py set-domain` (attach + CNAME + SSL active — live-tested in #97) |
  | 8 | Save `~/.mainbranch/sites.json` with `template: lander, hosting: cloudflare` |

  **`build --one-shot (lander)` — 6-step flow:**

  1. Resolve offer context (existing pattern)
  2. Load `lander-generation-system.md` verbatim as subagent system prompt
  3. Compose user message: `offer.md` + `audience.md` + reference URLs (default `howdy.md`, `thelastbill.com`)
  4. Invoke `Agent` tool (`subagent_type=general-purpose`, `Write` access)
  5. Validate output: file presence, footer grep, `og_render.py render`
  6. Operator commits + pushes; CF auto-deploys (after #98) or `wrangler pages deploy`

  **"What's NOT in the lander branch"** section — explicit anti-drift list so future agents don't reintroduce `pnpm install`, `site-config.ts`, section-types catalog, or Anthropic SDK wrappers.

- **References section** restructured into "Lander branch" and "Next.js branch" so the operator (or a future maintainer) immediately sees which docs apply to which path.

## What's untouched

The existing saas / high-ticket Next.js flow gets zero edits. Steps 2–11 of `Mode: setup`, plus `Mode: configure / build / preview / publish` for the Next.js path, all stay as-is. References for those paths (`frontend-design.md`, `section-patterns.md`, `deployment.md`, `examples-and-troubleshooting.md`) are kept and listed under "Next.js branch."

## Test plan

- [x] Reference link integrity — all 8 ref links in `SKILL.md` resolve to existing files.
- [x] `bash ~/.claude/skills/test-skills/test-skills.sh` — **152/162** (10 pre-existing failures, **0 new failures introduced**). The pre-existing `/site` line-count failure remains pre-existing; this PR did not introduce it.
- [x] No source naming of prior prompt vendors anywhere in the diff (per #94's working principle).
- [ ] **Live integration of `/site build --one-shot`** — deferred per the agreed test plan. Skill prose is exercised when the operator runs it; full end-to-end validation happens when `/start launch` (#92) orchestrates the chain, or when you/I run it manually against a real offer mid-PR.

## Why no `pages_gen.py`, no Anthropic SDK, no template repo

Per the stacked-skill decision file (link above):

- **Atoms = deterministic external API + closed-enum errors.** Lander HTML/CSS/SVG generation uses LLM judgment, so it's a subagent (not an atom).
- **Claude Code IS the LLM.** Spawning a subagent via the `Agent` tool inside the running session = native, no API key, no budget caps, no retry plumbing.
- **No template repo.** The reference URLs (`howdy.md`, `thelastbill.com`) are taste anchors, not source files. Each lander generates fresh — variance is the feature, not a bug.

The `references/anti-patterns.md` file makes these rules explicit so future skill extensions don't drift.

## What this unlocks

Per the V1 sequence in [#94's pinned current-state](https://github.com/mainbranch-ai/vip/issues/94#issuecomment-4331171498):

1. ✓ `og_render.py` (#100, merged)
2. ✓ `/site` extension (this PR)
3. Pages git auto-deploy fix (#98) — once shipped, `git push` to project repo auto-deploys, replacing manual `wrangler pages deploy` in step 6
4. `stripe.py` atom (#99) — products + payment links
5. `/start launch <project>` (#92) — orchestrates the 6 phases

Refs #89, #93, #94. Builds on #95–#97 + #100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)