### PR TITLE
[docs] README refresh — anti-SaaS thesis + URL sweep + mb CLI surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ your-business/
 │   │   └── [offer-name]/
 │   │       ├── offer.md   <- Offer-specific transformation
 │   │       └── audience.md <- Offer-specific audience (optional)
-│   ├── brand/             <- Visual identity, positioning
+│   ├── visual-identity/   <- Image gen prompts, palette, type, paired imagery
 │   ├── proof/
 │   │   ├── testimonials.md <- Social proof
 │   │   └── angles/        <- Proven messaging angles
@@ -251,7 +251,7 @@ your-business/
 │       └── content-strategy.md <- Pillars, platforms, cadence
 ├── research/              <- Your investigations
 ├── decisions/             <- Your choices
-└── outputs/               <- All generated content (lifecycle via frontmatter status)
+└── campaigns/             <- All generated content (lifecycle via frontmatter status)
 ```
 
 You fill in the reference files. Claude reads them when generating.

--- a/README.md
+++ b/README.md
@@ -299,6 +299,9 @@ Devon updates the Main Branch repository with new skills and improvements.
 **In the Skool community:**
 Post in the Main Branch group. Tag @Devon for technical questions.
 
+**Not in the Skool community?**
+Open an issue at [github.com/noontide-co/mainbranch/issues](https://github.com/noontide-co/mainbranch/issues).
+
 **Common issues:**
 - "404 error" or "Repository not found" — Verify the URL and your network. The repo is public; no access request needed.
 - "Claude does not see my files" — Make sure you started Claude in your business repo folder and ran `/start`
@@ -332,7 +335,7 @@ You can, but you do not need to. The skills are designed to work out of the box.
 
 **What makes this different from ChatGPT?**
 
-ChatGPT forgets everything between sessions. Main Branch remembers because your business info lives in files that Claude reads every time.
+ChatGPT lives in Sam Altman's box. Main Branch lives in your filesystem. Your offer, audience, voice, research, and decisions are markdown in your own git repo — versioned, portable, not subject to a SaaS provider's TOS, retention policy, or downtime. The agent reads your files; the data sits with you.
 
 **I am stuck. What do I do?**
 
@@ -352,6 +355,8 @@ That file has:
 - Git commit conventions
 
 You do not need to read it to get started. But it is there when you want to go deeper.
+
+**Decision history:** the engine v0.1.0 master decision lives at [`decisions/2026-04-29-mb-vip-v0-1-0-master.md`](decisions/2026-04-29-mb-vip-v0-1-0-master.md). All shipping decisions are dated, versioned, and committed alongside the code that implements them.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Main Branch
 
-Open-source Claude Code skills and a small `mb` CLI for running business-as-files workflows.
+**Run your business as files in git. Stop renting it from someone else's dashboard.**
+
+Main Branch is the `mb` CLI plus a set of MIT-licensed Claude Code skills for running business-as-files workflows. Your offer, audience, voice, research, decisions, and campaigns live in a six-folder taxonomy in your own git repo — versioned, portable, agent-readable. Built for Claude Code first; cross-agent at v0.2+.
 
 
 ## Honest current state (v0.1)

--- a/README.md
+++ b/README.md
@@ -5,11 +5,28 @@
 Main Branch is the `mb` CLI plus a set of MIT-licensed Claude Code skills for running business-as-files workflows. Your offer, audience, voice, research, decisions, and campaigns live in a six-folder taxonomy in your own git repo — versioned, portable, agent-readable. Built for Claude Code first; cross-agent at v0.2+.
 
 
+## Install
+
+```bash
+pipx install mainbranch
+```
+
+That puts the `mb` CLI on your PATH. Run `mb --help` to see subcommands. (PyPI publish is the next launch step — until then, install in developer mode below.)
+
+For developer mode (cloning the engine repo to hack on skills):
+
+```bash
+git clone https://github.com/noontide-co/mainbranch.git
+```
+
+See [CHANGELOG.md](CHANGELOG.md) for what's in this release.
+
+---
+
 ## Honest current state (v0.1)
 
 - **Built for Claude Code.** Cross-platform skill support is a v0.2+ commitment.
 - **Schema is v1; will evolve.** Frontmatter shapes covered by `mb validate` are stable for v0.1.x; breaking changes bump the major.
-- **Install: `pipx install mainbranch`** (recommended, once published) or `git clone https://github.com/noontide-co/mainbranch` (developer mode).
 - **Cross-agent compatibility matrix lands at v0.2.** Codex, Cursor, Hermes, local LLMs are not first-class targets in v0.1.
 
 The engine v0.1.0 decision lives at [`decisions/2026-04-29-mb-vip-v0-1-0-master.md`](decisions/2026-04-29-mb-vip-v0-1-0-master.md).

--- a/README.md
+++ b/README.md
@@ -168,6 +168,26 @@ That is it. You are ready to generate.
 
 ---
 
