### PR TITLE
chore(release): prepare 0.1.0

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -8,8 +8,7 @@ name: publish-pypi
 # OIDC claim must match the pending publisher:
 #   owner=noontide-co, repo=mainbranch, workflow=publish-pypi.yml, env=pypi.
 #
-# First test release: tag `oe-v0.1.0.dev0` and use the Releases UI.
-# Promote to `oe-v0.1.0` once dev0 has been smoke-tested on a clean machine.
+# Publish release: tag `oe-v0.1.0` and use the Releases UI.
 #
 # Release notes: the `extract-changelog` job parses CHANGELOG.md for the
 # section matching the release tag and updates the GitHub Release body

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,98 +11,16 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
-### What this means for you (plain English)
+No unreleased changes yet.
 
-Since v0.1.0, here's what's changed in your day-to-day if you're a member:
+## [0.1.0] - 2026-05-01
 
-- **Better "what's new" notices.** Instead of a separate announcements
-  file that nobody updated, the engine now uses this CHANGELOG. You'll
-  see banners in `/start` and `/pull` when there's a real release.
-- **More archetype detail in `/site`.** The 5 archetype templates that
-  shipped as stubs in v0.1.0 are now full reference files — you'll get
-  richer brand-voice guidance when you build a site for a contrarian
-  brand, a redemption-arc brand, etc.
-- **Quality gates got tighter.** New CI jobs catch packaging mistakes
-  before they hit you. You won't notice them unless something breaks
-  upstream and we catch it before merge.
-
-OSS / contributor detail below.
-
-### Added
-
-- **CHANGELOG.md** itself (Keep a Changelog format). Replaces the
-  `.claude/announcements.md` file as the single source of truth for what's
-  new in the engine. `/start` and `/pull` now diff the current version
-  against `~/.config/vip/local.yaml:last_seen_version` and surface unread
-  entries as a "What's new" banner.
-- **`wheel-install-smoke` CI job** (`.github/workflows/ci.yml`). Builds the
-  `mainbranch` wheel + sdist, installs into a clean venv, and verifies
-  the CLI surfaces `mb --version`, `mb --help`, `mb skill list`, and
-  `mb doctor` all run to clean exit, plus `python -c "import mb"` works.
-  Catches packaging drift (missing `py.typed`, stale `package-data`,
-  entry-point registration gaps) that the editable-install matrix can't
-  see. **Note:** the wheel does NOT yet ship populated `mb/_data/skills/`
-  in v0.1.0 — `mb skill list` runs cleanly but returns an empty bundle.
-  Skill bundling at build time is deferred to a v0.1.x follow-up. Pattern
-  borrowed from `companyctx`.
-- **70% coverage threshold** in CI (`mb/pyproject.toml` +
-  `.github/workflows/ci.yml`). Test-suite blocks merge if `--cov-fail-under=70`
-  fails. Minimal smoke tests added to `mb/tests/` to cover `educational`,
-  `think`, and CLI entry-point modules that were under-tested.
-- **5 archetype detail files promoted from stubs to full** under
-  `.claude/skills/site/references/archetypes/`: `victim.md`,
-  `tragedy-mindset.md`, `dark-hero.md`, `redemption.md`,
-  `tragic-comedy.md`. Each now carries the same shape as the existing
-  4 archetypes (wounded-healer, savior, david-goliath, broken-hero):
-  definition, when to use, audience-current-trap reframe (where applicable),
-  do-not-state list, paired-imagery template, headline formulas (where
-  applicable), voice anchor, anti-patterns, brand applications.
-  Source: `research/2026-04-29-marketing-site-brief-framework-yt-mining.md`
-  (Chase Hughes 9-archetype framework). The `archetypes.md` catalog now
-  lists real one-line blurbs instead of `(stub)` tags.
-- **Canonical `vip-path-resolution.md` reference** at
-  `.claude/reference/vip-path-resolution.md`. Single source of truth for
-  the bash + python3 resolver that locates mb-vip via
-  `.claude/settings.local.json:additionalDirectories` first, with
-  `~/.config/vip/local.yaml:vip_path` as the fallback. Includes failure
-  modes and recovery. Replaces inline copies of the resolver across at
-  least 5 reference files.
-
-### Changed
-
-- **`/pull` and `/start` now read CHANGELOG entries** instead of
-  `.claude/announcements.md`. The "what's new" surface diff'd against the
-  user's `last_seen_version` (stored in `~/.config/vip/local.yaml`).
-  Behaviour is unchanged from the user's perspective: a banner appears
-  the first time they pull a release, gets dismissed when they engage,
-  and stops surfacing after the version is marked seen.
-- **`.github/workflows/publish-pypi.yml`** now extracts the matching
-  CHANGELOG section as the GitHub Release body. Pattern borrowed from
-  `companyctx`'s publish workflow.
-- **5 reference files** that previously inlined the vip-path resolver
-  (`.claude/skills/setup/references/cwd-detection.md`,
-  `.claude/skills/help/references/troubleshooting.md` (×2 occurrences),
-  `.claude/skills/pull/SKILL.md`,
-  `.claude/reference/pull-engine-updates.md`) now point at the canonical
-  `vip-path-resolution.md` reference. Resolver semantics are unchanged.
-
-### Removed
-
-- **`.claude/announcements.md`** — superseded by `CHANGELOG.md`. The
-  announcements format (per-skill `seen` tracking via slugs) is replaced
-  by per-version `last_seen_version` tracking, which compresses to a
-  single string in user config.
-
-## [0.1.0] - 2026-04-29 (Phase 2 RC)
-
-First Phase 2 release candidate. The engine is now a real Python package
+First public engine release. The engine is now a real Python package
 (`mainbranch` on PyPI, `mb` CLI) with a six-folder business-as-files
 taxonomy and a /site shape upgrade that adopts Chase Hughes' 9-archetype
