### PR TITLE
[add] mb onboard adaptive setup flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,13 @@ Main Branch is the `mb` CLI plus MIT-licensed agent workflows for running busine
 
 ```bash
 pipx install mainbranch
-mb init my-business --name "My Business"
+mb onboard --name "My Business" --path my-business
 cd my-business
 claude
 /start
 ```
 
-That's it. `mb init` sets up the six folders, wires Claude Code to the bundled skills, and gives you a fresh git repo. `/start` walks you through the rest — gathers your business context (offer, audience, voice), drafts the reference files, and routes you to the right workflow.
+That's it. `mb onboard` guides the human setup, creates or connects your business repo, wires Claude Code to the bundled skills, and shows the exact next commands. `mb init` still exists as the quiet scriptable primitive underneath it. `/start` walks you through the rest — gathers your business context (offer, audience, voice), drafts the reference files, and routes you to the right workflow.
 
 After the first session, the daily flow is:
 
@@ -127,6 +127,7 @@ The CLI surface for the engine. Built for Claude Code first; runtime-agnostic by
 
 | Command | What it does |
 |---|---|
+| `mb onboard` | Human setup flow: create or connect a business repo, explain the substrate, wire Claude Code skills, and show the next `/start` step. |
 | `mb init` | Set up a fresh business repo (six folders, CLAUDE.md, git init). |
 | `mb status` | Show a local-first daily briefing: repo health, runtime wiring, recent decisions/research/git activity, and GitHub tasks when `gh` is authenticated. |
 | `mb doctor` | Check the environment — repo shape, frontmatter sanity, settings on disk. Walks you through fixes. |

--- a/docs/BEGINNER-SETUP.md
+++ b/docs/BEGINNER-SETUP.md
@@ -73,11 +73,14 @@ Pick a name and a folder. Then:
 
 ```bash
 cd ~/Documents/GitHub          # or wherever you keep code
-mb init my-business --name "My Business"
+mb onboard --name "My Business" --path my-business
 cd my-business
 ```
 
-`mb init` scaffolds the six-folder taxonomy (`core/`, `research/`, `decisions/`, `log/`, `campaigns/`, `documents/`) plus a `CLAUDE.md`, `.gitignore`, and the bridge files Claude Code needs to find Main Branch's skills.
+`mb onboard` walks you through the setup, explains why Main Branch uses local
+files, git, and GitHub, scaffolds the six-folder taxonomy (`core/`,
+`research/`, `decisions/`, `log/`, `campaigns/`, `documents/`), and wires the
+bridge files Claude Code needs to find Main Branch's skills.
 
 ---
 
@@ -140,6 +143,7 @@ Or just run `/pull` inside Claude Code — it figures out which install you have
 
 | Command | What it does |
 |---|---|
+| `mb onboard` | Guided setup for humans. Creates or connects a business repo and shows the next `/start` step. |
 | `mb init` | Scaffold a fresh business repo. |
 | `mb doctor` | Check that everything is set up correctly. Walks you through fixes. |
 | `mb skill link --repo .` | Repair Claude Code skill discovery if `/start` doesn't show up. |

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -39,11 +39,14 @@ For most users:
 
 ```bash
 pipx install mainbranch
-mb init my-business --name "My Business"
+mb onboard --name "My Business" --path my-business
 cd my-business
 claude
 /start
 ```
+
+Use `mb init my-business --name "My Business"` when you need the quiet,
+scriptable scaffold primitive without the human setup flow.
 
 For contributors:
 

--- a/mb/README.md
+++ b/mb/README.md
@@ -22,6 +22,7 @@ mb --version
 
 | Command | What it does |
 |---|---|
