### PR TITLE
[docs] Propose GitHub-native business OS direction

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,12 @@ The engine v0.1.0 decision lives at [`decisions/2026-04-29-mb-vip-v0-1-0-master.
 
 v0.1 is the CLI + Claude Code adapter foundation; v0.2+ broadens runtime compatibility and deepens the workflow surfaces. Direction, not promises.
 
+The proposed long-range product direction is captured in
+[`decisions/2026-05-02-github-native-business-os.md`](decisions/2026-05-02-github-native-business-os.md):
+Main Branch as a GitHub-native business operating system, with `mb` as the
+control plane, GitHub as the team layer, graph/structured data as the
+intelligence layer, and agent runtimes as execution.
+
 - `mb books` — BeanCount integration for ledger workflows ([#128](https://github.com/noontide-co/mainbranch/issues/128))
 - `mb fulfillment` — agency-arm tooling for delivery ops
 - Runtime compatibility — Codex, Cursor, OpenClaw, Hermes, local LLMs (v0.2+)

--- a/decisions/2026-05-02-github-native-business-os.md
+++ b/decisions/2026-05-02-github-native-business-os.md
@@ -312,6 +312,9 @@ real external users, clear commands, and enough depth that keeping it inside
 
 The detailed v0.2.0 product slice is in
 [`docs/prd/v0-2-first-run-daily-briefing.md`](../docs/prd/v0-2-first-run-daily-briefing.md).
+The agent workflow, PR review, and runtime eval contract for building that
+slice is in
+[`docs/prd/v0-2-agent-workflow-and-evals.md`](../docs/prd/v0-2-agent-workflow-and-evals.md).
 
 1. Add `mb onboard` as the human setup flow; leave `mb init` scriptable.
 2. Add a TTY-aware bare `mb` launch screen that routes to onboard, status,

--- a/decisions/2026-05-02-github-native-business-os.md
+++ b/decisions/2026-05-02-github-native-business-os.md
@@ -44,6 +44,8 @@ But the product experience is still narrow:
   first-class system.
 - GitHub activity is still presented as developer activity instead of business
   meaning.
+- There is no dashboard/server mode. All state is currently repo state plus
+  small local config, and every `mb` invocation starts, acts, and exits.
 
 This is acceptable for v0.1. It should not be the v0.2 shape.
 
@@ -127,6 +129,89 @@ The execution layer should:
 `mb` should not become a chat client or model host. It should wire runtimes,
 check health, sync integrations, expose JSON, and make the repo legible.
 
+## State Model
+
+The earlier "stateless CLI" framing is correct only for the base command
+surface. It should not become a religion.
+
+Main Branch needs three kinds of state:
+
+### Canonical State
+
+Canonical state is the business itself and must live in git:
+
+- reference files;
+- research;
+- decisions;
+- plans;
+- campaign artifacts;
+- durable summaries;
+- files changed through PRs.
+
+This state is portable, reviewable, branchable, and mergeable. It is the reason
+the system works.
+
+### Local Operational State
+
+Local operational state can live outside git:
+
+- credentials;
+- integration connection metadata;
+- last sync timestamps;
+- local indexes;
+- database cache;
+- runtime preferences;
+- dashboard/server config;
+- logs and temporary run records.
+
+This state belongs under a Main Branch home directory such as `~/.mainbranch/`
+or a per-instance path. It should be repairable by `mb doctor`, inspectable by
+`mb status`, and rebuildable when possible.
+
+### Live Process State
+
+Live process state exists only when the user intentionally starts a running
+surface:
+
+- local dashboard;
+- background sync;
+- local API server;
+- watch mode;
+- scheduled jobs;
+- runtime bridge.
+
+This state is allowed, but it must be explicit. A user should know when they
+are running Main Branch as a local service. The default CLI should remain safe,
+boring, and scriptable.
+
+## Dashboard Direction
+
+A dashboard is likely necessary if Main Branch becomes the operating surface for
+goals, GitHub activity, graph views, metrics, and integrations.
+
+The dashboard should not replace the repo. It should be a local or self-hosted
+view over the repo, GitHub, graph index, structured database, and connected
+tools.
+
+The likely shape:
+
+- `mb dashboard` or `mb serve` starts a local web UI;
+- first run creates a local instance directory;
+- the server reads business repos and GitHub activity;
+- structured metrics live in the local database/index;
+- credentials are read through the credential layer, never from the repo;
+- the UI shows business-language views over issues, PRs, goals, spend, graph,
+  and recent decisions;
+- production/team mode can later point at hosted Postgres or another durable
+  backend, but local-first should be the default.
+
+This follows the right lesson from dashboard-first systems like Paperclip: a
+dashboard implies a running server and persistent database. Main Branch should
+adopt that when the surface earns it, but it should not force a server into the
+install path before the repo/CLI/skill loop is solid.
+
+The dashboard's job is observability and control, not canonical memory.
+
 ## Onboarding Direction
 
 The biggest immediate product gap is onboarding.
@@ -201,6 +286,8 @@ real external users, clear commands, and enough depth that keeping it inside
 ## What Not To Do
 
 - Do not make `mb` a daemon by default.
+- Do not pretend a dashboard can exist without explicit local process state,
+  server config, and a database/index.
 - Do not make `mb` a chat interface.
 - Do not hide GitHub so deeply that power users lose the real primitive.
 - Do not put secrets in repo files, `CLAUDE.md`, or frontmatter.
@@ -219,6 +306,8 @@ real external users, clear commands, and enough depth that keeping it inside
 6. Add GitHub briefing primitives: assigned issues, mentions, PRs merged this
    week, blocked work, and business-language reframing.
 7. Add structured sync/indexing for one real data source before generalizing.
+8. Add an explicit dashboard spike only after `mb status`, graph/indexing, and
+   one integration sync have real data to show.
 
 ## Success Criteria
 
@@ -235,4 +324,3 @@ The v0.2 product direction is working when a non-technical operator can:
 The system should feel continuous, but the continuity should come from the repo,
 GitHub activity, graph, database index, and `/start`/`/end` ritual, not from a
 fragile long-running CLI process.
-

--- a/decisions/2026-05-02-github-native-business-os.md
+++ b/decisions/2026-05-02-github-native-business-os.md
@@ -1,0 +1,238 @@
+---
+title: Main Branch as GitHub-native business operating system
+date: 2026-05-02
+status: proposed
+tags: [product-direction, github, cli, integrations, graph, business-os]
+---
+
+# Main Branch as GitHub-Native Business Operating System
+
+## Decision
+
+Main Branch should move from "CLI plus Claude Code skills" toward a
+GitHub-native operating system for running a real business with AI.
+
+The core substrate stays the same:
+
+- the business lives in files in a git repo;
+- GitHub issues are work items;
+- pull requests are conversations and proposals;
+- git history is the evolution story;
+- agent runtimes execute against that source of truth.
+
+The product shift is that `mb` becomes the control plane that makes this
+substrate usable for non-developers while preserving the real primitives for
+technical operators.
+
+## Current Reality
+
+The v0.1 architecture made the right foundational calls:
+
+- `mb` is a stateless, scriptable CLI.
+- The business repo is the durable state.
+- Claude Code skills are the first execution adapter.
+- The engine is runtime-agnostic by design.
+- Skills and the CLI are packaged together through PyPI.
+- GitHub is already the public collaboration and release surface.
+
+But the product experience is still narrow:
+
+- `mb init` is a scaffold, not an adaptive onboarding flow.
+- `/start` is a Claude Code skill, not yet a full business briefing.
+- `mb graph` is a DOT exporter, not an operator-facing intelligence surface.
+- Tool integrations are skill-specific and credential handling is not yet a
+  first-class system.
+- GitHub activity is still presented as developer activity instead of business
+  meaning.
+
+This is acceptable for v0.1. It should not be the v0.2 shape.
+
+## Product Model
+
+Main Branch should be understood as five layers.
+
+### 1. Narrative Brain
+
+The git repo remains the source of truth:
+
+- `core/` for evergreen reference;
+- `research/` for investigations;
+- `decisions/` for choices and rationale;
+- `campaigns/`, `log/`, `documents/`, and finance files for operating history.
+
+Markdown stays human-readable. Git history stays inspectable. No database
+replaces the files.
+
+### 2. GitHub Team Layer
+
+GitHub is the team operating surface:
+
+- issues become tasks, blockers, requests, and follow-ups;
+- pull requests become conversations around proposed changes;
+- review comments become durable discussion;
+- merge history becomes "what shipped";
+- mentions, labels, assignees, and milestones become the daily coordination
+  feed.
+
+For non-technical users, Main Branch should translate GitHub vocabulary by
+default. A PR can be presented as a proposal, review, or shipped change. An
+issue can be presented as a task. Technical users should be able to see the raw
+GitHub terms.
+
+No Slack is required for the core work loop.
+
+### 3. Graph Layer
+
+The repo should gain an Obsidian-style graph layer over time:
+
+- frontmatter links;
+- wikilinks;
+- tags for people, companies, offers, channels, competitors, and metrics;
+- research-to-decision-to-campaign relationships;
+- git history reports for how important files changed over time.
+
+The graph is for both humans and agents. It lets `/start`, `/think`, and future
+runtime adapters enrich context quickly without loading the whole repo.
+
+### 4. Structured Data Layer
+
+Main Branch should add a local structured data layer for facts that are bad at
+being markdown:
+
+- ads metrics;
+- SEO and analytics data;
+- social performance;
+- P&L and ledger summaries;
+- site performance;
+- campaign spend;
+- goal progress.
+
+SQLite or DuckDB is the right first shape. The database is an index and query
+cache, not the source of truth. Rebuildable data can live outside git. Durable
+summaries and decisions flow back into markdown.
+
+### 5. Execution Layer
+
+Claude Code skills remain first-class today. Codex, Cursor, OpenClaw, Hermes,
+and local runtimes are compatibility targets.
+
+The execution layer should:
+
+- make ads, sites, social posts, plans, and reports;
+- review outcomes against rubrics;
+- surface hard truths instead of validating weak strategy;
+- propose next actions;
+- write durable learnings back into the repo.
+
+`mb` should not become a chat client or model host. It should wire runtimes,
+check health, sync integrations, expose JSON, and make the repo legible.
+
+## Onboarding Direction
+
+The biggest immediate product gap is onboarding.
+
+`mb init` should stay as the quiet, scriptable primitive. Add a higher-level
+`mb onboard` flow for humans.
+
+The onboarding flow should:
+
+- detect user sophistication with GitHub, terminal, and Claude Code;
+- offer beginner, intermediate, and power-user paths;
+- create or connect an existing business repo;
+- explain why GitHub, git, Cloudflare, and local files are used;
+- wire Claude Code skills and verify discovery;
+- introduce GitHub language mapping;
+- end with the exact daily ritual: open repo, run the runtime, invoke `/start`.
+
+The tone can carry playful trail-style flavor for first-time CLI users, but it
+must be skippable and must not slow down technical users.
+
+## Credential and Integration Direction
+
+Environment variables are not durable enough for the target audience.
+
+`mb` should own integration setup:
+
+- `mb connect <provider>` for Google, Meta, Cloudflare, Postiz, Apify, Beancount,
+  Whisper/transcription, and future providers;
+- OS keychain as primary credential storage;
+- encrypted local config as fallback;
+- repo-level metadata for connected providers and last sync timestamps;
+- `mb doctor` checks for broken or missing integrations;
+- skills call `mb` or read standardized integration outputs instead of asking
+  users to hand-edit env files.
+
+Credentials never belong in the business repo.
+
+## Daily Briefing Direction
+
+`/start` should become the daily business briefing.
+
+It should eventually summarize:
+
+- recent merged PRs and what they mean for the business;
+- open issues that need the operator;
+- assigned tasks and blocked work;
+- goals by offer;
+- ad spend and performance;
+- site and SEO signals;
+- P&L or ledger summaries;
+- recent decisions and stale research;
+- recommended actions, scored through rubrics and guardrails.
+
+The briefing should not be a generic digest. It should reframe raw GitHub and
+tool data into business meaning.
+
+## Specialized CLIs
+
+`mb` should remain the umbrella control plane.
+
+Specialized CLIs may emerge when a skill becomes a product surface:
+
+- site work may become a Cloudflare-backed CMS/deploy CLI;
+- ads work may become an ads analysis and launch CLI;
+- books work may become the Beancount/P&L CLI;
+- fulfillment work may become the agency delivery CLI.
+
+Do not split early. A new CLI earns its own package only when the domain has
+real external users, clear commands, and enough depth that keeping it inside
+`mb` makes the umbrella worse.
+
+## What Not To Do
+
+- Do not make `mb` a daemon by default.
+- Do not make `mb` a chat interface.
+- Do not hide GitHub so deeply that power users lose the real primitive.
+- Do not put secrets in repo files, `CLAUDE.md`, or frontmatter.
+- Do not make a database the canonical brain.
+- Do not claim runtime compatibility before adapters are tested.
+- Do not add playful onboarding that technical users cannot skip.
+
+## Near-Term Build Order
+
+1. Add `mb onboard` as the human setup flow; leave `mb init` scriptable.
+2. Add `mb start` as a clean handoff helper that verifies repo wiring and prints
+   or launches the configured runtime command.
+3. Add `mb status` as the cheap repo health summary for humans and agents.
+4. Upgrade `mb graph` toward an interactive graph and entity/tag model.
+5. Add `mb connect` foundation with keychain-backed credential storage.
+6. Add GitHub briefing primitives: assigned issues, mentions, PRs merged this
+   week, blocked work, and business-language reframing.
+7. Add structured sync/indexing for one real data source before generalizing.
+
+## Success Criteria
+
+The v0.2 product direction is working when a non-technical operator can:
+
+1. install Main Branch;
+2. create or connect a business repo;
+3. understand why GitHub is the business operating layer;
+4. open a daily briefing;
+5. see what changed, what matters, and what to do next;
+6. run a skill or runtime workflow that acts on that briefing;
+7. close the loop with a decision, PR, or updated reference file.
+
+The system should feel continuous, but the continuity should come from the repo,
+GitHub activity, graph, database index, and `/start`/`/end` ritual, not from a
+fragile long-running CLI process.
+

--- a/decisions/2026-05-02-github-native-business-os.md
+++ b/decisions/2026-05-02-github-native-business-os.md
@@ -219,6 +219,19 @@ The biggest immediate product gap is onboarding.
 `mb init` should stay as the quiet, scriptable primitive. Add a higher-level
 `mb onboard` flow for humans.
 
+Running bare `mb` in an interactive terminal should not feel like a dead help
+dump forever. It should become a beautiful launch screen that orients the user:
+
+- "new here?" -> `mb onboard`;
+- "already have a repo?" -> connect or open recent repos;
+- "daily work?" -> `mb status` / `mb start`;
+- "something broken?" -> `mb doctor`;
+- "power user?" -> show raw command list.
+
+This launch screen must be TTY-aware. In non-interactive contexts, scripts,
+tests, and CI should still get deterministic help/exit behavior. `mb --help`
+must always remain the full plain command reference.
+
 The onboarding flow should:
 
 - detect user sophistication with GitHub, terminal, and Claude Code;
@@ -298,15 +311,17 @@ real external users, clear commands, and enough depth that keeping it inside
 ## Near-Term Build Order
 
 1. Add `mb onboard` as the human setup flow; leave `mb init` scriptable.
-2. Add `mb start` as a clean handoff helper that verifies repo wiring and prints
+2. Add a TTY-aware bare `mb` launch screen that routes to onboard, status,
+   start, doctor, and help without breaking scripts.
+3. Add `mb start` as a clean handoff helper that verifies repo wiring and prints
    or launches the configured runtime command.
-3. Add `mb status` as the cheap repo health summary for humans and agents.
-4. Upgrade `mb graph` toward an interactive graph and entity/tag model.
-5. Add `mb connect` foundation with keychain-backed credential storage.
-6. Add GitHub briefing primitives: assigned issues, mentions, PRs merged this
+4. Add `mb status` as the cheap repo health summary for humans and agents.
+5. Upgrade `mb graph` toward an interactive graph and entity/tag model.
+6. Add `mb connect` foundation with keychain-backed credential storage.
+7. Add GitHub briefing primitives: assigned issues, mentions, PRs merged this
    week, blocked work, and business-language reframing.
-7. Add structured sync/indexing for one real data source before generalizing.
-8. Add an explicit dashboard spike only after `mb status`, graph/indexing, and
+8. Add structured sync/indexing for one real data source before generalizing.
+9. Add an explicit dashboard spike only after `mb status`, graph/indexing, and
    one integration sync have real data to show.
 
 ## Success Criteria

--- a/decisions/2026-05-02-github-native-business-os.md
+++ b/decisions/2026-05-02-github-native-business-os.md
@@ -310,6 +310,9 @@ real external users, clear commands, and enough depth that keeping it inside
 
 ## Near-Term Build Order
 
+The detailed v0.2.0 product slice is in
+[`docs/prd/v0-2-first-run-daily-briefing.md`](../docs/prd/v0-2-first-run-daily-briefing.md).
+
 1. Add `mb onboard` as the human setup flow; leave `mb init` scriptable.
 2. Add a TTY-aware bare `mb` launch screen that routes to onboard, status,
    start, doctor, and help without breaking scripts.

--- a/docs/prd/v0-2-agent-workflow-and-evals.md
+++ b/docs/prd/v0-2-agent-workflow-and-evals.md
@@ -20,9 +20,9 @@ development process should match the product thesis:
 - checks prove the deterministic layer;
 - runtime evals prove the human/agent loop.
 
-This PRD defines the cold-start template, PR review template, and evaluation
-ladder for v0.2 work. It is written for Devon's Conductor setup, but the
-contract is runtime-agnostic. Any agent runtime should be able to follow it.
+This PRD defines the agent startup template, PR review template, and evaluation
+ladder for v0.2 work. The contract is runtime-agnostic. Any agent runtime or
+human contributor should be able to follow it.
 
 ## Problem
 
@@ -45,7 +45,7 @@ issues and PRs with evidence.
 
 ## Goals
 
-- Give every Conductor-spawned agent the same starting shape.
+- Give every agent or contributor the same starting shape.
 - Preserve one issue per branch and one PR per concern.
 - Make PR review check product direction, not only syntax.
 - Add runtime evals that exercise Claude Code and skills, not only `mb`.
@@ -63,18 +63,16 @@ issues and PRs with evidence.
 - No issue epics. Work is sorted by priority, status, and release.
 - No model invocation from `mb` itself.
 
-## Conductor Cold Start Template
+## Agent Startup Template
 
-Use this as the default pre-PR template for Main Branch workspaces.
+Use this as the default pre-PR template for Main Branch work.
 
 ```md
-You are working inside Conductor on Devon's Mac.
-
 ## Workspace
 
 Workspace: {workspace_dir}
 Target branch: main
-Branch naming: dmthepm/<short-specific-name>
+Branch naming: follow the repository's branch convention.
 
 One branch owns one issue or one tightly scoped PR. Do not broaden scope
 silently. If you find adjacent work, open or comment on a follow-up issue.
@@ -130,11 +128,11 @@ Preferred evidence order:
 6. screenshots only when a visual or runtime UI matters.
 ```
 
-## Per-Branch Cold Start File
+## Per-Branch Startup File
 
 Every substantial branch should create a gitignored note at
-`.context/cold-start.md`. This is not the final artifact, but it keeps agents
-honest during the run.
+`.context/cold-start.md` or an equivalent local scratch file. This is not the
+final artifact, but it keeps agents honest during the run.
 
 Suggested shape:
 
@@ -406,7 +404,7 @@ When a branch reveals a repeated failure, choose one durable fix:
 - clarify an error message;
 - update a PRD or decision;
 - open a follow-up issue with priority, status, and release;
-- update Conductor preferences if the workflow rule belongs at agent startup.
+- update private maintainer workflow docs if the rule belongs at agent startup.
 
 Do not keep operational truth only in chat. Chat can decide; the repo must
 remember.

--- a/docs/prd/v0-2-agent-workflow-and-evals.md
+++ b/docs/prd/v0-2-agent-workflow-and-evals.md
@@ -1,0 +1,442 @@
+---
+title: "PRD: v0.2 Agent Workflow + Runtime Evals"
+status: draft
+date: 2026-05-02
+release: v0.2.0
+linked_decision: decisions/2026-05-02-github-native-business-os.md
+linked_prd: docs/prd/v0-2-first-run-daily-briefing.md
+---
+
+# PRD: v0.2 Agent Workflow + Runtime Evals
+
+## Summary
+
+Main Branch is being built by agents inside branch-per-issue workspaces. The
+development process should match the product thesis:
+
+- repo files are durable context;
+- issues define work;
+- PRs carry proposals and evidence;
+- checks prove the deterministic layer;
+- runtime evals prove the human/agent loop.
+
+This PRD defines the cold-start template, PR review template, and evaluation
+ladder for v0.2 work. It is written for Devon's Conductor setup, but the
+contract is runtime-agnostic. Any agent runtime should be able to follow it.
+
+## Problem
+
+The v0.2 product direction is larger than a normal CLI feature set. It touches
+first-run UX, GitHub briefing, skill wiring, runtime handoff, graph primitives,
+and eventually dashboard state.
+
+If every agent starts from chat context, the system drifts:
+
+- one agent optimizes for CLI mechanics while another optimizes for business
+  positioning;
+- stale issue labels survive after priorities change;
+- PRs pass unit tests but fail the actual Claude Code first-run loop;
+- decisions stay in conversation instead of becoming durable repo context;
+- future agents relearn the same product boundary.
+
+The fix is a durable operating loop: cold start from repo truth, work one issue
+per branch, validate with both code checks and runtime smoke tests, then update
+issues and PRs with evidence.
+
+## Goals
+
+- Give every Conductor-spawned agent the same starting shape.
+- Preserve one issue per branch and one PR per concern.
+- Make PR review check product direction, not only syntax.
+- Add runtime evals that exercise Claude Code and skills, not only `mb`.
+- Keep evals staged so agents can move quickly without pretending every change
+  needs a full manual smoke.
+- Capture learnings back into docs, issues, tests, or decisions.
+- Support future runtimes without rewriting the workflow.
+
+## Non-Goals
+
+- No hosted CI for interactive Claude Code in v0.2.0.
+- No fake automation that claims to test an authenticated runtime without
+  actually launching it.
+- No giant mandatory context dump for every agent.
+- No issue epics. Work is sorted by priority, status, and release.
+- No model invocation from `mb` itself.
+
+## Conductor Cold Start Template
+
+Use this as the default pre-PR template for Main Branch workspaces.
+
+```md
+You are working inside Conductor on Devon's Mac.
+
+## Workspace
+
+Workspace: {workspace_dir}
+Target branch: main
+Branch naming: dmthepm/<short-specific-name>
+
+One branch owns one issue or one tightly scoped PR. Do not broaden scope
+silently. If you find adjacent work, open or comment on a follow-up issue.
+
+## Start Here
+
+1. Read `CLAUDE.md`.
+2. Read `decisions/2026-05-02-github-native-business-os.md`.
+3. Read `docs/prd/v0-2-first-run-daily-briefing.md`.
+4. Read `docs/prd/v0-2-agent-workflow-and-evals.md`.
+5. Read the assigned GitHub issue and all comments.
+6. Check open PRs that may touch the same files.
+
+## North Star
+
+Main Branch is a GitHub-native business operating system. `mb` is the
+deterministic control plane. Agent-runtime skills are the judgment layer. GitHub
+issues are tasks. PRs are proposals/conversations. The repo is the durable
+business brain.
+
+## Scope
+
+Before editing, write a short scope note in `.context/cold-start.md`:
+
+- issue / PR link;
+- intended release;
+- priority and status;
+- in-scope files;
+- explicit non-goals;
+- validation plan;
+- whether runtime smoke is required.
+
+## Workflow
+
+1. Investigate from source files and issue context.
+2. Make the smallest coherent change.
+3. Validate deterministically.
+4. Run runtime/manual evals when the user-facing loop changed.
+5. Update docs/issues when the work changes product truth.
+6. Open or update the PR with evidence.
+
+## Evidence Rules
+
+No "done" without evidence.
+
+Preferred evidence order:
+
+1. local test output;
+2. CLI smoke output;
+3. runtime smoke evidence;
+4. GitHub issue/PR/check state;
+5. source-code references;
+6. screenshots only when a visual or runtime UI matters.
+```
+
+## Per-Branch Cold Start File
+
+Every substantial branch should create a gitignored note at
+`.context/cold-start.md`. This is not the final artifact, but it keeps agents
+honest during the run.
+
+Suggested shape:
+
+```md
+# Cold Start
+
+Issue:
+Release:
+Priority:
+Status:
+
+## Read
+
+- [ ] CLAUDE.md
+- [ ] Business OS decision
+- [ ] v0.2 PRD
+- [ ] Assigned issue/comments
+- [ ] Existing tests near touched code
+
+## Scope
+
+In:
+
+Out:
+
+## Risks
+
+- 
+
+## Validation Plan
+
+- Static:
+- CLI:
+- Fixture repo:
+- Runtime/manual:
+
+## Evidence Log
+
+- 
+```
+
+The final PR should not rely on `.context/`. Anything durable belongs in docs,
+tests, decisions, or issue comments.
+
+## PR Creation Template
+
+Every PR should tell reviewers what is in the box without requiring them to
+reconstruct the branch.
+
+```md
+## Scope
+
+- 
+
+## Product Fit
+
+- Which decision / PRD / issue this implements:
+- What user loop changes:
+- What stays out of scope:
+
+## Changes
+
+- 
+
+## Validation
+
+- Static:
+- CLI:
+- Fixture repo:
+- Runtime/manual:
+
+## Issue Updates
+
+- Closes:
+- Follow-ups opened:
+
+## Risk
+
+- 
+```
+
+For decision or PRD-only PRs, replace "Validation" with "Review Focus" and list
+the product questions the reviewer should resolve.
+
+## Code Review Template
+
+Reviewers and review agents should lead with findings. Summaries come after
+risks.
+
+```md
+## Must Fix
+
+1. 
+
+## Suggestions
+
+1. 
+
+## Product Alignment
+
+- Matches the Business OS direction?
+- Preserves `mb` as deterministic control plane?
+- Keeps skills as runtime/judgment layer?
+- Does not overclaim runtime compatibility?
+- Uses GitHub language in a way non-developers can understand?
+
+## State Model
+
+- Canonical state stays in git?
+- Local operational state stays out of git?
+- Live process state is explicit?
+- Secrets are never committed?
+
+## Validation Review
+
+- Static checks are present?
+- CLI behavior tested in TTY and non-TTY modes when relevant?
+- `--json` / exit-code behavior tested when relevant?
+- Fixture business repo smoke included when repo shape changes?
+- Claude Code/runtime smoke included when skill discovery or first-run flow
+  changes?
+
+## Verdict
+
+APPROVE / REQUEST CHANGES / NEEDS DISCUSSION
+```
+
+## Evaluation Ladder
+
+Use the lightest eval that proves the changed behavior. Do not run heavy manual
+checks for documentation-only branches, but do not let user-facing runtime work
+ship on unit tests alone.
+
+### Level 0: Docs and Decision Checks
+
+Use for docs, PRDs, issue cleanup, roadmap, and decision files.
+
+Required:
+
+- frontmatter present where the repo expects it;
+- links resolve or are obviously future references;
+- no stale product claims;
+- no secrets;
+- issue/PR state matches the document.
+
+### Level 1: Static Code Checks
+
+Use for any Python, packaging, workflow, or template change.
+
+Required:
+
+```bash
+ruff format --check
+ruff check
+mypy mb
+pytest -q --cov
+```
+
+Add narrower tests when the touched area has a faster focused target.
+
+### Level 2: CLI Contract Tests
+
+Use for any `mb` command, output, prompt, or exit-code change.
+
+Required:
+
+- unit tests below the Typer command layer;
+- `CliRunner` tests for command output;
+- non-interactive behavior tested;
+- JSON output tested when present;
+- exit codes tested for success and expected user-fixable failure.
+
+TTY-aware commands must test both paths:
+
+- interactive TTY shows the product surface;
+- non-TTY / `--help` stays deterministic and scriptable.
+
+### Level 3: Package and Install Smoke
+
+Use for packaging, bundled skills, update, skill-linking, or first-run changes.
+
+Required:
+
+```bash
+python -m build
+python -m venv /tmp/mainbranch-smoke
+/tmp/mainbranch-smoke/bin/pip install dist/*.whl
+/tmp/mainbranch-smoke/bin/mb --version
+/tmp/mainbranch-smoke/bin/mb skill list
+```
+
+For pipx-sensitive changes, run a real pipx smoke when practical:
+
+```bash
+pipx install --force dist/*.whl
+mb --version
+mb doctor
+```
+
+### Level 4: Business Repo Fixture Smoke
+
+Use for onboarding, init, doctor, validate, graph, status, update, and start
+changes.
+
+Required flow in a temp directory:
+
+```bash
+mb init test-business
+cd test-business
+mb doctor
+mb status
+mb validate
+```
+
+Expected evidence:
+
+- repo tree created correctly;
+- `.claude/` skill wiring exists when expected;
+- `mb doctor` reports repairable issues clearly;
+- dirty git state is expected and explained;
+- no command writes outside the requested repo except allowed local config.
+
+### Level 5: Agent Runtime Smoke
+
+Use when first-run, skill discovery, `/start`, `/pull`, `/think`, or runtime
+handoff behavior changes.
+
+This is manual or semi-automated in v0.2.0. Do not pretend it is covered by
+unit tests.
+
+Claude Code smoke:
+
+```bash
+tmpdir="$(mktemp -d)"
+cd "$tmpdir"
+mb init test-business
+cd test-business
+mb doctor
+claude
+# inside Claude Code:
+# /start
+```
+
+Record evidence in the PR:
+
+- Claude Code opened in the business repo, not the engine repo;
+- `/start` was discoverable;
+- skill had access to expected repo context;
+- failure or missing auth path was clear if the runtime could not be launched.
+
+Future runtime smokes should follow the same contract for Codex, Cursor,
+OpenClaw, Hermes, or local LLM adapters:
+
+- runtime opens against the business repo;
+- skill/workflow discovery works;
+- the runtime can read canonical repo files;
+- output writes to the expected repo paths;
+- `mb` remains the deterministic setup/status layer.
+
+## Self-Improving Loop
+
+Every issue branch should leave the system easier for the next agent.
+
+When a branch reveals a repeated failure, choose one durable fix:
+
+- add or update a test;
+- add a fixture;
+- improve `mb doctor`;
+- clarify an error message;
+- update a PRD or decision;
+- open a follow-up issue with priority, status, and release;
+- update Conductor preferences if the workflow rule belongs at agent startup.
+
+Do not keep operational truth only in chat. Chat can decide; the repo must
+remember.
+
+## Issue Hygiene Rules
+
+Issues should be maintained with simple fields:
+
+- priority: Urgent, High, Medium, Low;
+- status: Backlog, To Do, In Progress, Canceled, Duplicate;
+- release: v0.1.x, v0.2.0, v0.2.1, v0.2.2, v0.3+.
+
+No epics are required. If a body says "epic", rename it to a decision,
+direction, or umbrella issue only when it still carries real coordination value.
+
+Cold start should check for stale work:
+
+- `In Progress` issue with no PR or comment should be nudged or moved back;
+- shipped work should be closed with a release/link comment;
+- duplicated work should be marked duplicate rather than left open;
+- future ideas should sit in Backlog with a release guess, not pretend to be
+  active.
+
+## What This Means For v0.2.0
+
+The first-run/daily-briefing release is not done until both layers pass:
+
+- deterministic CLI checks prove `mb` can scaffold, inspect, update, and hand
+  off reliably;
+- runtime smoke proves a human can actually enter Claude Code and use `/start`
+  from the generated business repo.
+
+That is the product promise. Unit tests alone are necessary but insufficient.

--- a/docs/prd/v0-2-first-run-daily-briefing.md
+++ b/docs/prd/v0-2-first-run-daily-briefing.md
@@ -345,6 +345,11 @@ Avoid overclaiming. v0.2.0 is still terminal-first and Claude-Code-first.
 
 ## Release Plan
 
+Each release should be a meaningful product slice. Avoid splitting work so
+finely that cold start, PR creation, review, CI, and merge overhead cost more
+than the feature. Prefer one branch per coherent user loop, with multiple
+concern-based commits inside the branch.
+
 ### v0.2.0
 
 - #184 bare `mb` launch screen
@@ -353,12 +358,36 @@ Avoid overclaiming. v0.2.0 is still terminal-first and Claude-Code-first.
 - #186 `mb start`
 - #174 `mb update`
 
+Success criteria:
+
+- a fresh user can install Main Branch and run bare `mb`;
+- the launch screen makes the next step obvious without breaking `mb --help` or
+  non-interactive scripts;
+- onboarding can create or connect a business repo and explain GitHub in
+  business language;
+- `mb status` gives a useful daily briefing without invoking a model;
+- `mb start` gets the user to Claude Code with skill discovery verified or a
+  clear repair path;
+- `mb update` handles pipx and clone/source installs accurately;
+- the full first-run loop is proven with CLI tests, fixture repo smoke, and a
+  Claude Code `/start` smoke or an explicit blocker note.
+
 ### v0.2.1
 
 - #188 GitHub activity briefing primitives
 - #121 graph index + interactive view
 - #122 cross-reference validation
 - #187 `mb connect` foundation
+
+Success criteria:
+
+- `mb status` can include cheap GitHub activity when `gh` is authenticated;
+- graph/index output can answer basic entity, tag, and relationship questions;
+- cross-reference validation catches stale links and broken references;
+- `mb connect` establishes the credential/config pattern without putting
+  secrets in the repo;
+- at least one real business repo can use the briefing and graph data without
+  manual file spelunking.
 
 ### v0.2.2
 
@@ -368,12 +397,31 @@ Avoid overclaiming. v0.2.0 is still terminal-first and Claude-Code-first.
 - #130 tool tethering
 - #143 similar-bets graph query
 
+Success criteria:
+
+- the runtime adapter contract is documented and tested against Claude Code plus
+  at least one other runtime target;
+- invocation hints do not hardcode Claude Code as the only path;
+- tool tethering produces clear setup/repair guidance;
+- similar-bets queries demonstrate that graph context improves real workflow
+  selection;
+- compatibility claims stay narrower than what has been tested.
+
 ### v0.3.0+
 
 - #189 dashboard spike
 - #128 `mb books`
 - site/ads/think deeper workflow surfaces
 - first structured data sync
+
+Success criteria:
+
+- dashboard/server mode is explicit, local-first, and optional;
+- local operational state has a documented home and repair story;
+- one structured data sync proves the database/index pattern before
+  generalizing;
+- domain-specific workflow surfaces earn their scope through real usage rather
+  than splitting into premature separate CLIs.
 
 ## Linear Mapping
 

--- a/docs/prd/v0-2-first-run-daily-briefing.md
+++ b/docs/prd/v0-2-first-run-daily-briefing.md
@@ -1,0 +1,415 @@
+---
+title: "PRD: v0.2 First-Run + Daily Briefing"
+status: draft
+date: 2026-05-02
+release: v0.2.0
+linked_decision: decisions/2026-05-02-github-native-business-os.md
+linked_issues:
+  - https://github.com/noontide-co/mainbranch/issues/173
+  - https://github.com/noontide-co/mainbranch/issues/184
+  - https://github.com/noontide-co/mainbranch/issues/185
+  - https://github.com/noontide-co/mainbranch/issues/186
+  - https://github.com/noontide-co/mainbranch/issues/174
+---
+
+# PRD: v0.2 First-Run + Daily Briefing
+
+## Summary
+
+Main Branch v0.2.0 should prove the new product shape without building a
+dashboard first.
+
+The release should make `mb` feel like the front door to a GitHub-native
+business operating system:
+
+1. bare `mb` gives a polished interactive launch screen;
+2. `mb onboard` guides humans through setup or repo connection;
+3. `mb status` gives a cheap daily business/repo briefing;
+4. `mb start` makes the handoff to Claude Code explicit and repairable;
+5. `mb update` keeps the install and bundled workflows current.
+
+This release does not need full integrations, a live dashboard, autonomous
+agents, or multi-runtime execution. It needs to turn the first-run and daily-run
+loops into a coherent product.
+
+## Problem
+
+The v0.1 CLI works, but it assumes the user already understands the system.
+
+Current behavior:
+
+- `mb init` scaffolds a repo but does not teach or adapt.
+- Bare `mb` behaves like a traditional command reference.
+- The handoff to Claude Code is mostly copy/paste guidance.
+- `/start` carries the daily entry surface, but `mb` does not yet give a
+  pre-runtime status view.
+- GitHub is present, but not yet reframed as the business team layer.
+
+This is enough for technical early adopters. It is not enough for the operator
+who needs to be taught why git, GitHub, Claude Code, and local files matter.
+
+## Goals
+
+- Make first-run feel intentional, educational, and safe.
+- Respect both beginners and power users.
+- Preserve scriptability and boring CLI behavior where required.
+- Establish `mb status` as the reusable daily briefing primitive.
+- Make the Claude Code handoff explicit, diagnosable, and repairable.
+- Create terminal output that feels like a product, not a scaffolding script.
+- Keep all canonical business state in the repo.
+
+## Non-Goals
+
+- No dashboard/server process in v0.2.0.
+- No background daemon.
+- No model invocation inside `mb`.
+- No full multi-runtime adapter execution.
+- No Google/Meta/Postiz/Cloudflare analytics sync yet.
+- No secrets/credentials system beyond what is already required for current
+  doctor checks.
+- No database/index beyond cheap reads from git, filesystem, and GitHub CLI.
+
+## Target Users
+
+### Beginner
+
+They have little or no terminal/GitHub experience. They need confidence, plain
+language, and the "why" behind the stack.
+
+Success for this user: they can install, create a repo, understand that GitHub
+is where the business work lives, and start Claude Code without feeling lost.
+
+### Intermediate
+
+They have GitHub or terminal exposure but do not yet think of GitHub as a
+business operating layer.
+
+Success for this user: they can connect or create a repo, understand the file
+taxonomy, and know when to use `mb` vs Claude Code.
+
+### Power User
+
+They already live in git, GitHub, and terminal tools.
+
+Success for this user: they can skip education, inspect raw commands, connect an
+existing repo, and see useful status/JSON surfaces quickly.
+
+## User Experience Principles
+
+- Teach the model, not only the mechanics.
+- Let users skip explanations.
+- Use business language by default, raw GitHub language when useful.
+- Make the terminal warmer without turning it into a toy.
+- Keep failure messages repair-oriented.
+- Never hide where data lives.
+- Never put secrets in repo files.
+
+## Product Scope
+
+### 1. Bare `mb` Launch Screen
+
+Linked issue: #184
+
+When a user runs `mb` with no arguments in an interactive terminal, show a
+polished launch screen.
+
+Required routes:
+
+- "New here?" -> `mb onboard`
+- "Daily work" -> `mb status`
+- "Open agent runtime" -> `mb start`
+- "Fix/check setup" -> `mb doctor`
+- "Power user commands" -> normal command reference
+
+TTY rules:
+
+- Interactive TTY: show launch screen.
+- Non-TTY: keep deterministic help/exit behavior.
+- `mb --help`: always show plain command reference.
+- Tests must cover TTY vs non-TTY behavior.
+
+Tone:
+
+- Light trail/retro flavor is allowed.
+- No giant ASCII wall by default.
+- Must be fast to render.
+- Must not require reading a long story before using the tool.
+
+Acceptance:
+
+- Bare `mb` in a normal terminal shows the launch screen.
+- `mb --help` stays plain.
+- Piped/non-interactive invocation does not hang or prompt.
+- Launch screen links to real commands that exist or clearly say "coming next"
+  only inside this release branch before implementation lands.
+
+### 2. `mb onboard`
+
+Linked issue: #185
+
+`mb onboard` is the human setup flow. `mb init` remains the quiet, scriptable
+primitive.
+
+Required capabilities:
+
+- Detect or ask experience level:
+  - terminal familiarity;
+  - GitHub familiarity;
+  - Claude Code installed/known;
+  - existing repo vs new repo.
+- Offer three paths:
+  - beginner guided setup;
+  - intermediate setup with shorter explanations;
+  - power-user setup with advanced options and minimal copy.
+- Create a new repo through `mb init` or connect an existing repo.
+- Explain why GitHub is used as the team/business layer.
+- Explain where canonical business state lives.
+- Wire Claude Code skills through existing skill-link code.
+- Verify skill discovery and runtime readiness through doctor/status checks.
+- End with exact next commands.
+
+Suggested beginner flow:
+
+1. Welcome/launch screen.
+2. "Have you used GitHub before?"
+3. "Create new business repo or connect existing?"
+4. Business name and repo path.
+5. Short explanation: GitHub = tasks/conversations/history, repo = business
+   brain, Claude Code = first execution runtime.
+6. Scaffold/connect.
+7. Verify `gh`, `git`, `claude`, skill wiring.
+8. Show daily ritual.
+
+Power-user requirements:
+
+- `--yes` or equivalent fast path for smoke tests.
+- `--path`, `--name`, and existing repo options.
+- No forced educational copy.
+
+Acceptance:
+
+- Re-running is idempotent.
+- Existing initialized repo is detected and repaired, not overwritten.
+- Missing `gh` or Claude Code results in clear repair instructions.
+- Does not require a GitHub API write for local-only setup.
+- Produces `--json` output or a clear future path for automation.
+
+### 3. `mb status`
+
+Linked issue: #173
+
+`mb status` is the first daily briefing primitive. It should be cheap, local
+first, and useful before any dashboard exists.
+
+Required sections:
+
+- Repo:
+  - path;
+  - whether it looks like a Main Branch repo;
+  - git branch and dirty/clean state;
+  - install mode and Main Branch version.
+- Runtime:
+  - Claude Code found/missing;
+  - skill wiring found/missing;
+  - suggested repair command.
+- Brain:
+  - counts for core, research, decisions, campaigns/log/documents;
+  - recent research;
+  - recent decisions;
+  - stale proposed/running decisions if detectable.
+- GitHub, when `gh` is authenticated:
+  - assigned open issues;
+  - review requests or mentions if available cheaply;
+  - recent merged PRs;
+  - blocked/stale labels where present.
+- Next actions:
+  - one to five deterministic suggestions based on checks.
+
+Output modes:
+
+- human terminal summary by default;
+- `--json` with stable top-level sections;
+- degraded mode when `gh`, network, or git data is unavailable.
+
+Acceptance:
+
+- Runs in under a few seconds on a normal repo.
+- Does not invoke a model.
+- Does not modify repo files.
+- Does not require GitHub auth to be useful.
+- `/start` can later call or mimic its data model.
+
+### 4. `mb start`
+
+Linked issue: #186
+
+`mb start` is the runtime handoff helper.
+
+Required behavior:
+
+- Resolve target repo:
+  - current directory if it is a Main Branch repo;
+  - `--repo <path>` override;
+  - future recent-repos support can come later.
+- Run the handoff-relevant subset of `mb status` or `mb doctor`.
+- Verify Claude Code is installed.
+- Verify skill wiring.
+- Print the exact command:
+
+```bash
+cd <repo>
+claude
+# then run /start
+```
+
+Optional behavior:
+
+- `--launch` may run `claude` directly if safe.
+- `--json` emits command, repo path, runtime, and readiness.
+
+Acceptance:
+
+- Does not invoke a model itself.
+- Handles missing Claude Code with install guidance.
+- Handles missing skill wiring with `mb skill link --repo <path>`.
+- Safe to run repeatedly.
+
+### 5. `mb update`
+
+Linked issue: #174
+
+`mb update` should own the install-mode-aware refresh mechanism that `/pull`
+can later call or explain.
+
+Required behavior:
+
+- Detect install mode:
+  - pipx/PyPI;
+  - editable/source clone;
+  - unknown.
+- For pipx installs, recommend or run `pipx upgrade mainbranch`.
+- For clone/source mode, recommend or run `git pull --ff-only`.
+- Repair skill links after update when needed.
+- Print what changed or where to read changelog when available.
+
+Acceptance:
+
+- Safe dry-run mode.
+- Clear output for pipx vs clone mode.
+- Does not corrupt editable installs.
+
+## Data and State
+
+v0.2.0 should use only:
+
+- repo files;
+- git metadata;
+- existing `.claude/` skill wiring;
+- existing local config if present;
+- GitHub CLI reads where authenticated.
+
+Do not add a database in v0.2.0. Do not add background sync. Do not add a
+dashboard server.
+
+## CLI/API Requirements
+
+Every new command should support:
+
+- human terminal output;
+- clear exit codes;
+- no hangs in non-interactive mode;
+- testable functions below the Typer command layer;
+- JSON output where another skill/runtime/dashboard will likely consume it.
+
+Suggested exit code conventions:
+
+- `0`: usable / success;
+- `1`: expected user-fixable issue;
+- `2`: command/runtime error;
+- `130`: user canceled.
+
+## Copy and Language
+
+Use business-first language, with raw terms in parentheses when helpful.
+
+Examples:
+
+- "tasks (GitHub issues)"
+- "proposals/conversations (pull requests)"
+- "what shipped (merged PRs)"
+- "business brain (your repo)"
+
+Avoid overclaiming. v0.2.0 is still terminal-first and Claude-Code-first.
+
+## Release Plan
+
+### v0.2.0
+
+- #184 bare `mb` launch screen
+- #185 `mb onboard`
+- #173 `mb status`
+- #186 `mb start`
+- #174 `mb update`
+
+### v0.2.1
+
+- #188 GitHub activity briefing primitives
+- #121 graph index + interactive view
+- #122 cross-reference validation
+- #187 `mb connect` foundation
+
+### v0.2.2
+
+- #177 runtime adapter contract
+- #124 cross-runtime compatibility
+- #131 runtime-aware invocation hints
+- #130 tool tethering
+- #143 similar-bets graph query
+
+### v0.3.0+
+
+- #189 dashboard spike
+- #128 `mb books`
+- site/ads/think deeper workflow surfaces
+- first structured data sync
+
+## Linear Mapping
+
+| Issue | Priority | Status | Release |
+|---|---|---|---|
+| #112 Accept GitHub-native business OS direction | Urgent | In Progress | v0.2 Direction |
+| #183 PR: GitHub-native business OS decision | Urgent | In Progress | v0.2 Direction |
+| #184 TTY-aware bare `mb` launch screen | Urgent | To Do | v0.2.0 |
+| #185 `mb onboard` adaptive setup flow | Urgent | To Do | v0.2.0 |
+| #173 `mb status` daily briefing v0 | Urgent | To Do | v0.2.0 |
+| #186 `mb start` runtime handoff helper | High | To Do | v0.2.0 |
+| #174 `mb update` install-mode-aware refresh | High | To Do | v0.2.0 |
+| #80 `/ads` compliance gate | Urgent | To Do | v0.1.3 |
+| #188 GitHub activity briefing primitives | High | To Do | v0.2.1 |
+| #187 `mb connect` foundation | High | To Do | v0.2.1 |
+| #121 graph index + interactive view | High | To Do | v0.2.1 |
+
+Everything not listed above stays backlog unless explicitly pulled forward.
+
+## Open Questions
+
+- Should bare `mb` route to `mb status` by default after onboarding has run?
+- Should `mb onboard` create GitHub repos through `gh` or only local repos in
+  v0.2.0?
+- Should `mb start --launch` exist in v0.2.0 or should it only print commands?
+- What is the minimum useful GitHub read for `mb status` without slowing it down?
+- Where should recent repo selection live: local config now or wait for v0.2.1?
+
+## Definition of Done
+
+v0.2.0 is done when a fresh user can:
+
+1. install Main Branch;
+2. run `mb`;
+3. choose onboarding;
+4. create or connect a business repo;
+5. run `mb status` and understand the repo state;
+6. run `mb start` and reach Claude Code with clear `/start` instructions;
+7. update Main Branch through `mb update`;
+8. recover from common missing-tool states through clear repair guidance.
+

--- a/docs/prd/v0-2-first-run-daily-briefing.md
+++ b/docs/prd/v0-2-first-run-daily-briefing.md
@@ -10,6 +10,8 @@ linked_issues:
   - https://github.com/noontide-co/mainbranch/issues/185
   - https://github.com/noontide-co/mainbranch/issues/186
   - https://github.com/noontide-co/mainbranch/issues/174
+related_prds:
+  - docs/prd/v0-2-agent-workflow-and-evals.md
 ---
 
 # PRD: v0.2 First-Run + Daily Briefing
@@ -413,3 +415,9 @@ v0.2.0 is done when a fresh user can:
 7. update Main Branch through `mb update`;
 8. recover from common missing-tool states through clear repair guidance.
 
+Development work for this release should follow the agent workflow and runtime
+eval ladder in
+[`docs/prd/v0-2-agent-workflow-and-evals.md`](v0-2-agent-workflow-and-evals.md).
+In particular, CLI tests are not enough for first-run work: changes that affect
+skill discovery, runtime handoff, or `/start` need a Claude Code smoke or an
+explicit note explaining why it could not be run.


### PR DESCRIPTION
## Summary
- add a proposed decision record for Main Branch as a GitHub-native business operating system
- define the five-layer product model: narrative brain, GitHub team layer, graph layer, structured data layer, execution layer
- capture the state/dashboard direction: repo remains canonical, local operational state is allowed, live process state must be explicit
- add the v0.2 first-run + daily briefing PRD for bare `mb`, `mb onboard`, `mb status`, `mb start`, and `mb update`
- add release-level success criteria so v0.2 work is grouped by coherent user loops instead of tiny issue overhead
- add a public-safe agent workflow + runtime eval PRD for startup, PR review, issue hygiene, CLI checks, fixture smoke, and Claude Code `/start` smoke
- link the proposed direction from the README roadmap without claiming it has shipped

## Notes
This is intentionally proposed, not accepted. The README remains grounded in v0.1 reality. The agent workflow PRD is now generic and public-safe; Devon-specific Conductor preferences live in `devon-homelab` instead. First-run work should not be considered done on CLI tests alone when the user-facing loop depends on Claude Code skill discovery.

## Tests
- `git diff --check`