### PR TITLE
docs: update public repo move references

### DIFF
--- a/.claude/reference/minisite.md
+++ b/.claude/reference/minisite.md
@@ -400,7 +400,7 @@ This is the quality bar: an LLM that produces the same minisite twice on the sam
 - `noontide-co/noontide-ops` `decisions/2026-04-27-credential-provisioning.md`
 
 **Onboarding:**
-- mb-vip issue [#94](https://github.com/mainbranch-ai/vip/issues/94) — V1 onboarding pinned current-state
+- Main Branch issue [#94](https://github.com/noontide-co/mainbranch/issues/94) — V1 onboarding pinned current-state
 
 ---
 

--- a/.claude/skills/help/references/troubleshooting.md
+++ b/.claude/skills/help/references/troubleshooting.md
@@ -27,22 +27,22 @@ claude --version
 
 ## "Repository not found" / 404 Error
 
-You don't have access to the vip repository yet.
+Use the public Main Branch engine repo:
 
 **Fix:**
-1. Share your GitHub username with Devon in Skool
-2. Wait for confirmation that access was granted
+1. Open `https://github.com/noontide-co/mainbranch` in your browser
+2. Confirm the URL is typed exactly in GitHub Desktop or terminal
 3. Try cloning again
 
-**Note:** Access is granted manually. Give it time.
+**Note:** The engine repo is public. A 404 usually means the old URL is being used or the URL was mistyped.
 
 ---
 
-## "Can't push to vip" / Permission Denied
+## "Can't push to Main Branch" / Permission Denied
 
 This is expected behavior, not an error.
 
-**vip is read-only.** You can pull updates but cannot push changes.
+**Main Branch is read-only for most users.** You can pull updates but cannot push changes.
 
 Your business data goes in YOUR OWN repo (created via `/setup`). That repo you can push to.
 
@@ -65,11 +65,11 @@ xcode-select --install
 
 ## GitHub Desktop: "Repository not found"
 
-Same as the 404 error above. You need access first.
+Same as the 404 error above. Use the public repo URL:
 
-1. Share your GitHub username with Devon
-2. Wait for confirmation
-3. Try again in GitHub Desktop
+```text
+https://github.com/noontide-co/mainbranch
+```
 
 ---
 

--- a/.claude/skills/help/references/two-repos.md
+++ b/.claude/skills/help/references/two-repos.md
@@ -4,7 +4,7 @@ This is the key concept. Once you get this, everything else makes sense.
 
 ---
 
-## vip (The Engine)
+## Main Branch (The Engine)
 
 The shared system everyone uses. Contains:
 - Skills (`/ads`, `/think`, `/setup`, `/vsl`, etc.)
@@ -36,7 +36,7 @@ This is what makes your outputs sound like YOU.
 ## How They Work Together
 
 ```
-your-business/                    vip/ (linked from business repo)
+your-business/                    mainbranch/ (linked from business repo)
 ├── Your offer                    ├── Skills
 ├── Your audience                 ├── Templates
 ├── Your voice                    ├── Frameworks
@@ -45,7 +45,7 @@ your-business/                    vip/ (linked from business repo)
 └── (yours, you own it)
 ```
 
-You start Claude in your business repo. `/setup` connects vip through `.claude/settings.local.json` for file access, and adds bridge links when needed for skill discovery. The engine then reads your business data and generates content that sounds like you.
+You start Claude in your business repo. `/setup` connects Main Branch through `.claude/settings.local.json` for file access, and adds bridge links when needed for skill discovery. The engine then reads your business data and generates content that sounds like you.
 
 **Same engine + different data = different outputs for each business.**
 
@@ -57,7 +57,7 @@ Unity (the game engine) provides physics, rendering, audio systems. But Unity al
 
 The engine + your assets = your game.
 
-- **vip** = Unity (the engine)
+- **Main Branch** = Unity (the engine)
 - **Your business repo** = Your game assets
 - **Skills** = Engine features you can use
 - **Reference files** = The assets that make it yours
@@ -83,7 +83,7 @@ The engine + your assets = your game.
 
 | Content | Location | Why |
 |---------|----------|-----|
-| Skills, templates | vip | Shared with all members |
+| Skills, templates | Main Branch | Shared with all members |
 | Your offer, audience, voice | Your repo | Business-specific |
 | Your testimonials and proof | Your repo | Business-specific |
 | Your research and decisions | Your repo | Business-specific |

--- a/.claude/skills/setup/references/claude-md-guide.md
+++ b/.claude/skills/setup/references/claude-md-guide.md
@@ -29,19 +29,19 @@ CLAUDE.md is the **always-loaded business brain**. Claude reads this file at the
 
 ## Engine
 
-This repo contains your **business data**. It's powered by **vip** (the engine).
+This repo contains your **business data**. It's powered by **Main Branch** (the engine).
 
 **Setup:**
-1. Clone vip: `git clone https://github.com/mainbranch-ai/vip.git`
+1. Clone Main Branch: `git clone https://github.com/noontide-co/mainbranch.git`
 2. Start Claude in THIS folder (your business repo) and run `/start`
-3. vip is linked via `.claude/settings.local.json` (with bridge links as compatibility fallback)
+3. Main Branch is linked via `.claude/settings.local.json` (with bridge links as compatibility fallback)
 
 **How it works:**
-- Engine (vip): Contains skills, lenses, frameworks. You pull updates but never edit.
+- Engine (Main Branch): Contains skills, lenses, frameworks. You pull updates but never edit.
 - Data (this repo): Contains your business context. You own and edit this.
 - Skills read from your `reference/` and output to your `outputs/`
 
-**If `/start` isn't available:** Skills may need bridge links. Find the vip path from `.claude/settings.local.json` (the `additionalDirectories` array), then read `[vip-path]/.claude/skills/start/references/auto-heal.md` and follow the repair steps. After repair, tell the user to restart Claude.
+**If `/start` isn't available:** Skills may need bridge links. Find the Main Branch path from `.claude/settings.local.json` (the `additionalDirectories` array), then read `[engine-path]/.claude/skills/start/references/auto-heal.md` and follow the repair steps. After repair, tell the user to restart Claude.
 
 ---
 

--- a/.claude/skills/setup/references/templates.md
+++ b/.claude/skills/setup/references/templates.md
@@ -571,23 +571,23 @@ status: complete
 
 This is the **data repo** (knowledge base) for [Business Name].
 
-It uses [vip](https://github.com/mainbranch-ai/vip) as the **engine** — skills, lenses, and frameworks that generate content from your data.
+It uses [Main Branch](https://github.com/noontide-co/mainbranch) as the **engine** — skills, lenses, and frameworks that generate content from your data.
 
 ### Setup
 
 1. **Clone the engine** (if you haven't):
    ```bash
-   git clone https://github.com/mainbranch-ai/vip.git
+   git clone https://github.com/noontide-co/mainbranch.git
    ```
 
 2. **Start Claude in this folder** (your business repo) and run `/start`
 
-3. **vip is linked** via `.claude/settings.local.json` (bridge links handle skill discovery fallback)
+3. **Main Branch is linked** via `.claude/settings.local.json` (bridge links handle skill discovery fallback)
 
 ### How It Works
 
 ```
-ENGINE (vip)     +     DATA (this repo)     =     OUTPUT
+ENGINE (mainbranch)     +     DATA (this repo)     =     OUTPUT
 ├── Skills                             ├── reference/            ├── Ads
 ├── Lenses                             ├── research/             ├── Emails
 └── Pull updates, don't edit           └── You own this          └── Content

--- a/.claude/skills/vsl/references/frameworks/skool-18-section.md
+++ b/.claude/skills/vsl/references/frameworks/skool-18-section.md
@@ -42,7 +42,7 @@ Do you ever feel like [specific pain point]? You're watching others [achieve des
 
 **Example**:
 ```
-Do you ever feel like your Skool group isn't growing fast enough? Or maybe it's barely growing at all? You're watching other groups add thousands of dollars in MRR, winning the Skool Games, and you wonder, 'What am I doing wrong?' You might think your offer isn't strong enough, or that you don't have enough traffic, or even that your About page is not converting anyone. If all of this is familiar, you're not alone.
+Do you ever feel like your Skool group isn't growing fast enough? Or maybe it's barely growing at all? You're watching other groups gain traction and build momentum, and you wonder, 'What am I doing wrong?' You might think your offer isn't strong enough, or that you don't have enough traffic, or even that your About page is not converting anyone. If all of this is familiar, you're not alone.
 ```
 
 ---
@@ -55,39 +55,39 @@ Do you ever feel like your Skool group isn't growing fast enough? Or maybe it's 
 - Relate to their situation — show you were once in their shoes
 - Bridge the gap with a genuine story
 - Introduce a mentor, catalyst, or turning point
-- Highlight specific transformation results for credibility
+- Highlight credible transformation patterns without inventing unverifiable numbers
 
 **Template**:
 ```
-When we started [situation], we had [problem]. But when [catalyst/event], we saw our opportunity. We went all-in on [solution], and the results were [positive outcome].
+When we started [situation], we had [problem]. But when [catalyst/event], we saw our opportunity. We went all-in on [solution], and it changed [what shifted].
 ```
 
 **Example**:
 ```
-When we started our Skool group, nobody knew us; we had no audience. But we wanted reliable, recurring revenue with a high profit margin. So when Skool launched their Meta integration, we saw our opportunity. We went all-in on Facebook ads to promote our Skool group, and the results were crazy. In the first two months, we hit $10K MRR, and in September, we won the Skool Games adding $37K in MRR in a single month—all profitable, all thanks to ads.
+When we started our Skool group, nobody knew us; we had no audience. But we wanted a more reliable way to reach the right people. So when we saw a path to use Facebook ads intentionally, we took it seriously. We went all-in on learning how to promote the group, and it changed how we thought about growth. Instead of waiting for referrals or content to compound, we had a repeatable way to put the offer in front of the right people.
 ```
 
 ---
 
 ## 3. Peek the Plan
 
-**Objective**: Position yourself as the guide ready to help them achieve similar results.
+**Objective**: Position yourself as the guide ready to help them pursue a similar path.
 
 **Guidance**:
 - Reverse roles: you're now the mentor
 - Give sneak peek of what's coming
-- Establish authority with proof
+- Establish authority with experience and a clear point of view
 - Add open hook to create curiosity
-- Suggest plan is risk-free or low-risk
+- Keep risk language accurate to the offer's actual terms
 
 **Template**:
 ```
-Now, I want to share [what you've learned], so you can [achieve similar results]. And the best part is, you can start today, totally risk-free.
+Now, I want to share [what you've learned], so you can [achieve desired path]. And the best part is, you can start in a way that matches [actual risk terms].
 ```
 
 **Example**:
 ```
-Now, I want to share everything we've learned from building the largest Skool ads group, so you can learn how to start and scale your own community with ads. And the best part is that you can start today, totally risk-free.
+Now, I want to share everything we've learned from helping community owners use ads more intentionally, so you can learn how to start and scale your own community with ads. And the best part is that you can start with clear expectations and a simple first step.
 ```
 
 ---
@@ -147,12 +147,12 @@ And I know that you might be wondering, 'Do I need to be ready to run ads to joi
 
 **Template**:
 ```
-You don't need to [overcome obstacle], because we'll [provide solution]. Plus, you can [additional benefit]. When you know how to [key action], you'll see results.
+You don't need to [overcome obstacle], because we'll [provide solution]. Plus, you can [additional benefit]. When you know how to [key action], you'll know what to do next.
 ```
 
 **Example**:
 ```
-You don't need to be fully prepared right now, because we'll guide you on how to get your account set up and your group ready, because ads give you the ability to bring visitors to your About page every day on autopilot. Plus, you can adjust your budget based on your situation—there's no need to spend hundreds or thousands of dollars a day. We've got people in the Ads Lab spending just $10 a day and getting new members. When you know how to create the right ads, which buttons to push, and how to structure your Skool group, you'll see results.
+You don't need to be fully prepared right now, because we'll guide you on how to get your account set up and your group ready, because ads give you the ability to bring visitors to your About page every day on autopilot. Plus, you can adjust your budget based on your situation; there's no need to start with an aggressive spend. When you know how to create the right ads, which buttons to push, and how to structure your Skool group, you'll have a clearer path to consistent growth.
 ```
 
 ---
@@ -164,7 +164,7 @@ You don't need to be fully prepared right now, because we'll guide you on how to
 **Guidance**:
 - Use variety of examples (different backgrounds, situations)
 - Follow framework: "Like [Name], who [achieved result]. Then there's [Name], who [another success]."
-- Include specific numbers and timeframes
+- Use real testimonials only when approved for public use; otherwise use clearly fictionalized composite examples
 - Appeal broadly to different audience segments
 
 **Template**:
@@ -174,13 +174,13 @@ Like [Name], who [achieved result]. Then there's [Name], who [another success].
 
 **Example**:
 ```
-Like Sarah, who helps consignment store owners increase their sales. She went from 40 to 110 members in her $97 community in just 3 months. She's now doing over $10k a month thanks to ads.
+Note: The names below are fictionalized composites. Replace them with approved real testimonials before publishing a client VSL.
 
-And Haley, a former Skool Games winner, called herself an ads newbie when she joined, but she knew ads were key to growing her group. Just two weeks later, in her first test, she spent $282 and made $1,800 in MRR. Now, she and her husband are doing over $40K a month.
+Like Maya, who helps local service owners improve their sales process. She came in with a solid offer but inconsistent traffic. After tightening her positioning and testing a simple ad angle, she finally had a predictable way to start conversations with better-fit prospects.
 
-Peyton, with no following and 3 members in his free fitness group, started running ads and grew to 65 potential high-ticket clients in just one week. And now he has over 300.
+Then there's Jordan, who had almost no audience and was relying on manual outreach. Ads helped him learn which promise people actually cared about, and that clarity improved his group, his sales calls, and his content.
 
-Also Mazen, who helps people stay fit with fun bodyweight skills, joined the group less than a month ago making around $1,200. In under a month, he's already crossed the $3K/month mark, giving undeniable credit to our group.
+And there's Lena, who teaches a niche skill in a small market. She didn't need a massive audience; she needed a sharper message and a way to consistently reach the right people. That shift made growth feel practical instead of random.
 ```
 
 ---
@@ -192,7 +192,7 @@ Also Mazen, who helps people stay fit with fun bodyweight skills, joined the gro
 **Guidance**:
 - Slow down speaking pace
 - Create more intimate atmosphere
-- Use statistical proof
+- Use approved proof only; otherwise explain the pattern without numbers
 - Help them visualize success
 
 **Template**:
@@ -202,7 +202,7 @@ Your [goal] will benefit from [solution]. How am I so sure? Because we are consi
 
 **Example**:
 ```
-Your group will benefit from running ads. How am I so sure? Because we are consistently seeing Skool group owners inside the Ads Lab—some who aren't even English speakers—following our plan, running ads, and getting new members. Now, imagine if that was you. Qualified members joining your group every single day—it's possible.
+Your group can benefit from running ads. How am I so sure? Because the pattern is consistent: when community owners clarify their offer, tighten the page cold traffic sees, and test ads with discipline, they stop guessing and start learning from the market. Now, imagine if that was you. Qualified members discovering your group every day; it's possible.
 ```
 
 ---
@@ -237,19 +237,19 @@ Instead of spending time searching for the right members, the ads do the work fo
 **Guidance**:
 - Compare with high-priced alternatives
 - Stack benefits to emphasize value
-- Mention fast, easy, guaranteed attributes
+- Mention ease and risk only when the offer actually supports those claims
 - Elicit another soft yes
 
 **Template**:
 ```
-Right now, businesses are spending [high price] trying to [achieve goal] because [reason]. But what if you didn't have to spend [high price] to get that knowledge? What if you could [achieve goal] from the start, without [obstacle]? Would you at least consider trying it out, knowing you don't need to [big investment]—and can start risk-free?
+Right now, businesses are spending [resource] trying to [achieve goal] because [reason]. But what if you didn't have to waste [resource] to get that knowledge? What if you could [pursue goal] from the start, without [obstacle]? Would you at least consider trying it out, knowing you can start with [actual risk terms]?
 ```
 
 **Example**:
 ```
-Right now, businesses are spending thousands of dollars trying to learn the best strategies to run ads because, again, ads can be your magnet, always pulling in the right audience. But what if you didn't have to spend thousands to get that knowledge?
+Right now, businesses often waste time and budget trying to learn the best strategies to run ads because, again, ads can be your magnet, always pulling in the right audience. But what if you didn't have to figure it out alone?
 
-What if you could learn to run ads the right way from the start, without wasting money? Would you at least consider trying it out, knowing you don't need to spend a fortune—and can start risk-free?
+What if you could learn to run ads the right way from the start, without avoidable trial and error? Would you at least consider trying it out, knowing you can start carefully and keep the risk controlled?
 ```
 
 ---
@@ -265,16 +265,16 @@ What if you could learn to run ads the right way from the start, without wasting
 
 **Template**:
 ```
-If you really want to [achieve goal], [solution] is the key. You can start seeing results in [short time frame]. It doesn't take much skill—if you can [simple tasks], you can [use solution].
+If you really want to [achieve goal], [solution] can help. You can start learning in [realistic time frame]. It doesn't take much skill to begin; if you can [simple tasks], you can [use solution].
 ```
 
 **Example**:
 ```
-If you really want to get more out of your Skool group, running ads is the key. You can start seeing results in just a few hours.
+If you really want to get more out of your Skool group, running ads can become a useful growth channel. You can start learning from the market quickly.
 
 It doesn't take much skill—if you can watch a video, type on a keyboard, and come up with a picture or video idea, you can run ads. You don't need to be an expert; you just need to know how to create a good ad and press the right buttons, and the ads will do the rest.
 
-Think of running ads like using a vending machine. You enter a dollar, press the right buttons, and get exactly what you want. You don't need to understand how the machine works inside—just which buttons to press. Ads work the same way. Learn a few key things (that we will teach you), and they'll deliver the results.
+Think of running ads like using a dashboard. You do not need to understand every technical detail before you begin, but you do need to know which signals matter and which actions to take next. Learn a few key things (that we will teach you), and the process gets much less intimidating.
 ```
 
 ---
@@ -297,7 +297,7 @@ Sounds interesting? Great. [Solution] removes the biggest obstacles that stop mo
 ```
 Sounds interesting? Great. Running ads removes the biggest obstacles that stop most people from growing their Skool group. You don't need a huge audience, technical skills, or lots of free time.
 
-In fact, many of our most successful members started with no followers and no ad experience. Everything you need is built into our process, and we'll guide you through every step.
+In fact, this process is designed for people who are not ad experts yet. Everything you need is built into the process, and we'll guide you through every step.
 ```
 
 ---
@@ -308,7 +308,7 @@ In fact, many of our most successful members started with no followers and no ad
 
 **Guidance**:
 - Anticipate further doubts
-- Provide proof with examples
+- Use approved proof only; otherwise use examples as teaching scenarios
 - Emphasize ease of starting
 
 **Template**:
@@ -318,11 +318,11 @@ You might be asking, '[Question]?' Don't worry—you'll [reassurance].
 
 **Example**:
 ```
-You might be asking, 'What kind of ads work best for Skool groups?' Don't worry—you'll see real-time examples from other members and their results, so you can learn from what's already working.
+You might be asking, 'What kind of ads work best for Skool groups?' Don't worry; you'll see examples, breakdowns, and the reasoning behind them, so you can learn what to look for.
 
-If you're wondering, 'How fast can I see results?' It depends on how quickly you use what we teach and adjust based on feedback from the community or our live calls. The faster you act, the faster you'll see results.
+If you're wondering, 'How fast can I learn what works?' It depends on how quickly you use what we teach and adjust based on feedback from the community or our live calls. The faster you act, the faster you'll gather useful signal.
 
-And if you're asking, 'Is it really worth it?' Look, when you run ads the right way, the money you save can cover the cost of the group in just a day or two.
+And if you're asking, 'Is it really worth it?' Look, when you run ads the right way, you make better decisions with your budget and stop guessing about what your audience responds to.
 ```
 
 ---
@@ -365,11 +365,11 @@ Worst case? You [minimal loss]. Best case? You [significant gain]. And maybe you
 
 **Example**:
 ```
-Worst case? You join, do nothing, and still walk away with your money back and knowledge that took us thousands of hours and millions of dollars to learn—knowledge you can use in your next project.
+Worst case? You join, do nothing, and still walk away with a clearer understanding of how ads work for communities; knowledge you can use in your next project.
 
-Best case? You make a no-risk move and completely change how fast your Skool group grows, just like these members have.
+Best case? You make a careful move and completely change how you approach growth for your Skool group.
 
-And maybe you're not looking to grow super aggressively, but how would an extra $1,000, $2,000, or even $10,000 a month impact your group?
+And maybe you're not looking to grow super aggressively, but how would a more predictable path to better-fit members change the way you run your group?
 ```
 
 ---
@@ -391,9 +391,9 @@ The only thing that's certain is that if you don't [take action], nothing will c
 
 **Example**:
 ```
-The only thing that's certain is that if you don't take action, nothing will change. But if you do, you could be the next one growing your Skool group and seeing steady monthly income.
+The only thing that's certain is that if you don't take action, nothing will change. But if you do, you could be the next one growing your Skool group with a clearer, more repeatable process.
 
-The Ads Lab is here to make sure that happens. We're committed to helping you succeed, and we stand behind that 100%.
+This program is here to make sure that happens. We're committed to helping you succeed, and we stand behind that 100%.
 
 So, are you ready to take that step?
 ```
@@ -405,18 +405,18 @@ So, are you ready to take that step?
 **Objective**: Remove remaining barriers by minimizing perceived risk.
 
 **Guidance**:
-- Offer guarantees (money-back, trials)
+- Only mention guarantees, refunds, or trials when the offer actually supports them
 - Show goodwill — emphasize you want them to succeed
 - Build trust and reinforce credibility
 
 **Template**:
 ```
-And if you're worried about [risk], we offer [guarantee]. Try [solution], and if you're not [satisfied], we'll [refund/resolve]. We're here to help you succeed, and we just want you to [achieve goal].
+And if you're worried about [risk], here is the actual policy: [terms]. Try [solution], and if it is not the right fit, follow [refund/cancellation/support path]. We're here to help you succeed, and we just want you to [achieve goal].
 ```
 
 **Example**:
 ```
-And if you're worried about taking the leap, we offer a 14-day money-back guarantee. Try The Ads Lab, and if you're not seeing the results you want or decide it's not for you, just let us know, and we'll give you a full refund—no questions asked.
+And if you're worried about taking the leap, use whatever guarantee or trial policy your offer actually supports. Try the program, and if it is not the right fit, follow the stated policy for refunds or cancellation.
 
 We're here to help you succeed, and we just want you to grow your group.
 ```

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -6,9 +6,7 @@ name: publish-pypi
 # GitHub Environment with at least one required reviewer.
 #
 # OIDC claim must match the pending publisher:
-#   owner=mainbranch-ai, repo=vip, workflow=publish-pypi.yml, env=pypi.
-#   (After transfer to noontide-co/mainbranch, update this comment +
-#    register a new pending publisher on PyPI.)
+#   owner=noontide-co, repo=mainbranch, workflow=publish-pypi.yml, env=pypi.
 #
 # First test release: tag `oe-v0.1.0.dev0` and use the Releases UI.
 # Promote to `oe-v0.1.0` once dev0 has been smoke-tested on a clean machine.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to mb-vip
+# Contributing to Main Branch
 
-mb-vip is a public repo. Anyone can read it; not everyone is wired in to the engine cadence. The contributor flow below documents how the work happens, what gates run, and what discipline rules apply.
+Main Branch is a public repo. Anyone can read it; not everyone is wired in to the engine cadence. The contributor flow below documents how the work happens, what gates run, and what discipline rules apply.
 
 These rules are **tool-agnostic.** Conductor users, Codex users, Cursor users, and direct CLI contributors all follow the same shape — the rules describe the work, not the editor.
 
@@ -70,14 +70,14 @@ Never rewrite. Follow-up fixes after review = NEW commits on top. **Never force-
 
 ## Public/private smell test
 
-mb-vip is a **public repo**. Apply the test on every commit:
+Main Branch is a **public repo**. Apply the test on every commit:
 
 > "Would the reader (anyone with internet) be embarrassed or uncomfortable reading this?"
 
 | Answer | Where it goes |
 |---|---|
-| Yes | Stays in your private repo. mb-vip does not see it. |
-| Meh, fine | mb-vip is fine. |
+| Yes | Stays in your private repo. Main Branch does not see it. |
+| Meh, fine | Main Branch is fine. |
 | Not sure | Default private. Sanitize and re-evaluate. |
 
 Specifically:
@@ -119,6 +119,8 @@ PR reviews use this shape:
 
 ## How to find the work
 
-The v0.1.0 master decision is `decisions/2026-04-29-mb-vip-v0-1-0-master.md`. It locks vocabulary, repo shape, ship list, /site upgrade scope, and the conductor preferences encoded above.
+The engine v0.1.0 decision is `decisions/2026-04-29-mb-vip-v0-1-0-master.md`. It locks vocabulary, repo shape, ship list, /site upgrade scope, and the conductor preferences encoded above.
+
+The companion business-side master plan is tracked in `noontide-co/projects#119`. Read it when a contribution touches product positioning, public launch sequencing, pricing, the agency arm, or the four CLI pillars.
 
 If you're considering a contribution, read it first.

--- a/README.md
+++ b/README.md
@@ -1,16 +1,18 @@
-# Main Branch VIP
+# Main Branch
 
-Turn Claude into your personal marketing team. Create ads, scripts, and community content that sounds like YOU.
+Open-source Claude Code skills and a small `mb` CLI for running business-as-files workflows.
 
 
 ## Honest current state (v0.1)
 
 - **Built for Claude Code.** Cross-platform skill support is a v0.2+ commitment.
 - **Schema is v1; will evolve.** Frontmatter shapes covered by `mb validate` are stable for v0.1.x; breaking changes bump the major.
-- **Install: `pipx install mainbranch`** (recommended, once published) or `git clone https://github.com/mainbranch-ai/vip` (developer mode).
+- **Install: `pipx install mainbranch`** (recommended, once published) or `git clone https://github.com/noontide-co/mainbranch` (developer mode).
 - **Cross-agent compatibility matrix lands at v0.2.** Codex, Cursor, Hermes, local LLMs are not first-class targets in v0.1.
 
-The v0.1.0 master decision lives at [`decisions/2026-04-29-mb-vip-v0-1-0-master.md`](decisions/2026-04-29-mb-vip-v0-1-0-master.md).
+The engine v0.1.0 decision lives at [`decisions/2026-04-29-mb-vip-v0-1-0-master.md`](decisions/2026-04-29-mb-vip-v0-1-0-master.md).
+
+The business-side master plan is tracked in [`noontide-co/projects#119`](https://github.com/noontide-co/projects/pull/119), which amends the launch direction around a CLI-first public product, Skool as the paid wrapper, and the four v0.1 pillars: ads, books, pages, and fulfillment.
 
 ---
 
@@ -94,23 +96,23 @@ Open GitHub Desktop. Click **File > Clone Repository**.
 
 Paste this URL:
 ```
-https://github.com/mainbranch-ai/vip
+https://github.com/noontide-co/mainbranch
 ```
 
 Choose where to save it (remember the location!). Click **Clone**.
 
-### Step 2: First Session (Run From vip)
+### Step 2: First Session (Run From mainbranch)
 
-Open a terminal in the **vip** folder you just cloned:
+Open a terminal in the **mainbranch** folder you just cloned:
 
 **Mac:**
 ```bash
-cd ~/Documents/GitHub/vip
+cd ~/Documents/GitHub/mainbranch
 ```
 
 **Windows (Git Bash):**
 ```bash
-cd /c/Users/YourName/Documents/GitHub/vip
+cd /c/Users/YourName/Documents/GitHub/mainbranch
 ```
 
 Run Claude and type `/setup`:
@@ -132,7 +134,7 @@ You can paste text, share URLs, or upload files. Claude organizes it all for you
 
 ### Step 4: Daily Workflow (After Setup)
 
-After setup, work from your **business repo** (not vip):
+After setup, work from your **business repo** (not the Main Branch engine repo):
 ```bash
 cd ~/Documents/GitHub/[your-business]
 claude
@@ -237,13 +239,13 @@ You fill in the reference files. Claude reads them when generating.
 
 ---
 
-## Keeping vip Updated
+## Keeping Main Branch Updated
 
-Devon updates the vip repository with new skills and improvements.
+Devon updates the Main Branch repository with new skills and improvements.
 
 **Updates happen automatically when you run `/start`.** You can also run `/pull` anytime to get the latest.
 
-**GitHub Desktop (optional):** If you want to see what changed or pull updates manually, open GitHub Desktop, select vip, and click Pull origin. The History tab shows exactly what changed in each update.
+**GitHub Desktop (optional):** If you want to see what changed or pull updates manually, open GitHub Desktop, select `mainbranch`, and click Pull origin. The History tab shows exactly what changed in each update.
 
 ---
 
@@ -257,7 +259,7 @@ Post in the Main Branch group. Tag @Devon for technical questions.
 - "Claude does not see my files" — Make sure you started Claude in your business repo folder and ran `/start`
 - "Skills are not working" — Check that `.claude/settings.local.json` exists and run `/start` once to auto-repair missing bridge links. If still broken, run `/setup`.
 - "Output sounds generic" — Add more detail to your reference files, especially voice.md
-- "I edited vip but can't push" — That's expected. vip is read-only. Your business data goes in YOUR repo.
+- "I edited Main Branch but can't push" — That's expected for most users. Main Branch is the shared engine. Your business data goes in YOUR repo.
 
 ---
 

--- a/docs/BEGINNER-SETUP.md
+++ b/docs/BEGINNER-SETUP.md
@@ -7,7 +7,7 @@ Quick setup for Claude Code + Main Branch. For the full curriculum with videos a
 ## Prerequisites
 
 1. **GitHub account** - [github.com/signup](https://github.com/signup)
-2. **Repository access** - Share your GitHub username with Devon in Skool, wait for confirmation
+2. **Main Branch engine repo** - Public at [github.com/noontide-co/mainbranch](https://github.com/noontide-co/mainbranch)
 3. **Claude subscription** - Pro ($20/mo) or Max ($100-200/mo) at [claude.ai](https://claude.ai)
 
 ---
@@ -30,17 +30,17 @@ curl -fsSL https://claude.ai/install.sh | bash
 irm https://claude.ai/install.ps1 | iex
 ```
 
-### 3. Clone vip
+### 3. Clone Main Branch
 
-In GitHub Desktop: **File → Clone Repository → GitHub.com tab → select `mainbranch-ai/vip`**
+In GitHub Desktop: **File → Clone Repository → URL tab → paste `https://github.com/noontide-co/mainbranch`**
 
 ### 4. First Session (One-Time Setup)
 
-Open Terminal in the **vip** folder and run Claude:
+Open Terminal in the **mainbranch** folder and run Claude:
 
-**Mac:** Open Terminal, type `cd `, drag the vip folder from Finder into Terminal, press Enter.
+**Mac:** Open Terminal, type `cd `, drag the mainbranch folder from Finder into Terminal, press Enter.
 
-**Windows:** Right-click inside the vip folder → "Open in Terminal"
+**Windows:** Right-click inside the mainbranch folder -> "Open in Terminal"
 
 ```bash
 claude
@@ -48,12 +48,12 @@ claude
 
 Then type `/setup`. It will:
 - Create your business repo
-- Configure vip as the skill source
+- Configure Main Branch as the skill source
 - Walk you through adding your business context
 
 ### 5. Daily Workflow (After Setup)
 
-After the first session, you work from your **business repo** (not vip):
+After the first session, you work from your **business repo** (not the Main Branch engine repo):
 
 ```bash
 cd ~/Documents/GitHub/[your-business]
@@ -61,7 +61,7 @@ claude
 /start
 ```
 
-`/start` detects your business repo and routes you to the right skill. vip linkage is configured by setup via `settings.local.json`, plus compatibility bridge links when needed.
+`/start` detects your business repo and routes you to the right skill. Main Branch linkage is configured by setup via `settings.local.json`, plus compatibility bridge links when needed.
 
 When you're done for the day:
 
@@ -91,7 +91,7 @@ echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc && source ~/.bashrc
 
 ### "Repository not found" / 404
 
-You don't have access yet. Share your GitHub username with Devon and wait for confirmation.
+The public engine repo is `https://github.com/noontide-co/mainbranch`. If GitHub Desktop shows a 404, check that the URL is typed exactly or open the repo in your browser first.
 
 ### Xcode Command Line Tools (Mac)
 
@@ -99,16 +99,16 @@ If you see a popup about developer tools, click Install. You'll need it for Git 
 
 To reinstall if you canceled: `xcode-select --install`
 
-### Can't push to vip
+### Can't push to Main Branch
 
-Expected. vip is read-only. Your business data goes in your own repo (created via `/setup`).
+Expected for most users. Main Branch is the shared engine. Your business data goes in your own repo (created via `/setup`).
 
 ---
 
 ## The Two Repos
 
 ```
-vip/                    your-business/
+mainbranch/             your-business/
 ├── Skills              ├── Your offer
 ├── Templates           ├── Your audience
 ├── Frameworks          ├── Your voice

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -9,7 +9,7 @@ Complete technical reference for how Main Branch works as an AI-native business 
 Main Branch operates on a fundamental separation:
 
 ```
-ENGINE (vip)     +     DATA (your business repo)     =     OUTPUT
+ENGINE (mainbranch)     +     DATA (your business repo)     =     OUTPUT
 ├── Skills                             ├── Reference                       ├── Ads, Scripts, Content (outputs/)
 ├── Lenses                             │   (incl. content-strategy.md)     ├── Wiki (separate repo)
 └── Frameworks                         ├── Research                        └── Site (separate repo)
@@ -215,7 +215,7 @@ your-business/
 ## Folder Structure: Engine Repo
 
 ```
-vip/
+mainbranch/
 ├── CLAUDE.md                        # Philosophy + reference
 ├── docs/
 │   └── system-architecture.md       # This file
@@ -465,9 +465,9 @@ Skills should load context progressively:
 
 ### Setup
 
-1. Clone vip locally
+1. Clone Main Branch locally
 2. Create or clone your business repo
-3. Run `/setup` to configure vip linkage (writes `.claude/settings.local.json` and compatibility links when needed)
+3. Run `/setup` to configure Main Branch linkage (writes `.claude/settings.local.json` and compatibility links when needed)
 4. Start Claude in your business repo and run `/start`
 
 ### In Practice
@@ -475,23 +475,23 @@ Skills should load context progressively:
 ```
 Claude Code Session:
 ├── Primary (CWD): ~/projects/my-business/
-│   ├── .claude/settings.local.json  ← additionalDirectories points to vip
+│   ├── .claude/settings.local.json  ← additionalDirectories points to mainbranch
 │   ├── .claude/skills/*             ← bridge links for skill discovery fallback
 │   ├── reference/
 │   ├── outputs/
 │   └── ...
 │
-└── Additional directory (read-only): ~/Documents/GitHub/vip/
+└── Additional directory (read-only): ~/Documents/GitHub/mainbranch/
     ├── .claude/skills/              ← canonical skill source
     ├── .claude/lenses/
     └── ...
 ```
 
 When you invoke `/ads`:
-1. Claude loads skill from vip
+1. Claude loads skill from Main Branch
 2. Skill reads context from my-business/reference/
 3. Output goes to my-business/outputs/
-4. Review uses lenses from vip
+4. Review uses lenses from Main Branch
 
 Users with a wiki or site have additional repos accessed via config files (`~/.mainbranch/wiki.json`, `~/.mainbranch/sites.json`), not as working directories.
 

--- a/mb/README.md
+++ b/mb/README.md
@@ -1,6 +1,6 @@
 # mainbranch (`mb`)
 
-Engine umbrella for [Main Branch](https://mainbranch.io) — scaffolds, validates, and graphs business-as-files repos.
+Engine umbrella for [Main Branch](https://github.com/noontide-co/mainbranch) — scaffolds, validates, and graphs business-as-files repos.
 
 This package is the Python entry point. Skills, playbooks, educational content, and consumer-repo templates ship as bundled package data. The actual day-to-day "do work" surfaces are Claude Code skills (markdown), invoked from inside Claude Code.
 
@@ -31,7 +31,7 @@ mb --version
 
 ## Status
 
-v0.1 is **Built for Claude Code only**. Cross-agent compatibility is a v0.2+ commitment. The schema is v1 and will evolve. The full master decision lives at `decisions/2026-04-29-mb-vip-v0-1-0-master.md` in the engine repo.
+v0.1 is **Built for Claude Code only**. Cross-agent compatibility is a v0.2+ commitment. The schema is v1 and will evolve. The engine decision lives at `decisions/2026-04-29-mb-vip-v0-1-0-master.md`; the business-side master plan is tracked in `noontide-co/projects#119`.
 
 ## License
 

--- a/mb/mb/_data/templates/CLAUDE.md.tmpl
+++ b/mb/mb/_data/templates/CLAUDE.md.tmpl
@@ -37,4 +37,4 @@ mb educational <topic>   # read the long-form rationale for an opinionated defau
 `@{{GH_USERNAME}}`
 
 For the engine docs (skills, vocabulary, the v0.1 master decision), see
-https://github.com/mainbranch-ai/vip.
+https://github.com/noontide-co/mainbranch.

--- a/mb/pyproject.toml
+++ b/mb/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "mainbranch"
 version = "0.1.0.dev0"
-description = "Main Branch engine umbrella — scaffolds, validates, and graphs business-as-files repos. Built for Claude Code."
+description = "Main Branch engine umbrella - scaffolds, validates, and graphs business-as-files repos. Built for Claude Code."
 readme = "README.md"
 requires-python = ">=3.10"
 license = { file = "LICENSE" }
@@ -54,9 +54,9 @@ dev = [
 mb = "mb.cli:app"
 
 [project.urls]
-Homepage = "https://github.com/mainbranch-ai/vip"
-Repository = "https://github.com/mainbranch-ai/vip"
-Issues = "https://github.com/mainbranch-ai/vip/issues"
+Homepage = "https://github.com/noontide-co/mainbranch"
+Repository = "https://github.com/noontide-co/mainbranch"
+Issues = "https://github.com/noontide-co/mainbranch/issues"
 
 [tool.setuptools.packages.find]
 where = ["."]


### PR DESCRIPTION
## Summary

- Updates public-facing docs and package metadata from the old `mainbranch-ai/vip` path to `noontide-co/mainbranch`.
- References the business-side master plan in `noontide-co/projects#119` where product positioning, launch sequencing, pricing, agency-arm, and four-pillar CLI direction are now tracked.
- Removes real-name and hard-number proof claims from the public VSL framework example, replacing them with fictionalized composites and accuracy guidance.

## Validation

- `python3 -m ruff format --check .` from `mb/`
- `python3 -m ruff check .` from `mb/`
- `python3 -m mypy mb` from `mb/`
- `pytest -q` from `mb/`
