### PR TITLE
[update] Add first-run wheel smokes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,6 +250,74 @@ jobs:
           assert (root / ".claude/reference/vip-path-resolution.md").is_file(), root
           PY
 
+      - name: Smoke — mb onboard creates a business repo
+        run: |
+          repo="$(mktemp -d)/acme-brewing"
+          .venv-smoke/bin/mb onboard --yes --name "Acme Brewing" --path "$repo" --json > onboard.json
+          cat onboard.json
+          test -f "$repo/CLAUDE.md" \
+            || { echo "::error::CLAUDE.md missing after onboard"; exit 1; }
+          test -f "$repo/.claude/skills/start/SKILL.md" \
+            || { echo "::error::start skill bridge missing after onboard"; exit 1; }
+          .venv-smoke/bin/python - "$repo" <<'PY'
+          import json, pathlib, sys
+
+          repo = pathlib.Path(sys.argv[1])
+          report = json.load(open("onboard.json"))
+          assert report["ok"] is True
+          assert report["repo"]["looks_initialized"] is True
+          assert report["skill_wiring"]["ok"] is True
+          assert report["path"] == str(repo.resolve())
+          PY
+
+      - name: Smoke — mb start emits handoff JSON
+        run: |
+          repo="$(mktemp -d)/acme-brewing"
+          .venv-smoke/bin/mb onboard --yes --name "Acme Brewing" --path "$repo" --json >/dev/null
+          set +e
+          .venv-smoke/bin/mb start --repo "$repo" --json > start.json
+          rc=$?
+          set -e
+          cat start.json
+          if [ "$rc" -gt 1 ]; then
+            echo "::error::mb start --json crashed (exit $rc)"
+            exit 1
+          fi
+          .venv-smoke/bin/python - "$repo" <<'PY'
+          import json, pathlib, sys
+
+          repo = pathlib.Path(sys.argv[1])
+          report = json.load(open("start.json"))
+          assert report["repo"]["looks_like_mainbranch_repo"] is True
+          assert report["runtime"]["skill_wiring"]["ok"] is True
+          assert report["command"]["cwd"] == str(repo.resolve())
+          assert report["command"]["follow_up"] == "/start"
+          assert report["launch"]["attempted"] is False
+          PY
+
+      - name: Smoke — mb start rejects JSON launch mode
+        run: |
+          repo="$(mktemp -d)/acme-brewing"
+          .venv-smoke/bin/mb onboard --yes --name "Acme Brewing" --path "$repo" --json >/dev/null
+          set +e
+          .venv-smoke/bin/mb start --repo "$repo" --json --launch > start-launch.json
+          rc=$?
+          set -e
+          cat start-launch.json
+          if [ "$rc" -ne 2 ]; then
+            echo "::error::mb start --json --launch should exit 2, got $rc"
+            exit 1
+          fi
+          .venv-smoke/bin/python - <<'PY'
+          import json
+
+          report = json.load(open("start-launch.json"))
+          assert report["ok"] is False
+          assert report["launch"]["requested"] is True
+          assert report["launch"]["attempted"] is False
+          assert "--json" in report["launch"]["blocked_reason"]
+          PY
+
       - name: Smoke — mb status on initialized repo emits JSON
         run: |
           repo=$(mktemp -d)

--- a/docs/prd/v0-2-first-run-daily-briefing.md
+++ b/docs/prd/v0-2-first-run-daily-briefing.md
@@ -427,13 +427,13 @@ Success criteria:
 
 | Issue | Priority | Status | Release |
 |---|---|---|---|
