### PR TITLE
[docs] Lead README with the why before the what

### DIFF
--- a/.claude/reference/pull-engine-updates.md
+++ b/.claude/reference/pull-engine-updates.md
@@ -45,7 +45,7 @@ fi
 
 ---
 
-## Step 0.5: Pull Business Repo Updates (start skill only)
+## Pull Business Repo Updates (start skill only)
 
 Once business repo is confirmed, pull its latest updates from `REPO_PATH`:
 

--- a/.claude/skills/start/SKILL.md
+++ b/.claude/skills/start/SKILL.md
@@ -59,7 +59,7 @@ Apply to: business repo selection, skill routing, any multiple choice.
 │
 ├── Check context level ──────────────→ Fresh? Full load. Heavy? Warn user.
 │
-├── Detect business repo ─────────────→ CWD-first detection (see Step 0)
+├── Detect business repo ─────────────→ CWD-first detection (see Step 2)
 │   ├── CWD has reference/core/ or core/? → This IS the repo. Proceed.
 │   ├── CWD has .claude/skills/? ─────→ User is in vip (old workflow). Trigger migration.
 │   └── Neither? ────────────────────→ Check config, then ask user.
@@ -80,7 +80,7 @@ Apply to: business repo selection, skill routing, any multiple choice.
 │
 ├── Pull business repo updates ───────→ (your repo, silently)
 │
-├── Offer detection ──────────────────→ (multi-offer only, see Step 1.5)
+├── Offer detection ──────────────────→ (multi-offer only, see Step 8)
 │   ├── offers/ exists? ─────────────→ Prompt or restore from .vip/local.yaml
 │   └── no offers/ ──────────────────→ Single-offer mode, skip
 │
@@ -112,15 +112,15 @@ Apply to: business repo selection, skill routing, any multiple choice.
 
 ---
 
-## Step -1: Pull Engine Updates
+## Step 1: Pull Engine Updates
 
 Pull vip updates. CWD is the business repo — resolve vip path first. **Do NOT silently swallow failures.** Users on stale code get broken features.
 
-See **[../../reference/pull-engine-updates.md](../../reference/pull-engine-updates.md)** for the canonical pull script, result handling table, the failure warning to surface, and the matching Step 0.5 business-repo pull logic.
+See **[../../reference/pull-engine-updates.md](../../reference/pull-engine-updates.md)** for the canonical pull script, result handling table, the failure warning to surface, and the matching Step 3 business-repo pull logic.
 
 ---
 
-## Step 0: Detect Business Repo (CWD-First)
+## Step 2: Detect Business Repo (CWD-First)
 
 The user starts Claude in their business repo. Check CWD first before falling back to config.
 
@@ -136,13 +136,13 @@ See **[references/repo-detection.md](references/repo-detection.md)** for the ful
 
 ---
 
-## Step 0.5: Pull Business Repo Updates
+## Step 3: Pull Business Repo Updates
 
-Once business repo is confirmed, pull its latest updates from `REPO_PATH`. See **[../../reference/pull-engine-updates.md](../../reference/pull-engine-updates.md)** "Step 0.5" section for the pull command and the result-handling table.
+Once business repo is confirmed, pull its latest updates from `REPO_PATH`. See **[../../reference/pull-engine-updates.md](../../reference/pull-engine-updates.md)** "Pull Business Repo Updates" section for the pull command and the result-handling table.
 
 ---
 
-## Step 0.75: MCP Pre-Flight (Not Full Research Detection)
+## Step 4: MCP Pre-Flight (Not Full Research Detection)
 
 Check for MCPs required by skills user might invoke. See [mcp-preflight.md](references/mcp-preflight.md).
 
@@ -162,7 +162,7 @@ If user's stated intent involves research, route to /think — it will handle to
 
 ---
 
-## Step 0.8: Tool Status Audit (Lightweight Self-Heal)
+## Step 5: Tool Status Audit (Lightweight Self-Heal)
 
 Run a lightweight `.vip/config.yaml` audit before readiness to repair stale `status: false` entries and normalize missing `last_checked` values.
 
@@ -174,7 +174,7 @@ See [tool-status-audit.md](references/tool-status-audit.md) for the full procedu
 
 ---
 
-## Step 0.9: Readiness Assessment
+## Step 6: Readiness Assessment
 
 **Run AFTER MCP pre-flight and tool-status audit, BEFORE routing.** Scores reference files, checks session state, and gates routing so users don't jump into output skills with thin context.
 
