### PR TITLE
docs: fix Skool community URL — /main-branch → /main

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -10,5 +10,5 @@ contact_links:
     url: https://github.com/noontide-co/mainbranch/blob/main/SECURITY.md
     about: Do not file a public issue. See SECURITY.md for the private reporting paths.
   - name: Main Branch community (Skool)
-    url: https://skool.com/main-branch
+    url: https://skool.com/main
     about: Operator-specific help, calls, classroom, and live bets.

--- a/README.md
+++ b/README.md
@@ -324,4 +324,4 @@ You do not need to read it to get started. But it is there when you want to go d
 
 ## Community
 
-[skool.com/main-branch](https://skool.com/main-branch)
+[skool.com/main](https://skool.com/main)

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -30,7 +30,7 @@ For platform support, read [docs/compatibility.md](docs/compatibility.md).
 | Need | Best place |
 |---|---|
 | Bug in `mb` or bundled skills | [GitHub Issues](https://github.com/noontide-co/mainbranch/issues) |
-| Setup help as a Main Branch member | [Skool community](https://skool.com/main-branch) |
+| Setup help as a Main Branch member | [Skool community](https://skool.com/main) |
 | Feature request or roadmap discussion | GitHub Issues |
 | Security concern | Private report; see [SECURITY.md](SECURITY.md) |
 | General Claude Code account problem | Anthropic support |


### PR DESCRIPTION
Three live references to `skool.com/main-branch` corrected to the actual community URL `skool.com/main`.

- `README.md` community link
- `SUPPORT.md` routing table
- `.github/ISSUE_TEMPLATE/config.yml` contact link

One commit, no behavior change. Stale historical references in noontide-projects/research/ are tracked separately (lower priority — old research files, not user-facing surfaces).