-| #112 Accept GitHub-native business OS direction | Urgent | In Progress | v0.2 Direction |
-| #183 PR: GitHub-native business OS decision | Urgent | In Progress | v0.2 Direction |
-| #184 TTY-aware bare `mb` launch screen | Urgent | To Do | v0.2.0 |
-| #185 `mb onboard` adaptive setup flow | Urgent | To Do | v0.2.0 |
-| #173 `mb status` daily briefing v0 | Urgent | To Do | v0.2.0 |
-| #186 `mb start` runtime handoff helper | High | To Do | v0.2.0 |
-| #174 `mb update` install-mode-aware refresh | High | To Do | v0.2.0 |
+| #112 Accept GitHub-native business OS direction | Urgent | Closed | v0.2 Direction |
+| #183 PR: GitHub-native business OS decision | Urgent | Merged | v0.2 Direction |
+| #184 TTY-aware bare `mb` launch screen | Urgent | Closed | v0.2.0 |
+| #185 `mb onboard` adaptive setup flow | Urgent | Closed | v0.2.0 |
+| #173 `mb status` daily briefing v0 | Urgent | Closed | v0.2.0 |
+| #186 `mb start` runtime handoff helper | High | Closed | v0.2.0 |
+| #174 `mb update` install-mode-aware refresh | High | Closed | v0.2.0 |
 | #80 `/ads` compliance gate | Urgent | To Do | v0.1.3 |
 | #188 GitHub activity briefing primitives | High | To Do | v0.2.1 |
 | #187 `mb connect` foundation | High | To Do | v0.2.1 |
@@ -445,8 +445,7 @@ Everything not listed above stays backlog unless explicitly pulled forward.
 
 - Should bare `mb` route to `mb status` by default after onboarding has run?
 - Should `mb onboard` create GitHub repos through `gh` or only local repos in
-  v0.2.0?
-- Should `mb start --launch` exist in v0.2.0 or should it only print commands?
+  v0.2.1+?
 - What is the minimum useful GitHub read for `mb status` without slowing it down?
 - Where should recent repo selection live: local config now or wait for v0.2.1?
 


### PR DESCRIPTION
## Summary
- adds release-path wheel smokes for the newly merged `mb onboard` and `mb start` first-run surfaces
- proves wheel-installed onboarding creates a business repo with Claude Code skill wiring intact
- proves `mb start --json` emits a structured handoff report and `mb start --json --launch` rejects launch safely
- updates the v0.2 first-run PRD issue map so merged/closed slices no longer read as To Do

## Scope
- In: `.github/workflows/ci.yml` wheel-install-smoke coverage for `mb onboard` / `mb start`; `docs/prd/v0-2-first-run-daily-briefing.md` status cleanup
- Out: CLI behavior changes, release automation, Linear release configuration, issue retagging

## Commits
- `e2d2cab` — `[update] Add first-run wheel smokes`

## Release / Issues
- Release: Main Branch 0.2.0 first-run durability follow-up
- Linear ID(s): none directly assigned to this follow-up branch
- Closes: none
- Refs: #173, #174, #184, #185, #186
- Follow-ups: keep full runtime `/start` smoke as Level 5 validation for future runtime-handoff changes

## Success Metric
- The CI wheel-install-smoke job fails if a built wheel cannot run the first-run loop through `mb onboard` and `mb start` with valid JSON contracts and intact skill wiring.

## Validation
- Level 0 docs/decision: v0.2 PRD Linear/GitHub mapping updated to reflect merged/closed first-run slices
- Level 1 static: `git diff --check`; parsed `.github/workflows/ci.yml` with PyYAML; `scripts/check.sh`
- Level 2 CLI: `scripts/check.sh` passed (`73 passed`, coverage `79.86%`)
- Level 3 package/install: added CI wheel-install smokes for `mb onboard`, `mb start --json`, and `mb start --json --launch`; full wheel job will run on this PR
- Level 4 fixture repo: covered by the new CI smoke steps creating temp business repos from the installed wheel
- Level 5 runtime smoke: not run; this PR only hardens deterministic CI coverage after the runtime-handoff commands merged

## Public / Private Boundary
- Public repo changes stay generic: CI coverage and public PRD state only.
- Private Conductor validation preferences were updated separately in `devon-homelab` and are not included in this public PR.
