### PR TITLE
[docs] Add compatibility and support docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ pipx install mainbranch
 
 That puts the `mb` CLI on your PATH. Run `mb --help` to see subcommands.
 
-Tested on macOS and Linux. Windows is experimental in v0.1; track [issue #151](https://github.com/noontide-co/mainbranch/issues/151) for status.
+Tested on macOS and Linux. Windows is experimental in v0.1; see
+[docs/compatibility.md](docs/compatibility.md) and track
+[#151](https://github.com/noontide-co/mainbranch/issues/151) for status.
 
 For developer / advanced / legacy mode (cloning the engine repo to hack on skills):
 
@@ -258,6 +260,9 @@ Post in the Main Branch group. Tag @Devon for technical questions.
 
 **Not in the Skool community?**
 Open an issue at [github.com/noontide-co/mainbranch/issues](https://github.com/noontide-co/mainbranch/issues).
+
+For platform support and security reporting, see [SUPPORT.md](SUPPORT.md),
+[SECURITY.md](SECURITY.md), and [docs/compatibility.md](docs/compatibility.md).
 
 **Common issues:**
 - "404 error" or "Repository not found" — Verify the URL and your network. The repo is public; no access request needed.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,60 @@
+# Security Policy
+
+Main Branch is local-first software. It installs the `mb` CLI, writes files into
+business repos you choose, and wires Claude Code to bundled skills. There is no
+hosted Main Branch service in the open-source engine.
+
+## Supported versions
+
+| Version | Supported |
+|---|---|
+| 0.1.x | Yes |
+| Older versions | No |
+
+Security fixes ship in the next patch release when practical.
+
+## Reporting a vulnerability
+
+Please do not open a public issue for a suspected vulnerability.
+
+Report privately by one of these paths:
+
+- Use GitHub's private vulnerability reporting flow if it is available on this
+  repository.
+- Email `devon@noontide.co` with the subject `Main Branch security`.
+
+Include:
+
+- The affected version (`mb --version`)
+- Operating system and install mode (`pipx` or clone)
+- Reproduction steps
+- Expected impact
+- Any logs or screenshots that do not expose private business data
+
+## Scope
+
+In scope:
+
+- Unsafe file writes outside the requested repo
+- Unsafe handling of symlinks or bridge links
+- Path traversal in `mb init`, `mb skill link`, `mb resolve`, or related CLI
+  commands
+- Accidental exposure of private business data in generated files or logs
+- GitHub Actions, packaging, or release workflow issues that could affect users
+
+Out of scope:
+
+- Bugs in Claude Code or Anthropic accounts
+- Bugs in GitHub, pipx, Python, or operating-system package managers
+- Prompt-injection reports that require a user to intentionally paste hostile
+  content into their own private business repo, unless Main Branch amplifies that
+  content into an unsafe action
+- Social engineering against maintainers or community members
+
+## Response expectations
+
+We aim to acknowledge valid private reports within 7 days. If the issue is real,
+we will coordinate a fix, publish a patch release when needed, and credit the
+reporter unless they prefer to remain anonymous.
+
+There is no paid bug bounty program.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,60 @@
+# Support
+
+Use the narrowest support path that matches the problem.
+
+## Setup or usage help
+
+Start local:
+
+```bash
+mb doctor
+```
+
+If Claude Code does not see `/start`, run this from your business repo:
+
+```bash
+mb skill link --repo .
+```
+
+Then restart Claude Code and run:
+
+```text
+/start
+```
+
+For step-by-step setup, read [docs/BEGINNER-SETUP.md](docs/BEGINNER-SETUP.md).
+For platform support, read [docs/compatibility.md](docs/compatibility.md).
+
+## Where to ask
+
+| Need | Best place |
+|---|---|
+| Bug in `mb` or bundled skills | [GitHub Issues](https://github.com/noontide-co/mainbranch/issues) |
+| Setup help as a Main Branch member | Skool community |
+| Feature request or roadmap discussion | GitHub Issues |
+| Security concern | Private report; see [SECURITY.md](SECURITY.md) |
+| General Claude Code account problem | Anthropic support |
+
+## Before opening an issue
+
+Please include:
+
+- `mb --version`
+- Operating system
+- Install mode (`pipx` or clone)
+- The command or slash skill you ran
+- What happened
+- What you expected
+- Any relevant output from `mb doctor`
+
+Do not include private business data, member information, API keys, Stripe IDs,
+or unreleased client work in a public issue.
+
+## What the paid community covers
+
+The open-source repo gives you the `mb` CLI, bundled skills, schema, and public
+docs.
+
+The paid community is for operator-specific help: curated examples, calls,
+classroom material, live bets, and support for applying the system to your own
+business. The open-source engine remains usable without joining the community.

--- a/docs/BEGINNER-SETUP.md
+++ b/docs/BEGINNER-SETUP.md
@@ -41,7 +41,7 @@ Same flow as macOS — use `apt install pipx` (Debian/Ubuntu) or `dnf install pi
 
 ### Windows
 
-> **Windows is experimental in v0.1.** It may work but isn't tested in CI; expect rough edges. Track [issue #151](https://github.com/noontide-co/mainbranch/issues/151) for status. Power users are welcome to try the steps below.
+> **Windows is experimental in v0.1.** It may work but isn't tested in CI; expect rough edges. See [compatibility](compatibility.md) and track [issue #151](https://github.com/noontide-co/mainbranch/issues/151) for status. Power users are welcome to try the steps below.
 
 ```powershell
 # 1. Install Claude Code
@@ -174,6 +174,7 @@ Then restart Claude. This re-wires skill discovery in your business repo.
 - **In Claude Code:** type `/help` or describe the issue in plain English.
 - **In Skool:** post in the Main Branch group with a screenshot of the exact error. Tag Devon for setup issues.
 - **For OSS contributors:** open an issue at [https://github.com/noontide-co/mainbranch/issues](https://github.com/noontide-co/mainbranch/issues).
+- **Platform support:** see [compatibility](compatibility.md).
 
 ---
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,0 +1,79 @@
+# Compatibility
+
+Main Branch v0.1.x is intentionally narrow: `mb` plus bundled Claude Code skills.
+This page is the public compatibility contract for that surface.
+
+## Supported matrix
+
+| Surface | v0.1.x status | Notes |
+|---|---|---|
+| macOS | Supported | Primary development path. Recommended for beginners. |
+| Linux | Supported for `mb`; supported when Claude Code is installed | CI runs the Python package on Linux. Claude Code must be installed separately. |
+| Windows | Experimental | Not tested in CI for v0.1.x. Track [#151](https://github.com/noontide-co/mainbranch/issues/151). |
+| Python | 3.10, 3.11, 3.12 | CI gates all three versions. |
+| Install mode | `pipx install mainbranch` | Canonical public install path. |
+| Developer mode | Git clone | For contributors who want to edit the engine or skills. |
+| Agent runtime | Claude Code | First-class in v0.1.x. |
+| Codex, Cursor, Hermes, local LLMs | Roadmap | Cross-agent support is v0.2+. |
+
+## What "supported" means
+
+Supported means:
+
+- CI runs the relevant Python gates before merge.
+- The documented setup path is expected to work.
+- Bugs should be filed as GitHub issues.
+- Regressions in the supported path are release-quality problems.
+
+Experimental means:
+
+- The path may work for power users.
+- It is not part of the v0.1.x release gate.
+- Workarounds are welcome, but breakage is not treated as a launch blocker.
+
+## Recommended setup
+
+For most users:
+
+```bash
+pipx install mainbranch
+mb init my-business --name "My Business"
+cd my-business
+claude
+/start
+```
+
+For contributors:
+
+```bash
+git clone https://github.com/noontide-co/mainbranch.git
+cd mainbranch
+```
+
+Use clone mode only if you are editing the engine, docs, or bundled skills.
+
+## Updating
+
+For `pipx` installs:
+
+```bash
+pipx upgrade mainbranch
+```
+
+For clone installs:
+
+```bash
+git pull origin main
+```
+
+Inside Claude Code, `/pull` detects the install mode and runs the appropriate
+update path.
+
+## Known v0.1.x limits
+
+- Claude Code is the only first-class agent runtime.
+- Windows is experimental.
+- Skills are bundled into the installed Python package, so public users update
+  skills by upgrading `mainbranch`.
+- The CLI scaffolds, validates, graphs, resolves, and links skills. Most
+  business workflows still happen through Claude Code slash commands.

--- a/mb/pyproject.toml
+++ b/mb/pyproject.toml
@@ -57,6 +57,9 @@ mb = "mb.cli:app"
 Homepage = "https://github.com/noontide-co/mainbranch"
 Repository = "https://github.com/noontide-co/mainbranch"
 Issues = "https://github.com/noontide-co/mainbranch/issues"
+Documentation = "https://github.com/noontide-co/mainbranch/blob/main/docs/BEGINNER-SETUP.md"
+Changelog = "https://github.com/noontide-co/mainbranch/blob/main/CHANGELOG.md"
+Support = "https://github.com/noontide-co/mainbranch/blob/main/SUPPORT.md"
 
 [tool.setuptools.packages.find]
 where = ["."]


### PR DESCRIPTION
## Summary

Adds the next public-trust layer after the README truth pass:

- `docs/compatibility.md` with the v0.1.x support matrix: macOS/Linux supported, Windows experimental, Claude Code first, cross-agent later.
- `SECURITY.md` with supported versions, private reporting paths, scope, and response expectations.
- `SUPPORT.md` with the right path for setup help, bug reports, feature requests, security reports, and paid-community help.
- README and beginner guide links to the compatibility/support/security docs.
- PyPI project URLs for documentation, changelog, and support.

## Why

The repo is now public and installable. The remaining gap was that public users had no explicit compatibility contract, no security reporting path, and no support routing. This keeps the Windows story honest without adding new support burden.

## Validation

Ran in a throwaway venv under `/tmp` because this shell did not have repo tooling on PATH:

```bash
ruff format --check .
ruff check .
mypy mb
pytest -q
```

Result: 33 tests passed; ruff and mypy clean. Also ran `git diff --check`.
