### PR TITLE
[fix] pages.create-project — git-connected by default (live-tested + thelastbill migrated)

### DIFF
--- a/.claude/skills/site/references/cloudflare-pages-link.md
+++ b/.claude/skills/site/references/cloudflare-pages-link.md
@@ -1,6 +1,47 @@
 # Cloudflare Pages Git Link
 
-Use this when the Pages project does not exist yet. This is the one V1 dashboard step that creates a Git-connected Pages project with auto-deploy.
+Two scenarios live in this doc, in order of how often you'll hit them:
+
+1. **First time on this Cloudflare account: bind the GitHub App** (the OAuth handshake step that gets you out of CF code `8000011`)
+2. **Manual Pages project creation via dashboard** (rare — `pages.py create-project` is the default; this is the dashboard fallback)
+
+---
+
+## 1. Bind the Cloudflare Pages GitHub App to your account (first-time-per-account)
+
+You only need this once per Cloudflare account. Skip if `pages.py create-project` is already working without `github_app_not_installed` errors.
+
+**Background.** CF Pages needs two things:
+
+- The **GitHub App** installed on the GitHub account/org that owns your lander repo (so CF can read commits)
+- An **OAuth handshake** between that install and your CF account (so CF knows which install to use for *your* projects)
+
+Just installing the App on GitHub isn't enough. The OAuth handshake fires from the CF dashboard, not from GitHub. The non-obvious part: the dashboard never has a stand-alone "set up Git integration" button. The handshake gets triggered only as a side-effect of starting the Workers/Pages **Create application** flow. You don't have to actually create anything — connecting the repo in the flow is enough; the OAuth side-effect is what we want.
+
+**The path that works (Devon's verified discovery):**
+
+1. Go to https://dash.cloudflare.com — confirm the right account is selected (top-left switcher)
+2. Left sidebar: **Build** group → **Compute** → **Workers & Pages**
+3. Click **Create application** (blue button, top-right)
+4. Click **Continue with GitHub** (or "Continue with GitHub" — wording varies by recent UI updates)
+5. Authorize the **Cloudflare Workers and Pages** GitHub App when GitHub asks. Choose the GitHub account or org that owns your lander repo.
+   - If GitHub asks "All repositories" vs "Only select repositories" — pick "All repositories" for least friction across future landers, or pick the specific repo if you want to scope tightly.
+6. After GitHub redirects you back to Cloudflare, you'll see a list of your repos. **Connect a repo** — any repo is fine; the connection itself is what completes the OAuth handshake.
+7. **Don't finish creating the application.** Close the tab or click cancel. The handshake already fired the moment GitHub redirected back to CF.
+
+Once that's done, `pages.py create-project` (or any API call to `POST /pages/projects` with `source.type=github`) will work for repos owned by the account you authorized.
+
+**If you have multiple GitHub accounts/orgs**: install on each one that owns repos you'll deploy from. Each install fires its own OAuth handshake, so repeat the steps above per account.
+
+**Direct install URL** (only useful if you've already done the dashboard handshake at least once): https://github.com/apps/cloudflare-workers-and-pages — visit this to add the App to additional GitHub accounts/orgs after the initial bind.
+
+**Symptom you should never see again:** `pages.py create-project` returning `error.code: github_app_not_installed` with CF error code `8000011`. If you do, the OAuth handshake hasn't fired for the GitHub account that owns the target repo — repeat the steps above.
+
+---
+
+## 2. Manual Pages project creation via dashboard (fallback)
+
+Only use this if `pages.py create-project` can't be used for some reason (CI environment, no API access). The atom is the default path.
 
 1. Go to https://dash.cloudflare.com
 2. Left sidebar: under the **Build** group, click **Compute** → **Workers & Pages**. (Cloudflare moved this entry under Compute; if you remember it as a top-level link, look one level deeper.)

--- a/.claude/skills/site/scripts/pages.py
+++ b/.claude/skills/site/scripts/pages.py
@@ -1,13 +1,25 @@
 #!/usr/bin/env python3
 """pages.py — Cloudflare Pages operations atom.
 
-Subcommand:
-    set-domain  Idempotent: attach a custom domain to an existing Cloudflare
-                Pages project, then poll until the custom-domain status is active.
+Subcommands:
+    create-project  Create a Pages project, default source.type=github so
+                    `git push` auto-deploys. Idempotent on re-run with
+                    matching source config; returns dns_misconfigured
+                    behavior if config drifts.
 
-Invocation: `python3 pages.py set-domain <project_name> <domain>`
+    set-domain      Idempotent: attach a custom domain to an existing
+                    Cloudflare Pages project, ensure the verification
+                    DNS record exists, then poll until the custom-domain
+                    status is active.
+
+Invocation: `python3 pages.py <subcommand> <args>`
 Output: companyctx-shape envelope JSON on stdout, logs on stderr.
 Exit code: 0 on ok|partial, 1 on degraded.
+
+Per `decisions/2026-04-27-git-auto-deploy-non-negotiable.md`: every
+Pages project the chassis creates must default to git source. The
+`--source=direct-upload` flag exists as opt-out for CI environments
+that can't install the Cloudflare GitHub App.
 """
 
 from __future__ import annotations
@@ -36,6 +48,14 @@ from dns import CfResult, _cf_call, _cf_classify_error  # noqa: E402
 
 _PROJECT_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,57}[a-z0-9]$")
 _DOMAIN_RE = re.compile(r"^(?=.{1,253}$)([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,}$")
+# GitHub owner / repo names: alphanumerics + dash + underscore + dot.
+# Length capped to 100 (org max is 39, repo max is 100).
+_GH_OWNER_RE = re.compile(r"^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,38})$")
+_GH_REPO_RE = re.compile(r"^[a-zA-Z0-9._-]{1,100}$")
+
+# CF Pages GitHub App install URL — surfaced in suggestions when CF reports
+# code 8000011 (Pages Git installation broken). Verified live 2026-04-27.
+_CF_GITHUB_APP_INSTALL_URL = "https://github.com/apps/cloudflare-workers-and-pages"
 
 
 PagesSetDomainErrorCode = Literal[
@@ -343,9 +363,381 @@ def _wait_for_domain_active(
         time.sleep(min(10, max(2, timeout_seconds // 30)))
 
 
+# ---------------------------------------------------------------------------
+# create-project — atom subcommand for git-connected Pages project creation
+# ---------------------------------------------------------------------------
+
+PagesCreateProjectErrorCode = Literal[
+    "invalid_project_name",
+    "invalid_repo_owner",
+    "invalid_repo_name",
+    "cf_account_id_missing",
+    "cf_unauthenticated",
+    "cf_rate_limited",
+    "github_app_not_installed",
+    "repo_not_found",
+    "project_already_exists",
+    "project_source_mismatch",
+    "cf_request_failed",
+    "network_timeout",
+]
+
+
+class PagesCreateProjectError(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    code: PagesCreateProjectErrorCode
+    message: str
+    suggestion: str | None = None
+
+
+class PagesCreateProjectData(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    project_name: str
+    source_type: Literal["github", "direct-upload"]
+    repo_owner: str | None = None
+    repo_name: str | None = None
+    production_branch: str = "main"
+    project_id: str | None = None
+    pages_subdomain: str | None = None
+    already_existed: bool = False
+    created_now: bool = False
+
+
+class PagesCreateProjectEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    schema_version: Literal["0.1.0"] = SCHEMA_VERSION
+    status: EnvelopeStatus
+    data: PagesCreateProjectData
+    provenance: dict[str, ProviderRunMetadata] = Field(default_factory=dict)
+    error: PagesCreateProjectError | None = None
+
+    @model_validator(mode="after")
+    def _v(self) -> PagesCreateProjectEnvelope:
+        return validate_status_consistency(self)  # type: ignore[return-value]
+
+
+def _map_cf_create_error(result: CfResult) -> PagesCreateProjectError:
+    """Map CF-side failures during create-project to closed-enum codes.
+
+    Three codes worth surfacing distinctly from the generic _cf_classify_error
+    pipeline because they have specific operator-actionable suggestions:
+      8000011  CF Pages Git installation broken — surface install URL
+      8000007  Project not found (used as a not-yet-created signal elsewhere,
+                 but here means CF couldn't find the GitHub repo)
+      409 / "already exists" → project_already_exists
+    """
+    if result.error_code == 8000011:
+        return PagesCreateProjectError(
+            code="github_app_not_installed",
+            message=result.error_message or "Cloudflare Pages Git installation has an internal issue.",
+            suggestion=(
+                f"Install (or re-install) the Cloudflare Pages GitHub App at {_CF_GITHUB_APP_INSTALL_URL} "
+                "on the GitHub account/org that owns the repo. After install, complete the OAuth handshake "
+                "in the Cloudflare dashboard if prompted, then retry."
+            ),
+        )
+
+    err_msg = (result.error_message or "").lower()
+    if result.status_code == 409 or "already exists" in err_msg:
+        return PagesCreateProjectError(
+            code="project_already_exists",
+            message=result.error_message or "A Pages project with this name already exists in the account.",
+            suggestion="Pick a different project name, or query the existing project with GET /pages/projects/{name}.",
+        )
+
+    if "not found" in err_msg and ("repo" in err_msg or "repository" in err_msg):
+        return PagesCreateProjectError(
+            code="repo_not_found",
+            message=result.error_message or "Cloudflare could not access the named GitHub repo.",
+            suggestion=(
+                "Verify the owner and repo_name; confirm the Cloudflare Pages GitHub App has access to "
+                "this repo (it may be installed on the account but with 'Only select repositories' "
+                "configured to exclude it)."
+            ),
+        )
+
+    code, suggestion = _cf_classify_error(result)
+    if code in ("cf_unauthenticated", "cf_rate_limited", "network_timeout"):
+        return PagesCreateProjectError(
+            code=code,  # type: ignore[arg-type]
+            message=result.error_message or code,
+            suggestion=suggestion,
+        )
+    return PagesCreateProjectError(
+        code="cf_request_failed",
+        message=result.error_message or "Cloudflare Pages create-project request failed.",
+        suggestion=suggestion,
+    )
+
+
+def _existing_project_source_matches(
+    payload: dict, source_type: str, repo_owner: str | None, repo_name: str | None, branch: str
+) -> bool:
+    """Return True if an existing project's source config matches what we'd create."""
+    src = payload.get("source") or {}
+    if not isinstance(src, dict):
+        return source_type == "direct-upload" and src is None
+    if src.get("type") != source_type:
+        return False
+    if source_type == "direct-upload":
+        return True
+    cfg = src.get("config") or {}
+    return (
+        cfg.get("owner") == repo_owner
+        and cfg.get("repo_name") == repo_name
+        and cfg.get("production_branch") == branch
+    )
+
+
 @click.group()
 def cli() -> None:
     """pages.py — Cloudflare Pages operations atom."""
+
+
+@cli.command("create-project")
+@click.argument("project_name")
+@click.option(
+    "--repo-owner",
+    default=None,
+    help="GitHub owner (user or org) for source.type=github. Required unless --source=direct-upload.",
+)
+@click.option(
+    "--repo-name",
+    default=None,
+    help="GitHub repo name for source.type=github. Required unless --source=direct-upload.",
+)
+@click.option(
+    "--branch",
+    default="main",
+    show_default=True,
+    help="Production branch.",
+)
+@click.option(
+    "--source",
+    "source_type",
+    type=click.Choice(["github", "direct-upload"]),
+    default="github",
+    show_default=True,
+    help="Source binding. Default github = git auto-deploy. Use direct-upload only for CI/restricted environments.",
+)
+@click.option(
+    "--account-id",
+    default=None,
+    help="Cloudflare account ID. Defaults to CF_ACCOUNT_ID from the environment.",
+)
+def create_project(
+    project_name: str,
+    repo_owner: str | None,
+    repo_name: str | None,
+    branch: str,
+    source_type: str,
+    account_id: str | None,
+) -> None:
+    """Create a Cloudflare Pages project. Default source.type=github so git push auto-deploys.
+
+    Idempotent: if a project with this name already exists with matching source config,
+    returns ok with `already_existed: true`. Mismatched source returns project_source_mismatch.
+    """
+    project_name = project_name.strip().lower()
+    branch = branch.strip()
+    repo_owner = (repo_owner or "").strip() or None
+    repo_name = (repo_name or "").strip() or None
+    provenance: dict[str, ProviderRunMetadata] = {}
+
+    if not _PROJECT_RE.match(project_name):
+        env = PagesCreateProjectEnvelope(
+            status="degraded",
+            data=PagesCreateProjectData(project_name=project_name, source_type=source_type),  # type: ignore[arg-type]
+            error=PagesCreateProjectError(
+                code="invalid_project_name",
+                message=f"Project name {project_name!r} is not a valid Cloudflare Pages project name.",
+                suggestion="Use 2–58 chars: lowercase letters, digits, dashes; no leading/trailing dash.",
+            ),
+        )
+        sys.exit(emit(env))
+
+    if source_type == "github":
+        if not repo_owner or not _GH_OWNER_RE.match(repo_owner):
+            env = PagesCreateProjectEnvelope(
+                status="degraded",
+                data=PagesCreateProjectData(
+                    project_name=project_name, source_type=source_type, repo_owner=repo_owner  # type: ignore[arg-type]
+                ),
+                error=PagesCreateProjectError(
+                    code="invalid_repo_owner",
+                    message=f"--repo-owner {repo_owner!r} is missing or not a valid GitHub login.",
+                    suggestion="Pass --repo-owner with the GitHub user or org login that owns the repo.",
+                ),
+            )
+            sys.exit(emit(env))
+        if not repo_name or not _GH_REPO_RE.match(repo_name):
+            env = PagesCreateProjectEnvelope(
+                status="degraded",
+                data=PagesCreateProjectData(
+                    project_name=project_name, source_type=source_type, repo_owner=repo_owner, repo_name=repo_name  # type: ignore[arg-type]
+                ),
+                error=PagesCreateProjectError(
+                    code="invalid_repo_name",
+                    message=f"--repo-name {repo_name!r} is missing or not a valid GitHub repo name.",
+                    suggestion="Pass --repo-name with the bare repo name (no owner prefix, no .git suffix).",
+                ),
+            )
+            sys.exit(emit(env))
+
+    token = os.environ.get("CLOUDFLARE_API_TOKEN")
+    if not token:
+        env = PagesCreateProjectEnvelope(
+            status="degraded",
+            data=PagesCreateProjectData(project_name=project_name, source_type=source_type),  # type: ignore[arg-type]
+            error=PagesCreateProjectError(
+                code="cf_unauthenticated",
+                message="CLOUDFLARE_API_TOKEN not set.",
+                suggestion="Add CLOUDFLARE_API_TOKEN with Cloudflare Pages:Edit to ~/.config/vip/env.sh.",
+            ),
+        )
+        sys.exit(emit(env))
+
+    account_id = (account_id or os.environ.get("CF_ACCOUNT_ID") or "").strip()
+    if not account_id:
+        env = PagesCreateProjectEnvelope(
+            status="degraded",
+            data=PagesCreateProjectData(project_name=project_name, source_type=source_type),  # type: ignore[arg-type]
+            error=PagesCreateProjectError(
+                code="cf_account_id_missing",
+                message="No Cloudflare account ID supplied.",
+                suggestion="Pass --account-id or set CF_ACCOUNT_ID in ~/.config/vip/env.sh.",
+            ),
+        )
+        sys.exit(emit(env))
+
+    # Idempotency check: GET the project first. 404 → fall through to create.
+    log(f"Checking whether Pages project {project_name} already exists...")
+    lookup = _cf_call("GET", f"/accounts/{account_id}/pages/projects/{project_name}", token)
+    provenance["cf_pages_project_lookup"] = ProviderRunMetadata(
+        status="ok" if lookup.ok else ("not_configured" if lookup.status_code == 404 else "failed"),
+        latency_ms=lookup.latency_ms,
+        error=None if lookup.ok else (lookup.error_message or "unknown"),
+        provider_version="cloudflare-api-v4",
+    )
+
+    if lookup.ok:
+        existing = lookup.payload if isinstance(lookup.payload, dict) else {}
+        if _existing_project_source_matches(existing, source_type, repo_owner, repo_name, branch):
+            log(f"Project exists with matching source config — idempotent ok.")
+            env = PagesCreateProjectEnvelope(
+                status="ok",
+                data=PagesCreateProjectData(
+                    project_name=project_name,
+                    source_type=source_type,  # type: ignore[arg-type]
+                    repo_owner=repo_owner,
+                    repo_name=repo_name,
+                    production_branch=branch,
+                    project_id=existing.get("id"),
+                    pages_subdomain=existing.get("subdomain"),
+                    already_existed=True,
+                    created_now=False,
+                ),
+                provenance=provenance,
+            )
+            sys.exit(emit(env))
+
+        # Source mismatch: don't silently change. Surface for the operator.
+        existing_source = (existing.get("source") or {}).get("type") or "direct-upload"
+        env = PagesCreateProjectEnvelope(
+            status="degraded",
+            data=PagesCreateProjectData(
+                project_name=project_name,
+                source_type=source_type,  # type: ignore[arg-type]
+                repo_owner=repo_owner,
+                repo_name=repo_name,
+                production_branch=branch,
+                project_id=existing.get("id"),
+                pages_subdomain=existing.get("subdomain"),
+                already_existed=True,
+                created_now=False,
+            ),
+            provenance=provenance,
+            error=PagesCreateProjectError(
+                code="project_source_mismatch",
+                message=(
+                    f"Project {project_name!r} exists with source.type={existing_source!r}, "
+                    f"but caller requested {source_type!r} with owner={repo_owner}/{repo_name} "
+                    f"branch={branch}."
+                ),
+                suggestion=(
+                    "Direct-upload projects cannot be migrated via PATCH (CF code 8000069). "
+                    "To switch source, delete the project and re-create with the desired source. "
+                    "Note: deleting unbinds any custom domain, which would need re-attachment via set-domain."
+                ),
+            ),
+        )
+        sys.exit(emit(env))
+
+    if lookup.status_code != 404:
+        # Lookup failed for a reason other than 404. Surface that error.
+        env = PagesCreateProjectEnvelope(
+            status="degraded",
+            data=PagesCreateProjectData(project_name=project_name, source_type=source_type),  # type: ignore[arg-type]
+            provenance=provenance,
+            error=_map_cf_create_error(lookup),
+        )
+        sys.exit(emit(env))
+
+    # 404 → project does not exist. Create it.
+    body: dict = {"name": project_name, "production_branch": branch}
+    if source_type == "github":
+        body["source"] = {
+            "type": "github",
+            "config": {
+                "owner": repo_owner,
+                "repo_name": repo_name,
+                "production_branch": branch,
+            },
+        }
+    else:
+        # direct-upload: omit source field entirely (CF defaults to direct-upload)
+        pass
+
+    log(f"Creating Pages project {project_name} (source={source_type})...")
+    create = _cf_call("POST", f"/accounts/{account_id}/pages/projects", token, json_body=body)
+    provenance["cf_pages_project_create"] = ProviderRunMetadata(
+        status="ok" if create.ok else "failed",
+        latency_ms=create.latency_ms,
+        error=None if create.ok else (create.error_message or "unknown"),
+        provider_version="cloudflare-api-v4",
+    )
+    if not create.ok:
+        env = PagesCreateProjectEnvelope(
+            status="degraded",
+            data=PagesCreateProjectData(
+                project_name=project_name,
+                source_type=source_type,  # type: ignore[arg-type]
+                repo_owner=repo_owner,
+                repo_name=repo_name,
+                production_branch=branch,
+            ),
+            provenance=provenance,
+            error=_map_cf_create_error(create),
+        )
+        sys.exit(emit(env))
+
+    payload = create.payload if isinstance(create.payload, dict) else {}
+    env = PagesCreateProjectEnvelope(
+        status="ok",
+        data=PagesCreateProjectData(
+            project_name=project_name,
+            source_type=source_type,  # type: ignore[arg-type]
+            repo_owner=repo_owner,
+            repo_name=repo_name,
+            production_branch=branch,
+            project_id=payload.get("id"),
+            pages_subdomain=payload.get("subdomain"),
+            already_existed=False,
+            created_now=True,
+        ),
+        provenance=provenance,
+    )
+    sys.exit(emit(env))
 
 
 @cli.command("set-domain")

--- a/.claude/skills/site/scripts/pages.py
+++ b/.claude/skills/site/scripts/pages.py
@@ -431,9 +431,12 @@ def _map_cf_create_error(result: CfResult) -> PagesCreateProjectError:
             code="github_app_not_installed",
             message=result.error_message or "Cloudflare Pages Git installation has an internal issue.",
             suggestion=(
-                f"Install (or re-install) the Cloudflare Pages GitHub App at {_CF_GITHUB_APP_INSTALL_URL} "
-                "on the GitHub account/org that owns the repo. After install, complete the OAuth handshake "
-                "in the Cloudflare dashboard if prompted, then retry."
+                "The Cloudflare Pages GitHub App needs to be installed AND OAuth-bound to your CF account. "
+                "Install alone is not enough — the dashboard OAuth handshake is the load-bearing step. "
+                "Quickest path (verified): dash.cloudflare.com → Compute → Workers & Pages → Create application "
+                "→ Continue with GitHub → connect any repo, then close the tab without finishing the create. "
+                "Full walkthrough in .claude/skills/site/references/cloudflare-pages-link.md. "
+                f"Direct App install URL (use after the first handshake): {_CF_GITHUB_APP_INSTALL_URL}."
             ),
         )
 

--- a/.claude/skills/site/scripts/test_atoms.py
+++ b/.claude/skills/site/scripts/test_atoms.py
@@ -44,10 +44,15 @@ from domain import (
     DomainCheckResult,
 )
 from pages import (
+    PagesCreateProjectData,
+    PagesCreateProjectEnvelope,
+    PagesCreateProjectError,
     PagesSetDomainData,
     PagesSetDomainEnvelope,
     PagesSetDomainError,
     _domain_payload_to_data,
+    _existing_project_source_matches,
+    _map_cf_create_error,
     _map_cf_error,
     _wait_for_domain_active,
 )
@@ -667,6 +672,168 @@ def test_pages_wait_for_domain_active_error_status(monkeypatch: pytest.MonkeyPat
     assert err is not None
     assert err.code == "dns_misconfigured"
     assert "CNAME missing" in err.message
+
+
+# ---------------------------------------------------------------------------
+# PagesCreateProjectEnvelope (#98 — git-source-by-default)
+# ---------------------------------------------------------------------------
+
+
+def test_pages_create_project_ok_round_trip() -> None:
+    env = PagesCreateProjectEnvelope(
+        status="ok",
+        data=PagesCreateProjectData(
+            project_name="chassis-git-test",
+            source_type="github",
+            repo_owner="noontide-co",
+            repo_name="thelastbill-test",
+            production_branch="main",
+            project_id="b6dacee6-fa1e-497f-b81b-369927a475a7",
+            pages_subdomain="chassis-git-test.pages.dev",
+            already_existed=False,
+            created_now=True,
+        ),
+        provenance={
+            "cf_pages_project_create": ProviderRunMetadata(
+                status="ok", latency_ms=3992, provider_version="cloudflare-api-v4"
+            )
+        },
+    )
+    parsed = PagesCreateProjectEnvelope.model_validate_json(env.model_dump_json())
+    assert parsed.data.created_now is True
+    assert parsed.data.source_type == "github"
+    assert parsed.data.repo_owner == "noontide-co"
+
+
+def test_pages_create_project_idempotent_already_existed() -> None:
+    """Idempotent path: project already exists with matching source."""
+    env = PagesCreateProjectEnvelope(
+        status="ok",
+        data=PagesCreateProjectData(
+            project_name="chassis-git-test",
+            source_type="github",
+            repo_owner="noontide-co",
+            repo_name="thelastbill-test",
+            production_branch="main",
+            project_id="b6dacee6-fa1e-497f-b81b-369927a475a7",
+            pages_subdomain="chassis-git-test.pages.dev",
+            already_existed=True,
+            created_now=False,
+        ),
+    )
+    assert env.error is None
+    assert env.data.already_existed is True
+    assert env.data.created_now is False
+
+
+def test_pages_create_project_error_codes_closed() -> None:
+    with pytest.raises(ValidationError):
+        PagesCreateProjectError(code="not_a_real_create_code", message="x")  # type: ignore[arg-type]
+
+
+def test_pages_create_project_source_type_closed() -> None:
+    with pytest.raises(ValidationError):
+        PagesCreateProjectData(project_name="x", source_type="bitbucket")  # type: ignore[arg-type]
+
+
+def test_existing_project_source_matches_github_match() -> None:
+    payload = {
+        "source": {
+            "type": "github",
+            "config": {
+                "owner": "noontide-co",
+                "repo_name": "thelastbill-test",
+                "production_branch": "main",
+            },
+        }
+    }
+    assert _existing_project_source_matches(
+        payload, "github", "noontide-co", "thelastbill-test", "main"
+    ) is True
+
+
+def test_existing_project_source_matches_owner_mismatch() -> None:
+    payload = {
+        "source": {
+            "type": "github",
+            "config": {
+                "owner": "dmthepm",
+                "repo_name": "thelastbill-test",
+                "production_branch": "main",
+            },
+        }
+    }
+    assert _existing_project_source_matches(
+        payload, "github", "noontide-co", "thelastbill-test", "main"
+    ) is False
+
+
+def test_existing_project_source_matches_type_mismatch() -> None:
+    """direct-upload project (source: null) should not match github request."""
+    assert _existing_project_source_matches(
+        {"source": None}, "github", "noontide-co", "thelastbill-test", "main"
+    ) is False
+
+
+def test_map_cf_create_error_8000011_github_app() -> None:
+    """Code 8000011 → github_app_not_installed with install URL in suggestion."""
+    result = CfResult(
+        ok=False,
+        latency_ms=300,
+        status_code=400,
+        error_code=8000011,
+        error_message="There is an internal issue with your Cloudflare Pages Git installation.",
+    )
+    err = _map_cf_create_error(result)
+    assert err.code == "github_app_not_installed"
+    assert "github.com/apps/cloudflare-workers-and-pages" in (err.suggestion or "")
+
+
+def test_map_cf_create_error_409_already_exists() -> None:
+    result = CfResult(
+        ok=False,
+        latency_ms=80,
+        status_code=409,
+        error_message="A project with this name already exists.",
+    )
+    err = _map_cf_create_error(result)
+    assert err.code == "project_already_exists"
+
+
+def test_map_cf_create_error_repo_not_found() -> None:
+    result = CfResult(
+        ok=False,
+        latency_ms=120,
+        status_code=400,
+        error_message="The repository was not found.",
+    )
+    err = _map_cf_create_error(result)
+    assert err.code == "repo_not_found"
+
+
+def test_map_cf_create_error_passes_through_auth() -> None:
+    """Generic auth failure (no specific create-project code) routes to cf_unauthenticated."""
+    result = CfResult(
+        ok=False,
+        latency_ms=50,
+        status_code=401,
+        error_message="invalid token",
+    )
+    err = _map_cf_create_error(result)
+    assert err.code == "cf_unauthenticated"
+
+
+def test_map_cf_create_error_generic_fallback() -> None:
+    """Unrecognized failure → cf_request_failed (closed-enum, no silent ok)."""
+    result = CfResult(
+        ok=False,
+        latency_ms=50,
+        status_code=500,
+        error_code=9999,
+        error_message="boom",
+    )
+    err = _map_cf_create_error(result)
+    assert err.code == "cf_request_failed"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes [#98](https://github.com/mainbranch-ai/vip/issues/98). Every Pages project the chassis creates now ships with `source.type=github` by default — `git push` auto-deploys, no manual `wrangler pages deploy` step ever again. Per [`decisions/2026-04-27-git-auto-deploy-non-negotiable.md`](https://github.com/noontide-co/noontide-ops/blob/dmthepm/launch-site-skill/decisions/2026-04-27-git-auto-deploy-non-negotiable.md): *"if you just open Claude Code and open the repo, you could just talk and merge a branch and it updates your site."*

`thelastbill.com` migrated mid-PR from direct-upload to git-connected, **live-verified** with a real `git push` triggering auto-deploy in <25s.

## Research findings (probes ran before code)

| Probe | Result |
|---|---|
| Current state of `thelastbill` | `source: null` — direct-upload, never git-connected |
| `PATCH` to add `source.type=github` on existing project | Code `8000069`: *"You cannot update the source object in a Direct Uploads project."* — migration requires delete + recreate |
| `POST` with github source on fresh project (initial) | Code `8000011`: *"internal issue with your Cloudflare Pages Git installation"* — CF Pages GitHub App not installed on the right account |

Resolution: transferred `dmthepm/thelastbill-test` → `noontide-co/thelastbill-test`, installed CF Pages GitHub App on the `noontide-co` org. Probe 3 then green.

## What's in this PR

**`pages.py create-project <name>` — new subcommand, ~280 lines:**

```
pages.py create-project <name>
  --repo-owner <owner>           (required for source=github)
  --repo-name <repo>             (required for source=github)
  --branch main                  (default: main)
  --source github|direct-upload  (default: github)
  --account-id <id>              (default: CF_ACCOUNT_ID env)
```

- **Idempotent:** `GET` first; if project exists with matching source config → `already_existed: true`. Mismatched source → `project_source_mismatch` error (won't silently change).
- **Source verification helper** (`_existing_project_source_matches`): checks `source.type` + `owner` + `repo_name` + `production_branch`. Direct-upload projects (`source: null`) never match a github request.
- **Error mapping** (`_map_cf_create_error`):

| CF signal | Closed-enum code |
|---|---|
| Code `8000011` | `github_app_not_installed` (suggestion includes install URL `https://github.com/apps/cloudflare-workers-and-pages`) |
| HTTP 409 / "already exists" | `project_already_exists` |
| Message contains "not found" + "repo" | `repo_not_found` |
| HTTP 401 / cf code 9106-9109/6003-6111 | `cf_unauthenticated` (delegated to existing classifier) |
| Anything else | `cf_request_failed` (verbatim http + cf code in suggestion) |

**Closed-enum errors:**

`invalid_project_name | invalid_repo_owner | invalid_repo_name | cf_account_id_missing | cf_unauthenticated | cf_rate_limited | github_app_not_installed | repo_not_found | project_already_exists | project_source_mismatch | cf_request_failed | network_timeout`

## Live integration

**Test 1 — fresh project via the atom:**

```
$ python3 pages.py create-project chassis-git-test \
    --repo-owner noontide-co --repo-name thelastbill-test --branch main

Checking whether Pages project chassis-git-test already exists...
Creating Pages project chassis-git-test (source=github)...
status: ok, created_now: true, project_id: b6dacee6-..., latency 4s
```

Pushed probe commit → CF auto-deployed within 20s at `https://8ebaa142.chassis-git-test.pages.dev`, stage `deploy/success`.

**Test 2 — idempotent re-run:**

```
status: ok, already_existed: true, created_now: false, latency 256ms
```

Single GET, no POST. Cleaned up project after.

**Test 3 — `thelastbill` migration (the load-bearing one):**

| Step | Result |
|---|---|
| Detach `thelastbill.com` from old project | success (CF requires this before project delete; code `8000028` if you skip) |
| Delete direct-upload project | success |
| Create new project via atom (`source=github`, `noontide-co/thelastbill-test`) | status: ok, created_now: true |
| Re-attach `thelastbill.com` via existing `pages.set-domain` | status: ok, ssl_active: true, validation: active, verification: active. CNAME from #97's prior run was idempotently reused (`dns_record_created_now: false`) |
| Push probe commit | Deployment `a24e220f` fired in <25s, tied to commit `8a4f876` |
| `https://thelastbill.com` final | HTTP 200 |
| Final source binding | `type=github`, `owner=noontide-co`, `repo=thelastbill-test`, `branch=main` |

The "true git connection" question is settled. `thelastbill` now auto-deploys on every push.

## Tests

- **66/66** pass (54 carried + 12 new for create-project)
  - Envelope round-trip (ok + idempotent already-existed)
  - Closed-enum rejection (error code + `source_type` Literal)
  - `_existing_project_source_matches` — github match, owner mismatch, direct-upload-to-github mismatch
  - `_map_cf_create_error` — code 8000011 (with install URL in suggestion), 409 already-exists, repo-not-found, generic auth, generic fallback
- **Regression: 152/162** (10 pre-existing failures, **0 introduced**)

## Known gaps + follow-ups

- **No `delete-project` subcommand.** Migration used raw curl for the one-time event. Adding a permanent atom subcommand for delete wasn't requested in #98 and would widen scope. Easy follow-up if needed.
- **#94 onboarding update** is the issue's step 3 — flagged for next pass per the spec ("after research lands").
- **GitHub App install discipline:** members will need the App installed on whichever GitHub account/org owns their lander repo. The atom's `github_app_not_installed` error surfaces the exact install URL when this trips. Worth a one-line addition to the V1 onboarding checklist when we get to it.

## What this unlocks

- **The chassis UX promise is now real.** Every future lander created via `/site setup --template lander` (per #101) will be git-connected from minute one.
- **`/start launch <project>` (#92)** can now promise zero-touch deploy: the orchestration spawns the generation subagent, subagent writes files, operator commits + pushes, CF auto-deploys. No manual deploy step in the chain.

Refs #98, #94. Builds on #97 (`pages.set-domain`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)