### PR TITLE
[add] mb update install-mode refresh

### DIFF
--- a/.claude/reference/pull-engine-updates.md
+++ b/.claude/reference/pull-engine-updates.md
@@ -1,42 +1,29 @@
 # Pull Engine Updates
 
-Canonical bash for pulling latest Main Branch updates at the start of any skill invocation. CWD is the business repo — resolve the engine path first. **Do NOT silently swallow failures.** Users on stale code get broken features.
+Canonical command for pulling latest Main Branch updates at the start of any skill invocation. CWD is the business repo. **Do NOT silently swallow failures.** Users on stale code get broken features.
 
-For the canonical resolver (bash + python3, settings.local.json first, ~/.config/vip/local.yaml fallback) see **[vip-path-resolution.md](vip-path-resolution.md)**. Run that snippet, then:
+`mb update` owns the install-mode mechanics. It detects pipx vs clone installs, runs the correct update command, and refreshes skill links for the business repo.
 
 ```bash
-if [ -n "$VIP_PATH" ] && [ -f "$VIP_PATH/.claude/skills/start/SKILL.md" ]; then
-  if git -C "$VIP_PATH" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-    git -C "$VIP_PATH" pull origin main 2>&1
-  elif command -v pipx >/dev/null 2>&1 && pipx list --short 2>/dev/null | grep -q '^mainbranch '; then
-    pipx upgrade mainbranch 2>&1
-    mb skill link --repo "${REPO_PATH:-.}" 2>&1
-  else
-    echo "NO_UPDATE_MODE"
-  fi
-else
-  echo "NO_ENGINE_PATH"
-fi
+mb update --repo "${REPO_PATH:-.}" --json 2>&1
 ```
 
 ## Handle the Result
 
 | Result | What to say |
 |--------|-------------|
-| "Already up to date." | Say nothing |
-| "upgraded package mainbranch" / "upgraded shared libraries" | "Updated Main Branch and refreshed skill links." |
-| "Updating..." / files changed | "Pulled latest engine updates." |
-| `NO_UPDATE_MODE` | "Main Branch is linked, but I couldn't tell how to update it. Try `pipx upgrade mainbranch` if you installed with pipx, or pull the engine repo in GitHub Desktop if you cloned it." |
-| `NO_ENGINE_PATH` / VIP_PATH empty | "Couldn't find Main Branch. Run `mb skill link --repo .`, then restart Claude." |
-| Any error (auth, network) | Show the warning below |
+| JSON `"ok": true`, old_version == new_version | Say nothing |
+| JSON `"ok": true`, old_version != new_version | "Updated Main Branch and refreshed skill links." |
+| Invalid JSON or missing engine root | "Couldn't find Main Branch. Run `mb skill link --repo .`, then restart Claude." |
+| JSON `"ok": false` or command failure | Show the warning below |
 
 ## If Pull Fails — Show This Warning
 
 > "I wasn't able to pull the latest Main Branch updates. This means you may be running on an old version and missing new features.
 >
 > Common fixes:
-> 1. **Installed with pipx?** Run `pipx upgrade mainbranch`, then `mb skill link --repo .`
-> 2. **Using a cloned engine repo?** Open GitHub Desktop → select mainbranch → click 'Fetch origin'
+> 1. Run `mb update --check --repo .` to see which install path Main Branch detects
+> 2. Run `mb update --repo .` again after fixing the reported error
 > 3. **Network issue?** Check your internet connection
 >
 > You can continue, but some features may not work as expected."

--- a/.claude/skills/pull/SKILL.md
+++ b/.claude/skills/pull/SKILL.md
@@ -11,7 +11,7 @@ Update the Main Branch engine.
 
 ## What It Does
 
-Resolves the Main Branch engine path and updates that install — NOT from the current working directory (which is your business repo). pipx installs upgrade the `mainbranch` package; clone-based installs run `git pull`.
+Runs `mb update` for the mechanical engine refresh. The CLI detects whether Main Branch was installed with pipx or from a clone, updates that install, and refreshes skill links for the current business repo. This skill keeps ownership of the "what's new" narrative after the CLI step completes.
 
 ### Step 1: Resolve VIP Path
 
