### PR TITLE
[refactor] /site — router + per-shape refs + audit (lander, minisite, website)

### DIFF
--- a/.claude/skills/site/SKILL.md
+++ b/.claude/skills/site/SKILL.md
@@ -1,19 +1,18 @@
 ---
 name: site
-description: "Generate and deploy landing pages from business reference files. Use when:
-  (1) Setting up a new site from a starter template
-  (2) Applying brand identity from reference files
-  (3) Building or editing page sections
-  (4) Previewing locally
-  (5) Publishing to Netlify
+description: "Triage and build any site shape — lander (1 page), minisite (~4 pages), or full website — and graduate between them. Routes to per-shape build flow, reads from business reference files, deploys to Cloudflare Pages with git auto-deploy. Use when:
+  (1) Operator says 'I want a site' / 'I want a lander' / 'spin up a one-pager'
+  (2) Setting up a new site of any shape from offer + audience material
+  (3) Updating / iterating on an existing site
+  (4) Graduating a site to a new shape (lander → minisite → website → website + CMS)
+  (5) Previewing or publishing changes
 
-  Triggered by: /site, 'build a site', 'landing page', 'deploy site', 'website',
-  'update my site', 'publish site', 'I need a site', 'put this online'"
+  Triggered by: /site, 'build a site', 'landing page', 'lander', 'minisite', 'website', 'I need a site', 'spin up a site', 'put this online', 'publish site', 'deploy site', 'update my site', 'graduate my site', 'add a CMS to my site'"
 ---
 
 # Site
 
-Generate and deploy landing pages from your business reference files.
+Pick a site shape, build it from your business reference files, ship it to Cloudflare Pages with git auto-deploy. Graduate up the shape ladder when an offer earns it.
 
 ---
 
@@ -38,7 +37,7 @@ try:
 except: print('')
 " 2>/dev/null)
 
