### PR TITLE
[MAIN-173] Add mb status daily briefing v0

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,11 @@ claude
 
 That's it. `mb init` sets up the six folders, wires Claude Code to the bundled skills, and gives you a fresh git repo. `/start` walks you through the rest — gathers your business context (offer, audience, voice), drafts the reference files, and routes you to the right workflow.
 
-After the first session, the daily flow is three lines:
+After the first session, the daily flow is:
 
 ```bash
 cd ~/Documents/GitHub/my-business
+mb status
 claude
 /start
 ```
@@ -127,6 +128,7 @@ The CLI surface for the engine. Built for Claude Code first; runtime-agnostic by
 | Command | What it does |
 |---|---|
 | `mb init` | Set up a fresh business repo (six folders, CLAUDE.md, git init). |
+| `mb status` | Show a local-first daily briefing: repo health, runtime wiring, recent decisions/research/git activity, and GitHub tasks when `gh` is authenticated. |
 | `mb doctor` | Check the environment — repo shape, frontmatter sanity, settings on disk. Walks you through fixes. |
 | `mb validate` | Frontmatter shape check across `core/`, `research/`, `decisions/`, `log/`, `campaigns/`, `documents/`. Pass/fail per file. |
 | `mb graph` | Walk the link graph (`linked_research` / `linked_decisions` / `supersedes`) and emit Graphviz DOT. `--open` renders to PNG and opens it. |

