### PR TITLE
[MAIN-178] Add TTY-aware bare mb launch screen

### DIFF
--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -62,7 +62,7 @@ def _render_launch_screen() -> None:
                 "",
                 "Choose a trail:",
                 "  New here      mb onboard       guided setup (coming in v0.2)",
-                "  Daily work    mb status        business/repo briefing (coming in v0.2)",
+                "  Daily work    mb status        business/repo briefing",
                 "                mb start         open the agent runtime (coming in v0.2)",
                 "  Broken setup  mb doctor        check git, GitHub, Claude Code, and skills",
                 "  Power user    mb --help        full command list",

--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -27,7 +27,8 @@ app = typer.Typer(
         "Run your business as files in git. Main Branch scaffolds your repo, "
         "checks it, graphs it, and wires it into Claude Code."
     ),
-    no_args_is_help=True,
+    no_args_is_help=False,
+    invoke_without_command=True,
     add_completion=False,
 )
 
@@ -45,8 +46,35 @@ def _version_callback(value: bool) -> None:
         raise typer.Exit()
 
 
+def _is_interactive_terminal() -> bool:
+    return sys.stdin.isatty() and sys.stdout.isatty()
+
+
+def _render_launch_screen() -> None:
+    typer.echo(
+        "\n".join(
+            [
+                "",
+                "Main Branch",
+                "Stay connected to the business while agents handle execution.",
+                "",
+                "Choose a trail:",
+                "  New here      mb onboard       guided setup (coming in v0.2)",
+                "  Daily work    mb status        business/repo briefing (coming in v0.2)",
+                "                mb start         open the agent runtime (coming in v0.2)",
+                "  Broken setup  mb doctor        check git, GitHub, Claude Code, and skills",
+                "  Power user    mb --help        full command list",
+                "",
+                "Plain command reference: mb --plain",
+                "",
+            ]
+        )
+    )
+
+
 @app.callback()
 def main_callback(
+    ctx: typer.Context,
     version: bool = typer.Option(
         False,
         "--version",
@@ -54,8 +82,19 @@ def main_callback(
         is_eager=True,
         help="Show version and exit.",
     ),
+    plain: bool = typer.Option(
+        False,
+        "--plain",
+        help="Show the plain command reference instead of the launch screen.",
+    ),
 ) -> None:
-    """Root callback — version flag only."""
+    """Root callback — version flag and bare launch routing."""
+    if ctx.invoked_subcommand is not None:
+        return
+    if plain or not _is_interactive_terminal():
+        typer.echo(ctx.get_help())
+        return
+    _render_launch_screen()
 
 
 @app.command("init")

--- a/mb/tests/test_cli.py
+++ b/mb/tests/test_cli.py
@@ -44,6 +44,7 @@ def test_bare_mb_tty_shows_launch_screen(monkeypatch: pytest.MonkeyPatch) -> Non
     assert "Choose a trail" in result.stdout
     assert "mb onboard" in result.stdout
     assert "mb status" in result.stdout
+    assert "mb status        business/repo briefing (coming in v0.2)" not in result.stdout
     assert "mb start" in result.stdout
     assert "mb doctor" in result.stdout
     assert "mb --help" in result.stdout

--- a/mb/tests/test_cli.py
+++ b/mb/tests/test_cli.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import pytest
 from typer.testing import CliRunner
 
+import mb.cli as cli_mod
 from mb import __version__
 from mb.cli import app
 
@@ -20,6 +22,42 @@ def test_help_runs() -> None:
     result = runner.invoke(app, ["--help"])
     assert result.exit_code == 0
     assert "scaffolds" in result.stdout.lower() or "main branch" in result.stdout.lower()
+    assert "Choose a trail" not in result.stdout
+
+
+def test_bare_mb_non_tty_keeps_plain_help(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cli_mod, "_is_interactive_terminal", lambda: False)
+
+    result = runner.invoke(app, [])
+
+    assert result.exit_code == 0
+    assert "Usage:" in result.stdout
+    assert "Choose a trail" not in result.stdout
+
+
+def test_bare_mb_tty_shows_launch_screen(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cli_mod, "_is_interactive_terminal", lambda: True)
+
+    result = runner.invoke(app, [])
+
+    assert result.exit_code == 0
+    assert "Choose a trail" in result.stdout
+    assert "mb onboard" in result.stdout
+    assert "mb status" in result.stdout
+    assert "mb start" in result.stdout
+    assert "mb doctor" in result.stdout
+    assert "mb --help" in result.stdout
+    assert "Usage:" not in result.stdout
+
+
+def test_plain_escape_hatch_keeps_help_in_tty(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cli_mod, "_is_interactive_terminal", lambda: True)
+
+    result = runner.invoke(app, ["--plain"])
+
+    assert result.exit_code == 0
+    assert "Usage:" in result.stdout
+    assert "Choose a trail" not in result.stdout
 
 
 def test_skill_list_runs() -> None:


### PR DESCRIPTION
## Scope

- Add a TTY-aware bare `mb` launch screen for interactive terminals.
- Preserve plain command help for non-TTY invocations, `mb --help`, and the new `mb --plain` escape hatch.
- Add CLI tests covering TTY, non-TTY, help, and `--plain` behavior.

## Product Fit

- Implements MAIN-178 / GitHub #184 for v0.2.0 first-run polish.
- Bare `mb` becomes the human entry surface without changing the scriptable command reference.
- `mb onboard`, `mb status`, and `mb start` are shown as coming-next v0.2 routes rather than stubbed commands.

## Changes

- Root Typer app now invokes its callback with no command instead of always delegating no-arg behavior to help.
- Interactive terminals render the launch screen.
- Non-interactive terminals and `--plain` render the normal help output.

## Validation

- Static: `python3 -m ruff format --check`; `python3 -m ruff check`; `mypy mb`
- CLI: `pytest mb/tests/test_cli.py -q`; `python3 -m mb` non-TTY help; `python3 -m mb` under TTY launch screen
- Full unit suite: `pytest -q`
- Runtime/manual: Not run; this only changes deterministic CLI launch text and does not touch skill discovery or runtime handoff.

## Issue Updates

Closes #184

## Risk

- Low. The behavior is gated on both stdin and stdout being TTYs, and `--help` remains Typer-owned plain help.