+| `mb onboard` | Human setup flow. Creates or connects a business repo, explains the local files/git/GitHub substrate, wires Claude Code skills, verifies discovery, and prints the next `/start` step. Supports `--yes` and `--json` for smoke tests. |
 | `mb init` | Scaffold a new business repo (six folders, CLAUDE.md, CODEOWNERS, `git init`) and wire the bundled Claude Code skill adapter. One question only: business name. |
 | `mb doctor` | Diagnostic. Checks Claude Code, gh auth, network, librsvg, runtime wiring, and package freshness. Warns on cloud-backed finance paths and offers educational triage. |
 | `mb status` | Daily briefing. Summarizes repo shape, install/runtime readiness, recent brain files, recent git activity, and GitHub tasks when `gh` is authenticated. Supports `--json`. |

--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -155,7 +155,7 @@ def _render_onboard_human(result: dict[str, Any]) -> None:
     mark = "[green]ready[/green]" if result["ok"] else "[red]needs repair[/red]"
     console.print(f"\n[bold]mb onboard[/bold]  {mark}")
     console.print(f"repo: {result['path']}")
-    console.print(f"path: {result['level']} / {result['action']}\n")
+    console.print(f"level / action: {result['level']} / {result['action']}\n")
 
     if result["level"] != "power":
         console.print("[bold]Why this stack[/bold]")
@@ -234,8 +234,10 @@ def onboard_cmd(
             "Comfort level (beginner/intermediate/power)",
             default="beginner" if level == "auto" else level,
         )
+        if selected_level != "power":
+            _render_onboard_intro(selected_level)
         selected_mode = typer.prompt(
-            "Create a new repo or connect an existing one? (new/connect)",
+            "Create a new repo, connect an existing one, or auto-detect? (new/connect/auto)",
             default="auto" if mode == "auto" else mode,
         )
         if not business_name and selected_mode != "connect":
