### PR TITLE
fix(package): bundle skills into wheel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,13 +80,9 @@ jobs:
     # vary across 3.10/3.11/3.12 enough to justify matrixing. We pick 3.12
     # (latest supported target). Pattern borrowed from companyctx.
     #
-    # Note (v0.1.0): mb/_data/skills/ ships empty in the source tree
-    # — `mb skill list` resolves via source-checkout fallback in dev,
-    # which the wheel by definition can't see. The smoke job validates
-    # the wheel-shipped surface (entry point, importable package,
-    # py.typed) and tolerates an empty `mb skill list` until the v0.1.x
-    # follow-up wires _data/skills/ population at build time. See
-    # CHANGELOG / decisions/2026-04-29-mb-vip-v0-1-0-master.md.
+    # Release wheels must carry the bundled skills/playbooks as package
+    # data. The source tree keeps a single authoritative copy under
+    # .claude/; setup.py copies that data into mb/_data/ at build time.
     name: wheel-install-smoke
     runs-on: ubuntu-latest
     defaults:
@@ -109,7 +105,7 @@ jobs:
       - name: Build sdist + wheel
         run: python -m build
 
-      - name: Verify py.typed shipped in wheel
+      - name: Verify package data shipped in wheel
         # The editable install test suite can't catch a missing py.typed —
         # it reads straight from the source tree. A wheel without py.typed
         # silently degrades downstream mypy to Any. Fail loudly here.
@@ -119,6 +115,10 @@ jobs:
           python -m zipfile -l "$wheel"
           python -m zipfile -l "$wheel" | grep -E '(^|/)mb/py\.typed([[:space:]]|$)' \
             || { echo "::error::py.typed missing from wheel"; exit 1; }
+          python -m zipfile -l "$wheel" | grep -E '(^|/)mb/_data/skills/start/SKILL\.md([[:space:]]|$)' \
+            || { echo "::error::bundled skills missing from wheel"; exit 1; }
+          python -m zipfile -l "$wheel" | grep -E '(^|/)mb/_data/playbooks/ship-bet/SKILL\.md([[:space:]]|$)' \
+            || { echo "::error::bundled playbooks missing from wheel"; exit 1; }
 
       - name: Create fresh venv and install the wheel
         # Fresh venv means no repo sources on sys.path — a genuine
@@ -166,15 +166,14 @@ jobs:
           grep -qi "main branch\|scaffolds" help.txt \
             || { echo "::error::root --help output missing expected description"; exit 1; }
 
-      - name: Smoke — mb skill list (does not crash)
-        # v0.1.0: wheel ships with mb/_data/skills/ empty (skills live in
-        # the engine repo's .claude/skills/ and aren't yet copied into
-        # _data/skills/ at build time). The smoke job asserts the command
-        # runs to clean exit; population of _data/skills/ is tracked as
-        # a v0.1.x follow-up.
+      - name: Smoke — mb skill list is populated
         run: |
-          .venv-smoke/bin/mb skill list
-          echo "exit=$?"
+          .venv-smoke/bin/mb skill list > skills.txt
+          cat skills.txt
+          grep -qx "start" skills.txt \
+            || { echo "::error::mb skill list missing bundled start skill"; exit 1; }
+          grep -qx "think" skills.txt \
+            || { echo "::error::mb skill list missing bundled think skill"; exit 1; }
 
       - name: Smoke — mb doctor (runs against empty cwd)
         # A second user-facing CLI surface that doesn't depend on bundled

