### PR TITLE
docs(readme): remove pre-publish install wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Main Branch is the `mb` CLI plus a set of MIT-licensed Claude Code skills for ru
 pipx install mainbranch
 ```
 
-That puts the `mb` CLI on your PATH. Run `mb --help` to see subcommands. (PyPI publish is the next launch step — until then, install in developer mode below.)
+That puts the `mb` CLI on your PATH. Run `mb --help` to see subcommands.
 
 For developer mode (cloning the engine repo to hack on skills):
 


### PR DESCRIPTION
## What changed

- Removes the stale `once published` qualifier from the README install line now that `mainbranch==0.1.0` is live on PyPI.

## Validation

- `rg -n "once published|next launch step|0\.1\.0\.dev|TestPyPI|dev0" README.md docs mb .github CHANGELOG.md` returns no matches.
- GitHub repo description set to: `Open-source Claude Code skills and the mb CLI for running business-as-files workflows.`