@@ -244,8 +246,6 @@ def onboard_cmd(
         if target == "." and business_name:
             default_path = onboard_mod._slug(business_name)
         target = typer.prompt("Repo path", default=default_path)
-        if typer.confirm("Show the short why behind the setup?", default=selected_level != "power"):
-            _render_onboard_intro(selected_level)
 
     try:
         result = onboard_mod.run(

--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import sys
+from typing import Any
 
 import typer
 
@@ -17,6 +18,7 @@ from mb import doctor as doctor_mod
 from mb import educational as educational_mod
 from mb import graph as graph_mod
 from mb import init as init_mod
+from mb import onboard as onboard_mod
 from mb import resolve as resolve_mod
 from mb import status as status_mod
 from mb import think as think_mod
@@ -61,7 +63,7 @@ def _render_launch_screen() -> None:
                 "Stay connected to the business while agents handle execution.",
                 "",
                 "Choose a trail:",
-                "  New here      mb onboard       guided setup (coming in v0.2)",
+                "  New here      mb onboard       guided setup",
                 "  Daily work    mb status        business/repo briefing",
                 "                mb start         open the agent runtime (coming in v0.2)",
                 "  Broken setup  mb doctor        check git, GitHub, Claude Code, and skills",
@@ -125,6 +127,141 @@ def init_cmd(
         else:
             typer.echo(f"could not set up: {result.get('error')}", err=True)
             raise typer.Exit(1)
+
+
+def _onboard_target_path(path_arg: str, path_opt: str, name: str) -> str:
+    explicit = path_opt.strip() or path_arg.strip()
+    if explicit:
+        return explicit
+    return onboard_mod._slug(name) if name.strip() else "."
+
+
+def _render_onboard_intro(level: str) -> None:
+    if level == "power":
+        typer.echo("Main Branch keeps the business in local files, git history, and GitHub work.")
+        return
+    typer.echo("")
+    typer.echo("Main Branch works because the business lives somewhere durable:")
+    typer.echo("  local files  - readable, portable business memory")
+    typer.echo("  git          - the evolution story and rollback layer")
+    typer.echo("  GitHub       - tasks, proposals, reviews, and shipped history")
+    typer.echo("  Claude Code  - the first execution runtime for judgment-heavy work")
+
+
+def _render_onboard_human(result: dict[str, Any]) -> None:
+    from rich.console import Console
+
+    console = Console()
+    mark = "[green]ready[/green]" if result["ok"] else "[red]needs repair[/red]"
+    console.print(f"\n[bold]mb onboard[/bold]  {mark}")
+    console.print(f"repo: {result['path']}")
+    console.print(f"path: {result['level']} / {result['action']}\n")
+
+    if result["level"] != "power":
+        console.print("[bold]Why this stack[/bold]")
+        console.print("  Local files are the business brain.")
+        console.print("  Git remembers how the business changed.")
+        console.print("  GitHub turns tasks and proposals into a team surface.")
+        console.print("  Claude Code is the first runtime that can act on the repo.\n")
+
+    tools = result["tools"]
+    skill_wiring = result["skill_wiring"]
+    git = tools["git"]
+    github = tools["github_cli"]
+    claude = tools["claude_code"]
+    console.print("[bold]Checks[/bold]")
+    console.print(f"  {'ok' if git['found'] else 'warn'}  git")
+    github_state = "ok" if github["found"] and github["authenticated"] else "warn"
+    console.print(f"  {github_state}  GitHub CLI")
+    console.print(f"  {'ok' if claude['found'] else 'warn'}  Claude Code")
+    console.print(f"  {'ok' if skill_wiring['ok'] else 'fail'}  Claude Code skill discovery")
+
+    warnings = result["warnings"]
+    errors = result["errors"]
+    if warnings:
+        console.print("\n[yellow]Repair notes[/yellow]")
+        for warning in warnings:
+            console.print(f"  - {warning}")
+    if errors:
+        console.print("\n[red]Could not finish setup[/red]")
+        for error in errors:
+            console.print(f"  - {error}")
+        console.print(f"\nRun `{result['doctor_command']}` for repair steps.")
+        return
+
+    console.print("\n[bold]Next[/bold]")
+    for step in result["next_steps"]:
+        console.print(f"  {step}")
+    if warnings:
+        console.print(f"\nFor a full setup check, run `{result['doctor_command']}`.")
+    console.print()
+
+
+@app.command("onboard")
+def onboard_cmd(
+    path_arg: str = typer.Argument("", help="Repo path to create or connect."),
+    path_opt: str = typer.Option("", "--path", help="Repo path to create or connect."),
+    name: str = typer.Option("", "--name", help="Business name."),
+    mode: str = typer.Option(
+        "auto",
+        "--mode",
+        help="Setup mode: auto, new, or connect.",
+    ),
+    level: str = typer.Option(
+        "auto",
+        "--level",
+        help="Experience level: auto, beginner, intermediate, or power.",
+    ),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Use defaults and never prompt."),
+    json_out: bool = typer.Option(False, "--json", help="Machine-readable output."),
+) -> None:
+    """Guide a human through first setup or reconnect an existing repo."""
+    interactive = onboard_mod.is_interactive()
+    if not yes and not interactive:
+        typer.echo(
+            "mb onboard needs a terminal prompt. Use `mb onboard --yes` for scripts.", err=True
+        )
+        raise typer.Exit(2)
+
+    selected_level = level
+    selected_mode = mode
+    target = _onboard_target_path(path_arg, path_opt, name)
+    business_name = name
+
+    if not yes:
+        typer.echo("Main Branch setup")
+        selected_level = typer.prompt(
+            "Comfort level (beginner/intermediate/power)",
+            default="beginner" if level == "auto" else level,
+        )
+        selected_mode = typer.prompt(
+            "Create a new repo or connect an existing one? (new/connect)",
+            default="auto" if mode == "auto" else mode,
+        )
+        if not business_name and selected_mode != "connect":
+            business_name = typer.prompt("Business name")
+        default_path = target
+        if target == "." and business_name:
+            default_path = onboard_mod._slug(business_name)
+        target = typer.prompt("Repo path", default=default_path)
+        if typer.confirm("Show the short why behind the setup?", default=selected_level != "power"):
+            _render_onboard_intro(selected_level)
+
+    try:
+        result = onboard_mod.run(
+            path=target,
+            name=business_name,
+            mode=selected_mode,
+            level=selected_level,
+        )
+    except ValueError as exc:
+        typer.echo(f"mb onboard: {exc}", err=True)
+        raise typer.Exit(2) from exc
+    if json_out:
+        typer.echo(json.dumps(result, indent=2))
+    else:
+        _render_onboard_human(result)
+    raise typer.Exit(0 if result["ok"] else 1)
 
 
 @app.command("doctor")

--- a/mb/mb/onboard.py
+++ b/mb/mb/onboard.py
@@ -161,6 +161,7 @@ def run(
     warnings: list[str] = []
     created: list[str] = []
     action = normalized_mode
+    result_business_name = name.strip() if normalized_mode == "connect" else ""
     init_result: dict[str, Any] | None = None
     link_result: dict[str, Any] | None = None
 
@@ -174,6 +175,7 @@ def run(
         action = "repaired" if before["claude_md"] else "connected"
     else:
         business_name = name.strip() or target.name.replace("-", " ").title()
+        result_business_name = business_name
         init_result = init_mod.run(path=str(target), name=business_name)
         created.extend(str(item) for item in init_result.get("created", []))
         if init_result["status"] == "error":
@@ -212,7 +214,7 @@ def run(
         "path": str(target),
         "mode": normalized_mode,
         "level": selected_level,
-        "business_name": name.strip() or target.name.replace("-", " ").title(),
+        "business_name": result_business_name,
         "created": created,
         "repo": {
             "before": before,

--- a/mb/mb/onboard.py
+++ b/mb/mb/onboard.py
@@ -1,0 +1,234 @@
+"""``mb onboard`` — adaptive human setup flow for Main Branch."""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+from mb import init as init_mod
+from mb.engine import link_skills, link_status
+
+LEVELS = {"beginner", "intermediate", "power"}
+MODES = {"new", "connect", "auto"}
+
+
+def _which(name: str) -> str:
+    return shutil.which(name) or ""
+
+
+def _run_command(args: list[str], cwd: Path | None = None, timeout: float = 5.0) -> dict[str, Any]:
+    try:
+        result = subprocess.run(
+            args,
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except FileNotFoundError:
+        return {"ok": False, "stdout": "", "stderr": f"{args[0]} not found", "returncode": 127}
+    except subprocess.TimeoutExpired:
+        return {"ok": False, "stdout": "", "stderr": "command timed out", "returncode": 124}
+    except subprocess.SubprocessError as exc:
+        return {"ok": False, "stdout": "", "stderr": str(exc), "returncode": 1}
+    return {
+        "ok": result.returncode == 0,
+        "stdout": result.stdout,
+        "stderr": result.stderr,
+        "returncode": result.returncode,
+    }
+
+
+def _slug(value: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+    return slug or "my-business"
+
+
+def _repo_markers(repo: Path) -> dict[str, bool]:
+    return {
+        "exists": repo.exists(),
+        "git": (repo / ".git").exists(),
+        "claude_md": (repo / "CLAUDE.md").is_file(),
+        "core": (repo / "core").is_dir() or (repo / "reference" / "core").exists(),
+        "research": (repo / "research").is_dir(),
+        "decisions": (repo / "decisions").is_dir(),
+        "skill_start": (repo / ".claude" / "skills" / "start" / "SKILL.md").is_file(),
+    }
+
+
+def _looks_initialized(markers: dict[str, bool]) -> bool:
+    shaped_dirs = sum(1 for key in ("core", "research", "decisions") if markers[key])
+    return markers["claude_md"] and shaped_dirs >= 2
+
+
+def _tool_readiness(repo: Path) -> dict[str, Any]:
+    git_path = _which("git")
+    gh_path = _which("gh")
+    claude_path = _which("claude")
+    gh_auth = False
+    git_repo = False
+
+    if git_path:
+        git_probe = _run_command(["git", "rev-parse", "--is-inside-work-tree"], cwd=repo)
+        git_repo = git_probe["ok"] and git_probe["stdout"].strip() == "true"
+    if gh_path:
+        gh_probe = _run_command(["gh", "auth", "status"], cwd=repo)
+        gh_auth = gh_probe["ok"]
+
+    return {
+        "git": {
+            "found": bool(git_path),
+            "path": git_path,
+            "repo": git_repo,
+            "repair": "" if git_path else "Install git, then run `mb doctor`.",
+        },
+        "github_cli": {
+            "found": bool(gh_path),
+            "authenticated": gh_auth,
+            "path": gh_path,
+            "repair": ""
+            if gh_path and gh_auth
+            else (
+                "Install GitHub CLI: https://cli.github.com/ and run `gh auth login`."
+                if not gh_path
+                else "Run `gh auth login` to connect GitHub tasks and proposals."
+            ),
+        },
+        "claude_code": {
+            "found": bool(claude_path),
+            "path": claude_path,
+            "repair": "" if claude_path else "Install Claude Code: https://claude.ai/install",
+        },
+    }
+
+
+def _infer_level(tool_readiness: dict[str, Any]) -> str:
+    git = bool(tool_readiness["git"]["found"])
+    gh = bool(
+        tool_readiness["github_cli"]["found"] and tool_readiness["github_cli"]["authenticated"]
+    )
+    claude = bool(tool_readiness["claude_code"]["found"])
+    if git and gh and claude:
+        return "power"
+    if git and (gh or claude):
+        return "intermediate"
+    return "beginner"
+
+
+def _normalize_level(level: str) -> str:
+    normalized = level.strip().lower().replace("_", "-")
+    if normalized == "power-user":
+        normalized = "power"
+    if normalized and normalized not in LEVELS and normalized != "auto":
+        raise ValueError("level must be beginner, intermediate, power, or auto")
+    return normalized or "auto"
+
+
+def _normalize_mode(mode: str, existing: bool) -> str:
+    normalized = mode.strip().lower()
+    if normalized not in MODES:
+        raise ValueError("mode must be new, connect, or auto")
+    if normalized == "auto":
+        return "connect" if existing else "new"
+    return normalized
+
+
+def _next_steps(repo: Path) -> list[str]:
+    return [
+        f"cd {repo}",
+        "claude",
+        "/start",
+    ]
+
+
+def run(
+    *,
+    path: str,
+    name: str = "",
+    mode: str = "auto",
+    level: str = "auto",
+) -> dict[str, Any]:
+    """Create or connect a business repo and verify the Claude Code handoff."""
+    target = Path(path).expanduser().resolve()
+    before = _repo_markers(target)
+    normalized_mode = _normalize_mode(mode, _looks_initialized(before))
+
+    errors: list[str] = []
+    warnings: list[str] = []
+    created: list[str] = []
+    action = normalized_mode
+    init_result: dict[str, Any] | None = None
+    link_result: dict[str, Any] | None = None
+
+    if normalized_mode == "connect" and not target.exists():
+        errors.append(f"cannot connect missing repo: {target}")
+    elif normalized_mode == "connect":
+        link_result = link_skills(target)
+        created.extend(str(item) for item in link_result.get("created", []))
+        if not link_result.get("ok"):
+            errors.extend(str(item) for item in link_result.get("errors", []))
+        action = "repaired" if before["claude_md"] else "connected"
+    else:
+        business_name = name.strip() or target.name.replace("-", " ").title()
+        init_result = init_mod.run(path=str(target), name=business_name)
+        created.extend(str(item) for item in init_result.get("created", []))
+        if init_result["status"] == "error":
+            errors.append(str(init_result.get("error") or "mb init failed"))
+        elif init_result["status"] == "already-initialized":
+            action = "repaired"
+        else:
+            action = "created"
+
+    after = _repo_markers(target)
+    wiring = link_status(target)
+    tools = _tool_readiness(target)
+    selected_level = _normalize_level(level)
+    if selected_level == "auto":
+        selected_level = _infer_level(tools)
+
+    if not after["git"]:
+        warnings.append("Repo is not a git work tree. Run `git init` or `mb doctor` for repair.")
+    if normalized_mode == "connect" and not _looks_initialized(after):
+        errors.append(
+            "Existing repo does not look like a Main Branch repo. "
+            "Run `mb onboard --mode new --path <repo> --name <business>` to scaffold it."
+        )
+    if not tools["github_cli"]["found"] or not tools["github_cli"]["authenticated"]:
+        warnings.append(str(tools["github_cli"]["repair"]))
+    if not tools["claude_code"]["found"]:
+        warnings.append(str(tools["claude_code"]["repair"]))
+    if not wiring["ok"]:
+        warnings.append("Claude Code skill discovery is not wired. Run `mb doctor` for details.")
+
+    ok = not errors and wiring["ok"] and after["claude_md"]
+    return {
+        "ok": ok,
+        "status": "ok" if ok else "error",
+        "action": action,
+        "path": str(target),
+        "mode": normalized_mode,
+        "level": selected_level,
+        "business_name": name.strip() or target.name.replace("-", " ").title(),
+        "created": created,
+        "repo": {
+            "before": before,
+            "after": after,
+            "looks_initialized": _looks_initialized(after),
+        },
+        "tools": tools,
+        "skill_wiring": wiring,
+        "warnings": [warning for warning in warnings if warning],
+        "errors": errors,
+        "doctor_command": f"mb doctor {target}",
+        "next_steps": _next_steps(target),
+        "init": init_result,
+        "link": link_result,
+    }
+
+
+def is_interactive() -> bool:
+    return sys.stdin.isatty() and sys.stdout.isatty()

--- a/mb/mb/onboard.py
+++ b/mb/mb/onboard.py
@@ -167,6 +167,11 @@ def run(
 
     if normalized_mode == "connect" and not target.exists():
         errors.append(f"cannot connect missing repo: {target}")
+    elif normalized_mode == "connect" and not _looks_initialized(before):
+        errors.append(
+            "Existing repo does not look like a Main Branch repo. "
+            "Run `mb onboard --mode new --path <repo> --name <business>` to scaffold it."
+        )
     elif normalized_mode == "connect":
         link_result = link_skills(target)
         created.extend(str(item) for item in link_result.get("created", []))
@@ -194,11 +199,6 @@ def run(
 
     if not after["git"]:
         warnings.append("Repo is not a git work tree. Run `git init` or `mb doctor` for repair.")
-    if normalized_mode == "connect" and not _looks_initialized(after):
-        errors.append(
-            "Existing repo does not look like a Main Branch repo. "
-            "Run `mb onboard --mode new --path <repo> --name <business>` to scaffold it."
-        )
     if not tools["github_cli"]["found"] or not tools["github_cli"]["authenticated"]:
         warnings.append(str(tools["github_cli"]["repair"]))
     if not tools["claude_code"]["found"]:

--- a/mb/tests/test_onboard.py
+++ b/mb/tests/test_onboard.py
@@ -95,6 +95,9 @@ def test_onboard_connect_uninitialized_repo_explains_repair(tmp_path: Path, monk
     assert result["ok"] is False
     assert any("does not look like a Main Branch repo" in error for error in result["errors"])
     assert result["doctor_command"].startswith("mb doctor ")
+    assert result["created"] == []
+    assert not (repo / ".claude").exists()
+    assert not (repo / ".gitignore").exists()
 
 
 def test_onboard_cli_noninteractive_requires_yes(monkeypatch) -> None:

--- a/mb/tests/test_onboard.py
+++ b/mb/tests/test_onboard.py
@@ -1,0 +1,130 @@
+"""``mb onboard`` adaptive setup flow."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from mb import onboard as onboard_mod
+from mb.cli import app
+
+runner = CliRunner()
+
+
+def _tool_path(name: str) -> str:
+    if name == "git":
+        return shutil.which("git") or ""
+    return ""
+
+
+def test_onboard_yes_creates_repo_and_reports_next_steps(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(onboard_mod, "_which", _tool_path)
+    repo = tmp_path / "acme"
+
+    result = onboard_mod.run(
+        path=str(repo),
+        name="Acme Brewing",
+        mode="new",
+        level="beginner",
+    )
+
+    assert result["ok"] is True
+    assert result["action"] == "created"
+    assert result["level"] == "beginner"
+    assert (repo / "CLAUDE.md").exists()
+    assert (repo / ".claude" / "skills" / "start" / "SKILL.md").exists()
+    assert result["skill_wiring"]["ok"] is True
+    assert result["next_steps"] == [f"cd {repo.resolve()}", "claude", "/start"]
+    assert any("Claude Code" in warning for warning in result["warnings"])
+    assert any(
+        "gh auth login" in warning or "GitHub CLI" in warning for warning in result["warnings"]
+    )
+
+
+def test_onboard_rerun_is_idempotent(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(onboard_mod, "_which", _tool_path)
+    repo = tmp_path / "acme"
+
+    first = onboard_mod.run(path=str(repo), name="Acme", mode="new", level="auto")
+    second = onboard_mod.run(path=str(repo), name="Acme", mode="auto", level="auto")
+
+    assert first["action"] == "created"
+    assert second["action"] == "repaired"
+    assert second["ok"] is True
+    assert second["repo"]["before"]["claude_md"] is True
+    assert (repo / "CLAUDE.md").exists()
+
+
+def test_onboard_connect_repairs_existing_initialized_repo(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(onboard_mod, "_which", _tool_path)
+    repo = tmp_path / "acme"
+    onboard_mod.run(path=str(repo), name="Acme", mode="new", level="power")
+    settings = repo / ".claude" / "settings.local.json"
+    settings.unlink()
+
+    result = onboard_mod.run(path=str(repo), name="", mode="connect", level="power")
+
+    assert result["ok"] is True
+    assert result["action"] == "repaired"
+    assert settings.exists()
+    assert result["skill_wiring"]["ok"] is True
+
+
+def test_onboard_connect_missing_repo_routes_to_doctor(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(onboard_mod, "_which", _tool_path)
+    repo = tmp_path / "missing"
+
+    result = onboard_mod.run(path=str(repo), name="", mode="connect", level="power")
+
+    assert result["ok"] is False
+    assert "cannot connect missing repo" in result["errors"][0]
+    assert result["doctor_command"].startswith("mb doctor ")
+
+
+def test_onboard_connect_uninitialized_repo_explains_repair(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(onboard_mod, "_which", _tool_path)
+    repo = tmp_path / "plain"
+    repo.mkdir()
+
+    result = onboard_mod.run(path=str(repo), name="", mode="connect", level="power")
+
+    assert result["ok"] is False
+    assert any("does not look like a Main Branch repo" in error for error in result["errors"])
+    assert result["doctor_command"].startswith("mb doctor ")
+
+
+def test_onboard_cli_noninteractive_requires_yes(monkeypatch) -> None:
+    monkeypatch.setattr(onboard_mod, "is_interactive", lambda: False)
+
+    result = runner.invoke(app, ["onboard"])
+
+    assert result.exit_code == 2
+    assert "Use `mb onboard --yes`" in result.stderr
+
+
+def test_onboard_cli_yes_json_smoke(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(onboard_mod, "_which", _tool_path)
+    monkeypatch.setattr(onboard_mod, "is_interactive", lambda: False)
+    repo = tmp_path / "acme"
+
+    result = runner.invoke(
+        app,
+        [
+            "onboard",
+            "--yes",
+            "--name",
+            "Acme Brewing",
+            "--path",
+            str(repo),
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["path"] == str(repo.resolve())
+    assert payload["next_steps"][-1] == "/start"

--- a/mb/tests/test_onboard.py
+++ b/mb/tests/test_onboard.py
@@ -69,6 +69,7 @@ def test_onboard_connect_repairs_existing_initialized_repo(tmp_path: Path, monke
 
     assert result["ok"] is True
     assert result["action"] == "repaired"
+    assert result["business_name"] == ""
     assert settings.exists()
     assert result["skill_wiring"]["ok"] is True
 
@@ -128,3 +129,24 @@ def test_onboard_cli_yes_json_smoke(tmp_path: Path, monkeypatch) -> None:
     assert payload["ok"] is True
     assert payload["path"] == str(repo.resolve())
     assert payload["next_steps"][-1] == "/start"
+
+
+def test_onboard_cli_interactive_path_renders_clear_labels(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(onboard_mod, "_which", _tool_path)
+    monkeypatch.setattr(onboard_mod, "is_interactive", lambda: True)
+    repo = tmp_path / "interactive"
+
+    result = runner.invoke(
+        app,
+        ["onboard"],
+        input=f"beginner\nnew\nInteractive Business\n{repo}\n",
+    )
+
+    assert result.exit_code == 0
+    assert "Main Branch works because the business lives somewhere durable" in result.stdout
+    assert "new/connect/auto" in result.stdout
+    assert "repo:" in result.stdout
+    assert "interactive" in result.stdout
+    assert "level / action: beginner / created" in result.stdout
+    assert "path: beginner / created" not in result.stdout
+    assert "Show the short why" not in result.stdout


### PR DESCRIPTION
## Summary
- Adds `mb onboard` as the human first-run setup path for creating or connecting a business repo.
- Preserves `mb init` as the quiet scriptable primitive underneath onboarding.
- Verifies repo shape, Git/GitHub/Claude Code readiness, and Claude Code skill discovery, then prints the exact `cd`, `claude`, `/start` handoff.
- Updates public setup docs so humans start with `mb onboard` while power users can still use `mb init` directly.

## Scope
- In: `mb onboard` create/connect flow, `--yes` smoke path, `--json`, idempotent reruns, repair routing to `mb doctor`, focused CLI tests, and setup docs.
- Out: bare `mb` launch screen beyond removing the “coming” label, full `mb status` or `mb start`, GitHub API repo creation, credentials, dashboard/server mode, and new runtime adapter claims.

## Commits
- `2438f1a` — `[add] MAIN-179 onboard setup flow`.
- `09eaa0b` — `[fix] MAIN-179 polish onboard prompts`.

## Release / Issues
- Release: v0.2.0.
- Linear ID(s): MAIN-179.
- Closes: #185.
- Refs: `decisions/2026-05-02-github-native-business-os.md`, `docs/prd/v0-2-first-run-daily-briefing.md`.
- Follow-ups: run full interactive Claude Code `/start` smoke before tagging v0.2.0.

## Success Metric
A first-time user can run `mb onboard`, create or connect a business repo without overwriting existing state, see repair guidance through `mb doctor`, and finish with exact commands to enter Claude Code and invoke `/start`.

## Validation
- Level 0 docs/decision: README, beginner setup, compatibility, and package README now route human setup through `mb onboard` while documenting `mb init` as scriptable.
- Level 1 static: `scripts/check.sh` passed from repo root, including ruff format/check and mypy.
- Level 2 CLI: `scripts/check.sh` passed 66 pytest tests with coverage 79.23%, including non-interactive and interactive onboard paths.
- Level 3 package/install: not run; packaging files were not changed.
- Level 4 fixture repo: `PYTHONPATH=mb python3 -m mb onboard --yes --name "Smoke Business" --path <tmp>/smoke-business --json` returned `ok: true`, `action: created`; `mb doctor <tmp>/smoke-business --json` returned `ok: true`, including `claude-code` and `skill-wiring` checks.
- Level 5 runtime smoke: not completed; `claude --help` worked, but `claude doctor` hung with no output and was killed, so this PR verifies discovery via generated repo wiring and `mb doctor`, not an interactive Claude `/start` session.

## Public / Private Boundary
- Public docs stay generic to Main Branch and do not add Devon/Conductor/private customer details.
