### PR TITLE
[public-prep] LICENSE + scrub clients + URL hygiene + vocab sweep

### DIFF
--- a/.claude/reference/minisite.md
+++ b/.claude/reference/minisite.md
@@ -191,7 +191,7 @@ The generation subagent reads `kind` + `render` + `url` and renders the home CTA
 
 The default for offers that charge money. `stripe.py create-payment-link` runs against the offer; the returned URL is the conversion endpoint.
 
-The "kind of payment" is operator-declared in `offer.md` — `deposit`, `full`, `subscription` (V2), or `custom`. The atom doesn't decide; it just creates the payment link with the amount the operator specified.
+The "kind of payment" is operator-declared in `offer.md` — `deposit`, `full`, `subscription` (V2), or `custom`. The tool doesn't decide; it just creates the payment link with the amount the operator specified.
 
 | Field | Default | Source |
 |---|---|---|
@@ -200,10 +200,10 @@ The "kind of payment" is operator-declared in `offer.md` — `deposit`, `full`, 
 | `description` | offer.md `payment_description` or generated | offer.md or LLM |
 | `statement_descriptor` | offer.md `statement_descriptor` or `NOONTIDE` | offer.md or fallback (max 22 chars) |
 | `metadata.mb_offer` | `<offer-slug>` | derived from offer's directory name |
-| `metadata.mb_kind` | `"deposit"` (V1 hardcoded) | atom constant |
+| `metadata.mb_kind` | `"deposit"` (V1 hardcoded) | tool constant |
 | `success_url` | `https://<domain>/start/thanks/` | derived from `sites.json` `domain` |
 
-The atom emits `payment_link.url` in its envelope. The orchestration writes that URL into the project repo (e.g., `<repo>/.mainbranch/conversion.json`) so the generation subagent reads it during the build phase and substitutes it into every CTA href on the site.
+The tool emits `payment_link.url` in its envelope. The orchestration writes that URL into the project repo (e.g., `<repo>/.mainbranch/conversion.json`) so the generation subagent reads it during the build phase and substitutes it into every CTA href on the site.
 
 > **V1 vs. planned.** `stripe.py` currently hardcodes `metadata.mb_kind = "deposit"` and does not read `payment_kind` from `offer.md`. The next iteration accepts a `--kind` flag (default: `payment`) and falls back to `offer.md`'s `payment_kind` field, so an operator charging full price (or running a consult-fee, etc.) gets honest metadata. Until that ships, every Stripe-backed minisite labels its payment as a "deposit" in Stripe's metadata — accurate when it is one, awkward when it isn't.
 
@@ -297,7 +297,7 @@ For lead/appointment: standard pixel taxonomy events. The subagent uses the conv
 |---|---|---|
 | `offer.md` exists and has minimum fields | Generation | File presence + frontmatter parse |
 | `audience.md` exists | Generation | File presence |
-| Cloudflare creds + GitHub App | All atom calls | `verify_live.py` returns 3/3 (Cloudflare scopes + zone lookup + domain-check) |
+| Cloudflare creds + GitHub App | All tool calls | `verify_live.py` returns 3/3 (Cloudflare scopes + zone lookup + domain-check) |
 | Domain decision | Setup | Operator confirms own-or-buy |
 | Tracking IDs (if declared) | Generation | offer.md frontmatter parse — if any tracking field present, validate format |
 
