### PR TITLE
[docs] Accept runtime-agnostic mb boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Run your business as files in git. Stop renting it from someone else's dashboard.**
 
-Main Branch is the `mb` CLI plus a set of MIT-licensed Claude Code skills for running business-as-files workflows. Your offer, audience, voice, research, decisions, and campaigns live in a six-folder taxonomy in your own git repo — versioned, portable, agent-readable. Built for Claude Code first; cross-agent at v0.2+.
+Main Branch is the `mb` CLI plus MIT-licensed agent workflows for running business-as-files systems. Those workflows are packaged for Claude Code today, with Codex, Cursor, OpenClaw, Hermes, and local runtimes targeted next. Your offer, audience, voice, research, decisions, and campaigns live in a six-folder taxonomy in your own git repo -- versioned, portable, agent-readable.
 
 
 ## Install
@@ -38,7 +38,7 @@ See [CHANGELOG.md](CHANGELOG.md) for what's in this release.
 What's actually in the wheel today:
 
 - **`mb` CLI**: `init`, `doctor`, `validate`, `graph`, `skill list`, `skill path`, `skill link`, `educational`, `resolve`, `think`
-- **Bundled Claude Code skills**: `/ads`, `/end`, `/help`, `/organic`, `/pull`, `/setup`, `/site`, `/start`, `/think`, `/vsl`, `/wiki` plus composable skills (`skill-brief-draft`, `skill-concept`, `skill-review`)
+- **Bundled Claude Code skill adapter**: `/ads`, `/end`, `/help`, `/organic`, `/pull`, `/setup`, `/site`, `/start`, `/think`, `/vsl`, `/wiki` plus composable skills (`skill-brief-draft`, `skill-concept`, `skill-review`)
 - **Public engine** under MIT license
 - **PyPI distribution** via `pipx install mainbranch`
 
@@ -46,11 +46,11 @@ What's actually in the wheel today:
 
 ## Roadmap
 
