### PR TITLE
[add] V1 atom — stripe.py (create-payment-link, idempotent, mb_ metadata)

### DIFF
--- a/.claude/reference/minisite.md
+++ b/.claude/reference/minisite.md
@@ -1,6 +1,6 @@
 # Minisite — V1 Chassis Spec
 
-The canonical contract for what a minisite **is** in the Main Branch chassis. Implementation flows live elsewhere; this file is the source of truth for page list, content contracts, post-payment flow, tracking, and walkthrough UX.
+The canonical contract for what a minisite **is** in Main Branch. Implementation flows live elsewhere; this file is the source of truth for page list, content contracts, post-payment flow, tracking, and walkthrough UX.
 
 When `/site`, `/start launch`, `stripe.py`, or any future skill ships behavior that touches a minisite, that behavior conforms to this spec. If the spec changes, update this file first; downstream code follows.
 
@@ -8,11 +8,11 @@ When `/site`, `/start launch`, `stripe.py`, or any future skill ships behavior t
 
 ## What a minisite is
 
-A **minisite** is a small (~4–6 page) static-HTML site, generated fresh per offer, deployed to Cloudflare Pages with git auto-deploy. It's the V1 chassis target — the speedrun shape that takes an offer from offer-locked to live-on-a-custom-apex with a working Stripe deposit gateway in under an hour.
+A **minisite** is a small (~4–6 page) static-HTML site, generated fresh per offer, deployed to Cloudflare Pages with git auto-deploy. It's the V1 speedrun target — taking an offer from offer-locked to live-on-a-custom-apex with a working Stripe deposit gateway in under an hour.
 
 Not a template. Not inheritance. Each minisite is generated from scratch by a Claude Code subagent reading `offer.md` + `audience.md` + reference URLs. Two runs on the same offer produce visually distinct sites (variance is the feature).
 
-The minisite is one of three site shapes the chassis supports — see [`graduation.md`](../skills/site/references/graduation.md) for the full ladder (lander → minisite → website → website + CMS).
+The minisite is one of three site shapes `/site` supports — see [`graduation.md`](../skills/site/references/graduation.md) for the full ladder (lander → minisite → website → website + CMS).
 
 ---
 
@@ -45,11 +45,11 @@ A coaching offer often lands on home + how-it-works + proof + faq. A software of
 |---|---|
 | `/privacy/` | Privacy policy. Boilerplate fine for V1. |
 | `/terms/` | Terms of service. Boilerplate fine for V1. |
-| `/start/thanks/` | Post-payment landing. **Required.** This is Stripe's `success_url` default for the chassis. |
+| `/start/thanks/` | Post-payment landing. **Required.** This is Stripe's `success_url` default. |
 
 The home page is the conversion target — its primary CTA links directly to the Stripe payment-link URL. There is no separate `/start/` page; that ceremony adds a click without adding signal.
 
-### Required chassis files (repo root)
+### Required infrastructure files (repo root)
 
 | Path | Purpose |
 |---|---|
@@ -107,7 +107,7 @@ The Stripe URL is the same one used everywhere on the site. Until the link is wi
 
 ### Privacy / Terms
 
-Boilerplate language is fine for V1. The chassis assumes the operator's lawyer reviews before scale. Boilerplate must include: data collected (email, payment info via Stripe), how it's used, retention policy, contact for requests. Generate from a template or LLM but mark as boilerplate in a comment.
+Boilerplate language is fine for V1. Main Branch assumes the operator's lawyer reviews before scale. Boilerplate must include: data collected (email, payment info via Stripe), how it's used, retention policy, contact for requests. Generate from a template or LLM but mark as boilerplate in a comment.
 
 ### Start / Thanks (`/start/thanks/`)
 
@@ -206,7 +206,7 @@ The generation subagent fires standard conversion events when the corresponding 
 
 ---
 
-## Pre-flight gates (before chassis runs)
+## Pre-flight gates (before `/start launch` runs)
 
 `/start launch <offer>` must verify these before money or state changes:
 
@@ -220,7 +220,7 @@ The generation subagent fires standard conversion events when the corresponding 
 | Domain decision | Setup | Operator confirms own-or-buy via `/site setup` triage |
 | Tracking IDs (if declared) | Generation | offer.md frontmatter parse — if any tracking field present, validate format |
 
-Failed gate = halt with a specific message and routing suggestion. No silent skips, no partial chassis runs.
+Failed gate = halt with a specific message and routing suggestion. No silent skips, no partial runs.
 
 ---
 
