### PR TITLE
[refactor] /site — conversion-agnostic, brief→site one-flow, operating principles

### DIFF
--- a/.claude/reference/minisite.md
+++ b/.claude/reference/minisite.md
@@ -1,6 +1,6 @@
-# Minisite — V1 Chassis Spec
+# Minisite — V1 Spec
 
-The canonical contract for what a minisite **is** in Main Branch. Implementation flows live elsewhere; this file is the source of truth for page list, content contracts, post-payment flow, tracking, and walkthrough UX.
+The canonical contract for what a minisite **is** in Main Branch. Implementation flows live elsewhere; this file is the source of truth for page list, content contracts, conversion endpoint, tracking, and walkthrough UX.
 
 When `/site`, `/start launch`, `stripe.py`, or any future skill ships behavior that touches a minisite, that behavior conforms to this spec. If the spec changes, update this file first; downstream code follows.
 
@@ -8,7 +8,7 @@ When `/site`, `/start launch`, `stripe.py`, or any future skill ships behavior t
 
 ## What a minisite is
 
-A **minisite** is a small (~4–6 page) static-HTML site, generated fresh per offer, deployed to Cloudflare Pages with git auto-deploy. It's the V1 speedrun target — taking an offer from offer-locked to live-on-a-custom-apex with a working Stripe deposit gateway in under an hour.
+A **minisite** is a small (~4–6 page) static-HTML site, generated fresh per offer, deployed to Cloudflare Pages with git auto-deploy. It's the V1 speedrun target — taking an offer from offer-locked to live-on-a-custom-apex with a working conversion endpoint in under an hour.
 
 Not a template. Not inheritance. Each minisite is generated from scratch by a Claude Code subagent reading `offer.md` + `audience.md` + reference URLs. Two runs on the same offer produce visually distinct sites (variance is the feature).
 
@@ -34,10 +34,10 @@ The generation subagent picks the supporting pages that best serve **this** offe
 | Path | Purpose | Source material |
 |---|---|---|
 | `/proof/` | Testimonials, case studies, outcome data, trust badges | `proof/testimonials.md`, `proof/angles/*.md` |
-| `/pricing/` | Pricing card, what's included, payment CTA | `offer.md` (pricing), Stripe payment-link URL |
+| `/pricing/` | Pricing card, what's included, conversion CTA | `offer.md` (pricing), conversion endpoint URL |
 | `/faq/` | Top objections answered, ordered by likelihood-of-asking | `audience.md` (objections), `offer.md` |
 
-A coaching offer often lands on home + how-it-works + proof + faq. A software offer often lands on home + how-it-works + pricing + faq. A billing tool with strong proof might land on home + how-it-works + proof + pricing + faq. All valid.
+A coaching offer often lands on home + how-it-works + proof + faq. A software offer often lands on home + how-it-works + pricing + faq. A services offer with strong proof might land on home + how-it-works + proof + pricing + faq. All valid.
 
 ### Required infrastructure pages
 
@@ -45,9 +45,9 @@ A coaching offer often lands on home + how-it-works + proof + faq. A software of
 |---|---|
 | `/privacy/` | Privacy policy. Boilerplate fine for V1. |
 | `/terms/` | Terms of service. Boilerplate fine for V1. |
-| `/start/thanks/` | Post-payment landing. **Required.** This is Stripe's `success_url` default. |
+| `/start/thanks/` | Post-conversion landing. **Required.** This is the default destination after a successful conversion (Stripe `success_url`, lead-form submit redirect, etc.). |
 
-The home page is the conversion target — its primary CTA links directly to the Stripe payment-link URL. There is no separate `/start/` page; that ceremony adds a click without adding signal.
+The home page is the conversion target — its primary CTA links directly to the conversion endpoint URL (Stripe payment page, lead-form, booking link, etc. — see "Conversion endpoint" below). There is no separate `/start/` page; that ceremony adds a click without adding signal.
 
 ### Required infrastructure files (repo root)
 
@@ -69,14 +69,14 @@ What goes on each page by default. The generation subagent has aesthetic freedom
 
 ### Home (`/`)
 
-- **Hero:** transformation phrase (≤2 lines), signature visual, primary CTA linking directly to the Stripe payment-link URL
+- **Hero:** transformation phrase (≤2 lines), signature visual, primary CTA linking directly to the conversion endpoint URL
 - **Value prop:** 3 short reasons or one extended argument; pulled from `offer.md`
 - **Brief proof:** 1–3 testimonials or stat callouts (full proof lives at `/proof/` if picked)
 - **Founder/brand glimpse:** 1–2 sentences from `soul.md` or `offer.md` if relevant
-- **Secondary CTA:** repeat of primary, often with different copy ("ready when you are"), same Stripe URL
+- **Secondary CTA:** repeat of primary, often with different copy ("ready when you are"), same conversion URL
 - **Footer:** Noontide footer (see below)
 
-The Stripe URL is the same one used everywhere on the site. Until the link is wired, placeholder `https://buy.stripe.com/PLACEHOLDER` ships and the `/start launch` orchestration substitutes the real URL during the build phase.
+The conversion URL is the same one used everywhere on the site. Until the URL is wired, placeholder `https://CONVERSION-PLACEHOLDER` ships and the `/start launch` orchestration substitutes the real URL during the build phase.
 
 ### How It Works (`/how-it-works/`)
 
@@ -96,7 +96,7 @@ The Stripe URL is the same one used everywhere on the site. Until the link is wi
 
 - **Pricing card(s):** offer.md determines tier structure; one or three tiers, never two
 - **What's included:** bullet list of concrete deliverables per tier
-- **Payment CTA:** primary CTA links directly to the Stripe payment-link URL (same URL the home hero uses)
+- **Conversion CTA:** primary CTA links directly to the conversion endpoint URL (same URL the home hero uses)
 - **Trust signal:** brief mention of guarantee/refund/etc. if offer.md declares one
 
 ### FAQ (`/faq/`, when picked)
@@ -107,17 +107,17 @@ The Stripe URL is the same one used everywhere on the site. Until the link is wi
 
 ### Privacy / Terms
 
-Boilerplate language is fine for V1. Main Branch assumes the operator's lawyer reviews before scale. Boilerplate must include: data collected (email, payment info via Stripe), how it's used, retention policy, contact for requests. Generate from a template or LLM but mark as boilerplate in a comment.
+Boilerplate language is fine for V1. Main Branch assumes the operator's lawyer reviews before scale. Boilerplate must include: data collected (email, payment info if applicable, form data), how it's used, retention policy, contact for requests. Generate from a template or LLM but mark as boilerplate in a comment.
 
 ### Start / Thanks (`/start/thanks/`)
 
-The post-payment landing page. Stripe's `success_url` redirects here after a successful deposit.
+The post-conversion landing page. Wherever the conversion endpoint allows a redirect target (Stripe `success_url`, lead-form thank-you page, etc.), it points here.
 
-- **Confirmation:** "Thanks. Your deposit is confirmed."
+- **Confirmation:** matches the conversion kind. "Thanks. Your payment is confirmed." for Stripe; "Thanks. We'll be in touch." for lead forms; "Thanks. Your booking is confirmed." for appointments.
 - **What happens next:** explicit timeline — "you'll get an email within X minutes," "I'll personally reach out within Y hours," etc. Pulled from `offer.md` fulfillment notes.
