### PR TITLE
[update] Sync Linear release after PyPI publish

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -117,3 +117,39 @@ jobs:
 
       - name: Publish via trusted publisher
         uses: pypa/gh-action-pypi-publish@release/v1
+
+  linear-release:
+    name: Sync Linear release
+    needs: [publish]
+    runs-on: ubuntu-latest
+    if: startsWith(github.event.release.tag_name, 'oe-v')
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Derive Linear release metadata
+        id: meta
+        run: |
+          tag="${{ github.event.release.tag_name }}"
+          version="${tag#oe-v}"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "name=Main Branch $version" >> "$GITHUB_OUTPUT"
+
+      - name: Sync issues into Linear release
+        uses: linear/linear-release-action@v0
+        with:
+          access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
+          command: sync
+          name: ${{ steps.meta.outputs.name }}
+          version: ${{ steps.meta.outputs.tag }}
+
+      - name: Mark Linear release as released
+        uses: linear/linear-release-action@v0
+        with:
+          access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
+          command: complete
+          version: ${{ steps.meta.outputs.tag }}


### PR DESCRIPTION
## Summary
- adds Linear release sync to the existing PyPI publish workflow
- runs only after trusted-publisher upload succeeds, so Linear `Released` means the package is actually installable
- uses GitHub release tags like `oe-v0.2.0` as the Linear release version and names releases like `Main Branch 0.2.0`

## Scope
- In: `.github/workflows/publish-pypi.yml` final post-publish Linear sync job
- Out: path filters, continuous-release pipeline, manual Linear release creation

## Release / Issues
- Release: Linear release automation for future `oe-v*` package releases
- Closes: none

## Success Metric
- On the next published `oe-v*` GitHub Release, the PyPI publish workflow syncs matching Linear issue references into the `Main Branch <version>` release and marks that Linear release complete only after PyPI publish succeeds.

## Validation
- [x] `git diff --check`
- [x] parsed `.github/workflows/publish-pypi.yml` with PyYAML and confirmed jobs: `build`, `release-notes`, `publish`, `linear-release`
- [ ] not run: `actionlint` unavailable locally

## Notes
The GitHub secret `LINEAR_ACCESS_KEY` must exist in `noontide-co/mainbranch` Actions secrets. Devon confirmed it was added before this PR.