+## The `mb` CLI
+
+The CLI surface for the engine. Built for Claude Code first; cross-agent at v0.2+. Most workflows still happen via slash-prompt skills inside Claude Code — the `mb` CLI is the scaffolder, validator, and grapher around them.
+
+| Command | What it does |
+|---|---|
+| `mb init` | Scaffold a fresh business repo (six-folder taxonomy, CLAUDE.md, git init). |
+| `mb doctor` | Check the environment — repo shape, frontmatter sanity, settings on disk. Walks you through fixes. |
+| `mb validate` | Frontmatter shape check across `core/`, `research/`, `decisions/`, `log/`, `campaigns/`, `documents/`. Pass/fail per file. |
+| `mb graph` | Walk the link graph (`linked_research` / `linked_decisions` / `supersedes`) and emit Graphviz DOT. `--open` renders to PNG and opens it. |
+| `mb think <topic>` | Print the `/think` invocation hint. Run inside Claude Code for the full flow. |
+| `mb resolve <key>` | Resolve a reference path through OSS / paid layered lookup. |
+| `mb educational <topic>` | Print an educational triage file (powers `mb doctor`'s "tell me more" prompts). |
+| `mb skill list` | List the skills bundled with this engine. |
+| `mb skill path <name>` | Print the on-disk path to a bundled skill. |
+
+For the full list: `mb --help`.
+
+---
+
 ## What Are Skills?
 
 Skills are pre-built workflows you invoke with slash prompts (for example, `/start`, `/ads`, `/think`).

--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ See [CHANGELOG.md](CHANGELOG.md) for what's in this release.
 
 ---
 
+## What's new
+
+See [CHANGELOG.md](CHANGELOG.md). Each release ships a "What this means for you" plain-English section above the technical detail — the relevant bits in 30 seconds.
+
+---
+
 ## Honest current state (v0.1)
 
 - **Built for Claude Code.** Cross-platform skill support is a v0.2+ commitment.


### PR DESCRIPTION
## Summary

Refresh the public-facing README on `noontide-co/mainbranch` to match the v0.1.0 reality post-transfer + post-Marco amendments. The README is the first thing strangers see now that the repo is public — it was drifting from the master decision's anti-SaaS thesis and didn't reflect the `mb` CLI as the product surface.

Lands as 6 concern-based commits per the refresh plan.

## Commits

1. `docs(readme): retitle + new anti-SaaS subhead` — Replaces the marketing subhead with the v0.1.0 master Thesis hook ("Run your business as files in git. Stop renting it from someone else's dashboard.") and adds a 1-paragraph elaboration naming the `mb` CLI, MIT licensing, six-folder taxonomy, and Claude-Code-first posture.
2. `docs(readme): add top-of-page Install section` — Promotes install instructions to a top-level `## Install` section. Leads with `pipx install mainbranch` (caveated as "PyPI publish is the next launch step" since the package isn't on PyPI yet) plus a developer-mode `git clone` fallback.
3. `docs(readme): URL + path sweep — outputs/ → campaigns/, brand/ → visual-identity/` — Updates folder-structure diagram to v0.1.0 reality. (Most `vip → mainbranch` URL/path scrubs already landed in #160 / #153.)
4. `docs(readme): add mb CLI quick-reference section` — New `## The mb CLI` section with a table of subcommands (`init`, `doctor`, `validate`, `graph`, `think`, `resolve`, `educational`, `skill list`, `skill path`). Subcommands verified against `mb/mb/cli.py`.
5. `docs(readme): add prominent What's New / CHANGELOG link` — New mini-section pointing at CHANGELOG.md and naming the "What this means for you" plain-English block each release ships.
6. `docs(readme): reframe ChatGPT comparison + community/help update` — Rewrites the ChatGPT FAQ answer against the anti-SaaS thesis, adds an OSS-visitor route to "Need Help?" (issues link), adds a "Decision history" pointer at the end of "Technical Details".

## Anchors

- Master decision (business): [`noontide-projects/decisions/2026-04-29-main-branch-v0-1-0-master.md`](https://github.com/noontide-co/projects) — Thesis, Marketing hook, Amendment §1 (CLI-first repackaging), §5 (Phase 2 launch shift).
- Master decision (engine): [`decisions/2026-04-29-mb-vip-v0-1-0-master.md`](https://github.com/noontide-co/mainbranch/blob/main/decisions/2026-04-29-mb-vip-v0-1-0-master.md).
- CHANGELOG: [`CHANGELOG.md`](https://github.com/noontide-co/mainbranch/blob/main/CHANGELOG.md) — `[0.1.0]` entry + ELI5 "What this means for you" block.

## Pre-push gates

Ran from `mb/`:

- `python3 -m ruff format --check .` — 20 files already formatted
- `python3 -m ruff check .` — All checks passed
- `python3 -m mypy mb` — Success: no issues found in 10 source files
- `python3 -m pytest -q --cov=mb --cov-fail-under=70` — 30 passed; coverage 70.70% (threshold 70% reached)

## Test plan

- [ ] Verify rendered README on github.com looks right (subhead bold, Install code block, mb CLI table)
- [ ] Confirm `pipx install mainbranch` caveat reads honestly (we will remove it once TestPyPI smoke ships)
- [ ] Confirm folder-structure diagram matches `mb init` output (campaigns/, visual-identity/)
- [ ] Spot-check no broken links to CHANGELOG.md and the master decision file

## Notes

- Draft PR. Mark ready for review once the rendered README has been eyeballed.
- Any "vip" word still appearing in the README is intentional historical context (the `mb-vip-v0-1-0-master.md` decision filename, the `.vip/` consumer-side config directory).