@@ -20,18 +20,7 @@ For the canonical bash + python3 resolver (settings.local.json first, ~/.config/
 ### Step 2: Update Main Branch
 
 ```bash
-if [ -n "$VIP_PATH" ] && [ -f "$VIP_PATH/.claude/skills/start/SKILL.md" ]; then
-  if git -C "$VIP_PATH" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-    git -C "$VIP_PATH" pull origin main 2>&1
-  elif command -v pipx >/dev/null 2>&1 && pipx list --short 2>/dev/null | grep -q '^mainbranch '; then
-    pipx upgrade mainbranch 2>&1
-    mb skill link --repo "${REPO_PATH:-.}" 2>&1
-  else
-    echo "NO_UPDATE_MODE"
-  fi
-else
-  echo "NO_ENGINE_PATH"
-fi
+mb update --repo "${REPO_PATH:-.}" --json 2>&1
 ```
 
 ### Step 3: Pull Business Repo (if it has a remote)
@@ -42,17 +31,17 @@ git pull origin main 2>&1
 
 ### Handling Results
 
-**Main Branch updated:** "Updated Main Branch and refreshed skill links." — then read the CHANGELOG and surface unread entries (see "What's New from CHANGELOG" below).
+**Main Branch updated:** If the JSON result has `"ok": true`, say "Updated Main Branch and refreshed skill links." — then read the CHANGELOG and surface unread entries (see "What's New from CHANGELOG" below).
 
-**Main Branch current:** "Engine already up to date." — still surface unread CHANGELOG entries (the user might not have run /start since the last release landed).
+**Main Branch current:** If old_version and new_version match, "Engine already up to date." — still surface unread CHANGELOG entries (the user might not have run /start since the last release landed).
 
-**Main Branch path not found:** "Couldn't find Main Branch. Run `mb skill link --repo .`, then restart Claude."
+**Main Branch path not found:** If the JSON result is not valid or reports an engine-root error, say "Couldn't find Main Branch. Run `mb skill link --repo .`, then restart Claude."
 
 **Business repo updated:** "Also pulled updates for [repo-name]."
 
 **Business repo current or local-only:** Say nothing.
 
-**Error:** "Couldn't update: [error]. If you installed with pipx, try `pipx upgrade mainbranch`. If you cloned the engine repo, open GitHub Desktop → select mainbranch → click 'Fetch origin'."
+**Error:** "Couldn't update: [error]. Try `mb update --check --repo .` to see which install path Main Branch detects."
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,16 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
-No unreleased changes yet.
+### Added
+
+- Added `mb update` for install-mode-aware engine refreshes. It detects pipx vs
+  clone installs, supports `--check` dry-runs, emits `--json` result envelopes,
+  and refreshes skill links after updates.
+
+### Changed
+
+- Updated `/pull` so the skill delegates mechanical update work to `mb update`
+  and keeps ownership of the human-readable changelog summary.
 
 ## [0.1.2] - 2026-05-01
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -56,20 +56,17 @@ Use clone mode only if you are editing the engine, docs, or bundled skills.
 
 ## Updating
 
-For `pipx` installs:
+Use the CLI update contract from inside your business repo:
 
 ```bash
-pipx upgrade mainbranch
+mb update
 ```
 
-For clone installs:
-
-```bash
-git pull origin main
-```
-
-Inside Claude Code, `/pull` detects the install mode and runs the appropriate
-update path.
+`mb update` detects whether the engine is a `pipx` install or clone checkout,
+runs the appropriate update path, and refreshes skill links. Use
+`mb update --check` for a dry-run and `mb update --json` for automation.
+Inside Claude Code, `/pull` calls `mb update` for this mechanical step and keeps
+ownership of the human-readable "what's new" summary.
 
 ## Known v0.1.x limits
 

--- a/mb/README.md
+++ b/mb/README.md
@@ -26,6 +26,7 @@ mb --version
 | `mb doctor` | Diagnostic. Checks Claude Code, gh auth, network, librsvg, runtime wiring, and package freshness. Warns on cloud-backed finance paths and offers educational triage. |
 | `mb validate` | Frontmatter shape check across `decisions/`, `core/offers/`, `research/`, `log/`, `campaigns/`, `documents/`. Exit 1 on any fail. |
 | `mb graph` | Walk linked_research / linked_decisions / supersedes; emit Graphviz DOT to stdout. `--open` shells to `dot` + `open`. |
+| `mb update` | Refresh the Main Branch engine according to install mode (`pipx` upgrade or clone `git pull`) and repair skill links. `--check` dry-runs; `--json` emits an envelope. |
 | `mb think <topic>` | Print the /think workflow invocation hint for the currently supported runtime. |
 | `mb resolve <key>` | Resolve a reference path (checks free first, then paid). |
 | `mb skill path <name>` | Print the on-disk path to a bundled skill. |

--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -19,6 +19,7 @@ from mb import graph as graph_mod
 from mb import init as init_mod
 from mb import resolve as resolve_mod
 from mb import think as think_mod
+from mb import update as update_mod
 from mb import validate as validate_mod
 
 app = typer.Typer(
@@ -165,6 +166,21 @@ def educational_cmd(
 ) -> None:
     """Print an educational triage file. Powers doctor's 'tell me more' prompts."""
     educational_mod.run(topic=topic)
+
+
+@app.command("update")
+def update_cmd(
+    repo: str = typer.Option(".", "--repo", help="Business repo whose skill links refresh."),
+    check: bool = typer.Option(False, "--check", help="Dry-run only; do not upgrade or relink."),
+    json_out: bool = typer.Option(False, "--json", help="Machine-readable output."),
+) -> None:
+    """Refresh Main Branch according to its install mode."""
+    result = update_mod.run(repo=repo, check=check)
+    if json_out:
+        typer.echo(json.dumps(result, indent=2))
+    else:
+        update_mod.render_human(result)
+    raise typer.Exit(0 if result["ok"] else 1)
 
 
 @skill_app.command("path")

--- a/mb/mb/update.py
+++ b/mb/mb/update.py
@@ -65,6 +65,16 @@ def _version_from_git_ref(root: Path, ref: str) -> str | None:
     return match.group(1) if match else None
 
 
+def _fetch_origin_main(root: Path) -> tuple[bool, str | None]:
+    result = _run_command(
+        ["git", "fetch", "origin", "main:refs/remotes/origin/main", "--quiet"],
+        cwd=root,
+    )
+    if result.returncode == 0:
+        return True, None
+    return False, _command_error("git fetch origin main", result)
+
+
 def _version_from_mb_command() -> str | None:
     result = _run_command(["mb", "--version"])
     if result.returncode != 0:
@@ -78,34 +88,48 @@ def _command_error(label: str, result: subprocess.CompletedProcess[str]) -> str:
     return f"{label} failed with exit code {result.returncode}: {details or 'no output'}"
 
 
+def _list_field(result: dict[str, Any], key: str) -> list[str]:
+    value = result.get(key, [])
+    return [str(item) for item in value] if isinstance(value, list) else []
+
+
 def _skill_count_from_link_result(result: dict[str, Any]) -> int:
     total = 0
-    for key in ("linked", "copied", "skipped"):
-        value = result.get(key, [])
-        if isinstance(value, list):
-            total += len(value)
+    for key in ("linked", "copied"):
+        total += len(_list_field(result, key))
     return total
 
 
-def _link_skills(repo: Path) -> tuple[int, list[str], dict[str, Any] | None]:
+def _link_warnings(payload: dict[str, Any]) -> list[str]:
+    skipped = _list_field(payload, "skipped")
+    if not skipped:
+        return []
+    return [
+        "could not refresh existing non-link skill path(s): " + ", ".join(skipped),
+    ]
+
+
+def _link_skills(repo: Path) -> tuple[int, list[str], list[str], dict[str, Any] | None]:
     result = _run_command(["mb", "skill", "link", "--repo", str(repo), "--json"])
     if result.returncode != 0:
-        return 0, [_command_error("mb skill link", result)], None
+        return 0, [_command_error("mb skill link", result)], [], None
     try:
         payload = json.loads(result.stdout)
     except json.JSONDecodeError:
-        return 0, ["mb skill link returned invalid JSON"], None
+        return 0, ["mb skill link returned invalid JSON"], [], None
     if not isinstance(payload, dict):
-        return 0, ["mb skill link returned an unexpected JSON payload"], None
+        return 0, ["mb skill link returned an unexpected JSON payload"], [], None
     errors = payload.get("errors", [])
     parsed_errors = [str(error) for error in errors] if isinstance(errors, list) else []
+    warnings = _link_warnings(payload)
     if payload.get("ok") is not True:
         return (
             _skill_count_from_link_result(payload),
             parsed_errors or ["mb skill link failed"],
+            warnings,
             payload,
         )
-    return _skill_count_from_link_result(payload), [], payload
+    return _skill_count_from_link_result(payload), [], warnings, payload
 
 
 def _base_result(repo: Path, *, check: bool, mode: str, root: Path | None) -> dict[str, Any]:
@@ -119,6 +143,7 @@ def _base_result(repo: Path, *, check: bool, mode: str, root: Path | None) -> di
         "new_version": None,
         "skills_relinked_count": 0,
         "actions": [],
+        "warnings": [],
         "errors": [],
     }
 
@@ -143,7 +168,7 @@ def run(repo: str | Path = ".", *, check: bool = False) -> dict[str, Any]:
             result["new_version"] = _latest_pypi_version() or result["old_version"]
             result["actions"] = [
                 "would run `pipx upgrade mainbranch`",
-                f"would run `mb skill link --repo {target_repo}`",
+                f"would run `mb skill link --repo {target_repo} --json`",
             ]
         else:
             if root is None:
@@ -151,13 +176,22 @@ def run(repo: str | Path = ".", *, check: bool = False) -> dict[str, Any]:
                 result["errors"].append("could not locate Main Branch engine root")
                 result["new_version"] = result["old_version"]
                 return result
+            fetched, fetch_error = _fetch_origin_main(root)
+            result["actions"].append(f"ran `git fetch origin main --quiet` in {root}")
+            if not fetched:
+                result["ok"] = False
+                result["errors"].append(fetch_error or "git fetch origin main failed")
+                result["new_version"] = result["old_version"]
+                return result
             result["new_version"] = (
                 _version_from_git_ref(root, "origin/main") or result["old_version"]
             )
-            result["actions"] = [
-                f"would run `git pull` in {root}",
-                f"would run `mb skill link --repo {target_repo}`",
-            ]
+            result["actions"].extend(
+                [
+                    f"would run `git pull` in {root}",
+                    f"would run `mb skill link --repo {target_repo} --json`",
+                ]
+            )
         result["skills_relinked_count"] = len(bundled_skills())
         return result
 
@@ -190,9 +224,10 @@ def run(repo: str | Path = ".", *, check: bool = False) -> dict[str, Any]:
             return result
         result["new_version"] = _engine_version(root)
 
-    linked_count, link_errors, _link_payload = _link_skills(target_repo)
-    result["actions"].append(f"ran `mb skill link --repo {target_repo}`")
+    linked_count, link_errors, link_warnings, _link_payload = _link_skills(target_repo)
+    result["actions"].append(f"ran `mb skill link --repo {target_repo} --json`")
     result["skills_relinked_count"] = linked_count
+    result["warnings"].extend(link_warnings)
     if link_errors:
         result["ok"] = False
         result["errors"].extend(link_errors)
@@ -220,3 +255,6 @@ def render_human(result: dict[str, Any]) -> None:
     if result.get("errors"):
         for error in result["errors"]:
             print(f"error: {error}")
+    if result.get("warnings"):
+        for warning in result["warnings"]:
+            print(f"warning: {warning}")

--- a/mb/mb/update.py
+++ b/mb/mb/update.py
@@ -15,6 +15,7 @@ from mb import __version__
 from mb.engine import bundled_skills, engine_root, install_mode
 
 VERSION_RE = re.compile(r'__version__\s*=\s*["\']([^"\']+)["\']')
+CLONE_UPDATE_COMMAND = ["git", "pull", "--ff-only", "origin", "main"]
 
 
 def _run_command(args: list[str], *, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
@@ -188,7 +189,7 @@ def run(repo: str | Path = ".", *, check: bool = False) -> dict[str, Any]:
             )
             result["actions"].extend(
                 [
-                    f"would run `git pull` in {root}",
+                    f"would run `git pull --ff-only origin main` in {root}",
                     f"would run `mb skill link --repo {target_repo} --json`",
                 ]
             )
@@ -215,8 +216,8 @@ def run(repo: str | Path = ".", *, check: bool = False) -> dict[str, Any]:
             result["new_version"] = result["old_version"]
             result["errors"].append("could not locate Main Branch engine root")
             return result
-        pull = _run_command(["git", "pull"], cwd=root)
-        result["actions"].append(f"ran `git pull` in {root}")
+        pull = _run_command(CLONE_UPDATE_COMMAND, cwd=root)
+        result["actions"].append(f"ran `git pull --ff-only origin main` in {root}")
         if pull.returncode != 0:
             result["ok"] = False
             result["new_version"] = result["old_version"]

--- a/mb/mb/update.py
+++ b/mb/mb/update.py
@@ -1,0 +1,222 @@
+"""Install-mode-aware Main Branch engine updates."""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+from mb import __version__
+from mb.engine import bundled_skills, engine_root, install_mode
+
+VERSION_RE = re.compile(r'__version__\s*=\s*["\']([^"\']+)["\']')
+
+
+def _run_command(args: list[str], *, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        args,
+        cwd=str(cwd) if cwd is not None else None,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def _engine_version(root: Path | None = None) -> str:
+    root = root or engine_root()
+    if root is None:
+        return __version__
+
+    candidates = [
+        root / "mb" / "mb" / "__init__.py",
+        root / "mb" / "__init__.py",
+    ]
+    for candidate in candidates:
+        if not candidate.exists():
+            continue
+        match = VERSION_RE.search(candidate.read_text(encoding="utf-8"))
+        if match:
+            return match.group(1)
+    return __version__
+
+
+def _latest_pypi_version(timeout: float = 3.0) -> str | None:
+    url = "https://pypi.org/pypi/mainbranch/json"
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as response:
+            data = json.loads(response.read().decode("utf-8"))
+    except (OSError, TimeoutError, urllib.error.URLError, json.JSONDecodeError):
+        return None
+    info = data.get("info", {})
+    version = info.get("version") if isinstance(info, dict) else None
+    return version if isinstance(version, str) and version else None
+
+
+def _version_from_git_ref(root: Path, ref: str) -> str | None:
+    result = _run_command(["git", "show", f"{ref}:mb/mb/__init__.py"], cwd=root)
+    if result.returncode != 0:
+        return None
+    match = VERSION_RE.search(result.stdout)
+    return match.group(1) if match else None
+
+
+def _version_from_mb_command() -> str | None:
+    result = _run_command(["mb", "--version"])
+    if result.returncode != 0:
+        return None
+    match = re.search(r"\bmb\s+(.+)\s*$", result.stdout.strip())
+    return match.group(1) if match else None
+
+
+def _command_error(label: str, result: subprocess.CompletedProcess[str]) -> str:
+    details = (result.stderr or result.stdout).strip()
+    return f"{label} failed with exit code {result.returncode}: {details or 'no output'}"
+
+
+def _skill_count_from_link_result(result: dict[str, Any]) -> int:
+    total = 0
+    for key in ("linked", "copied", "skipped"):
+        value = result.get(key, [])
+        if isinstance(value, list):
+            total += len(value)
+    return total
+
+
+def _link_skills(repo: Path) -> tuple[int, list[str], dict[str, Any] | None]:
+    result = _run_command(["mb", "skill", "link", "--repo", str(repo), "--json"])
+    if result.returncode != 0:
+        return 0, [_command_error("mb skill link", result)], None
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return 0, ["mb skill link returned invalid JSON"], None
+    if not isinstance(payload, dict):
+        return 0, ["mb skill link returned an unexpected JSON payload"], None
+    errors = payload.get("errors", [])
+    parsed_errors = [str(error) for error in errors] if isinstance(errors, list) else []
+    if payload.get("ok") is not True:
+        return (
+            _skill_count_from_link_result(payload),
+            parsed_errors or ["mb skill link failed"],
+            payload,
+        )
+    return _skill_count_from_link_result(payload), [], payload
+
+
+def _base_result(repo: Path, *, check: bool, mode: str, root: Path | None) -> dict[str, Any]:
+    return {
+        "ok": True,
+        "mode": mode,
+        "check": check,
+        "repo": str(repo),
+        "engine_root": str(root) if root is not None else None,
+        "old_version": _engine_version(root),
+        "new_version": None,
+        "skills_relinked_count": 0,
+        "actions": [],
+        "errors": [],
+    }
+
+
+def run(repo: str | Path = ".", *, check: bool = False) -> dict[str, Any]:
+    """Update the active Main Branch install and refresh business-repo skills."""
+    target_repo = Path(repo).resolve()
+    mode = install_mode()
+    root = engine_root()
+    result = _base_result(target_repo, check=check, mode=mode, root=root)
+
+    if mode not in {"pipx", "clone"}:
+        result["ok"] = False
+        result["new_version"] = result["old_version"]
+        result["errors"].append(
+            f"unsupported install mode: {mode}. Expected a pipx install or git clone."
+        )
+        return result
+
+    if check:
+        if mode == "pipx":
+            result["new_version"] = _latest_pypi_version() or result["old_version"]
+            result["actions"] = [
+                "would run `pipx upgrade mainbranch`",
+                f"would run `mb skill link --repo {target_repo}`",
+            ]
+        else:
+            if root is None:
+                result["ok"] = False
+                result["errors"].append("could not locate Main Branch engine root")
+                result["new_version"] = result["old_version"]
+                return result
+            result["new_version"] = (
+                _version_from_git_ref(root, "origin/main") or result["old_version"]
+            )
+            result["actions"] = [
+                f"would run `git pull` in {root}",
+                f"would run `mb skill link --repo {target_repo}`",
+            ]
+        result["skills_relinked_count"] = len(bundled_skills())
+        return result
+
+    if mode == "pipx":
+        if shutil.which("pipx") is None:
+            result["ok"] = False
+            result["new_version"] = result["old_version"]
+            result["errors"].append("pipx install mode detected, but `pipx` is not on PATH")
+            return result
+        upgrade = _run_command(["pipx", "upgrade", "mainbranch"])
+        result["actions"].append("ran `pipx upgrade mainbranch`")
+        if upgrade.returncode != 0:
+            result["ok"] = False
+            result["new_version"] = result["old_version"]
+            result["errors"].append(_command_error("pipx upgrade mainbranch", upgrade))
+            return result
+        result["new_version"] = _version_from_mb_command() or result["old_version"]
+    else:
+        if root is None:
+            result["ok"] = False
+            result["new_version"] = result["old_version"]
+            result["errors"].append("could not locate Main Branch engine root")
+            return result
+        pull = _run_command(["git", "pull"], cwd=root)
+        result["actions"].append(f"ran `git pull` in {root}")
+        if pull.returncode != 0:
+            result["ok"] = False
+            result["new_version"] = result["old_version"]
+            result["errors"].append(_command_error("git pull", pull))
+            return result
+        result["new_version"] = _engine_version(root)
+
+    linked_count, link_errors, _link_payload = _link_skills(target_repo)
+    result["actions"].append(f"ran `mb skill link --repo {target_repo}`")
+    result["skills_relinked_count"] = linked_count
+    if link_errors:
+        result["ok"] = False
+        result["errors"].extend(link_errors)
+    return result
+
+
+def render_human(result: dict[str, Any]) -> None:
+    """Print a concise human-readable update result."""
+    old = result.get("old_version") or "unknown"
+    new = result.get("new_version") or "unknown"
+    mode = result.get("mode") or "unknown"
+    count = result.get("skills_relinked_count", 0)
+
+    if result.get("check"):
+        print(f"install mode: {mode}")
+        print(f"version: {old} -> {new}")
+        for action in result.get("actions", []):
+            print(action)
+        if count:
+            print(f"would refresh {count} skill link(s)")
+    elif result.get("ok"):
+        print(f"updated Main Branch ({old} -> {new})")
+        print(f"refreshed {count} skill link(s)")
+
+    if result.get("errors"):
+        for error in result["errors"]:
+            print(f"error: {error}")

--- a/mb/tests/test_update.py
+++ b/mb/tests/test_update.py
@@ -122,7 +122,7 @@ def test_update_check_clone_fetches_before_reading_origin(monkeypatch: Any, tmp_
     assert result["skills_relinked_count"] == 3
     assert calls == [(["git", "fetch", "origin", "main:refs/remotes/origin/main", "--quiet"], root)]
     assert "ran `git fetch origin main --quiet`" in result["actions"][0]
-    assert "would run `git pull`" in result["actions"][1]
+    assert "would run `git pull --ff-only origin main`" in result["actions"][1]
     assert result["actions"][2].endswith(" --json`")
 
 
@@ -154,7 +154,7 @@ def test_update_clone_pulls_engine_root_then_relinks(monkeypatch: Any, tmp_path:
 
     def fake_run(args: list[str], *, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
         calls.append((args, cwd))
-        if args == ["git", "pull"]:
+        if args == ["git", "pull", "--ff-only", "origin", "main"]:
             init_file.write_text('__version__ = "0.2.0"\n')
             return _completed(args, stdout="Already up to date.")
         if args[:3] == ["mb", "skill", "link"]:
@@ -185,7 +185,7 @@ def test_update_clone_pulls_engine_root_then_relinks(monkeypatch: Any, tmp_path:
     assert result["warnings"] == [
         "could not refresh existing non-link skill path(s): .claude/skills/start"
     ]
-    assert calls[0] == (["git", "pull"], root)
+    assert calls[0] == (["git", "pull", "--ff-only", "origin", "main"], root)
 
 
 def test_update_json_cli_envelope(monkeypatch: Any, tmp_path: Path) -> None:

--- a/mb/tests/test_update.py
+++ b/mb/tests/test_update.py
@@ -1,0 +1,171 @@
+"""``mb update`` install-mode contract tests."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from typer.testing import CliRunner
+
+from mb import __version__
+from mb import update as update_mod
+from mb.cli import app
+
+runner = CliRunner()
+
+
+def _completed(
+    args: list[str],
+    *,
+    stdout: str = "",
+    stderr: str = "",
+    returncode: int = 0,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(
+        args=args,
+        returncode=returncode,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+def test_update_check_pipx_does_not_run_commands(monkeypatch: Any, tmp_path: Path) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(args: list[str], *, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+        calls.append(args)
+        return _completed(args)
+
+    monkeypatch.setattr(update_mod, "install_mode", lambda: "pipx")
+    monkeypatch.setattr(update_mod, "engine_root", lambda: tmp_path / "_engine")
+    monkeypatch.setattr(update_mod, "_latest_pypi_version", lambda: "0.2.0")
+    monkeypatch.setattr(update_mod, "bundled_skills", lambda: ["pull", "start"])
+    monkeypatch.setattr(update_mod, "_run_command", fake_run)
+
+    result = update_mod.run(repo=tmp_path / "biz", check=True)
+
+    assert result["ok"] is True
+    assert result["old_version"] == __version__
+    assert result["new_version"] == "0.2.0"
+    assert result["skills_relinked_count"] == 2
+    assert calls == []
+
+
+def test_update_pipx_runs_upgrade_then_relinks(monkeypatch: Any, tmp_path: Path) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(args: list[str], *, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+        calls.append(args)
+        if args == ["pipx", "upgrade", "mainbranch"]:
+            return _completed(args, stdout="upgraded package mainbranch")
+        if args == ["mb", "--version"]:
+            return _completed(args, stdout="mb 0.2.0\n")
+        if args[:3] == ["mb", "skill", "link"]:
+            return _completed(
+                args,
+                stdout=json.dumps(
+                    {
+                        "ok": True,
+                        "linked": [".claude/skills/start"],
+                        "copied": [],
+                        "skipped": [".claude/skills/pull"],
+                        "errors": [],
+                    }
+                ),
+            )
+        return _completed(args, returncode=1, stderr="unexpected")
+
+    monkeypatch.setattr(update_mod, "install_mode", lambda: "pipx")
+    monkeypatch.setattr(update_mod, "engine_root", lambda: tmp_path / "_engine")
+    monkeypatch.setattr(update_mod.shutil, "which", lambda name: "/opt/homebrew/bin/pipx")
+    monkeypatch.setattr(update_mod, "_run_command", fake_run)
+
+    repo = tmp_path / "biz"
+    result = update_mod.run(repo=repo)
+
+    assert result["ok"] is True
+    assert result["new_version"] == "0.2.0"
+    assert result["skills_relinked_count"] == 2
+    assert calls == [
+        ["pipx", "upgrade", "mainbranch"],
+        ["mb", "--version"],
+        ["mb", "skill", "link", "--repo", str(repo.resolve()), "--json"],
+    ]
+
+
+def test_update_check_clone_reads_origin_without_pull(monkeypatch: Any, tmp_path: Path) -> None:
+    root = tmp_path / "engine"
+    (root / "mb" / "mb").mkdir(parents=True)
+    (root / "mb" / "mb" / "__init__.py").write_text('__version__ = "0.1.2"\n')
+
+    monkeypatch.setattr(update_mod, "install_mode", lambda: "clone")
+    monkeypatch.setattr(update_mod, "engine_root", lambda: root)
+    monkeypatch.setattr(update_mod, "_version_from_git_ref", lambda _root, _ref: "0.2.0")
+    monkeypatch.setattr(update_mod, "bundled_skills", lambda: ["pull", "start", "think"])
+
+    result = update_mod.run(repo=tmp_path / "biz", check=True)
+
+    assert result["ok"] is True
+    assert result["old_version"] == "0.1.2"
+    assert result["new_version"] == "0.2.0"
+    assert result["skills_relinked_count"] == 3
+    assert "would run `git pull`" in result["actions"][0]
+
+
+def test_update_clone_pulls_engine_root_then_relinks(monkeypatch: Any, tmp_path: Path) -> None:
+    root = tmp_path / "engine"
+    (root / "mb" / "mb").mkdir(parents=True)
+    init_file = root / "mb" / "mb" / "__init__.py"
+    init_file.write_text('__version__ = "0.1.2"\n')
+    calls: list[tuple[list[str], Path | None]] = []
+
+    def fake_run(args: list[str], *, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+        calls.append((args, cwd))
+        if args == ["git", "pull"]:
+            init_file.write_text('__version__ = "0.2.0"\n')
+            return _completed(args, stdout="Already up to date.")
+        if args[:3] == ["mb", "skill", "link"]:
+            return _completed(
+                args,
+                stdout=json.dumps(
+                    {
+                        "ok": True,
+                        "linked": [],
+                        "copied": [],
+                        "skipped": [".claude/skills/start"],
+                        "errors": [],
+                    }
+                ),
+            )
+        return _completed(args, returncode=1, stderr="unexpected")
+
+    monkeypatch.setattr(update_mod, "install_mode", lambda: "clone")
+    monkeypatch.setattr(update_mod, "engine_root", lambda: root)
+    monkeypatch.setattr(update_mod, "_run_command", fake_run)
+
+    result = update_mod.run(repo=tmp_path / "biz")
+
+    assert result["ok"] is True
+    assert result["old_version"] == "0.1.2"
+    assert result["new_version"] == "0.2.0"
+    assert result["skills_relinked_count"] == 1
+    assert calls[0] == (["git", "pull"], root)
+
+
+def test_update_json_cli_envelope(monkeypatch: Any, tmp_path: Path) -> None:
+    monkeypatch.setattr(update_mod, "install_mode", lambda: "pipx")
+    monkeypatch.setattr(update_mod, "engine_root", lambda: tmp_path / "_engine")
+    monkeypatch.setattr(update_mod, "_latest_pypi_version", lambda: "0.2.0")
+    monkeypatch.setattr(update_mod, "bundled_skills", lambda: ["start"])
+
+    result = runner.invoke(app, ["update", "--repo", str(tmp_path / "biz"), "--check", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["mode"] == "pipx"
+    assert payload["old_version"] == __version__
+    assert payload["new_version"] == "0.2.0"
+    assert payload["skills_relinked_count"] == 1
+    assert payload["errors"] == []

--- a/mb/tests/test_update.py
+++ b/mb/tests/test_update.py
@@ -120,9 +120,7 @@ def test_update_check_clone_fetches_before_reading_origin(monkeypatch: Any, tmp_
     assert result["old_version"] == "0.1.2"
     assert result["new_version"] == "0.2.0"
     assert result["skills_relinked_count"] == 3
-    assert calls == [
-        (["git", "fetch", "origin", "main:refs/remotes/origin/main", "--quiet"], root)
-    ]
+    assert calls == [(["git", "fetch", "origin", "main:refs/remotes/origin/main", "--quiet"], root)]
     assert "ran `git fetch origin main --quiet`" in result["actions"][0]
     assert "would run `git pull`" in result["actions"][1]
     assert result["actions"][2].endswith(" --json`")
@@ -290,9 +288,7 @@ def test_update_relink_payload_errors_are_reported(monkeypatch: Any, tmp_path: P
 
     assert count == 1
     assert errors == ["could not locate bundled Main Branch engine root"]
-    assert warnings == [
-        "could not refresh existing non-link skill path(s): .claude/skills/pull"
-    ]
+    assert warnings == ["could not refresh existing non-link skill path(s): .claude/skills/pull"]
     assert parsed == payload
 
 

--- a/mb/tests/test_update.py
+++ b/mb/tests/test_update.py
@@ -169,3 +169,128 @@ def test_update_json_cli_envelope(monkeypatch: Any, tmp_path: Path) -> None:
     assert payload["new_version"] == "0.2.0"
     assert payload["skills_relinked_count"] == 1
     assert payload["errors"] == []
+
+
+def test_update_rejects_unknown_install_mode(monkeypatch: Any, tmp_path: Path) -> None:
+    monkeypatch.setattr(update_mod, "install_mode", lambda: "wheel")
+    monkeypatch.setattr(update_mod, "engine_root", lambda: tmp_path / "_engine")
+
+    result = update_mod.run(repo=tmp_path / "biz")
+
+    assert result["ok"] is False
+    assert result["mode"] == "wheel"
+    assert result["new_version"] == result["old_version"]
+    assert "unsupported install mode" in result["errors"][0]
+
+
+def test_update_pipx_missing_binary_returns_error(monkeypatch: Any, tmp_path: Path) -> None:
+    monkeypatch.setattr(update_mod, "install_mode", lambda: "pipx")
+    monkeypatch.setattr(update_mod, "engine_root", lambda: tmp_path / "_engine")
+    monkeypatch.setattr(update_mod.shutil, "which", lambda name: None)
+
+    result = update_mod.run(repo=tmp_path / "biz")
+
+    assert result["ok"] is False
+    assert result["new_version"] == result["old_version"]
+    assert result["errors"] == ["pipx install mode detected, but `pipx` is not on PATH"]
+
+
+def test_update_pipx_upgrade_failure_skips_relink(monkeypatch: Any, tmp_path: Path) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(args: list[str], *, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+        calls.append(args)
+        return _completed(args, returncode=2, stderr="network down")
+
+    monkeypatch.setattr(update_mod, "install_mode", lambda: "pipx")
+    monkeypatch.setattr(update_mod, "engine_root", lambda: tmp_path / "_engine")
+    monkeypatch.setattr(update_mod.shutil, "which", lambda name: "/opt/homebrew/bin/pipx")
+    monkeypatch.setattr(update_mod, "_run_command", fake_run)
+
+    result = update_mod.run(repo=tmp_path / "biz")
+
+    assert result["ok"] is False
+    assert result["skills_relinked_count"] == 0
+    assert calls == [["pipx", "upgrade", "mainbranch"]]
+    assert "network down" in result["errors"][0]
+
+
+def test_update_relink_invalid_json_is_reported(monkeypatch: Any, tmp_path: Path) -> None:
+    root = tmp_path / "engine"
+    (root / "mb" / "mb").mkdir(parents=True)
+    (root / "mb" / "mb" / "__init__.py").write_text('__version__ = "0.1.2"\n')
+
+    def fake_run(args: list[str], *, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+        if args == ["git", "pull"]:
+            return _completed(args)
+        return _completed(args, stdout="not-json")
+
+    monkeypatch.setattr(update_mod, "install_mode", lambda: "clone")
+    monkeypatch.setattr(update_mod, "engine_root", lambda: root)
+    monkeypatch.setattr(update_mod, "_run_command", fake_run)
+
+    result = update_mod.run(repo=tmp_path / "biz")
+
+    assert result["ok"] is False
+    assert result["skills_relinked_count"] == 0
+    assert result["errors"] == ["mb skill link returned invalid JSON"]
+
+
+def test_update_relink_payload_errors_are_reported(monkeypatch: Any, tmp_path: Path) -> None:
+    payload = {
+        "ok": False,
+        "linked": [],
+        "copied": [".claude/skills/start"],
+        "skipped": [".claude/skills/pull"],
+        "errors": ["could not locate bundled Main Branch engine root"],
+    }
+
+    def fake_run(args: list[str], *, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+        return _completed(args, stdout=json.dumps(payload))
+
+    monkeypatch.setattr(update_mod, "_run_command", fake_run)
+
+    count, errors, parsed = update_mod._link_skills(tmp_path / "biz")
+
+    assert count == 2
+    assert errors == ["could not locate bundled Main Branch engine root"]
+    assert parsed == payload
+
+
+def test_update_render_human_check_and_error(capsys: Any) -> None:
+    update_mod.render_human(
+        {
+            "check": True,
+            "mode": "clone",
+            "old_version": "0.1.2",
+            "new_version": "0.2.0",
+            "skills_relinked_count": 3,
+            "actions": ["would run `git pull`"],
+            "errors": ["boom"],
+        }
+    )
+
+    output = capsys.readouterr().out
+
+    assert "install mode: clone" in output
+    assert "version: 0.1.2 -> 0.2.0" in output
+    assert "would refresh 3 skill link(s)" in output
+    assert "error: boom" in output
+
+
+def test_update_render_human_success(capsys: Any) -> None:
+    update_mod.render_human(
+        {
+            "ok": True,
+            "check": False,
+            "old_version": "0.1.2",
+            "new_version": "0.2.0",
+            "skills_relinked_count": 4,
+            "errors": [],
+        }
+    )
+
+    output = capsys.readouterr().out
+
+    assert "updated Main Branch (0.1.2 -> 0.2.0)" in output
+    assert "refreshed 4 skill link(s)" in output

--- a/mb/tests/test_update.py
+++ b/mb/tests/test_update.py
@@ -87,7 +87,10 @@ def test_update_pipx_runs_upgrade_then_relinks(monkeypatch: Any, tmp_path: Path)
 
     assert result["ok"] is True
     assert result["new_version"] == "0.2.0"
-    assert result["skills_relinked_count"] == 2
+    assert result["skills_relinked_count"] == 1
+    assert result["warnings"] == [
+        "could not refresh existing non-link skill path(s): .claude/skills/pull"
+    ]
     assert calls == [
         ["pipx", "upgrade", "mainbranch"],
         ["mb", "--version"],
@@ -95,13 +98,19 @@ def test_update_pipx_runs_upgrade_then_relinks(monkeypatch: Any, tmp_path: Path)
     ]
 
 
-def test_update_check_clone_reads_origin_without_pull(monkeypatch: Any, tmp_path: Path) -> None:
+def test_update_check_clone_fetches_before_reading_origin(monkeypatch: Any, tmp_path: Path) -> None:
     root = tmp_path / "engine"
     (root / "mb" / "mb").mkdir(parents=True)
     (root / "mb" / "mb" / "__init__.py").write_text('__version__ = "0.1.2"\n')
+    calls: list[tuple[list[str], Path | None]] = []
+
+    def fake_run(args: list[str], *, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+        calls.append((args, cwd))
+        return _completed(args)
 
     monkeypatch.setattr(update_mod, "install_mode", lambda: "clone")
     monkeypatch.setattr(update_mod, "engine_root", lambda: root)
+    monkeypatch.setattr(update_mod, "_run_command", fake_run)
     monkeypatch.setattr(update_mod, "_version_from_git_ref", lambda _root, _ref: "0.2.0")
     monkeypatch.setattr(update_mod, "bundled_skills", lambda: ["pull", "start", "think"])
 
@@ -111,7 +120,31 @@ def test_update_check_clone_reads_origin_without_pull(monkeypatch: Any, tmp_path
     assert result["old_version"] == "0.1.2"
     assert result["new_version"] == "0.2.0"
     assert result["skills_relinked_count"] == 3
-    assert "would run `git pull`" in result["actions"][0]
+    assert calls == [
+        (["git", "fetch", "origin", "main:refs/remotes/origin/main", "--quiet"], root)
+    ]
+    assert "ran `git fetch origin main --quiet`" in result["actions"][0]
+    assert "would run `git pull`" in result["actions"][1]
+    assert result["actions"][2].endswith(" --json`")
+
+
+def test_update_check_clone_reports_fetch_failure(monkeypatch: Any, tmp_path: Path) -> None:
+    root = tmp_path / "engine"
+    (root / "mb" / "mb").mkdir(parents=True)
+    (root / "mb" / "mb" / "__init__.py").write_text('__version__ = "0.1.2"\n')
+
+    def fake_run(args: list[str], *, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+        return _completed(args, returncode=128, stderr="no network")
+
+    monkeypatch.setattr(update_mod, "install_mode", lambda: "clone")
+    monkeypatch.setattr(update_mod, "engine_root", lambda: root)
+    monkeypatch.setattr(update_mod, "_run_command", fake_run)
+
+    result = update_mod.run(repo=tmp_path / "biz", check=True)
+
+    assert result["ok"] is False
+    assert result["new_version"] == "0.1.2"
+    assert "no network" in result["errors"][0]
 
 
 def test_update_clone_pulls_engine_root_then_relinks(monkeypatch: Any, tmp_path: Path) -> None:
@@ -150,7 +183,10 @@ def test_update_clone_pulls_engine_root_then_relinks(monkeypatch: Any, tmp_path:
     assert result["ok"] is True
     assert result["old_version"] == "0.1.2"
     assert result["new_version"] == "0.2.0"
-    assert result["skills_relinked_count"] == 1
+    assert result["skills_relinked_count"] == 0
+    assert result["warnings"] == [
+        "could not refresh existing non-link skill path(s): .claude/skills/start"
+    ]
     assert calls[0] == (["git", "pull"], root)
 
 
@@ -250,10 +286,13 @@ def test_update_relink_payload_errors_are_reported(monkeypatch: Any, tmp_path: P
 
     monkeypatch.setattr(update_mod, "_run_command", fake_run)
 
-    count, errors, parsed = update_mod._link_skills(tmp_path / "biz")
+    count, errors, warnings, parsed = update_mod._link_skills(tmp_path / "biz")
 
-    assert count == 2
+    assert count == 1
     assert errors == ["could not locate bundled Main Branch engine root"]
+    assert warnings == [
+        "could not refresh existing non-link skill path(s): .claude/skills/pull"
+    ]
     assert parsed == payload
 
 
@@ -267,6 +306,7 @@ def test_update_render_human_check_and_error(capsys: Any) -> None:
             "skills_relinked_count": 3,
             "actions": ["would run `git pull`"],
             "errors": ["boom"],
+            "warnings": ["careful"],
         }
     )
 
@@ -276,6 +316,7 @@ def test_update_render_human_check_and_error(capsys: Any) -> None:
     assert "version: 0.1.2 -> 0.2.0" in output
     assert "would refresh 3 skill link(s)" in output
     assert "error: boom" in output
+    assert "warning: careful" in output
 
 
 def test_update_render_human_success(capsys: Any) -> None:


### PR DESCRIPTION
## Summary
- Adds `mb update` as the deterministic update surface for Main Branch engine refreshes.
- Detects pipx vs clone installs, supports dry-run `--check`, and emits a JSON result envelope for automation.
- Refreshes Claude Code skill links after a successful update and reports relink counts/errors.
- Updates `/pull` so it delegates update mechanics to `mb update` while keeping the changelog narrative.

## Scope
- In: CLI update command, install-mode execution paths, JSON/dry-run contract, skill-link refresh, `/pull` instructions, public docs, changelog, and focused CLI tests.
- Out: human-language "what's new" rendering, auto-update on session start, runtime smoke, and unrelated package metadata cleanup.

## Commits
- `61af7a0` — `[add] MAIN-174 install-mode update command`.
- `82ecb16` — `[fix] MAIN-174 cover update error paths`.
- `94b3666` — `[fix] MAIN-174 clarify update relink checks`.
- `b2b1ffa` — `[fix] MAIN-174 format update tests`.
- `2b78a2f` — `[fix] MAIN-174 pull clone main explicitly`.

## Release / Issues
- Release: Main Branch 0.2.0
- Linear ID(s): MAIN-174
- Closes: #174
- Refs: `decisions/2026-05-01-mb-cli-vs-agent-workflows-boundary.md`
- Follow-ups: package metadata deprecation warnings from setuptools can be handled separately.

## Success Metric
- Running `mb update` from a business repo performs the correct engine refresh for pipx or clone installs, refreshes skill links, and gives scripts a stable `--json` envelope without requiring `/pull` to own package-manager logic.

## Validation
- Level 0 docs/decision: updated `/pull`, pull reference docs, compatibility docs, package README, and `CHANGELOG.md`.
- Level 1 static: `pipx run 'ruff==0.6.9' format --check .` passed; `pipx run 'ruff==0.6.9' check .` passed; `mypy mb` passed; `git diff --check` passed.
- Level 2 CLI: `pytest mb/tests/test_update.py mb/tests/test_cli.py -q` passed; `pytest mb/tests/test_update.py -q` passed; `python3 -m mb update --check --json` emitted the expected clone-mode envelope with a fetched remote ref, `git pull --ff-only origin main`, and `--json` relink preview.
- Level 3 package/install: `python3 -m build` passed and included `mb/update.py` in the sdist and wheel; `pytest tests/ -v --cov=mb --cov-report=term-missing --cov-fail-under=70` passed at 72.39% total coverage; isolated `pipx` wheel install plus `mb update --check --json` passed using temporary `PIPX_HOME`/`PIPX_BIN_DIR`; existing setuptools license metadata deprecation warnings were observed.
- Level 4 fixture repo: temporary clone/origin smoke passed by mutating remote `main` to `9.9.9` and verifying clone-mode `--check --json` fetched before reporting `old_version: 0.1.2`, `new_version: 9.9.9`.
- Level 5 runtime smoke: not run; this change is CLI/update mechanics plus skill instructions, not runtime discovery.

## Public / Private Boundary
- No private Devon, Conductor, customer, or live runtime details were added; `.context/` remains local scratch only.
