### PR TITLE
fix: complete pipx skill wiring for v0.1.1

### DIFF
--- a/.claude/educational/upgrading-mainbranch.md
+++ b/.claude/educational/upgrading-mainbranch.md
@@ -1,0 +1,33 @@
+---
+type: educational
+topic: upgrading-mainbranch
+status: stub
+last-updated: 2026-05-01
+---
+
+# How Main Branch updates work after pipx install
+
+If you installed Main Branch with `pipx install mainbranch`, your skills live
+inside the installed Python package. That is good for clean setup: there is no
+engine repo to clone, and `mb init` can link Claude Code directly to the
+packaged skills.
+
+It also means updates come through PyPI. When Devon ships a new version, run:
+
+```bash
+pipx upgrade mainbranch
+```
+
+Then re-link your business repo if needed:
+
+```bash
+mb skill link --repo /path/to/your-business
+```
+
+If you use the older clone-based setup, updates still come from Git:
+
+```bash
+git -C ~/Documents/GitHub/mb-vip pull origin main
+```
+
+`/pull` detects the install mode and chooses the right update path.

--- a/.claude/reference/pull-engine-updates.md
+++ b/.claude/reference/pull-engine-updates.md
@@ -1,13 +1,22 @@
 # Pull Engine Updates
 
-Canonical bash for pulling latest vip updates at the start of any skill invocation. CWD is the business repo — resolve vip path first. **Do NOT silently swallow failures.** Users on stale code get broken features.
+Canonical bash for pulling latest Main Branch updates at the start of any skill invocation. CWD is the business repo — resolve the engine path first. **Do NOT silently swallow failures.** Users on stale code get broken features.
 
 For the canonical resolver (bash + python3, settings.local.json first, ~/.config/vip/local.yaml fallback) see **[vip-path-resolution.md](vip-path-resolution.md)**. Run that snippet, then:
 
 ```bash
-# Pull if found and valid
-[ -n "$VIP_PATH" ] && [ -f "$VIP_PATH/.claude/skills/start/SKILL.md" ] && \
-  git -C "$VIP_PATH" pull origin main 2>&1
+if [ -n "$VIP_PATH" ] && [ -f "$VIP_PATH/.claude/skills/start/SKILL.md" ]; then
+  if git -C "$VIP_PATH" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    git -C "$VIP_PATH" pull origin main 2>&1
+  elif command -v pipx >/dev/null 2>&1 && pipx list --short 2>/dev/null | grep -q '^mainbranch '; then
+    pipx upgrade mainbranch 2>&1
+    mb skill link --repo "${REPO_PATH:-.}" 2>&1
+  else
+    echo "NO_UPDATE_MODE"
+  fi
+else
+  echo "NO_ENGINE_PATH"
+fi
 ```
 
 ## Handle the Result