-Where this is going. v0.1 is the CLI + skills foundation; v0.2+ broadens compatibility and deepens the workflow surfaces. The list below is direction, not promises.
+Where this is going. v0.1 is the CLI + Claude Code adapter foundation; v0.2+ broadens runtime compatibility and deepens the workflow surfaces. The list below is direction, not promises.
 
 - `mb books` — BeanCount integration for ledger workflows ([#128](https://github.com/noontide-co/mainbranch/issues/128))
 - `mb fulfillment` — agency-arm tooling for delivery ops
-- Cross-agent compatibility — Codex, Cursor, Hermes, local LLMs (v0.2+)
+- Runtime compatibility — Codex, Cursor, OpenClaw, Hermes, local LLMs (v0.2+)
 - Deeper `/site` workflows — lander → minisite → website graduation
 - Dashboard — web UI for the bets-in-public feed (v0.2–v0.3)
 - Skool → GitHub webhook automation (v0.2)
@@ -76,9 +76,9 @@ See [CHANGELOG.md](CHANGELOG.md). Each release ships a "What this means for you"
 
 ## Honest current state (v0.1)
 
-- **Built for Claude Code.** Cross-platform skill support is a v0.2+ commitment.
+- **Built for Claude Code today.** Portable runtime support is a v0.2+ commitment.
 - **Schema is v1; will evolve.** Frontmatter shapes covered by `mb validate` are stable for v0.1.x; breaking changes bump the major.
-- **Cross-agent compatibility matrix lands at v0.2.** Codex, Cursor, Hermes, local LLMs are not first-class targets in v0.1.
+- **Runtime compatibility matrix lands at v0.2.** Codex, Cursor, OpenClaw, Hermes, and local LLMs are not first-class targets in v0.1.
 
 The engine v0.1.0 decision lives at [`decisions/2026-04-29-mb-vip-v0-1-0-master.md`](decisions/2026-04-29-mb-vip-v0-1-0-master.md).
 
@@ -145,7 +145,7 @@ You'll also need a Claude Pro ($20/mo) or Max subscription. Install Claude Code 
 
 ## The `mb` CLI
 
-The CLI surface for the engine. Built for Claude Code first; cross-agent at v0.2+. Most workflows still happen via slash-prompt skills inside Claude Code — the `mb` CLI is the scaffolder, validator, and grapher around them.
+The CLI surface for the engine. Built for Claude Code first; runtime-agnostic by design. Most workflows still happen via slash-prompt skills inside Claude Code today -- the `mb` CLI is the scaffolder, validator, grapher, updater, and future adapter layer around them.
 
 | Command | What it does |
 |---|---|

--- a/decisions/2026-05-01-mb-cli-vs-agent-workflows-boundary.md
+++ b/decisions/2026-05-01-mb-cli-vs-agent-workflows-boundary.md
@@ -1,0 +1,147 @@
+---
+type: decision
+date: 2026-05-01
+status: accepted
+topic: The mb CLI vs portable agent workflows product boundary
+linked_decisions:
+  - decisions/2026-04-29-mb-vip-v0-1-0-master.md
+participants: [Devon, Codex]
+tags: [v0-2, cli, workflows, runtimes, product-boundary, decision]
+---
+
+# The mb CLI vs Portable Agent Workflows
+
+## Decision
+
+`mb` is the deterministic, inspectable, scriptable substrate for a
+business-as-files repo. It owns repo shape, validation, migration, status,
+updates, graphing, and runtime wiring.
+
+Agent workflows are the judgment-heavy layer. They read from and write to the
+same business repo, but they run inside whatever agent runtime hosts them.
+Claude Code is the first fully supported adapter in v0.1.x. Codex, Cursor,
+OpenClaw, Hermes, and local LLM runtimes are v0.2+ compatibility targets.
+
+The boundary is hard:
+
+- `mb` does not invoke a model.
+- `mb` does not hold a conversation.
+- `mb` does not become a chat client, daemon, scheduler, artifact generator, or
+  vector store.
+- Agent workflows do not own structural invariants like schema, migration, or
+  repo health.
+
+Main Branch is runtime-agnostic by design. `mb` writes and verifies files;
+whichever runtime hosts the workflow reads those files.
+
+## Why This Matters
+
+v0.1.1 made the public install path real: `pipx install mainbranch`, `mb init`,
+Claude Code wiring, and `mb doctor` all work. That makes the next product
+question urgent: is `mb` just a helper for Claude Code, or is it the durable
+surface of Main Branch?
+
+This decision makes the answer explicit. `mb` is the stable operating surface.
+Claude Code is the first client. Future runtimes should be able to consume the
+same repo shape and workflow definitions without forking the product.
+
+## What `mb` Owns
+
+- **`mb init`** - scaffold a business repo, write templates, initialize git, and
+  wire configured runtimes.
+- **`mb doctor`** - diagnose repo shape, install mode, runtime discovery, auth,
+  and common local environment problems.
+- **`mb validate`** - enforce deterministic frontmatter and schema rules across
+  business files.
+- **`mb graph`** - emit a parseable graph from research, decisions, supersession,
+  and cross-links.
+- **`mb update`** - perform install-mode-aware engine refreshes: pipx upgrade,
+  git pull, package-data refresh, and runtime-link repair.
+- **`mb skill list/path/link`** - inspect and wire the currently packaged
+  Claude Code skill adapter.
+- **`mb migrate`** - run dry-run-able, diff-visible schema and path migrations.
+- **`mb status`** - provide a cheap health summary for operators, agents,
+  dashboards, and CI.
+- **Runtime adapter wiring** - eventually support configured adapters such as
+  `claude`, `codex`, `cursor`, `openclaw`, `hermes`, and local runtime endpoints.
+
+Every `mb` verb should be one-shot, exit-coded, and eventually `--json`
+parseable. The CLI's value is its contract, not its intelligence.
+
+## What Agent Workflows Own
+
+- Research, decide, codify loops.
+- Content generation: ads, VSLs, organic posts, sites, decks, wiki work.
+- Session bookends and intent routing: start, end, help, pull narration.
+- Any task whose output depends on judgment, voice, synthesis, or conversation.
+
+In v0.1.x these workflows are packaged as Claude Code skills. That packaging is
+an adapter, not the permanent architecture.
+
+## Runtime Posture
+
+### Claude Code
+
+First-class in v0.1.x. `mb init` writes `.claude/settings.local.json` and bridge
+links. `mb doctor` validates Claude Code discovery. The bundled workflow package
+ships as Claude Code skills.
+
+### Codex, Cursor, Hermes
+
+First-tier v0.2+ compatibility targets. They should consume the same business
+repo and workflow definitions through their own adapter layer.
+
+### OpenClaw
+
+OpenClaw remains a first-tier public compatibility target because adoption in
+the wider market matters. Devon's internal Noontide preference may be Hermes +
+Paperclip, but that preference does not decide the public engine's runtime
+surface. Main Branch should meet users where they already operate.
+
+### Paperclip
+
+Paperclip is better understood as an orchestration or supervision layer than as
+the workflow runtime itself. Main Branch should expose stable repo and JSON
+contracts that Paperclip can supervise later, without making `mb` a Paperclip
+subsystem.
+
+### Local LLMs
+
+Local models are a long-term endpoint. The same boundary holds: `mb` keeps the
+repo legible and portable; the local runtime hosts the model interaction.
+
+## What This Means For v0.2
+
+The clean v0.2 CLI issues are:
+
+1. `mb status` - repo health summary.
+2. `mb update` - install-mode-aware engine refresh.
+3. `mb migrate` - schema and path migration helpers.
+4. `mb skill validate <name>` - validate the current Claude Code skill package.
+
+The risky issue is `mb workflow run <name>`. It should not ship as "shell out to
+Claude" with runtime support bolted on later. The right v0.2 work is to design
+the runtime adapter contract first. If `workflow run` cannot stay
+non-conversational and runtime-agnostic across Claude Code plus at least one
+other runtime, close the issue and document per-runtime launch commands instead.
+
+## Non-Features
+
+`mb` deliberately does not:
+
+- call Anthropic, OpenAI, local LLMs, or any model provider;
+- own conversation state;
+- stream a chat UI;
+- run a background daemon;
+- schedule jobs;
+- generate ads, sites, decks, or copy;
+- store embeddings or run a vector database.
+
+Those are valid products. They are not the `mb` product.
+
+## Review Trigger
+
+Revisit this decision if more than 30 percent of v0.2 milestone work proposes
+verbs that invoke models, manage conversation state, or require persistent
+service behavior. That is product-boundary drift, not normal implementation
+detail.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,6 +1,6 @@
 # Compatibility
 
-Main Branch v0.1.x is intentionally narrow: `mb` plus bundled Claude Code skills.
+Main Branch v0.1.x is intentionally narrow: `mb` plus bundled Claude Code skills as the first adapter for portable agent workflows.
 This page is the public compatibility contract for that surface.
 
 ## Supported matrix
@@ -14,7 +14,7 @@ This page is the public compatibility contract for that surface.
 | Install mode | `pipx install mainbranch` | Canonical public install path. |
 | Developer mode | Git clone | For contributors who want to edit the engine or skills. |
 | Agent runtime | Claude Code | First-class in v0.1.x. |
-| Codex, Cursor, Hermes, local LLMs | Roadmap | Cross-agent support is v0.2+. |
+| Codex, Cursor, OpenClaw, Hermes, local LLMs | Roadmap | Runtime support is v0.2+. `mb` is runtime-agnostic by design. |
 
 **Windows tip — try WSL2.** If you're on Windows and want a working setup today, use [Windows Subsystem for Linux 2 (WSL2)](https://learn.microsoft.com/en-us/windows/wsl/install). Inside WSL2, follow the supported Linux flow. The pipx install path works there.
 
@@ -73,9 +73,10 @@ update path.
 
 ## Known v0.1.x limits
 
-- Claude Code is the only first-class agent runtime.
+- Claude Code is the only first-class agent runtime in v0.1.x.
 - Windows is experimental.
 - Skills are bundled into the installed Python package, so public users update
   skills by upgrading `mainbranch`.
-- The CLI scaffolds, validates, graphs, resolves, and links skills. Most
-  business workflows still happen through Claude Code slash commands.
+- The CLI scaffolds, validates, graphs, resolves, and links the current Claude
+  Code skill adapter. Most business workflows still happen through Claude Code
+  slash commands in v0.1.x.

--- a/mb/pyproject.toml
+++ b/mb/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "mainbranch"
 version = "0.1.1"
-description = "Main Branch engine umbrella - scaffolds, validates, and graphs business-as-files repos. Built for Claude Code."
+description = "Main Branch engine umbrella - scaffolds, validates, and graphs business-as-files repos. Claude Code first, runtime-agnostic by design."
 readme = "README.md"
 requires-python = ">=3.10"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Summary

Accepts the runtime-agnostic product boundary for Main Branch:

- adds an accepted decision for `mb` as deterministic substrate and portable agent workflows as the judgment layer
- frames Claude Code as the first supported adapter, not the long-term ceiling
- names Codex, Cursor, OpenClaw, Hermes, Paperclip, and local LLMs in the right roles
- updates README, compatibility docs, and PyPI description language to match the boundary

## Why

The previous CLI stance was directionally right but too Claude-Code-centered. Main Branch should make the business repo portable across agent runtimes. `mb` owns repo health, schema, migration, update, status, graphing, and adapter wiring; runtimes own model interaction and judgment-heavy workflows.

## Validation

```bash
python3 - <<'PY'
from pathlib import Path
import tomllib
tomllib.loads(Path('mb/pyproject.toml').read_text())
print('toml ok')
PY
cd mb
ruff format --check .
ruff check .
mypy mb
pytest -q
```

Result: TOML OK, ruff clean, mypy clean, 33 tests passed.
