### PR TITLE
[add] mb start runtime handoff

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -41,8 +41,7 @@ For most users:
 pipx install mainbranch
 mb init my-business --name "My Business"
 cd my-business
-claude
-/start
+mb start
 ```
 
 For contributors:

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -41,7 +41,7 @@ For most users:
 pipx install mainbranch
 mb init my-business --name "My Business"
 cd my-business
-mb start
+mb start --launch
 ```
 
 For contributors:

--- a/mb/README.md
+++ b/mb/README.md
@@ -25,6 +25,7 @@ mb --version
 | `mb init` | Scaffold a new business repo (six folders, CLAUDE.md, CODEOWNERS, `git init`) and wire the bundled Claude Code skill adapter. One question only: business name. |
 | `mb doctor` | Diagnostic. Checks Claude Code, gh auth, network, librsvg, runtime wiring, and package freshness. Warns on cloud-backed finance paths and offers educational triage. |
 | `mb status` | Daily briefing. Summarizes repo shape, install/runtime readiness, recent brain files, recent git activity, and GitHub tasks when `gh` is authenticated. Supports `--json`. |
+| `mb start` | Runtime handoff. Verifies the current business repo, git, Claude Code, and `/start` skill wiring, then prints the exact `claude` command or launches it with `--launch`. Supports `--json`. |
 | `mb validate` | Frontmatter shape check across `decisions/`, `core/offers/`, `research/`, `log/`, `campaigns/`, `documents/`. Exit 1 on any fail. |
 | `mb graph` | Walk linked_research / linked_decisions / supersedes; emit Graphviz DOT to stdout. `--open` shells to `dot` + `open`. |
 | `mb update` | Refresh the Main Branch engine according to install mode (`pipx` upgrade or clone `git pull`) and repair skill links. `--check` dry-runs; `--json` emits an envelope. |

--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -18,6 +18,7 @@ from mb import educational as educational_mod
 from mb import graph as graph_mod
 from mb import init as init_mod
 from mb import resolve as resolve_mod
+from mb import start as start_mod
 from mb import status as status_mod
 from mb import think as think_mod
 from mb import update as update_mod
@@ -63,7 +64,7 @@ def _render_launch_screen() -> None:
                 "Choose a trail:",
                 "  New here      mb onboard       guided setup (coming in v0.2)",
                 "  Daily work    mb status        business/repo briefing",
-                "                mb start         open the agent runtime (coming in v0.2)",
+                "                mb start         open the agent runtime",
                 "  Broken setup  mb doctor        check git, GitHub, Claude Code, and skills",
                 "  Power user    mb --help        full command list",
                 "",
