### PR TITLE
[docs] Point Windows tracking at CI issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ That puts the `mb` CLI on your PATH. Run `mb --help` to see subcommands.
 
 Tested on macOS and Linux. Windows is experimental in v0.1; see
 [docs/compatibility.md](docs/compatibility.md) and track
-[#151](https://github.com/noontide-co/mainbranch/issues/151) for status.
+[#137](https://github.com/noontide-co/mainbranch/issues/137) for Windows CI/support work.
 
 For developer / advanced / legacy mode (cloning the engine repo to hack on skills):
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -9,7 +9,7 @@ This page is the public compatibility contract for that surface.
 |---|---|---|
 | macOS | Supported | Primary development path. Recommended for beginners. |
 | Linux | Supported for `mb`; supported when Claude Code is installed | CI runs the Python package on Linux. Claude Code must be installed separately. |
-| Windows | Experimental | Not tested in CI for v0.1.x. Track [#151](https://github.com/noontide-co/mainbranch/issues/151). |
+| Windows | Experimental | Not tested in CI for v0.1.x. Track [#137](https://github.com/noontide-co/mainbranch/issues/137). |
 | Python | 3.10, 3.11, 3.12 | CI gates all three versions. |
 | Install mode | `pipx install mainbranch` | Canonical public install path. |
 | Developer mode | Git clone | For contributors who want to edit the engine or skills. |


### PR DESCRIPTION
## Summary
- point README and compatibility docs at #137 for Windows CI/support work
- remove stale #151 references before closing the completed compatibility-banner issue

## Tests
- not run (docs-only link update)