@@ -261,7 +261,7 @@ The orchestration mode (lives in `/start`, ships in #92) walks the operator thro
 
 ### Phase 6 — Ship
 
-- Operator commits + pushes (or chassis does on their Y)
+- Operator commits + pushes (or `/start launch` does on their Y)
 - Cloudflare auto-deploys
 - Verify `https://<domain>/` returns 200
 - Print summary: live URL, repo URL, total spend, time-to-ship
@@ -272,9 +272,9 @@ The orchestration mode (lives in `/start`, ships in #92) walks the operator thro
 
 Two runs of the generation subagent on the same `offer.md` + `audience.md` must produce visually distinct sites — different palettes, hero artifacts, page choices, microcopy.
 
-If two runs produce identical output, the soft brief was too prescriptive. The chassis is supposed to surprise. See [`anti-patterns.md`](../skills/site/references/anti-patterns.md) — over-prescription is the anti-pattern that kills variance.
+If two runs produce identical output, the soft brief was too prescriptive. Generation is supposed to surprise. See [`anti-patterns.md`](../skills/site/references/anti-patterns.md) — over-prescription is the anti-pattern that kills variance.
 
-This is the chassis's quality bar: an LLM that produces the same minisite twice on the same offer is the LLM not making aesthetic decisions, and that's broken.
+This is the quality bar: an LLM that produces the same minisite twice on the same offer is the LLM not making aesthetic decisions, and that's broken.
 
 ---
 

--- a/.claude/reference/minisite.md
+++ b/.claude/reference/minisite.md
@@ -158,11 +158,11 @@ When `stripe.py create-payment-link <offer-slug>` runs against the offer:
 | `currency` | `usd` | hardcoded V1; multi-currency is V2 |
 | `description` | offer.md `deposit_description` or generated | offer.md or LLM |
 | `statement_descriptor` | offer.md `statement_descriptor` or `NOONTIDE` | offer.md or fallback (max 22 chars) |
-| `metadata.chassis_offer` | `<offer-slug>` | derived from offer's directory name |
-| `metadata.chassis_kind` | `deposit` | hardcoded for V1 |
+| `metadata.mb_offer` | `<offer-slug>` | derived from offer's directory name |
+| `metadata.mb_kind` | `deposit` | hardcoded for V1 |
 | `success_url` | `https://<domain>/start/thanks/` | derived from `sites.json` `domain` |
 
-The atom emits the `payment_link.url` in its envelope. The orchestration writes that URL into the project repo (e.g., `<repo>/.chassis/stripe-deposit.json`) so the generation subagent reads it during the build phase and substitutes it into every CTA href on the site (home hero, secondary CTA, pricing CTA if shipped).
+The atom emits the `payment_link.url` in its envelope. The orchestration writes that URL into the project repo (e.g., `<repo>/.mainbranch/stripe-deposit.json`) so the generation subagent reads it during the build phase and substitutes it into every CTA href on the site (home hero, secondary CTA, pricing CTA if shipped).
 
 ### What's NOT in the post-payment flow (V1)
 
@@ -251,7 +251,7 @@ The orchestration mode (lives in `/start`, ships in #92) walks the operator thro
 ### Phase 4 — Stripe
 
 - `stripe.py create-payment-link <offer-slug> --amount <cents>` 
-- Write returned URL to `<repo>/.chassis/stripe-deposit.json`
+- Write returned URL to `<repo>/.mainbranch/stripe-deposit.json`
 
 ### Phase 5 — Generation
 

--- a/.claude/skills/site/SKILL.md
+++ b/.claude/skills/site/SKILL.md
@@ -78,11 +78,11 @@ The skill reads from the business repo and writes to the site repo. These are se
 
 ## Prerequisites
 
-Default chassis path uses **Cloudflare Pages** (better CLI, better domain integration, git auto-deploy, supports static and build-step sites alike).
+Default deploy target is **Cloudflare Pages** (better CLI, better domain integration, git auto-deploy, supports static and build-step sites alike).
 
 | Tool | Required for | Install |
 |---|---|---|
-| Cloudflare account | All site shapes (chassis default) | https://dash.cloudflare.com (free) |
+| Cloudflare account | All site shapes (default) | https://dash.cloudflare.com (free) |
 | `gh` CLI authenticated | Repo creation | `brew install gh` + `gh auth login` |
 | Cloudflare API token + account ID + GitHub App install | Atom-driven domain/DNS/Pages flow | One-time: `bash .claude/skills/site/scripts/setup_creds.sh` then [`references/cloudflare-pages-link.md`](references/cloudflare-pages-link.md) for the GitHub App OAuth handshake |
 | `offer.md` + `audience.md` | Site generation | Build via `/think` first if missing |
@@ -95,7 +95,7 @@ python3 .claude/skills/site/scripts/verify_live.py
 ```
 Expect 3/3 passed (Cloudflare scopes + zone lookup + domain-check CLI). Porkbun skipped is fine for the CF-registered path.
 
-Netlify is supported as a legacy fallback for pre-chassis Next.js templates only — see [`references/deployment.md`](references/deployment.md). Not the chassis target.
+Netlify is supported as a legacy fallback for pre-V1 Next.js templates only — see [`references/deployment.md`](references/deployment.md). Not the default target.
 
 ---
 
@@ -168,14 +168,14 @@ Ask the operator. Route based on the answer; don't assume.
 >
 > **A. New site from scratch.** Pick a shape:
 > - 🟦 **Lander** (1 page, all-in-one) — hero + offer + proof + CTA + footer. Maximum focus, minimum nav.
->   *V1: chassis-shape lander generation not yet wired. Use **Minisite** for single-page-feel use cases — its `/start/` page covers the focused conversion target.* Future spec: [`references/lander-build.md`](references/lander-build.md).
+>   *V1: per-offer lander generation not yet wired. Use **Minisite** for single-page-feel use cases — its home page covers the focused conversion target.* Future spec: [`references/lander-build.md`](references/lander-build.md).
 >
-> - 🟩 **Minisite** (~4 pages, static HTML) — home + how-it-works + 2 LLM-picked + privacy/terms/start/start-thanks. Designed fresh per offer by a generation subagent. **V1 chassis target.**
+> - 🟩 **Minisite** (~4–6 pages, static HTML) — home + how-it-works + 2–4 LLM-picked + privacy/terms/start-thanks. Designed fresh per offer by a generation subagent. **V1 target.**
 >   Best for: paid-ad lander tests, single-offer first deploys, deposit-gateway flows.
 >   Flow: [`references/minisite-build.md`](references/minisite-build.md). Engine spec: `mb-vip/.claude/reference/minisite.md`.
 >
 > - 🟨 **Website** (full, multi-section, build step likely) — depth, blog, multiple offers, knowledge base, course area.
->   *V1 status:* chassis-shape Website generation pending. Legacy Next.js templates (`saas`, `high-ticket`) work today as starting points.
+>   *V1 status:* per-offer Website generation pending. Legacy Next.js templates (`saas`, `high-ticket`) work today as starting points.
 >   Flow: [`references/website-build.md`](references/website-build.md).
 >
 > **B. Iterating on an existing site.** Same shape, more content / edits.
@@ -263,7 +263,7 @@ If conversation compacted or context was lost:
 
 ## Scope
 
-Site shapes the chassis covers: **lander** (1 page), **minisite** (~4 pages), **website** (full). Plus graduation paths up the ladder, including bolt-on CMS for the website tier.
+Site shapes `/site` covers: **lander** (1 page), **minisite** (~4–6 pages), **website** (full). Plus graduation paths up the ladder, including bolt-on CMS for the website tier.
 
 **Not for:**
 - Wikis (`/wiki`)
@@ -278,8 +278,8 @@ Site shapes the chassis covers: **lander** (1 page), **minisite** (~4 pages), **
 **Triage + per-shape build flows:**
 
 - [references/lander-build.md](references/lander-build.md) — 1-page shape (V1 stub)
-- [references/minisite-build.md](references/minisite-build.md) — ~4-page shape (V1 chassis target)
-- [references/website-build.md](references/website-build.md) — full-site shape (Next.js + future chassis-shape)
+- [references/minisite-build.md](references/minisite-build.md) — ~4–6 page shape (V1 target)
+- [references/website-build.md](references/website-build.md) — full-site shape (Next.js + future per-offer generation)
 - [references/graduation.md](references/graduation.md) — paths between shapes + CMS bolt-on (Sanity, Contentful, Notion, etc.)
 
 **Generation + design (used by per-shape flows):**
@@ -293,5 +293,5 @@ Site shapes the chassis covers: **lander** (1 page), **minisite** (~4 pages), **
 
 **Legacy:**
 
-- [references/deployment.md](references/deployment.md) — Netlify deploy walkthrough (pre-chassis fallback)
+- [references/deployment.md](references/deployment.md) — Netlify deploy walkthrough (legacy fallback)
 - [references/examples-and-troubleshooting.md](references/examples-and-troubleshooting.md) — usage examples, common fixes

--- a/.claude/skills/site/references/anti-patterns.md
+++ b/.claude/skills/site/references/anti-patterns.md
@@ -32,7 +32,7 @@ Lessons from prior failed prompt attempts. Each pattern below was tried, produce
 
 **Result:** The LLM operates as a mail-merge engine. Output structure is locked to whatever the template authors imagined. Aesthetic invention is impossible — the template predetermined every section, every copy slot, every interactive element.
 
-**Fix:** No template repo. The chassis ships zero source files for the LLM to inherit from. The LLM generates fresh HTML/CSS/SVG per offer, with reference URLs as taste anchors only. If two runs on the same offer produce identical output, the chassis is broken.
+**Fix:** No template repo. `/site` ships zero source files for the LLM to inherit from. The LLM generates fresh HTML/CSS/SVG per offer, with reference URLs as taste anchors only. If two runs on the same offer produce identical output, generation is broken.
 
 ## 5. Over-enumerating "available sections"
 
@@ -54,13 +54,13 @@ Lessons from prior failed prompt attempts. Each pattern below was tried, produce
 
 **Pattern:** "Make sure that if I run this twice, I get similar output."
 
-**Result:** The LLM clamps to the safe default. Variance is the feature — different runs produce visually distinct output that all fit the offer. The chassis is supposed to surprise.
+**Result:** The LLM clamps to the safe default. Variance is the feature — different runs produce visually distinct output that all fit the offer. Generation is supposed to surprise.
 
 **Fix:** The system prompt explicitly tests for variance: *"If two runs on the same offer produce visually identical output, you've been too conservative."* The skill's acceptance criteria include "running --one-shot twice on the same spec produces visually different output."
 
 ---
 
-## How to write a critique that doesn't break the chassis
+## How to write a critique that doesn't break generation
 
 When you don't like a generated minisite:
 
@@ -69,4 +69,4 @@ When you don't like a generated minisite:
 - **Ask for a different decision, not a different parameter.** "Pick a different hero artifact — a receipt, not a stamp" → not → "change `<svg viewBox='0 0 100 100'>` to `<svg viewBox='0 0 200 200'>`."
 - **Re-run before iterating.** Sometimes the first generation is conservative. A re-run often produces a sharper take. Iterate by re-running, not by directing.
 
-The chassis only works when the LLM is making aesthetic decisions. Every constraint we add is a decision we're taking away. Add only the structural ones (file presence, footer, perf, SEO, OG dimensions) — leave the rest open.
+Generation only works when the LLM is making aesthetic decisions. Every constraint we add is a decision we're taking away. Add only the structural ones (file presence, footer, perf, SEO, OG dimensions) — leave the rest open.

--- a/.claude/skills/site/references/graduation.md
+++ b/.claude/skills/site/references/graduation.md
@@ -1,6 +1,6 @@
 # Graduation — Site Shape Transitions
 
-When an offer pulls more traffic, the site that supports it often needs more. The chassis ships three site shapes (lander, minisite, website) and a fourth posture (website with a CMS bolted on for non-developer content editing). Sites can graduate up the ladder; this file documents the paths and when to take each.
+When an offer pulls more traffic, the site that supports it often needs more. `/site` ships three site shapes (lander, minisite, website) and a fourth posture (website with a CMS bolted on for non-developer content editing). Sites can graduate up the ladder; this file documents the paths and when to take each.
 
 V1 doesn't ship an automated graduation tool — these are operator-decision moments triggered by real signal. The skill recognizes the signal, surfaces the option, walks through the change. Future versions may script more of it.
 
@@ -99,7 +99,7 @@ Past ~10–15 pages, component reuse + a build step pays off. Two sub-options:
 4. Configure rebuild webhooks: Sanity content publish → triggers Cloudflare Pages rebuild (CF Pages supports deploy hooks).
 5. Editor team uses Sanity Studio (sanity.studio/{project}) to add/edit content; on publish, the website rebuilds and deploys automatically.
 
-**The chassis stays the same.** The Cloudflare Pages project doesn't care about the CMS; it just sees a git push or a deploy hook fire and rebuilds.
+**The deploy target stays the same.** The Cloudflare Pages project doesn't care about the CMS; it just sees a git push or a deploy hook fire and rebuilds.
 
 **Gotchas:**
 - Build time grows as content grows. For a static site with hundreds of CMS items, build can take 5+ minutes. Consider on-demand revalidation (Next.js ISR) or chunked builds at that point.
@@ -119,6 +119,6 @@ Past ~10–15 pages, component reuse + a build step pays off. Two sub-options:
 
 ## What V1 ships vs. what's automated later
 
-V1 ships these graduation paths as **documented manual flows** — the chassis recognizes the signal, surfaces the option, but the operator does the work (with Claude Code's help via `/site` modes).
+V1 ships these graduation paths as **documented manual flows** — `/site` recognizes the signal, surfaces the option, but the operator does the work (with Claude Code's help via `/site` modes).
 
 Future versions might add `/site graduate <new-shape>` as a skill mode that automates the bulk of the transition (creates the new repo, ports content, swaps the apex domain). That ships only after the manual flow has been run on real graduations and the patterns are stable enough to script.

--- a/.claude/skills/site/references/lander-build.md
+++ b/.claude/skills/site/references/lander-build.md
@@ -2,9 +2,9 @@
 
 The lander shape: 1 page, all-in-one. Hero + offer + proof + CTA + footer, all on `index.html`. Maximum focus, minimum nav.
 
-**V1 status:** the chassis-shape lander generation system prompt is not yet written. For single-page-feel use cases in V1, use the **minisite** shape — its `/start/` page already serves as the focused conversion target, while the home page does the brand work. See [`minisite-build.md`](minisite-build.md).
+**V1 status:** the per-offer lander generation system prompt is not yet written. For single-page-feel use cases in V1, use the **minisite** shape — the home page does the brand work and links straight to Stripe checkout. See [`minisite-build.md`](minisite-build.md).
 
-When chassis-shape lander generation lands, this file gets the same shape as `minisite-build.md`:
+When per-offer lander generation lands, this file gets the same shape as `minisite-build.md`:
 
 - `setup (lander)` — atom chain (domain, dns, pages, custom-domain), single-file project repo, Cloudflare Pages git-connected
 - `build --one-shot (lander)` — generation subagent invoked with `lander-generation-system.md` (also future) + offer/audience/reference URLs; produces `index.html` + `_headers` + `og.svg` + `favicon.svg` (no per-section subdirectories)
@@ -19,9 +19,9 @@ Three reasons:
 
 1. **The minisite covers the use case.** A 4-page minisite where 3 of the pages are linked from the home hero gives the same psychological "single focused funnel" feel as a 1-page lander, without losing the room for proof + how-it-works + faq.
 2. **Vagueness at single-page is harder.** Less surface area for variance — the system prompt risks producing visually identical output across runs unless we're disciplined. Minisite has more room to surprise.
-3. **Conversion data lives at the minisite tier.** Devon's first chassis run is paid Google Ads → minisite → Stripe deposit. The lander shape becomes load-bearing only when there's a real reason to compress to one page (very specific offers, retargeting flows, etc.) — that signal hasn't surfaced yet.
+3. **Conversion data lives at the minisite tier.** Devon's first V1 run is paid Google Ads → minisite → Stripe deposit. The lander shape becomes load-bearing only when there's a real reason to compress to one page (very specific offers, retargeting flows, etc.) — that signal hasn't surfaced yet.
 
-When it does, this file gets the full shape and the chassis adds a `lander-generation-system.md` peer to `minisite-generation-system.md`.
+When it does, this file gets the full shape and `/site` adds a `lander-generation-system.md` peer to `minisite-generation-system.md`.
 
 ---
 

--- a/.claude/skills/site/references/minisite-build.md
+++ b/.claude/skills/site/references/minisite-build.md
@@ -2,7 +2,7 @@
 
 The minisite shape: ~4 pages of static HTML, no build step, deployed to Cloudflare Pages with git auto-deploy. Designed fresh per offer by a generation subagent — no template inheritance.
 
-V1 chassis target. The default for paid-ad lander tests, single-offer first deploys, and deposit-gateway flows.
+V1 target. The default for paid-ad lander tests, single-offer first deploys, and deposit-gateway flows.
 
 The canonical contract for what a minisite *is* (page list, per-page content, post-payment flow, tracking, walkthrough UX) lives at `mb-vip/.claude/reference/minisite.md` (engine-side spec). This file is the **/site skill's implementation flow** — how the skill walks the operator through producing one.
 
@@ -126,4 +126,4 @@ Operator runs `git add -A && git commit && git push`. Cloudflare auto-deploys (p
 
 Re-running `/site build --one-shot` produces a fresh design (variance is the feature). For targeted edits, edit the file in the project repo directly and `git push` — Cloudflare auto-deploys.
 
-When the offer pulls more traffic and the minisite needs more pages or content depth, that's the **graduation signal**. See [`graduation.md`](graduation.md) for paths from minisite → website (chassis-shape full site) or minisite → Website + CMS (Sanity, Contentful, etc.).
+When the offer pulls more traffic and the minisite needs more pages or content depth, that's the **graduation signal**. See [`graduation.md`](graduation.md) for paths from minisite → website (per-offer full site) or minisite → Website + CMS (Sanity, Contentful, etc.).

--- a/.claude/skills/site/references/minisite-generation-system.md
+++ b/.claude/skills/site/references/minisite-generation-system.md
@@ -97,7 +97,7 @@ The user message includes 1–N reference URLs (default list: `https://howdy.md`
 - Notice what they DON'T do (no stock photo, no generic SaaS hero, no testimonial logo bar)
 - Now design something that **fits this offer**, at that polish level
 
-If two runs on the same offer produce visually identical output, you've been too conservative. The chassis is supposed to surprise.
+If two runs on the same offer produce visually identical output, you've been too conservative. Generation is supposed to surprise.
 
 ## OG image rules
 

--- a/.claude/skills/site/references/naming-heuristic.md
+++ b/.claude/skills/site/references/naming-heuristic.md
@@ -43,7 +43,7 @@ End of step 4: ~30 candidate names.
 
 ## Step 5 — Run `domain.py check` across multi-TLD
 
-For each candidate, check availability across the relevant TLDs. The default chassis priority:
+For each candidate, check availability across the relevant TLDs. The default TLD priority:
 
 ```bash
 python3 .claude/skills/site/scripts/domain.py check <candidate> \

--- a/.claude/skills/site/references/website-build.md
+++ b/.claude/skills/site/references/website-build.md
@@ -2,15 +2,15 @@
 
 The website shape: full multi-section site, often with a build step (Next.js, Astro, etc.), possibly with a blog, multi-offer support, knowledge base, course area. Larger surface area than a minisite; warrants component reuse and a structured site-config.
 
-V1 status: chassis-shape Website generation is not yet wired (a future companion to `minisite-generation-system.md`). For now, this flow uses the legacy Next.js templates (`saas` and `high-ticket` — Devon-specific examples) as starting points. They work via Netlify deploy or Cloudflare Pages with a build step.
+V1 status: per-offer Website generation is not yet wired (a future companion to `minisite-generation-system.md`). For now, this flow uses the legacy Next.js templates (`saas` and `high-ticket` — Devon-specific examples) as starting points. They work via Netlify deploy or Cloudflare Pages with a build step.
 
-When chassis-shape Website ships, this file gets a sibling section for the static-or-Next.js LLM-generated path.
+When per-offer Website generation ships, this file gets a sibling section for the static-or-Next.js LLM-generated path.
 
 ---
 
 ## Hosting decision (default: Cloudflare Pages)
 
-For new Website builds, Cloudflare Pages is the chassis default — better CLI, better domain integration, git auto-deploy, supports Next.js/Astro/React with build steps via build presets. Netlify works too and is documented in [`deployment.md`](deployment.md) as the legacy path; pick it only if you have specific Netlify-only needs.
+For new Website builds, Cloudflare Pages is the default — better CLI, better domain integration, git auto-deploy, supports Next.js/Astro/React with build steps via build presets. Netlify works too and is documented in [`deployment.md`](deployment.md) as the legacy path; pick it only if you have specific Netlify-only needs.
 
 For Cloudflare Pages with a build step:
 ```bash
@@ -25,11 +25,11 @@ For Netlify legacy path: see [`deployment.md`](deployment.md).
 
 ## setup (Next.js website)
 
-**1. Choose template.** Two pre-chassis examples:
+**1. Choose template.** Two pre-V1 examples:
 - **SaaS / Product** — Hero → Demo → Value Prop → Workflow → Examples → Integrations → CTA. Best for software, e-commerce, product companies.
 - **High-Ticket Services** — Hero → Solution → Pain → Process → Competitive → Objections → Proof → Qualification → FAQ → CTA. Best for coaching, consulting, agencies, $3k+ services.
 
-These are Devon-specific examples, not the broader Website tier. Future chassis-shape Website generation will produce fresh per-offer like the minisite shape.
+These are Devon-specific examples, not the broader Website tier. Future per-offer Website generation will produce fresh output per offer like the minisite shape.
 
 **2. Name + location.**
 - Site name (e.g., "my-landing-page")
@@ -262,4 +262,4 @@ Cloudflare Pages auto-deploys on push (per the git-connected project from setup 
 
 ## Graduating to a website with CMS
 
-When the website grows past ~10 pages or content needs to be edited by non-developers, the chassis supports bolting on a CMS. See [`graduation.md`](graduation.md) for the Sanity / Contentful / Notion-as-CMS / etc. paths.
+When the website grows past ~10 pages or content needs to be edited by non-developers, `/site` supports bolting on a CMS. See [`graduation.md`](graduation.md) for the Sanity / Contentful / Notion-as-CMS / etc. paths.

--- a/.claude/skills/site/scripts/pages.py
+++ b/.claude/skills/site/scripts/pages.py
@@ -17,7 +17,7 @@ Output: companyctx-shape envelope JSON on stdout, logs on stderr.
 Exit code: 0 on ok|partial, 1 on degraded.
 
 Per `decisions/2026-04-27-git-auto-deploy-non-negotiable.md`: every
-Pages project the chassis creates must default to git source. The
+Pages project this atom creates must default to git source. The
 `--source=direct-upload` flag exists as opt-out for CI environments
 that can't install the Cloudflare GitHub App.
 """

--- a/.claude/skills/site/scripts/setup_creds.sh
+++ b/.claude/skills/site/scripts/setup_creds.sh
@@ -6,7 +6,7 @@
 # ~/.config/vip/env.sh with chmod 600. Idempotent — re-running replaces
 # existing values for these three vars without duplicating lines.
 #
-# Token must have these scopes on the account that owns the chassis assets
+# Token must have these scopes on the account that owns the /site assets
 # (registrar domains + Pages projects + DNS zones):
 #   Cloudflare Registrar:Edit
 #   Zone:Read, Zone:Edit

--- a/.claude/skills/site/scripts/stripe.py
+++ b/.claude/skills/site/scripts/stripe.py
@@ -1,0 +1,869 @@
+#!/usr/bin/env python3
+"""stripe.py — Stripe payment-link automation atom.
+
+Subcommands:
+    create-payment-link <offer-slug>
+        Idempotent: ensures a Stripe product + price + payment link exist for
+        the given chassis offer slug. Returns the payment-link URL the
+        minisite hero CTA links to.
+
+    list-products
+        Lists active products with chassis_offer metadata. Debug helper.
+
+    archive-product <product-id>
+        Marks a product inactive (Stripe doesn't support hard delete).
+
+Invocation: `python3 stripe.py <subcommand> [args]`
+Output: companyctx-shape envelope JSON on stdout, logs on stderr.
+Exit code: 0 on ok|partial, 1 on degraded.
+
+Idempotency model (per `noontide-co/noontide-ops`
+decisions/2026-04-27-credential-provisioning.md):
+
+  1. Search products by metadata `chassis_offer:<slug>` AND
+     `chassis_kind:deposit`. If found AND product has stashed
+     `chassis_payment_link_url` in metadata → return that URL.
+  2. If not found, create product (with `default_price_data`) and payment
+     link. Stash the payment-link URL in product metadata for future
+     idempotency lookups. Use Stripe Idempotency-Key headers on every
+     create call to survive transient retries within the search-API's
+     eventual-consistency window (~minutes-to-hours).
+
+Spec: see `mb-vip/.claude/reference/minisite.md` ("Stripe payment-link
+defaults" table) for the canonical defaults this atom encodes.
+
+Test mode vs live mode: the atom is mode-agnostic — it uses whatever key
+is in `STRIPE_API_KEY`. Test keys start `sk_test_`, live keys `sk_live_`.
+Use test mode for chassis development; live mode for real offers.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+import time
+from pathlib import Path
+from typing import Literal
+
+import click
+import requests
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _envelope import (  # noqa: E402
+    SCHEMA_VERSION,
+    EnvelopeStatus,
+    ProviderRunMetadata,
+    emit,
+    log,
+    validate_status_consistency,
+)
+
+STRIPE_API_BASE = "https://api.stripe.com/v1"
+
+# Stripe limits.
+STATEMENT_DESCRIPTOR_MAX = 22
+STATEMENT_DESCRIPTOR_RE = re.compile(r"^[A-Za-z0-9 .\-]{5,22}$")
+# Stripe's documented minimum charge is $0.50 USD (50 cents).
+MIN_AMOUNT_CENTS = 50
+
+DEFAULT_STATEMENT_DESCRIPTOR = "NOONTIDE"
+
+# Chassis-fixed metadata keys per minisite spec.
+META_OFFER = "chassis_offer"
+META_KIND = "chassis_kind"
+META_KIND_VALUE = "deposit"
+META_PAYMENT_LINK_URL = "chassis_payment_link_url"
+META_CREATED_AT = "chassis_created_at"
+
+# ---------------------------------------------------------------------------
+# Envelope shape
+# ---------------------------------------------------------------------------
+
+StripeErrorCode = Literal[
+    "stripe_unauthenticated",
+    "stripe_rate_limited",
+    "network_timeout",
+    "invalid_amount",
+    "invalid_currency",
+    "invalid_offer_slug",
+    "invalid_statement_descriptor",
+    "invalid_success_url",
+    "missing_api_key",
+    "account_not_configured",
+    "stripe_request_failed",
+    "product_not_found",
+]
+
+
+class StripeError(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    code: StripeErrorCode
+    message: str
+    suggestion: str | None = None
+
+
+class CreatePaymentLinkData(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    offer_slug: str
+    payment_link_url: str | None = None
+    payment_link_id: str | None = None
+    product_id: str | None = None
+    price_id: str | None = None
+    amount_cents: int | None = None
+    currency: str | None = None
+    statement_descriptor: str | None = None
+    success_url: str | None = None
+    created_now: bool = False
+    """True if this run created the product. False = returned existing (idempotent)."""
+
+
+class ListProductsData(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    products: list[dict] = Field(default_factory=list)
+    count: int = 0
+
+
+class ArchiveProductData(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    product_id: str
+    archived: bool = False
+
+
+class CreatePaymentLinkEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    schema_version: Literal["0.1.0"] = SCHEMA_VERSION
+    status: EnvelopeStatus
+    data: CreatePaymentLinkData
+    provenance: dict[str, ProviderRunMetadata] = Field(default_factory=dict)
+    error: StripeError | None = None
+
+    @model_validator(mode="after")
+    def _v(self) -> CreatePaymentLinkEnvelope:
+        return validate_status_consistency(self)  # type: ignore[return-value]
+
+
+class ListProductsEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    schema_version: Literal["0.1.0"] = SCHEMA_VERSION
+    status: EnvelopeStatus
+    data: ListProductsData
+    provenance: dict[str, ProviderRunMetadata] = Field(default_factory=dict)
+    error: StripeError | None = None
+
+    @model_validator(mode="after")
+    def _v(self) -> ListProductsEnvelope:
+        return validate_status_consistency(self)  # type: ignore[return-value]
+
+
+class ArchiveProductEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    schema_version: Literal["0.1.0"] = SCHEMA_VERSION
+    status: EnvelopeStatus
+    data: ArchiveProductData
+    provenance: dict[str, ProviderRunMetadata] = Field(default_factory=dict)
+    error: StripeError | None = None
+
+    @model_validator(mode="after")
+    def _v(self) -> ArchiveProductEnvelope:
+        return validate_status_consistency(self)  # type: ignore[return-value]
+
+
+# ---------------------------------------------------------------------------
+# Stripe HTTP helpers
+# ---------------------------------------------------------------------------
+
+
+class StripeResult(BaseModel):
+    """Internal: a Stripe API response normalized for atom consumption."""
+
+    model_config = ConfigDict(extra="forbid")
+    ok: bool
+    latency_ms: int
+    status_code: int
+    payload: dict | None = None
+    error_type: str | None = None  # Stripe's `error.type`
+    error_code: str | None = None  # Stripe's `error.code`
+    error_message: str | None = None
+
+
+def _form_encode(data: dict, prefix: str = "") -> list[tuple[str, str]]:
+    """Stripe's API uses application/x-www-form-urlencoded with bracket nesting.
+
+    Examples:
+      {"line_items": [{"price": "p_1"}]}
+        → [("line_items[0][price]", "p_1")]
+      {"metadata": {"chassis_offer": "x"}}
+        → [("metadata[chassis_offer]", "x")]
+      {"default_price_data": {"unit_amount": 10000, "currency": "usd"}}
+        → [("default_price_data[unit_amount]", "10000"),
+           ("default_price_data[currency]", "usd")]
+    """
+    out: list[tuple[str, str]] = []
+    for k, v in data.items():
+        key = f"{prefix}[{k}]" if prefix else k
+        if isinstance(v, dict):
+            out.extend(_form_encode(v, key))
+        elif isinstance(v, list):
+            for i, item in enumerate(v):
+                if isinstance(item, dict):
+                    out.extend(_form_encode(item, f"{key}[{i}]"))
+                else:
+                    out.append((f"{key}[{i}]", str(item)))
+        elif isinstance(v, bool):
+            out.append((key, "true" if v else "false"))
+        elif v is None:
+            continue
+        else:
+            out.append((key, str(v)))
+    return out
+
+
+def _stripe_call(
+    method: str,
+    path: str,
+    api_key: str,
+    body: dict | None = None,
+    idempotency_key: str | None = None,
+    query: dict | None = None,
+) -> StripeResult:
+    url = f"{STRIPE_API_BASE}{path}"
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Stripe-Version": "2024-06-20",
+    }
+    if idempotency_key:
+        headers["Idempotency-Key"] = idempotency_key
+
+    form_data = _form_encode(body) if body else None
+    start = time.monotonic()
+    try:
+        resp = requests.request(
+            method,
+            url,
+            headers=headers,
+            data=form_data,
+            params=query,
+            timeout=30,
+        )
+    except requests.Timeout:
+        return StripeResult(
+            ok=False,
+            latency_ms=int((time.monotonic() - start) * 1000),
+            status_code=0,
+            error_message="timeout",
+        )
+    except requests.RequestException as exc:
+        return StripeResult(
+            ok=False,
+            latency_ms=int((time.monotonic() - start) * 1000),
+            status_code=0,
+            error_message=f"request_exception: {exc.__class__.__name__}",
+        )
+
+    latency_ms = int((time.monotonic() - start) * 1000)
+    try:
+        payload = resp.json()
+    except ValueError:
+        return StripeResult(
+            ok=False,
+            latency_ms=latency_ms,
+            status_code=resp.status_code,
+            error_message="non_json_response",
+        )
+
+    if resp.ok:
+        return StripeResult(
+            ok=True,
+            latency_ms=latency_ms,
+            status_code=resp.status_code,
+            payload=payload,
+        )
+
+    err = payload.get("error") or {}
+    return StripeResult(
+        ok=False,
+        latency_ms=latency_ms,
+        status_code=resp.status_code,
+        payload=payload,
+        error_type=err.get("type"),
+        error_code=err.get("code"),
+        error_message=err.get("message"),
+    )
+
+
+def _classify_error(result: StripeResult) -> tuple[StripeErrorCode, str]:
+    """Map a failed Stripe response to a closed-enum error code + suggestion."""
+    if result.error_message == "timeout":
+        return "network_timeout", "Stripe API timed out. Retry; check connectivity."
+    if result.status_code == 401 or result.error_type == "invalid_request_error" and (
+        result.error_code in ("api_key_expired", "api_key_invalid")
+    ):
+        return (
+            "stripe_unauthenticated",
+            "Verify STRIPE_API_KEY is correct (sk_test_... or sk_live_...) and not revoked. "
+            "Manage at https://dashboard.stripe.com/apikeys.",
+        )
+    if result.status_code == 401:
+        return (
+            "stripe_unauthenticated",
+            "Stripe rejected the API key. Confirm STRIPE_API_KEY is set and current.",
+        )
+    if result.status_code == 429:
+        return "stripe_rate_limited", "Stripe rate-limited the request. Back off and retry."
+    if result.status_code == 404:
+        return (
+            "product_not_found",
+            "The referenced product does not exist or was archived.",
+        )
+    # account_not_configured: 400-class with messages about missing Stripe account setup.
+    if result.status_code == 400 and result.error_message and (
+        "account" in result.error_message.lower()
+        and ("complete" in result.error_message.lower() or "activate" in result.error_message.lower())
+    ):
+        return (
+            "account_not_configured",
+            "Complete Stripe account setup (business profile, bank account) at "
+            "https://dashboard.stripe.com/settings/account.",
+        )
+    return (
+        "stripe_request_failed",
+        f"Stripe rejected the request: {result.error_message or 'unknown'} "
+        f"(http {result.status_code}, type {result.error_type}, code {result.error_code}).",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+# Lowercased slug: alphanumeric + hyphen + underscore. Matches typical offer
+# directory naming under reference/offers/<slug>/.
+OFFER_SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,62}$")
+
+
+def _validate_offer_slug(slug: str) -> str | None:
+    if not OFFER_SLUG_RE.match(slug):
+        return (
+            f"Offer slug {slug!r} is invalid. Use lowercase letters, digits, "
+            "hyphens, or underscores; start with alphanumeric; max 63 chars."
+        )
+    return None
+
+
+def _validate_statement_descriptor(descriptor: str) -> str | None:
+    if not STATEMENT_DESCRIPTOR_RE.match(descriptor):
+        return (
+            f"Statement descriptor {descriptor!r} is invalid. "
+            "Stripe requires 5–22 chars, ASCII letters/digits/spaces/dots/hyphens, "
+            "no special characters."
+        )
+    return None
+
+
+def _truncate_descriptor(value: str) -> str:
+    """Trim whitespace and truncate to Stripe's 22-char limit."""
+    cleaned = re.sub(r"\s+", " ", value).strip()
+    return cleaned[:STATEMENT_DESCRIPTOR_MAX]
+
+
+# ---------------------------------------------------------------------------
+# Search + create flow
+# ---------------------------------------------------------------------------
+
+
+def _search_existing_product(
+    api_key: str, offer_slug: str, provenance: dict[str, ProviderRunMetadata]
+) -> tuple[dict | None, StripeResult | None]:
+    """Search for an existing product matching this offer.
+
+    Returns (product_dict, result). If product_dict is None and result.ok is
+    True, no match was found (clean run, just empty). If result.ok is False,
+    the API call itself failed.
+    """
+    query = (
+        f'metadata[\'{META_OFFER}\']:\'{offer_slug}\' '
+        f'AND metadata[\'{META_KIND}\']:\'{META_KIND_VALUE}\' '
+        f"AND active:'true'"
+    )
+    result = _stripe_call(
+        "GET",
+        "/products/search",
+        api_key,
+        query={"query": query, "limit": 1},
+    )
+    provenance["stripe_products_search"] = ProviderRunMetadata(
+        status="ok" if result.ok else "failed",
+        latency_ms=result.latency_ms,
+        error=result.error_message,
+        provider_version="stripe-2024-06-20",
+    )
+    if not result.ok:
+        return None, result
+    data = (result.payload or {}).get("data") or []
+    if not data:
+        return None, result
+    return data[0], result
+
+
+def _update_product_metadata(
+    api_key: str,
+    product_id: str,
+    metadata_updates: dict[str, str],
+    provenance: dict[str, ProviderRunMetadata],
+) -> StripeResult:
+    body = {"metadata": metadata_updates}
+    result = _stripe_call("POST", f"/products/{product_id}", api_key, body=body)
+    provenance["stripe_product_update"] = ProviderRunMetadata(
+        status="ok" if result.ok else "failed",
+        latency_ms=result.latency_ms,
+        error=result.error_message,
+        provider_version="stripe-2024-06-20",
+    )
+    return result
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+@click.group()
+def cli() -> None:
+    """stripe.py — Stripe payment-link automation atom."""
+
+
+@cli.command("create-payment-link")
+@click.argument("offer_slug")
+@click.option("--amount", "amount_cents", type=int, required=True, help="Deposit amount in US cents (e.g., 10000 for $100).")
+@click.option("--currency", default="usd", show_default=True, help="ISO currency code (V1: USD only).")
+@click.option("--description", default=None, help="Product description shown to customers.")
+@click.option(
+    "--statement-descriptor",
+    default=None,
+    help=f"Card statement descriptor (max {STATEMENT_DESCRIPTOR_MAX} chars). Defaults to {DEFAULT_STATEMENT_DESCRIPTOR!r}.",
+)
+@click.option(
+    "--success-url",
+    required=True,
+    help="URL Stripe redirects to after successful payment. Must be HTTPS.",
+)
+@click.option(
+    "--product-name",
+    default=None,
+    help="Product name shown in Stripe dashboard. Defaults to the offer slug.",
+)
+def create_payment_link(
+    offer_slug: str,
+    amount_cents: int,
+    currency: str,
+    description: str | None,
+    statement_descriptor: str | None,
+    success_url: str,
+    product_name: str | None,
+) -> None:
+    """Ensure a Stripe payment link exists for OFFER_SLUG, returning the URL."""
+    provenance: dict[str, ProviderRunMetadata] = {}
+
+    # --- Input validation ---
+    slug_err = _validate_offer_slug(offer_slug)
+    if slug_err:
+        env = CreatePaymentLinkEnvelope(
+            status="degraded",
+            data=CreatePaymentLinkData(offer_slug=offer_slug),
+            error=StripeError(
+                code="invalid_offer_slug",
+                message=slug_err,
+                suggestion="Use the offer's directory name from reference/offers/.",
+            ),
+        )
+        sys.exit(emit(env))
+
+    if amount_cents < MIN_AMOUNT_CENTS:
+        env = CreatePaymentLinkEnvelope(
+            status="degraded",
+            data=CreatePaymentLinkData(offer_slug=offer_slug, amount_cents=amount_cents),
+            error=StripeError(
+                code="invalid_amount",
+                message=f"Amount {amount_cents} is below Stripe's minimum of {MIN_AMOUNT_CENTS} cents.",
+                suggestion=f"Pass --amount with at least {MIN_AMOUNT_CENTS} (50 cents).",
+            ),
+        )
+        sys.exit(emit(env))
+
+    if not currency.isalpha() or len(currency) != 3:
+        env = CreatePaymentLinkEnvelope(
+            status="degraded",
+            data=CreatePaymentLinkData(offer_slug=offer_slug, currency=currency),
+            error=StripeError(
+                code="invalid_currency",
+                message=f"Currency {currency!r} is not a 3-letter ISO code.",
+                suggestion="Pass --currency=usd (V1 only supports USD).",
+            ),
+        )
+        sys.exit(emit(env))
+    currency_lower = currency.lower()
+
+    descriptor = _truncate_descriptor(statement_descriptor or DEFAULT_STATEMENT_DESCRIPTOR)
+    desc_err = _validate_statement_descriptor(descriptor)
+    if desc_err:
+        env = CreatePaymentLinkEnvelope(
+            status="degraded",
+            data=CreatePaymentLinkData(offer_slug=offer_slug, statement_descriptor=descriptor),
+            error=StripeError(
+                code="invalid_statement_descriptor",
+                message=desc_err,
+                suggestion="Use 5–22 ASCII letters/digits/spaces/dots/hyphens.",
+            ),
+        )
+        sys.exit(emit(env))
+
+    if not success_url.startswith("https://"):
+        env = CreatePaymentLinkEnvelope(
+            status="degraded",
+            data=CreatePaymentLinkData(offer_slug=offer_slug, success_url=success_url),
+            error=StripeError(
+                code="invalid_success_url",
+                message=f"Success URL must be HTTPS: {success_url!r}",
+                suggestion="Pass --success-url=https://<domain>/start/thanks/.",
+            ),
+        )
+        sys.exit(emit(env))
+
+    api_key = os.environ.get("STRIPE_API_KEY", "").strip()
+    if not api_key:
+        env = CreatePaymentLinkEnvelope(
+            status="degraded",
+            data=CreatePaymentLinkData(offer_slug=offer_slug),
+            error=StripeError(
+                code="missing_api_key",
+                message="STRIPE_API_KEY is not set in the environment.",
+                suggestion="Add `export STRIPE_API_KEY=sk_test_...` to ~/.config/vip/env.sh and `source` it.",
+            ),
+        )
+        sys.exit(emit(env))
+
+    # --- Idempotency check via product search ---
+    log(f"Checking for existing chassis_offer={offer_slug} product...")
+    existing, search_result = _search_existing_product(api_key, offer_slug, provenance)
+    if search_result is not None and not search_result.ok:
+        code, suggestion = _classify_error(search_result)
+        env = CreatePaymentLinkEnvelope(
+            status="degraded",
+            data=CreatePaymentLinkData(offer_slug=offer_slug),
+            provenance=provenance,
+            error=StripeError(code=code, message=search_result.error_message or "search failed", suggestion=suggestion),
+        )
+        sys.exit(emit(env))
+
+    if existing:
+        existing_url = (existing.get("metadata") or {}).get(META_PAYMENT_LINK_URL)
+        if existing_url:
+            log(f"Found existing product {existing.get('id')} with payment link, returning idempotent.")
+            env = CreatePaymentLinkEnvelope(
+                status="ok",
+                data=CreatePaymentLinkData(
+                    offer_slug=offer_slug,
+                    payment_link_url=existing_url,
+                    product_id=existing.get("id"),
+                    price_id=existing.get("default_price"),
+                    amount_cents=amount_cents,
+                    currency=currency_lower,
+                    statement_descriptor=descriptor,
+                    success_url=success_url,
+                    created_now=False,
+                ),
+                provenance=provenance,
+            )
+            sys.exit(emit(env))
+        log(f"Found existing product {existing.get('id')} but no stashed payment link — creating one.")
+        product_id = existing.get("id")
+        price_id = existing.get("default_price")
+    else:
+        # --- Create product (with default_price_data) ---
+        log(f"Creating new Stripe product for offer={offer_slug}...")
+        created_at = str(int(time.time()))
+        product_body = {
+            "name": product_name or offer_slug,
+            "active": True,
+            "default_price_data": {
+                "currency": currency_lower,
+                "unit_amount": amount_cents,
+            },
+            "metadata": {
+                META_OFFER: offer_slug,
+                META_KIND: META_KIND_VALUE,
+                META_CREATED_AT: created_at,
+            },
+        }
+        if description:
+            product_body["description"] = description
+        if descriptor:
+            product_body["statement_descriptor"] = descriptor
+
+        product_result = _stripe_call(
+            "POST",
+            "/products",
+            api_key,
+            body=product_body,
+            idempotency_key=f"chassis-{offer_slug}-product",
+        )
+        provenance["stripe_product_create"] = ProviderRunMetadata(
+            status="ok" if product_result.ok else "failed",
+            latency_ms=product_result.latency_ms,
+            error=product_result.error_message,
+            provider_version="stripe-2024-06-20",
+        )
+        if not product_result.ok:
+            code, suggestion = _classify_error(product_result)
+            env = CreatePaymentLinkEnvelope(
+                status="degraded",
+                data=CreatePaymentLinkData(offer_slug=offer_slug),
+                provenance=provenance,
+                error=StripeError(code=code, message=product_result.error_message or "create failed", suggestion=suggestion),
+            )
+            sys.exit(emit(env))
+
+        product = product_result.payload or {}
+        product_id = product.get("id")
+        # Stripe expands default_price as ID string by default, full object with ?expand.
+        default_price = product.get("default_price")
+        price_id = default_price if isinstance(default_price, str) else (
+            (default_price or {}).get("id") if isinstance(default_price, dict) else None
+        )
+
+    if not product_id or not price_id:
+        env = CreatePaymentLinkEnvelope(
+            status="degraded",
+            data=CreatePaymentLinkData(offer_slug=offer_slug),
+            provenance=provenance,
+            error=StripeError(
+                code="stripe_request_failed",
+                message="Stripe product create succeeded but response missing id or default_price.",
+                suggestion="Re-run; if persistent, inspect the raw provenance entry.",
+            ),
+        )
+        sys.exit(emit(env))
+
+    # --- Create payment link ---
+    log(f"Creating payment link for product={product_id} price={price_id}...")
+    link_body = {
+        "line_items": [
+            {"price": price_id, "quantity": 1},
+        ],
+        "after_completion": {
+            "type": "redirect",
+            "redirect": {"url": success_url},
+        },
+        "metadata": {
+            META_OFFER: offer_slug,
+            META_KIND: META_KIND_VALUE,
+        },
+    }
+    link_result = _stripe_call(
+        "POST",
+        "/payment_links",
+        api_key,
+        body=link_body,
+        idempotency_key=f"chassis-{offer_slug}-link",
+    )
+    provenance["stripe_payment_link_create"] = ProviderRunMetadata(
+        status="ok" if link_result.ok else "failed",
+        latency_ms=link_result.latency_ms,
+        error=link_result.error_message,
+        provider_version="stripe-2024-06-20",
+    )
+    if not link_result.ok:
+        code, suggestion = _classify_error(link_result)
+        env = CreatePaymentLinkEnvelope(
+            status="degraded",
+            data=CreatePaymentLinkData(
+                offer_slug=offer_slug,
+                product_id=product_id,
+                price_id=price_id,
+            ),
+            provenance=provenance,
+            error=StripeError(code=code, message=link_result.error_message or "payment link create failed", suggestion=suggestion),
+        )
+        sys.exit(emit(env))
+
+    payment_link = link_result.payload or {}
+    payment_link_url = payment_link.get("url")
+    payment_link_id = payment_link.get("id")
+
+    # --- Stash payment link URL on product metadata for future idempotency ---
+    if payment_link_url:
+        update_result = _update_product_metadata(
+            api_key,
+            product_id,
+            {META_PAYMENT_LINK_URL: payment_link_url},
+            provenance,
+        )
+        if not update_result.ok:
+            log(f"Warning: failed to stash payment_link_url on product metadata: {update_result.error_message}")
+
+    env = CreatePaymentLinkEnvelope(
+        status="ok",
+        data=CreatePaymentLinkData(
+            offer_slug=offer_slug,
+            payment_link_url=payment_link_url,
+            payment_link_id=payment_link_id,
+            product_id=product_id,
+            price_id=price_id,
+            amount_cents=amount_cents,
+            currency=currency_lower,
+            statement_descriptor=descriptor,
+            success_url=success_url,
+            created_now=existing is None,
+        ),
+        provenance=provenance,
+    )
+    sys.exit(emit(env))
+
+
+@cli.command("list-products")
+@click.option("--offer-slug", default=None, help="Filter by chassis_offer metadata.")
+@click.option("--limit", default=20, show_default=True, type=int, help="Max products to return (1-100).")
+def list_products(offer_slug: str | None, limit: int) -> None:
+    """List active chassis products. Debug helper."""
+    provenance: dict[str, ProviderRunMetadata] = {}
+    api_key = os.environ.get("STRIPE_API_KEY", "").strip()
+    if not api_key:
+        env = ListProductsEnvelope(
+            status="degraded",
+            data=ListProductsData(),
+            error=StripeError(
+                code="missing_api_key",
+                message="STRIPE_API_KEY is not set in the environment.",
+                suggestion="Add `export STRIPE_API_KEY=sk_test_...` to ~/.config/vip/env.sh.",
+            ),
+        )
+        sys.exit(emit(env))
+
+    if offer_slug:
+        slug_err = _validate_offer_slug(offer_slug)
+        if slug_err:
+            env = ListProductsEnvelope(
+                status="degraded",
+                data=ListProductsData(),
+                error=StripeError(code="invalid_offer_slug", message=slug_err, suggestion=None),
+            )
+            sys.exit(emit(env))
+
+    if offer_slug:
+        query = (
+            f'metadata[\'{META_OFFER}\']:\'{offer_slug}\' '
+            f'AND metadata[\'{META_KIND}\']:\'{META_KIND_VALUE}\' '
+            f"AND active:'true'"
+        )
+        result = _stripe_call(
+            "GET",
+            "/products/search",
+            api_key,
+            query={"query": query, "limit": max(1, min(limit, 100))},
+        )
+    else:
+        result = _stripe_call(
+            "GET",
+            "/products",
+            api_key,
+            query={"active": "true", "limit": max(1, min(limit, 100))},
+        )
+    provenance["stripe_products_list"] = ProviderRunMetadata(
+        status="ok" if result.ok else "failed",
+        latency_ms=result.latency_ms,
+        error=result.error_message,
+        provider_version="stripe-2024-06-20",
+    )
+
+    if not result.ok:
+        code, suggestion = _classify_error(result)
+        env = ListProductsEnvelope(
+            status="degraded",
+            data=ListProductsData(),
+            provenance=provenance,
+            error=StripeError(code=code, message=result.error_message or "list failed", suggestion=suggestion),
+        )
+        sys.exit(emit(env))
+
+    items = (result.payload or {}).get("data") or []
+    # Trim to the fields callers actually need (id, name, default_price, metadata, created).
+    trimmed = [
+        {
+            "id": p.get("id"),
+            "name": p.get("name"),
+            "active": p.get("active"),
+            "default_price": p.get("default_price"),
+            "metadata": p.get("metadata") or {},
+            "created": p.get("created"),
+        }
+        for p in items
+    ]
+
+    env = ListProductsEnvelope(
+        status="ok",
+        data=ListProductsData(products=trimmed, count=len(trimmed)),
+        provenance=provenance,
+    )
+    sys.exit(emit(env))
+
+
+@cli.command("archive-product")
+@click.argument("product_id")
+def archive_product(product_id: str) -> None:
+    """Mark a product inactive (Stripe doesn't support hard delete)."""
+    provenance: dict[str, ProviderRunMetadata] = {}
+    api_key = os.environ.get("STRIPE_API_KEY", "").strip()
+    if not api_key:
+        env = ArchiveProductEnvelope(
+            status="degraded",
+            data=ArchiveProductData(product_id=product_id),
+            error=StripeError(
+                code="missing_api_key",
+                message="STRIPE_API_KEY is not set in the environment.",
+                suggestion="Add `export STRIPE_API_KEY=sk_test_...` to ~/.config/vip/env.sh.",
+            ),
+        )
+        sys.exit(emit(env))
+
+    if not product_id.startswith("prod_"):
+        env = ArchiveProductEnvelope(
+            status="degraded",
+            data=ArchiveProductData(product_id=product_id),
+            error=StripeError(
+                code="invalid_offer_slug",
+                message=f"Product id {product_id!r} doesn't look like a Stripe product id (expected prod_...).",
+                suggestion="Pass the prod_... id from `stripe.py list-products`.",
+            ),
+        )
+        sys.exit(emit(env))
+
+    result = _stripe_call("POST", f"/products/{product_id}", api_key, body={"active": False})
+    provenance["stripe_product_archive"] = ProviderRunMetadata(
+        status="ok" if result.ok else "failed",
+        latency_ms=result.latency_ms,
+        error=result.error_message,
+        provider_version="stripe-2024-06-20",
+    )
+
+    if not result.ok:
+        code, suggestion = _classify_error(result)
+        env = ArchiveProductEnvelope(
+            status="degraded",
+            data=ArchiveProductData(product_id=product_id),
+            provenance=provenance,
+            error=StripeError(code=code, message=result.error_message or "archive failed", suggestion=suggestion),
+        )
+        sys.exit(emit(env))
+
+    env = ArchiveProductEnvelope(
+        status="ok",
+        data=ArchiveProductData(product_id=product_id, archived=True),
+        provenance=provenance,
+    )
+    sys.exit(emit(env))
+
+
+if __name__ == "__main__":
+    cli()

--- a/.claude/skills/site/scripts/stripe.py
+++ b/.claude/skills/site/scripts/stripe.py
@@ -3,12 +3,12 @@
 
 Subcommands:
     create-payment-link <offer-slug>
-        Idempotent: ensures a Stripe product + price + payment link exist for
-        the given chassis offer slug. Returns the payment-link URL the
+        Idempotent: ensures a Stripe product + price + payment link exist
+        for the given offer slug. Returns the payment-link URL the
         minisite hero CTA links to.
 
     list-products
-        Lists active products with chassis_offer metadata. Debug helper.
+        Lists active products with `mb_offer` metadata. Debug helper.
 
     archive-product <product-id>
         Marks a product inactive (Stripe doesn't support hard delete).
@@ -20,9 +20,9 @@ Exit code: 0 on ok|partial, 1 on degraded.
 Idempotency model (per `noontide-co/noontide-ops`
 decisions/2026-04-27-credential-provisioning.md):
 
-  1. Search products by metadata `chassis_offer:<slug>` AND
-     `chassis_kind:deposit`. If found AND product has stashed
-     `chassis_payment_link_url` in metadata → return that URL.
+  1. Search products by metadata `mb_offer:<slug>` AND `mb_kind:deposit`.
+     If found AND product has stashed `mb_payment_link_url` in metadata
+     → return that URL.
   2. If not found, create product (with `default_price_data`) and payment
      link. Stash the payment-link URL in product metadata for future
      idempotency lookups. Use Stripe Idempotency-Key headers on every
@@ -34,7 +34,7 @@ defaults" table) for the canonical defaults this atom encodes.
 
 Test mode vs live mode: the atom is mode-agnostic — it uses whatever key
 is in `STRIPE_API_KEY`. Test keys start `sk_test_`, live keys `sk_live_`.
-Use test mode for chassis development; live mode for real offers.
+Use test mode while iterating; live mode for real offers.
 """
 
 from __future__ import annotations
@@ -70,12 +70,13 @@ MIN_AMOUNT_CENTS = 50
 
 DEFAULT_STATEMENT_DESCRIPTOR = "NOONTIDE"
 
-# Chassis-fixed metadata keys per minisite spec.
-META_OFFER = "chassis_offer"
-META_KIND = "chassis_kind"
+# Main Branch metadata keys per minisite spec. The `mb_` prefix namespaces
+# our products from anything else in the operator's Stripe account.
+META_OFFER = "mb_offer"
+META_KIND = "mb_kind"
 META_KIND_VALUE = "deposit"
-META_PAYMENT_LINK_URL = "chassis_payment_link_url"
-META_CREATED_AT = "chassis_created_at"
+META_PAYMENT_LINK_URL = "mb_payment_link_url"
+META_CREATED_AT = "mb_created_at"
 
 # ---------------------------------------------------------------------------
 # Envelope shape
@@ -194,8 +195,8 @@ def _form_encode(data: dict, prefix: str = "") -> list[tuple[str, str]]:
     Examples:
       {"line_items": [{"price": "p_1"}]}
         → [("line_items[0][price]", "p_1")]
-      {"metadata": {"chassis_offer": "x"}}
-        → [("metadata[chassis_offer]", "x")]
+      {"metadata": {"mb_offer": "x"}}
+        → [("metadata[mb_offer]", "x")]
       {"default_price_data": {"unit_amount": 10000, "currency": "usd"}}
         → [("default_price_data[unit_amount]", "10000"),
            ("default_price_data[currency]", "usd")]
@@ -545,7 +546,7 @@ def create_payment_link(
         sys.exit(emit(env))
 
     # --- Idempotency check via product search ---
-    log(f"Checking for existing chassis_offer={offer_slug} product...")
+    log(f"Checking for existing mb_offer={offer_slug} product...")
     existing, search_result = _search_existing_product(api_key, offer_slug, provenance)
     if search_result is not None and not search_result.ok:
         code, suggestion = _classify_error(search_result)
@@ -607,7 +608,7 @@ def create_payment_link(
             "/products",
             api_key,
             body=product_body,
-            idempotency_key=f"chassis-{offer_slug}-product",
+            idempotency_key=f"mb-{offer_slug}-product",
         )
         provenance["stripe_product_create"] = ProviderRunMetadata(
             status="ok" if product_result.ok else "failed",
@@ -666,7 +667,7 @@ def create_payment_link(
         "/payment_links",
         api_key,
         body=link_body,
-        idempotency_key=f"chassis-{offer_slug}-link",
+        idempotency_key=f"mb-{offer_slug}-link",
     )
     provenance["stripe_payment_link_create"] = ProviderRunMetadata(
         status="ok" if link_result.ok else "failed",
@@ -723,10 +724,10 @@ def create_payment_link(
 
 
 @cli.command("list-products")
-@click.option("--offer-slug", default=None, help="Filter by chassis_offer metadata.")
+@click.option("--offer-slug", default=None, help="Filter by mb_offer metadata.")
 @click.option("--limit", default=20, show_default=True, type=int, help="Max products to return (1-100).")
 def list_products(offer_slug: str | None, limit: int) -> None:
-    """List active chassis products. Debug helper."""
+    """List active products. Filter to Main Branch products via --offer-slug."""
     provenance: dict[str, ProviderRunMetadata] = {}
     api_key = os.environ.get("STRIPE_API_KEY", "").strip()
     if not api_key:

--- a/.claude/skills/site/scripts/test_atoms.py
+++ b/.claude/skills/site/scripts/test_atoms.py
@@ -683,13 +683,13 @@ def test_pages_create_project_ok_round_trip() -> None:
     env = PagesCreateProjectEnvelope(
         status="ok",
         data=PagesCreateProjectData(
-            project_name="chassis-git-test",
+            project_name="mb-git-test",
             source_type="github",
             repo_owner="noontide-co",
             repo_name="thelastbill-test",
             production_branch="main",
             project_id="b6dacee6-fa1e-497f-b81b-369927a475a7",
-            pages_subdomain="chassis-git-test.pages.dev",
+            pages_subdomain="mb-git-test.pages.dev",
             already_existed=False,
             created_now=True,
         ),
@@ -710,13 +710,13 @@ def test_pages_create_project_idempotent_already_existed() -> None:
     env = PagesCreateProjectEnvelope(
         status="ok",
         data=PagesCreateProjectData(
-            project_name="chassis-git-test",
+            project_name="mb-git-test",
             source_type="github",
             repo_owner="noontide-co",
             repo_name="thelastbill-test",
             production_branch="main",
             project_id="b6dacee6-fa1e-497f-b81b-369927a475a7",
-            pages_subdomain="chassis-git-test.pages.dev",
+            pages_subdomain="mb-git-test.pages.dev",
             already_existed=True,
             created_now=False,
         ),
@@ -1010,7 +1010,7 @@ def _png_chunk(chunk_type: bytes, data: bytes) -> bytes:
 # StripeEnvelope (atom 6)
 # ---------------------------------------------------------------------------
 
-# The atom file is named `stripe.py` to match the chassis convention. The
+# The atom file is named `stripe.py` to match the /site atom convention. The
 # `sys.path.insert` at the top of this test file puts the scripts directory
 # first, so `import stripe` resolves to the local atom rather than the
 # (unrelated, not installed) Stripe Python SDK.

--- a/.claude/skills/site/scripts/test_atoms.py
+++ b/.claude/skills/site/scripts/test_atoms.py
@@ -1096,10 +1096,10 @@ def test_stripe_form_encode_list_of_dicts() -> None:
 
 def test_stripe_form_encode_metadata() -> None:
     encoded = dict(stripe_module._form_encode({
-        "metadata": {"chassis_offer": "thelastbill", "chassis_kind": "deposit"},
+        "metadata": {"mb_offer": "thelastbill", "mb_kind": "deposit"},
     }))
-    assert encoded["metadata[chassis_offer]"] == "thelastbill"
-    assert encoded["metadata[chassis_kind]"] == "deposit"
+    assert encoded["metadata[mb_offer]"] == "thelastbill"
+    assert encoded["metadata[mb_kind]"] == "deposit"
 
 
 def test_stripe_form_encode_booleans() -> None:
@@ -1268,9 +1268,9 @@ def test_stripe_cli_idempotent_returns_existing(monkeypatch: pytest.MonkeyPatch)
         "id": "prod_existing",
         "default_price": "price_existing",
         "metadata": {
-            "chassis_offer": "thelastbill",
-            "chassis_kind": "deposit",
-            "chassis_payment_link_url": "https://buy.stripe.com/EXISTING",
+            "mb_offer": "thelastbill",
+            "mb_kind": "deposit",
+            "mb_payment_link_url": "https://buy.stripe.com/EXISTING",
         },
     }
 
@@ -1309,7 +1309,7 @@ def test_stripe_cli_creates_when_no_existing(monkeypatch: pytest.MonkeyPatch) ->
                 payload={
                     "id": "prod_new",
                     "default_price": "price_new",
-                    "metadata": {"chassis_offer": "thelastbill"},
+                    "metadata": {"mb_offer": "thelastbill"},
                 },
             )
         if path == "/payment_links" and method == "POST":

--- a/.claude/skills/site/scripts/test_atoms.py
+++ b/.claude/skills/site/scripts/test_atoms.py
@@ -1007,6 +1007,361 @@ def _png_chunk(chunk_type: bytes, data: bytes) -> bytes:
 
 
 # ---------------------------------------------------------------------------
+# StripeEnvelope (atom 6)
+# ---------------------------------------------------------------------------
+
+# The atom file is named `stripe.py` to match the chassis convention. The
+# `sys.path.insert` at the top of this test file puts the scripts directory
+# first, so `import stripe` resolves to the local atom rather than the
+# (unrelated, not installed) Stripe Python SDK.
+import stripe as stripe_module
+from stripe import (
+    CreatePaymentLinkData,
+    CreatePaymentLinkEnvelope,
+    ListProductsData,
+    ListProductsEnvelope,
+    StripeError,
+    StripeResult,
+)
+
+
+def test_stripe_create_payment_link_ok_round_trip() -> None:
+    env = CreatePaymentLinkEnvelope(
+        status="ok",
+        data=CreatePaymentLinkData(
+            offer_slug="thelastbill",
+            payment_link_url="https://buy.stripe.com/abc123",
+            payment_link_id="plink_123",
+            product_id="prod_123",
+            price_id="price_123",
+            amount_cents=10000,
+            currency="usd",
+            statement_descriptor="NOONTIDE LASTBILL",
+            success_url="https://thelastbill.com/start/thanks/",
+            created_now=True,
+        ),
+        provenance={
+            "stripe_product_create": ProviderRunMetadata(
+                status="ok",
+                latency_ms=420,
+                provider_version="stripe-2024-06-20",
+            ),
+        },
+    )
+    blob = env.model_dump_json()
+    rehydrated = CreatePaymentLinkEnvelope.model_validate_json(blob)
+    assert rehydrated.status == "ok"
+    assert rehydrated.data.payment_link_url == "https://buy.stripe.com/abc123"
+    assert rehydrated.error is None
+
+
+def test_stripe_envelope_degraded_requires_error() -> None:
+    with pytest.raises(ValidationError):
+        CreatePaymentLinkEnvelope(
+            status="degraded",
+            data=CreatePaymentLinkData(offer_slug="x"),
+            error=None,
+        )
+
+
+def test_stripe_envelope_ok_forbids_error() -> None:
+    with pytest.raises(ValidationError):
+        CreatePaymentLinkEnvelope(
+            status="ok",
+            data=CreatePaymentLinkData(offer_slug="x"),
+            error=StripeError(code="stripe_request_failed", message="x"),
+        )
+
+
+def test_stripe_error_codes_closed() -> None:
+    with pytest.raises(ValidationError):
+        StripeError(code="not_a_real_code", message="x")  # type: ignore[arg-type]
+
+
+def test_stripe_form_encode_nested_dict() -> None:
+    encoded = dict(stripe_module._form_encode({
+        "default_price_data": {"currency": "usd", "unit_amount": 10000},
+    }))
+    assert encoded["default_price_data[currency]"] == "usd"
+    assert encoded["default_price_data[unit_amount]"] == "10000"
+
+
+def test_stripe_form_encode_list_of_dicts() -> None:
+    encoded = dict(stripe_module._form_encode({
+        "line_items": [{"price": "price_1", "quantity": 1}],
+    }))
+    assert encoded["line_items[0][price]"] == "price_1"
+    assert encoded["line_items[0][quantity]"] == "1"
+
+
+def test_stripe_form_encode_metadata() -> None:
+    encoded = dict(stripe_module._form_encode({
+        "metadata": {"chassis_offer": "thelastbill", "chassis_kind": "deposit"},
+    }))
+    assert encoded["metadata[chassis_offer]"] == "thelastbill"
+    assert encoded["metadata[chassis_kind]"] == "deposit"
+
+
+def test_stripe_form_encode_booleans() -> None:
+    encoded = dict(stripe_module._form_encode({"active": True}))
+    assert encoded["active"] == "true"
+
+
+def test_stripe_truncate_descriptor() -> None:
+    assert stripe_module._truncate_descriptor("  NOONTIDE  ") == "NOONTIDE"
+    assert stripe_module._truncate_descriptor("NOONTIDE THE LAST BILL EXTRA") == "NOONTIDE THE LAST BILL"
+    assert len(stripe_module._truncate_descriptor("NOONTIDE THE LAST BILL EXTRA")) == 22
+
+
+def test_stripe_validate_offer_slug_ok() -> None:
+    assert stripe_module._validate_offer_slug("thelastbill") is None
+    assert stripe_module._validate_offer_slug("the-last-bill") is None
+    assert stripe_module._validate_offer_slug("offer_1") is None
+
+
+def test_stripe_validate_offer_slug_rejects_uppercase() -> None:
+    err = stripe_module._validate_offer_slug("TheLastBill")
+    assert err is not None and "invalid" in err.lower()
+
+
+def test_stripe_validate_offer_slug_rejects_leading_hyphen() -> None:
+    err = stripe_module._validate_offer_slug("-thelastbill")
+    assert err is not None
+
+
+def test_stripe_validate_statement_descriptor_ok() -> None:
+    assert stripe_module._validate_statement_descriptor("NOONTIDE") is None
+    assert stripe_module._validate_statement_descriptor("NOONTIDE LAST BILL") is None
+
+
+def test_stripe_validate_statement_descriptor_rejects_special_chars() -> None:
+    assert stripe_module._validate_statement_descriptor("NOON<>TIDE") is not None
+
+
+def test_stripe_classify_error_unauthenticated() -> None:
+    code, suggestion = stripe_module._classify_error(StripeResult(
+        ok=False,
+        latency_ms=100,
+        status_code=401,
+        error_message="Invalid API Key",
+    ))
+    assert code == "stripe_unauthenticated"
+    assert "STRIPE_API_KEY" in suggestion
+
+
+def test_stripe_classify_error_rate_limited() -> None:
+    code, _ = stripe_module._classify_error(StripeResult(
+        ok=False,
+        latency_ms=100,
+        status_code=429,
+        error_message="rate limit",
+    ))
+    assert code == "stripe_rate_limited"
+
+
+def test_stripe_classify_error_timeout() -> None:
+    code, _ = stripe_module._classify_error(StripeResult(
+        ok=False,
+        latency_ms=30000,
+        status_code=0,
+        error_message="timeout",
+    ))
+    assert code == "network_timeout"
+
+
+def test_stripe_classify_error_generic_fallback() -> None:
+    code, _ = stripe_module._classify_error(StripeResult(
+        ok=False,
+        latency_ms=100,
+        status_code=500,
+        error_message="server error",
+    ))
+    assert code == "stripe_request_failed"
+
+
+# ---------------------------------------------------------------------------
+# stripe.py CLI: validation paths (no network)
+# ---------------------------------------------------------------------------
+
+from click.testing import CliRunner as _StripeCliRunner
+
+
+def _run_stripe(args: list[str], env: dict[str, str] | None = None) -> dict:
+    runner = _StripeCliRunner()
+    result = runner.invoke(stripe_module.cli, args, env=env or {})
+    return json.loads(result.stdout)
+
+
+def test_stripe_cli_missing_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("STRIPE_API_KEY", raising=False)
+    payload = _run_stripe([
+        "create-payment-link", "thelastbill",
+        "--amount", "10000",
+        "--success-url", "https://thelastbill.com/start/thanks/",
+    ])
+    assert payload["status"] == "degraded"
+    assert payload["error"]["code"] == "missing_api_key"
+
+
+def test_stripe_cli_invalid_amount(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("STRIPE_API_KEY", "sk_test_dummy")
+    payload = _run_stripe([
+        "create-payment-link", "thelastbill",
+        "--amount", "10",
+        "--success-url", "https://thelastbill.com/start/thanks/",
+    ])
+    assert payload["status"] == "degraded"
+    assert payload["error"]["code"] == "invalid_amount"
+
+
+def test_stripe_cli_invalid_currency(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("STRIPE_API_KEY", "sk_test_dummy")
+    payload = _run_stripe([
+        "create-payment-link", "thelastbill",
+        "--amount", "10000",
+        "--currency", "US",
+        "--success-url", "https://thelastbill.com/start/thanks/",
+    ])
+    assert payload["status"] == "degraded"
+    assert payload["error"]["code"] == "invalid_currency"
+
+
+def test_stripe_cli_invalid_success_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("STRIPE_API_KEY", "sk_test_dummy")
+    payload = _run_stripe([
+        "create-payment-link", "thelastbill",
+        "--amount", "10000",
+        "--success-url", "http://thelastbill.com/start/thanks/",
+    ])
+    assert payload["status"] == "degraded"
+    assert payload["error"]["code"] == "invalid_success_url"
+
+
+def test_stripe_cli_invalid_statement_descriptor(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("STRIPE_API_KEY", "sk_test_dummy")
+    payload = _run_stripe([
+        "create-payment-link", "thelastbill",
+        "--amount", "10000",
+        "--success-url", "https://thelastbill.com/start/thanks/",
+        "--statement-descriptor", "NO<>NE",
+    ])
+    assert payload["status"] == "degraded"
+    assert payload["error"]["code"] == "invalid_statement_descriptor"
+
+
+def test_stripe_cli_invalid_offer_slug(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("STRIPE_API_KEY", "sk_test_dummy")
+    payload = _run_stripe([
+        "create-payment-link", "TheLastBill",
+        "--amount", "10000",
+        "--success-url", "https://thelastbill.com/start/thanks/",
+    ])
+    assert payload["status"] == "degraded"
+    assert payload["error"]["code"] == "invalid_offer_slug"
+
+
+def test_stripe_cli_idempotent_returns_existing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Search returns an existing product with stashed payment-link URL → idempotent ok."""
+    monkeypatch.setenv("STRIPE_API_KEY", "sk_test_dummy")
+
+    existing_product = {
+        "id": "prod_existing",
+        "default_price": "price_existing",
+        "metadata": {
+            "chassis_offer": "thelastbill",
+            "chassis_kind": "deposit",
+            "chassis_payment_link_url": "https://buy.stripe.com/EXISTING",
+        },
+    }
+
+    def fake_search(api_key, slug, prov):  # type: ignore[no-untyped-def]
+        prov["stripe_products_search"] = ProviderRunMetadata(
+            status="ok", latency_ms=50, provider_version="stripe-2024-06-20"
+        )
+        return existing_product, StripeResult(ok=True, latency_ms=50, status_code=200)
+
+    monkeypatch.setattr(stripe_module, "_search_existing_product", fake_search)
+
+    payload = _run_stripe([
+        "create-payment-link", "thelastbill",
+        "--amount", "10000",
+        "--success-url", "https://thelastbill.com/start/thanks/",
+    ])
+    assert payload["status"] == "ok"
+    assert payload["data"]["payment_link_url"] == "https://buy.stripe.com/EXISTING"
+    assert payload["data"]["created_now"] is False
+    assert payload["data"]["product_id"] == "prod_existing"
+
+
+def test_stripe_cli_creates_when_no_existing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Search returns nothing; product + payment link get created in sequence."""
+    monkeypatch.setenv("STRIPE_API_KEY", "sk_test_dummy")
+
+    calls: list[tuple[str, str]] = []
+
+    def fake_call(method, path, api_key, body=None, idempotency_key=None, query=None):  # type: ignore[no-untyped-def]
+        calls.append((method, path))
+        if path == "/products/search":
+            return StripeResult(ok=True, latency_ms=10, status_code=200, payload={"data": []})
+        if path == "/products" and method == "POST":
+            return StripeResult(
+                ok=True, latency_ms=20, status_code=200,
+                payload={
+                    "id": "prod_new",
+                    "default_price": "price_new",
+                    "metadata": {"chassis_offer": "thelastbill"},
+                },
+            )
+        if path == "/payment_links" and method == "POST":
+            return StripeResult(
+                ok=True, latency_ms=15, status_code=200,
+                payload={"id": "plink_new", "url": "https://buy.stripe.com/NEW"},
+            )
+        if path.startswith("/products/prod_new") and method == "POST":
+            return StripeResult(ok=True, latency_ms=10, status_code=200, payload={"id": "prod_new"})
+        raise AssertionError(f"unexpected call: {method} {path}")
+
+    monkeypatch.setattr(stripe_module, "_stripe_call", fake_call)
+
+    payload = _run_stripe([
+        "create-payment-link", "thelastbill",
+        "--amount", "10000",
+        "--success-url", "https://thelastbill.com/start/thanks/",
+    ])
+    assert payload["status"] == "ok"
+    assert payload["data"]["payment_link_url"] == "https://buy.stripe.com/NEW"
+    assert payload["data"]["created_now"] is True
+    assert payload["data"]["product_id"] == "prod_new"
+    assert payload["data"]["price_id"] == "price_new"
+    # Confirm the call sequence: search → create product → create link → update metadata
+    assert ("GET", "/products/search") in calls
+    assert ("POST", "/products") in calls
+    assert ("POST", "/payment_links") in calls
+
+
+def test_stripe_cli_unauthenticated_passthrough(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A 401 from Stripe surfaces as `stripe_unauthenticated`."""
+    monkeypatch.setenv("STRIPE_API_KEY", "sk_test_bad")
+
+    def fake_call(method, path, api_key, body=None, idempotency_key=None, query=None):  # type: ignore[no-untyped-def]
+        return StripeResult(
+            ok=False, latency_ms=20, status_code=401,
+            error_message="Invalid API Key provided",
+            error_type="invalid_request_error",
+        )
+
+    monkeypatch.setattr(stripe_module, "_stripe_call", fake_call)
+
+    payload = _run_stripe([
+        "create-payment-link", "thelastbill",
+        "--amount", "10000",
+        "--success-url", "https://thelastbill.com/start/thanks/",
+    ])
+    assert payload["status"] == "degraded"
+    assert payload["error"]["code"] == "stripe_unauthenticated"
+
+
+# ---------------------------------------------------------------------------
 
 import shutil  # placed at the bottom so prior tests don't shadow it
 

--- a/.claude/skills/site/scripts/verify_live.py
+++ b/.claude/skills/site/scripts/verify_live.py
@@ -126,7 +126,7 @@ def _surface_cf_errors(body: dict | None) -> None:
 
 
 def check_cf_auth() -> bool:
-    """Verify the token has the three scopes the CF-registered chassis path needs.
+    """Verify the token has the three scopes the CF-registered path needs.
 
     Note: we don't use /user/tokens/verify — that endpoint is for User-scoped
     tokens only and returns code 1000 ('Invalid API Token') for Account-scoped


### PR DESCRIPTION
Refs #99 #89 #92

## Summary

Adds `stripe.py` — the V1 atom that wraps Stripe's API to create idempotent payment links from a Main Branch offer slug, returning the URL that the minisite home CTA links to. Idempotency is metadata-based (`mb_offer` + `mb_kind=deposit` search) with Stripe `Idempotency-Key` headers belt-and-suspendering against transient retries; closed-enum errors cover auth, rate-limit, timeout, validation, and account-not-configured paths. Ships with 27 contract tests covering envelope shape, validators, error classifier, form encoder, and full CLI flow (idempotent-existing, create-from-empty, 401 passthrough), plus minor spec follow-ups locking the same `mb_` namespace and `<repo>/.mainbranch/stripe-deposit.json` state-file path.

## Test plan

- [x] 27 stripe contract tests pass; full atom suite 93/93
- [x] Skill regression suite green at baseline (152/162, no new failures)
- [ ] Live test (deferred — no `STRIPE_API_KEY` yet): test-mode `create-payment-link` against a throwaway slug, verify idempotency on re-run, archive after

🤖 Generated with [Claude Code](https://claude.com/claude-code)