-# Fallback: check ~/.config/vip/local.yaml (needs PyYAML)
+# Fallback: ~/.config/vip/local.yaml
 if [ -z "$VIP_PATH" ] || [ ! -f "$VIP_PATH/.claude/skills/start/SKILL.md" ]; then
   VIP_PATH=$(python3 -c "
 import os
@@ -50,7 +49,6 @@ except: print('')
 " 2>/dev/null)
 fi
 
-# Pull if found and valid
 [ -n "$VIP_PATH" ] && [ -f "$VIP_PATH/.claude/skills/start/SKILL.md" ] && \
   git -C "$VIP_PATH" pull origin main 2>&1
 ```
@@ -66,10 +64,7 @@ your-business-repo/          <- Reference files READ from here
 └── reference/domain/         (content-strategy.md)
 
 your-site-repo/              <- Site code WRITTEN here
-├── app/                      (layout.tsx, page.tsx, globals.css)
-├── components/               (hero.tsx, cta.tsx, etc.)
-├── site-config.ts            (all brand-specific content)
-└── public/                   (images, favicon)
+                             (shape-specific layout — see per-shape build refs)
 
 ~/.mainbranch/sites.json     <- Config pointing to repos
 
@@ -83,19 +78,24 @@ The skill reads from the business repo and writes to the site repo. These are se
 
 ## Prerequisites
 
-Before first run, verify:
+Default chassis path uses **Cloudflare Pages** (better CLI, better domain integration, git auto-deploy, supports static and build-step sites alike).
 
+| Tool | Required for | Install |
+|---|---|---|
+| Cloudflare account | All site shapes (chassis default) | https://dash.cloudflare.com (free) |
+| `gh` CLI authenticated | Repo creation | `brew install gh` + `gh auth login` |
+| Cloudflare API token + account ID + GitHub App install | Atom-driven domain/DNS/Pages flow | One-time: `bash .claude/skills/site/scripts/setup_creds.sh` then [`references/cloudflare-pages-link.md`](references/cloudflare-pages-link.md) for the GitHub App OAuth handshake |
+| `offer.md` + `audience.md` | Site generation | Build via `/think` first if missing |
+| Node 18+ + pnpm | **Only for Website shape** with Next.js / Astro build step | `brew install node && npm install -g pnpm` |
+
+Verify atom credentials with:
 ```bash
-node --version    # Need 18+
-pnpm --version    # Package manager
-gh auth status    # GitHub CLI authenticated
+source ~/.config/vip/env.sh
+python3 .claude/skills/site/scripts/verify_live.py
 ```
+Expect 3/3 passed (Cloudflare scopes + zone lookup + domain-check CLI). Porkbun skipped is fine for the CF-registered path.
 
-- **Node.js 18+** — Required for Next.js
-- **pnpm** — Package manager (`npm install -g pnpm` if missing)
-- **GitHub CLI** — For repo creation (`brew install gh` on Mac)
-- **Netlify account** — Free tier works. Created during setup if needed.
-- **Business reference files** — At minimum: `offer.md` and `audience.md`
+Netlify is supported as a legacy fallback for pre-chassis Next.js templates only — see [`references/deployment.md`](references/deployment.md). Not the chassis target.
 
 ---
 
@@ -126,516 +126,126 @@ Before loading reference files, resolve the active offer:
 **Offer-aware files** (check offers/ first, fall back to core/): `offer.md`, `audience.md`
 **Accumulate files** (load both): `testimonials.md` (offer-specific + brand-level)
 
-**Site config extension:** `~/.mainbranch/sites.json` can include an `offer` field to link a site to a specific offer:
+`~/.mainbranch/sites.json` can include an `offer` field that overrides `.vip/local.yaml`:
 
 ```json
 {
-  "name": "community-landing",
-  "offer": "community",
+  "name": "thelastbill",
+  "offer": "the-last-bill",
   "site_repo": "/absolute/path/to/site-repo",
   "business_repo": "/absolute/path/to/business-repo",
-  "template": "high-ticket",
-  "hosting": "netlify",
-  "domain": "community.example.com"
+  "shape": "minisite",
+  "hosting": "cloudflare",
+  "domain": "thelastbill.com"
 }
 ```
-
-When a site has an `offer` field, use that as the active offer instead of reading `.vip/local.yaml`.
 
 ---
 
 ## Reference Required
 
 | File | Path | Required |
-|------|------|----------|
-| Offer | `offers/[active]/offer.md` or `core/offer.md` (resolved via path resolution) | **Yes** |
-| Audience | `offers/[active]/audience.md` or `core/audience.md` (resolved via path resolution) | **Yes** |
-| Voice | `reference/core/voice.md` (always core) | Recommended |
-| Soul | `reference/core/soul.md` (always core) | Optional |
-| Testimonials | `reference/proof/testimonials.md` + `offers/[active]/testimonials.md` (accumulate) | Recommended |
+|---|---|---|
+| Offer | `offers/[active]/offer.md` or `core/offer.md` (resolved) | **Yes** |
+| Audience | `offers/[active]/audience.md` or `core/audience.md` (resolved) | **Yes** |
+| Voice | `reference/core/voice.md` | Recommended |
+| Soul | `reference/core/soul.md` | Optional |
+| Testimonials | `reference/proof/testimonials.md` (+ offer-specific if exists) | Recommended |
 | Angles | `reference/proof/angles/*.md` | Optional |
-| Content Strategy | `reference/domain/content-strategy.md` (always brand-level) | Optional |
+| Content Strategy | `reference/domain/content-strategy.md` | Optional |
 | Skool Surfaces | `reference/domain/funnel/skool-surfaces.md` | Optional (congruence) |
 
 If required files are missing, stop and route to `/think codify`:
-
 > "Your offer.md is missing. I need it to generate the site. Run `/think` to build your reference files first."
+
+---
+
+## Triage — What Are You Building?
+
+Ask the operator. Route based on the answer; don't assume.
+
+> **What are you doing?**
+>
+> **A. New site from scratch.** Pick a shape:
+> - 🟦 **Lander** (1 page, all-in-one) — hero + offer + proof + CTA + footer. Maximum focus, minimum nav.
+>   *V1: chassis-shape lander generation not yet wired. Use **Minisite** for single-page-feel use cases — its `/start/` page covers the focused conversion target.* Future spec: [`references/lander-build.md`](references/lander-build.md).
+>
+> - 🟩 **Minisite** (~4 pages, static HTML) — home + how-it-works + 2 LLM-picked + privacy/terms/start/start-thanks. Designed fresh per offer by a generation subagent. **V1 chassis target.**
+>   Best for: paid-ad lander tests, single-offer first deploys, deposit-gateway flows.
+>   Flow: [`references/minisite-build.md`](references/minisite-build.md). Engine spec: `mb-vip/.claude/reference/minisite.md`.
+>
+> - 🟨 **Website** (full, multi-section, build step likely) — depth, blog, multiple offers, knowledge base, course area.
+>   *V1 status:* chassis-shape Website generation pending. Legacy Next.js templates (`saas`, `high-ticket`) work today as starting points.
+>   Flow: [`references/website-build.md`](references/website-build.md).
+>
+> **B. Iterating on an existing site.** Same shape, more content / edits.
+> - Editing pages, adding sections, updating copy → go straight to **Mode: build** (per the existing site's shape)
+> - Just publishing your work → **Mode: publish**
+>
+> **C. Graduating to a different shape.** Existing site has earned more.
+> - Lander → Minisite (single-pager pulls more content)
+> - Minisite → Website (4 pages becoming 10+, blog, multi-offer)
+> - Website → Website + CMS (Sanity / Contentful / etc. for non-dev editing)
+> - Read [`references/graduation.md`](references/graduation.md) — when to graduate, what changes, manual vs scripted.
+
+If the operator can't articulate which they're doing, ask the predecessor question: *"What goal are you trying to hit? Drive paid traffic to a deposit? Sell a course? Replace your current Squarespace?"* Their answer maps cleanly to a shape.
+
+---
+
+## Modes (cross-shape)
+
+| Mode | What it does | Trigger |
+|---|---|---|
+| **setup** | First-run for a new site of the chosen shape | "new site", "spin up", "build me a site" |
+| **build** | Generate or edit content (shape-specific — see per-shape ref) | "build", "regenerate", "add a section" |
+| **preview** | Local server / dev environment (shape-specific) | "preview", "show me locally" |
+| **publish** | Stage, commit, push — Cloudflare auto-deploys | "publish", "ship it", "deploy" |
+
+Per-shape detail in the build refs:
+- [`references/minisite-build.md`](references/minisite-build.md) — minisite full flow
+- [`references/website-build.md`](references/website-build.md) — Next.js website flow
+- [`references/lander-build.md`](references/lander-build.md) — lander (V1 stub; mostly delegates to minisite)
+
+The `publish` mode is shape-agnostic when the project is git-connected to Cloudflare Pages: `git push` triggers auto-deploy. For legacy Netlify-deployed projects, see [`references/deployment.md`](references/deployment.md).
 
 ---
 
 ## Reference-to-Section Mapping
 
+How offer/audience/voice/proof material flows into a generated site:
+
 | Reference File | Produces |
-|---------------|----------|
+|---|---|
 | Resolved `offer.md` | Hero headline/subhead, value prop, pricing, CTA copy |
 | Resolved `audience.md` | Pain point sections, objection handling, copy language/tone |
-| `voice.md` (always core) | Color palette, font selection, aesthetic mood, copy tone |
-| `soul.md` (always core) | About/mission section, founder story, credibility badge |
-| `testimonials.md` (accumulated) | Social proof section, stat counters, trust badges |
+| `voice.md` | Color palette, font selection, aesthetic mood, copy tone |
+| `soul.md` | About/mission section, founder story, credibility badge |
+| `testimonials.md` | Social proof, stat counters, trust badges |
 | `angles/*.md` | Page structure — which angle drives section order |
-| `content-strategy.md` (brand-level) | CTA destinations, newsletter signup integration |
-
-Detailed mapping rules: [references/section-patterns.md](references/section-patterns.md)
-
----
-
-## Modes
-
-| Mode | What It Does | Trigger |
-|------|--------------|---------|
-| **setup** | Pick template, scaffold repo, install, deploy | First run, "new site" |
-| **configure** | Apply brand (colors, fonts, metadata) from reference | After setup, "change brand" |
-| **build** | Generate/edit page sections from reference files | "add section", "update hero", "rebuild" |
-| **preview** | Start dev server for local preview | "preview", "show me" |
-| **publish** | Git commit + push → Netlify auto-deploy | "publish", "deploy", "ship it" |
-
----
-
-## Mode: setup
-
-First-time setup. Creates a new site repo from a starter template.
-
-### Step 1: Choose Site Shape
-
-Present options. Site shape, not business vertical — vertical is in `offer.md`.
-
-> **What kind of site are you building?**
->
-> 1. **Lander** (1 page, all-in-one) — single page: hero + offer + proof + CTA + footer.
->    *V1 status:* pattern defined, generation system prompt not yet written. Use **Minisite** for now if you need single-page-feel — option 2 already covers that case via its `/start/` page.
->
-> 2. **Minisite** (~4 pages, static HTML) — home + `how-it-works/` + 2 LLM-picked from `{proof, pricing, start, faq}` + required `privacy/`, `terms/`, `start/thanks/`. Designed fresh per offer by a generation subagent. **Cloudflare Pages by default. V1 chassis target.**
->    Best for: paid-ad minisite tests, single-offer first deploys, deposit-gateway flows.
->    Spec: [`mb-vip/.claude/reference/minisite.md`](../../reference/minisite.md). Skill flow below: see "Minisite Template Branch."
->
-> 3. **Website** (full, multi-section, build step likely) — for businesses with content depth (blog, multiple offers, knowledge base, course area).
->    *V1 status:* pattern defined, chassis-shape Website generation not yet wired. Legacy Next.js templates (`saas`, `high-ticket`) work via Steps 2–11 below as starting points; those are pre-chassis examples that fit a few specific verticals. The full Website tier evolves in V2.
-
-**Hosting default:** Cloudflare Pages for all three shapes. Better CLI, better domain integration, git auto-deploy out of the box. Netlify path stays for the legacy `saas` / `high-ticket` templates only — not the chassis target.
-
-**Graduation:** sites can graduate up the shape ladder when an offer earns it. Lander → Minisite (the single-pager pulls traffic that wants more proof, more pages emerge). Minisite → Website (a winning minisite gets deeper content, a blog, multi-offer support, course area). The graduation isn't automatic; it's an operator decision triggered by the offer pulling traffic that wants more content. V1 doesn't ship a graduation tool — manual repo work for now; future skill mode if it becomes recurring.
-
-If `minisite` is chosen, **skip Steps 2–11 below and go to "Minisite Template Branch"** — that flow uses Cloudflare Pages + atoms. Steps 2–11 apply to the legacy `saas` / `high-ticket` Next.js templates only.
-
-### Step 2: Name and Location
-
-Ask:
-- Site name (e.g., "my-landing-page")
-- Location (default: `~/sites/[name]`)
-
-### Step 3: Check Prerequisites
-
-```bash
-node --version && pnpm --version && gh auth status
-```
-
-If anything missing, help them install before proceeding.
-
-### Step 4: Create GitHub Repo
-
-```bash
-gh repo create [name] --private --clone --directory [location]
-cd [location]
-```
-
-### Step 5: Add Template as Upstream
-
-```bash
-git remote add upstream https://github.com/mainbranch-ai/site-template-[saas|high-ticket].git
-git fetch upstream
-git merge upstream/main --allow-unrelated-histories -m "Initial template merge"
-```
-
-### Step 6: Install Dependencies
-
-```bash
-pnpm install
-```
-
-Handle common errors:
-- Wrong Node version → suggest `nvm use 18`
-- pnpm not found → `npm install -g pnpm`
-
-### Step 7: Verify Build
-
-```bash
-pnpm build
-```
-
-If build fails, troubleshoot before proceeding. Don't deploy a broken build.
-
-### Step 8: Initial Commit and Push
-
-```bash
-git add -A
-git commit -m "[add] Initial site from template"
-git push -u origin main
-```
-
-### Step 9: Deploy to Netlify
-
-Walk user through Netlify dashboard. See [references/deployment.md](references/deployment.md) for full walkthrough.
-
-Key settings: Build command = `pnpm build`, Publish directory = `out`, NODE_VERSION = `20`.
-
-### Step 10: Detect Business Repo
-
-Ask: "Where is your business repo with reference files?" Confirm the path has `reference/core/` files.
-
-If the business repo has `reference/offers/`, ask which offer this site is for. Store the offer in the sites.json config (see `offer` field above).
-
-### Step 11: Save Config
-
-Write `~/.mainbranch/sites.json`:
-
-```json
-[
-  {
-    "name": "[site-name]",
-    "site_repo": "/absolute/path/to/site-repo",
-    "business_repo": "/absolute/path/to/business-repo",
-    "template": "saas",
-    "hosting": "netlify",
-    "domain": "[name].netlify.app"
-  }
-]
-```
-
-Create `~/.mainbranch/` directory if it doesn't exist.
-
-**Exit:**
-
-> "Site deployed at https://[url]. Run `/site configure` to apply your brand, or `/site build` to start customizing sections from your reference files."
-
----
-
-## Minisite Template Branch
-
-When the operator picked the `minisite` template in Step 1, the setup and build flows are different from the Next.js templates above. Static HTML, no build step, Cloudflare Pages, atom-driven domain + DNS + custom-domain attachment.
-
-### setup (minisite)
-
-**1. Name + project repo.** Ask the operator:
-- Site name (e.g., `thelastbill`). Becomes the Pages project name.
-- Project repo location (default: sibling of vip — `~/Documents/GitHub/<name>` for solo, `~/Documents/GitHub/noontide-sites/<name>` for Noontide work). Empty repo, no template merge.
-- Apex domain. If they don't have one, route to [`references/naming-heuristic.md`](references/naming-heuristic.md) — an 8-step playbook for generating + validating brand-tier names.
-
-**2. Atom-chain prerequisites.** Confirm the credentials are in place via:
-```bash
-source ~/.config/vip/env.sh
-python3 .claude/skills/site/scripts/verify_live.py
-```
-Expect 3/3 passed (Cloudflare scopes + zone lookup + domain-check CLI). Porkbun skipped is fine for the CF-registered path.
-
-If anything's red, route the operator to `bash .claude/skills/site/scripts/setup_creds.sh` to provision Cloudflare credentials, then re-run.
-
-**3. Domain — buy-new vs. existing.** Ask:
-- "Already own the domain?" → skip to step 4 with the domain name
-- "Need to buy?" → run `python3 .claude/skills/site/scripts/domain.py check <name> --tlds .com,.co,.io` first to confirm availability + TLD support. If `extension_not_supported_via_api`, fall back to the Cloudflare dashboard (https://dash.cloudflare.com/registrar — confirm the right account before purchase). For API-supported TLDs and after explicit operator Y on price, proceed with `domain.py buy <name>` — *will be wired in a follow-up PR; today the buy is dashboard for the first minisite, then API once `domain.py buy --registrar=cloudflare` lands*.
-
-**4. DNS ensure.** Once the domain is owned (CF Registrar or Porkbun), run:
-```bash
-python3 .claude/skills/site/scripts/dns.py ensure <domain> --registrar cloudflare --skip-propagation-poll
-```
-For CF-registered domains the zone is auto-created with NS already at CF — this is an idempotent verification, not a state change. For Porkbun-registered domains, the atom swaps NS to CF nameservers and polls propagation.
-
-**5. GitHub repo + initial scaffold push.** Create the project repo and push a placeholder `index.html` so the Pages project has something to deploy:
-```bash
-gh repo create <owner>/<name> --public --add-readme
-git clone https://github.com/<owner>/<name>.git ~/Documents/GitHub/<name>
-cd ~/Documents/GitHub/<name>
-echo '<!doctype html><title><name></title><h1>soon</h1>' > index.html
-git add -A && git commit -m "[add] placeholder" && git push
-```
-
-**6. Cloudflare Pages project.** Create via wrangler (no dashboard click needed):
-```bash
-wrangler pages project create <name> --production-branch main
-wrangler pages deploy . --project-name <name> --branch main
-```
-This deploys the placeholder to `https://<hash>.<name>.pages.dev`. The git-source connection (auto-deploy on push) is added by `pages.py create-project` once **#98** ships; until then, manual `wrangler pages deploy` after each push, or one-time UI walkthrough at [`references/cloudflare-pages-link.md`](references/cloudflare-pages-link.md).
-
-**7. Custom domain attach + DNS verification.** Run:
-```bash
-python3 .claude/skills/site/scripts/pages.py set-domain <name> <domain> --timeout-seconds 300
-```
-The atom attaches the domain, creates the CNAME record in the zone (the step the dashboard hides), and polls until SSL is active. Expect ~3-4 min total. Live-tested end-to-end in PR #97.
-
-**8. Save config.** Same `~/.mainbranch/sites.json` structure as the Next.js path:
-```json
-{
-  "name": "<name>",
-  "site_repo": "/absolute/path/to/repo",
-  "business_repo": "/absolute/path/to/business-repo",
-  "template": "minisite",
-  "hosting": "cloudflare",
-  "domain": "<full apex>"
-}
-```
-
-**Exit:**
-> "Minisite ready at https://<domain>. Placeholder deployed; run `/site build --one-shot` to generate the actual minisite from your offer + audience specs."
-
-### build --one-shot (minisite)
-
-This is the load-bearing mode — where Claude (the operator's running session) spawns a subagent that generates fresh HTML/CSS/SVG for this offer. No template inheritance. No placeholder tokens. No Anthropic SDK call. The subagent is a Claude Code subagent, spawned via the `Agent` tool.
-
-**1. Resolve offer context.** Use the existing offer-context resolution above (lines 116–145). At minimum: `offer.md` + `audience.md` paths + the active offer slug.
-
-**2. Load the system prompt.** Read [`references/minisite-generation-system.md`](references/minisite-generation-system.md) verbatim. This is the load-bearing artifact — the full hard-constraints + soft-brief framing for the generation subagent. Pass it as the subagent's system prompt unmodified.
-
-**3. Build the user message.** Compose:
-- Resolved `offer.md` content
-- Resolved `audience.md` content
-- Optional `voice.md` snippets (anchor phrases, named enemies, "never say" list)
-- Reference URLs — defaults: `https://howdy.md`, `https://thelastbill.com`. Operator can pass `--reference URL` to add or replace
-- Project repo absolute path (where the subagent writes via `Write`)
-- Soft directive: *"Generate fresh HTML/CSS/SVG for this offer. The reference URLs are taste anchors, not templates — read them for polish level, then design something that fits **this** offer. Surprise me."*
-
-Anti-patterns to avoid in your own framing of the user message: see [`references/anti-patterns.md`](references/anti-patterns.md). The big ones: don't lock typography or colors, don't enumerate available sections, don't ask the subagent to "make it look like the references," don't suppress variance.
-
-**4. Spawn the subagent.** Invoke the `Agent` tool with `subagent_type=general-purpose`, the system prompt from step 2, and the user message from step 3. The subagent has `Write` access; it will write files directly to the project repo path.
-
-**5. Validate the output.** After the subagent returns, run these checks against the project repo:
-
-- **Required files present:** `index.html`, `how-it-works/index.html`, two more page directories with `index.html`, `privacy/index.html`, `terms/index.html`, `_headers`, `_redirects`, `robots.txt`, `sitemap.xml`, `og.svg`, `favicon.svg`. Each missing file = a fix request to the subagent.
-- **Footer presence:** `grep -L "Noontide Collective LLC" *.html **/*.html` should return nothing (or only files where `offer.md` declared a different parent entity — check the override).
-- **OG render:** `python3 .claude/skills/site/scripts/og_render.py render <repo>/og.svg <repo>/og.png`. Envelope must return `status: ok` with `width: 1200, height: 630`. Failure → fix request to subagent (likely `og.svg` viewBox is wrong).
-- **Lighthouse smoke (optional, V1.1):** `npx lighthouse http://localhost:8000 --only-categories=performance --form-factor=mobile` against a local `python3 -m http.server` running in the project repo. Score ≥ 90 = pass.
-
-**6. Commit + push (operator's call).** Once validation is green, summarize for the operator:
-- Files written
-- Hero artifact picked
-- Color palette
-- Two page choices
-- Suggested commit message: `"[add] one-shot minisite generation for <offer>"`
-
-Operator runs `git add -A && git commit && git push`. Cloudflare auto-deploys (after #98) or operator runs `wrangler pages deploy` manually.
-
-**Variance test (acceptance criterion):** Running `/site build --one-shot` twice on the same offer must produce visually different output. If it doesn't, the soft brief was too prescriptive — re-read [`references/anti-patterns.md`](references/anti-patterns.md).
-
-### What's NOT in the minisite branch
-
-- No `pnpm install`, no `pnpm build`. Static HTML only.
-- No `site-config.ts` pattern. Each minisite generates its own one-off structure.
-- No section-types menu (the Next.js section catalog at lines 381–399 doesn't apply).
-- No `configure` mode separate from `build --one-shot` — the generation subagent reads voice.md / offer.md directly and bakes the brand decisions into the output.
-- No Anthropic API key. No `pages_gen.py` Python wrapper. The generation runs inside the operator's Claude Code session via the `Agent` tool.
-
----
-
-## Mode: configure
-
-Apply brand identity from reference files to the site's visual system.
-
-### What It Reads
-
-- `voice.md` — Aesthetic direction, tone, personality
-- `offer.md` — Headline copy, value proposition
-- `soul.md` — Mission text, credibility elements
-
-### What It Changes
-
-- `app/globals.css` — CSS custom properties (colors, fonts)
-- `app/layout.tsx` — Font imports, metadata
-- `site-config.ts` — Brand name, tagline, metadata
-
-### Voice-to-Aesthetic Derivation
-
-| Voice Trait | Design Implication |
-|---|---|
-| Warm, personal | Rounded corners, warm palette, serif or humanist sans display font |
-| Direct, authoritative | Sharp corners, high contrast, geometric sans or strong serif |
-| Playful, energetic | Bold colors, larger type scale, bouncy motion, personality fonts |
-| Premium, refined | Restrained palette, ample whitespace, thin weights, serif display |
-| Technical, expert | Monospace accents, structured grids, muted palette with signal color |
-
-See [references/frontend-design.md](references/frontend-design.md) for font pairings, color systems, and motion guidelines.
-
-### Steps
-
-1. Read `voice.md` — determine aesthetic direction
-2. Read `offer.md` — extract headline, tagline, CTA text
-3. Choose font pairing based on voice (see frontend-design reference)
-4. Choose color palette based on brand positioning
-5. Update CSS variables in `globals.css`
-6. Update font imports in `layout.tsx`
-7. Update metadata (title, description, OG tags) in `layout.tsx`
-
-### Checkpoint
-
-> "Preview the brand changes? Run `/site preview` to see them locally, or continue to `/site build` to generate sections."
-
----
-
-## Mode: build
-
-The core generation mode. Reads reference files and generates page sections.
-
-### How It Works
-
-1. Resolve offer context (see Offer Context Resolution above) — use offer-specific `offer.md` and `audience.md` when available
-2. Read reference files from business repo (resolved paths)
-3. Generate or update `site-config.ts` — the single source of all brand-specific content
-4. Generate or edit component files in `components/`
-5. Update page composition in `app/page.tsx`
-
-### The site-config.ts Pattern
-
-All brand-specific content lives in one file. Components import from it:
-
-```typescript
-// site-config.ts
-export const siteConfig = {
-  brand: {
-    name: "Your Business",
-    tagline: "Your tagline from offer.md",
-    email: "you@example.com",
-  },
-  hero: {
-    eyebrow: "DERIVED FROM AUDIENCE.MD",
-    headline: "Derived from offer.md headline",
-    subhead: "Derived from offer.md value proposition",
-    ctaText: "Derived from offer.md CTA",
-    ctaUrl: "#pricing",
-  },
-  // ... sections populated from reference files
-}
-```
-
-### Section Types Available
-
-| Section Type | Purpose | Reference Source |
-|---|---|---|
-| `hero` | Headline, subhead, CTA, badge | offer.md, audience.md |
-| `reasons-grid` | Pain point cards | audience.md |
-| `process-stepper` | How it works timeline | offer.md (mechanism) |
-| `credibility` | Stats, testimonials, trust | testimonials.md |
-| `competitive-positioning` | Why you vs alternatives | offer.md, audience.md |
-| `objection-handling` | FAQ-style objection reframes | audience.md |
-| `faq` | Standard Q&A accordion | offer.md, audience.md |
-| `cta-simple` | Headline + button + microcopy | offer.md |
-| `cta-application` | Multi-step qualification form | audience.md, offer.md |
-| `examples-grid` | Use case cards | offer.md |
-| `trust-strip` | Logo bar | testimonials.md |
-| `interactive-explorer` | Clickable detail showcase | offer.md (features) |
-| `integration-river` | Scrolling logo marquee | offer.md (integrations) |
-| `footer` | Brand, contact, legal | brand info |
-
-See [references/section-patterns.md](references/section-patterns.md) for detailed generation rules per section.
-
-### Build Flows
-
-**Full rebuild:** Read all reference files → regenerate `site-config.ts` → regenerate all components
-
-**Add section:** Ask which section type → read relevant reference → generate component → add to `page.tsx`
-
-**Edit section:** Read current component → read relevant reference → update content and copy
-
-### Copy Guidelines
-
-- Pull language directly from reference files. Don't invent marketing speak.
-- Headlines from `offer.md` — the transformation, not the feature
-- Pain points from `audience.md` — their words, not generic
-- Testimonials from `testimonials.md` only — never fabricate
-- CTAs from `offer.md` — specific action, not generic "Learn More"
-- If site drives traffic to Skool, cross-reference `skool-surfaces.md` for messaging consistency between the landing page and the Skool about page
-
-### Design Guidelines
-
-Follow [references/frontend-design.md](references/frontend-design.md):
-
-- No generic fonts (Inter, Roboto, Arial banned)
-- Bold color commitment (not safe grays)
-- Hero animation is mandatory (GSAP stagger reveal)
-- CTA color is sacred — nothing else shares it
-- Mobile-first responsive
-- `prefers-reduced-motion` respected
-
-### Checkpoint
-
-> "Section generated. Want to preview it, add another section, or publish?"
-
----
-
-## Mode: preview
-
-Start local dev server for immediate feedback.
-
-### Steps
-
-1. Read config, get site repo path
-2. Start dev server:
-
-```bash
-cd [site_repo] && pnpm dev
-```
-
-3. Server starts at `http://localhost:3000`
-4. User reviews in browser, requests changes
-
-This mode is iterative. User stays in preview until satisfied, then routes to `/site publish`.
-
-### Checkpoint
-
-> "Looking good? Make changes, or publish when ready."
-
----
-
-## Mode: publish
-
-Ship changes to production.
-
-### Steps
-
-1. Read config, navigate to site repo
-2. Verify build passes:
-
-```bash
-cd [site_repo] && pnpm build
-```
-
-3. If build fails, fix before proceeding.
-4. Check git status:
-
-```bash
-git status
-git diff --stat
-```
-
-5. Stage, commit, and push:
-
-```bash
-git add -A
-git commit -m "[update] Description of changes"
-git push origin main
-```
-
-6. Netlify auto-deploys on push.
-
-**Exit:**
-
-> "Pushed to GitHub. Netlify will auto-deploy in ~1-2 minutes. Check status at https://app.netlify.com → [project-name]."
+| `content-strategy.md` | CTA destinations, newsletter signup integration |
+
+Detail per-shape:
+- Minisite: [`references/minisite-generation-system.md`](references/minisite-generation-system.md) (the system prompt) + [`references/anti-patterns.md`](references/anti-patterns.md)
+- Website (Next.js): [`references/section-patterns.md`](references/section-patterns.md) + [`references/frontend-design.md`](references/frontend-design.md)
 
 ---
 
 ## Pipeline Position
 
-The site is **infrastructure**, not recurring content. It's the destination that the content pipeline drives traffic to.
+The site is **infrastructure**, not recurring content. It's the destination the content pipeline drives traffic to.
 
 ```
 /think → reference files (the foundation)
      ↓
-/site → landing page (conversion endpoint)
+/site → site (conversion endpoint)
      ↓ drives traffic to:
-/ads → paid traffic → landing page
-/organic → social links → landing page
-/newsletter → email CTA → landing page
+/ads → paid traffic → site
+/organic → social links → site
+/newsletter → email CTA → site
 ```
 
-When reference files change significantly (new offer, new pricing), consider rebuilding:
-
-> "Your offer.md was updated since the site was last published. Want to run `/site build` to update your landing page?"
+When reference files change significantly (new offer, new pricing), consider re-running build:
+> "Your offer.md was updated since the site was last published. Want to run `/site build` to update?"
 
 ---
 
@@ -644,42 +254,44 @@ When reference files change significantly (new offer, new pricing), consider reb
 If conversation compacted or context was lost:
 
 1. **Re-invoke `/site`** to reload skill context
-2. **Check config:**
-
-```bash
-cat ~/.mainbranch/sites.json 2>/dev/null
-```
-
-3. **Check site repo status:**
-
-```bash
-cd [site_repo] && git status && git log --oneline -5
-```
-
-4. **Detect what mode was active** from git history and file state
-5. Resume from last completed step
+2. **Check config:** `cat ~/.mainbranch/sites.json 2>/dev/null`
+3. **Identify the site shape** from the config's `shape` field; load the corresponding build ref
+4. **Check site repo status:** `cd <site_repo> && git status && git log --oneline -5`
+5. **Resume from last completed step** based on git history + sites.json state
 
 ---
 
 ## Scope
 
-- **v1 is single-page only** — multi-page funnels are future
-- **Not for:** wikis (`/wiki`), email templates (`/newsletter`), quick mockups without reference files
+Site shapes the chassis covers: **lander** (1 page), **minisite** (~4 pages), **website** (full). Plus graduation paths up the ladder, including bolt-on CMS for the website tier.
+
+**Not for:**
+- Wikis (`/wiki`)
+- Email templates (`/newsletter`)
+- Quick mockups without business reference files
+- Apps with auth, dashboards, real-time features (use a separate app skill)
 
 ---
 
 ## References
 
-**Minisite branch (static HTML, Cloudflare Pages, atom-driven):**
+**Triage + per-shape build flows:**
 
-- [references/minisite-generation-system.md](references/minisite-generation-system.md) — Load-bearing system prompt for the `--one-shot` generation subagent. Hard constraints + soft brief + reference handling rules.
-- [references/anti-patterns.md](references/anti-patterns.md) — What NOT to bake into prompts (over-prescription, hex-locked critique, "make it look like X", template tokens). Read before extending the system prompt.
-- [references/naming-heuristic.md](references/naming-heuristic.md) — 8-step playbook for picking a brand-tier domain when the operator hits "I need a domain."
-- [references/cloudflare-pages-link.md](references/cloudflare-pages-link.md) — Dashboard walkthrough for the one-time CF Pages Git connect (fallback path; default uses `wrangler pages project create`).
+- [references/lander-build.md](references/lander-build.md) — 1-page shape (V1 stub)
+- [references/minisite-build.md](references/minisite-build.md) — ~4-page shape (V1 chassis target)
+- [references/website-build.md](references/website-build.md) — full-site shape (Next.js + future chassis-shape)
+- [references/graduation.md](references/graduation.md) — paths between shapes + CMS bolt-on (Sanity, Contentful, Notion, etc.)
 
-**Next.js branch (saas / high-ticket templates):**
+**Generation + design (used by per-shape flows):**
 
-- [references/frontend-design.md](references/frontend-design.md) — Typography, color, motion, anti-AI-slop standards
-- [references/section-patterns.md](references/section-patterns.md) — How reference files map to page sections
-- [references/deployment.md](references/deployment.md) — Netlify setup and troubleshooting
-- [references/examples-and-troubleshooting.md](references/examples-and-troubleshooting.md) — Usage examples, common fixes
+- [references/minisite-generation-system.md](references/minisite-generation-system.md) — load-bearing system prompt for minisite generation subagent
+- [references/anti-patterns.md](references/anti-patterns.md) — what NOT to bake into prompts
+- [references/naming-heuristic.md](references/naming-heuristic.md) — 8-step domain naming playbook
+- [references/cloudflare-pages-link.md](references/cloudflare-pages-link.md) — CF Pages GitHub App handshake walkthrough
+- [references/frontend-design.md](references/frontend-design.md) — typography, color, motion (Next.js-relevant)
+- [references/section-patterns.md](references/section-patterns.md) — section catalog (Next.js-relevant)
+
+**Legacy:**
+
+- [references/deployment.md](references/deployment.md) — Netlify deploy walkthrough (pre-chassis fallback)
+- [references/examples-and-troubleshooting.md](references/examples-and-troubleshooting.md) — usage examples, common fixes

--- a/.claude/skills/site/SKILL.md
+++ b/.claude/skills/site/SKILL.md
@@ -195,22 +195,27 @@ Detailed mapping rules: [references/section-patterns.md](references/section-patt
 
 First-time setup. Creates a new site repo from a starter template.
 
-### Step 1: Choose Template
+### Step 1: Choose Site Shape
 
-Present options:
+Present options. Site shape, not business vertical — vertical is in `offer.md`.
 
-> **Which template fits your business?**
+> **What kind of site are you building?**
 >
-> 1. **SaaS / Product** (Next.js) — Hero → Demo → Value Prop → Workflow → Examples → Integrations → CTA
->    Best for: software, e-commerce, product companies. Has a build step.
+> 1. **Lander** (1 page, all-in-one) — single page: hero + offer + proof + CTA + footer.
+>    *V1 status:* pattern defined, generation system prompt not yet written. Use **Minisite** for now if you need single-page-feel — option 2 already covers that case via its `/start/` page.
 >
-> 2. **High-Ticket Services** (Next.js) — Hero → Solution → Pain → Process → Competitive → Objections → Proof → Qualification → FAQ → CTA
->    Best for: coaching, consulting, agencies, $3k+ services. Has a build step.
+> 2. **Minisite** (~4 pages, static HTML) — home + `how-it-works/` + 2 LLM-picked from `{proof, pricing, start, faq}` + required `privacy/`, `terms/`, `start/thanks/`. Designed fresh per offer by a generation subagent. **Cloudflare Pages by default. V1 chassis target.**
+>    Best for: paid-ad minisite tests, single-offer first deploys, deposit-gateway flows.
+>    Spec: [`mb-vip/.claude/reference/minisite.md`](../../reference/minisite.md). Skill flow below: see "Minisite Template Branch."
 >
-> 3. **Lander** (static HTML) — 4 pages designed fresh per offer by an LLM-generation subagent. No build step. No template inheritance.
->    Best for: speedrun lander tests, paid-ad landing pages, single-offer first deploys. **Picks Cloudflare Pages + atom-driven domain setup.** See "Lander Template Branch" below.
+> 3. **Website** (full, multi-section, build step likely) — for businesses with content depth (blog, multiple offers, knowledge base, course area).
+>    *V1 status:* pattern defined, chassis-shape Website generation not yet wired. Legacy Next.js templates (`saas`, `high-ticket`) work via Steps 2–11 below as starting points; those are pre-chassis examples that fit a few specific verticals. The full Website tier evolves in V2.
 
-If `lander` is chosen, **skip Steps 2–11 below and go to "Lander Template Branch"** — that flow uses Cloudflare Pages + atoms, not Netlify + Next.js. The existing Steps 2–11 apply only to `saas` / `high-ticket`.
+**Hosting default:** Cloudflare Pages for all three shapes. Better CLI, better domain integration, git auto-deploy out of the box. Netlify path stays for the legacy `saas` / `high-ticket` templates only — not the chassis target.
+
+**Graduation:** sites can graduate up the shape ladder when an offer earns it. Lander → Minisite (the single-pager pulls traffic that wants more proof, more pages emerge). Minisite → Website (a winning minisite gets deeper content, a blog, multi-offer support, course area). The graduation isn't automatic; it's an operator decision triggered by the offer pulling traffic that wants more content. V1 doesn't ship a graduation tool — manual repo work for now; future skill mode if it becomes recurring.
+
+If `minisite` is chosen, **skip Steps 2–11 below and go to "Minisite Template Branch"** — that flow uses Cloudflare Pages + atoms. Steps 2–11 apply to the legacy `saas` / `high-ticket` Next.js templates only.
 
 ### Step 2: Name and Location
 
@@ -304,11 +309,11 @@ Create `~/.mainbranch/` directory if it doesn't exist.
 
 ---
 
-## Lander Template Branch
+## Minisite Template Branch
 
-When the operator picked the `lander` template in Step 1, the setup and build flows are different from the Next.js templates above. Static HTML, no build step, Cloudflare Pages, atom-driven domain + DNS + custom-domain attachment.
+When the operator picked the `minisite` template in Step 1, the setup and build flows are different from the Next.js templates above. Static HTML, no build step, Cloudflare Pages, atom-driven domain + DNS + custom-domain attachment.
 
-### setup (lander)
+### setup (minisite)
 
 **1. Name + project repo.** Ask the operator:
 - Site name (e.g., `thelastbill`). Becomes the Pages project name.
@@ -326,7 +331,7 @@ If anything's red, route the operator to `bash .claude/skills/site/scripts/setup
 
 **3. Domain — buy-new vs. existing.** Ask:
 - "Already own the domain?" → skip to step 4 with the domain name
-- "Need to buy?" → run `python3 .claude/skills/site/scripts/domain.py check <name> --tlds .com,.co,.io` first to confirm availability + TLD support. If `extension_not_supported_via_api`, fall back to the Cloudflare dashboard (https://dash.cloudflare.com/registrar — confirm the right account before purchase). For API-supported TLDs and after explicit operator Y on price, proceed with `domain.py buy <name>` — *will be wired in a follow-up PR; today the buy is dashboard for the first lander, then API once `domain.py buy --registrar=cloudflare` lands*.
+- "Need to buy?" → run `python3 .claude/skills/site/scripts/domain.py check <name> --tlds .com,.co,.io` first to confirm availability + TLD support. If `extension_not_supported_via_api`, fall back to the Cloudflare dashboard (https://dash.cloudflare.com/registrar — confirm the right account before purchase). For API-supported TLDs and after explicit operator Y on price, proceed with `domain.py buy <name>` — *will be wired in a follow-up PR; today the buy is dashboard for the first minisite, then API once `domain.py buy --registrar=cloudflare` lands*.
 
 **4. DNS ensure.** Once the domain is owned (CF Registrar or Porkbun), run:
 ```bash
@@ -362,22 +367,22 @@ The atom attaches the domain, creates the CNAME record in the zone (the step the
   "name": "<name>",
   "site_repo": "/absolute/path/to/repo",
   "business_repo": "/absolute/path/to/business-repo",
-  "template": "lander",
+  "template": "minisite",
   "hosting": "cloudflare",
   "domain": "<full apex>"
 }
 ```
 
 **Exit:**
-> "Lander chassis ready at https://<domain>. Placeholder deployed; run `/site build --one-shot` to generate the actual lander from your offer + audience specs."
+> "Minisite ready at https://<domain>. Placeholder deployed; run `/site build --one-shot` to generate the actual minisite from your offer + audience specs."
 
-### build --one-shot (lander)
+### build --one-shot (minisite)
 
 This is the load-bearing mode — where Claude (the operator's running session) spawns a subagent that generates fresh HTML/CSS/SVG for this offer. No template inheritance. No placeholder tokens. No Anthropic SDK call. The subagent is a Claude Code subagent, spawned via the `Agent` tool.
 
 **1. Resolve offer context.** Use the existing offer-context resolution above (lines 116–145). At minimum: `offer.md` + `audience.md` paths + the active offer slug.
 
-**2. Load the system prompt.** Read [`references/lander-generation-system.md`](references/lander-generation-system.md) verbatim. This is the load-bearing artifact — the full hard-constraints + soft-brief framing for the generation subagent. Pass it as the subagent's system prompt unmodified.
+**2. Load the system prompt.** Read [`references/minisite-generation-system.md`](references/minisite-generation-system.md) verbatim. This is the load-bearing artifact — the full hard-constraints + soft-brief framing for the generation subagent. Pass it as the subagent's system prompt unmodified.
 
 **3. Build the user message.** Compose:
 - Resolved `offer.md` content
@@ -387,7 +392,7 @@ This is the load-bearing mode — where Claude (the operator's running session) 
 - Project repo absolute path (where the subagent writes via `Write`)
 - Soft directive: *"Generate fresh HTML/CSS/SVG for this offer. The reference URLs are taste anchors, not templates — read them for polish level, then design something that fits **this** offer. Surprise me."*
 
-Anti-patterns to avoid in your own framing of the user message: see [`references/anti-patterns.md`](references/anti-patterns.md). The big ones: don't lock typography or colors, don't enumerate available sections, don't ask the subagent to "make it look like Howdy," don't suppress variance.
+Anti-patterns to avoid in your own framing of the user message: see [`references/anti-patterns.md`](references/anti-patterns.md). The big ones: don't lock typography or colors, don't enumerate available sections, don't ask the subagent to "make it look like the references," don't suppress variance.
 
 **4. Spawn the subagent.** Invoke the `Agent` tool with `subagent_type=general-purpose`, the system prompt from step 2, and the user message from step 3. The subagent has `Write` access; it will write files directly to the project repo path.
 
@@ -403,16 +408,16 @@ Anti-patterns to avoid in your own framing of the user message: see [`references
 - Hero artifact picked
 - Color palette
 - Two page choices
-- Suggested commit message: `"[add] one-shot lander generation for <offer>"`
+- Suggested commit message: `"[add] one-shot minisite generation for <offer>"`
 
 Operator runs `git add -A && git commit && git push`. Cloudflare auto-deploys (after #98) or operator runs `wrangler pages deploy` manually.
 
 **Variance test (acceptance criterion):** Running `/site build --one-shot` twice on the same offer must produce visually different output. If it doesn't, the soft brief was too prescriptive — re-read [`references/anti-patterns.md`](references/anti-patterns.md).
 
-### What's NOT in the lander branch
+### What's NOT in the minisite branch
 
 - No `pnpm install`, no `pnpm build`. Static HTML only.
-- No `site-config.ts` pattern. Each lander generates its own one-off structure.
+- No `site-config.ts` pattern. Each minisite generates its own one-off structure.
 - No section-types menu (the Next.js section catalog at lines 381–399 doesn't apply).
 - No `configure` mode separate from `build --one-shot` — the generation subagent reads voice.md / offer.md directly and bakes the brand decisions into the output.
 - No Anthropic API key. No `pages_gen.py` Python wrapper. The generation runs inside the operator's Claude Code session via the `Agent` tool.
@@ -665,9 +670,9 @@ cd [site_repo] && git status && git log --oneline -5
 
 ## References
 
-**Lander branch (static HTML, Cloudflare Pages, atom-driven):**
+**Minisite branch (static HTML, Cloudflare Pages, atom-driven):**
 
-- [references/lander-generation-system.md](references/lander-generation-system.md) — Load-bearing system prompt for the `--one-shot` generation subagent. Hard constraints + soft brief + reference handling rules.
+- [references/minisite-generation-system.md](references/minisite-generation-system.md) — Load-bearing system prompt for the `--one-shot` generation subagent. Hard constraints + soft brief + reference handling rules.
 - [references/anti-patterns.md](references/anti-patterns.md) — What NOT to bake into prompts (over-prescription, hex-locked critique, "make it look like X", template tokens). Read before extending the system prompt.
 - [references/naming-heuristic.md](references/naming-heuristic.md) — 8-step playbook for picking a brand-tier domain when the operator hits "I need a domain."
 - [references/cloudflare-pages-link.md](references/cloudflare-pages-link.md) — Dashboard walkthrough for the one-time CF Pages Git connect (fallback path; default uses `wrangler pages project create`).

--- a/.claude/skills/site/references/anti-patterns.md
+++ b/.claude/skills/site/references/anti-patterns.md
@@ -1,18 +1,18 @@
-# Anti-Patterns — What NOT to Bake Into Lander Generation
+# Anti-Patterns — What NOT to Bake Into Minisite Generation
 
-Lessons from prior failed prompt attempts. Each pattern below was tried, produced bad output, and is now explicitly avoided. The lander generation system prompt (`lander-generation-system.md`) is shaped around these.
+Lessons from prior failed prompt attempts. Each pattern below was tried, produced bad output, and is now explicitly avoided. The minisite generation system prompt (`minisite-generation-system.md`) is shaped around these.
 
 ## 1. Over-prescription
 
 **Pattern:** The prompt specifies typography (`font-family: Inter, sans-serif`), exact hex colors (`#0a0a0a` background, `#fafafa` text, `#3b82f6` CTA), section structure (`hero → 3-up features → testimonial carousel → pricing table → CTA`), spacing scale, even shadow values.
 
-**Result:** Every output looks like every other output. The LLM has nothing to decide; it slot-fills. The lander becomes indistinguishable from a generic SaaS template, regardless of offer.
+**Result:** Every output looks like every other output. The LLM has nothing to decide; it slot-fills. The minisite becomes indistinguishable from a generic SaaS template, regardless of offer.
 
-**Fix in `lander-generation-system.md`:** Specify structural constraints (4 pages, SEO, footer, mobile-first, perf budget). Leave aesthetic decisions — palette, typography, section order, hero artifact — to the LLM with reference URLs as taste signal.
+**Fix in `minisite-generation-system.md`:** Specify structural constraints (4 pages, SEO, footer, mobile-first, perf budget). Leave aesthetic decisions — palette, typography, section order, hero artifact — to the LLM with reference URLs as taste signal.
 
 ## 2. Hex-locked color critique
 
-**Pattern:** Reviewing a generated lander, telling the LLM "the CTA needs to be `#10b981` and the heading should be `#0f172a` not `#1e293b`."
+**Pattern:** Reviewing a generated minisite, telling the LLM "the CTA needs to be `#10b981` and the heading should be `#0f172a` not `#1e293b`."
 
 **Result:** The LLM stops making aesthetic judgments. Future runs default to "ask the operator for hex codes." The agent loses the ability to pick a palette that fits the offer's voice.
 
@@ -20,9 +20,9 @@ Lessons from prior failed prompt attempts. Each pattern below was tried, produce
 
 ## 3. "Make it look like Howdy"
 
-**Pattern:** Pointing at a successful lander and saying "make this offer's lander look like that."
+**Pattern:** Pointing at a successful minisite and saying "make this offer's minisite look like that."
 
-**Result:** Surface-copying. The LLM lifts colors, layouts, fonts. The new lander reads as derivative — and worse, it doesn't fit the new offer's tone (a billing tool's lander shouldn't feel like a spiritual coach's).
+**Result:** Surface-copying. The LLM lifts colors, layouts, fonts. The new minisite reads as derivative — and worse, it doesn't fit the new offer's tone (a billing tool's minisite shouldn't feel like a spiritual coach's).
 
 **Fix:** Reference URLs are **polish anchors**, not templates. The system prompt explicitly says: "read them for polish level, not structure to copy." The user message frames them as "here's the level of intentionality we want; now design something fresh that fits **this** offer."
 
@@ -38,7 +38,7 @@ Lessons from prior failed prompt attempts. Each pattern below was tried, produce
 
 **Pattern:** "Choose from these section types: hero-left-image, hero-right-image, three-up-grid, four-up-grid, testimonial-quote-block, testimonial-carousel, pricing-table-3-tier, faq-accordion, cta-banner..."
 
-**Result:** The LLM picks from a menu instead of inventing. The lander reads as assembled rather than designed. Same problem as #1 (over-prescription) but applied at the section level.
+**Result:** The LLM picks from a menu instead of inventing. The minisite reads as assembled rather than designed. Same problem as #1 (over-prescription) but applied at the section level.
 
 **Fix:** The system prompt names the four pages and a few decision points (which two extra pages this offer needs, what the hero artifact should be). It does not enumerate component types. The LLM decides what each page contains.
 
@@ -62,7 +62,7 @@ Lessons from prior failed prompt attempts. Each pattern below was tried, produce
 
 ## How to write a critique that doesn't break the chassis
 
-When you don't like a generated lander:
+When you don't like a generated minisite:
 
 - **Describe the quality, not the value.** "The hero feels too cold for an emotional offer" → not → "change `#0a0a0a` to `#1c1917`."
 - **Name the missing thing, not the present thing.** "There's no signature visual; the hero is just text" → not → "remove the gradient."

--- a/.claude/skills/site/references/cloudflare-pages-link.md
+++ b/.claude/skills/site/references/cloudflare-pages-link.md
@@ -13,7 +13,7 @@ You only need this once per Cloudflare account. Skip if `pages.py create-project
 
 **Background.** CF Pages needs two things:
 
-- The **GitHub App** installed on the GitHub account/org that owns your lander repo (so CF can read commits)
+- The **GitHub App** installed on the GitHub account/org that owns your site repo (so CF can read commits)
 - An **OAuth handshake** between that install and your CF account (so CF knows which install to use for *your* projects)
 
 Just installing the App on GitHub isn't enough. The OAuth handshake fires from the CF dashboard, not from GitHub. The non-obvious part: the dashboard never has a stand-alone "set up Git integration" button. The handshake gets triggered only as a side-effect of starting the Workers/Pages **Create application** flow. You don't have to actually create anything — connecting the repo in the flow is enough; the OAuth side-effect is what we want.
@@ -24,8 +24,8 @@ Just installing the App on GitHub isn't enough. The OAuth handshake fires from t
 2. Left sidebar: **Build** group → **Compute** → **Workers & Pages**
 3. Click **Create application** (blue button, top-right)
 4. Click **Continue with GitHub** (or "Continue with GitHub" — wording varies by recent UI updates)
-5. Authorize the **Cloudflare Workers and Pages** GitHub App when GitHub asks. Choose the GitHub account or org that owns your lander repo.
-   - If GitHub asks "All repositories" vs "Only select repositories" — pick "All repositories" for least friction across future landers, or pick the specific repo if you want to scope tightly.
+5. Authorize the **Cloudflare Workers and Pages** GitHub App when GitHub asks. Choose the GitHub account or org that owns your site repo.
+   - If GitHub asks "All repositories" vs "Only select repositories" — pick "All repositories" for least friction across future sites, or pick the specific repo if you want to scope tightly.
 6. After GitHub redirects you back to Cloudflare, you'll see a list of your repos. **Connect a repo** — any repo is fine; the connection itself is what completes the OAuth handshake.
 7. **Don't finish creating the application.** Close the tab or click cancel. The handshake already fired the moment GitHub redirected back to CF.
 

--- a/.claude/skills/site/references/graduation.md
+++ b/.claude/skills/site/references/graduation.md
@@ -1,0 +1,124 @@
+# Graduation — Site Shape Transitions
+
+When an offer pulls more traffic, the site that supports it often needs more. The chassis ships three site shapes (lander, minisite, website) and a fourth posture (website with a CMS bolted on for non-developer content editing). Sites can graduate up the ladder; this file documents the paths and when to take each.
+
+V1 doesn't ship an automated graduation tool — these are operator-decision moments triggered by real signal. The skill recognizes the signal, surfaces the option, walks through the change. Future versions may script more of it.
+
+---
+
+## When to graduate
+
+| Signal | Suggests graduating from → to |
+|---|---|
+| 1-page lander pulls traffic that lingers on hero but doesn't convert; people want more proof or process detail before deciding | **Lander → Minisite** |
+| Minisite paid-ad funnel gets meaningful conversions; offer is validated; team wants to add blog, case studies, multiple offer pages, course/community area | **Minisite → Website** |
+| Website grows past ~10 pages OR non-developers (marketing, ops, founder partner) need to edit content without git access | **Website → Website + CMS** |
+| Website needs structured content (case studies, courses, products, locations) with relationships and queries | **Website → Website + CMS** |
+| Site outgrows static; needs auth, gated content, dashboards, complex forms | (out of scope for /site — use a separate app skill or upgrade to a full SPA) |
+
+Don't graduate prematurely. Each tier costs operational complexity. Graduate when the *current* tier is failing — not because a future tier sounds neat.
+
+---
+
+## Lander → Minisite
+
+**What changes:**
+- 1 page → 4 pages (home + how-it-works + 2 LLM-picked + privacy/terms/start/start-thanks)
+- Single hero focus → distributed proof + how-it-works + faq across pages
+- Same domain, same Cloudflare Pages project (no infra change)
+
+**Mechanics:**
+1. Run `/site build --one-shot` against the existing project. The minisite generation subagent reads the same offer.md / audience.md and produces a 4-page version. The home page stays focused; supporting pages get the proof, mechanism, and faq content.
+2. Confirm `/start/` (the focused conversion CTA) and `/start/thanks/` are present (minisite shape requires them).
+3. Update `~/.mainbranch/sites.json` `shape` field: `lander` → `minisite`.
+4. `git push` — Cloudflare auto-deploys.
+5. (Optional) Re-run `og_render.py` if the og.svg changed.
+
+**Gotcha:** if the lander had a meta description / OG image tuned for the single-page funnel, the minisite generation may produce different OG content. Either accept the new content or pass `--reference <old-lander-url>` to the subagent's reference list to anchor toward continuity.
+
+---
+
+## Minisite → Website
+
+**What changes:**
+- 4 pages → 10+ pages (blog, multiple offers, knowledge base, course area, etc.)
+- Static HTML → likely Next.js / Astro with build step (component reuse pays off past ~6 pages)
+- Possibly: deeper navigation (header nav, footer site map), search, taxonomy
+
+**Two paths:**
+
+### A. Stay static, expand
+
+Keep the static HTML, add more directories. Simple, no build step. Works for ~10–15 page sites without taxonomy.
+
+1. Add new pages directly in the project repo (`/about/`, `/blog/`, `/case-studies/<slug>/`, etc.)
+2. Update `sitemap.xml`, `_headers`, internal nav by hand or with a small subagent prompt
+3. `git push` — Cloudflare auto-deploys
+
+### B. Migrate to Next.js / Astro / similar
+
+Past ~10–15 pages, component reuse + a build step pays off. Two sub-options:
+
+- **Re-platform onto a Next.js template** (e.g., the legacy `saas` / `high-ticket` templates) — see [`website-build.md`](website-build.md). The minisite content gets ported to component structures; offer.md / audience.md drive `site-config.ts`. Keep the same domain — just point Cloudflare Pages at a build command (`pnpm build`) and output dir (`out` / `dist`).
+- **Keep static, add a generator** (e.g., 11ty, Astro static mode) — middle ground. Build step but lighter than Next.js.
+
+**Mechanics for path B (Next.js example):**
+1. Create a parallel Next.js repo. The minisite repo's content gets copied/adapted into Next.js components.
+2. Configure CF Pages project's build settings (in dashboard): build command `pnpm build`, output `out`. Or create a fresh Pages project pointed at the new repo.
+3. Test on a `*.pages.dev` URL before flipping the apex domain.
+4. When ready, detach the apex domain from the old project and re-attach to the new one (use the `pages.py set-domain` atom).
+5. Update `~/.mainbranch/sites.json` — `shape: website`, `template: <next-template>`, optionally archive the old minisite repo.
+
+**Gotcha:** SEO continuity. The minisite's URLs (`/how-it-works/`, `/proof/`, etc.) should map cleanly to the new site's URLs. Use `_redirects` for any path changes.
+
+---
+
+## Website → Website + CMS
+
+**Why bolt on a CMS:**
+- Non-developers need to edit content (blog posts, case studies, product info) without touching git
+- Content has structure that benefits from queries (filter case studies by industry, list courses by topic)
+- Multi-language or multi-region content needs centralization
+- Editorial workflow (drafts, review, publish) needs explicit status
+
+**Common CMS options for static sites:**
+
+| CMS | Strength | When to pick |
+|---|---|---|
+| **Sanity** | Real-time, structured content with relationships, GROQ queries, customizable Studio editor | Most flexible; preferred for complex content models |
+| **Contentful** | Mature, enterprise-y, broad ecosystem | When team wants a polished editor and doesn't need infinite custom schema |
+| **Notion as CMS** | Use existing Notion workspace as content source via API | Lowest friction if team already lives in Notion; trade-off: Notion's API is rate-limited and not built for high traffic |
+| **Markdown in repo** (no CMS) | Files in git, edited via PR, all version-controlled | Best when content editors are comfortable with git or willing to use the GitHub web UI |
+| **Decap CMS** (formerly Netlify CMS) | Git-backed, self-hosted, free | When you want a CMS UI but don't want a third-party SaaS bill |
+
+**Bolt-on mechanics (Sanity example, as the most common):**
+
+1. Create a Sanity project at https://sanity.io. Define schema for the content types (blog posts, case studies, etc.) — schema lives in code, deploys to Sanity hosted Studio.
+2. Add `@sanity/client` to the website repo. Page templates fetch content from Sanity at build time (for static sites) or runtime (for SSR sites).
+3. Migrate existing markdown / hand-written content into Sanity via the Studio or import script.
+4. Configure rebuild webhooks: Sanity content publish → triggers Cloudflare Pages rebuild (CF Pages supports deploy hooks).
+5. Editor team uses Sanity Studio (sanity.studio/{project}) to add/edit content; on publish, the website rebuilds and deploys automatically.
+
+**The chassis stays the same.** The Cloudflare Pages project doesn't care about the CMS; it just sees a git push or a deploy hook fire and rebuilds.
+
+**Gotchas:**
+- Build time grows as content grows. For a static site with hundreds of CMS items, build can take 5+ minutes. Consider on-demand revalidation (Next.js ISR) or chunked builds at that point.
+- Editor permissions: Sanity has roles, but coordinate with the team on who can publish vs. draft.
+- Asset hosting: Sanity hosts images by default with a CDN. If you want assets on your own CDN, configure Sanity's asset URL to proxy or use a transform.
+
+---
+
+## Anti-patterns when graduating
+
+- **Skipping tiers.** Lander → Website + CMS in one move is usually a sign the team wants to "do it right the first time." That's almost always premature. Each tier validates whether the next is needed.
+- **Graduating before the offer is validated.** A minisite that's not converting doesn't need more pages — it needs a better offer or a different message. Graduating won't fix the upstream problem.
+- **Bolting a CMS on too early.** A 5-page website with infrequent content updates doesn't need Sanity overhead. Edit pages directly via git PRs until the team's velocity demands a CMS.
+- **Re-platforming because the team is bored.** If the current tier works, leave it alone. Engineering inertia is a feature when conversion data says you're winning.
+
+---
+
+## What V1 ships vs. what's automated later
+
+V1 ships these graduation paths as **documented manual flows** — the chassis recognizes the signal, surfaces the option, but the operator does the work (with Claude Code's help via `/site` modes).
+
+Future versions might add `/site graduate <new-shape>` as a skill mode that automates the bulk of the transition (creates the new repo, ports content, swaps the apex domain). That ships only after the manual flow has been run on real graduations and the patterns are stable enough to script.

--- a/.claude/skills/site/references/lander-build.md
+++ b/.claude/skills/site/references/lander-build.md
@@ -1,0 +1,30 @@
+# Lander — Build Flow
+
+The lander shape: 1 page, all-in-one. Hero + offer + proof + CTA + footer, all on `index.html`. Maximum focus, minimum nav.
+
+**V1 status:** the chassis-shape lander generation system prompt is not yet written. For single-page-feel use cases in V1, use the **minisite** shape — its `/start/` page already serves as the focused conversion target, while the home page does the brand work. See [`minisite-build.md`](minisite-build.md).
+
+When chassis-shape lander generation lands, this file gets the same shape as `minisite-build.md`:
+
+- `setup (lander)` — atom chain (domain, dns, pages, custom-domain), single-file project repo, Cloudflare Pages git-connected
+- `build --one-shot (lander)` — generation subagent invoked with `lander-generation-system.md` (also future) + offer/audience/reference URLs; produces `index.html` + `_headers` + `og.svg` + `favicon.svg` (no per-section subdirectories)
+- Validation: footer presence, OG render, single-page Lighthouse score
+- What's NOT (no nav, no multi-page structure, no `/start/thanks/` separate page — thanks state shown inline or via Stripe's default thanks page)
+
+---
+
+## Why not ship a lander generation system in V1
+
+Three reasons:
+
+1. **The minisite covers the use case.** A 4-page minisite where 3 of the pages are linked from the home hero gives the same psychological "single focused funnel" feel as a 1-page lander, without losing the room for proof + how-it-works + faq.
+2. **Vagueness at single-page is harder.** Less surface area for variance — the system prompt risks producing visually identical output across runs unless we're disciplined. Minisite has more room to surprise.
+3. **Conversion data lives at the minisite tier.** Devon's first chassis run is paid Google Ads → minisite → Stripe deposit. The lander shape becomes load-bearing only when there's a real reason to compress to one page (very specific offers, retargeting flows, etc.) — that signal hasn't surfaced yet.
+
+When it does, this file gets the full shape and the chassis adds a `lander-generation-system.md` peer to `minisite-generation-system.md`.
+
+---
+
+## Graduating up
+
+A successful lander often pulls traffic that wants more proof / more pages → graduate to **minisite**. See [`graduation.md`](graduation.md) for the path.

--- a/.claude/skills/site/references/minisite-build.md
+++ b/.claude/skills/site/references/minisite-build.md
@@ -1,0 +1,129 @@
+# Minisite — Build Flow
+
+The minisite shape: ~4 pages of static HTML, no build step, deployed to Cloudflare Pages with git auto-deploy. Designed fresh per offer by a generation subagent — no template inheritance.
+
+V1 chassis target. The default for paid-ad lander tests, single-offer first deploys, and deposit-gateway flows.
+
+The canonical contract for what a minisite *is* (page list, per-page content, post-payment flow, tracking, walkthrough UX) lives at `mb-vip/.claude/reference/minisite.md` (engine-side spec). This file is the **/site skill's implementation flow** — how the skill walks the operator through producing one.
+
+---
+
+## setup (minisite)
+
+**1. Name + project repo.** Ask the operator:
+- Site name (e.g., `thelastbill`). Becomes the Pages project name.
+- Project repo location (default: sibling of vip — `~/Documents/GitHub/<name>` for solo work, `~/Documents/GitHub/noontide-sites/<name>` for Noontide work). Empty repo, no template merge.
+- Apex domain. If they don't have one, route to [`naming-heuristic.md`](naming-heuristic.md) — an 8-step playbook for generating + validating brand-tier names.
+
+**2. Atom-chain prerequisites.** Confirm the credentials are in place:
+```bash
+source ~/.config/vip/env.sh
+python3 .claude/skills/site/scripts/verify_live.py
+```
+Expect 3/3 passed (Cloudflare scopes + zone lookup + domain-check CLI). Porkbun skipped is fine for the CF-registered path.
+
+If anything's red, route the operator to `bash .claude/skills/site/scripts/setup_creds.sh` to provision Cloudflare credentials, then re-run.
+
+**3. Domain — buy-new vs. existing.** Ask:
+- "Already own the domain?" → skip to step 4 with the domain name.
+- "Need to buy?" → run `python3 .claude/skills/site/scripts/domain.py check <name> --tlds .com,.co,.io` first to confirm availability + TLD support. If `extension_not_supported_via_api`, fall back to the Cloudflare dashboard at https://dash.cloudflare.com/registrar (confirm the right account before purchase). For API-supported TLDs and after explicit operator Y on price, proceed with `domain.py buy <name>` once that subcommand wires the live API call.
+
+**4. DNS ensure.** Once the domain is owned (CF Registrar or Porkbun), run:
+```bash
+python3 .claude/skills/site/scripts/dns.py ensure <domain> --registrar cloudflare --skip-propagation-poll
+```
+For CF-registered domains the zone is auto-created with NS already at CF — this is an idempotent verification, not a state change. For Porkbun-registered domains, the atom swaps NS to CF nameservers and polls propagation.
+
+**5. GitHub repo + initial scaffold push.** Create the project repo and push a placeholder `index.html` so the Pages project has something to deploy:
+```bash
+gh repo create <owner>/<name> --public --add-readme
+git clone https://github.com/<owner>/<name>.git ~/Documents/GitHub/<name>
+cd ~/Documents/GitHub/<name>
+echo '<!doctype html><title><name></title><h1>soon</h1>' > index.html
+git add -A && git commit -m "[add] placeholder" && git push
+```
+
+**6. Cloudflare Pages project (git-connected).** The atom creates the project with `source.type=github` so every push auto-deploys:
+```bash
+python3 .claude/skills/site/scripts/pages.py create-project <name> --repo-owner <owner> --repo-name <repo> --branch main
+```
+Live-tested in PR #102. If you hit `github_app_not_installed`, the envelope's `suggestion` field walks through the dashboard handshake step (Compute → Workers & Pages → Create application → Continue with GitHub → connect any repo → close the tab); see [`cloudflare-pages-link.md`](cloudflare-pages-link.md) for the full path.
+
+**7. Custom domain attach + DNS verification.** Run:
+```bash
+python3 .claude/skills/site/scripts/pages.py set-domain <name> <domain> --timeout-seconds 300
+```
+The atom attaches the domain, creates the CNAME record in the zone (the step the dashboard hides), and polls until SSL is active. Expect ~3-4 min total. Live-tested end-to-end in PR #97.
+
+**8. Save config.** Write or extend `~/.mainbranch/sites.json`:
+```json
+{
+  "name": "<name>",
+  "site_repo": "/absolute/path/to/repo",
+  "business_repo": "/absolute/path/to/business-repo",
+  "shape": "minisite",
+  "hosting": "cloudflare",
+  "domain": "<full apex>"
+}
+```
+
+**Exit:**
+> "Minisite ready at https://<domain>. Placeholder deployed; run `/site build --one-shot` to generate the actual minisite from your offer + audience specs."
+
+---
+
+## build --one-shot (minisite)
+
+The load-bearing mode — where Claude (the operator's running session) spawns a subagent that generates fresh HTML/CSS/SVG for this offer. No template inheritance. No placeholder tokens. No Anthropic SDK call. The subagent is a Claude Code subagent, spawned via the `Agent` tool.
+
+**1. Resolve offer context.** Use the offer-context resolution from `SKILL.md`. At minimum: `offer.md` + `audience.md` paths + the active offer slug.
+
+**2. Load the system prompt.** Read [`minisite-generation-system.md`](minisite-generation-system.md) verbatim. This is the load-bearing artifact — the full hard-constraints + soft-brief framing for the generation subagent. Pass it as the subagent's system prompt unmodified.
+
+**3. Build the user message.** Compose:
+- Resolved `offer.md` content
+- Resolved `audience.md` content
+- Optional `voice.md` snippets (anchor phrases, named enemies, "never say" list)
+- Reference URLs — defaults: `https://howdy.md`, `https://thelastbill.com`. Operator can pass `--reference URL` to add or replace.
+- Project repo absolute path (where the subagent writes via `Write`)
+- Soft directive: *"Generate fresh HTML/CSS/SVG for this offer. The reference URLs are taste anchors, not templates — read them for polish level, then design something that fits **this** offer. Surprise me."*
+
+Anti-patterns to avoid in your own framing of the user message: see [`anti-patterns.md`](anti-patterns.md). The big ones: don't lock typography or colors, don't enumerate available sections, don't ask the subagent to "make it look like the references," don't suppress variance.
+
+**4. Spawn the subagent.** Invoke the `Agent` tool with `subagent_type=general-purpose`, the system prompt from step 2, and the user message from step 3. The subagent has `Write` access; it will write files directly to the project repo path.
+
+**5. Validate the output.** After the subagent returns, run these checks against the project repo:
+
+- **Required files present:** `index.html`, `how-it-works/index.html`, two more page directories with `index.html`, `privacy/index.html`, `terms/index.html`, `_headers`, `_redirects`, `robots.txt`, `sitemap.xml`, `og.svg`, `favicon.svg`. Each missing file = a fix request to the subagent.
+- **Footer presence:** `grep -L "Noontide Collective LLC" *.html **/*.html` should return nothing (or only files where `offer.md` declared a different parent entity — check the override).
+- **OG render:** `python3 .claude/skills/site/scripts/og_render.py render <repo>/og.svg <repo>/og.png`. Envelope must return `status: ok` with `width: 1200, height: 630`. Failure → fix request to subagent (likely `og.svg` viewBox is wrong).
+- **Lighthouse smoke (optional, V1.1):** `npx lighthouse http://localhost:8000 --only-categories=performance --form-factor=mobile` against a local `python3 -m http.server` running in the project repo. Score ≥ 90 = pass.
+
+**6. Commit + push (operator's call).** Once validation is green, summarize for the operator:
+- Files written
+- Hero artifact picked
+- Color palette
+- Two page choices
+- Suggested commit message: `"[add] one-shot minisite generation for <offer>"`
+
+Operator runs `git add -A && git commit && git push`. Cloudflare auto-deploys (per the git-connected Pages project from step 6 of setup).
+
+**Variance test (acceptance criterion):** Running `/site build --one-shot` twice on the same offer must produce visually different output. If it doesn't, the soft brief was too prescriptive — re-read [`anti-patterns.md`](anti-patterns.md).
+
+---
+
+## What's NOT in the minisite shape
+
+- No `pnpm install`, no `pnpm build`. Static HTML only.
+- No `site-config.ts` pattern. Each minisite generates its own one-off structure.
+- No section-types menu (the Next.js section catalog from `website-build.md` doesn't apply).
+- No `configure` mode separate from `build --one-shot` — the generation subagent reads voice.md / offer.md directly and bakes the brand decisions into the output.
+- No Anthropic API key. No `pages_gen.py` Python wrapper. The generation runs inside the operator's Claude Code session via the `Agent` tool.
+
+---
+
+## Iterating after first build
+
+Re-running `/site build --one-shot` produces a fresh design (variance is the feature). For targeted edits, edit the file in the project repo directly and `git push` — Cloudflare auto-deploys.
+
+When the offer pulls more traffic and the minisite needs more pages or content depth, that's the **graduation signal**. See [`graduation.md`](graduation.md) for paths from minisite → website (chassis-shape full site) or minisite → Website + CMS (Sanity, Contentful, etc.).

--- a/.claude/skills/site/references/minisite-generation-system.md
+++ b/.claude/skills/site/references/minisite-generation-system.md
@@ -1,6 +1,6 @@
-# Lander Generation — System Prompt
+# Minisite Generation — System Prompt
 
-This file is the **load-bearing artifact** for `/site build --one-shot`. The skill loads this content as the system prompt for the lander-generation subagent. Edit with care: the constraints below define the chassis.
+This file is the **load-bearing artifact** for `/site build --one-shot`. The skill loads this content as the system prompt for the minisite-generation subagent. Edit with care: the constraints below define the minisite shape.
 
 The skill also passes the resolved `offer.md` + `audience.md` + reference URLs as the user message. The subagent generates HTML/CSS/SVG with the `Write` tool into the project repo. The skill validates the output afterward (file presence, footer, OG render).
 

--- a/.claude/skills/site/references/naming-heuristic.md
+++ b/.claude/skills/site/references/naming-heuristic.md
@@ -2,7 +2,7 @@
 
 A repeatable playbook for picking a brand-tier domain when the operator hits "I need a domain." Use this when the offer doesn't already have a name. Run via `domain.py check` and validate the top picks with `domain-check --info` before purchase.
 
-The goal is a `.com` (or `.co`, `.app`, `.io`) that reads as a confident standalone brand — not a generic descriptor or a clever-but-forgettable pun. Spend 15 minutes here; the name will outlive the lander by years.
+The goal is a `.com` (or `.co`, `.app`, `.io`) that reads as a confident standalone brand — not a generic descriptor or a clever-but-forgettable pun. Spend 15 minutes here; the name will outlive the site by years.
 
 ---
 

--- a/.claude/skills/site/references/website-build.md
+++ b/.claude/skills/site/references/website-build.md
@@ -1,0 +1,265 @@
+# Website — Build Flow
+
+The website shape: full multi-section site, often with a build step (Next.js, Astro, etc.), possibly with a blog, multi-offer support, knowledge base, course area. Larger surface area than a minisite; warrants component reuse and a structured site-config.
+
+V1 status: chassis-shape Website generation is not yet wired (a future companion to `minisite-generation-system.md`). For now, this flow uses the legacy Next.js templates (`saas` and `high-ticket` — Devon-specific examples) as starting points. They work via Netlify deploy or Cloudflare Pages with a build step.
+
+When chassis-shape Website ships, this file gets a sibling section for the static-or-Next.js LLM-generated path.
+
+---
+
+## Hosting decision (default: Cloudflare Pages)
+
+For new Website builds, Cloudflare Pages is the chassis default — better CLI, better domain integration, git auto-deploy, supports Next.js/Astro/React with build steps via build presets. Netlify works too and is documented in [`deployment.md`](deployment.md) as the legacy path; pick it only if you have specific Netlify-only needs.
+
+For Cloudflare Pages with a build step:
+```bash
+python3 .claude/skills/site/scripts/pages.py create-project <name> \
+  --repo-owner <owner> --repo-name <repo> --branch main
+# Build settings configured in CF dashboard once: Build command (e.g., `pnpm build`), Output dir (`out` or `dist`)
+```
+
+For Netlify legacy path: see [`deployment.md`](deployment.md).
+
+---
+
+## setup (Next.js website)
+
+**1. Choose template.** Two pre-chassis examples:
+- **SaaS / Product** — Hero → Demo → Value Prop → Workflow → Examples → Integrations → CTA. Best for software, e-commerce, product companies.
+- **High-Ticket Services** — Hero → Solution → Pain → Process → Competitive → Objections → Proof → Qualification → FAQ → CTA. Best for coaching, consulting, agencies, $3k+ services.
+
+These are Devon-specific examples, not the broader Website tier. Future chassis-shape Website generation will produce fresh per-offer like the minisite shape.
+
+**2. Name + location.**
+- Site name (e.g., "my-landing-page")
+- Location (default: `~/sites/[name]`)
+
+**3. Check prerequisites.**
+```bash
+node --version    # Need 18+
+pnpm --version    # Package manager
+gh auth status    # GitHub CLI authenticated
+```
+If anything missing, install before proceeding:
+- Wrong Node version → `nvm use 18`
+- pnpm not found → `npm install -g pnpm`
+- gh not authenticated → `gh auth login`
+
+**4. Create GitHub repo.**
+```bash
+gh repo create [name] --private --clone --directory [location]
+cd [location]
+```
+
+**5. Add template as upstream.**
+```bash
+git remote add upstream https://github.com/mainbranch-ai/site-template-[saas|high-ticket].git
+git fetch upstream
+git merge upstream/main --allow-unrelated-histories -m "Initial template merge"
+```
+
+**6. Install dependencies.**
+```bash
+pnpm install
+```
+
+**7. Verify build.**
+```bash
+pnpm build
+```
+If build fails, troubleshoot before proceeding. Don't deploy a broken build.
+
+**8. Initial commit and push.**
+```bash
+git add -A
+git commit -m "[add] Initial site from template"
+git push -u origin main
+```
+
+**9. Deploy.**
+- **Cloudflare Pages (default):** `python3 .claude/skills/site/scripts/pages.py create-project <name> --repo-owner <owner> --repo-name <repo> --branch main` — git-connected, auto-deploys on push. Configure build command (`pnpm build`) + output directory (`out` or `dist`) in the CF dashboard once.
+- **Netlify (legacy):** see [`deployment.md`](deployment.md). Key settings: Build command = `pnpm build`, Publish directory = `out`, NODE_VERSION = `20`.
+
+**10. Detect business repo.** Ask: "Where is your business repo with reference files?" Confirm the path has `reference/core/` files. If the business repo has `reference/offers/`, ask which offer this site is for. Store the offer in the sites.json config.
+
+**11. Save config.** Write `~/.mainbranch/sites.json`:
+```json
+[
+  {
+    "name": "<site-name>",
+    "site_repo": "/absolute/path/to/site-repo",
+    "business_repo": "/absolute/path/to/business-repo",
+    "shape": "website",
+    "template": "saas",
+    "hosting": "cloudflare",
+    "domain": "<your-cf-pages-or-custom-apex>"
+  }
+]
+```
+
+Create `~/.mainbranch/` directory if it doesn't exist.
+
+**Exit:**
+> "Site deployed at https://<url>. Run `/site configure` to apply your brand, or `/site build` to start customizing sections from your reference files."
+
+---
+
+## configure (Next.js website)
+
+Apply brand identity from reference files to the site's visual system.
+
+**What it reads:**
+- `voice.md` — Aesthetic direction, tone, personality
+- `offer.md` — Headline copy, value proposition
+- `soul.md` — Mission text, credibility elements
+
+**What it changes:**
+- `app/globals.css` — CSS custom properties (colors, fonts)
+- `app/layout.tsx` — Font imports, metadata
+- `site-config.ts` — Brand name, tagline, metadata
+
+**Voice-to-aesthetic derivation:**
+
+| Voice Trait | Design Implication |
+|---|---|
+| Warm, personal | Rounded corners, warm palette, serif or humanist sans display font |
+| Direct, authoritative | Sharp corners, high contrast, geometric sans or strong serif |
+| Playful, energetic | Bold colors, larger type scale, bouncy motion, personality fonts |
+| Premium, refined | Restrained palette, ample whitespace, thin weights, serif display |
+| Technical, expert | Monospace accents, structured grids, muted palette with signal color |
+
+See [`frontend-design.md`](frontend-design.md) for font pairings, color systems, and motion guidelines.
+
+**Steps:**
+1. Read `voice.md` — determine aesthetic direction
+2. Read `offer.md` — extract headline, tagline, CTA text
+3. Choose font pairing based on voice (see frontend-design reference)
+4. Choose color palette based on brand positioning
+5. Update CSS variables in `globals.css`
+6. Update font imports in `layout.tsx`
+7. Update metadata (title, description, OG tags) in `layout.tsx`
+
+**Checkpoint:**
+> "Preview the brand changes? Run `/site preview` to see them locally, or continue to `/site build` to generate sections."
+
+---
+
+## build (Next.js website)
+
+The core generation mode. Reads reference files and generates page sections.
+
+**How it works:**
+1. Resolve offer context — use offer-specific `offer.md` and `audience.md` when available
+2. Read reference files from business repo (resolved paths)
+3. Generate or update `site-config.ts` — the single source of all brand-specific content
+4. Generate or edit component files in `components/`
+5. Update page composition in `app/page.tsx`
+
+**The site-config.ts pattern:**
+
+All brand-specific content lives in one file. Components import from it:
+
+```typescript
+// site-config.ts
+export const siteConfig = {
+  brand: {
+    name: "Your Business",
+    tagline: "Your tagline from offer.md",
+    email: "you@example.com",
+  },
+  hero: {
+    eyebrow: "DERIVED FROM AUDIENCE.MD",
+    headline: "Derived from offer.md headline",
+    subhead: "Derived from offer.md value proposition",
+    ctaText: "Derived from offer.md CTA",
+    ctaUrl: "#pricing",
+  },
+  // ... sections populated from reference files
+}
+```
+
+**Section types available:**
+
+| Section Type | Purpose | Reference Source |
+|---|---|---|
+| `hero` | Headline, subhead, CTA, badge | offer.md, audience.md |
+| `reasons-grid` | Pain point cards | audience.md |
+| `process-stepper` | How it works timeline | offer.md (mechanism) |
+| `credibility` | Stats, testimonials, trust | testimonials.md |
+| `competitive-positioning` | Why you vs alternatives | offer.md, audience.md |
+| `objection-handling` | FAQ-style objection reframes | audience.md |
+| `faq` | Standard Q&A accordion | offer.md, audience.md |
+| `cta-simple` | Headline + button + microcopy | offer.md |
+| `cta-application` | Multi-step qualification form | audience.md, offer.md |
+| `examples-grid` | Use case cards | offer.md |
+| `trust-strip` | Logo bar | testimonials.md |
+| `interactive-explorer` | Clickable detail showcase | offer.md (features) |
+| `integration-river` | Scrolling logo marquee | offer.md (integrations) |
+| `footer` | Brand, contact, legal | brand info |
+
+See [`section-patterns.md`](section-patterns.md) for detailed generation rules per section.
+
+**Build flows:**
+- **Full rebuild:** Read all reference files → regenerate `site-config.ts` → regenerate all components.
+- **Add section:** Ask which section type → read relevant reference → generate component → add to `page.tsx`.
+- **Edit section:** Read current component → read relevant reference → update content and copy.
+
+**Copy guidelines:**
+- Pull language directly from reference files. Don't invent marketing speak.
+- Headlines from `offer.md` — the transformation, not the feature.
+- Pain points from `audience.md` — their words, not generic.
+- Testimonials from `testimonials.md` only — never fabricate.
+- CTAs from `offer.md` — specific action, not generic "Learn More."
+- If site drives traffic to Skool, cross-reference `skool-surfaces.md` for messaging consistency between the landing page and the Skool about page.
+
+**Design guidelines:** Follow [`frontend-design.md`](frontend-design.md):
+- No generic fonts (Inter, Roboto, Arial banned)
+- Bold color commitment (not safe grays)
+- Hero animation is mandatory (GSAP stagger reveal)
+- CTA color is sacred — nothing else shares it
+- Mobile-first responsive
+- `prefers-reduced-motion` respected
+
+**Checkpoint:**
+> "Section generated. Want to preview it, add another section, or publish?"
+
+---
+
+## preview (Next.js website)
+
+Start local dev server for immediate feedback.
+
+```bash
+cd <site_repo> && pnpm dev
+```
+
+Server starts at `http://localhost:3000`. User reviews in browser, requests changes. Iterative — stay in preview until satisfied, then route to publish.
+
+**Checkpoint:**
+> "Looking good? Make changes, or publish when ready."
+
+---
+
+## publish (Next.js website)
+
+Ship changes to production.
+
+```bash
+cd <site_repo> && pnpm build       # Verify build passes; fix before proceeding
+git status && git diff --stat       # Review changes
+git add -A
+git commit -m "[update] Description of changes"
+git push origin main
+```
+
+Cloudflare Pages auto-deploys on push (per the git-connected project from setup step 9). Netlify legacy path also auto-deploys on push.
+
+**Exit:**
+> "Pushed to GitHub. Cloudflare will auto-deploy in ~1-2 minutes (or Netlify if you set up legacy). Live URL: https://<domain>."
+
+---
+
+## Graduating to a website with CMS
+
+When the website grows past ~10 pages or content needs to be edited by non-developers, the chassis supports bolting on a CMS. See [`graduation.md`](graduation.md) for the Sanity / Contentful / Notion-as-CMS / etc. paths.

--- a/.claude/skills/site/scripts/og_render.py
+++ b/.claude/skills/site/scripts/og_render.py
@@ -13,7 +13,7 @@ Output: companyctx-shape envelope JSON on stdout, logs on stderr.
 Exit code: 0 on ok|partial, 1 on degraded.
 
 Why this is its own atom (per stacked-skill decision 2026-04-27):
-- Lander HTML/CSS/SVG generation happens via subagents inside the
+- Site HTML/CSS/SVG generation happens via subagents inside the
   /site build --one-shot skill. That's not API work — Claude Code is
   the LLM.
 - But the SVG → PNG render IS deterministic external work: shell out


### PR DESCRIPTION
## Summary

Audit + restructure pass on `/site`. The skill is no longer minisite-only — it now triages across three site shapes (**lander**, **minisite**, **website**) plus graduation paths between them, including bolt-on CMS for the website tier.

Following the [Anthropic skill-creator](https://github.com/anthropics/skills) progressive-disclosure convention: router SKILL.md + per-variant references. SKILL.md was 686 lines (over the 500-line skill-creator target). Now **297 lines**.

## Why this PR exists

Devon's audit directive after PR #101 (the `/site` extension that introduced `lander` template framing): the skill drifted into being minisite-only with stale Netlify scaffolding throughout. The triage didn't actually triage — Step 1 listed shapes but routed via "skip Steps 2–11" comments. Graduation paths between shapes weren't documented anywhere. Prereqs listed "Netlify account — Free tier works" when Devon explicitly prefers Cloudflare.

This PR is the cleanup. No atom code changes; pure skill prose + reference reorganization.

## Audit findings (10 nonsense items, all fixed)

| Where | Was | Now |
|---|---|---|
| Frontmatter trigger | "Publishing to Netlify" | Drop Netlify; broaden triggers to lander/minisite/website/graduate; Cloudflare default |
| Prereqs | "Netlify account — Free tier works. Created during setup if needed." | **Removed.** Cloudflare account = chassis default; Node + pnpm now flagged as Website-only |
| sites.json examples | `template: high-ticket, hosting: netlify` | Shape-current: `shape: minisite, hosting: cloudflare` |
| Setup Step 9 | Netlify dashboard walkthrough as only deploy path | Moved to `website-build.md`; Cloudflare default for all three shapes |
| Mode: publish | "Netlify auto-deploys on push" | Cloudflare auto-deploys (per #102's git-connected Pages project) |
| Scope line | "v1 is single-page only — multi-page funnels are future" | Removed (stale; lander/minisite/website all V1) |
| Self-references | "the Next.js section catalog at lines 381–399" | Killed — content moved to website-build.md |
| Self-references | "lines 116–145" for offer context resolution | Killed — replaced with descriptive pointer |
| Step 1 menu | "skip Steps 2–11" branching | Real triage with explicit routes to per-shape refs |
| Graduation paths | Not documented anywhere | New `references/graduation.md` (124 lines) |

## New file structure

```
/site SKILL.md (297 lines, router-shaped)
└── references/
    ├── lander-build.md         (30 lines, V1 stub)
    ├── minisite-build.md       (129 lines, V1 chassis target)
    ├── website-build.md        (265 lines, Next.js + future chassis-shape)
    ├── graduation.md           (124 lines, paths + CMS bolt-on)
    │
    ├── minisite-generation-system.md  (existing — load-bearing system prompt)
    ├── anti-patterns.md               (existing)
    ├── naming-heuristic.md            (existing)
    ├── cloudflare-pages-link.md       (existing)
    ├── frontend-design.md             (existing — Next.js-relevant)
    ├── section-patterns.md            (existing — Next.js-relevant)
    ├── deployment.md                  (kept as legacy Netlify ref)
    └── examples-and-troubleshooting.md (kept)
```

## New triage (progressive disclosure)

```
What are you doing?
  A. New site from scratch — pick a shape:
     - Lander (1 page)   → references/lander-build.md
     - Minisite (~4 pgs) → references/minisite-build.md  ← V1 chassis
     - Website (full)    → references/website-build.md
  B. Iterating on existing — go to Mode: build (per shape) or publish
  C. Graduating shapes  → references/graduation.md
```

If the operator can't articulate which: predecessor question — "what goal are you trying to hit?" Their answer maps cleanly to a shape.

## Graduation paths (now documented)

- **Lander → Minisite** — single-pager pulls more content; same domain, same Pages project, re-run `/site build --one-shot`
- **Minisite → Website** — 4 pages → 10+, blog, multi-offer; two paths (stay-static-expand or migrate to Next.js/Astro)
- **Website → Website + CMS** — bolt on Sanity / Contentful / Notion-as-CMS / Decap / markdown-in-repo when content grows or non-developers need to edit
- Anti-patterns: skipping tiers, premature graduation, re-platforming out of boredom

V1 ships these as documented manual flows. Future versions may add `/site graduate <new-shape>` as an automated mode.

## Test plan

- [x] `bash ~/.claude/skills/test-skills/test-skills.sh` — **152/162** (10 pre-existing, **0 introduced**)
- [x] `python3 -m pytest .claude/skills/site/scripts/test_atoms.py` — **66/66** (atom code unchanged; rename-only sweep from prior commit on this branch is preserved)
- [x] All 12 reference links in SKILL.md resolve to existing files
- [x] Frontmatter description renders in available-skills system reminder (verified live)
- [x] No `Netlify` in any chassis-default position; only in `deployment.md` legacy ref
- [x] No `lander` references where 4-page is meant; "Lander" preserved only where 1-page shape is the intent

## What this unblocks (subsequent PRs)

1. **`mb-vip/.claude/reference/minisite.md`** (V1 chassis spec — engine-side cross-skill reference per Devon's earlier directive). The SKILL.md already references it.
2. **`stripe.py` atom** (#99). Builds against a stable `/site` interface; success_url contract aligns with the minisite shape's `/start/thanks/` page.
3. **`/start launch`** orchestration (#92). The triage shape is in place for `/start launch <offer>` to route into `/site` cleanly.

## What's untouched

The atom layer (`.claude/skills/site/scripts/`): `_envelope.py`, `domain.py`, `dns.py`, `pages.py`, `og_render.py`, `verify_live.py`, `setup_creds.sh`, `test_atoms.py` — all unchanged. They're shape-agnostic deterministic API wrappers.

The first commit on this branch (`978243c`) was a rename sweep that preceded this restructure: `lander-generation-system.md` → `minisite-generation-system.md` plus body sweeps. That commit + this restructure together = the full audit + course-correction landing.

Refs #94 (V1 onboarding pinned current-state), the [OE v2 naming convention](https://github.com/noontide-co/noontide-projects/blob/main/decisions/2026-04-23-noontide-operating-environment-v2.md), and the [Anthropic skill-creator](https://github.com/anthropics/skills) progressive-disclosure pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)