@@ -15,8 +24,10 @@ For the canonical resolver (bash + python3, settings.local.json first, ~/.config
 | Result | What to say |
 |--------|-------------|
 | "Already up to date." | Say nothing |
+| "upgraded package mainbranch" / "upgraded shared libraries" | "Updated Main Branch and refreshed skill links." |
 | "Updating..." / files changed | "Pulled latest engine updates." |
-| VIP_PATH empty (not found) | "Couldn't find vip. Run `/setup` to configure, or check `~/.config/vip/local.yaml`." |
+| `NO_UPDATE_MODE` | "Main Branch is linked, but I couldn't tell how to update it. Try `pipx upgrade mainbranch` if you installed with pipx, or pull the engine repo in GitHub Desktop if you cloned it." |
+| `NO_ENGINE_PATH` / VIP_PATH empty | "Couldn't find Main Branch. Run `mb skill link --repo .`, then restart Claude." |
 | Any error (auth, network) | Show the warning below |
 
 ## If Pull Fails — Show This Warning
@@ -24,10 +35,9 @@ For the canonical resolver (bash + python3, settings.local.json first, ~/.config
 > "I wasn't able to pull the latest Main Branch updates. This means you may be running on an old version and missing new features.
 >
 > Common fixes:
-> 1. **GitHub Desktop not running?** Open it and make sure you're signed in
-> 2. **Subscription inactive?** Check your Main Branch access in Skool
+> 1. **Installed with pipx?** Run `pipx upgrade mainbranch`, then `mb skill link --repo .`
+> 2. **Using a cloned engine repo?** Open GitHub Desktop → select mainbranch → click 'Fetch origin'
 > 3. **Network issue?** Check your internet connection
-> 4. **Try manually:** Open GitHub Desktop → select vip → click 'Fetch origin'
 >
 > You can continue, but some features may not work as expected."
 
@@ -64,5 +74,5 @@ fi
 
 ### Why Both Repos
 
-- Engine (vip) → new skills, playbooks, compliance frameworks
+- Main Branch engine → new skills, playbooks, compliance frameworks
 - Business repo → your reference files, decisions, research

--- a/.claude/skills/pull/SKILL.md
+++ b/.claude/skills/pull/SKILL.md
@@ -1,28 +1,37 @@
 ---
 name: pull
-description: Quick pull latest vip updates from GitHub. Use when user wants to update vip without running /start, says "pull", "update", or "get latest", wants to see what changed, or after Devon announces features in Skool. Note that /start pulls automatically, so skip /pull if running /start next.
+description: Quick update Main Branch. Use when user wants to update the engine without running /start, says "pull", "update", or "get latest", wants to see what changed, or after Devon announces features in Skool. Note that /start updates automatically, so skip /pull if running /start next.
 ---
 
 # Pull
 
-Pull latest vip engine updates from GitHub.
+Update the Main Branch engine.
 
 ---
 
 ## What It Does
 
-Resolves the vip path and pulls updates there — NOT from the current working directory (which is your business repo).
+Resolves the Main Branch engine path and updates that install — NOT from the current working directory (which is your business repo). pipx installs upgrade the `mainbranch` package; clone-based installs run `git pull`.
 
 ### Step 1: Resolve VIP Path
 
 For the canonical bash + python3 resolver (settings.local.json first, ~/.config/vip/local.yaml fallback), see **[../../reference/vip-path-resolution.md](../../reference/vip-path-resolution.md)**.
 
-### Step 2: Pull VIP
+### Step 2: Update Main Branch
 
 ```bash
-# Pull if found and valid
-[ -n "$VIP_PATH" ] && [ -f "$VIP_PATH/.claude/skills/start/SKILL.md" ] && \
-  git -C "$VIP_PATH" pull origin main 2>&1
+if [ -n "$VIP_PATH" ] && [ -f "$VIP_PATH/.claude/skills/start/SKILL.md" ]; then
+  if git -C "$VIP_PATH" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    git -C "$VIP_PATH" pull origin main 2>&1
+  elif command -v pipx >/dev/null 2>&1 && pipx list --short 2>/dev/null | grep -q '^mainbranch '; then
+    pipx upgrade mainbranch 2>&1
+    mb skill link --repo "${REPO_PATH:-.}" 2>&1
+  else
+    echo "NO_UPDATE_MODE"
+  fi
+else
+  echo "NO_ENGINE_PATH"
+fi
 ```
 
 ### Step 3: Pull Business Repo (if it has a remote)
@@ -33,17 +42,17 @@ git pull origin main 2>&1
 
 ### Handling Results
 
-**VIP updated:** "Pulled latest engine updates." — then read the CHANGELOG and surface unread entries (see "What's New from CHANGELOG" below).
+**Main Branch updated:** "Updated Main Branch and refreshed skill links." — then read the CHANGELOG and surface unread entries (see "What's New from CHANGELOG" below).
 
-**VIP current:** "Engine already up to date." — still surface unread CHANGELOG entries (the user might not have run /start since vip last had a release land).
+**Main Branch current:** "Engine already up to date." — still surface unread CHANGELOG entries (the user might not have run /start since the last release landed).
 
-**VIP path not found:** "Couldn't find vip. Run `/setup` to configure your vip path, or check `~/.config/vip/local.yaml`."
+**Main Branch path not found:** "Couldn't find Main Branch. Run `mb skill link --repo .`, then restart Claude."
 
 **Business repo updated:** "Also pulled updates for [repo-name]."
 
 **Business repo current or local-only:** Say nothing.
 
-**Error:** "Couldn't pull: [error]. Try: Open GitHub Desktop → select vip → click 'Fetch origin'."
+**Error:** "Couldn't update: [error]. If you installed with pipx, try `pipx upgrade mainbranch`. If you cloned the engine repo, open GitHub Desktop → select mainbranch → click 'Fetch origin'."
 
 ---
 

--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -145,8 +145,8 @@ See **[references/context-gathering.md](references/context-gathering.md)** for:
 ```bash
 # Always create:
 mkdir -p .vip
-mkdir -p reference/core reference/brand reference/proof/angles reference/domain
-mkdir -p research decisions outputs
+mkdir -p reference/core reference/visual-identity reference/proof/angles reference/domain
+mkdir -p research decisions campaigns documents
 ```
 
 **Multi-offer only (if user has multiple offers from Step 2.5):**

--- a/.claude/skills/start/SKILL.md
+++ b/.claude/skills/start/SKILL.md
@@ -13,7 +13,7 @@ Single entry point for Main Branch. Detect user state, context level, experience
 
 ## CRITICAL: Repo Selection Rules
 
-**CWD-first wins.** If `reference/core/` exists in CWD, the user is already in their business repo — no selection needed. Just confirm: "Working in **[repo-name]**."
+**CWD-first wins.** If `reference/core/` or `core/` exists in CWD, the user is already in their business repo — no selection needed. Just confirm: "Working in **[repo-name]**."
 
 **Only ask which repo when CWD is NOT a business repo** (fallback to config). In that case, list ALL validated repos from `recent_repos`:
 
@@ -37,7 +37,7 @@ Single entry point for Main Branch. Detect user state, context level, experience
 **DO NOT skip this question when in fallback mode.** Users have multiple repos. The saved default is a suggestion, not automatic.
 
 **Exceptions (skip selection entirely):**
-- CWD has `reference/core/` — user chose their repo by cd'ing into it
+- CWD has `reference/core/` or `core/` — user chose their repo by cd'ing into it
 - User explicitly ran `/start [repo-name]` with a specific path
 
 **After user selects a repo:** If the selected repo is not the current `default_repo`, ask: "Want me to save [repo-name] as your default? (faster startup next time)" If yes, update `default_repo` in `~/.config/vip/local.yaml`.
@@ -60,7 +60,7 @@ Apply to: business repo selection, skill routing, any multiple choice.
 ├── Check context level ──────────────→ Fresh? Full load. Heavy? Warn user.
 │
 ├── Detect business repo ─────────────→ CWD-first detection (see Step 0)
-│   ├── CWD has reference/core/? ─────→ This IS the repo. Proceed.
+│   ├── CWD has reference/core/ or core/? → This IS the repo. Proceed.
 │   ├── CWD has .claude/skills/? ─────→ User is in vip (old workflow). Trigger migration.
 │   └── Neither? ────────────────────→ Check config, then ask user.
 │
@@ -127,7 +127,7 @@ The user starts Claude in their business repo. Check CWD first before falling ba
 **Quick gist:**
 
 ```
-1. test -d "reference/core"  → THIS IS the business repo. Skip to config.
+1. test -d "reference/core" || test -d "core"  → THIS IS the business repo. Skip to config.
 2. test -f ".claude/skills/start/SKILL.md"  → user is in vip; migrate.
 3. Otherwise → fall back to ~/.config/vip/local.yaml.
 ```

--- a/.claude/skills/start/references/auto-heal.md
+++ b/.claude/skills/start/references/auto-heal.md
@@ -32,6 +32,18 @@ REPO_PATH="$PWD"
 
 ## Step 1: Find vip path
 
+If the `mb` CLI exists, prefer the packaged repair path. It handles pipx
+installs and clone-based installs, writes `settings.local.json`, creates
+bridge links, and updates `.gitignore`:
+
+```bash
+if command -v mb >/dev/null 2>&1; then
+  mb skill link --repo "$REPO_PATH"
+fi
+```
+
+Then verify Step 3. If it passes, skip the manual symlink loop below.
+
 ```bash
 VIP_PATH=$(REPO_PATH="$REPO_PATH" python3 -c "
 import json, os
@@ -44,12 +56,12 @@ for d in dirs:
 echo "VIP_PATH=$VIP_PATH"
 ```
 
-If empty: `settings.local.json` is missing or doesn't point to vip. Tell the user to run `/setup` from vip, or manually create `REPO_PATH/.claude/settings.local.json`:
+If empty: `settings.local.json` is missing or doesn't point to Main Branch. Tell the user to run `mb skill link --repo "$REPO_PATH"` if the CLI is installed, or manually create `REPO_PATH/.claude/settings.local.json`:
 
 ```json
 {
   "permissions": {
-    "additionalDirectories": ["/absolute/path/to/vip"]
+    "additionalDirectories": ["/absolute/path/to/mainbranch"]
   }
 }
 ```
@@ -124,7 +136,7 @@ If HEAL_OK:
 > "I've set up the skill bridge links. **Please restart Claude** (Ctrl+C, then `claude`) — skills like `/start` will appear in the dropdown on next launch."
 
 If HEAL_FAILED:
-> "Auto-repair failed. Check that vip is cloned locally and the path in `.claude/settings.local.json` is correct."
+> "Auto-repair failed. If you installed with pipx, run `pipx upgrade mainbranch` and `mb skill link --repo .`. If you cloned the engine, check that the path in `.claude/settings.local.json` is correct."
 
 ---
 

--- a/.claude/skills/start/references/repo-detection.md
+++ b/.claude/skills/start/references/repo-detection.md
@@ -8,7 +8,7 @@ CWD-first detection of the business repo, with config fallback. The user starts 
 
 ```
 1. Check CWD for business repo fingerprint:
-   test -d "reference/core"
+   test -d "reference/core" || test -d "core"
    ├── YES → This IS the business repo. Use CWD. Skip to config loading.
    └── NO → Continue to step 2.
 
@@ -55,7 +55,7 @@ Once business repo is identified (from CWD or config), load settings:
 
 If CWD detection fails (step 3 above), present options from config:
 
-**Validate EVERY path in config before showing it to the user.** Never present a dead path as an option. For each path in `default_repo` and `recent_repos`, check `test -d "[path]/reference/core"`. If invalid, attempt recovery (check sibling folders for a renamed repo) and auto-prune dead entries. See [config-system.md](config-system.md) for the full recovery algorithm.
+**Validate EVERY path in config before showing it to the user.** Never present a dead path as an option. For each path in `default_repo` and `recent_repos`, check `test -d "[path]/reference/core" || test -d "[path]/core"`. If invalid, attempt recovery (check sibling folders for a renamed repo) and auto-prune dead entries. See [config-system.md](config-system.md) for the full recovery algorithm.
 
 **ALWAYS present numbered options** — even with ONE repo found:
 
@@ -76,14 +76,14 @@ If CWD detection fails (step 3 above), present options from config:
 
 Use fallbacks in order:
 
-1. **Scan additionalDirectories** for paths containing `reference/core/`
+1. **Scan additionalDirectories** for paths containing `reference/core/` or `core/`
 2. **Use bash to find repos** (if step 1 fails)
    ```bash
-   find ~/Documents/GitHub -maxdepth 3 -type d -name "reference" -exec test -d "{}/core" \; -print 2>/dev/null
+   find ~/Documents/GitHub -maxdepth 3 -type d \( -name "reference" -o -name "core" \) -print 2>/dev/null
    ```
 3. **Ask the user** (if nothing found)
 
-**Verify with Read, not Glob:** Use `Read` on `[path]/reference/core/soul.md` to confirm it's a business repo. `soul.md` is always in `core/` (even multi-offer repos).
+**Verify with Read, not Glob:** Use `Read` on `[path]/reference/core/soul.md` or `[path]/core/soul.md` to confirm it's a business repo. `soul.md` is always in `core/` (even multi-offer repos).
 
 **Skip vip** — any path containing `.claude/skills/start/SKILL.md` is the engine, not a business repo.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,9 +80,9 @@ jobs:
     # vary across 3.10/3.11/3.12 enough to justify matrixing. We pick 3.12
     # (latest supported target). Pattern borrowed from companyctx.
     #
-    # Release wheels must carry the bundled skills/playbooks as package
-    # data. The source tree keeps a single authoritative copy under
-    # .claude/; setup.py copies that data into mb/_data/ at build time.
+    # Release wheels must carry the bundled engine root as package data.
+    # The source tree keeps a single authoritative copy under .claude/;
+    # setup.py copies that data into mb/_engine/.claude/ at build time.
     name: wheel-install-smoke
     runs-on: ubuntu-latest
     defaults:
@@ -115,10 +115,12 @@ jobs:
           python -m zipfile -l "$wheel"
           python -m zipfile -l "$wheel" | grep -E '(^|/)mb/py\.typed([[:space:]]|$)' \
             || { echo "::error::py.typed missing from wheel"; exit 1; }
-          python -m zipfile -l "$wheel" | grep -E '(^|/)mb/_data/skills/start/SKILL\.md([[:space:]]|$)' \
+          python -m zipfile -l "$wheel" | grep -E '(^|/)mb/_engine/\.claude/skills/start/SKILL\.md([[:space:]]|$)' \
             || { echo "::error::bundled skills missing from wheel"; exit 1; }
-          python -m zipfile -l "$wheel" | grep -E '(^|/)mb/_data/playbooks/ship-bet/SKILL\.md([[:space:]]|$)' \
+          python -m zipfile -l "$wheel" | grep -E '(^|/)mb/_engine/\.claude/playbooks/ship-bet/SKILL\.md([[:space:]]|$)' \
             || { echo "::error::bundled playbooks missing from wheel"; exit 1; }
+          python -m zipfile -l "$wheel" | grep -E '(^|/)mb/_engine/\.claude/reference/vip-path-resolution\.md([[:space:]]|$)' \
+            || { echo "::error::bundled reference files missing from wheel"; exit 1; }
 
       - name: Create fresh venv and install the wheel
         # Fresh venv means no repo sources on sys.path — a genuine
@@ -174,6 +176,25 @@ jobs:
             || { echo "::error::mb skill list missing bundled start skill"; exit 1; }
           grep -qx "think" skills.txt \
             || { echo "::error::mb skill list missing bundled think skill"; exit 1; }
+
+      - name: Smoke — mb init wires Claude Code skills
+        run: |
+          repo=$(mktemp -d)
+          .venv-smoke/bin/mb init "$repo" --name "Acme Brewing"
+          test -f "$repo/.claude/settings.local.json" \
+            || { echo "::error::settings.local.json missing"; exit 1; }
+          test -f "$repo/.claude/skills/start/SKILL.md" \
+            || { echo "::error::start skill bridge missing"; exit 1; }
+          .venv-smoke/bin/python - "$repo" <<'PY'
+          import json, pathlib, sys
+          repo = pathlib.Path(sys.argv[1])
+          settings = json.loads((repo / ".claude/settings.local.json").read_text())
+          dirs = settings["permissions"]["additionalDirectories"]
+          assert dirs, "additionalDirectories empty"
+          root = pathlib.Path(dirs[0])
+          assert (root / ".claude/skills/start/SKILL.md").is_file(), root
+          assert (root / ".claude/reference/vip-path-resolution.md").is_file(), root
+          PY
 
       - name: Smoke — mb doctor (runs against empty cwd)
         # A second user-facing CLI surface that doesn't depend on bundled

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -8,7 +8,7 @@ name: publish-pypi
 # OIDC claim must match the pending publisher:
 #   owner=noontide-co, repo=mainbranch, workflow=publish-pypi.yml, env=pypi.
 #
-# Publish release: tag `oe-v0.1.0` and use the Releases UI.
+# Publish release: tag `oe-vMAJOR.MINOR.PATCH` and use the Releases UI.
 #
 # Release notes: the `extract-changelog` job parses CHANGELOG.md for the
 # section matching the release tag and updates the GitHub Release body

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,56 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 No unreleased changes yet.
 
+## [0.1.1] - 2026-05-01
+
+v0.1.1 makes the public `pipx install mainbranch` path work end-to-end
+for Claude Code users. v0.1.0 published the package and bundled skills;
+this patch wires those bundled skills into new business repos so `/start`,
+`/think`, `/ads`, and the rest are discoverable without cloning the
+engine repo.
+
+### What this means for you (plain English)
+
+- **New members can use the simple install path.** Run
+  `pipx install mainbranch`, then `mb init`, then start Claude in the new
+  business repo and run `/start`.
+- **Existing clone-based members are not broken.** If your business repos
+  already link to a local Main Branch checkout, that flow still works.
+- **Updates now match your install type.** pipx users upgrade with
+  `pipx upgrade mainbranch`; clone users still pull the engine repo.
+  `/pull` now explains and runs the right path.
+- **`mb doctor` catches broken skill wiring.** If `/start` is not
+  discoverable, it tells you to run `mb skill link --repo .`.
+
+### Fixed
+
+- **`mb init` now writes Claude Code wiring.** It creates
+  `.claude/settings.local.json`, points `additionalDirectories` at the
+  active Main Branch engine root, and creates per-skill bridge links under
+  `.claude/skills/`.
+- **Wheel layout now preserves the full engine shape.** Build artifacts
+  copy repo-root `.claude/` into `mb/_engine/.claude/`, including
+  `skills/`, `playbooks/`, `reference/`, `lenses/`, `educational/`, and
+  `scripts/`. Relative skill links such as `../../reference/...` now work
+  from an installed wheel.
+- **`mb skill list` and `mb skill path` use the active engine root.** They
+  work against the packaged wheel layout and the source checkout layout.
+- **`/pull` is install-mode aware.** Clone-based installs still run
+  `git pull`; pipx installs run `pipx upgrade mainbranch` and refresh
+  skill links with `mb skill link --repo .`.
+- **Bridge links are gitignored.** `mb init` and `mb skill link` add
+  machine-local `.claude/settings.local.json` plus per-skill bridge links
+  to `.gitignore`.
+
+### Added
+
+- **`mb skill link --repo <path>`** to repair or refresh Claude Code skill
+  discovery for an existing business repo.
+- **`mb educational upgrading-mainbranch`** with the short explanation for
+  pipx upgrades and clone-based updates.
+- **Release-path wheel smoke coverage** for the installed engine root,
+  reference files, `mb init` settings, and bridge-link discovery.
+
 ## [0.1.0] - 2026-05-01
 
 First public engine release. The engine is now a real Python package

--- a/mb/README.md
+++ b/mb/README.md
@@ -4,7 +4,7 @@ Engine umbrella for [Main Branch](https://github.com/noontide-co/mainbranch) —
 
 This package is the Python entry point. Skills, playbooks, educational content, and consumer-repo templates ship as bundled package data. The actual day-to-day "do work" surfaces are Claude Code skills (markdown), invoked from inside Claude Code.
 
-The source tree keeps skills and playbooks in one place: repo-root `.claude/skills/` and `.claude/playbooks/`. During sdist/wheel builds, `setup.py` copies those directories into `mb/_data/skills/` and `mb/_data/playbooks/` inside the build artifact so installed wheels can resolve `mb skill list` without a source checkout.
+The source tree keeps the engine payload in one place: repo-root `.claude/`. During sdist/wheel builds, `setup.py` copies that tree into `mb/_engine/.claude/` inside the build artifact so installed wheels can resolve skills, playbooks, reference files, lenses, and educational prompts without a source checkout.
 
 ## Install
 
@@ -22,13 +22,14 @@ mb --version
 
 | Command | What it does |
 |---|---|
-| `mb init` | Scaffold a new business repo (six folders, CLAUDE.md, CODEOWNERS, `git init`). One question only: business name. |
-| `mb doctor` | Diagnostic. Checks Claude Code, gh auth, network, librsvg. Warns on cloud-backed finance paths and offers educational triage. |
+| `mb init` | Scaffold a new business repo (six folders, CLAUDE.md, CODEOWNERS, `git init`) and wire bundled skills for Claude Code. One question only: business name. |
+| `mb doctor` | Diagnostic. Checks Claude Code, gh auth, network, librsvg, skill wiring, and package freshness. Warns on cloud-backed finance paths and offers educational triage. |
 | `mb validate` | Frontmatter shape check across `decisions/`, `core/offers/`, `research/`, `log/`, `campaigns/`, `documents/`. Exit 1 on any fail. |
 | `mb graph` | Walk linked_research / linked_decisions / supersedes; emit Graphviz DOT to stdout. `--open` shells to `dot` + `open`. |
 | `mb think <topic>` | Print the /think skill invocation hint for Claude Code (or run inside a session). |
 | `mb resolve <key>` | Resolve a reference path through the OSS / paid layered lookup. |
 | `mb skill path <name>` | Print the on-disk path to a bundled skill. |
+| `mb skill link --repo <path>` | Wire or repair Claude Code skill discovery for a business repo. |
 | `mb educational <topic>` | Print an educational triage file. Powers `mb doctor`'s "tell me more" prompts. |
 
 ## Status

--- a/mb/mb/__init__.py
+++ b/mb/mb/__init__.py
@@ -7,6 +7,6 @@ file stays a thin dispatcher.
 
 from __future__ import annotations
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 __all__ = ["__version__"]

--- a/mb/mb/_data/templates/CLAUDE.md.tmpl
+++ b/mb/mb/_data/templates/CLAUDE.md.tmpl
@@ -13,6 +13,8 @@ files are the memory; agents read what's here and write back.
 - `log/` — running activity log
 - `campaigns/` — paid + organic campaign artifacts
 - `documents/` — anything that doesn't belong above
+- `reference/` — compatibility paths for Claude Code skills
+  (`reference/core` points at `core/`)
 
 ## Conventions
 

--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -184,6 +184,34 @@ def skill_list_cmd() -> None:
         typer.echo(s)
 
 
+@skill_app.command("link")
+def skill_link_cmd(
+    repo: str = typer.Option(".", "--repo", help="Business repo to wire for Claude Code."),
+    json_out: bool = typer.Option(False, "--json", help="Machine-readable output."),
+) -> None:
+    """Wire bundled skills into a business repo for Claude Code discovery."""
+    from mb.engine import link_skills
+
+    result = link_skills(repo)
+    if json_out:
+        typer.echo(json.dumps(result, indent=2))
+    else:
+        if result["ok"]:
+            typer.echo(f"linked Main Branch engine: {result['engine_root']}")
+            typer.echo(f"repo: {result['repo']}")
+            if result["linked"]:
+                typer.echo(f"skills linked: {len(result['linked'])}")
+            if result["copied"]:
+                typer.echo(f"skills copied: {len(result['copied'])}")
+            if result["skipped"]:
+                typer.echo(f"skills skipped: {len(result['skipped'])}")
+        else:
+            typer.echo("could not link Main Branch skills", err=True)
+            for error in result["errors"]:
+                typer.echo(f"- {error}", err=True)
+            raise typer.Exit(1)
+
+
 def _entry() -> None:
     """Defensive entrypoint used by ``python -m mb`` and tests."""
     try:

--- a/mb/mb/doctor.py
+++ b/mb/mb/doctor.py
@@ -13,8 +13,14 @@ import os
 import shutil
 import socket
 import subprocess
+import sys
+import urllib.error
+import urllib.request
 from pathlib import Path
 from typing import Any
+
+from mb import __version__
+from mb.engine import install_mode, link_status
 
 CLOUD_PREFIXES = (
     "Library/Mobile Documents",  # iCloud Drive
@@ -62,6 +68,66 @@ def _rsvg() -> tuple[bool, str]:
     if _which("rsvg-convert"):
         return True, "rsvg-convert on PATH"
     return False, "rsvg-convert missing (brew install librsvg)"
+
+
+def _version_key(version: str) -> tuple[int, ...]:
+    parts: list[int] = []
+    for piece in version.split("."):
+        digits = ""
+        for char in piece:
+            if not char.isdigit():
+                break
+            digits += char
+        parts.append(int(digits or "0"))
+    return tuple(parts)
+
+
+def _latest_pypi_version(timeout: float = 3.0) -> str:
+    with urllib.request.urlopen("https://pypi.org/pypi/mainbranch/json", timeout=timeout) as resp:
+        data = resp.read().decode("utf-8")
+    import json
+
+    parsed = json.loads(data)
+    version = parsed.get("info", {}).get("version", "")
+    return version if isinstance(version, str) else ""
+
+
+def _mainbranch_version_check() -> dict[str, Any]:
+    mode = install_mode()
+    if mode in {"clone", "source"}:
+        return {
+            "name": "mainbranch-version",
+            "ok": True,
+            "detail": f"{__version__} ({mode} mode)",
+            "severity": "info",
+        }
+
+    try:
+        latest = _latest_pypi_version()
+    except (OSError, TimeoutError, urllib.error.URLError):
+        return {
+            "name": "mainbranch-version",
+            "ok": True,
+            "detail": f"{__version__}; could not check PyPI for latest",
+            "severity": "info",
+        }
+
+    if latest and _version_key(latest) > _version_key(__version__):
+        return {
+            "name": "mainbranch-version",
+            "ok": False,
+            "detail": (
+                f"installed {__version__}, latest is {latest}. "
+                "Run `pipx upgrade mainbranch`; for context run "
+                "`mb educational upgrading-mainbranch`."
+            ),
+            "severity": "warn",
+        }
+    return {
+        "name": "mainbranch-version",
+        "ok": True,
+        "detail": f"{__version__} is current" if latest else __version__,
+    }
 
 
 def _detect_cloud_paths(repo: Path) -> list[str]:
@@ -121,6 +187,25 @@ def run(path: str) -> dict[str, Any]:
         }
     )
 
+    wiring = link_status(repo)
+    wiring_ok = bool(wiring["ok"])
+    checks.append(
+        {
+            "name": "skill-wiring",
+            "ok": wiring_ok,
+            "detail": (
+                f"start skill linked via {wiring['engine_root']}"
+                if wiring_ok
+                else "Claude Code skill links missing. Run `mb skill link --repo .`."
+            ),
+            "severity": "ok"
+            if wiring_ok
+            else ("warn" if not (repo / "CLAUDE.md").exists() else "error"),
+        }
+    )
+
+    checks.append(_mainbranch_version_check())
+
     cloud_hits = _detect_cloud_paths(repo)
     cloud_ok = not cloud_hits
     checks.append(
@@ -156,6 +241,7 @@ def run(path: str) -> dict[str, Any]:
         "ok": overall and not hard_fail,
         "checks": checks,
         "repo": str(repo),
+        "python": sys.version.split()[0],
     }
 
 

--- a/mb/mb/educational.py
+++ b/mb/mb/educational.py
@@ -1,8 +1,9 @@
 """``mb educational <topic>`` — load and print an educational triage file.
 
 Files live at ``.claude/educational/<topic>.md`` in the engine repo and
-are bundled as package data under ``mb/_data/educational/``. The doctor
-subcommand wires "tell me more" prompts to this loader.
+are bundled as package data under the synthetic ``mb/_engine/.claude/``
+root. Older wheels also carried copies under ``mb/_data/educational/``;
+that path remains a compatibility fallback.
 """
 
 from __future__ import annotations
@@ -11,20 +12,28 @@ import sys
 from importlib import resources
 from pathlib import Path
 
+from mb.engine import engine_root
+
 
 def _engine_path() -> Path | None:
-    """Return the engine-repo .claude/educational/ path if running from a checkout."""
-    here = Path(__file__).resolve()
-    for parent in (here.parent.parent.parent.parent, here.parent.parent.parent):
-        cand = parent / ".claude" / "educational"
-        if cand.exists():
+    """Return the active engine .claude/educational/ path."""
+    root = engine_root()
+    if root is not None:
+        cand = root / ".claude" / "educational"
+        if cand.is_dir():
             return cand
     return None
 
 
 def load(topic: str) -> str | None:
     """Return the markdown body for ``topic`` or None if not found."""
-    # Try bundled data first.
+    engine = _engine_path()
+    if engine is not None:
+        cand = engine / f"{topic}.md"
+        if cand.exists():
+            return cand.read_text(encoding="utf-8")
+
+    # Compatibility fallback for v0.1.0 package data.
     try:
         ref = (
             resources.files("mb").joinpath("_data").joinpath("educational").joinpath(f"{topic}.md")
@@ -32,11 +41,6 @@ def load(topic: str) -> str | None:
         return ref.read_text(encoding="utf-8")
     except (FileNotFoundError, ModuleNotFoundError, AttributeError):
         pass
-    engine = _engine_path()
-    if engine is not None:
-        cand = engine / f"{topic}.md"
-        if cand.exists():
-            return cand.read_text(encoding="utf-8")
     return None
 
 
@@ -46,7 +50,8 @@ def run(topic: str) -> None:
     if body is None:
         print(
             f"educational topic not found: {topic}\n"
-            "Try one of: anti-cloud-backup, cloudflare-vs-vercel, github-vs-gdocs",
+            "Try one of: anti-cloud-backup, cloudflare-vs-vercel, "
+            "github-vs-gdocs, upgrading-mainbranch",
             file=sys.stderr,
         )
         sys.exit(1)

--- a/mb/mb/engine.py
+++ b/mb/mb/engine.py
@@ -1,0 +1,266 @@
+"""Locate and link the bundled Main Branch engine payload.
+
+The public wheel carries a synthetic engine root at ``mb/_engine`` whose
+shape mirrors the source checkout enough for Claude Code skills:
+
+```
+mb/_engine/.claude/skills/...
+mb/_engine/.claude/reference/...
+mb/_engine/.claude/lenses/...
+```
+
+Source checkouts use the repository root directly. Keeping both install
+modes behind this module lets ``mb init`` and ``mb skill link`` wire the
+same Claude Code discovery surface for pipx users and clone-based users.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+from importlib import resources
+from pathlib import Path
+from typing import Any
+
+ENGINE_MARKER = Path(".claude") / "skills" / "start" / "SKILL.md"
+GITIGNORE_HEADER = "# Main Branch local Claude wiring"
+
+
+def _is_engine_root(path: Path) -> bool:
+    return (path / ENGINE_MARKER).is_file()
+
+
+def source_engine_root() -> Path | None:
+    """Return the repo root when running from a source checkout."""
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        if _is_engine_root(parent):
+            return parent
+    return None
+
+
+def packaged_engine_root() -> Path | None:
+    """Return the installed wheel's synthetic engine root, if present."""
+    try:
+        ref = resources.files("mb").joinpath("_engine")
+        root = Path(str(ref))
+        if _is_engine_root(root):
+            return root
+    except (FileNotFoundError, ModuleNotFoundError, AttributeError):
+        pass
+    return None
+
+
+def engine_root() -> Path | None:
+    """Return the best engine root for this install.
+
+    Prefer the packaged payload when it exists so pipx installs win over
+    stale clone paths. Source checkouts fall back to the repository root.
+    """
+    return packaged_engine_root() or source_engine_root()
+
+
+def skills_dir(root: Path | None = None) -> Path | None:
+    root = root or engine_root()
+    if root is None:
+        return None
+    candidate = root / ".claude" / "skills"
+    return candidate if candidate.is_dir() else None
+
+
+def bundled_skills() -> list[str]:
+    """Names of bundled skills, alphabetically."""
+    root = skills_dir()
+    if root is None:
+        return []
+    return sorted(d.name for d in root.iterdir() if d.is_dir())
+
+
+def skill_path(name: str) -> Path | None:
+    """Return on-disk path to a bundled skill's directory."""
+    root = skills_dir()
+    if root is None:
+        return None
+    candidate = root / name
+    return candidate if candidate.is_dir() else None
+
+
+def _read_settings(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _write_settings(repo: Path, root: Path) -> bool:
+    settings_path = repo / ".claude" / "settings.local.json"
+    data = _read_settings(settings_path)
+    permissions = data.setdefault("permissions", {})
+    if not isinstance(permissions, dict):
+        permissions = {}
+        data["permissions"] = permissions
+
+    existing = permissions.get("additionalDirectories", [])
+    if not isinstance(existing, list):
+        existing = []
+
+    root_str = str(root)
+    cleaned = [str(p) for p in existing if isinstance(p, str) and p != root_str]
+    permissions["additionalDirectories"] = [root_str, *cleaned]
+
+    rendered = json.dumps(data, indent=2, sort_keys=True) + "\n"
+    changed = not settings_path.exists() or settings_path.read_text(encoding="utf-8") != rendered
+    if changed:
+        settings_path.parent.mkdir(parents=True, exist_ok=True)
+        settings_path.write_text(rendered, encoding="utf-8")
+    return changed
+
+
+def _append_unique_gitignore(repo: Path, entries: list[str]) -> bool:
+    gitignore = repo / ".gitignore"
+    existing_text = gitignore.read_text(encoding="utf-8") if gitignore.exists() else ""
+    existing_lines = set(existing_text.splitlines())
+
+    to_add = [entry for entry in entries if entry not in existing_lines]
+    if not to_add:
+        return False
+
+    prefix = "" if not existing_text or existing_text.endswith("\n") else "\n"
+    block = [GITIGNORE_HEADER, *to_add]
+    if GITIGNORE_HEADER in existing_lines:
+        block = to_add
+    gitignore.write_text(existing_text + prefix + "\n".join(block) + "\n", encoding="utf-8")
+    return True
+
+
+def _link_or_copy(source: Path, dest: Path) -> str:
+    if dest.is_symlink():
+        try:
+            if dest.resolve(strict=True) == source.resolve(strict=True):
+                return "unchanged"
+        except FileNotFoundError:
+            pass
+        dest.unlink()
+    elif dest.exists():
+        return "skipped"
+
+    try:
+        dest.symlink_to(source, target_is_directory=True)
+        return "linked"
+    except OSError:
+        shutil.copytree(
+            source,
+            dest,
+            ignore=shutil.ignore_patterns("__pycache__", ".DS_Store"),
+        )
+        return "copied"
+
+
+def link_skills(repo: str | Path) -> dict[str, Any]:
+    """Wire bundled skills into a business repo for Claude Code discovery."""
+    target = Path(repo).resolve()
+    target.mkdir(parents=True, exist_ok=True)
+
+    root = engine_root()
+    if root is None:
+        return {
+            "ok": False,
+            "repo": str(target),
+            "engine_root": None,
+            "created": [],
+            "linked": [],
+            "copied": [],
+            "skipped": [],
+            "errors": ["could not locate bundled Main Branch engine root"],
+        }
+
+    claude_dir = target / ".claude"
+    skill_link_dir = claude_dir / "skills"
+    skill_link_dir.mkdir(parents=True, exist_ok=True)
+
+    created: list[str] = []
+    if _write_settings(target, root):
+        created.append(".claude/settings.local.json")
+
+    linked: list[str] = []
+    copied: list[str] = []
+    skipped: list[str] = []
+
+    for name in bundled_skills():
+        source = root / ".claude" / "skills" / name
+        dest = skill_link_dir / name
+        mode = _link_or_copy(source, dest)
+        rel = f".claude/skills/{name}"
+        if mode == "linked":
+            linked.append(rel)
+            created.append(rel)
+        elif mode == "copied":
+            copied.append(rel)
+            created.append(rel)
+        elif mode == "skipped":
+            skipped.append(rel)
+
+    gitignore_entries = [
+        ".claude/settings.local.json",
+        *[f".claude/skills/{name}" for name in bundled_skills()],
+    ]
+    if _append_unique_gitignore(target, gitignore_entries):
+        created.append(".gitignore")
+
+    return {
+        "ok": True,
+        "repo": str(target),
+        "engine_root": str(root),
+        "created": created,
+        "linked": linked,
+        "copied": copied,
+        "skipped": skipped,
+        "errors": [],
+    }
+
+
+def link_status(repo: str | Path) -> dict[str, Any]:
+    """Return whether ``repo`` can discover Main Branch skills."""
+    target = Path(repo).resolve()
+    root = engine_root()
+    settings_path = target / ".claude" / "settings.local.json"
+    settings = _read_settings(settings_path)
+    dirs = settings.get("permissions", {}).get("additionalDirectories", [])
+    if not isinstance(dirs, list):
+        dirs = []
+
+    root_str = str(root) if root is not None else ""
+    settings_has_engine = bool(root_str and root_str in dirs)
+    start_link = target / ".claude" / "skills" / "start"
+    start_skill = start_link / "SKILL.md"
+    start_link_ok = start_skill.is_file()
+
+    return {
+        "ok": settings_has_engine and start_link_ok,
+        "repo": str(target),
+        "engine_root": root_str or None,
+        "settings_path": str(settings_path),
+        "settings_has_engine": settings_has_engine,
+        "start_link_ok": start_link_ok,
+        "start_link": str(start_link),
+    }
+
+
+def install_mode() -> str:
+    """Best-effort install mode label for diagnostics and skill prose."""
+    root = engine_root()
+    if root is None:
+        return "unknown"
+    if packaged_engine_root() is not None:
+        prefix = Path(os.environ.get("PIPX_HOME", "")).expanduser()
+        root_text = str(root)
+        if "pipx" in root_text or (str(prefix) and str(prefix) in root_text):
+            return "pipx"
+        return "wheel"
+    if (root / ".git").exists():
+        return "clone"
+    return "source"

--- a/mb/mb/init.py
+++ b/mb/mb/init.py
@@ -14,6 +14,8 @@ from importlib import resources
 from pathlib import Path
 from typing import Any
 
+from mb.engine import link_skills
+
 # The canonical six. v0.1 lock; v0.2 unlocks via .vip/config.yaml paths block.
 DATA_FOLDERS = [
     "core",
@@ -39,6 +41,13 @@ __pycache__/
 node_modules/
 .venv/
 """
+
+
+REFERENCE_DIRS = [
+    "reference/proof/angles",
+    "reference/domain",
+    "reference/visual-identity",
+]
 
 
 def _gh_username() -> str:
@@ -77,6 +86,19 @@ def _render(text: str, mapping: dict[str, str]) -> str:
     return out
 
 
+def _link_or_mkdir(source: Path, dest: Path) -> str:
+    if dest.exists() or dest.is_symlink():
+        return "exists"
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        rel_source = os.path.relpath(source, start=dest.parent)
+        dest.symlink_to(rel_source, target_is_directory=True)
+        return "symlink"
+    except OSError:
+        dest.mkdir(parents=True, exist_ok=True)
+        return "directory"
+
+
 def run(path: str, name: str) -> dict[str, Any]:
     """Scaffold ``path`` as a Main Branch consumer repo.
 
@@ -87,10 +109,12 @@ def run(path: str, name: str) -> dict[str, Any]:
     target.mkdir(parents=True, exist_ok=True)
 
     if (target / "CLAUDE.md").exists():
+        link_result = link_skills(target)
         return {
             "status": "already-initialized",
             "path": str(target),
-            "created": [],
+            "created": link_result["created"],
+            "skill_link": link_result,
         }
 
     business_name = name.strip() or os.environ.get("MB_BUSINESS_NAME", "").strip()
@@ -111,8 +135,23 @@ def run(path: str, name: str) -> dict[str, Any]:
         # .gitkeep so empty folders survive git
         keep = d / ".gitkeep"
         if not keep.exists():
-            keep.write_text("")
+            keep.write_text("", encoding="utf-8")
             created.append(f"{sub}/.gitkeep")
+
+    for sub in REFERENCE_DIRS:
+        d = target / sub
+        d.mkdir(parents=True, exist_ok=True)
+        keep = d / ".gitkeep"
+        if not keep.exists():
+            keep.write_text("", encoding="utf-8")
+            created.append(f"{sub}/.gitkeep")
+
+    # Current Claude Code skills read reference/core and reference/offers.
+    # Keep those paths as compatibility bridges to the CLI's root core tree.
+    for source_name, dest_name in (("core", "reference/core"), ("core/offers", "reference/offers")):
+        mode = _link_or_mkdir(target / source_name, target / dest_name)
+        if mode != "exists":
+            created.append(dest_name + ("/" if mode == "directory" else ""))
 
     mapping = {
         "BUSINESS_NAME": business_name,
@@ -120,18 +159,21 @@ def run(path: str, name: str) -> dict[str, Any]:
     }
 
     claude_tmpl = _read_template("CLAUDE.md.tmpl") or _DEFAULT_CLAUDE
-    (target / "CLAUDE.md").write_text(_render(claude_tmpl, mapping))
+    (target / "CLAUDE.md").write_text(_render(claude_tmpl, mapping), encoding="utf-8")
     created.append("CLAUDE.md")
 
     codeowners_tmpl = _read_template("CODEOWNERS.tmpl") or f"* @{gh_user}\n"
     github_dir = target / ".github"
     github_dir.mkdir(exist_ok=True)
-    (github_dir / "CODEOWNERS").write_text(_render(codeowners_tmpl, mapping))
+    (github_dir / "CODEOWNERS").write_text(_render(codeowners_tmpl, mapping), encoding="utf-8")
     created.append(".github/CODEOWNERS")
 
     gitignore_tmpl = _read_template(".gitignore.tmpl") or DEFAULT_GITIGNORE
-    (target / ".gitignore").write_text(_render(gitignore_tmpl, mapping))
+    (target / ".gitignore").write_text(_render(gitignore_tmpl, mapping), encoding="utf-8")
     created.append(".gitignore")
+
+    link_result = link_skills(target)
+    created.extend(path for path in link_result["created"] if path not in created)
 
     if shutil.which("git") and not (target / ".git").exists():
         try:
@@ -151,6 +193,7 @@ def run(path: str, name: str) -> dict[str, Any]:
         "path": str(target),
         "created": created,
         "business_name": business_name,
+        "skill_link": link_result,
     }
 
 
@@ -171,6 +214,8 @@ This is a Main Branch consumer repo. Your business is a tree of files.
 - `log/` — running activity log
 - `campaigns/` — paid + organic campaign artifacts
 - `documents/` — anything that doesn't belong above
+- `reference/` — compatibility paths for Claude Code skills
+  (`reference/core` points at `core/`)
 
 ## Conventions
 

--- a/mb/mb/resolve.py
+++ b/mb/mb/resolve.py
@@ -22,6 +22,9 @@ from typing import Any
 
 import yaml
 
+from mb.engine import bundled_skills as _bundled_skills
+from mb.engine import skill_path as _skill_path
+
 CANONICAL_PATHS = {
     "core": "core",
     "research": "research",
@@ -94,38 +97,9 @@ def run(key: str, repo: str = ".") -> dict[str, Any]:
 
 def skill_path(name: str) -> Path | None:
     """Return on-disk path to a bundled skill's directory."""
-    try:
-        ref = resources.files("mb").joinpath("_data").joinpath("skills").joinpath(name)
-        if ref.is_dir():
-            return Path(str(ref))
-    except (FileNotFoundError, ModuleNotFoundError, AttributeError):
-        pass
-    # Source-checkout fallback to the engine repo's .claude/skills/<name>/.
-    here = Path(__file__).resolve()
-    for parent in (here.parent.parent.parent.parent, here.parent.parent.parent):
-        cand = parent / ".claude" / "skills" / name
-        if cand.exists():
-            return cand
-    return None
+    return _skill_path(name)
 
 
 def bundled_skills() -> list[str]:
     """Names of bundled skills (alphabetical)."""
-    out: list[str] = []
-    try:
-        ref = resources.files("mb").joinpath("_data").joinpath("skills")
-        if ref.is_dir():
-            for child in ref.iterdir():
-                if child.is_dir():
-                    out.append(child.name)
-    except (FileNotFoundError, ModuleNotFoundError, AttributeError):
-        pass
-    if not out:
-        # Source-checkout fallback
-        here = Path(__file__).resolve()
-        for parent in (here.parent.parent.parent.parent, here.parent.parent.parent):
-            cand = parent / ".claude" / "skills"
-            if cand.exists():
-                out = [d.name for d in cand.iterdir() if d.is_dir()]
-                break
-    return sorted(out)
+    return _bundled_skills()

--- a/mb/pyproject.toml
+++ b/mb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mainbranch"
-version = "0.1.0"
+version = "0.1.1"
 description = "Main Branch engine umbrella - scaffolds, validates, and graphs business-as-files repos. Built for Claude Code."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -64,7 +64,7 @@ include = ["mb*"]
 exclude = ["tests*"]
 
 [tool.setuptools.package-data]
-mb = ["_data/**/*", "py.typed"]
+mb = ["_data/**/*", "_engine/**/*", "_engine/.claude/**/*", "py.typed"]
 
 [tool.ruff]
 line-length = 100

--- a/mb/setup.py
+++ b/mb/setup.py
@@ -10,18 +10,23 @@ from setuptools.command.sdist import sdist as _sdist
 PROJECT_ROOT = Path(__file__).resolve().parent
 REPO_ROOT = PROJECT_ROOT.parent
 
-GENERATED_DATA = {
-    "skills": REPO_ROOT / ".claude" / "skills",
-    "playbooks": REPO_ROOT / ".claude" / "playbooks",
-}
+ENGINE_SUBDIRS = (
+    "educational",
+    "lenses",
+    "playbooks",
+    "reference",
+    "scripts",
+    "skills",
+)
 
 
 def _copy_generated_data(target_root: Path) -> None:
-    data_root = target_root / "mb" / "_data"
-    for name, source in GENERATED_DATA.items():
+    engine_claude = target_root / "mb" / "_engine" / ".claude"
+    for name in ENGINE_SUBDIRS:
+        source = REPO_ROOT / ".claude" / name
         if not source.exists():
             continue
-        target = data_root / name
+        target = engine_claude / name
         if target.exists():
             shutil.rmtree(target)
         shutil.copytree(

--- a/mb/tests/test_cli.py
+++ b/mb/tests/test_cli.py
@@ -26,3 +26,12 @@ def test_skill_list_runs() -> None:
     result = runner.invoke(app, ["skill", "list"])
     assert result.exit_code == 0
     assert "start" in result.stdout.splitlines()
+
+
+def test_skill_link_wires_repo(tmp_path) -> None:
+    repo = tmp_path / "biz"
+    repo.mkdir()
+    result = runner.invoke(app, ["skill", "link", "--repo", str(repo), "--json"])
+    assert result.exit_code == 0
+    assert (repo / ".claude" / "settings.local.json").exists()
+    assert (repo / ".claude" / "skills" / "start" / "SKILL.md").exists()

--- a/mb/tests/test_doctor.py
+++ b/mb/tests/test_doctor.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from mb.doctor import _detect_cloud_paths, run
+from mb.init import run as init_run
 
 
 def test_doctor_runs_on_empty_dir(tmp_path: Path) -> None:
@@ -12,6 +13,8 @@ def test_doctor_runs_on_empty_dir(tmp_path: Path) -> None:
     assert "checks" in report
     names = {c["name"] for c in report["checks"]}
     assert {"claude-code", "gh-auth", "network", "anti-cloud-backup"}.issubset(names)
+    assert "skill-wiring" in names
+    assert "mainbranch-version" in names
 
 
 def test_cloud_path_detection_via_symlink(tmp_path: Path, monkeypatch) -> None:
@@ -35,3 +38,11 @@ def test_doctor_clean_finance_passes(tmp_path: Path) -> None:
     report = run(path=str(repo))
     cloud = next(c for c in report["checks"] if c["name"] == "anti-cloud-backup")
     assert cloud["ok"] is True
+
+
+def test_doctor_skill_wiring_passes_after_init(tmp_path: Path) -> None:
+    repo = tmp_path / "biz"
+    init_run(path=str(repo), name="Acme")
+    report = run(path=str(repo))
+    wiring = next(c for c in report["checks"] if c["name"] == "skill-wiring")
+    assert wiring["ok"] is True

--- a/mb/tests/test_init.py
+++ b/mb/tests/test_init.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from mb.init import DATA_FOLDERS, run
@@ -13,9 +14,25 @@ def test_init_scaffolds_folders(tmp_path: Path) -> None:
     assert result["status"] == "ok"
     for folder in DATA_FOLDERS:
         assert (target / folder).is_dir(), f"missing {folder}"
+    assert (target / "reference" / "core" / ".gitkeep").exists()
+    assert (target / "reference" / "offers" / ".gitkeep").exists()
+    assert (target / "reference" / "proof" / "angles").is_dir()
+    assert (target / "reference" / "domain").is_dir()
+    assert (target / "reference" / "visual-identity").is_dir()
     assert (target / "CLAUDE.md").exists()
     assert (target / ".github" / "CODEOWNERS").exists()
     assert (target / ".gitignore").exists()
+    assert (target / ".claude" / "settings.local.json").exists()
+    assert (target / ".claude" / "skills" / "start" / "SKILL.md").exists()
+
+    settings = json.loads((target / ".claude" / "settings.local.json").read_text())
+    dirs = settings["permissions"]["additionalDirectories"]
+    assert dirs
+    assert (Path(dirs[0]) / ".claude" / "skills" / "start" / "SKILL.md").exists()
+
+    gitignore = (target / ".gitignore").read_text()
+    assert ".claude/settings.local.json" in gitignore
+    assert ".claude/skills/start" in gitignore
     assert "Acme Brewing" in (target / "CLAUDE.md").read_text()
 
 

--- a/mb/tests/test_resolve.py
+++ b/mb/tests/test_resolve.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from mb.resolve import run
+from mb.engine import engine_root
+from mb.resolve import bundled_skills, run, skill_path
 
 
 def test_resolve_local_override(tmp_path: Path) -> None:
@@ -23,3 +24,12 @@ def test_resolve_unknown_key_returns_unresolved_or_stub(tmp_path: Path) -> None:
     out = run(key="nonexistent-9f3a", repo=str(repo))
     # Either unresolved or a stub. Both are valid; nothing crashes.
     assert "resolved" in out
+
+
+def test_skill_path_uses_engine_root() -> None:
+    root = engine_root()
+    assert root is not None
+    path = skill_path("start")
+    assert path is not None
+    assert path == root / ".claude" / "skills" / "start"
+    assert "think" in bundled_skills()


### PR DESCRIPTION
## What changed

- Bumps `mainbranch` to `0.1.1` for a launch-blocker patch release.
- Packages a synthetic engine root at `mb/_engine/.claude/` so wheels preserve skills, playbooks, reference files, lenses, educational prompts, and scripts.
- Adds `mb skill link --repo <path>` and makes `mb init` wire Claude Code automatically with `.claude/settings.local.json` plus per-skill bridge links.
- Keeps clone-mode intact while letting pipx-mode win when the packaged engine root exists.
- Adds repo-shape compatibility paths so current Claude skills can detect and read repos created by `mb init`.
- Makes `/pull` and the canonical pull reference install-mode aware: clone installs use `git pull`; pipx installs use `pipx upgrade mainbranch` and refresh skill links.
- Adds `mb doctor` checks for skill wiring and package freshness, plus `mb educational upgrading-mainbranch`.
- Tightens wheel smoke CI to verify `_engine/.claude`, reference files, `mb init`, settings, and bridge-link discovery.

## Why

`mainbranch==0.1.0` is live, but the public install path was not actually safe to advertise: `pipx install mainbranch && mb init && claude && /start` installed the CLI and bundled skills, but did not make those skills discoverable to Claude Code. It also left `/pull` teaching the old git-clone update path for pipx users.

## Validation

- `python3 -m ruff format --check .`
- `python3 -m ruff check .`
- `python3 -m mypy mb`
- `pytest -q` (`33 passed`)
- `python3 -m build`
- Inspected wheel for `mb/_engine/.claude/skills/start/SKILL.md`, `mb/_engine/.claude/reference/pull-engine-updates.md`, and `mb/_engine/.claude/educational/upgrading-mainbranch.md`
- Isolated pipx install from built wheel:
  - `mb --version` => `mb 0.1.1`
  - `mb init` created `.claude/settings.local.json`, bridge links, gitignore entries, and `reference/core` compatibility path
  - `mb doctor --json` reported `skill-wiring` ok