--- a/mb/README.md
+++ b/mb/README.md
@@ -18,12 +18,13 @@ That puts `mb` on your PATH. Verify:
 mb --version
 ```
 
-## Subcommands (v0.1)
+## Subcommands
 
 | Command | What it does |
 |---|---|
 | `mb init` | Scaffold a new business repo (six folders, CLAUDE.md, CODEOWNERS, `git init`) and wire the bundled Claude Code skill adapter. One question only: business name. |
 | `mb doctor` | Diagnostic. Checks Claude Code, gh auth, network, librsvg, runtime wiring, and package freshness. Warns on cloud-backed finance paths and offers educational triage. |
+| `mb status` | Daily briefing. Summarizes repo shape, install/runtime readiness, recent brain files, recent git activity, and GitHub tasks when `gh` is authenticated. Supports `--json`. |
 | `mb validate` | Frontmatter shape check across `decisions/`, `core/offers/`, `research/`, `log/`, `campaigns/`, `documents/`. Exit 1 on any fail. |
 | `mb graph` | Walk linked_research / linked_decisions / supersedes; emit Graphviz DOT to stdout. `--open` shells to `dot` + `open`. |
 | `mb think <topic>` | Print the /think workflow invocation hint for the currently supported runtime. |

--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -18,6 +18,7 @@ from mb import educational as educational_mod
 from mb import graph as graph_mod
 from mb import init as init_mod
 from mb import resolve as resolve_mod
+from mb import status as status_mod
 from mb import think as think_mod
 from mb import validate as validate_mod
 
@@ -98,6 +99,19 @@ def doctor_cmd(
     else:
         doctor_mod.render_human(report)
     raise typer.Exit(0 if report["ok"] else 1)
+
+
+@app.command("status")
+def status_cmd(
+    path: str = typer.Argument(".", help="Business repo to brief."),
+    json_out: bool = typer.Option(False, "--json", help="Machine-readable output."),
+) -> None:
+    """Show a cheap daily briefing for a Main Branch repo."""
+    report = status_mod.run(path=path)
+    if json_out:
+        typer.echo(json.dumps(report, indent=2))
+    else:
+        status_mod.render_human(report)
 
 
 @app.command("validate")

--- a/mb/mb/engine.py
+++ b/mb/mb/engine.py
@@ -256,9 +256,10 @@ def install_mode() -> str:
     if root is None:
         return "unknown"
     if packaged_engine_root() is not None:
-        prefix = Path(os.environ.get("PIPX_HOME", "")).expanduser()
         root_text = str(root)
-        if "pipx" in root_text or (str(prefix) and str(prefix) in root_text):
+        pipx_home = os.environ.get("PIPX_HOME", "").strip()
+        prefix = Path(pipx_home).expanduser() if pipx_home else None
+        if "pipx" in root_text or (prefix is not None and str(prefix) in root_text):
             return "pipx"
         return "wheel"
     if (root / ".git").exists():

--- a/mb/mb/status.py
+++ b/mb/mb/status.py
@@ -1,0 +1,602 @@
+"""``mb status`` — cheap daily briefing for a Main Branch repo."""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+from datetime import date, datetime
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from mb import __version__
+from mb.engine import install_mode, link_status
+
+IMPORTANT_DIRS = (
+    "core",
+    "reference/core",
+    "research",
+    "decisions",
+    "campaigns",
+    "log",
+    "documents",
+)
+STALE_DECISION_DAYS = 14
+
+
+def _which(name: str) -> str:
+    return shutil.which(name) or ""
+
+
+def _run_command(args: list[str], cwd: Path | None = None, timeout: float = 3.0) -> dict[str, Any]:
+    try:
+        result = subprocess.run(
+            args,
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except FileNotFoundError:
+        return {"ok": False, "returncode": 127, "stdout": "", "stderr": f"{args[0]} not found"}
+    except subprocess.TimeoutExpired:
+        return {"ok": False, "returncode": 124, "stdout": "", "stderr": "command timed out"}
+    except subprocess.SubprocessError as exc:
+        return {"ok": False, "returncode": 1, "stdout": "", "stderr": str(exc)}
+    return {
+        "ok": result.returncode == 0,
+        "returncode": result.returncode,
+        "stdout": result.stdout,
+        "stderr": result.stderr,
+    }
+
+
+def _looks_like_mainbranch_repo(repo: Path) -> dict[str, Any]:
+    markers = {
+        "claude_md": (repo / "CLAUDE.md").is_file(),
+        "core": (repo / "core").is_dir() or (repo / "reference" / "core").exists(),
+        "research": (repo / "research").is_dir(),
+        "decisions": (repo / "decisions").is_dir(),
+        "skill_wiring": (repo / ".claude" / "skills" / "start" / "SKILL.md").is_file(),
+    }
+    required_shape_count = sum(bool(markers[name]) for name in ("core", "research", "decisions"))
+    looks_like = bool(markers["claude_md"] and required_shape_count >= 2)
+    missing = [name for name, present in markers.items() if not present and name != "skill_wiring"]
+    return {
+        "looks_like_mainbranch_repo": looks_like,
+        "markers": markers,
+        "missing_markers": missing,
+    }
+
+
+def _git_info(repo: Path) -> dict[str, Any]:
+    if not _which("git"):
+        return {"available": False, "inside_work_tree": False, "error": "git not on PATH"}
+
+    inside = _run_command(["git", "rev-parse", "--is-inside-work-tree"], cwd=repo)
+    if not inside["ok"] or inside["stdout"].strip() != "true":
+        return {
+            "available": True,
+            "inside_work_tree": False,
+            "error": "not a git work tree",
+        }
+
+    branch = _run_command(["git", "branch", "--show-current"], cwd=repo)
+    commit = _run_command(["git", "rev-parse", "--short", "HEAD"], cwd=repo)
+    status = _run_command(["git", "status", "--porcelain"], cwd=repo)
+    remote = _run_command(["git", "config", "--get", "remote.origin.url"], cwd=repo)
+
+    dirty_lines = (
+        [line for line in status["stdout"].splitlines() if line.strip()] if status["ok"] else []
+    )
+    return {
+        "available": True,
+        "inside_work_tree": True,
+        "branch": branch["stdout"].strip() if branch["ok"] else "",
+        "commit": commit["stdout"].strip() if commit["ok"] else "",
+        "dirty": bool(dirty_lines),
+        "dirty_count": len(dirty_lines),
+        "dirty_files": dirty_lines[:10],
+        "remote": remote["stdout"].strip() if remote["ok"] else "",
+        "error": "" if status["ok"] else status["stderr"].strip(),
+    }
+
+
+def _git_recent_activity(repo: Path, git: dict[str, Any]) -> dict[str, Any]:
+    if not git.get("inside_work_tree"):
+        return {"available": False, "items": [], "error": git.get("error") or "git unavailable"}
+
+    cmd = [
+        "git",
+        "log",
+        "--since=14 days ago",
+        "--date=short",
+        "--pretty=format:%h%x09%ad%x09%s",
+        "--name-only",
+        "--",
+        "core",
+        "reference/core",
+        "research",
+        "decisions",
+        "campaigns",
+        "log",
+        "documents",
+    ]
+    result = _run_command(cmd, cwd=repo)
+    if not result["ok"]:
+        return {"available": False, "items": [], "error": result["stderr"].strip()}
+
+    items: list[dict[str, Any]] = []
+    current: dict[str, Any] | None = None
+    for raw_line in result["stdout"].splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        parts = line.split("\t", 2)
+        if len(parts) == 3 and re.fullmatch(r"[0-9a-f]{4,}", parts[0]):
+            if current is not None:
+                items.append(current)
+            current = {"commit": parts[0], "date": parts[1], "subject": parts[2], "files": []}
+            continue
+        if current is not None:
+            current["files"].append(line)
+    if current is not None:
+        items.append(current)
+
+    return {"available": True, "items": items[:8], "error": ""}
+
+
+def _read_frontmatter(path: Path) -> dict[str, Any]:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return {}
+    if not text.startswith("---"):
+        return {}
+    end = text.find("\n---", 3)
+    if end == -1:
+        return {}
+    raw = text[3:end].strip()
+    try:
+        parsed = yaml.safe_load(raw) or {}
+    except yaml.YAMLError:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _parse_date(value: Any, fallback_path: Path) -> date | None:
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    if isinstance(value, str):
+        try:
+            return date.fromisoformat(value[:10])
+        except ValueError:
+            pass
+    match = re.match(r"(\d{4}-\d{2}-\d{2})", fallback_path.name)
+    if match:
+        try:
+            return date.fromisoformat(match.group(1))
+        except ValueError:
+            return None
+    return None
+
+
+def _relative_markdown_files(repo: Path, folder: str) -> list[Path]:
+    root = repo / folder
+    if not root.exists():
+        return []
+    return sorted(
+        (path for path in root.rglob("*.md") if path.is_file()),
+        key=lambda path: path.stat().st_mtime,
+        reverse=True,
+    )
+
+
+def _file_summary(
+    repo: Path, path: Path, frontmatter: dict[str, Any] | None = None
+) -> dict[str, Any]:
+    meta = frontmatter if frontmatter is not None else _read_frontmatter(path)
+    item_date = _parse_date(meta.get("date"), path)
+    try:
+        rel = path.relative_to(repo).as_posix()
+    except ValueError:
+        rel = str(path)
+    return {
+        "path": rel,
+        "title": _title_from_markdown(path),
+        "date": item_date.isoformat() if item_date else "",
+        "status": str(meta.get("status", "") or ""),
+        "updated_at": datetime.fromtimestamp(path.stat().st_mtime).isoformat(timespec="seconds"),
+    }
+
+
+def _title_from_markdown(path: Path) -> str:
+    try:
+        for line in path.read_text(encoding="utf-8").splitlines():
+            stripped = line.strip()
+            if stripped.startswith("# "):
+                return stripped[2:].strip()
+    except OSError:
+        pass
+    return path.stem.replace("-", " ")
+
+
+def _brain(repo: Path) -> dict[str, Any]:
+    counts: dict[str, int] = {}
+    for folder in IMPORTANT_DIRS:
+        root = repo / folder
+        counts[folder] = (
+            sum(1 for path in root.rglob("*.md") if path.is_file()) if root.exists() else 0
+        )
+
+    decision_files = _relative_markdown_files(repo, "decisions")
+    decisions: list[dict[str, Any]] = []
+    stale: list[dict[str, Any]] = []
+    today = date.today()
+
+    for path in decision_files:
+        meta = _read_frontmatter(path)
+        item = _file_summary(repo, path, meta)
+        decisions.append(item)
+        status = item["status"].lower()
+        decision_date = _parse_date(meta.get("date"), path)
+        if status in {"proposed", "running"} and decision_date is not None:
+            age_days = (today - decision_date).days
+            if age_days > STALE_DECISION_DAYS:
+                stale_item = dict(item)
+                stale_item["age_days"] = age_days
+                stale.append(stale_item)
+
+    research = [
+        _file_summary(repo, path) for path in _relative_markdown_files(repo, "research")[:5]
+    ]
+
+    return {
+        "counts": counts,
+        "recent_decisions": decisions[:5],
+        "stale_decisions": stale[:5],
+        "recent_research": research,
+    }
+
+
+def _repo_full_name(remote: str) -> str:
+    if not remote:
+        return ""
+    patterns = [
+        r"github\.com[:/](?P<owner>[^/]+)/(?P<repo>[^/.]+)(?:\.git)?$",
+        r"https://github\.com/(?P<owner>[^/]+)/(?P<repo>[^/.]+)(?:\.git)?$",
+    ]
+    for pattern in patterns:
+        match = re.search(pattern, remote)
+        if match:
+            return f"{match.group('owner')}/{match.group('repo')}"
+    return ""
+
+
+def _gh_json(args: list[str], repo: Path) -> tuple[bool, Any, str]:
+    result = _run_command(args, cwd=repo, timeout=5.0)
+    if not result["ok"]:
+        return False, None, result["stderr"].strip() or result["stdout"].strip()
+    try:
+        return True, json.loads(result["stdout"] or "[]"), ""
+    except json.JSONDecodeError:
+        return False, None, "gh returned invalid JSON"
+
+
+def _github(repo: Path, git: dict[str, Any]) -> dict[str, Any]:
+    if not _which("gh"):
+        return {
+            "available": False,
+            "authenticated": False,
+            "repo": _repo_full_name(str(git.get("remote", ""))),
+            "assigned_issues": [],
+            "review_requests": [],
+            "recent_merged_prs": [],
+            "errors": ["gh not on PATH"],
+        }
+
+    auth = _run_command(["gh", "auth", "status"], cwd=repo, timeout=5.0)
+    if not auth["ok"]:
+        return {
+            "available": True,
+            "authenticated": False,
+            "repo": _repo_full_name(str(git.get("remote", ""))),
+            "assigned_issues": [],
+            "review_requests": [],
+            "recent_merged_prs": [],
+            "errors": ["gh not authenticated"],
+        }
+
+    errors: list[str] = []
+    repo_name = _repo_full_name(str(git.get("remote", "")))
+    assigned_ok, assigned, assigned_error = _gh_json(
+        [
+            "gh",
+            "issue",
+            "list",
+            "--state",
+            "open",
+            "--assignee",
+            "@me",
+            "--limit",
+            "5",
+            "--json",
+            "number,title,url,updatedAt,labels",
+        ],
+        repo,
+    )
+    if not assigned_ok:
+        errors.append(f"issues: {assigned_error}")
+
+    reviews_ok, reviews, reviews_error = _gh_json(
+        [
+            "gh",
+            "pr",
+            "list",
+            "--state",
+            "open",
+            "--search",
+            "review-requested:@me",
+            "--limit",
+            "5",
+            "--json",
+            "number,title,url,updatedAt,author",
+        ],
+        repo,
+    )
+    if not reviews_ok:
+        errors.append(f"review requests: {reviews_error}")
+
+    merged_ok, merged, merged_error = _gh_json(
+        [
+            "gh",
+            "pr",
+            "list",
+            "--state",
+            "merged",
+            "--limit",
+            "5",
+            "--json",
+            "number,title,url,mergedAt,body",
+        ],
+        repo,
+    )
+    if not merged_ok:
+        errors.append(f"merged PRs: {merged_error}")
+
+    merged_prs = [_summarize_pr(pr) for pr in merged] if isinstance(merged, list) else []
+    return {
+        "available": True,
+        "authenticated": True,
+        "repo": repo_name,
+        "assigned_issues": assigned if isinstance(assigned, list) else [],
+        "review_requests": reviews if isinstance(reviews, list) else [],
+        "recent_merged_prs": merged_prs,
+        "errors": errors,
+    }
+
+
+def _summarize_pr(pr: dict[str, Any]) -> dict[str, Any]:
+    title = str(pr.get("title", "") or "")
+    body = str(pr.get("body", "") or "")
+    summary = ""
+    for line in body.splitlines():
+        stripped = line.strip().strip("-* ")
+        if stripped and not stripped.startswith("#"):
+            summary = stripped
+            break
+    if not summary:
+        summary = title
+    return {
+        "number": pr.get("number"),
+        "title": title,
+        "url": pr.get("url", ""),
+        "mergedAt": pr.get("mergedAt", ""),
+        "what_shipped": summary[:220],
+    }
+
+
+def _runtime(repo: Path) -> dict[str, Any]:
+    claude_path = _which("claude")
+    wiring = link_status(repo)
+    return {
+        "claude_code": {
+            "found": bool(claude_path),
+            "path": claude_path,
+            "repair": "" if claude_path else "Install Claude Code: https://claude.ai/install",
+        },
+        "skill_wiring": {
+            **wiring,
+            "repair": ""
+            if wiring["ok"]
+            else "Run `mb skill link --repo .` from the business repo.",
+        },
+    }
+
+
+def _install() -> dict[str, Any]:
+    mode = install_mode()
+    return {
+        "version": __version__,
+        "mode": mode,
+        "ok": mode != "unknown",
+        "detail": f"mb {__version__} ({mode} mode)",
+    }
+
+
+def _readiness(report: dict[str, Any]) -> dict[str, Any]:
+    checks = [
+        {
+            "name": "mainbranch_repo",
+            "ok": bool(report["repo"]["looks_like_mainbranch_repo"]),
+            "weight": 25,
+            "repair": "Run `mb init` in a new business repo or cd into an existing one.",
+        },
+        {
+            "name": "git_repo",
+            "ok": bool(report["git"].get("inside_work_tree")),
+            "weight": 20,
+            "repair": "Run `git init` if this should be a business repo.",
+        },
+        {
+            "name": "install",
+            "ok": bool(report["install"]["ok"]),
+            "weight": 15,
+            "repair": "Reinstall Main Branch with `pipx install mainbranch`.",
+        },
+        {
+            "name": "skill_wiring",
+            "ok": bool(report["runtime"]["skill_wiring"]["ok"]),
+            "weight": 25,
+            "repair": report["runtime"]["skill_wiring"]["repair"],
+        },
+        {
+            "name": "claude_code",
+            "ok": bool(report["runtime"]["claude_code"]["found"]),
+            "weight": 15,
+            "repair": report["runtime"]["claude_code"]["repair"],
+        },
+    ]
+    possible = sum(int(check["weight"]) for check in checks)
+    score = sum(int(check["weight"]) for check in checks if check["ok"])
+    next_actions = [str(check["repair"]) for check in checks if not check["ok"] and check["repair"]]
+
+    if report["git"].get("dirty"):
+        next_actions.append(
+            "Review or commit the current git changes before handing work to an agent."
+        )
+    if report["brain"]["stale_decisions"]:
+        next_actions.append("Review stale proposed/running decisions in `decisions/`.")
+    if not report["github"]["authenticated"]:
+        next_actions.append("Run `gh auth login` to include assigned issues and shipped PRs.")
+    if not next_actions:
+        next_actions.append("Run `claude` in this repo, then `/start`.")
+
+    percent = round((score / possible) * 100) if possible else 0
+    if percent >= 85:
+        level = "ready"
+    elif percent >= 60:
+        level = "needs_attention"
+    else:
+        level = "not_ready"
+    return {
+        "score": percent,
+        "level": level,
+        "checks": checks,
+        "next_actions": next_actions[:5],
+    }
+
+
+def run(path: str = ".") -> dict[str, Any]:
+    """Build a deterministic daily briefing report."""
+    repo_path = Path(path).resolve()
+    repo_shape = _looks_like_mainbranch_repo(repo_path)
+    git = _git_info(repo_path)
+    report: dict[str, Any] = {
+        "ok": True,
+        "repo": {"path": str(repo_path), **repo_shape},
+        "install": _install(),
+        "runtime": _runtime(repo_path),
+        "git": git,
+        "git_activity": _git_recent_activity(repo_path, git),
+        "brain": _brain(repo_path),
+        "github": _github(repo_path, git),
+    }
+    report["readiness"] = _readiness(report)
+    report["ok"] = report["readiness"]["level"] != "not_ready"
+    return report
+
+
+def render_human(report: dict[str, Any]) -> None:
+    """Print a concise terminal briefing."""
+    from rich.console import Console
+
+    console = Console()
+    repo = report["repo"]
+    git = report["git"]
+    runtime = report["runtime"]
+    brain = report["brain"]
+    github = report["github"]
+    readiness = report["readiness"]
+
+    console.print(f"\n[bold]mb status[/bold]  {repo['path']}")
+    console.print(
+        f"[bold]{readiness['level'].replace('_', ' ')}[/bold]  {readiness['score']}/100\n"
+    )
+
+    repo_mark = (
+        "[green]yes[/green]" if repo["looks_like_mainbranch_repo"] else "[yellow]no[/yellow]"
+    )
+    branch = git.get("branch") or "(unknown)"
+    dirty = "dirty" if git.get("dirty") else "clean"
+    if not git.get("inside_work_tree"):
+        branch = "not a git repo"
+        dirty = str(git.get("error") or "")
+    console.print(
+        f"[bold]Repo[/bold] {repo_mark} Main Branch repo  branch: {branch}  state: {dirty}"
+    )
+    console.print(f"[bold]Install[/bold] {report['install']['detail']}")
+
+    claude = runtime["claude_code"]
+    skills = runtime["skill_wiring"]
+    claude_mark = "[green]found[/green]" if claude["found"] else "[yellow]missing[/yellow]"
+    skill_mark = "[green]wired[/green]" if skills["ok"] else "[yellow]missing[/yellow]"
+    console.print(f"[bold]Runtime[/bold] Claude Code: {claude_mark}  skills: {skill_mark}")
+
+    counts = brain["counts"]
+    console.print(
+        "[bold]Brain[/bold] "
+        f"core {counts['core'] + counts['reference/core']}  "
+        f"research {counts['research']}  decisions {counts['decisions']}  "
+        f"campaigns {counts['campaigns']}  log {counts['log']}  documents {counts['documents']}"
+    )
+
+    if brain["recent_decisions"]:
+        console.print("\n[bold]Recent decisions[/bold]")
+        for item in brain["recent_decisions"][:3]:
+            suffix = f" [{item['status']}]" if item["status"] else ""
+            console.print(f"  - {item['date'] or item['updated_at'][:10]}  {item['title']}{suffix}")
+    if brain["stale_decisions"]:
+        console.print("[yellow]Stale proposed/running decisions[/yellow]")
+        for item in brain["stale_decisions"][:3]:
+            console.print(f"  - {item['path']} ({item['age_days']} days)")
+    if brain["recent_research"]:
+        console.print("\n[bold]Recent research[/bold]")
+        for item in brain["recent_research"][:3]:
+            console.print(f"  - {item['date'] or item['updated_at'][:10]}  {item['title']}")
+
+    if report["git_activity"]["items"]:
+        console.print("\n[bold]Recent git activity[/bold]")
+        for item in report["git_activity"]["items"][:3]:
+            files = ", ".join(item["files"][:2])
+            if len(item["files"]) > 2:
+                files += f" +{len(item['files']) - 2}"
+            console.print(f"  - {item['date']} {item['commit']}  {item['subject']}  {files}")
+
+    console.print("\n[bold]GitHub[/bold]")
+    if not github["available"]:
+        console.print("  gh unavailable; skipping issues and PRs.")
+    elif not github["authenticated"]:
+        console.print("  gh not authenticated; run `gh auth login` to include business tasks.")
+    else:
+        console.print(
+            f"  assigned issues: {len(github['assigned_issues'])}  "
+            f"review requests: {len(github['review_requests'])}  "
+            f"recent merged PRs: {len(github['recent_merged_prs'])}"
+        )
+        for issue in github["assigned_issues"][:3]:
+            console.print(f"  - issue #{issue['number']}: {issue['title']}")
+        for pr in github["recent_merged_prs"][:3]:
+            console.print(f"  - shipped #{pr['number']}: {pr['what_shipped']}")
+        for error in github["errors"][:2]:
+            console.print(f"  [yellow]degraded:[/yellow] {error}")
+
+    console.print("\n[bold]Next[/bold]")
+    for action in readiness["next_actions"]:
+        console.print(f"  - {action}")
+    console.print()

--- a/mb/mb/status.py
+++ b/mb/mb/status.py
@@ -355,7 +355,7 @@ def _github(repo: Path, git: dict[str, Any]) -> dict[str, Any]:
             "--state",
             "merged",
             "--limit",
-            "5",
+            "20",
             "--json",
             "number,title,url,mergedAt,body",
         ],
@@ -364,7 +364,7 @@ def _github(repo: Path, git: dict[str, Any]) -> dict[str, Any]:
     if not merged_ok:
         errors.append(f"merged PRs: {merged_error}")
 
-    merged_prs = [_summarize_pr(pr) for pr in merged] if isinstance(merged, list) else []
+    merged_prs = _recent_merged_prs(merged) if isinstance(merged, list) else []
     return {
         "available": True,
         "authenticated": True,
@@ -374,6 +374,11 @@ def _github(repo: Path, git: dict[str, Any]) -> dict[str, Any]:
         "recent_merged_prs": merged_prs,
         "errors": errors,
     }
+
+
+def _recent_merged_prs(prs: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    sorted_prs = sorted(prs, key=lambda pr: str(pr.get("mergedAt", "") or ""), reverse=True)
+    return [_summarize_pr(pr) for pr in sorted_prs[:5]]
 
 
 def _summarize_pr(pr: dict[str, Any]) -> dict[str, Any]:

--- a/mb/mb/status.py
+++ b/mb/mb/status.py
@@ -267,15 +267,10 @@ def _brain(repo: Path) -> dict[str, Any]:
 def _repo_full_name(remote: str) -> str:
     if not remote:
         return ""
-    patterns = [
-        r"github\.com[:/](?P<owner>[^/]+)/(?P<repo>[^/.]+)(?:\.git)?$",
-        r"https://github\.com/(?P<owner>[^/]+)/(?P<repo>[^/.]+)(?:\.git)?$",
-    ]
-    for pattern in patterns:
-        match = re.search(pattern, remote)
-        if match:
-            return f"{match.group('owner')}/{match.group('repo')}"
-    return ""
+    match = re.search(r"github\.com[:/](?P<owner>[^/]+)/(?P<repo>[^/]+?)(?:\.git)?/?$", remote)
+    if not match:
+        return ""
+    return f"{match.group('owner')}/{match.group('repo')}"
 
 
 def _gh_json(args: list[str], repo: Path) -> tuple[bool, Any, str]:

--- a/mb/tests/test_resolve.py
+++ b/mb/tests/test_resolve.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from mb import engine as engine_mod
 from mb.engine import engine_root
 from mb.resolve import bundled_skills, run, skill_path
 
@@ -33,3 +34,12 @@ def test_skill_path_uses_engine_root() -> None:
     assert path is not None
     assert path == root / ".claude" / "skills" / "start"
     assert "think" in bundled_skills()
+
+
+def test_install_mode_does_not_treat_empty_pipx_home_as_prefix(tmp_path: Path, monkeypatch) -> None:
+    root = tmp_path / "tmp.with.dot" / "site-packages" / "mb" / "_engine"
+    monkeypatch.delenv("PIPX_HOME", raising=False)
+    monkeypatch.setattr(engine_mod, "packaged_engine_root", lambda: root)
+    monkeypatch.setattr(engine_mod, "source_engine_root", lambda: None)
+
+    assert engine_mod.install_mode() == "wheel"

--- a/mb/tests/test_status.py
+++ b/mb/tests/test_status.py
@@ -206,7 +206,20 @@ def test_status_github_authenticated_branches(tmp_path: Path, monkeypatch) -> No
             return False, None, "search failed"
         return (
             True,
-            [{"number": 192, "title": "Briefing", "body": "## Scope\n- Shipped status"}],
+            [
+                {
+                    "number": 190,
+                    "title": "Older",
+                    "body": "older",
+                    "mergedAt": "2026-05-01T10:00:00Z",
+                },
+                {
+                    "number": 192,
+                    "title": "Briefing",
+                    "body": "## Scope\n- Shipped status",
+                    "mergedAt": "2026-05-02T10:00:00Z",
+                },
+            ],
             "",
         )
 
@@ -219,6 +232,7 @@ def test_status_github_authenticated_branches(tmp_path: Path, monkeypatch) -> No
     assert github["authenticated"] is True
     assert github["repo"] == "noontide-co/mainbranch"
     assert github["assigned_issues"][0]["number"] == 173
+    assert github["recent_merged_prs"][0]["number"] == 192
     assert github["recent_merged_prs"][0]["what_shipped"] == "Shipped status"
     assert github["errors"] == ["review requests: search failed"]
 
@@ -226,6 +240,15 @@ def test_status_github_authenticated_branches(tmp_path: Path, monkeypatch) -> No
         status_mod._summarize_pr({"title": "Fallback title", "body": "# Heading"})["what_shipped"]
         == "Fallback title"
     )
+    assert [
+        pr["number"]
+        for pr in status_mod._recent_merged_prs(
+            [
+                {"number": index, "title": str(index), "mergedAt": f"2026-05-{index:02d}T00:00:00Z"}
+                for index in range(1, 8)
+            ]
+        )
+    ] == [7, 6, 5, 4, 3]
 
     monkeypatch.setattr(
         status_mod,

--- a/mb/tests/test_status.py
+++ b/mb/tests/test_status.py
@@ -80,6 +80,9 @@ def test_status_low_level_helpers_handle_edge_cases(tmp_path: Path, monkeypatch)
     assert status_mod._repo_full_name("https://github.com/noontide-co/mainbranch.git") == (
         "noontide-co/mainbranch"
     )
+    assert status_mod._repo_full_name("https://github.com/noontide-co/some.io.git") == (
+        "noontide-co/some.io"
+    )
     assert status_mod._repo_full_name("") == ""
 
     missing = tmp_path / "missing.md"

--- a/mb/tests/test_status.py
+++ b/mb/tests/test_status.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 import json
 import shutil
+import subprocess
+from datetime import date, datetime
 from pathlib import Path
+from typing import Any
 
 from typer.testing import CliRunner
 
@@ -68,3 +71,223 @@ def test_status_detects_non_business_repo(tmp_path: Path, monkeypatch) -> None:
     assert report["repo"]["looks_like_mainbranch_repo"] is False
     assert report["readiness"]["level"] == "not_ready"
     assert any("mb init" in action for action in report["readiness"]["next_actions"])
+
+
+def test_status_low_level_helpers_handle_edge_cases(tmp_path: Path, monkeypatch) -> None:
+    assert status_mod._repo_full_name("git@github.com:noontide-co/mainbranch.git") == (
+        "noontide-co/mainbranch"
+    )
+    assert status_mod._repo_full_name("https://github.com/noontide-co/mainbranch.git") == (
+        "noontide-co/mainbranch"
+    )
+    assert status_mod._repo_full_name("") == ""
+
+    missing = tmp_path / "missing.md"
+    plain = tmp_path / "plain.md"
+    plain.write_text("# Plain\n", encoding="utf-8")
+    unclosed = tmp_path / "unclosed.md"
+    unclosed.write_text("---\nstatus: proposed\n", encoding="utf-8")
+    bad_yaml = tmp_path / "bad.md"
+    bad_yaml.write_text("---\n:\n---\n", encoding="utf-8")
+
+    assert status_mod._read_frontmatter(missing) == {}
+    assert status_mod._read_frontmatter(plain) == {}
+    assert status_mod._read_frontmatter(unclosed) == {}
+    assert status_mod._read_frontmatter(bad_yaml) == {}
+
+    assert status_mod._parse_date(datetime(2026, 5, 2, 8, 30), plain) == date(2026, 5, 2)
+    assert status_mod._parse_date(date(2026, 5, 2), plain) == date(2026, 5, 2)
+    assert status_mod._parse_date("not-a-date", tmp_path / "2026-05-01-note.md") == date(2026, 5, 1)
+    assert status_mod._parse_date("not-a-date", tmp_path / "note.md") is None
+
+    external = tmp_path / "external.md"
+    external.write_text("no heading\n", encoding="utf-8")
+    summary = status_mod._file_summary(tmp_path / "repo", external)
+    assert summary["path"] == str(external)
+    assert summary["title"] == "external"
+
+    def raise_missing(*args: object, **kwargs: object) -> object:
+        raise FileNotFoundError
+
+    monkeypatch.setattr(subprocess, "run", raise_missing)
+    assert status_mod._run_command(["missing-bin"])["returncode"] == 127
+
+    def raise_timeout(*args: object, **kwargs: object) -> object:
+        raise subprocess.TimeoutExpired(cmd="slow", timeout=1)
+
+    monkeypatch.setattr(subprocess, "run", raise_timeout)
+    assert status_mod._run_command(["slow"])["returncode"] == 124
+
+    def raise_subprocess(*args: object, **kwargs: object) -> object:
+        raise subprocess.SubprocessError("boom")
+
+    monkeypatch.setattr(subprocess, "run", raise_subprocess)
+    assert status_mod._run_command(["boom"])["stderr"] == "boom"
+
+
+def test_status_git_activity_parser_and_failure(tmp_path: Path, monkeypatch) -> None:
+    def fake_run_command(
+        args: list[str], cwd: Path | None = None, timeout: float = 3.0
+    ) -> dict[str, Any]:
+        assert args[1] == "log"
+        return {
+            "ok": True,
+            "stdout": (
+                "abc123\t2026-05-02\tUpdate offer\n"
+                "core/offer.md\n"
+                "research/2026-05-01-market.md\n\n"
+                "def456\t2026-05-01\tAdd decision\n"
+                "decisions/2026-05-01-pricing.md\n"
+            ),
+            "stderr": "",
+        }
+
+    monkeypatch.setattr(status_mod, "_run_command", fake_run_command)
+    activity = status_mod._git_recent_activity(tmp_path, {"inside_work_tree": True})
+
+    assert activity["available"] is True
+    assert activity["items"][0]["commit"] == "abc123"
+    assert activity["items"][0]["files"] == [
+        "core/offer.md",
+        "research/2026-05-01-market.md",
+    ]
+    assert activity["items"][1]["subject"] == "Add decision"
+    assert (
+        status_mod._git_recent_activity(tmp_path, {"inside_work_tree": False, "error": "no git"})[
+            "error"
+        ]
+        == "no git"
+    )
+
+    monkeypatch.setattr(
+        status_mod,
+        "_run_command",
+        lambda args, cwd=None, timeout=3.0: {"ok": False, "stdout": "", "stderr": "bad log"},
+    )
+    assert (
+        status_mod._git_recent_activity(tmp_path, {"inside_work_tree": True})["error"] == "bad log"
+    )
+
+
+def test_status_brain_marks_stale_decisions(tmp_path: Path, monkeypatch) -> None:
+    repo = tmp_path / "repo"
+    decisions = repo / "decisions"
+    decisions.mkdir(parents=True)
+    old_date = date.today().replace(year=date.today().year - 1)
+    (decisions / f"{old_date.isoformat()}-old.md").write_text(
+        f"---\ndate: {old_date.isoformat()}\nstatus: proposed\n---\n\n# Old proposal\n",
+        encoding="utf-8",
+    )
+    (repo / "research").mkdir()
+    (repo / "research" / "2026-05-01-market.md").write_text("# Market\n", encoding="utf-8")
+
+    brain = status_mod._brain(repo)
+
+    assert brain["recent_decisions"][0]["title"] == "Old proposal"
+    assert brain["stale_decisions"][0]["age_days"] > status_mod.STALE_DECISION_DAYS
+    assert brain["recent_research"][0]["title"] == "Market"
+
+
+def test_status_github_authenticated_branches(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(status_mod, "_which", lambda name: "/usr/bin/gh" if name == "gh" else "")
+    monkeypatch.setattr(
+        status_mod,
+        "_run_command",
+        lambda args, cwd=None, timeout=3.0: {"ok": True, "stdout": "", "stderr": ""},
+    )
+
+    def fake_gh_json(args: list[str], repo: Path) -> tuple[bool, Any, str]:
+        if args[1:3] == ["issue", "list"]:
+            return True, [{"number": 173, "title": "Status", "url": "u"}], ""
+        if args[1:3] == ["pr", "list"] and "--search" in args:
+            return False, None, "search failed"
+        return (
+            True,
+            [{"number": 192, "title": "Briefing", "body": "## Scope\n- Shipped status"}],
+            "",
+        )
+
+    monkeypatch.setattr(status_mod, "_gh_json", fake_gh_json)
+    github = status_mod._github(
+        tmp_path,
+        {"remote": "https://github.com/noontide-co/mainbranch.git"},
+    )
+
+    assert github["authenticated"] is True
+    assert github["repo"] == "noontide-co/mainbranch"
+    assert github["assigned_issues"][0]["number"] == 173
+    assert github["recent_merged_prs"][0]["what_shipped"] == "Shipped status"
+    assert github["errors"] == ["review requests: search failed"]
+
+    assert (
+        status_mod._summarize_pr({"title": "Fallback title", "body": "# Heading"})["what_shipped"]
+        == "Fallback title"
+    )
+
+    monkeypatch.setattr(
+        status_mod,
+        "_run_command",
+        lambda args, cwd=None, timeout=3.0: {"ok": False, "stdout": "", "stderr": "no auth"},
+    )
+    assert status_mod._github(tmp_path, {"remote": ""})["authenticated"] is False
+
+
+def test_status_renderer_prints_optional_sections(capsys) -> None:
+    report: dict[str, Any] = {
+        "repo": {"path": "/tmp/biz", "looks_like_mainbranch_repo": True},
+        "install": {"detail": "mb 0.1.2 (wheel mode)"},
+        "runtime": {
+            "claude_code": {"found": True},
+            "skill_wiring": {"ok": True},
+        },
+        "git": {"inside_work_tree": False, "dirty": False, "error": "not a git work tree"},
+        "brain": {
+            "counts": {
+                "core": 1,
+                "reference/core": 1,
+                "research": 1,
+                "decisions": 1,
+                "campaigns": 1,
+                "log": 1,
+                "documents": 1,
+            },
+            "recent_decisions": [
+                {"date": "2026-05-01", "updated_at": "", "title": "Pricing", "status": "accepted"}
+            ],
+            "stale_decisions": [
+                {"path": "decisions/old.md", "age_days": 30},
+            ],
+            "recent_research": [
+                {"date": "2026-05-01", "updated_at": "", "title": "Market"},
+            ],
+        },
+        "git_activity": {
+            "items": [
+                {
+                    "date": "2026-05-02",
+                    "commit": "abc123",
+                    "subject": "Update brain",
+                    "files": ["core/offer.md", "research/a.md", "decisions/b.md"],
+                }
+            ]
+        },
+        "github": {
+            "available": True,
+            "authenticated": True,
+            "assigned_issues": [{"number": 173, "title": "Status"}],
+            "review_requests": [],
+            "recent_merged_prs": [{"number": 192, "what_shipped": "Daily briefing"}],
+            "errors": ["merged PRs: degraded"],
+        },
+        "readiness": {"level": "ready", "score": 100, "next_actions": ["Run `claude`."]},
+    }
+
+    status_mod.render_human(report)
+
+    output = capsys.readouterr().out
+    assert "Recent decisions" in output
+    assert "Stale proposed/running decisions" in output
+    assert "Recent research" in output
+    assert "Recent git activity" in output
+    assert "issue #173" in output
+    assert "shipped #192" in output

--- a/mb/tests/test_status.py
+++ b/mb/tests/test_status.py
@@ -1,0 +1,70 @@
+"""``mb status`` daily briefing."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from mb import status as status_mod
+from mb.cli import app
+from mb.init import run as init_run
+
+runner = CliRunner()
+
+
+def _without_github_or_claude(name: str) -> str:
+    if name in {"gh", "claude"}:
+        return ""
+    return shutil.which(name) or ""
+
+
+def test_status_json_degrades_without_github(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+    (repo / "decisions" / "2026-05-01-pricing.md").write_text(
+        "---\ndate: 2026-05-01\nstatus: accepted\n---\n\n# Pricing\n",
+        encoding="utf-8",
+    )
+    (repo / "research" / "2026-05-01-market.md").write_text(
+        "---\ndate: 2026-05-01\nsource: desk\n---\n\n# Market\n",
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["status", str(repo), "--json"])
+
+    assert result.exit_code == 0
+    report = json.loads(result.stdout)
+    assert report["repo"]["looks_like_mainbranch_repo"] is True
+    assert report["runtime"]["skill_wiring"]["ok"] is True
+    assert report["github"]["authenticated"] is False
+    assert report["brain"]["counts"]["decisions"] == 1
+    assert report["brain"]["recent_research"][0]["title"] == "Market"
+    assert "readiness" in report
+
+
+def test_status_human_output_mentions_core_sections(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+
+    result = runner.invoke(app, ["status", str(repo)])
+
+    assert result.exit_code == 0
+    assert "mb status" in result.stdout
+    assert "Repo" in result.stdout
+    assert "Runtime" in result.stdout
+    assert "GitHub" in result.stdout
+    assert "Next" in result.stdout
+
+
+def test_status_detects_non_business_repo(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
+    report = status_mod.run(path=str(tmp_path))
+
+    assert report["repo"]["looks_like_mainbranch_repo"] is False
+    assert report["readiness"]["level"] == "not_ready"
+    assert any("mb init" in action for action in report["readiness"]["next_actions"])


### PR DESCRIPTION
## Scope

- Adds `mb status` as a local-first daily briefing for Main Branch business repos.
- Adds human terminal output and `--json` output with stable top-level sections for future `/start` and dashboard reuse.
- Fixes install-mode detection so empty `PIPX_HOME` does not make dotted venv paths look like pipx installs.

## Product Fit

- Implements MAIN-173 / Closes #173 for v0.2.0 first-run + daily briefing.
- Keeps `mb` deterministic and model-free: repo, git, filesystem, runtime wiring, and bounded `gh` reads only.
- Degrades when git, `gh`, auth, remotes, or network state are unavailable.

## Changes

- New `mb/mb/status.py` report builder and Rich renderer.
- New `mb status [path] [--json]` Typer command.
- Briefing covers repo shape, install/version mode, Claude Code presence, skill wiring, brain file counts, recent decisions/research, stale proposed/running decisions, recent git activity, assigned GitHub issues, review requests, recent merged PRs, readiness score, and next actions.
- README/package README now include `mb status` in the daily loop and command table.

## Validation

- Static: `python3 -m ruff format --check .`
- Static: `python3 -m ruff check .`
- Static: `python3 -m mypy mb`
- Tests: `python3 -m pytest -q --cov` (37 passed, 74.74% total coverage)
- Build: `python3 -m build` (passed; existing setuptools license deprecation warnings only)
- CLI smoke: fresh `mb init` repo, then `python3 -m mb status` and `python3 -m mb status --json` with local `PYTHONPATH`
- Wheel smoke: temp venv install from built wheel, `mb --version`, `mb init`, and `mb status --json`; install mode reported `wheel`

## Issue Updates

- Closes #173
- Linear: MAIN-173
- Target release: v0.2.0

## Risk

- GitHub queries are intentionally bounded to five assigned issues, review requests, and merged PRs.
- Runtime smoke was not run because this change does not invoke Claude Code; it only reports CLI/runtime readiness.