### PR TITLE
[release] Prepare 0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,33 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 No unreleased changes yet.
 
+## [0.1.2] - 2026-05-01
+
+v0.1.2 is a public framing and package-metadata release. It does not change
+installed behavior; it makes the repo, PyPI metadata, and decision history
+match the accepted runtime-agnostic product boundary.
+
+### What this means for you (plain English)
+
+- **Claude Code is still the supported v0.1 runtime.** Nothing changes for
+  existing members or new `pipx install mainbranch` users.
+- **Main Branch is not Claude-Code-only forever.** The public engine now
+  states the intended runtime posture clearly: Claude Code first, with Codex,
+  Cursor, OpenClaw, Hermes, and local runtimes targeted later.
+- **`mb` stays the stable substrate.** It owns repo shape, validation, status,
+  migration, updates, graphing, and runtime wiring. Agent runtimes own
+  judgment-heavy workflows.
+
+### Changed
+
+- Added the accepted decision
+  `decisions/2026-05-01-mb-cli-vs-agent-workflows-boundary.md`.
+- Updated README, compatibility docs, package description, and PyPI long
+  description language around runtime-agnostic positioning.
+- Amended the v0.1 master decision so its historical runtime list points to the
+  accepted runtime-agnostic boundary and includes OpenClaw as a first-tier
+  public compatibility target.
+
 ## [0.1.1] - 2026-05-01
 
 v0.1.1 makes the public `pipx install mainbranch` path work end-to-end

--- a/mb/README.md
+++ b/mb/README.md
@@ -2,7 +2,7 @@
 
 Engine umbrella for [Main Branch](https://github.com/noontide-co/mainbranch) — scaffolds, validates, and graphs business-as-files repos.
 
-This package is the Python entry point. Skills, playbooks, educational content, and consumer-repo templates ship as bundled package data. The actual day-to-day "do work" surfaces are Claude Code skills (markdown), invoked from inside Claude Code.
+This package is the Python entry point. Workflows, playbooks, educational content, and consumer-repo templates ship as bundled package data. In v0.1.x, the day-to-day "do work" surfaces are packaged as Claude Code skills (markdown), invoked from inside Claude Code. The `mb` CLI is runtime-agnostic by design: future adapters should let Codex, Cursor, OpenClaw, Hermes, and local runtimes operate against the same business-as-files repo.
 
 The source tree keeps the engine payload in one place: repo-root `.claude/`. During sdist/wheel builds, `setup.py` copies that tree into `mb/_engine/.claude/` inside the build artifact so installed wheels can resolve skills, playbooks, reference files, lenses, and educational prompts without a source checkout.
 
@@ -22,19 +22,19 @@ mb --version
 
 | Command | What it does |
 |---|---|
-| `mb init` | Scaffold a new business repo (six folders, CLAUDE.md, CODEOWNERS, `git init`) and wire bundled skills for Claude Code. One question only: business name. |
-| `mb doctor` | Diagnostic. Checks Claude Code, gh auth, network, librsvg, skill wiring, and package freshness. Warns on cloud-backed finance paths and offers educational triage. |
+| `mb init` | Scaffold a new business repo (six folders, CLAUDE.md, CODEOWNERS, `git init`) and wire the bundled Claude Code skill adapter. One question only: business name. |
+| `mb doctor` | Diagnostic. Checks Claude Code, gh auth, network, librsvg, runtime wiring, and package freshness. Warns on cloud-backed finance paths and offers educational triage. |
 | `mb validate` | Frontmatter shape check across `decisions/`, `core/offers/`, `research/`, `log/`, `campaigns/`, `documents/`. Exit 1 on any fail. |
 | `mb graph` | Walk linked_research / linked_decisions / supersedes; emit Graphviz DOT to stdout. `--open` shells to `dot` + `open`. |
-| `mb think <topic>` | Print the /think skill invocation hint for Claude Code (or run inside a session). |
+| `mb think <topic>` | Print the /think workflow invocation hint for the currently supported runtime. |
 | `mb resolve <key>` | Resolve a reference path through the OSS / paid layered lookup. |
 | `mb skill path <name>` | Print the on-disk path to a bundled skill. |
-| `mb skill link --repo <path>` | Wire or repair Claude Code skill discovery for a business repo. |
+| `mb skill link --repo <path>` | Wire or repair Claude Code skill discovery for a business repo. Future runtime adapters should get equivalent wiring commands. |
 | `mb educational <topic>` | Print an educational triage file. Powers `mb doctor`'s "tell me more" prompts. |
 
 ## Status
 
-v0.1 is **Built for Claude Code only**. Cross-agent compatibility is a v0.2+ commitment. The schema is v1 and will evolve. The engine decision lives at `decisions/2026-04-29-mb-vip-v0-1-0-master.md`; the business-side master plan is tracked in `noontide-co/projects#119`.
+v0.1 is **Claude Code first**. Runtime compatibility for Codex, Cursor, OpenClaw, Hermes, and local runtimes is a v0.2+ commitment. The schema is v1 and will evolve. The runtime boundary decision lives at `decisions/2026-05-01-mb-cli-vs-agent-workflows-boundary.md`; the engine master decision lives at `decisions/2026-04-29-mb-vip-v0-1-0-master.md`.
 
 ## License
 

--- a/mb/mb/__init__.py
+++ b/mb/mb/__init__.py
@@ -7,6 +7,6 @@ file stays a thin dispatcher.
 
 from __future__ import annotations
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 
 __all__ = ["__version__"]

--- a/mb/pyproject.toml
+++ b/mb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mainbranch"
-version = "0.1.1"
+version = "0.1.2"
 description = "Main Branch engine umbrella - scaffolds, validates, and graphs business-as-files repos. Claude Code first, runtime-agnostic by design."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Prepares `mainbranch` 0.1.2 as a package-metadata/framing patch release.

- bumps `mb` package version to 0.1.2
- adds CHANGELOG entry for the runtime-agnostic boundary release
- updates PyPI long description (`mb/README.md`) so it no longer reads as Claude-Code-only forever
- keeps installed behavior unchanged

## Validation

```bash
python3 - <<'PY'
from pathlib import Path
import tomllib
tomllib.loads(Path('mb/pyproject.toml').read_text())
print('toml ok')
PY
cd mb
ruff format --check .
ruff check .
mypy mb
pytest -q
```

Result: TOML OK, ruff clean, mypy clean, 33 tests passed.