@@ -199,21 +199,21 @@ Adapt display to `user.experience` level (beginner = full breakdown, advanced = 
 
 ---
 
-## Step 1: Defer Full Context Loading
+## Step 7: Defer Full Context Loading
 
-**Do NOT read full reference files into main.** Readiness (Step 0.9) already scored them — that's enough for routing. Full context loading happens in the selected skill or triage agents, not here.
+**Do NOT read full reference files into main.** Readiness (Step 6) already scored them — that's enough for routing. Full context loading happens in the selected skill or triage agents, not here.
 
 **Why:** Reading soul.md + offer.md + audience.md + voice.md into main burns 15-30K tokens that get duplicated when the skill re-reads them. The triage test showed /start hitting 61% context before any work began. Main stays lean; skills/agents load what they need.
 
-**What main knows after Step 0.9:** Readiness scores, which files exist, composite score, gaps. That's enough to present the menu and gate routing.
+**What main knows after Step 6:** Readiness scores, which files exist, composite score, gaps. That's enough to present the menu and gate routing.
 
 **Exception:** Read `[repo]/CLAUDE.md` (the business brain) — it's small and needed for personality/routing awareness. Skip the 4 core reference files.
 
-**Multi-offer context:** If `current_offer` is set (see Step 1.5), note the active offer for routing. Don't load the offer file — the selected skill will.
+**Multi-offer context:** If `current_offer` is set (see Step 8), note the active offer for routing. Don't load the offer file — the selected skill will.
 
 ---
 
-## Step 1.5: Offer Detection (Multi-Offer Only)
+## Step 8: Offer Detection (Multi-Offer Only)
 
 After loading core context, check for multi-offer:
 
@@ -238,7 +238,7 @@ find "$REPO_PATH/reference/offers" -mindepth 2 -maxdepth 2 -name "offer.md" 2>/d
 
 ---
 
-## Step 2: Detect State and Assess Completeness
+## Step 9: Detect State and Assess Completeness
 
 Check `reference/core/*.md`. No folder → `/setup`. Exists → check completeness:
 
@@ -255,9 +255,9 @@ Check `reference/core/*.md`. No folder → `/setup`. Exists → check completene
 
 ---
 
-## Step 3: Route by Intent
+## Step 10: Route by Intent
 
-**Respect readiness gates from Step 0.9.** If status is MINIMAL or EMPTY, do not offer output skills. If THIN, warn. See [readiness-assessment.md](references/readiness-assessment.md) for skill-specific requirements.
+**Respect readiness gates from Step 6.** If status is MINIMAL or EMPTY, do not offer output skills. If THIN, warn. See [readiness-assessment.md](references/readiness-assessment.md) for skill-specific requirements.
 
 **Show context:** Before presenting options, show: "Business: **[repo name]** | Offer: **[current_offer or 'single']**"
 
@@ -265,7 +265,7 @@ Check `reference/core/*.md`. No folder → `/setup`. Exists → check completene
 
 ---
 
-## Step 4: Help Mode
+## Step 11: Help Mode
 
 "Help" or confused → route to `/help`. Give quick overview first:
 
@@ -338,14 +338,14 @@ If re-invoked after compaction: re-read `~/.config/vip/local.yaml` for repo + id
 
 ## References
 
-- [../../reference/pull-engine-updates.md](../../reference/pull-engine-updates.md) — Step -1 + Step 0.5 pull scripts and failure warnings
-- [references/repo-detection.md](references/repo-detection.md) — Step 0 full CWD detection, migration, multi-repo selection, REPO_PATH, vip-loaded verification
-- [references/triage-menu.md](references/triage-menu.md) — Step 3 CHANGELOG banner, menu, "while you wait" pattern, auto-suggest/skip rules
+- [../../reference/pull-engine-updates.md](../../reference/pull-engine-updates.md) — Step 1 + Step 3 pull scripts and failure warnings
+- [references/repo-detection.md](references/repo-detection.md) — Step 2 full CWD detection, migration, multi-repo selection, REPO_PATH, vip-loaded verification
+- [references/triage-menu.md](references/triage-menu.md) — Step 10 CHANGELOG banner, menu, "while you wait" pattern, auto-suggest/skip rules
 - [references/auto-heal.md](references/auto-heal.md) — Bridge link recovery
 - [references/config-system.md](references/config-system.md) — Config loading and recovery
 - [references/mcp-preflight.md](references/mcp-preflight.md) — MCP pre-flight checks
-- [references/readiness-assessment.md](references/readiness-assessment.md) — Step 0.9 readiness scoring
-- [references/tool-status-audit.md](references/tool-status-audit.md) — Step 0.8 self-heal
+- [references/readiness-assessment.md](references/readiness-assessment.md) — Step 6 readiness scoring
+- [references/tool-status-audit.md](references/tool-status-audit.md) — Step 5 self-heal
 - [references/triage-agent.md](references/triage-agent.md) — Triage agent prompts and synthesis
 
 ---

--- a/.claude/skills/start/references/readiness-assessment.md
+++ b/.claude/skills/start/references/readiness-assessment.md
@@ -1,6 +1,6 @@
 # Readiness Assessment Reference
 
-Complete reference for the readiness assessment run by `/start` at Step 0.9. Contains scoring rubric, session state check, soul health check, routing gates, skill-specific readiness, and display format.
+Complete reference for the readiness assessment run by `/start` at Step 6. Contains scoring rubric, session state check, soul health check, routing gates, skill-specific readiness, and display format.
 
 ---
 
@@ -35,7 +35,7 @@ When checking section markers, search for these headings (case-insensitive). The
 
 ### How to Score
 
-**CRITICAL: Use absolute paths for ALL file reads and searches.** The repo path from Step 0 is an absolute path (e.g., `/Users/devon/Documents/GitHub/my-business`). Always use it — never use `~` or relative paths. The Glob and Read tools do not expand `~`, so `~/Documents/GitHub/repo/reference/proof` will silently return 0 results even when files exist.
+**CRITICAL: Use absolute paths for ALL file reads and searches.** The repo path from Step 2 is an absolute path (e.g., `/Users/devon/Documents/GitHub/my-business`). Always use it — never use `~` or relative paths. The Glob and Read tools do not expand `~`, so `~/Documents/GitHub/repo/reference/proof` will silently return 0 results even when files exist.
 
 1. **Read each file** with the Read tool using the absolute repo path (e.g., `[repo-path]/reference/core/soul.md`). If the read fails or returns empty, score 0.
 2. **Count lines** for the primary threshold check.

--- a/.claude/skills/start/references/repo-detection.md
+++ b/.claude/skills/start/references/repo-detection.md
@@ -1,4 +1,4 @@
-# Repo Detection (Step 0)
+# Repo Detection (Step 2)
 
 CWD-first detection of the business repo, with config fallback. The user starts Claude in their business repo — check CWD first before falling back to config.
 

--- a/.claude/skills/start/references/triage-agent.md
+++ b/.claude/skills/start/references/triage-agent.md
@@ -52,7 +52,7 @@ Spawn three agents in a single message using the Task tool. Each gets a focused 
 
 ### Reuse Readiness Data (Token Efficiency)
 
-The triage agents receive the readiness assessment results (scores, gaps, session state, recent commits) as input context. They do NOT re-scan these. The readiness assessment (Step 0.9) already ran git log, scored files, detected open decisions, and checked for uncodified research. Triage agents go DEEPER -- reading file contents, checking section quality, analyzing patterns across files, and connecting dots between soul alignment and tactical work.
+The triage agents receive the readiness assessment results (scores, gaps, session state, recent commits) as input context. They do NOT re-scan these. The readiness assessment (Step 6) already ran git log, scored files, detected open decisions, and checked for uncodified research. Triage agents go DEEPER -- reading file contents, checking section quality, analyzing patterns across files, and connecting dots between soul alignment and tactical work.
 
 **What readiness already computed (pass as context, do not recompute):**
 - Per-file scores (soul, offer, audience, voice, testimonials, angles)
@@ -75,8 +75,8 @@ Gather these in main and pass as structured text in each agent's prompt:
 
 | Content | How | Size | Passed To |
 |---------|-----|------|-----------|
-| Readiness scores (from Step 0.9) | Already computed | ~20 lines | All 3 agents |
-| Absolute repo path | From Step 0 | 1 line | All 3 agents (agents use this to Read files themselves) |
+| Readiness scores (from Step 6) | Already computed | ~20 lines | All 3 agents |
+| Absolute repo path | From Step 2 | 1 line | All 3 agents (agents use this to Read files themselves) |
 | Git log (30 days) | `git log --since="30 days ago" --oneline --no-merges` | ~30 lines | Agent 2 |
 | Reference file change list (30 days) | `git log --since="30 days ago" --name-only -- reference/` | ~20 lines | Agent 1, 3 |
 | Open decision file names | `grep -rl "status: proposed\|status: accepted" decisions/ 2>/dev/null` | ~10 lines | Agent 2 |
@@ -116,7 +116,7 @@ You are NOT an auditor. You are identifying the highest-leverage gaps.
 
 === READINESS SCORES ===
 
-[Scores from Step 0.9: soul X/3, offer X/3, audience X/3, voice X/3,
+[Scores from Step 6: soul X/3, offer X/3, audience X/3, voice X/3,
 testimonials X/3, angles X/3. Composite X/18.]
 
 === CURRENT OFFER ===

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ See [CHANGELOG.md](CHANGELOG.md) for what's in this release. Each release ships 
 Plain English boundary so nobody is surprised:
 
 - **Open-source (free, MIT)**: the `mb` CLI, all bundled skills, the schema, the framework, and the dashboard when it ships. Anyone can install and run — no account, no gating, no upsell wall.
-- **Paid community (Skool)**: $19/mo to watch us build offers in public — the team running real offers through `mb` on real ad accounts, in real time. $99/mo adds group calls.
+- **Paid community (Skool)**: Want to watch us build companies live with Main Branch? Free for 7 days, $19/mo after. $99/mo adds group calls.
 
 The OSS engine is fully usable on its own. The paid community is the live narration on top.
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Own the work. Rent only the rails.
 
 ## What it is
 
-Main Branch is the `mb` CLI plus MIT-licensed agent workflows for running business-as-files systems. Today the workflows ship for Claude Code; Codex, Cursor, OpenClaw, Hermes, and local runtimes are next. Your offer, audience, voice, research, decisions, and campaigns live in a six-folder taxonomy in your own git repo — versioned, portable, agent-readable.
+Main Branch is the `mb` CLI plus MIT-licensed agent workflows for running business-as-files systems. Today the workflows ship for Claude Code; Codex, Cursor, OpenClaw, Hermes, and local runtimes are next. Your offer, audience, voice, research, decisions, and campaigns live in six folders inside your own git repo — versioned, portable, agent-readable.
 
 ---
 
@@ -44,7 +44,7 @@ claude
 /start
 ```
 
-That's it. `mb init` scaffolds the six-folder taxonomy, wires Claude Code to the bundled skills, and gives you a fresh git repo. `/start` walks you through the rest — gathers your business context (offer, audience, voice), drafts the reference files, and routes you to the right workflow.
+That's it. `mb init` sets up the six folders, wires Claude Code to the bundled skills, and gives you a fresh git repo. `/start` walks you through the rest — gathers your business context (offer, audience, voice), drafts the reference files, and routes you to the right workflow.
 
 After the first session, the daily flow is three lines:
 
@@ -126,7 +126,7 @@ The CLI surface for the engine. Built for Claude Code first; runtime-agnostic by
 
 | Command | What it does |
 |---|---|
-| `mb init` | Scaffold a fresh business repo (six-folder taxonomy, CLAUDE.md, git init). |
+| `mb init` | Set up a fresh business repo (six folders, CLAUDE.md, git init). |
 | `mb doctor` | Check the environment — repo shape, frontmatter sanity, settings on disk. Walks you through fixes. |
 | `mb validate` | Frontmatter shape check across `core/`, `research/`, `decisions/`, `log/`, `campaigns/`, `documents/`. Pass/fail per file. |
 | `mb graph` | Walk the link graph (`linked_research` / `linked_decisions` / `supersedes`) and emit Graphviz DOT. `--open` renders to PNG and opens it. |

--- a/README.md
+++ b/README.md
@@ -191,9 +191,9 @@ See [CHANGELOG.md](CHANGELOG.md) for what's in this release. Each release ships 
 Plain English boundary so nobody is surprised:
 
 - **Open-source (free, MIT)**: the `mb` CLI, all bundled skills, the schema, the framework, and the dashboard when it ships. Anyone can install and run — no account, no gating, no upsell wall.
-- **Paid community (Skool)**: curated reference (Devon's voice corpus, compliance log, angles library), the live bets-in-public feed, group calls, classroom curriculum, and direct Devon access at higher tiers. You watch us run real offers through `mb` on real ad accounts.
+- **Paid community (Skool)**: $19/mo to watch us build offers in public — the team running real offers through `mb` on real ad accounts, in real time. $99/mo adds group calls.
 
-The OSS engine is fully usable on its own. The paid wrapper layers in operator-specific reference and live operator presence on top of the same files.
+The OSS engine is fully usable on its own. The paid community is the live narration on top.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ You already feel it. Your offer lives in Notion. Your voice lives in a thousand 
 
 You're renting your business. Not just the dashboards — the operational memory itself.
 
-The OSS gap closed in 2025. The tools to own your stack exist now. Almost nobody has carved time to migrate, because there's no coherent environment that ties it together.
+The open-source gap closed in 2025. The tools to own your stack exist now. Almost nobody has carved time to migrate, because there's no coherent environment that ties it together.
 
 Main Branch is that environment. Your offer, audience, voice, decisions, research, and campaigns live as markdown files in a git repo you own. The `mb` CLI scaffolds it. The bundled skills read those files and produce work that sounds like you — without re-prompting.
 
 The end state isn't sitting at a terminal all day. It's the opposite — eventually you dump thoughts from your phone, drafts get made, you approve, it executes. We're not all the way there. The work is still real. But the substrate is the right one to build on.
 
-We run businesses on this ourselves. The Skool community wraps the OSS — you watch us ship offers through `mb` live, on real ad accounts, including the AI-native agency arm we're building on top of it.
+We run businesses on this ourselves. The Skool community wraps Main Branch — you watch us ship offers through `mb` live, on real ad accounts, including the AI-native agency arm we're building on top of it.
 
 Own the work. Rent only the rails.
 
@@ -60,7 +60,7 @@ Tested on macOS and Linux. Windows is experimental in v0.1; see [docs/compatibil
 
 **New to Claude Code, git, or terminal?** Read [docs/BEGINNER-SETUP.md](docs/BEGINNER-SETUP.md) — it covers everything step-by-step, including common errors.
 
-**OSS contributors** who want to hack on skills can clone the engine repo directly:
+**Contributors** who want to hack on skills can clone the engine repo directly:
 
 ```bash
 git clone https://github.com/noontide-co/mainbranch.git
@@ -131,7 +131,7 @@ The CLI surface for the engine. Built for Claude Code first; runtime-agnostic by
 | `mb validate` | Frontmatter shape check across `core/`, `research/`, `decisions/`, `log/`, `campaigns/`, `documents/`. Pass/fail per file. |
 | `mb graph` | Walk the link graph (`linked_research` / `linked_decisions` / `supersedes`) and emit Graphviz DOT. `--open` renders to PNG and opens it. |
 | `mb think <topic>` | Print the `/think` invocation hint. Run inside Claude Code for the full flow. |
-| `mb resolve <key>` | Resolve a reference path through OSS / paid layered lookup. |
+| `mb resolve <key>` | Resolve a reference path (checks free first, then paid). |
 | `mb educational <topic>` | Print an educational triage file (powers `mb doctor`'s "tell me more" prompts). |
 | `mb skill list` | List the skills bundled with this engine. |
 | `mb skill path <name>` | Print the on-disk path to a bundled skill. |
@@ -191,9 +191,9 @@ See [CHANGELOG.md](CHANGELOG.md) for what's in this release. Each release ships 
 Plain English boundary so nobody is surprised:
 
 - **Open-source (free, MIT)**: the `mb` CLI, all bundled skills, the schema, the framework, and the dashboard when it ships. Anyone can install and run — no account, no gating, no upsell wall.
-- **Paid community (Skool)**: Want to watch us build companies live with Main Branch? Free for 7 days, $19/mo after. $99/mo adds group calls.
+- **Paid community (Skool)**: Want to watch us build companies live with Main Branch? Free for 7 days, $19/mo after.
 
-The OSS engine is fully usable on its own. The paid community is the live narration on top.
+Main Branch is fully usable on its own. The paid community is the live narration on top.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -6,116 +6,35 @@
 
 **Run your business as files in git. Stop renting it from someone else's dashboard.**
 
-Main Branch is the `mb` CLI plus MIT-licensed agent workflows for running business-as-files systems. Those workflows are packaged for Claude Code today, with Codex, Cursor, OpenClaw, Hermes, and local runtimes targeted next. Your offer, audience, voice, research, decisions, and campaigns live in a six-folder taxonomy in your own git repo -- versioned, portable, agent-readable.
+---
 
+## Why
 
-## Install
+Every SaaS tool gets better with every model update — and raises its prices. Your stuff should get better on your own computer.
 
-```bash
-pipx install mainbranch
-```
+You already feel it. Your offer lives in Notion. Your voice lives in a thousand Loom transcripts. Your audience research is in three Google Docs you can't find. Every chat session with your AI starts from zero — you re-paste, re-explain, re-describe, and the output is still generic. One of our members called it *building on quicksand*. That's the right word.
 
-That puts the `mb` CLI on your PATH. Run `mb --help` to see subcommands.
+You're renting your business. Not just the dashboards — the operational memory itself.
 
-Tested on macOS and Linux. Windows is experimental in v0.1; see
-[docs/compatibility.md](docs/compatibility.md) and track
-[#137](https://github.com/noontide-co/mainbranch/issues/137) for Windows CI/support work.
+The OSS gap closed in 2025. The tools to own your stack exist now. Almost nobody has carved time to migrate, because there's no coherent environment that ties it together.
 
-For developer / advanced / legacy mode (cloning the engine repo to hack on skills):
+Main Branch is that environment. Your offer, audience, voice, decisions, research, and campaigns live as markdown files in a git repo you own. The `mb` CLI scaffolds it. The bundled skills read those files and produce work that sounds like you — without re-prompting.
 
-```bash
-git clone https://github.com/noontide-co/mainbranch.git
-```
+The end state isn't sitting at a terminal all day. It's the opposite — eventually you dump thoughts from your phone, drafts get made, you approve, it executes. We're not all the way there. The work is still real. But the substrate is the right one to build on.
 
-OSS contributors who want to modify or contribute skills should clone the engine repo directly. Everyone else should stick with `pipx install mainbranch`.
+We run businesses on this ourselves. The Skool community wraps the OSS — you watch us ship offers through `mb` live, on real ad accounts, including the AI-native agency arm we're building on top of it.
 
-See [CHANGELOG.md](CHANGELOG.md) for what's in this release.
+Own the work. Rent only the rails.
 
 ---
 
-## What ships now
+## What it is
 
-What's actually in the wheel today:
-
-- **`mb` CLI**: `init`, `doctor`, `validate`, `graph`, `skill list`, `skill path`, `skill link`, `educational`, `resolve`, `think`
-- **Bundled Claude Code skill adapter**: `/ads`, `/end`, `/help`, `/organic`, `/pull`, `/setup`, `/site`, `/start`, `/think`, `/vsl`, `/wiki` plus composable skills (`skill-brief-draft`, `skill-concept`, `skill-review`)
-- **Public engine** under MIT license
-- **PyPI distribution** via `pipx install mainbranch`
+Main Branch is the `mb` CLI plus MIT-licensed agent workflows for running business-as-files systems. Today the workflows ship for Claude Code; Codex, Cursor, OpenClaw, Hermes, and local runtimes are next. Your offer, audience, voice, research, decisions, and campaigns live in a six-folder taxonomy in your own git repo — versioned, portable, agent-readable.
 
 ---
 
-## Roadmap
-
-Where this is going. v0.1 is the CLI + Claude Code adapter foundation; v0.2+ broadens runtime compatibility and deepens the workflow surfaces. The list below is direction, not promises.
-
-- `mb books` — BeanCount integration for ledger workflows ([#128](https://github.com/noontide-co/mainbranch/issues/128))
-- `mb fulfillment` — agency-arm tooling for delivery ops
-- Runtime compatibility — Codex, Cursor, OpenClaw, Hermes, local LLMs (v0.2+)
-- Deeper `/site` workflows — lander → minisite → website graduation
-- Dashboard — web UI for the bets-in-public feed (v0.2–v0.3)
-- Skool → GitHub webhook automation (v0.2)
-
----
-
-## Public OSS vs paid community
-
-Plain English boundary so nobody is surprised:
-
-- **Open-source (free, MIT)**: the `mb` CLI, all bundled skills, the schema, the framework. Anyone can install and run — no account, no gating, no upsell wall.
-- **Paid community (Skool)**: curated reference (Devon's voice corpus, compliance log, angles library), the live bets-in-public feed, group calls, classroom curriculum, and direct Devon access at higher tiers.
-
-The OSS engine is fully usable on its own. The paid wrapper layers in operator-specific reference and live operator presence on top of the same files.
-
----
-
-## What's new
-
-See [CHANGELOG.md](CHANGELOG.md). Each release ships a "What this means for you" plain-English section above the technical detail — the relevant bits in 30 seconds.
-
----
-
-## Honest current state (v0.1)
-
-- **Built for Claude Code today.** Portable runtime support is a v0.2+ commitment.
-- **Schema is v1; will evolve.** Frontmatter shapes covered by `mb validate` are stable for v0.1.x; breaking changes bump the major.
-- **Runtime compatibility matrix lands at v0.2.** Codex, Cursor, OpenClaw, Hermes, and local LLMs are not first-class targets in v0.1.
-
-The engine v0.1.0 decision lives at [`decisions/2026-04-29-mb-vip-v0-1-0-master.md`](decisions/2026-04-29-mb-vip-v0-1-0-master.md).
-
-The business-side master plan is tracked in [`noontide-co/projects#119`](https://github.com/noontide-co/projects/pull/119), which amends the launch direction around a CLI-first public product, Skool as the paid wrapper, and the four v0.1 pillars: ads, books, pages, and fulfillment.
-
----
-
-## First Time? Start Here
-
-**New to Claude Code, Git, or terminal?** Read the complete beginner guide:
-
-**[docs/BEGINNER-SETUP.md](docs/BEGINNER-SETUP.md)**
-
-It covers everything step-by-step, including common errors and how to fix them.
-
-**Already comfortable with terminal and git?** Keep reading below.
-
----
-
-## What You Can Do
-
-Once set up, you can:
-
-- Research topics and document decisions
-- Generate batches of ad copy in your voice
-- Create video scripts for Meta ads
-- Generate organic content — Reels, TikTok, carousels — from your reference files and research
-- Write VSL scripts for your community
-- Review ads for compliance before you run them
-- Build and deploy landing pages from your reference files
-- Close sessions intentionally with crystallize moments
-
-All of this happens through simple commands. No prompting skills required.
-
----
-
-## Quick Start
+## Quick start
 
 ```bash
 pipx install mainbranch
@@ -135,73 +54,38 @@ claude
 /start
 ```
 
-### Developer / advanced / legacy mode
+You'll need a Claude Pro ($20/mo) or Max subscription. Install Claude Code itself from [claude.ai](https://claude.ai) — see [docs/BEGINNER-SETUP.md](docs/BEGINNER-SETUP.md) for a step-by-step.
 
-OSS contributors who want to hack on skills can clone the engine repo and run `/setup` from there — that path still works and is how the engine itself is developed. For everyone else, `pipx` is the canonical path.
+Tested on macOS and Linux. Windows is experimental in v0.1; see [docs/compatibility.md](docs/compatibility.md) and track [#137](https://github.com/noontide-co/mainbranch/issues/137).
 
-You'll also need a Claude Pro ($20/mo) or Max subscription. Install Claude Code itself from [claude.ai](https://claude.ai) — see [docs/BEGINNER-SETUP.md](docs/BEGINNER-SETUP.md) if you need a step-by-step.
+**New to Claude Code, git, or terminal?** Read [docs/BEGINNER-SETUP.md](docs/BEGINNER-SETUP.md) — it covers everything step-by-step, including common errors.
 
----
+**OSS contributors** who want to hack on skills can clone the engine repo directly:
 
-## The `mb` CLI
-
-The CLI surface for the engine. Built for Claude Code first; runtime-agnostic by design. Most workflows still happen via slash-prompt skills inside Claude Code today -- the `mb` CLI is the scaffolder, validator, grapher, updater, and future adapter layer around them.
-
-| Command | What it does |
-|---|---|
-| `mb init` | Scaffold a fresh business repo (six-folder taxonomy, CLAUDE.md, git init). |
-| `mb doctor` | Check the environment — repo shape, frontmatter sanity, settings on disk. Walks you through fixes. |
-| `mb validate` | Frontmatter shape check across `core/`, `research/`, `decisions/`, `log/`, `campaigns/`, `documents/`. Pass/fail per file. |
-| `mb graph` | Walk the link graph (`linked_research` / `linked_decisions` / `supersedes`) and emit Graphviz DOT. `--open` renders to PNG and opens it. |
-| `mb think <topic>` | Print the `/think` invocation hint. Run inside Claude Code for the full flow. |
-| `mb resolve <key>` | Resolve a reference path through OSS / paid layered lookup. |
-| `mb educational <topic>` | Print an educational triage file (powers `mb doctor`'s "tell me more" prompts). |
-| `mb skill list` | List the skills bundled with this engine. |
-| `mb skill path <name>` | Print the on-disk path to a bundled skill. |
-| `mb skill link --repo .` | Repair Claude Code skill discovery in a business repo. |
-
-For the full list: `mb --help`.
-
----
-
-## What Are Skills?
-
-Skills are pre-built workflows you invoke with slash prompts (for example, `/start`, `/ads`, `/think`).
-
-Instead of figuring out how to prompt Claude, you invoke a skill with a slash prompt like `/ads` and Claude knows exactly what to do.
-
-**Example:**
-
-You type:
-```
-/ads
+```bash
+git clone https://github.com/noontide-co/mainbranch.git
 ```
 
-Claude reads your business files, then generates 5-6 complete ad concepts. Each concept includes headlines, primary text, and image prompts. All in your voice.
+---
 
-No prompt engineering. No explaining what you want. Just run the skill.
+## What you can do
+
+Once set up, you can:
+
+- Research topics and document decisions
+- Generate batches of ad copy in your voice
+- Create video scripts for Meta ads
+- Generate organic content — Reels, TikTok, carousels — from your reference files and research
+- Write VSL scripts for your community
+- Review ads for compliance before you run them
+- Build and deploy landing pages from your reference files
+- Close sessions intentionally with crystallize moments
+
+All of this happens through simple slash commands. No prompting skills required.
 
 ---
 
-## Available Skills
-
-| Skill | What It Does |
-|---------|-------------|
-| `/start` | Main entry point — figures out what you need and routes you there |
-| `/setup` | Set up your business repo (run this first if you're new) |
-| `/think` | Research, make decisions, add context, transcribe local recordings, update reference files |
-| `/ads` | Create ad copy (static or video) and review for compliance |
-| `/vsl` | Write video sales letter scripts (Skool or B2B) |
-| `/organic` | Generate organic content — Reels, TikTok, carousels |
-| `/site` | Generate and deploy landing pages from your reference files |
-| `/wiki` | Personal wiki with atomic notes |
-| `/end` | Close session — summary, crystallize, commit |
-| `/help` | Get answers, troubleshoot, learn the system |
-| `/pull` | Quick update — pulls latest skills from GitHub |
-
----
-
-## How It Works
+## How it works
 
 Main Branch is the engine. Your business info is the fuel.
 
@@ -211,13 +95,7 @@ Has all the skills    +     Has your business info
                       =     Outputs that sound like you
 ```
 
-You create a separate folder for YOUR business. That is where your offer, audience, voice, and testimonials live.
-
-The engine reads your files. Then it generates content specific to you.
-
----
-
-## Your Business Repo Structure
+You create a separate folder for YOUR business. That's where your offer, audience, voice, and testimonials live. The engine reads those files. Then it generates content specific to you.
 
 After running `mb init`, your business repo looks like this:
 
@@ -242,9 +120,84 @@ You fill in the reference files inside `core/`. Claude reads them when generatin
 
 ---
 
-## Updating Main Branch
+## The `mb` CLI
 
-How you update depends on how you installed:
+The CLI surface for the engine. Built for Claude Code first; runtime-agnostic by design. Most workflows still happen via slash-prompt skills inside Claude Code today — the `mb` CLI is the scaffolder, validator, grapher, updater, and future adapter layer around them.
+
+| Command | What it does |
+|---|---|
+| `mb init` | Scaffold a fresh business repo (six-folder taxonomy, CLAUDE.md, git init). |
+| `mb doctor` | Check the environment — repo shape, frontmatter sanity, settings on disk. Walks you through fixes. |
+| `mb validate` | Frontmatter shape check across `core/`, `research/`, `decisions/`, `log/`, `campaigns/`, `documents/`. Pass/fail per file. |
+| `mb graph` | Walk the link graph (`linked_research` / `linked_decisions` / `supersedes`) and emit Graphviz DOT. `--open` renders to PNG and opens it. |
+| `mb think <topic>` | Print the `/think` invocation hint. Run inside Claude Code for the full flow. |
+| `mb resolve <key>` | Resolve a reference path through OSS / paid layered lookup. |
+| `mb educational <topic>` | Print an educational triage file (powers `mb doctor`'s "tell me more" prompts). |
+| `mb skill list` | List the skills bundled with this engine. |
+| `mb skill path <name>` | Print the on-disk path to a bundled skill. |
+| `mb skill link --repo .` | Repair Claude Code skill discovery in a business repo. |
+
+Full list: `mb --help`.
+
+---
+
+## Skills
+
+Skills are pre-built workflows you invoke with slash prompts. Instead of figuring out how to prompt Claude, you type `/ads` and Claude knows exactly what to do — reads your business files, then generates output that matches your voice.
+
+| Skill | What it does |
+|---|---|
+| `/start` | Main entry point — figures out what you need and routes you there |
+| `/setup` | Set up your business repo (run this first if you're new) |
+| `/think` | Research, make decisions, add context, transcribe local recordings, update reference files |
+| `/ads` | Create ad copy (static or video) and review for compliance |
+| `/vsl` | Write video sales letter scripts (Skool or B2B) |
+| `/organic` | Generate organic content — Reels, TikTok, carousels |
+| `/site` | Generate and deploy landing pages from your reference files |
+| `/wiki` | Personal wiki with atomic notes |
+| `/end` | Close session — summary, crystallize, commit |
+| `/help` | Get answers, troubleshoot, learn the system |
+| `/pull` | Quick update — pulls latest skills from GitHub |
+
+---
+
+## Honest current state (v0.1)
+
+- **Built for Claude Code today.** Portable runtime support is a v0.2+ commitment.
+- **Schema is v1; will evolve.** Frontmatter shapes covered by `mb validate` are stable for v0.1.x; breaking changes bump the major.
+- **Runtime compatibility matrix lands at v0.2.** Codex, Cursor, OpenClaw, Hermes, and local LLMs are not first-class targets in v0.1.
+
+The engine v0.1.0 decision lives at [`decisions/2026-04-29-mb-vip-v0-1-0-master.md`](decisions/2026-04-29-mb-vip-v0-1-0-master.md). The business-side master plan is tracked in [`noontide-co/projects#119`](https://github.com/noontide-co/projects/pull/119).
+
+---
+
+## Roadmap
+
+v0.1 is the CLI + Claude Code adapter foundation; v0.2+ broadens runtime compatibility and deepens the workflow surfaces. Direction, not promises.
+
+- `mb books` — BeanCount integration for ledger workflows ([#128](https://github.com/noontide-co/mainbranch/issues/128))
+- `mb fulfillment` — agency-arm tooling for delivery ops
+- Runtime compatibility — Codex, Cursor, OpenClaw, Hermes, local LLMs (v0.2+)
+- Deeper `/site` workflows — lander → minisite → website graduation
+- Dashboard — visual operating loop for your bets and decisions, ships **free as part of `mb`** (v0.2–v0.3)
+- Skool → GitHub webhook automation (v0.2)
+
+See [CHANGELOG.md](CHANGELOG.md) for what's in this release. Each release ships a "What this means for you" plain-English section above the technical detail.
+
+---
+
+## Open source vs paid community
+
+Plain English boundary so nobody is surprised:
+
+- **Open-source (free, MIT)**: the `mb` CLI, all bundled skills, the schema, the framework, and the dashboard when it ships. Anyone can install and run — no account, no gating, no upsell wall.
+- **Paid community (Skool)**: curated reference (Devon's voice corpus, compliance log, angles library), the live bets-in-public feed, group calls, classroom curriculum, and direct Devon access at higher tiers. You watch us run real offers through `mb` on real ad accounts.
+
+The OSS engine is fully usable on its own. The paid wrapper layers in operator-specific reference and live operator presence on top of the same files.
+
+---
+
+## Updating
 
 - **pipx users (most people)**: `pipx upgrade mainbranch`. Or just run `/pull` inside Claude Code — it figures out which install you have and runs the right thing.
 - **Clone (developer mode)**: `git pull origin main` from the engine repo.
@@ -253,72 +206,54 @@ The CHANGELOG entry for the new version surfaces as a banner the next time you r
 
 ---
 
-## Need Help?
-
-**In the Skool community:**
-Post in the Main Branch group. Tag @Devon for technical questions.
-
-**Not in the Skool community?**
-Open an issue at [github.com/noontide-co/mainbranch/issues](https://github.com/noontide-co/mainbranch/issues).
-
-For platform support and security reporting, see [SUPPORT.md](SUPPORT.md),
-[SECURITY.md](SECURITY.md), and [docs/compatibility.md](docs/compatibility.md).
-
-**Common issues:**
-- "404 error" or "Repository not found" — Verify the URL and your network. The repo is public; no access request needed.
-- "Claude does not see my files" — Make sure you started Claude in your business repo folder and ran `/start`
-- "Skills are not working" — Run `mb skill link --repo .` from your business repo to repair bridge symlinks, then restart Claude. If still broken, run `/setup`.
-- "Output sounds generic" — Add more detail to your reference files, especially `core/voice.md`
-- "I edited Main Branch but can't push" — That's expected for most users. Main Branch is the shared engine. Your business data goes in YOUR repo.
-
----
-
 ## FAQ
 
 **Do I need to know how to code?**
-
 No. You invoke skills with slash prompts and answer questions.
 
 **What if I have multiple products under one brand?**
-
 Use one repo with an `offers/` folder. Each offer gets its own `offer.md`. Soul and voice stay shared in `core/`. Run `/setup` or `/think` to add offers.
 
 **What if I have multiple separate businesses?**
-
 Create a separate repo for each brand. If they share the same soul and voice, they can share a repo. If not, separate repos.
 
 **How do I update when new skills come out?**
-
 `pipx upgrade mainbranch`, or run `/pull` inside Claude Code.
 
 **Can I edit the skills?**
-
-You can, but you do not need to. The skills are designed to work out of the box.
+You can, but you don't need to. They're designed to work out of the box.
 
 **What makes this different from ChatGPT?**
-
 ChatGPT is a chat surface that resets between sessions. Main Branch is a CLI plus a skill set that reads files Claude can re-read every session — your offer, audience, voice, decisions, research — so outputs stay consistent with your business instead of restarting from zero.
 
-**I am stuck. What do I do?**
-
+**I'm stuck. What do I do?**
 Type `/start` again. It picks up where you left off.
 
 ---
 
-## Technical Details
+## Help
 
-Looking for the full system documentation? See [CLAUDE.md](CLAUDE.md).
+**In the Skool community:** post in the Main Branch group. Tag @Devon for technical questions.
 
-That file has:
-- Complete folder structure
-- File naming conventions
-- Domain rubrics by business type
-- Compliance frameworks
-- Git commit conventions
+**Not in the Skool community?** Open an issue at [github.com/noontide-co/mainbranch/issues](https://github.com/noontide-co/mainbranch/issues).
 
-You do not need to read it to get started. But it is there when you want to go deeper.
+For platform support and security reporting, see [SUPPORT.md](SUPPORT.md), [SECURITY.md](SECURITY.md), and [docs/compatibility.md](docs/compatibility.md).
 
-**Decision history:** the engine v0.1.0 master decision lives at [`decisions/2026-04-29-mb-vip-v0-1-0-master.md`](decisions/2026-04-29-mb-vip-v0-1-0-master.md). All shipping decisions are dated, versioned, and committed alongside the code that implements them.
+**Common issues:**
+
+- "404 error" or "Repository not found" — verify the URL and your network. The repo is public; no access request needed.
+- "Claude doesn't see my files" — make sure you started Claude in your business repo folder and ran `/start`.
+- "Skills aren't working" — run `mb skill link --repo .` from your business repo to repair bridge symlinks, then restart Claude. If still broken, run `/setup`.
+- "Output sounds generic" — add more detail to your reference files, especially `core/voice.md`.
+- "I edited Main Branch but can't push" — that's expected for most users. Main Branch is the shared engine. Your business data goes in YOUR repo.
+
+---
+
+## Technical details
+
+Looking for the full system documentation? See [CLAUDE.md](CLAUDE.md) — folder structure, file naming conventions, domain rubrics by business type, compliance frameworks, git commit conventions. You don't need to read it to get started.
+
+All shipping decisions are dated, versioned, and committed alongside the code that implements them.
 
 ---
 

--- a/docs/BEGINNER-SETUP.md
+++ b/docs/BEGINNER-SETUP.md
@@ -173,7 +173,7 @@ Then restart Claude. This re-wires skill discovery in your business repo.
 
 - **In Claude Code:** type `/help` or describe the issue in plain English.
 - **In Skool:** post in the Main Branch group with a screenshot of the exact error. Tag Devon for setup issues.
-- **For OSS contributors:** open an issue at [https://github.com/noontide-co/mainbranch/issues](https://github.com/noontide-co/mainbranch/issues).
+- **For contributors:** open an issue at [https://github.com/noontide-co/mainbranch/issues](https://github.com/noontide-co/mainbranch/issues).
 - **Platform support:** see [compatibility](compatibility.md).
 
 ---

--- a/mb/README.md
+++ b/mb/README.md
@@ -27,7 +27,7 @@ mb --version
 | `mb validate` | Frontmatter shape check across `decisions/`, `core/offers/`, `research/`, `log/`, `campaigns/`, `documents/`. Exit 1 on any fail. |
 | `mb graph` | Walk linked_research / linked_decisions / supersedes; emit Graphviz DOT to stdout. `--open` shells to `dot` + `open`. |
 | `mb think <topic>` | Print the /think workflow invocation hint for the currently supported runtime. |
-| `mb resolve <key>` | Resolve a reference path through the OSS / paid layered lookup. |
+| `mb resolve <key>` | Resolve a reference path (checks free first, then paid). |
 | `mb skill path <name>` | Print the on-disk path to a bundled skill. |
 | `mb skill link --repo <path>` | Wire or repair Claude Code skill discovery for a business repo. Future runtime adapters should get equivalent wiring commands. |
 | `mb educational <topic>` | Print an educational triage file. Powers `mb doctor`'s "tell me more" prompts. |

--- a/mb/mb/_data/fixtures/acme-brewing/CLAUDE.md
+++ b/mb/mb/_data/fixtures/acme-brewing/CLAUDE.md
@@ -1,4 +1,4 @@
 # Acme Brewing — Main Branch fixture
 
-A self-contained fake business used by `mb test` and CI. Stable, OSS-safe.
+A self-contained fake business used by `mb test` and CI. Stable; safe to ship in public.
 Do not put real numbers, real testimonials, or real vendor data here.

--- a/mb/mb/_data/stubs/soul.md
+++ b/mb/mb/_data/stubs/soul.md
@@ -7,11 +7,12 @@ status: stub
 
 Public stub. Replace at `core/soul.md` or subscribe at mainbranch.io/run.
 
-## Why this exists
+## Why this work matters
 
-The reconnection sentence. Why does this work matter to the person doing it?
+Why does this work matter to you? One or two real sentences. The kind of
+thing you'd say to a friend, not on a sales page.
 
 ## What pulls
 
-The interest engine. What does the operator want to learn more about
-that turns into the work? Without this, the work feels like push.
+What do you want to learn more about? When the work feels like pull (not
+push), it's usually because it overlaps with this.

--- a/mb/mb/_data/templates/CLAUDE.md.tmpl
+++ b/mb/mb/_data/templates/CLAUDE.md.tmpl
@@ -1,37 +1,37 @@
 # {{BUSINESS_NAME}}
 
-This is a Main Branch consumer repo. Your business is a tree of files. The
-files are the memory; agents read what's here and write back.
+Your business as files. Claude reads these; you edit them; git remembers them.
 
-## Folder taxonomy
+## Folders
 
-- `core/` — long-lived truth (offer, audience, voice, soul, finance)
+- `core/` — the things that don't change often (offer, audience, voice, soul, finance)
 - `core/offers/` — per-offer specifics
-- `core/finance/` — ledger and tax artifacts (see `mb educational anti-cloud-backup`)
-- `research/` — dated investigations
-- `decisions/` — dated choices, frontmatter status enum
+- `core/finance/` — ledger and tax artifacts
+  (run `mb educational anti-cloud-backup` for why this should not live in iCloud or Drive)
+- `research/` — dated notes from when you went looking
+- `decisions/` — dated choices, with rationale
 - `log/` — running activity log
-- `campaigns/` — paid + organic campaign artifacts
+- `campaigns/` — paid + organic campaign work
 - `documents/` — anything that doesn't belong above
-- `reference/` — compatibility paths for Claude Code skills
+- `reference/` — compatibility paths Claude Code skills read from
   (`reference/core` points at `core/`)
 
 ## Conventions
 
-- Decisions, research, offers, campaigns carry frontmatter. Run
-  `mb validate` to check shape.
-- Status enum: `proposed | running | scaling | killed | graduated | died`
-  (with `accepted | rejected | superseded` for decisions).
-- Single owner per file via `.github/CODEOWNERS`.
+- Decisions, research, offers, and campaigns carry a small block of metadata
+  at the top (frontmatter). Run `mb validate` to check it.
+- Status field: `proposed | running | scaling | killed | graduated | died`
+  (decisions also use `accepted | rejected | superseded`).
+- One owner per file via `.github/CODEOWNERS`.
 - Pull request titles use Conventional Commits.
 
 ## Helpful commands
 
 ```
-mb doctor                # diagnose this repo
-mb validate              # check frontmatter shape
-mb graph --open          # see the link graph
-mb educational <topic>   # read the long-form rationale for an opinionated default
+mb doctor                # see if anything is off in this repo
+mb validate              # check the metadata on your files
+mb graph --open          # see what links to what
+mb educational <topic>   # read why we picked the defaults we did
 ```
 
 ## Repo owner

--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -142,7 +142,7 @@ def resolve_cmd(
     repo: str = typer.Option(".", "--repo"),
     json_out: bool = typer.Option(False, "--json"),
 ) -> None:
-    """Resolve a reference path through OSS / paid layered lookup."""
+    """Resolve a reference path (checks free first, then paid)."""
     result = resolve_mod.run(key=key, repo=repo)
     if json_out:
         typer.echo(json.dumps(result, indent=2))

--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -24,8 +24,8 @@ from mb import validate as validate_mod
 app = typer.Typer(
     name="mb",
     help=(
-        "Main Branch engine umbrella. Scaffolds, validates, and graphs "
-        "business-as-files repos. Built for Claude Code."
+        "Run your business as files in git. Main Branch scaffolds your repo, "
+        "checks it, graphs it, and wires it into Claude Code."
     ),
     no_args_is_help=True,
     add_completion=False,
@@ -33,7 +33,7 @@ app = typer.Typer(
 
 skill_app = typer.Typer(
     name="skill",
-    help="Inspect bundled skills.",
+    help="Look at the bundled skills.",
     no_args_is_help=True,
 )
 app.add_typer(skill_app, name="skill")
@@ -64,19 +64,25 @@ def init_cmd(
     name: str = typer.Option("", "--name", help="Business name (skips prompt if given)."),
     json_out: bool = typer.Option(False, "--json", help="Machine-readable output."),
 ) -> None:
-    """Scaffold a fresh business repo with the six-folder taxonomy."""
+    """Set up a fresh business repo (six folders, CLAUDE.md, git init)."""
     result = init_mod.run(path=path, name=name)
     if json_out:
         typer.echo(json.dumps(result, indent=2))
     else:
         if result["status"] == "already-initialized":
-            typer.echo(f"already initialized at {result['path']}")
+            typer.echo(f"already set up at {result['path']} — nothing to do.")
         elif result["status"] == "ok":
-            typer.echo(f"initialized at {result['path']}")
+            typer.echo(f"set up {result['business_name']}.")
+            typer.echo("")
             for line in result["created"]:
                 typer.echo(f"  + {line}")
+            typer.echo("")
+            typer.echo("next:")
+            typer.echo(f"  cd {result['path']}")
+            typer.echo("  claude")
+            typer.echo("  /start")
         else:
-            typer.echo(f"init failed: {result.get('error')}", err=True)
+            typer.echo(f"could not set up: {result.get('error')}", err=True)
             raise typer.Exit(1)
 
 
@@ -85,7 +91,7 @@ def doctor_cmd(
     path: str = typer.Argument(".", help="Repo to diagnose."),
     json_out: bool = typer.Option(False, "--json", help="Machine-readable output."),
 ) -> None:
-    """Diagnose a Main Branch consumer repo. Exits 1 on red checks."""
+    """Check the health of a Main Branch repo. Exits 1 on red checks."""
     report = doctor_mod.run(path=path)
     if json_out:
         typer.echo(json.dumps(report, indent=2))
@@ -100,7 +106,7 @@ def validate_cmd(
     verbose: bool = typer.Option(False, "-v", "--verbose"),
     json_out: bool = typer.Option(False, "--json"),
 ) -> None:
-    """Validate frontmatter shape across the standard data folders."""
+    """Check the metadata at the top of your files (frontmatter shape)."""
     report = validate_mod.run(path=path, verbose=verbose)
     if json_out:
         typer.echo(json.dumps(report, indent=2))
@@ -197,18 +203,20 @@ def skill_link_cmd(
         typer.echo(json.dumps(result, indent=2))
     else:
         if result["ok"]:
-            typer.echo(f"linked Main Branch engine: {result['engine_root']}")
+            typer.echo(f"linked Main Branch: {result['engine_root']}")
             typer.echo(f"repo: {result['repo']}")
             if result["linked"]:
-                typer.echo(f"skills linked: {len(result['linked'])}")
+                typer.echo(f"  + linked {len(result['linked'])} skill(s)")
             if result["copied"]:
-                typer.echo(f"skills copied: {len(result['copied'])}")
+                typer.echo(f"  + copied {len(result['copied'])} skill(s)")
             if result["skipped"]:
-                typer.echo(f"skills skipped: {len(result['skipped'])}")
+                typer.echo(f"  · {len(result['skipped'])} already wired")
+            typer.echo("")
+            typer.echo("you're set — run `claude` and then /start.")
         else:
-            typer.echo("could not link Main Branch skills", err=True)
+            typer.echo("could not link Main Branch skills:", err=True)
             for error in result["errors"]:
-                typer.echo(f"- {error}", err=True)
+                typer.echo(f"  - {error}", err=True)
             raise typer.Exit(1)
 
 

--- a/mb/mb/doctor.py
+++ b/mb/mb/doctor.py
@@ -1,4 +1,4 @@
-"""``mb doctor`` — diagnose a Main Branch consumer repo.
+"""``mb doctor`` — check the health of a Main Branch repo.
 
 Checks Claude Code on PATH, gh auth status, network reachability,
 ``librsvg`` for ``tool-og-render``, and walks ``core/finance/`` looking
@@ -264,6 +264,6 @@ def render_human(report: dict[str, Any]) -> None:
         console.print(f"  {mark}  {c['name']:<22} {c['detail']}")
     console.print()
     if report["ok"]:
-        console.print("[green]all green[/green]")
+        console.print("[green]all good — you're set to run `claude`.[/green]")
     else:
-        console.print("[red]issues above; see remediation lines.[/red]")
+        console.print("[red]a few things to fix above — most are quick.[/red]")

--- a/mb/mb/init.py
+++ b/mb/mb/init.py
@@ -1,4 +1,4 @@
-"""``mb init`` — non-interactive scaffold for a Main Branch consumer repo.
+"""``mb init`` — non-interactive scaffold for a Main Branch business repo.
 
 Per master decision, v0.1 asks ONE question (business name). Path-config
 flexibility is locked; folder names are the canonical six. Re-running on
@@ -100,7 +100,7 @@ def _link_or_mkdir(source: Path, dest: Path) -> str:
 
 
 def run(path: str, name: str) -> dict[str, Any]:
-    """Scaffold ``path`` as a Main Branch consumer repo.
+    """Scaffold ``path`` as a Main Branch business repo.
 
     Returns a dict with ``status`` ∈ {ok, already-initialized, error},
     ``path`` (absolute), and ``created`` (list of relative paths created).
@@ -202,34 +202,34 @@ def run(path: str, name: str) -> dict[str, Any]:
 _DEFAULT_CLAUDE = """\
 # {{BUSINESS_NAME}}
 
-This is a Main Branch consumer repo. Your business is a tree of files.
+Your business as files. Claude reads these; you edit them; git remembers them.
 
-## Folder taxonomy
+## Folders
 
-- `core/` — long-lived truth (offer, audience, voice, soul)
+- `core/` — the things that don't change often (offer, audience, voice, soul)
 - `core/offers/` — per-offer specifics
 - `core/finance/` — ledger and tax artifacts
-- `research/` — dated investigations
-- `decisions/` — dated choices, frontmatter status enum
+- `research/` — dated notes from when you went looking
+- `decisions/` — dated choices, with rationale
 - `log/` — running activity log
-- `campaigns/` — paid + organic campaign artifacts
+- `campaigns/` — paid + organic campaign work
 - `documents/` — anything that doesn't belong above
-- `reference/` — compatibility paths for Claude Code skills
+- `reference/` — compatibility paths Claude Code skills read from
   (`reference/core` points at `core/`)
 
 ## Conventions
 
-- Decisions, research, and offers carry frontmatter. Run `mb validate` to
-  check shape.
-- Status enum: proposed | running | scaling | killed | graduated | died.
+- Decisions, research, and offers carry a small block of metadata at the top
+  (frontmatter). Run `mb validate` to check it.
+- Status field: proposed | running | scaling | killed | graduated | died.
 - One owner per file (CODEOWNERS pattern).
 
 ## Helpful commands
 
 ```
-mb doctor                  # diagnose this repo
-mb validate                # check frontmatter shape
-mb graph --open            # see the link graph
+mb doctor                  # see if anything is off in this repo
+mb validate                # check the metadata on your files
+mb graph --open            # see what links to what
 ```
 
 Visit https://mainbranch.io for the full system docs.

--- a/mb/mb/validate.py
+++ b/mb/mb/validate.py
@@ -119,7 +119,7 @@ def render_human(report: dict[str, Any], verbose: bool = False) -> None:
 
     console = Console()
     if not report["files"]:
-        console.print("[yellow]no files matched any schema[/yellow]")
+        console.print("[yellow]nothing to check yet.[/yellow]")
         return
     by_schema: dict[str, list[dict[str, Any]]] = {}
     for f in report["files"]:
@@ -134,7 +134,7 @@ def render_human(report: dict[str, Any], verbose: bool = False) -> None:
                     console.print(f"        - {e}")
     console.print()
     if report["ok"]:
-        console.print("[green]all schemas valid[/green]")
+        console.print("[green]all metadata looks right.[/green]")
     else:
         bad = sum(1 for f in report["files"] if not f["ok"])
-        console.print(f"[red]{bad} file(s) failed[/red]")
+        console.print(f"[red]{bad} file(s) need fixing — see above.[/red]")


### PR DESCRIPTION
Replaces the function-first opening with the SaaS-rental / building-on-quicksand framing so the operating thesis lands before the install instructions. Quick start, skills table, and CLI reference are preserved; roadmap now flags the dashboard as ships-free.