-- **Calendar link / next-step CTA:** if offer.md declares a booking step, link it here
+- **Calendar link / next-step CTA:** if `offer.md` declares a booking step (and it isn't already the conversion endpoint), link it here
 - **Optional:** social proof reinforcement (you joined N others)
-- **No upsell.** First page after payment is gratitude + next-step clarity, never another sale.
+- **No upsell.** First page after conversion is gratitude + next-step clarity, never another sale.
 
 ---
 
@@ -142,33 +142,109 @@ The skill's validation step greps every page for "Noontide Collective LLC" or th
 
 ---
 
-## Post-payment flow
+## Conversion endpoint
+
+Every minisite has **one** conversion endpoint — the URL the home hero CTA points to. The operator picks the kind during `/site` walkthrough; the spec stays open. Stripe is one of several options; the choice depends on the offer's actual conversion goal.
 
 ```
-Visitor → / (CTA click) → Stripe checkout (payment-link URL) → Stripe success → /start/thanks/
+Visitor → / (CTA click) → conversion endpoint → /start/thanks/
 ```
 
-### Stripe payment-link defaults
+### Supported kinds (V1)
 
-When `stripe.py create-payment-link <offer-slug>` runs against the offer:
+| Kind | What the URL is | When to pick | Tracking event |
+|---|---|---|---|
+| **Stripe payment page** | A Stripe-hosted Checkout / Payment Link URL (`https://buy.stripe.com/...`) | Charging money — full price, deposit, custom amount, etc. | `Purchase` |
+| **Lead form** | A hosted form URL (Tally, Typeform, Google Form, native HTML form) | Capturing leads / interest before sales conversation | `Lead` |
+| **Appointment booking** | A booking-link URL (Cal.com, Calendly, SavvyCal, etc.) | Sales-call funnels, consultations, fitting appointments | `Schedule` |
+| **Custom webhook** | An operator-supplied URL (their own form endpoint) | Advanced — own backend, custom flow | Operator-defined |
+
+Operator picks one. The minisite generates with whichever is selected. Two minisites for two different offers can ship with two different kinds.
+
+### Per-kind detail
+
+#### Stripe payment page
+
+The default for offers that charge money. `stripe.py create-payment-link` runs against the offer; the returned URL is the conversion endpoint.
+
+The "kind of payment" is operator-declared in `offer.md` — `deposit`, `full`, `subscription` (V2), or `custom`. The atom doesn't decide; it just creates the payment link with the amount the operator specified.
 
 | Field | Default | Source |
 |---|---|---|
-| `amount` | offer.md `deposit_amount_usd` × 100 (cents) | offer.md frontmatter |
+| `amount` | offer.md `payment_amount_usd` × 100 (cents) | offer.md frontmatter |
 | `currency` | `usd` | hardcoded V1; multi-currency is V2 |
-| `description` | offer.md `deposit_description` or generated | offer.md or LLM |
+| `description` | offer.md `payment_description` or generated | offer.md or LLM |
 | `statement_descriptor` | offer.md `statement_descriptor` or `NOONTIDE` | offer.md or fallback (max 22 chars) |
 | `metadata.mb_offer` | `<offer-slug>` | derived from offer's directory name |
-| `metadata.mb_kind` | `deposit` | hardcoded for V1 |
+| `metadata.mb_kind` | offer.md `payment_kind` (default: `payment`) | offer.md or fallback |
 | `success_url` | `https://<domain>/start/thanks/` | derived from `sites.json` `domain` |
 
-The atom emits the `payment_link.url` in its envelope. The orchestration writes that URL into the project repo (e.g., `<repo>/.mainbranch/stripe-deposit.json`) so the generation subagent reads it during the build phase and substitutes it into every CTA href on the site (home hero, secondary CTA, pricing CTA if shipped).
+The atom emits `payment_link.url` in its envelope. The orchestration writes that URL into the project repo (e.g., `<repo>/.mainbranch/conversion.json`) so the generation subagent reads it during the build phase and substitutes it into every CTA href on the site.
 
-### What's NOT in the post-payment flow (V1)
+> Note: `metadata.mb_kind` is operator-controlled. The atom ships with `payment` as the safe default, but the operator's `offer.md` can declare anything semantically meaningful (e.g., `deposit`, `full`, `consult-fee`). Tests that assume `mb_kind=deposit` are checking the legacy V1 behavior; the spec treats `payment` as the generic.
 
-- **No webhook handling.** Stripe emails the operator on payment success; that's the V1 notification. Webhooks for analytics, CRM sync, fulfillment automation are V2.
-- **No upsell on `/start/thanks/`.** First page after payment is gratitude.
-- **No subscription billing.** V1 deposits are one-off charges. Subscriptions are V2 when an offer needs ongoing payment.
+### Render mode per kind
+
+How the home CTA actually renders depends on the kind:
+
+| Kind | Render | Default |
+|---|---|---|
+| Stripe payment page | Link out (button → URL) | Link out |
+| Lead form | Inline form on home, modal on home, or link-out to hosted form | Operator picks; V1 default is hosted form link-out (lowest friction) |
+| Appointment booking | Link out to provider OR embed via provider SDK | V1 default link-out (simpler, fewer cross-origin concerns) |
+| Custom webhook | Form POST inline OR link out | Operator decides |
+
+The skill captures the render choice during walkthrough and stores it alongside the URL in `<repo>/.mainbranch/conversion.json`:
+
+```json
+{
+  "kind": "lead_form",
+  "url": "https://tally.so/r/abc123",
+  "render": "link_out",
+  "metadata": { "provider": "tally" }
+}
+```
+
+The generation subagent reads `kind` + `render` + `url` and renders the home CTA accordingly.
+
+#### Lead form
+
+For offers that capture interest before a sales conversation.
+
+Form provider options the operator can pick:
+
+| Provider | URL kind | Routing |
+|---|---|---|
+| **Tally** | `https://tally.so/r/<form-id>` | Tally captures; operator configures destination (email, Sheets, webhook) in Tally dashboard |
+| **Typeform** | `https://<workspace>.typeform.com/to/<form-id>` | Typeform captures; operator configures destination |
+| **Google Form** | `https://docs.google.com/forms/d/e/<form-id>/viewform` | Google captures to Sheets by default |
+| **Native HTML form + Formspree** | `https://formspree.io/f/<form-id>` | Operator's email; can webhook |
+| **Native HTML form + custom backend** | Operator's URL | Operator's responsibility |
+
+The skill's setup walkthrough asks: *"Where does the form data go?"* — captures the operator's pick, stores the form URL + render choice in `<repo>/.mainbranch/conversion.json`.
+
+#### Appointment booking
+
+For sales-call funnels, consultations, fitting appointments. The conversion endpoint is the booking-link URL.
+
+| Provider | URL kind |
+|---|---|
+| **Cal.com** | `https://cal.com/<username>/<event-type>` |
+| **Calendly** | `https://calendly.com/<username>/<event-type>` |
+| **SavvyCal** | `https://savvycal.com/<username>/<event-type>` |
+
+The home CTA can link out to the booking page directly OR embed it inline (provider's SDK). V1 default is link-out (simpler, fewer cross-origin concerns). The render choice is stored in `<repo>/.mainbranch/conversion.json`.
+
+#### Custom webhook
+
+For operators with their own form endpoint or advanced flow. The operator supplies a URL; the home CTA points there. The skill doesn't validate the destination — it's the operator's responsibility.
+
+### What's NOT in the conversion endpoint (V1)
+
+- **No multi-endpoint sites.** One minisite, one conversion endpoint. If an offer has multiple conversion paths (lead form *and* deposit), graduate to `/site → website` shape.
+- **No webhook handling for Stripe (V1).** Stripe emails the operator on payment success; that's the V1 notification. Webhooks for analytics, CRM sync, fulfillment automation are V2.
+- **No upsell on `/start/thanks/`.** First page after conversion is gratitude.
+- **No subscription billing (V1).** V1 Stripe payment pages are one-off charges. Subscriptions are V2.
 
 ---
 
@@ -188,15 +264,20 @@ If multiple are declared, all install. If GTM is declared, GA4 and Meta Pixel ty
 
 ### Conversion events
 
-The generation subagent fires standard conversion events when the corresponding tracking is installed:
+The generation subagent fires standard conversion events when the corresponding tracking is installed. The conversion event name matches the conversion endpoint's kind:
 
-| Event | When | Pixels |
-|---|---|---|
-| `PageView` | Every page load | All declared |
-| `InitiateCheckout` | Click on any Stripe CTA (home hero, secondary, pricing) | All declared |
-| `Purchase` | Page load on `/start/thanks/` | All declared |
+| Event | When | Pixels | Conversion kind |
+|---|---|---|---|
+| `PageView` | Every page load | All declared | (always) |
+| `InitiateCheckout` | Click on a Stripe CTA (home hero, secondary, pricing) | All declared | Stripe payment page |
+| `Purchase` | Page load on `/start/thanks/` (after Stripe success) | All declared | Stripe payment page |
+| `Lead` | Form submit success / page load on `/start/thanks/` | All declared | Lead form |
+| `Schedule` | Page load on `/start/thanks/` (after appointment booked, if redirect supported by provider) | All declared | Appointment booking |
+| (operator-defined) | Operator's webhook flow decides; default fires `Lead` on home-CTA click | All declared | Custom webhook |
 
-**`Purchase` event payload includes** `value: <amount_usd>`, `currency: usd`. Stripe doesn't pass the actual amount through the redirect; the subagent reads it from `offer.md` at build time.
+For Stripe: `Purchase` payload includes `value: <amount_usd>`, `currency: usd`. The subagent reads the amount from `offer.md` at build time (Stripe doesn't pass it through the redirect).
+
+For lead/appointment: standard pixel taxonomy events. The subagent uses the conversion-endpoint kind to pick which event(s) to fire.
 
 ### What's NOT in the tracking architecture (V1)
 
@@ -208,17 +289,27 @@ The generation subagent fires standard conversion events when the corresponding 
 
 ## Pre-flight gates (before `/start launch` runs)
 
-`/start launch <offer>` must verify these before money or state changes:
+`/start launch <offer>` must verify these before money or state changes. Some gates branch on the chosen conversion-endpoint kind.
+
+### Always-required gates
 
 | Gate | Required for | How verified |
 |---|---|---|
 | `offer.md` exists and has minimum fields | Generation | File presence + frontmatter parse |
 | `audience.md` exists | Generation | File presence |
-| `deposit_amount_usd` declared in offer.md | Stripe atom | Frontmatter field |
-| Stripe API key in env | Stripe atom | `STRIPE_API_KEY` env var |
 | Cloudflare creds + GitHub App | All atom calls | `verify_live.py` returns 3/3 (Cloudflare scopes + zone lookup + domain-check) |
-| Domain decision | Setup | Operator confirms own-or-buy via `/site setup` triage |
+| Domain decision | Setup | Operator confirms own-or-buy |
 | Tracking IDs (if declared) | Generation | offer.md frontmatter parse — if any tracking field present, validate format |
+
+### Conversion-endpoint gates (only the chosen kind's gates apply)
+
+| Conversion kind | Gate | How verified |
+|---|---|---|
+| Stripe payment page | `payment_amount_usd` declared in offer.md | Frontmatter field |
+| Stripe payment page | `STRIPE_API_KEY` env var | Shell env check |
+| Lead form | Form URL provided (or form-provider destination) | Operator input captured |
+| Appointment booking | Booking URL provided | Operator input captured |
+| Custom webhook | Endpoint URL provided | Operator input captured |
 
 Failed gate = halt with a specific message and routing suggestion. No silent skips, no partial runs.
 
@@ -231,7 +322,7 @@ The orchestration mode (lives in `/start`, ships in #92) walks the operator thro
 ### Phase 1 — Pre-flight
 
 - Verify offer locked (offer.md + audience.md present)
-- Verify creds (CF + Stripe + gh)
+- Verify creds (CF + gh; conversion-endpoint creds checked in phase 4 only if needed)
 - Surface what's missing with specific next-step commands
 
 ### Phase 2 — Domain
@@ -248,15 +339,21 @@ The orchestration mode (lives in `/start`, ships in #92) walks the operator thro
 - `pages.py create-project <name> --repo-owner <owner> --repo-name <repo> --source github`
 - `pages.py set-domain <name> <domain>` (attach + CNAME + SSL active)
 
-### Phase 4 — Stripe
+### Phase 4 — Conversion endpoint
 
-- `stripe.py create-payment-link <offer-slug> --amount <cents>` 
-- Write returned URL to `<repo>/.mainbranch/stripe-deposit.json`
+Operator picks the kind (Stripe / lead form / appointment / custom). Then per-kind:
+
+- **Stripe payment page:** `stripe.py create-payment-link <offer-slug> --amount <cents>` → write returned URL to `<repo>/.mainbranch/conversion.json`
+- **Lead form:** ask for the form URL (or pick a provider, get walked through setup), write to `<repo>/.mainbranch/conversion.json`
+- **Appointment booking:** ask for the booking URL, write to `<repo>/.mainbranch/conversion.json`
+- **Custom webhook:** ask for the URL, write to `<repo>/.mainbranch/conversion.json`
+
+The conversion.json file is the single source the generation subagent reads to wire CTAs.
 
 ### Phase 5 — Generation
 
 - Resolve offer context
-- Spawn generation subagent with `minisite-generation-system.md` + offer/audience/reference URLs + Stripe link from phase 4
+- Spawn generation subagent with `minisite-generation-system.md` + offer/audience/reference URLs + conversion-endpoint info from phase 4
 - Validate output (file presence, footer, og_render, optional Lighthouse)
 
 ### Phase 6 — Ship
@@ -284,6 +381,8 @@ This is the quality bar: an LLM that produces the same minisite twice on the sam
 - [`/site` SKILL.md](../skills/site/SKILL.md) — the skill that triages site shapes and routes to minisite-build.md
 - [`minisite-build.md`](../skills/site/references/minisite-build.md) — the operator-walkthrough flow
 - [`minisite-generation-system.md`](../skills/site/references/minisite-generation-system.md) — the load-bearing system prompt for the generation subagent
+- [`review.md`](../skills/site/references/review.md) — quality-gate steps the skill runs through before lock and before publish
+- [`concept-variations.md`](../skills/site/references/concept-variations.md) — parallel-on-localhost concept generation pattern
 - [`anti-patterns.md`](../skills/site/references/anti-patterns.md) — what NOT to bake into the system prompt
 - [`graduation.md`](../skills/site/references/graduation.md) — minisite → website paths + CMS bolt-on
 
@@ -292,7 +391,7 @@ This is the quality bar: an LLM that produces the same minisite twice on the sam
 - [`dns.py`](../skills/site/scripts/dns.py) — CF zone + NS swap
 - [`pages.py`](../skills/site/scripts/pages.py) — CF Pages project + custom domain
 - [`og_render.py`](../skills/site/scripts/og_render.py) — SVG → PNG (1200x630)
-- `stripe.py` — payment link creation (#99, V1 — landing soon)
+- [`stripe.py`](../skills/site/scripts/stripe.py) — Stripe payment link creation (one of several conversion-endpoint backends)
 
 **Decisions (durable architecture):**
 - `noontide-co/noontide-ops` `decisions/2026-04-27-lander-launch-skills.md`
@@ -307,12 +406,13 @@ This is the quality bar: an LLM that produces the same minisite twice on the sam
 
 ## Future direction (not V1, but planned)
 
-- **Chassis-as-CMS:** ongoing minisite editing via talk-and-update, not just one-time generation
-- **Webhook handling:** Stripe deposit-success → CRM sync, email triggers, fulfillment automation
+- **Edit-via-talk:** ongoing minisite editing via talk-and-update, not just one-time generation
+- **Stripe webhook handling:** payment-success → CRM sync, email triggers, fulfillment automation
 - **Subscription billing:** for offers that recur monthly/annually
 - **Server-side tracking:** for attribution accuracy when browser-side gaps surface
 - **Multi-currency:** non-USD pricing
 - **A/B testing:** same offer, two minisite variants, route paid traffic to compare
+- **Multi-endpoint sites:** lead-form + deposit on the same site (currently a graduation signal to website shape)
 - **Graduation tooling:** `/site graduate <new-shape>` automates minisite → website transitions
 
 These exist as known-future work. They influence design decisions today (don't paint into corners) but aren't load-bearing for the V1 ship.

--- a/.claude/reference/minisite.md
+++ b/.claude/reference/minisite.md
@@ -161,28 +161,6 @@ Visitor → / (CTA click) → conversion endpoint → /start/thanks/
 
 Operator picks one. The minisite generates with whichever is selected. Two minisites for two different offers can ship with two different kinds.
 
-### Per-kind detail
-
-#### Stripe payment page
-
-The default for offers that charge money. `stripe.py create-payment-link` runs against the offer; the returned URL is the conversion endpoint.
-
-The "kind of payment" is operator-declared in `offer.md` — `deposit`, `full`, `subscription` (V2), or `custom`. The atom doesn't decide; it just creates the payment link with the amount the operator specified.
-
-| Field | Default | Source |
-|---|---|---|
-| `amount` | offer.md `payment_amount_usd` × 100 (cents) | offer.md frontmatter |
-| `currency` | `usd` | hardcoded V1; multi-currency is V2 |
-| `description` | offer.md `payment_description` or generated | offer.md or LLM |
-| `statement_descriptor` | offer.md `statement_descriptor` or `NOONTIDE` | offer.md or fallback (max 22 chars) |
-| `metadata.mb_offer` | `<offer-slug>` | derived from offer's directory name |
-| `metadata.mb_kind` | offer.md `payment_kind` (default: `payment`) | offer.md or fallback |
-| `success_url` | `https://<domain>/start/thanks/` | derived from `sites.json` `domain` |
-
-The atom emits `payment_link.url` in its envelope. The orchestration writes that URL into the project repo (e.g., `<repo>/.mainbranch/conversion.json`) so the generation subagent reads it during the build phase and substitutes it into every CTA href on the site.
-
-> Note: `metadata.mb_kind` is operator-controlled. The atom ships with `payment` as the safe default, but the operator's `offer.md` can declare anything semantically meaningful (e.g., `deposit`, `full`, `consult-fee`). Tests that assume `mb_kind=deposit` are checking the legacy V1 behavior; the spec treats `payment` as the generic.
-
 ### Render mode per kind
 
 How the home CTA actually renders depends on the kind:
@@ -206,6 +184,28 @@ The skill captures the render choice during walkthrough and stores it alongside 
 ```
 
 The generation subagent reads `kind` + `render` + `url` and renders the home CTA accordingly.
+
+### Per-kind detail
+
+#### Stripe payment page
+
+The default for offers that charge money. `stripe.py create-payment-link` runs against the offer; the returned URL is the conversion endpoint.
+
+The "kind of payment" is operator-declared in `offer.md` — `deposit`, `full`, `subscription` (V2), or `custom`. The atom doesn't decide; it just creates the payment link with the amount the operator specified.
+
+| Field | Default | Source |
+|---|---|---|
+| `amount` | offer.md `payment_amount_usd` × 100 (cents) | offer.md frontmatter |
+| `currency` | `usd` | hardcoded V1; multi-currency is V2 |
+| `description` | offer.md `payment_description` or generated | offer.md or LLM |
+| `statement_descriptor` | offer.md `statement_descriptor` or `NOONTIDE` | offer.md or fallback (max 22 chars) |
+| `metadata.mb_offer` | `<offer-slug>` | derived from offer's directory name |
+| `metadata.mb_kind` | `"deposit"` (V1 hardcoded) | atom constant |
+| `success_url` | `https://<domain>/start/thanks/` | derived from `sites.json` `domain` |
+
+The atom emits `payment_link.url` in its envelope. The orchestration writes that URL into the project repo (e.g., `<repo>/.mainbranch/conversion.json`) so the generation subagent reads it during the build phase and substitutes it into every CTA href on the site.
+
+> **V1 vs. planned.** `stripe.py` currently hardcodes `metadata.mb_kind = "deposit"` and does not read `payment_kind` from `offer.md`. The next iteration accepts a `--kind` flag (default: `payment`) and falls back to `offer.md`'s `payment_kind` field, so an operator charging full price (or running a consult-fee, etc.) gets honest metadata. Until that ships, every Stripe-backed minisite labels its payment as a "deposit" in Stripe's metadata — accurate when it is one, awkward when it isn't.
 
 #### Lead form
 

--- a/.claude/skills/site/SKILL.md
+++ b/.claude/skills/site/SKILL.md
@@ -55,6 +55,22 @@ fi
 
 ---
 
+## Operating principles
+
+Four behaviors `/site` uses on every run, not optional:
+
+**1. One flow: brief → site.** The brief and the site live in the same skill. Don't tell the operator "build the brief in X, then come back for the site." `/site` walks: research → brief draft → review → lock → concept variations → publish → iterate. Continuous.
+
+**2. Foreground subagents, always.** When spawning subagents (research, concept generation, review passes), keep them in the foreground. Background subagents have a known file-write bug — files appear written but don't persist. Foreground only. See [`references/concept-variations.md`](references/concept-variations.md) for the spawn pattern.
+
+**3. Parallel by default.** Multiple research questions? Spawn agents in parallel. Multiple concept variations? Spawn in parallel. Multiple review passes? Spawn in parallel. Sequential is the exception, not the rule.
+
+**4. Publish-first, then iterate.** Push the rawest working version of the brief, then the rawest working concept, to GitHub immediately. Git history is the durable memory across context clears. Chat compaction can't be trusted. Iterate on top of committed work, not in-memory state.
+
+When research subagents record findings, they follow the [`/think` research patterns](../think/SKILL.md) — dated `research/YYYY-MM-DD-slug-claude-code.md` files with frontmatter (`linked_decisions: []`), so the research → decision → reference chain stays intact across the brief and the site.
+
+---
+
 ## Where Files Go
 
 ```
@@ -171,7 +187,7 @@ Ask the operator. Route based on the answer; don't assume.
 >   *V1: per-offer lander generation not yet wired. Use **Minisite** for single-page-feel use cases — its home page covers the focused conversion target.* Future spec: [`references/lander-build.md`](references/lander-build.md).
 >
 > - 🟩 **Minisite** (~4–6 pages, static HTML) — home + how-it-works + 2–4 LLM-picked + privacy/terms/start-thanks. Designed fresh per offer by a generation subagent. **V1 target.**
->   Best for: paid-ad lander tests, single-offer first deploys, deposit-gateway flows.
+>   Best for: paid-ad lander tests, single-offer first deploys, payment / lead-form / booking funnels.
 >   Flow: [`references/minisite-build.md`](references/minisite-build.md). Engine spec: `mb-vip/.claude/reference/minisite.md`.
 >
 > - 🟨 **Website** (full, multi-section, build step likely) — depth, blog, multiple offers, knowledge base, course area.
@@ -285,6 +301,8 @@ Site shapes `/site` covers: **lander** (1 page), **minisite** (~4–6 pages), **
 **Generation + design (used by per-shape flows):**
 
 - [references/minisite-generation-system.md](references/minisite-generation-system.md) — load-bearing system prompt for minisite generation subagent
+- [references/concept-variations.md](references/concept-variations.md) — parallel-on-localhost concept generation pattern (default 2)
+- [references/review.md](references/review.md) — quality-gate steps the skill runs through before lock and before publish
 - [references/anti-patterns.md](references/anti-patterns.md) — what NOT to bake into prompts
 - [references/naming-heuristic.md](references/naming-heuristic.md) — 8-step domain naming playbook
 - [references/cloudflare-pages-link.md](references/cloudflare-pages-link.md) — CF Pages GitHub App handshake walkthrough

--- a/.claude/skills/site/references/concept-variations.md
+++ b/.claude/skills/site/references/concept-variations.md
@@ -1,0 +1,97 @@
+# Concept Variations — Parallel Generation on Localhost
+
+After the brief is locked, `/site` generates **multiple visual concepts in parallel** so the operator can pick the one that lands best. Default is **2 concepts** to keep token cost low; the operator can raise the default once they've used the skill at least once.
+
+Each concept is just the home page — no sublinks, no navigation, no per-page detail. The point is design choice, not full-site comparison. The picked concept becomes the seed for the rest of the minisite.
+
+---
+
+## Why parallel concepts
+
+One generation produces one design language. Two produce a real choice. Three or five let the operator see a wider aesthetic space.
+
+Token economics matter — each concept is a full home-page generation (HTML + CSS + signature visual SVG). Default 2 keeps the floor low. The operator opts up if they're OK spending more.
+
+---
+
+## The flow
+
+1. **Brief locked.** The operator has confirmed offer framing, headline, value prop, conversion endpoint, and any framework choice.
+2. **Determine concept count.** Read `~/.config/vip/local.yaml` for `default_concepts`. If absent, use `2`.
+3. **Spawn N concept subagents in parallel** (foreground only). Each gets the same inputs:
+   - Locked brief, `offer.md`, `audience.md`, `voice.md`, `soul.md`
+   - **Conversion endpoint info** from `<repo>/.mainbranch/conversion.json` — kind (Stripe payment page / lead form / appointment booking / custom webhook), URL, and render mode (link-out / inline / embedded / form-POST). The home CTA rendering varies by kind, so concepts that don't know the kind will design the wrong shape (e.g., a pricing-card hero for what's actually a lead-form offer).
+   - A different "lean" instruction per concept (one warmer, one more structured, etc.).
+4. **Each subagent writes its concept to a separate localhost folder** under the project repo: `.mainbranch/concepts/concept-1/`, `concept-2/`, etc.
+5. **Start a localhost preview** for each concept (e.g., `python3 -m http.server` on different ports, or a single static server with subpath routing).
+6. **Surface URLs to operator.** "Open these and pick: http://localhost:8001 / http://localhost:8002. When you've picked, say `concept 1`."
+7. **Operator picks one.** The picked concept's files move from `.mainbranch/concepts/concept-N/` to the project root (or replace whatever's there).
+8. **Discard the rest.** Optionally archive to `.mainbranch/concepts/discarded/` for git history; otherwise delete.
+9. **First commit goes in immediately.** This is the rawest working version — push to GitHub before iterating. Per the [`Operating principles`](../SKILL.md) section: publish-first, then iterate.
+
+After pick + commit, the rest of the minisite (other pages — how-it-works, picked supporting pages, privacy/terms, /start/thanks/) generates with the picked concept as the design seed.
+
+---
+
+## Per-concept "lean"
+
+When spawning N concepts, the skill assigns each a slightly different instruction so they're not just LLM-randomness variants of the same thing:
+
+| Concept | Lean (example) |
+|---|---|
+| 1 | Editorial / typographic — type as the dominant visual element |
+| 2 | Illustrated / signature artifact — one custom SVG anchors the page |
+| 3 (if N≥3) | Documentarian / data-anchored — proof/numbers as the visual hook |
+| 4 (if N≥4) | Minimalist / single bold color — restraint as the statement |
+| 5 (if N=5) | Maximalist / motion-forward — animation drives the experience |
+
+Operators can override by supplying their own leans (e.g., "I want one warm + one cold"). The lean is short — a sentence each — and feeds the concept subagent's prompt.
+
+---
+
+## Default concept count
+
+Stored in `~/.config/vip/local.yaml` per the `start/references/config-system.md` config split:
+
+```yaml
+# ~/.config/vip/local.yaml
+vip_path: /path/to/vip
+user: dmthepm
+default_concepts: 3  # optional; defaults to 2 if absent
+```
+
+**First-run nudge:** after the operator picks a concept on their first `/site` run, the skill prompts:
+
+> Worked? Want more variations on the next run? You can raise the default — `default_concepts: 3` (or 5) in `~/.config/vip/local.yaml`. Each concept costs roughly the same token budget as one full home-page generation, so 5 ≈ 5x the home-page cost. 2 is fine if you're tight on budget.
+
+---
+
+## Foreground-only
+
+Concept subagents must run in the foreground. Background subagents have a known file-write bug — files appear written but don't persist (per [Operating principles](../SKILL.md)). Concept generation specifically needs files on disk to start the localhost preview, so a silent write failure blocks the whole flow.
+
+---
+
+## Token-saving tips
+
+- **Home page only.** No nav, no other pages. Each concept is one `index.html` + `styles.css` + `og.svg` + `favicon.svg`.
+- **Reuse offer/audience/voice loads.** All N subagents read the same reference files; the orchestration loads once and passes the content into each subagent's prompt rather than having each re-read.
+- **Discard fast.** When the operator picks, immediately delete the unpicked concepts so the project repo stays clean. The git history of the `.mainbranch/concepts/` folder shows what was tried.
+
+---
+
+## What this is NOT
+
+- **Not multi-page generation.** Picked concept seeds the *rest* of the site; concepts themselves are home-only.
+- **Not A/B testing.** That's a V2 feature — generating two minisites, deploying both, splitting paid traffic. Concept variations happen *before* deploy; A/B happens *after*.
+- **Not endless retries.** If the operator doesn't like any of the 2–5 concepts, the fix is usually upstream (clarify the brief, fix `voice.md`, run review again). Don't loop on more concepts hoping for randomness to save you.
+
+---
+
+## Cross-references
+
+- [`SKILL.md`](../SKILL.md) — Operating principles (foreground only, publish-first, parallel-by-default)
+- [`minisite-build.md`](minisite-build.md) — where concept generation fits in the operator walkthrough
+- [`minisite-generation-system.md`](minisite-generation-system.md) — the system prompt each concept subagent uses
+- [`anti-patterns.md`](anti-patterns.md) — what NOT to bake into concept prompts (over-prescription kills variance)
+- `start/references/config-system.md` — the `~/.config/vip/local.yaml` location for `default_concepts`

--- a/.claude/skills/site/references/minisite-build.md
+++ b/.claude/skills/site/references/minisite-build.md
@@ -1,40 +1,139 @@
 # Minisite — Build Flow
 
-The minisite shape: ~4 pages of static HTML, no build step, deployed to Cloudflare Pages with git auto-deploy. Designed fresh per offer by a generation subagent — no template inheritance.
+The minisite shape: ~4–6 pages of static HTML, no build step, deployed to Cloudflare Pages with git auto-deploy. Designed fresh per offer by a generation subagent — no template inheritance.
 
-V1 target. The default for paid-ad lander tests, single-offer first deploys, and deposit-gateway flows.
+V1 target. The default for paid-ad lander tests, single-offer first deploys, lead-form funnels, and conversion-gateway flows.
 
-The canonical contract for what a minisite *is* (page list, per-page content, post-payment flow, tracking, walkthrough UX) lives at `mb-vip/.claude/reference/minisite.md` (engine-side spec). This file is the **/site skill's implementation flow** — how the skill walks the operator through producing one.
+The canonical contract for what a minisite *is* (page list, per-page content, conversion endpoint, tracking, walkthrough UX) lives at `mb-vip/.claude/reference/minisite.md` (engine-side spec). This file is the **/site skill's implementation flow** — how the skill walks the operator through producing one.
 
 ---
 
-## setup (minisite)
+## Flow at a glance
 
-**1. Name + project repo.** Ask the operator:
+The minisite is built in one continuous flow. Brief and site are not separate skills — `/site` walks all of it:
+
+```
+1. Research      — parallel subagents in foreground, recording to /think research files
+2. Brief draft   — composed from research + reference files
+3. Review        — quality gates run in parallel; operator addresses or proceeds
+4. Brief lock    — committed to git as the first durable artifact
+5. Setup         — domain, DNS, repo, Pages (atom chain)
+6. Conversion    — operator picks endpoint kind, URL captured to .mainbranch/conversion.json
+7. Concepts      — N home-page variations on localhost (default 2), operator picks
+8. Publish raw   — picked concept committed and pushed; Cloudflare auto-deploys
+9. Build out     — rest of pages generated with picked concept as seed
+10. Pre-publish review
+11. Publish updates — git push, iterate
+```
+
+Every step that produces durable work commits to git before moving on. Git history is the durable memory; chat compaction can't be trusted.
+
+---
+
+## 1. Research
+
+Spawn parallel research subagents (foreground only — see [`SKILL.md` Operating principles](../SKILL.md#operating-principles)) for the questions the brief needs answered.
+
+Typical research questions:
+- What do this offer's customers actually say? (audience-language mining from interviews, reviews, Skool posts)
+- What's the best-performing competitor framing for this offer category?
+- What proof is available — testimonials with permission, outcome data, founder credentials?
+- What conversion-endpoint kind fits this offer (payment / lead / appointment)?
+
+Each subagent records its findings to a dated `research/YYYY-MM-DD-<slug>-claude-code.md` file in the business repo, with frontmatter following the [`/think` research pattern](../../think/SKILL.md):
+
+```yaml
+---
+type: research
+date: YYYY-MM-DD
+source: claude-code
+topics: [audience-mining, competitor-framing, proof-inventory]
+linked_decisions: []
+status: complete
+---
+```
+
+**Why this matters:** when the conversation compacts later, the operator (and the next session) can re-load the research from disk. Without persisted research, brief drafting is amnesia.
+
+---
+
+## 2. Brief draft
+
+The brief is the locked source of truth for the site. It's composed from:
+- Resolved `offer.md` (the framing, value prop, pricing, transformation)
+- Resolved `audience.md` (pain frame, language, objections)
+- `voice.md` (tone, register, named enemies, "never say")
+- The research files just produced
+- The conversion endpoint kind (operator's pick)
+
+The skill drafts the brief into a single markdown artifact in the business repo: `decisions/YYYY-MM-DD-minisite-brief-<offer-slug>.md` (per the [`/think` decision pattern](../../think/SKILL.md)).
+
+The brief includes:
+- **Headline + subhead** (≤2 lines, transformation-anchored)
+- **Value prop** (3 short reasons OR one extended argument)
+- **Mechanism summary** (for the how-it-works page)
+- **Picked supporting pages** (which 2–4 from `proof / pricing / faq` or operator-added)
+- **Conversion endpoint** (kind + URL or "to be wired in step 6")
+- **Voice anchor lines** (3–5 sentences from voice.md the subagent should pattern-match)
+- **Framework tag** (if any — PAS / AIDA / StoryBrand / founder-letter / none)
+
+---
+
+## 3. Review (pre-lock)
+
+Run [`review.md`](review.md) gates in parallel against the brief draft:
+- **research-grounded** — does the language match what real customers said?
+- **in-voice** — does the brief match `voice.md`?
+- **de-AI'd** — any AI tells (em-dash overuse, "in today's fast-paced world," empty intensifiers)?
+- **framework-true** — if a framework was declared, does the brief follow it?
+
+Synthesize findings; surface to operator. They address or proceed.
+
+---
+
+## 4. Brief lock
+
+Once review is addressed (or skipped with operator awareness), commit the brief to the business repo:
+
+```bash
+cd <business_repo>
+git add decisions/YYYY-MM-DD-minisite-brief-<slug>.md
+git commit -m "[lock] minisite brief — <slug>"
+git push
+```
+
+The brief is now durable. Move to setup.
+
+---
+
+## 5. Setup (atom chain)
+
+Same as before — infrastructure provisioning. This step doesn't touch the brief; it's purely about getting the empty deploy target ready.
+
+**5a. Name + project repo.** Ask the operator:
 - Site name (e.g., `thelastbill`). Becomes the Pages project name.
 - Project repo location (default: sibling of vip — `~/Documents/GitHub/<name>` for solo work, `~/Documents/GitHub/noontide-sites/<name>` for Noontide work). Empty repo, no template merge.
-- Apex domain. If they don't have one, route to [`naming-heuristic.md`](naming-heuristic.md) — an 8-step playbook for generating + validating brand-tier names.
+- Apex domain. If they don't have one, route to [`naming-heuristic.md`](naming-heuristic.md).
 
-**2. Atom-chain prerequisites.** Confirm the credentials are in place:
+**5b. Atom-chain prerequisites.** Confirm credentials are in place:
 ```bash
 source ~/.config/vip/env.sh
 python3 .claude/skills/site/scripts/verify_live.py
 ```
-Expect 3/3 passed (Cloudflare scopes + zone lookup + domain-check CLI). Porkbun skipped is fine for the CF-registered path.
+Expect 3/3 passed (Cloudflare scopes + zone lookup + domain-check CLI).
 
-If anything's red, route the operator to `bash .claude/skills/site/scripts/setup_creds.sh` to provision Cloudflare credentials, then re-run.
+If anything's red, route to `bash .claude/skills/site/scripts/setup_creds.sh`, then re-run.
 
-**3. Domain — buy-new vs. existing.** Ask:
-- "Already own the domain?" → skip to step 4 with the domain name.
-- "Need to buy?" → run `python3 .claude/skills/site/scripts/domain.py check <name> --tlds .com,.co,.io` first to confirm availability + TLD support. If `extension_not_supported_via_api`, fall back to the Cloudflare dashboard at https://dash.cloudflare.com/registrar (confirm the right account before purchase). For API-supported TLDs and after explicit operator Y on price, proceed with `domain.py buy <name>` once that subcommand wires the live API call.
+**5c. Domain — buy-new vs. existing.** Ask:
+- "Already own the domain?" → skip to 5d with the domain name.
+- "Need to buy?" → run `python3 .claude/skills/site/scripts/domain.py check <name> --tlds .com,.co,.io` first to confirm availability + TLD support. For API-supported TLDs and after explicit operator Y on price, proceed with `domain.py buy <name>`. For dashboard-only TLDs, fall back to https://dash.cloudflare.com/registrar.
 
-**4. DNS ensure.** Once the domain is owned (CF Registrar or Porkbun), run:
+**5d. DNS ensure.** Once the domain is owned:
 ```bash
 python3 .claude/skills/site/scripts/dns.py ensure <domain> --registrar cloudflare --skip-propagation-poll
 ```
-For CF-registered domains the zone is auto-created with NS already at CF — this is an idempotent verification, not a state change. For Porkbun-registered domains, the atom swaps NS to CF nameservers and polls propagation.
 
-**5. GitHub repo + initial scaffold push.** Create the project repo and push a placeholder `index.html` so the Pages project has something to deploy:
+**5e. GitHub repo + initial scaffold push.**
 ```bash
 gh repo create <owner>/<name> --public --add-readme
 git clone https://github.com/<owner>/<name>.git ~/Documents/GitHub/<name>
@@ -43,19 +142,19 @@ echo '<!doctype html><title><name></title><h1>soon</h1>' > index.html
 git add -A && git commit -m "[add] placeholder" && git push
 ```
 
-**6. Cloudflare Pages project (git-connected).** The atom creates the project with `source.type=github` so every push auto-deploys:
+**5f. Cloudflare Pages project (git-connected).**
 ```bash
 python3 .claude/skills/site/scripts/pages.py create-project <name> --repo-owner <owner> --repo-name <repo> --branch main
 ```
-Live-tested in PR #102. If you hit `github_app_not_installed`, the envelope's `suggestion` field walks through the dashboard handshake step (Compute → Workers & Pages → Create application → Continue with GitHub → connect any repo → close the tab); see [`cloudflare-pages-link.md`](cloudflare-pages-link.md) for the full path.
+If you hit `github_app_not_installed`, the envelope's `suggestion` field walks through the dashboard handshake step; see [`cloudflare-pages-link.md`](cloudflare-pages-link.md).
 
-**7. Custom domain attach + DNS verification.** Run:
+**5g. Custom domain attach + DNS verification.**
 ```bash
 python3 .claude/skills/site/scripts/pages.py set-domain <name> <domain> --timeout-seconds 300
 ```
-The atom attaches the domain, creates the CNAME record in the zone (the step the dashboard hides), and polls until SSL is active. Expect ~3-4 min total. Live-tested end-to-end in PR #97.
+~3-4 min total. Live-tested end-to-end in PR #97.
 
-**8. Save config.** Write or extend `~/.mainbranch/sites.json`:
+**5h. Save config.** Write or extend `~/.mainbranch/sites.json`:
 ```json
 {
   "name": "<name>",
@@ -67,48 +166,146 @@ The atom attaches the domain, creates the CNAME record in the zone (the step the
 }
 ```
 
-**Exit:**
-> "Minisite ready at https://<domain>. Placeholder deployed; run `/site build --one-shot` to generate the actual minisite from your offer + audience specs."
+---
+
+## 6. Conversion endpoint
+
+Operator picks the kind (per the [Conversion endpoint](../../../reference/minisite.md#conversion-endpoint) section of the engine spec):
+
+- **Stripe payment page** → run `stripe.py create-payment-link <offer-slug> --amount <cents> --success-url https://<domain>/start/thanks/`. Capture `payment_link.url` from the envelope.
+- **Lead form** → ask: "Where does form data go?" — capture provider + URL (Tally / Typeform / Google Form / native + Formspree / custom backend).
+- **Appointment booking** → ask for the booking-link URL (Cal.com / Calendly / SavvyCal).
+- **Custom webhook** → ask for the URL.
+
+Write the picked endpoint to `<site_repo>/.mainbranch/conversion.json`. The shape is the same for all kinds; the `metadata` block varies. Examples:
+
+```json
+// Stripe payment page
+{
+  "kind": "stripe_payment_page",
+  "url": "https://buy.stripe.com/abc123",
+  "render": "link_out",
+  "metadata": {
+    "amount_usd": 100,
+    "currency": "usd",
+    "stripe_product_id": "prod_xyz",
+    "stripe_payment_link_id": "plink_abc",
+    "payment_kind": "deposit"
+  }
+}
+
+// Lead form
+{
+  "kind": "lead_form",
+  "url": "https://tally.so/r/abc123",
+  "render": "link_out",
+  "metadata": { "provider": "tally" }
+}
+
+// Appointment booking
+{
+  "kind": "appointment_booking",
+  "url": "https://cal.com/devon/intro",
+  "render": "link_out",
+  "metadata": { "provider": "cal.com" }
+}
+
+// Custom webhook
+{
+  "kind": "custom_webhook",
+  "url": "https://operator-domain.com/leads",
+  "render": "form_post",
+  "metadata": {}
+}
+```
+
+The generation subagent in step 9 reads `kind` + `render` + `url` and renders the home CTA accordingly (link-out button, embedded form, embedded booking iframe, or form-POST handler).
 
 ---
 
-## build --one-shot (minisite)
+## 7. Concept variations (home page only)
 
-The load-bearing mode — where Claude (the operator's running session) spawns a subagent that generates fresh HTML/CSS/SVG for this offer. No template inheritance. No placeholder tokens. No Anthropic SDK call. The subagent is a Claude Code subagent, spawned via the `Agent` tool.
+Per [`concept-variations.md`](concept-variations.md): spawn N home-page concepts in parallel (default 2, operator-configurable in `~/.config/vip/local.yaml`).
 
-**1. Resolve offer context.** Use the offer-context resolution from `SKILL.md`. At minimum: `offer.md` + `audience.md` paths + the active offer slug.
+Each concept gets:
+- Locked brief from step 4
+- `offer.md`, `audience.md`, `voice.md`, `soul.md`
+- Conversion endpoint URL from step 6
+- A short "lean" instruction differentiating this concept from the others
 
-**2. Load the system prompt.** Read [`minisite-generation-system.md`](minisite-generation-system.md) verbatim. This is the load-bearing artifact — the full hard-constraints + soft-brief framing for the generation subagent. Pass it as the subagent's system prompt unmodified.
+Each writes to `<site_repo>/.mainbranch/concepts/concept-<n>/`. The skill starts a localhost preview for each, surfaces URLs to operator, waits for pick.
 
-**3. Build the user message.** Compose:
-- Resolved `offer.md` content
-- Resolved `audience.md` content
-- Optional `voice.md` snippets (anchor phrases, named enemies, "never say" list)
-- Reference URLs — defaults: `https://howdy.md`, `https://thelastbill.com`. Operator can pass `--reference URL` to add or replace.
-- Project repo absolute path (where the subagent writes via `Write`)
-- Soft directive: *"Generate fresh HTML/CSS/SVG for this offer. The reference URLs are taste anchors, not templates — read them for polish level, then design something that fits **this** offer. Surprise me."*
+Operator picks → picked files move to project root, others discarded (optionally archived to `.mainbranch/concepts/discarded/`).
 
-Anti-patterns to avoid in your own framing of the user message: see [`anti-patterns.md`](anti-patterns.md). The big ones: don't lock typography or colors, don't enumerate available sections, don't ask the subagent to "make it look like the references," don't suppress variance.
+---
 
-**4. Spawn the subagent.** Invoke the `Agent` tool with `subagent_type=general-purpose`, the system prompt from step 2, and the user message from step 3. The subagent has `Write` access; it will write files directly to the project repo path.
+## 8. Publish raw
 
-**5. Validate the output.** After the subagent returns, run these checks against the project repo:
+The picked home page is the rawest working version. Commit + push immediately:
 
-- **Required files present:** `index.html`, `how-it-works/index.html`, two more page directories with `index.html`, `privacy/index.html`, `terms/index.html`, `_headers`, `_redirects`, `robots.txt`, `sitemap.xml`, `og.svg`, `favicon.svg`. Each missing file = a fix request to the subagent.
-- **Footer presence:** `grep -L "Noontide Collective LLC" *.html **/*.html` should return nothing (or only files where `offer.md` declared a different parent entity — check the override).
-- **OG render:** `python3 .claude/skills/site/scripts/og_render.py render <repo>/og.svg <repo>/og.png`. Envelope must return `status: ok` with `width: 1200, height: 630`. Failure → fix request to subagent (likely `og.svg` viewBox is wrong).
-- **Lighthouse smoke (optional, V1.1):** `npx lighthouse http://localhost:8000 --only-categories=performance --form-factor=mobile` against a local `python3 -m http.server` running in the project repo. Score ≥ 90 = pass.
+```bash
+cd <site_repo>
+git add -A
+git commit -m "[add] picked home concept — <slug>"
+git push
+```
 
-**6. Commit + push (operator's call).** Once validation is green, summarize for the operator:
-- Files written
-- Hero artifact picked
-- Color palette
-- Two page choices
-- Suggested commit message: `"[add] one-shot minisite generation for <offer>"`
+Cloudflare auto-deploys (per the git-connected Pages project from step 5f). The site is now live with one page. The rest will follow.
 
-Operator runs `git add -A && git commit && git push`. Cloudflare auto-deploys (per the git-connected Pages project from step 6 of setup).
+---
 
-**Variance test (acceptance criterion):** Running `/site build --one-shot` twice on the same offer must produce visually different output. If it doesn't, the soft brief was too prescriptive — re-read [`anti-patterns.md`](anti-patterns.md).
+## 9. Build out remaining pages
+
+Spawn the minisite generation subagent (foreground) with the picked concept as the design seed. The subagent generates the rest of the pages (`how-it-works/`, picked supporting pages, `privacy/`, `terms/`, `start/thanks/`) consistent with the picked concept's design language.
+
+Inputs to the build subagent:
+- Picked `index.html` + `styles.css` from step 8 (the design seed)
+- Locked brief from step 4
+- Conversion endpoint URL from step 6
+- `offer.md`, `audience.md`, `voice.md`, optional `soul.md`
+- The system prompt from [`minisite-generation-system.md`](minisite-generation-system.md)
+
+Anti-patterns to avoid in the user message: see [`anti-patterns.md`](anti-patterns.md).
+
+**Validation after build-out:**
+
+- **Required files present:** `index.html`, `how-it-works/index.html`, two more page directories with `index.html`, `privacy/index.html`, `terms/index.html`, `start/thanks/index.html`, `_headers`, `_redirects`, `robots.txt`, `sitemap.xml`, `og.svg`, `favicon.svg`. Each missing file = a fix request to the subagent.
+- **Footer presence:** `grep -L "Noontide Collective LLC" *.html **/*.html` should return nothing (or only files where `offer.md` declared a different parent entity).
+- **OG render:** `python3 .claude/skills/site/scripts/og_render.py render <repo>/og.svg <repo>/og.png`. Envelope must return `status: ok` with `width: 1200, height: 630`.
+- **Conversion URL substitution:** every CTA href on every page should match the URL in `<repo>/.mainbranch/conversion.json` (no `https://CONVERSION-PLACEHOLDER` left).
+
+---
+
+## 10. Pre-publish review
+
+Run [`review.md`](review.md) gates in parallel against the full site copy:
+- **in-voice**, **de-AI'd**, **framework-true** (research-grounded only re-runs if reference files changed since brief lock).
+- Plus operator-defined gates from `<business_repo>/reference/review/*.md` if any.
+
+Synthesize findings; surface to operator. They address or proceed.
+
+---
+
+## 11. Publish updates + iterate
+
+```bash
+cd <site_repo>
+git add -A
+git commit -m "[add] minisite build-out — <slug>"
+git push
+```
+
+Cloudflare auto-deploys. Verify `https://<domain>/` returns 200 and shows the new pages.
+
+For targeted edits going forward, edit files in the project repo directly and `git push` — Cloudflare auto-deploys.
+
+---
+
+## Variance test (acceptance criterion)
+
+Running the full flow twice on the same offer must produce visually distinct sites — different palettes, hero artifacts, page choices, microcopy. Concept variations enforce this at the home-page level; build-out inherits the picked concept's seed but still has aesthetic latitude in the supporting pages.
+
+If two full runs produce identical output, the brief was over-specified or the concept-variations soft-brief was too prescriptive — re-read [`anti-patterns.md`](anti-patterns.md).
 
 ---
 
@@ -117,13 +314,30 @@ Operator runs `git add -A && git commit && git push`. Cloudflare auto-deploys (p
 - No `pnpm install`, no `pnpm build`. Static HTML only.
 - No `site-config.ts` pattern. Each minisite generates its own one-off structure.
 - No section-types menu (the Next.js section catalog from `website-build.md` doesn't apply).
-- No `configure` mode separate from `build --one-shot` — the generation subagent reads voice.md / offer.md directly and bakes the brand decisions into the output.
-- No Anthropic API key. No `pages_gen.py` Python wrapper. The generation runs inside the operator's Claude Code session via the `Agent` tool.
+- No Anthropic API key. The generation runs inside the operator's Claude Code session via the `Agent` tool.
+- No multi-endpoint conversion (one minisite, one conversion endpoint — graduate to website shape if you need both).
 
 ---
 
 ## Iterating after first build
 
-Re-running `/site build --one-shot` produces a fresh design (variance is the feature). For targeted edits, edit the file in the project repo directly and `git push` — Cloudflare auto-deploys.
+For targeted edits, edit the file in the project repo directly and `git push`. Cloudflare auto-deploys.
+
+For broader regeneration (new brief, new concept), re-run `/site` — it walks the same flow and detects existing state in the project repo.
 
 When the offer pulls more traffic and the minisite needs more pages or content depth, that's the **graduation signal**. See [`graduation.md`](graduation.md) for paths from minisite → website (per-offer full site) or minisite → Website + CMS (Sanity, Contentful, etc.).
+
+---
+
+## Cross-references
+
+- [`SKILL.md`](../SKILL.md) — Operating principles (foreground-only, publish-first, parallel-by-default)
+- [`review.md`](review.md) — quality gates run in steps 3 and 10
+- [`concept-variations.md`](concept-variations.md) — parallel concept generation in step 7
+- [`minisite-generation-system.md`](minisite-generation-system.md) — system prompt for the build-out subagent in step 9
+- [`anti-patterns.md`](anti-patterns.md) — what NOT to bake into prompts
+- [`naming-heuristic.md`](naming-heuristic.md) — domain naming playbook (used in step 5a if needed)
+- [`cloudflare-pages-link.md`](cloudflare-pages-link.md) — CF Pages GitHub App handshake (used in step 5f if needed)
+- [`graduation.md`](graduation.md) — when to move beyond minisite shape
+- Engine spec: `mb-vip/.claude/reference/minisite.md` — the contract this flow implements
+- [`/think`](../../think/SKILL.md) — research and decision recording patterns this flow follows

--- a/.claude/skills/site/references/minisite-generation-system.md
+++ b/.claude/skills/site/references/minisite-generation-system.md
@@ -20,9 +20,10 @@ These are structural, not aesthetic. Aesthetic decisions are yours.
 |---|---|
 | `index.html` | Home / hero / primary CTA |
 | `how-it-works/index.html` | Process or mechanism page |
-| Two more pages, your pick from: `proof/`, `pricing/`, `start/`, `faq/` | Pick the two that match this offer's pull |
+| 2–4 more pages, your pick from: `proof/`, `pricing/`, `faq/` (or others when warranted: `about/`, `contact/`) | Pick what serves this offer |
 | `privacy/index.html` | Placeholder privacy policy (boilerplate fine) |
 | `terms/index.html` | Placeholder terms (boilerplate fine) |
+| `start/thanks/index.html` | Post-conversion landing — `success_url` / form-redirect target |
 | `_headers` | Cloudflare Pages: security + cache headers |
 | `_redirects` | Empty starter; comment the format |
 | `robots.txt` | Allow all + sitemap link |
@@ -32,9 +33,22 @@ These are structural, not aesthetic. Aesthetic decisions are yours.
 
 `og.png` is rendered from your `og.svg` by the skill after you finish. Do not generate it.
 
+### Conversion endpoint awareness
+
+The user message includes `<repo>/.mainbranch/conversion.json`, which declares the conversion endpoint's `kind`, `url`, and `render` mode. Use it to render the home CTA correctly. Don't invent the conversion shape — the operator picked it.
+
+| Kind | Render | Home CTA copy guidance |
+|---|---|---|
+| `stripe_payment_page` | `link_out` (button → Stripe Checkout) | Action-oriented around payment ("Reserve your spot," "Get started," "Claim your seat") |
+| `lead_form` | `link_out` (button → hosted form), or inline / modal | Curiosity / low-commitment ("Get the playbook," "Tell us about your project," "Start the conversation") |
+| `appointment_booking` | `link_out` (button → booking page), or embedded | Specific to the meeting ("Book a 30-min intro," "Schedule your fitting") |
+| `custom_webhook` | Form POST inline, or link out | Operator-defined |
+
+The home hero CTA, secondary CTA, and any pricing CTA all use the same `url` from `conversion.json`. Don't fabricate URLs. Don't put a different CTA pattern on the pricing page than the home page.
+
 ### Page structure rules
 
-- 4 main pages max (privacy + terms don't count)
+- 4 main pages max (privacy + terms + start/thanks don't count toward the visible navigation)
 - URL-readable paths (`how-it-works/`, not `page-2/`)
 - Every page has a `<title>` (under 60 chars), `<meta name="description">` (under 160 chars), canonical link, OG + Twitter Card meta, viewport, charset
 - Every page ends with the **Noontide footer** (see below) as the last visible element

--- a/.claude/skills/site/references/minisite-generation-system.md
+++ b/.claude/skills/site/references/minisite-generation-system.md
@@ -48,7 +48,7 @@ The home hero CTA, secondary CTA, and any pricing CTA all use the same `url` fro
 
 ### Page structure rules
 
-- 4 main pages max (privacy + terms + start/thanks don't count toward the visible navigation)
+- 6 main pages max (privacy + terms + start/thanks don't count toward the visible navigation). Mandatory: home + how-it-works. LLM-picked: 2–4 more from `proof/`, `pricing/`, `faq/` (or others when warranted, e.g. `about/`, `contact/`). Don't pad to hit a number.
 - URL-readable paths (`how-it-works/`, not `page-2/`)
 - Every page has a `<title>` (under 60 chars), `<meta name="description">` (under 160 chars), canonical link, OG + Twitter Card meta, viewport, charset
 - Every page ends with the **Noontide footer** (see below) as the last visible element

--- a/.claude/skills/site/references/review.md
+++ b/.claude/skills/site/references/review.md
@@ -1,0 +1,108 @@
+# Review — Quality Gates for Brief and Site Copy
+
+The skill runs through review steps at two moments: **before locking the brief** and **before publishing the site**. Each gate spawns a parallel review subagent (foreground) that returns findings; the operator decides what to act on. Gates are not blocking — they're guidance, like the lenses `/ads review` runs.
+
+Review is plural. Multiple gates run in parallel and report back. The skill synthesizes the findings into one read-out for the operator.
+
+---
+
+## When review runs
+
+| Moment | What's being reviewed | Gates that apply |
+|---|---|---|
+| **Before brief lock** | The draft brief (offer framing, headline, value prop, audience-language match) | research-grounded, in-voice, de-AI'd, framework-true |
+| **Before publish** | The site copy as it exists in the project repo (home, how-it-works, picked pages) | in-voice, de-AI'd, framework-true (research-grounded re-runs only if reference files changed) |
+
+The `/site` flow stops at each moment, runs review in parallel, surfaces findings, asks the operator: *"Address these, or proceed?"* It's a checkpoint, not a wall.
+
+---
+
+## The default gates
+
+Each gate is a small subagent prompt (a "lens" in the same shape as `.claude/lenses/*.md`). Spawn in parallel; collect findings; render to operator.
+
+### research-grounded
+
+**Question:** Is the brief / copy backed by what real customers say?
+
+**Inputs:** the brief draft (or site copy), `audience.md`, any `research/*.md` files in the business repo.
+
+**Findings:** points where the language sounds invented vs. grounded. Specific lines to swap with audience-quoted phrasing. Or "looks grounded — no action needed."
+
+**Why it matters:** ungrounded copy reads as AI marketing-speak and converts poorly. The fix is usually pulling specific phrases from interviews, reviews, or transcripts the operator has on file.
+
+### in-voice
+
+**Question:** Does the copy match `voice.md`?
+
+**Inputs:** the brief draft (or site copy), `voice.md`.
+
+**Findings:** sentences that violate declared voice traits (e.g., "warm and personal" voice but the copy is corporate-clinical). Suggested rewrites in the right register.
+
+**Why it matters:** off-voice copy breaks brand cohesion and signals the system isn't actually using the operator's reference files.
+
+### de-AI'd
+
+**Question:** Does the copy have AI tells — generic hedging, em-dash overuse, "in today's fast-paced world," empty intensifiers, unnecessary numbered lists?
+
+**Inputs:** the brief draft (or site copy).
+
+**Findings:** specific sentences flagged with the AI-tell pattern (e.g., "this sentence has the 'unleash potential' pattern"). Suggested human rewrites.
+
+**Why it matters:** AI-sounding copy is the #1 signal that nothing custom happened. Even if the system *did* use the reference files, AI cadence destroys trust.
+
+### framework-true
+
+**Question:** If the offer / brief declares a framework (e.g., PAS, AIDA, StoryBrand, founder-letter), does the copy follow it?
+
+**Inputs:** the brief draft (or site copy), `offer.md` (which may declare a framework), the brief's structural plan.
+
+**Findings:** sections that don't fit the declared framework's beats, or are out of order. Suggested restructuring.
+
+**Why it matters:** an operator who picked a framework expects the output to follow it. Drift here is a quiet failure.
+
+---
+
+## Operator-defined gates
+
+Operators can extend with their own gates by dropping `.md` files in their business repo:
+
+```
+your-business-repo/
+└── reference/
+    └── review/                    <- operator's custom gates
+        ├── compliance-tier-1.md   <- e.g., FTC outcome-claim check
+        └── on-brand-tone.md       <- e.g., specific tone rules
+```
+
+Each file is a prompt for one review subagent. The skill picks them up automatically and runs them alongside the defaults.
+
+This is the same shape as `.claude/lenses/` for `/ads review`. Custom gates compose with the defaults — they don't replace them.
+
+---
+
+## How the skill runs review
+
+1. **Identify the moment** (pre-lock, pre-publish).
+2. **Collect inputs** the gates will need (brief draft, site copy, reference files).
+3. **Spawn one foreground subagent per gate, in parallel.** Each subagent reads its inputs and returns findings as a short markdown report.
+4. **Synthesize findings** into one combined report — group by gate, P1 / P2 / P3 priority, with specific line references.
+5. **Surface to operator.** "Here's what review surfaced. Address now, or proceed?"
+6. **Operator picks.** If they address: re-run the affected gates after edits. If they proceed: log the skipped findings to `.mainbranch/review-skipped.md` (visible in git history) and move on.
+
+---
+
+## Why "review" not "checks"
+
+"Checks" carries GitHub-PR-checks baggage and confuses operators who don't think in those terms. "Review" matches `/ads review` and reads naturally to anyone editing copy.
+
+The plural noun "review" works the same way `/ads review` does — one mode that runs multiple lenses in parallel and combines the output.
+
+---
+
+## Cross-references
+
+- [`/ads review`](../../ads/SKILL.md) — same multi-lens shape, same synthesis pattern
+- [`anti-patterns.md`](anti-patterns.md) — the anti-patterns that bypass review (over-prescription, padding, fabrication)
+- [`minisite-build.md`](minisite-build.md) — where review fits in the operator walkthrough
+- [`/think`](../../think/SKILL.md) — research patterns review depends on (research files, decisions linked to reference)

--- a/.claude/skills/start/references/config-system.md
+++ b/.claude/skills/start/references/config-system.md
@@ -131,6 +131,12 @@ media:
   # Per-type overrides (optional — defaults to {root}/{type}/)
   # images: /absolute/path/to/ad-images
   # videos: /absolute/path/to/ad-videos
+
+# Per-skill defaults (optional)
+# /site uses default_concepts to set how many home-page concepts
+# get generated in parallel. Default 2; raise to 3 or 5 if you're
+# OK spending more tokens for more variation.
+default_concepts: 2
 ```
 
 **CRITICAL: Always use absolute paths, never `~`.** The Glob and Read tools do not expand `~`, causing silent failures (0 results when files exist). When writing to `local.yaml`, always expand `~` to the full absolute path first. If `local.yaml` already contains `~`, auto-upgrade it to absolute during path validation.


### PR DESCRIPTION
Course-correction PR from a working call. Replaces the Stripe-deposit-only mental model with conversion-endpoint generality and lands the brief→site one-flow with explicit operating principles (foreground-only subagents, parallel-by-default, publish-first). Adds two new refs (review.md, concept-variations.md), restructures the minisite build flow to 11 steps, makes the generation system prompt conversion-kind aware, and documents `default_concepts` in the local-config schema.

7 files changed (+658 / −101). 152/162 regression baseline holds, no new failures. Three parallel review agents audited the work for generality / cross-doc consistency / principles propagation; their findings drove the final round of fixes (conversion-kind awareness in concepts + generation prompt, render modes per kind, webhook in tracking events, conversion.json shape examples for all four kinds).

## Test plan

- [x] Skill regression suite green at baseline (152/162)
- [x] Three parallel review agents — generality / consistency / principles — all clean or minor; findings addressed
- [x] Zero "chassis" residue in audited files
- [x] All markdown links resolve (no dead refs)
- [ ] Reviewer: confirm "review" is the right user-facing noun for the quality-gate step (vs "checks" / "verify")
- [ ] Reviewer: confirm 11-step flow in minisite-build.md is right shape (research → brief → lock → setup → conversion → concepts → publish raw → build out → review → publish)

🤖 Generated with [Claude Code](https://claude.com/claude-code)