-narrative framework as the brief layer. **The CLI surface is smoke-tested
-end-to-end; the skill bundle itself does NOT yet ship in the wheel — skills
-live in the `mb-vip` engine repo's `.claude/skills/` for v0.1.0 and are
-loaded via `additionalDirectories` from the consumer business repo. Wheel-time
-skill bundling is a v0.1.x follow-up.**
+narrative framework as the brief layer. The CLI surface is smoke-tested
+end-to-end, and the release wheel now bundles skills and playbooks as
+package data so `mb skill list` works without a source checkout.
 
 Locked under `decisions/2026-04-29-mb-vip-v0-1-0-master.md` (the engine
 master) and the matching noontide-projects business master at
@@ -133,7 +51,30 @@ If you're a Main Branch member, here's what changes in your day-to-day:
   know what changed.
 
 If you're an OSS contributor or you want the technical detail, the
-sections below cover what shipped in PRs #114 / #115 / #116 / #117.
+sections below cover what shipped in PRs #114 / #115 / #116 / #117 /
+#153 / #160 / #161.
+
+### Added — final public release prep (PRs #153 / #160 / #161)
+
+- **MIT LICENSE** at repo root for the public release.
+- **Public repo metadata and docs** moved to `noontide-co/mainbranch`.
+  README, beginner setup, package URLs, publish workflow comments, and
+  template docs now point at the new public repo path.
+- **PyPI trusted-publisher target** locked to
+  `owner=noontide-co, repo=mainbranch, workflow=publish-pypi.yml, env=pypi`.
+- **Wheel-time skill/playbook bundling.** `setup.py` copies
+  repo-root `.claude/skills/` and `.claude/playbooks/` into
+  `mb/_data/skills/` and `mb/_data/playbooks/` during sdist/wheel builds.
+  Source stays single-copy in `.claude/`; generated copies are not
+  committed.
+- **Wheel smoke now asserts a populated skill bundle.** CI checks for
+  `mb/_data/skills/start/SKILL.md`, `mb/_data/playbooks/ship-bet/SKILL.md`,
+  and verifies fresh wheel installs print `start` and `think` from
+  `mb skill list`.
+- **Public VSL example cleanup.** Real names, hard dollar claims, MRR
+  proof, and Ads Lab-specific proof claims were replaced with clearly
+  fictionalized composite examples and guidance to use only approved
+  testimonials.
 
 ### Added — V1 translation (PR #116)
 

--- a/mb/mb/__init__.py
+++ b/mb/mb/__init__.py
@@ -7,6 +7,6 @@ file stays a thin dispatcher.
 
 from __future__ import annotations
 
-__version__ = "0.1.0.dev0"
+__version__ = "0.1.0"
 
 __all__ = ["__version__"]

--- a/mb/pyproject.toml
+++ b/mb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mainbranch"
-version = "0.1.0.dev0"
+version = "0.1.0"
 description = "Main Branch engine umbrella - scaffolds, validates, and graphs business-as-files repos. Built for Claude Code."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## What changed

- Bumps the package version from `0.1.0.dev0` to `0.1.0` in `mb/pyproject.toml` and `mb/mb/__init__.py`.
- Converts the changelog from RC/dev wording into the real public `0.1.0` release notes.
- Records final public-release prep from #153, #160, and #161, including MIT licensing, repo move docs, PyPI trusted publisher path, bundled skills/playbooks, and public VSL example cleanup.
- Removes TestPyPI promotion wording from the PyPI publish workflow comment so the release path points directly at `oe-v0.1.0`.

## Why

We are skipping the TestPyPI dev smoke and cutting the real PyPI release. Main needs to carry the final `0.1.0` version and changelog before publishing the GitHub Release tag.

## Validation

- `python3 -m build`
- `python3 -m ruff format --check .`
- `python3 -m ruff check .`
- `python3 -m mypy mb`
- `pytest -q`
- `python3 -m zipfile -l dist/mainbranch-0.1.0-py3-none-any.whl` confirmed bundled `mb/_data/skills` and `mb/_data/playbooks`
- Fresh venv wheel install confirmed `mb --version` prints `mb 0.1.0` and `mb skill list` includes bundled skills