--- a/mb/README.md
+++ b/mb/README.md
@@ -4,6 +4,8 @@ Engine umbrella for [Main Branch](https://github.com/noontide-co/mainbranch) —
 
 This package is the Python entry point. Skills, playbooks, educational content, and consumer-repo templates ship as bundled package data. The actual day-to-day "do work" surfaces are Claude Code skills (markdown), invoked from inside Claude Code.
 
+The source tree keeps skills and playbooks in one place: repo-root `.claude/skills/` and `.claude/playbooks/`. During sdist/wheel builds, `setup.py` copies those directories into `mb/_data/skills/` and `mb/_data/playbooks/` inside the build artifact so installed wheels can resolve `mb skill list` without a source checkout.
+
 ## Install
 
 ```bash

--- a/mb/setup.py
+++ b/mb/setup.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+from setuptools import setup
+from setuptools.command.build_py import build_py as _build_py
+from setuptools.command.sdist import sdist as _sdist
+
+PROJECT_ROOT = Path(__file__).resolve().parent
+REPO_ROOT = PROJECT_ROOT.parent
+
+GENERATED_DATA = {
+    "skills": REPO_ROOT / ".claude" / "skills",
+    "playbooks": REPO_ROOT / ".claude" / "playbooks",
+}
+
+
+def _copy_generated_data(target_root: Path) -> None:
+    data_root = target_root / "mb" / "_data"
+    for name, source in GENERATED_DATA.items():
+        if not source.exists():
+            continue
+        target = data_root / name
+        if target.exists():
+            shutil.rmtree(target)
+        shutil.copytree(
+            source,
+            target,
+            ignore=shutil.ignore_patterns("__pycache__", ".DS_Store"),
+        )
+
+
+class build_py(_build_py):
+    def run(self) -> None:
+        super().run()
+        _copy_generated_data(Path(self.build_lib))
+
+
+class sdist(_sdist):
+    def make_release_tree(self, base_dir: str, files: list[str]) -> None:
+        super().make_release_tree(base_dir, files)
+        _copy_generated_data(Path(base_dir))
+
+
+setup(cmdclass={"build_py": build_py, "sdist": sdist})

--- a/mb/tests/test_cli.py
+++ b/mb/tests/test_cli.py
@@ -24,5 +24,5 @@ def test_help_runs() -> None:
 
 def test_skill_list_runs() -> None:
     result = runner.invoke(app, ["skill", "list"])
-    # May be empty in a clean test sandbox; what matters is non-crash exit.
     assert result.exit_code == 0
+    assert "start" in result.stdout.splitlines()

--- a/mb/tests/test_smoke_coverage.py
+++ b/mb/tests/test_smoke_coverage.py
@@ -157,9 +157,10 @@ def test_validate_command_exit_codes(tmp_path: Path) -> None:
 
 
 def test_skill_list_command_runs() -> None:
-    """`mb skill list` doesn't crash even with an empty bundled skill set."""
+    """`mb skill list` finds bundled skills in source checkouts."""
     result = runner.invoke(app, ["skill", "list"])
     assert result.exit_code == 0
+    assert "start" in result.stdout.splitlines()
 
 
 def test_main_help_describes_engine() -> None:


### PR DESCRIPTION
## Summary

Closes #134.

- Adds a setuptools build hook that copies repo-root `.claude/skills/` and `.claude/playbooks/` into `mb/_data/` for sdist and wheel artifacts.
- Keeps source-of-truth markdown only in `.claude/`; generated copies are not checked into source.
- Tightens wheel-install smoke so release wheels must include bundled skills/playbooks and `mb skill list` must be populated.
- Updates tests and `mb/README.md` to document the build-time copy behavior.

## Validation

- `python3 -m build` from `mb/`
- inspected wheel for `mb/_data/skills/start/SKILL.md`, `mb/_data/playbooks/ship-bet/SKILL.md`, and `mb/py.typed`
- inspected sdist for `mb/_data/skills/start/SKILL.md` and `mb/_data/playbooks/ship-bet/SKILL.md`
- fresh venv wheel install, then `mb skill list` showed bundled skills
- `python3 -m ruff format --check .` from `mb/`
- `python3 -m ruff check .` from `mb/`
- `python3 -m mypy mb` from `mb/`
- `pytest -q` from `mb/`