@@ -152,6 +153,29 @@ def status_cmd(
         typer.echo(json.dumps(report, indent=2))
     else:
         status_mod.render_human(report)
+
+
+@app.command("start")
+def start_cmd(
+    repo: str = typer.Option(
+        ".",
+        "--repo",
+        help="Business repo to hand off to the configured runtime.",
+    ),
+    launch: bool = typer.Option(
+        False,
+        "--launch",
+        help="Launch Claude Code after readiness checks pass in an interactive terminal.",
+    ),
+    json_out: bool = typer.Option(False, "--json", help="Machine-readable output."),
+) -> None:
+    """Check runtime handoff readiness and print or launch the Claude Code command."""
+    report = start_mod.run(repo=repo, launch=launch)
+    if json_out:
+        typer.echo(json.dumps(report, indent=2))
+    else:
+        start_mod.render_human(report)
+    raise typer.Exit(0 if report["ok"] else 1)
 
 
 @app.command("validate")

--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -165,11 +165,23 @@ def start_cmd(
     launch: bool = typer.Option(
         False,
         "--launch",
-        help="Launch Claude Code after readiness checks pass in an interactive terminal.",
+        help="Launch Claude Code after readiness checks pass. Cannot be combined with --json.",
     ),
     json_out: bool = typer.Option(False, "--json", help="Machine-readable output."),
 ) -> None:
     """Check runtime handoff readiness and print or launch the Claude Code command."""
+    if json_out and launch:
+        report = start_mod.run(repo=repo, launch=False)
+        message = "`--json` cannot be combined with `--launch`; run without `--json` to launch."
+        report["ok"] = False
+        report["errors"] = [message]
+        report["launch"]["requested"] = True
+        report["launch"]["safe"] = False
+        report["launch"]["attempted"] = False
+        report["launch"]["blocked_reason"] = message
+        typer.echo(json.dumps(report, indent=2))
+        raise typer.Exit(2)
+
     report = start_mod.run(repo=repo, launch=launch)
     if json_out:
         typer.echo(json.dumps(report, indent=2))

--- a/mb/mb/start.py
+++ b/mb/mb/start.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import shlex
 import shutil
 import subprocess
@@ -92,6 +93,8 @@ def _git_status(repo: Path) -> dict[str, Any]:
 
 
 def _display_command(repo: Path) -> str:
+    if os.name == "nt":
+        return f"cd /d {subprocess.list2cmdline([str(repo)])} && claude"
     return f"cd {shlex.quote(str(repo))} && claude"
 
 

--- a/mb/mb/start.py
+++ b/mb/mb/start.py
@@ -1,0 +1,292 @@
+"""``mb start`` — hand off from the CLI to the configured agent runtime."""
+
+from __future__ import annotations
+
+import shlex
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+from mb.engine import install_mode, link_status
+from mb.status import _looks_like_mainbranch_repo
+
+
+def _which(name: str) -> str:
+    return shutil.which(name) or ""
+
+
+def _is_interactive_terminal() -> bool:
+    return sys.stdin.isatty() and sys.stdout.isatty()
+
+
+def _run_command(args: list[str], cwd: Path, timeout: float = 3.0) -> dict[str, Any]:
+    try:
+        result = subprocess.run(
+            args,
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except FileNotFoundError:
+        return {"ok": False, "stdout": "", "stderr": f"{args[0]} not found", "returncode": 127}
+    except subprocess.TimeoutExpired:
+        return {"ok": False, "stdout": "", "stderr": "command timed out", "returncode": 124}
+    except subprocess.SubprocessError as exc:
+        return {"ok": False, "stdout": "", "stderr": str(exc), "returncode": 1}
+    return {
+        "ok": result.returncode == 0,
+        "stdout": result.stdout,
+        "stderr": result.stderr,
+        "returncode": result.returncode,
+    }
+
+
+def _git_status(repo: Path) -> dict[str, Any]:
+    if not repo.exists():
+        return {
+            "available": bool(_which("git")),
+            "inside_work_tree": False,
+            "branch": "",
+            "dirty": False,
+            "dirty_count": 0,
+            "error": "repo path does not exist",
+        }
+    if not _which("git"):
+        return {
+            "available": False,
+            "inside_work_tree": False,
+            "branch": "",
+            "dirty": False,
+            "dirty_count": 0,
+            "error": "git not on PATH",
+        }
+
+    inside = _run_command(["git", "rev-parse", "--is-inside-work-tree"], cwd=repo)
+    if not inside["ok"] or inside["stdout"].strip() != "true":
+        return {
+            "available": True,
+            "inside_work_tree": False,
+            "branch": "",
+            "dirty": False,
+            "dirty_count": 0,
+            "error": "not a git work tree",
+        }
+
+    branch = _run_command(["git", "branch", "--show-current"], cwd=repo)
+    status = _run_command(["git", "status", "--porcelain"], cwd=repo)
+    dirty_lines = (
+        [line for line in status["stdout"].splitlines() if line.strip()] if status["ok"] else []
+    )
+    return {
+        "available": True,
+        "inside_work_tree": True,
+        "branch": branch["stdout"].strip() if branch["ok"] else "",
+        "dirty": bool(dirty_lines),
+        "dirty_count": len(dirty_lines),
+        "dirty_files": dirty_lines[:10],
+        "error": "" if status["ok"] else status["stderr"].strip(),
+    }
+
+
+def _display_command(repo: Path) -> str:
+    return f"cd {shlex.quote(str(repo))} && claude"
+
+
+def _launch_claude(repo: Path) -> int:
+    try:
+        return subprocess.call(["claude"], cwd=repo)
+    except FileNotFoundError:
+        return 127
+    except subprocess.SubprocessError:
+        return 1
+
+
+def _build_checks(
+    repo_shape: dict[str, Any],
+    git: dict[str, Any],
+    claude_path: str,
+    wiring: dict[str, Any],
+) -> list[dict[str, Any]]:
+    dirty_detail = (
+        f"{git['dirty_count']} changed file(s)" if git.get("dirty") else "clean working tree"
+    )
+    return [
+        {
+            "name": "mainbranch_repo",
+            "ok": bool(repo_shape["looks_like_mainbranch_repo"]),
+            "severity": "error",
+            "detail": "Main Branch business repo"
+            if repo_shape["looks_like_mainbranch_repo"]
+            else "not a Main Branch business repo",
+            "repair": "Run from a business repo, or pass `--repo /path/to/business-repo`.",
+        },
+        {
+            "name": "git_work_tree",
+            "ok": bool(git.get("inside_work_tree")),
+            "severity": "error",
+            "detail": git.get("branch") or git.get("error") or "git work tree",
+            "repair": "Run `git init` if this should be a Main Branch business repo.",
+        },
+        {
+            "name": "git_clean",
+            "ok": not bool(git.get("dirty")),
+            "severity": "warn",
+            "detail": dirty_detail,
+            "repair": (
+                "Review, commit, or stash local changes before handing substantive work "
+                "to an agent."
+            ),
+        },
+        {
+            "name": "claude_code",
+            "ok": bool(claude_path),
+            "severity": "error",
+            "detail": claude_path or "claude not on PATH",
+            "repair": "Install Claude Code: https://claude.ai/install",
+        },
+        {
+            "name": "skill_wiring",
+            "ok": bool(wiring["ok"]),
+            "severity": "error",
+            "detail": "start skill discoverable"
+            if wiring["ok"]
+            else "Claude Code start skill is not wired",
+            "repair": "Run `mb skill link --repo .` from the business repo.",
+        },
+        {
+            "name": "install_mode",
+            "ok": install_mode() != "unknown",
+            "severity": "info",
+            "detail": install_mode(),
+            "repair": "Reinstall Main Branch with `pipx install mainbranch` if commands fail.",
+        },
+    ]
+
+
+def _hard_failures(checks: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        check
+        for check in checks
+        if not check["ok"] and check.get("severity") not in {"warn", "info"}
+    ]
+
+
+def _next_actions(
+    repo: Path,
+    checks: list[dict[str, Any]],
+    handoff_ready: bool,
+) -> list[str]:
+    actions = [str(check["repair"]) for check in checks if not check["ok"] and check["repair"]]
+    if handoff_ready:
+        actions.extend([f"Run `{_display_command(repo)}`.", "Then type `/start` in Claude Code."])
+    return actions[:6]
+
+
+def run(repo: str = ".", launch: bool = False) -> dict[str, Any]:
+    """Build a handoff report and optionally launch Claude Code."""
+    repo_path = Path(repo).expanduser().resolve()
+    repo_shape = _looks_like_mainbranch_repo(repo_path)
+    git = _git_status(repo_path)
+    claude_path = _which("claude")
+    wiring = link_status(repo_path)
+    checks = _build_checks(repo_shape, git, claude_path, wiring)
+    hard_failures = _hard_failures(checks)
+    handoff_ready = not hard_failures
+
+    launch_report: dict[str, Any] = {
+        "requested": launch,
+        "safe": handoff_ready and _is_interactive_terminal(),
+        "attempted": False,
+        "returncode": None,
+        "blocked_reason": "",
+    }
+    if launch and not handoff_ready:
+        launch_report["blocked_reason"] = "handoff checks are not passing"
+    elif launch and not launch_report["safe"]:
+        launch_report["blocked_reason"] = (
+            "not an interactive terminal; run the printed command yourself"
+        )
+    elif launch:
+        launch_report["attempted"] = True
+        launch_report["returncode"] = _launch_claude(repo_path)
+
+    ok = handoff_ready
+    if launch:
+        ok = bool(launch_report["attempted"] and launch_report["returncode"] == 0)
+
+    return {
+        "ok": ok,
+        "handoff_ready": handoff_ready,
+        "repo": {"path": str(repo_path), **repo_shape},
+        "git": git,
+        "runtime": {
+            "name": "claude-code",
+            "executable": "claude",
+            "found": bool(claude_path),
+            "path": claude_path,
+            "skill_wiring": wiring,
+        },
+        "checks": checks,
+        "command": {
+            "cwd": str(repo_path),
+            "argv": ["claude"],
+            "display": _display_command(repo_path),
+            "follow_up": "/start",
+        },
+        "launch": launch_report,
+        "next_actions": _next_actions(repo_path, checks, handoff_ready),
+    }
+
+
+def render_human(report: dict[str, Any]) -> None:
+    """Print the runtime handoff in a compact human-readable form."""
+    from rich.console import Console
+
+    console = Console()
+    repo = report["repo"]
+    git = report["git"]
+    runtime = report["runtime"]
+    wiring = runtime["skill_wiring"]
+    command = report["command"]
+    launch = report["launch"]
+
+    console.print(f"\n[bold]mb start[/bold]  {repo['path']}\n")
+    console.print(
+        "[bold]Repo[/bold] "
+        + ("[green]ok[/green]" if repo["looks_like_mainbranch_repo"] else "[red]missing[/red]")
+        + "  Main Branch business repo"
+    )
+    git_label = git.get("branch") or git.get("error") or "unknown"
+    dirty = "dirty" if git.get("dirty") else "clean"
+    console.print(
+        "[bold]Git[/bold]  "
+        + ("[green]ok[/green]" if git.get("inside_work_tree") else "[red]missing[/red]")
+        + f"  {git_label}  {dirty}"
+    )
+    console.print(
+        "[bold]Runtime[/bold]  Claude Code "
+        + ("[green]found[/green]" if runtime["found"] else "[red]missing[/red]")
+    )
+    console.print(
+        "[bold]Skills[/bold]  /start "
+        + ("[green]wired[/green]" if wiring["ok"] else "[red]missing[/red]")
+    )
+
+    console.print("\n[bold]Command[/bold]")
+    console.print(f"  {command['display']}")
+    console.print(f"  {command['follow_up']}")
+
+    if launch["requested"]:
+        if launch["attempted"]:
+            console.print(f"\n[bold]Launch[/bold] claude exited {launch['returncode']}")
+        else:
+            console.print(f"\n[yellow]Launch skipped:[/yellow] {launch['blocked_reason']}")
+
+    if report["next_actions"]:
+        console.print("\n[bold]Next[/bold]")
+        for action in report["next_actions"]:
+            console.print(f"  - {action}")
+    console.print()

--- a/mb/tests/test_start.py
+++ b/mb/tests/test_start.py
@@ -1,0 +1,109 @@
+"""``mb start`` runtime handoff."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+from typing import Any
+
+from typer.testing import CliRunner
+
+from mb import start as start_mod
+from mb.cli import app
+from mb.init import run as init_run
+
+runner = CliRunner()
+
+
+def _with_claude(name: str) -> str:
+    if name == "claude":
+        return "/usr/local/bin/claude"
+    return shutil.which(name) or ""
+
+
+def _without_claude(name: str) -> str:
+    if name == "claude":
+        return ""
+    return shutil.which(name) or ""
+
+
+def test_start_json_prints_ready_handoff(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(start_mod, "_which", _with_claude)
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+
+    result = runner.invoke(app, ["start", "--repo", str(repo), "--json"])
+
+    assert result.exit_code == 0
+    report = json.loads(result.stdout)
+    assert report["handoff_ready"] is True
+    assert report["runtime"]["found"] is True
+    assert report["runtime"]["skill_wiring"]["ok"] is True
+    assert report["command"]["argv"] == ["claude"]
+    assert report["command"]["display"].endswith(" && claude")
+    assert report["command"]["follow_up"] == "/start"
+    assert report["launch"]["requested"] is False
+
+
+def test_start_degrades_when_claude_is_missing(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(start_mod, "_which", _without_claude)
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+
+    result = runner.invoke(app, ["start", "--repo", str(repo), "--json"])
+
+    assert result.exit_code == 1
+    report = json.loads(result.stdout)
+    assert report["handoff_ready"] is False
+    claude_check = next(check for check in report["checks"] if check["name"] == "claude_code")
+    assert claude_check["ok"] is False
+    assert "Install Claude Code" in claude_check["repair"]
+
+
+def test_start_asks_for_repo_when_path_is_not_business_repo(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(start_mod, "_which", _with_claude)
+
+    result = runner.invoke(app, ["start", "--repo", str(tmp_path)])
+
+    assert result.exit_code == 1
+    assert "mb start" in result.stdout
+    assert "--repo /path/to/business-repo" in result.stdout
+
+
+def test_start_launch_is_blocked_outside_interactive_terminal(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(start_mod, "_which", _with_claude)
+    monkeypatch.setattr(start_mod, "_is_interactive_terminal", lambda: False)
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+
+    result = runner.invoke(app, ["start", "--repo", str(repo), "--launch", "--json"])
+
+    assert result.exit_code == 1
+    report = json.loads(result.stdout)
+    assert report["handoff_ready"] is True
+    assert report["launch"]["requested"] is True
+    assert report["launch"]["attempted"] is False
+    assert "interactive terminal" in report["launch"]["blocked_reason"]
+
+
+def test_start_launches_when_explicit_and_interactive(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(start_mod, "_which", _with_claude)
+    monkeypatch.setattr(start_mod, "_is_interactive_terminal", lambda: True)
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+    launched: dict[str, Any] = {}
+
+    def fake_launch(path: Path) -> int:
+        launched["path"] = str(path)
+        return 0
+
+    monkeypatch.setattr(start_mod, "_launch_claude", fake_launch)
+
+    result = runner.invoke(app, ["start", "--repo", str(repo), "--launch", "--json"])
+
+    assert result.exit_code == 0
+    report = json.loads(result.stdout)
+    assert launched["path"] == str(repo.resolve())
+    assert report["launch"]["attempted"] is True
+    assert report["launch"]["returncode"] == 0

--- a/mb/tests/test_start.py
+++ b/mb/tests/test_start.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import shlex
 import shutil
 from pathlib import Path
 from typing import Any
@@ -107,3 +108,14 @@ def test_start_launches_when_explicit_and_interactive(tmp_path: Path, monkeypatc
     assert launched["path"] == str(repo.resolve())
     assert report["launch"]["attempted"] is True
     assert report["launch"]["returncode"] == 0
+
+
+def test_start_display_command_is_os_aware(tmp_path: Path, monkeypatch) -> None:
+    repo = tmp_path / "path with spaces"
+
+    monkeypatch.setattr(start_mod.os, "name", "posix")
+    assert start_mod._display_command(repo) == f"cd {shlex.quote(str(repo))} && claude"
+
+    monkeypatch.setattr(start_mod.os, "name", "nt")
+    assert start_mod._display_command(repo).startswith("cd /d ")
+    assert start_mod._display_command(repo).endswith(" && claude")

--- a/mb/tests/test_start.py
+++ b/mb/tests/test_start.py
@@ -72,20 +72,39 @@ def test_start_asks_for_repo_when_path_is_not_business_repo(tmp_path: Path, monk
     assert "--repo /path/to/business-repo" in result.stdout
 
 
+def test_start_json_launch_is_rejected_without_launching(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(start_mod, "_which", _with_claude)
+    monkeypatch.setattr(start_mod, "_is_interactive_terminal", lambda: True)
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+
+    def fail_launch(path: Path) -> int:
+        raise AssertionError(f"should not launch in JSON mode: {path}")
+
+    monkeypatch.setattr(start_mod, "_launch_claude", fail_launch)
+
+    result = runner.invoke(app, ["start", "--repo", str(repo), "--launch", "--json"])
+
+    assert result.exit_code == 2
+    report = json.loads(result.stdout)
+    assert report["handoff_ready"] is True
+    assert report["launch"]["requested"] is True
+    assert report["launch"]["attempted"] is False
+    assert "--json" in report["launch"]["blocked_reason"]
+    assert "--launch" in report["errors"][0]
+
+
 def test_start_launch_is_blocked_outside_interactive_terminal(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(start_mod, "_which", _with_claude)
     monkeypatch.setattr(start_mod, "_is_interactive_terminal", lambda: False)
     repo = tmp_path / "acme"
     init_run(path=str(repo), name="Acme")
 
-    result = runner.invoke(app, ["start", "--repo", str(repo), "--launch", "--json"])
+    result = runner.invoke(app, ["start", "--repo", str(repo), "--launch"])
 
     assert result.exit_code == 1
-    report = json.loads(result.stdout)
-    assert report["handoff_ready"] is True
-    assert report["launch"]["requested"] is True
-    assert report["launch"]["attempted"] is False
-    assert "interactive terminal" in report["launch"]["blocked_reason"]
+    assert "Launch skipped" in result.stdout
+    assert "interactive terminal" in result.stdout
 
 
 def test_start_launches_when_explicit_and_interactive(tmp_path: Path, monkeypatch) -> None:
@@ -101,13 +120,12 @@ def test_start_launches_when_explicit_and_interactive(tmp_path: Path, monkeypatc
 
     monkeypatch.setattr(start_mod, "_launch_claude", fake_launch)
 
-    result = runner.invoke(app, ["start", "--repo", str(repo), "--launch", "--json"])
+    result = runner.invoke(app, ["start", "--repo", str(repo), "--launch"])
 
     assert result.exit_code == 0
-    report = json.loads(result.stdout)
     assert launched["path"] == str(repo.resolve())
-    assert report["launch"]["attempted"] is True
-    assert report["launch"]["returncode"] == 0
+    assert "Launch" in result.stdout
+    assert "claude exited 0" in result.stdout
 
 
 def test_start_display_command_is_os_aware(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- Adds `mb start` as the explicit CLI-to-Claude Code runtime handoff.
- Checks business repo shape, git state, Claude Code availability, and `/start` skill wiring before handoff.
- Prints a machine-readable JSON envelope and an exact launch command, with `--launch` guarded by interactive-terminal safety.
- Rejects `--json --launch` with structured JSON so runtime output cannot contaminate scripts.
- Updates the launch screen and compatibility docs so first-run users reach the runtime intentionally.

## Scope
- In: `mb start`, JSON/human output, explicit launch gating, missing-runtime degradation, OS-aware display command, focused CLI tests, and public docs updates.
- Out: model invocation inside `mb`, conversation state ownership, multi-runtime adapter execution before MAIN-177, and untested non-Claude runtime claims.

## Commits
- b7614d6 — [add] MAIN-180 mb start runtime handoff
- 5eff86e — [fix] MAIN-180 clarify start launch handoff
- 7b44e46 — [fix] MAIN-180 reject JSON launch mode

## Release / Issues
- Release: v0.2.0
- Linear ID(s): MAIN-180
- Closes: #186
- Refs: #177, #131
- Follow-ups: manual interactive Claude Code `/start` smoke before v0.2.0 release signoff.

## Success Metric
- From a Main Branch business repo, `mb start` tells the user whether Claude Code and `/start` are ready, prints the exact handoff command, and `mb start --launch` opens Claude Code only when checks and terminal safety allow it.

## Validation
- Level 0 docs/decision: compatibility quickstart and package README updated without private Conductor/customer details.
- Level 1 static: `scripts/check.sh` passed from repo root, including format, Ruff, mypy, and tests.
- Level 2 CLI: full test suite passed with 65 tests, including `mb start` JSON, missing Claude, wrong repo, JSON launch rejection, launch gating, launch path, and OS-aware command display.
- Level 3 package/install: `python3 -m build`; installed wheel into `/tmp/mainbranch-start-smoke`; `mb --version`, `mb init`, `mb start --json`, and `mb start --json --launch` passed, with JSON launch rejected as parseable JSON and `launch.attempted: false`.
- Level 4 fixture repo: fresh `mb init` business repo then `mb start --json` reported handoff ready and `/start` skill wiring OK; `mb start --json --launch` exited 2 with valid JSON.
- Level 5 runtime smoke: `claude --version` returned `2.1.119 (Claude Code)`; interactive Claude Code `/start` UI discovery was not run from this non-interactive agent session, so this remains explicit release-signoff evidence to collect.

## Public / Private Boundary
- No private Devon, Conductor, customer, credential, or live-runtime details were committed; `.context/` evidence stayed local scratch only.