@@ -332,7 +332,7 @@ The orchestration mode (lives in `/start`, ships in #92) walks the operator thro
 - For API-supported TLDs: `domain.py buy <name>` after explicit Y on price
 - For dashboard-only TLDs: route to https://dash.cloudflare.com/registrar with confirmation
 
-### Phase 3 — Infrastructure (atom chain)
+### Phase 3 — Infrastructure (tool chain)
 
 - `dns.py ensure <domain>` (idempotent)
 - Create project repo (`gh repo create`)

--- a/.claude/skills/site/SKILL.md
+++ b/.claude/skills/site/SKILL.md
@@ -77,7 +77,7 @@ Default deploy target is **Cloudflare Pages** (better CLI, better domain integra
 | `offer.md` + `audience.md` | Site generation | Build via `/think` first if missing |
 | Node 18+ + pnpm | **Only for Website shape** with Next.js / Astro build step | `brew install node && npm install -g pnpm` |
 
-Verify atom credentials with:
+Verify tool credentials with:
 ```bash
 source ~/.config/vip/env.sh
 python3 .claude/skills/site/scripts/verify_live.py

--- a/.claude/skills/site/references/cloudflare-pages-link.md
+++ b/.claude/skills/site/references/cloudflare-pages-link.md
@@ -41,7 +41,7 @@ Once that's done, `pages.py create-project` (or any API call to `POST /pages/pro
 
 ## 2. Manual Pages project creation via dashboard (fallback)
 
-Only use this if `pages.py create-project` can't be used for some reason (CI environment, no API access). The atom is the default path.
+Only use this if `pages.py create-project` can't be used for some reason (CI environment, no API access). The tool is the default path.
 
 1. Go to https://dash.cloudflare.com
 2. Left sidebar: under the **Build** group, click **Compute** → **Workers & Pages**. (Cloudflare moved this entry under Compute; if you remember it as a top-level link, look one level deeper.)

--- a/.claude/skills/site/references/graduation.md
+++ b/.claude/skills/site/references/graduation.md
@@ -66,7 +66,7 @@ Past ~10–15 pages, component reuse + a build step pays off. Two sub-options:
 1. Create a parallel Next.js repo. The minisite repo's content gets copied/adapted into Next.js components.
 2. Configure CF Pages project's build settings (in dashboard): build command `pnpm build`, output `out`. Or create a fresh Pages project pointed at the new repo.
 3. Test on a `*.pages.dev` URL before flipping the apex domain.
-4. When ready, detach the apex domain from the old project and re-attach to the new one (use the `pages.py set-domain` atom).
+4. When ready, detach the apex domain from the old project and re-attach to the new one (use the `pages.py set-domain` tool).
 5. Update `~/.mainbranch/sites.json` — `shape: website`, `template: <next-template>`, optionally archive the old minisite repo.
 
 **Gotcha:** SEO continuity. The minisite's URLs (`/how-it-works/`, `/proof/`, etc.) should map cleanly to the new site's URLs. Use `_redirects` for any path changes.

--- a/.claude/skills/site/references/lander-build.md
+++ b/.claude/skills/site/references/lander-build.md
@@ -6,7 +6,7 @@ The lander shape: 1 page, all-in-one. Hero + offer + proof + CTA + footer, all o
 
 When per-offer lander generation lands, this file gets the same shape as `minisite-build.md`:
 
-- `setup (lander)` — atom chain (domain, dns, pages, custom-domain), single-file project repo, Cloudflare Pages git-connected
+- `setup (lander)` — tool chain (domain, dns, pages, custom-domain), single-file project repo, Cloudflare Pages git-connected
 - `build --one-shot (lander)` — generation subagent invoked with `lander-generation-system.md` (also future) + offer/audience/reference URLs; produces `index.html` + `_headers` + `og.svg` + `favicon.svg` (no per-section subdirectories)
 - Validation: footer presence, OG render, single-page Lighthouse score
 - What's NOT (no nav, no multi-page structure, no `/start/thanks/` separate page — thanks state shown inline or via Stripe's default thanks page)

--- a/.claude/skills/site/references/minisite-build.md
+++ b/.claude/skills/site/references/minisite-build.md
@@ -17,7 +17,7 @@ The minisite is built in one continuous flow. Brief and site are not separate sk
 2. Brief draft   — composed from research + reference files
 3. Review        — quality gates run in parallel; operator addresses or proceeds
 4. Brief lock    — committed to git as the first durable artifact
-5. Setup         — domain, DNS, repo, Pages (atom chain)
+5. Setup         — domain, DNS, repo, Pages (tool chain)
 6. Conversion    — operator picks endpoint kind, URL captured to .mainbranch/conversion.json
 7. Concepts      — N home-page variations on localhost (default 2), operator picks
 8. Publish raw   — picked concept committed and pushed; Cloudflare auto-deploys
@@ -168,7 +168,7 @@ The brief is now durable. Move to setup.
 
 ---
 
-## 5. Setup (atom chain)
+## 5. Setup (tool chain)
 
 Same as before — infrastructure provisioning. This step doesn't touch the brief; it's purely about getting the empty deploy target ready.
 

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -6,7 +6,9 @@ name: publish-pypi
 # GitHub Environment with at least one required reviewer.
 #
 # OIDC claim must match the pending publisher:
-#   owner=mainbranch-ai, repo=mb-vip, workflow=publish-pypi.yml, env=pypi.
+#   owner=mainbranch-ai, repo=vip, workflow=publish-pypi.yml, env=pypi.
+#   (After transfer to noontide-co/mainbranch, update this comment +
+#    register a new pending publisher on PyPI.)
 #
 # First test release: tag `oe-v0.1.0.dev0` and use the Releases UI.
 # Promote to `oe-v0.1.0` once dev0 has been smoke-tested on a clean machine.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Devon Meadows / Noontide Collective LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Turn Claude into your personal marketing team. Create ads, scripts, and communit
 
 - **Built for Claude Code.** Cross-platform skill support is a v0.2+ commitment.
 - **Schema is v1; will evolve.** Frontmatter shapes covered by `mb validate` are stable for v0.1.x; breaking changes bump the major.
-- **Install: `pipx install mainbranch`** (recommended, once published) or `git clone https://github.com/mainbranch-ai/mb-vip` (developer mode).
+- **Install: `pipx install mainbranch`** (recommended, once published) or `git clone https://github.com/mainbranch-ai/vip` (developer mode).
 - **Cross-agent compatibility matrix lands at v0.2.** Codex, Cursor, Hermes, local LLMs are not first-class targets in v0.1.
 
 The v0.1.0 master decision lives at [`decisions/2026-04-29-mb-vip-v0-1-0-master.md`](decisions/2026-04-29-mb-vip-v0-1-0-master.md).
@@ -45,13 +45,7 @@ All of this happens through simple commands. No prompting skills required.
 
 ## Before You Start
 
-### 1. Get Repository Access (Required First)
-
-This is a private repository. You need access before you can clone it.
-
-**Share your GitHub username with Devon in the Skool community.** Wait for confirmation before proceeding.
-
-### 2. Install These Tools
+### 1. Install These Tools
 
 #### GitHub Desktop (Strongly Recommended)
 
@@ -259,7 +253,7 @@ Devon updates the vip repository with new skills and improvements.
 Post in the Main Branch group. Tag @Devon for technical questions.
 
 **Common issues:**
-- "404 error" or "Repository not found" — You need access first. Share your GitHub username with Devon.
+- "404 error" or "Repository not found" — Verify the URL and your network. The repo is public; no access request needed.
 - "Claude does not see my files" — Make sure you started Claude in your business repo folder and ran `/start`
 - "Skills are not working" — Check that `.claude/settings.local.json` exists and run `/start` once to auto-repair missing bridge links. If still broken, run `/setup`.
 - "Output sounds generic" — Add more detail to your reference files, especially voice.md

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -803,19 +803,6 @@ updated: 2026-01-13
 
 ---
 
-## Access Tiers (Noontide Internal)
-
-| Tier | Repo | Who | Contains |
-|------|------|-----|----------|
-| **Public** | main-branch | Everyone | Free Claude plugin |
-| **Members** | vip | Paying members | Engine (skills, lenses, frameworks) |
-| **Team** | noontide-projects | Employees, contractors | Internal project work |
-| **Owners** | noontide-ops | Founders | Legal, accounting, sensitive |
-
-Client repos (BDC, autism-rewired) are separate — can be handed off independently.
-
----
-
 ## Summary
 
 1. **Engine + Data separation** — Skills in engine, context in business repos

--- a/mb/mb/_data/templates/CLAUDE.md.tmpl
+++ b/mb/mb/_data/templates/CLAUDE.md.tmpl
@@ -37,4 +37,4 @@ mb educational <topic>   # read the long-form rationale for an opinionated defau
 `@{{GH_USERNAME}}`
 
 For the engine docs (skills, vocabulary, the v0.1 master decision), see
-https://github.com/mainbranch-ai/mb-vip.
+https://github.com/mainbranch-ai/vip.

--- a/mb/pyproject.toml
+++ b/mb/pyproject.toml
@@ -54,9 +54,9 @@ dev = [
 mb = "mb.cli:app"
 
 [project.urls]
-Homepage = "https://github.com/mainbranch-ai/mb-vip"
-Repository = "https://github.com/mainbranch-ai/mb-vip"
-Issues = "https://github.com/mainbranch-ai/mb-vip/issues"
+Homepage = "https://github.com/mainbranch-ai/vip"
+Repository = "https://github.com/mainbranch-ai/vip"
+Issues = "https://github.com/mainbranch-ai/vip/issues"
 
 [tool.setuptools.packages.find]
 where = ["."]


### PR DESCRIPTION
## Summary

Public-readiness fixes ahead of flipping `mainbranch-ai/vip` from private to public. Devon greenlit P1 + P2 from the prior read-only audit. Five concern-based commits.

URL normalization here uses the **current** repo path (`mainbranch-ai/vip`). The `mainbranch-ai/vip` → `noontide-co/mainbranch` transfer is a separate pre-transfer sweep, out of scope for this PR.

## Commits

1. `bc0526b` — `feat: add MIT LICENSE` — repo-root LICENSE, MIT, copyright Devon Meadows / Noontide Collective LLC.
2. `7ff6483` — `docs(architecture): strip Access Tiers section + scrub former-client names` — removes the Noontide-internal "Access Tiers" table from `docs/system-architecture.md` (was lines 806-815). That removal also scrubs the only repo references to BDC and autism-rewired (former clients).
3. `679ebcb` — `docs(readme): drop private-repo language + fix legacy URL inconsistency` — removes "Get Repository Access" Skool-gating block from `README.md`; updates "404 error" troubleshooting line to reflect public-repo state; fixes the line-10 clone URL from `mainbranch-ai/mb-vip` → `mainbranch-ai/vip` so it matches line-97.
4. `e577016` — `docs: normalize repo URL to mainbranch-ai/vip across markdown` — `mb/pyproject.toml` Homepage/Repository/Issues URLs corrected; `mb/mb/_data/templates/CLAUDE.md.tmpl` corrected; `.github/workflows/publish-pypi.yml` comment fixed + transfer-time TODO added. Decision record at `decisions/2026-04-29-mb-vip-v0-1-0-master.md` left untouched (immutable historical artifact).
5. `95d9f36` — `refactor(skill-site): sweep stale atom/molecule/compound vocab` — six stale `atom` references in `/site` swept to `tool` per #117 vocab lock. Python script docstrings (`scripts/*.py`) deliberately out of scope — internal-only, separate sweep if desired.

## Audit findings addressed

- LICENSE absent at repo root — fixed (commit 1).
- Noontide-internal "Access Tiers" leak — fixed (commit 2).
- Former-client names (BDC, autism-rewired) in repo — fixed (commit 2).
- README "private repo / Skool members" gate — fixed (commit 3).
- Mixed `mainbranch-ai/mb-vip` vs `mainbranch-ai/vip` URLs — normalized to `mainbranch-ai/vip` (commits 3 + 4).
- Stale `atom` vocab in `/site` post-#117 — swept (commit 5).

## Audit findings deliberately not addressed (Devon-confirmed)

- Ads Lab examples (Haley / Peyton / Mazen revenue claims) — kept as-is.
- Joel attribution in ads skill references — kept as-is.

## Pre-push gates

```
ruff format --check .  →  19 files already formatted
ruff check .           →  All checks passed!
mypy mb                →  Success: no issues found in 10 source files
pytest -q --cov=mb --cov-fail-under=70  →  30 passed, coverage 70.70%
SKILL.md line-count gate  →  no SKILL.md > 500 lines
```

(CI uses `mypy mb` — `mypy mb tests` flags two pre-existing `no-untyped-def` errors in `tests/test_init.py:30` + `tests/test_doctor.py:17`; both pre-date this PR and are not in CI's path. Out of scope.)

## Test plan

- [ ] CI green on `main` PR
- [ ] Verify `LICENSE` shows in GitHub repo header after merge
- [ ] Verify `git clone https://github.com/mainbranch-ai/vip` from README works once repo is public
- [ ] Spot-check `/site` flow: `Verify tool credentials with:` reads cleanly in `SKILL.md`