### PR TITLE
[hygiene] Contributor templates + Dependabot + #168 polish (security/support/compatibility)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -68,7 +68,7 @@ body:
     id: doctor
     attributes:
       label: "`mb doctor` output"
-      description: Paste the full output. Wrap in a collapsible block if long.
+      description: "Paste the output. If `mb doctor` could not run (e.g., `mb` not on PATH), write `mb doctor could not run` and explain why."
       value: |
         <details>
         <summary>mb doctor</summary>

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,90 @@
+name: Bug report
+description: Something in `mb` or a bundled skill is broken or behaves unexpectedly.
+title: "bug: "
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a bug. Please include enough detail that a maintainer can
+        reproduce it without follow-up. Do not include private business data,
+        member info, or API keys.
+
+  - type: input
+    id: mb-version
+    attributes:
+      label: "`mb --version` output"
+      description: Paste the exact version string. If `mb` is not on PATH, say so.
+      placeholder: "mb 0.1.1"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - macOS
+        - Linux
+        - Windows (experimental)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: install-mode
+    attributes:
+      label: Install mode
+      options:
+        - pipx
+        - clone (developer mode)
+    validations:
+      required: true
+
+  - type: input
+    id: command
+    attributes:
+      label: Command or skill that failed
+      description: e.g. `mb init`, `mb skill link --repo .`, `/start`, `/think`
+      placeholder: "mb skill link --repo ."
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: A clear description of the actual behavior, including any error output.
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-expected
+    attributes:
+      label: What you expected
+    validations:
+      required: true
+
+  - type: textarea
+    id: doctor
+    attributes:
+      label: "`mb doctor` output"
+      description: Paste the full output. Wrap in a collapsible block if long.
+      value: |
+        <details>
+        <summary>mb doctor</summary>
+
+        ```text
+        # paste output here
+        ```
+
+        </details>
+    validations:
+      required: true
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else
+      description: Stack traces, screenshots, or context that does not fit above.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Setup or usage help
+    url: https://github.com/noontide-co/mainbranch/blob/main/SUPPORT.md
+    about: Read SUPPORT.md first — it routes you to the narrowest path for your problem.
+  - name: Beginner setup walkthrough
+    url: https://github.com/noontide-co/mainbranch/blob/main/docs/BEGINNER-SETUP.md
+    about: Step-by-step setup for new members.
+  - name: Security report
+    url: https://github.com/noontide-co/mainbranch/blob/main/SECURITY.md
+    about: Do not file a public issue. See SECURITY.md for the private reporting paths.
+  - name: Main Branch community (Skool)
+    url: https://skool.com/main-branch
+    about: Operator-specific help, calls, classroom, and live bets.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,56 @@
+name: Feature request
+description: Propose a change to the `mb` CLI, a bundled skill, or the engine surface.
+title: "feat: "
+labels: ["enhancement", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the idea. Frame the problem before the solution — the surface
+        area for v0.1.x is intentionally narrow, and well-scoped problems are
+        easier to evaluate than abstract requests.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      description: What is the user-visible pain or gap? Who hits it and when?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Proposed surface
+      options:
+        - CLI subcommand
+        - Skill
+        - Both (CLI + skill)
+        - Other / not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed change
+      description: Sketch the shape — flags, behavior, edge cases. Pseudocode is fine.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Workarounds, prior attempts, or designs you rejected and why.
+    validations:
+      required: true
+
+  - type: input
+    id: related
+    attributes:
+      label: Related issues or PRs
+      description: "Link any prior conversation. Use `#N` or full URLs."
+      placeholder: "#42, #168"
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,37 @@
+name: Question
+description: A question about Main Branch that benefits future readers.
+title: "question: "
+labels: ["question", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Before filing — try the right channel first:**
+
+        - **Setup help?** Read [SUPPORT.md](https://github.com/noontide-co/mainbranch/blob/main/SUPPORT.md) and [docs/BEGINNER-SETUP.md](https://github.com/noontide-co/mainbranch/blob/main/docs/BEGINNER-SETUP.md).
+        - **Main Branch member?** Post in the Skool community — that is where operator-specific help lives.
+        - **Still here?** File only if the answer would benefit future readers searching the issue tracker.
+
+  - type: textarea
+    id: question
+    attributes:
+      label: Question
+      description: One or two sentences. Be specific.
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: What are you trying to do? Why does the answer matter?
+    validations:
+      required: true
+
+  - type: textarea
+    id: tried
+    attributes:
+      label: What you've tried
+      description: Docs you read, commands you ran, things you ruled out.
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,60 @@
+<!--
+  Thanks for contributing to Main Branch.
+
+  See CONTRIBUTING.md for branch + PR shape, concern-based commit
+  organization, and pre-push gates. Keep PRs scoped — one logical
+  change per PR, ideally 3–5 commits by concern.
+-->
+
+## Summary
+
+<!-- 1–2 sentences on the user-visible change. -->
+
+## Linked issue
+
+<!-- Use Closes #N for issues this PR resolves; Refs #N for related context. -->
+
+Closes #
+
+## Why
+
+<!-- Frame the problem before the solution. What pain or gap does this address? -->
+
+## Commits by concern
+
+<!-- One logical change per commit. Conventional commit prefixes. -->
+
+- [ ] Each commit body bullet-lists the changes in that commit
+- [ ] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
+- [ ] Conventional Commits format: `feat:`, `fix:`, `docs:`, `chore:`, `test:`, `refactor:`, `ci:`
+
+## Test plan
+
+Pre-push gates from `mb/`:
+
+```bash
+cd mb
+ruff format --check .
+ruff check .
+mypy mb
+pytest -q --cov=mb --cov-fail-under=70
+```
+
+- [ ] `ruff format --check` passes
+- [ ] `ruff check` passes
+- [ ] `mypy mb` passes
+- [ ] `pytest -q --cov=mb --cov-fail-under=70` passes
+- [ ] Wheel install smoke (if packaging touched)
+- [ ] SKILL.md ≤500 lines (if any skill touched)
+
+## CHANGELOG
+
+- [ ] Updated `CHANGELOG.md` `[Unreleased]` section, OR
+- [ ] N/A — change is invisible to users (internal refactor, CI-only, etc.)
+
+## Breaking changes
+
+- [ ] No
+- [ ] Yes — migration note below
+
+<!-- If yes, describe what users must do to migrate. -->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# Dependabot config — weekly sweep for Python deps and GitHub Actions.
+# pyproject.toml lives at /mb, so the pip ecosystem is rooted there.
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/mb"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,6 +23,8 @@ Report privately by one of these paths:
   repository.
 - Email `devon@noontide.co` with the subject `Main Branch security`.
 
+We aim to acknowledge reports within 7 days and ship a fix within 30 days when practical.
+
 Include:
 
 - The affected version (`mb --version`)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -55,8 +55,9 @@ Out of scope:
 
 ## Response expectations
 
-We aim to acknowledge valid private reports within 7 days. If the issue is real,
-we will coordinate a fix, publish a patch release when needed, and credit the
-reporter unless they prefer to remain anonymous.
+Per the commitment near the top of this file: acknowledge within 7 days, fix
+within 30 days when practical. For valid reports we coordinate a fix, publish
+a patch release when needed, and credit the reporter unless they prefer to
+remain anonymous.
 
 There is no paid bug bounty program.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -30,7 +30,7 @@ For platform support, read [docs/compatibility.md](docs/compatibility.md).
 | Need | Best place |
 |---|---|
 | Bug in `mb` or bundled skills | [GitHub Issues](https://github.com/noontide-co/mainbranch/issues) |
-| Setup help as a Main Branch member | Skool community |
+| Setup help as a Main Branch member | [Skool community](https://skool.com/main-branch) |
 | Feature request or roadmap discussion | GitHub Issues |
 | Security concern | Private report; see [SECURITY.md](SECURITY.md) |
 | General Claude Code account problem | Anthropic support |
@@ -39,6 +39,7 @@ For platform support, read [docs/compatibility.md](docs/compatibility.md).
 
 Please include:
 
+- Check [CHANGELOG.md](CHANGELOG.md) to see if your issue is fixed in a newer version.
 - `mb --version`
 - Operating system
 - Install mode (`pipx` or clone)

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -16,6 +16,8 @@ This page is the public compatibility contract for that surface.
 | Agent runtime | Claude Code | First-class in v0.1.x. |
 | Codex, Cursor, Hermes, local LLMs | Roadmap | Cross-agent support is v0.2+. |
 
+**Windows tip — try WSL2.** If you're on Windows and want a working setup today, use [Windows Subsystem for Linux 2 (WSL2)](https://learn.microsoft.com/en-us/windows/wsl/install). Inside WSL2, follow the supported Linux flow. The pipx install path works there.
+
 ## What "supported" means
 
 Supported means:


### PR DESCRIPTION
## Summary

Adds contributor hygiene primitives — Form-style issue templates, PR template, Dependabot config — and polishes the docs from #168 (SECURITY response window, SUPPORT linking + CHANGELOG self-serve check, compatibility WSL2 note for Windows users).

Files only. No backlog issue touches; that is PR #4 scope.

## Why

The repo went public for v0.1.x, but external contributors hit:

- **Unstructured triage.** Bug and feature reports came in as free-text, missing the version/OS/install-mode signals maintainers always have to ask for.
- **No PR shape.** CONTRIBUTING.md documented the discipline, but PR descriptions did not surface the checklist in front of reviewers.
- **No automated dep sweep.** Manual upgrades, no signal on stale GH Actions versions.
- **#168 leftover edges.** SECURITY.md had no concrete fix-window number near the reporting paths; SUPPORT.md pointed at "Skool community" as plain text; compatibility.md left Windows users with no actionable path.

## Commits by concern

```
ca11ee9 docs(compatibility): WSL2 note for Windows users
d94a406 docs(support): link Skool + CHANGELOG check
472cea3 docs(security): add response-window commitment
727c447 chore(github): add dependabot config
1c82511 chore(github): add PR template
5cbda2d chore(github): add issue templates (bug + feature + question + config)
```

## What changed

- `.github/ISSUE_TEMPLATE/bug.yml` — Form-style. Required: `mb --version`, OS, install mode, command/skill that failed, what happened / expected, `mb doctor` output. Title prefix `bug: `, labels `bug, triage`.
- `.github/ISSUE_TEMPLATE/feature.yml` — Form-style. Required: problem, proposed surface (CLI/skill/both), proposed change, alternatives, related issues. Title prefix `feat: `, labels `enhancement, triage`.
- `.github/ISSUE_TEMPLATE/question.yml` — front-loads SUPPORT.md + Skool routing. Required: question, context, what you've tried. Labels `question, triage`.
- `.github/ISSUE_TEMPLATE/config.yml` — `blank_issues_enabled: false`. Contact links to SUPPORT.md, BEGINNER-SETUP.md, SECURITY.md, Skool community.
- `.github/PULL_REQUEST_TEMPLATE.md` — summary, linked issue, why, commits-by-concern checklist, test plan covering ruff format + ruff check + mypy + pytest --cov, CHANGELOG `[Unreleased]` check, breaking-change declaration.
- `.github/dependabot.yml` — pip rooted at `/mb`, github-actions rooted at `/`, weekly cadence, 5 PR limit per ecosystem.
- `SECURITY.md` — added single-line response-window commitment ("acknowledge within 7 days, ship within 30 when practical") right after the email reporting path.
- `SUPPORT.md` — replaced bare "Skool community" text with the actual link; added CHANGELOG.md self-serve check as the first item in "Before opening an issue".
- `docs/compatibility.md` — one-paragraph WSL2 tip for Windows users between the supported matrix and "What 'supported' means".

## Test plan

Pre-push gates from `mb/` (docs-only and `.github/` config — gates clean):

- [x] `python3 -m ruff format --check .` — 21 files already formatted
- [x] `python3 -m ruff check .` — All checks passed
- [x] `python3 -m mypy mb` — Success: no issues found in 11 source files
- [x] `python3 -m pytest -q --cov=mb --cov-fail-under=70` — 33 passed, coverage 70.99%

## CHANGELOG

- [x] N/A — `.github/` config and external-facing doc polish, no user-visible engine behavior change.

## Breaking changes

- [x] No

## Out-of-band

- Private vulnerability reporting enabled via `gh api -X PUT /repos/noontide-co/mainbranch/private-vulnerability-reporting` — request returned successfully.

## Explicitly skipped (per scope)

- GitHub Discussions — not enabled.
- Branch protection `required_approving_review_count` — left at 0.
- `CODE_OF_CONDUCT.md` — separate PR if/when Devon decides.
- Backlog issue touches (close/retitle/retag/comment) — PR #4 scope.