### PR TITLE
[docs] Reduce stale release references

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-# Engine repo CODEOWNERS — v0.1 single-owner default.
+# Engine repo CODEOWNERS — single-owner default.
 # Multi-owner pattern: add per-path rules ABOVE this line, more specific first.
 # Example:
 #   /tools/tool-domain/   @dmthepm @co-owner-handle

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -15,7 +15,7 @@ body:
     attributes:
       label: "`mb --version` output"
       description: Paste the exact version string. If `mb` is not on PATH, say so.
-      placeholder: "mb 0.1.1"
+      placeholder: "mb X.Y.Z"
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -6,8 +6,8 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for the idea. Frame the problem before the solution — the surface
-        area for v0.1.x is intentionally narrow, and well-scoped problems are
+        Thanks for the idea. Frame the problem before the solution — the public
+        surface is intentionally narrow, and well-scoped problems are
         easier to evaluate than abstract requests.
 
   - type: textarea

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -30,20 +30,13 @@ Closes #
 
 ## Test plan
 
-Pre-push gates from `mb/`:
+Pre-push gate from repo root:
 
 ```bash
-cd mb
-ruff format --check .
-ruff check .
-mypy mb
-pytest -q --cov=mb --cov-fail-under=70
+scripts/check.sh
 ```
 
-- [ ] `ruff format --check` passes
-- [ ] `ruff check` passes
-- [ ] `mypy mb` passes
-- [ ] `pytest -q --cov=mb --cov-fail-under=70` passes
+- [ ] `scripts/check.sh` passes
 - [ ] Wheel install smoke (if packaging touched)
 - [ ] SKILL.md ≤500 lines (if any skill touched)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -226,7 +226,7 @@ sections below cover what shipped in PRs #114 / #115 / #116 / #117 /
   archetype + audience-current-archetype selection (Hughes 9-archetype
   framework). Paired-imagery rule replaces "what does this section say"
   with "what two things does this section put next to each other."
-  Stubs land for 5 of the 9 archetypes (filled out in the next release).
+  Stubs land for 5 of the 9 archetypes (to be filled out in a future release).
 - **Seven Sweeps review pass** (`.claude/skills/site/references/review.md`).
   Anti-pattern catalogue for AI-generated marketing copy with the
   "AI tells" reference (`ai-tells.md`).

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ claude
 
 You'll need a Claude Pro ($20/mo) or Max subscription. Install Claude Code itself from [claude.ai](https://claude.ai) — see [docs/BEGINNER-SETUP.md](docs/BEGINNER-SETUP.md) for a step-by-step.
 
-Tested on macOS and Linux. Windows is experimental in v0.1; see [docs/compatibility.md](docs/compatibility.md) and track [#137](https://github.com/noontide-co/mainbranch/issues/137).
+Tested on macOS and Linux. Windows is experimental; see [docs/compatibility.md](docs/compatibility.md) and track [#137](https://github.com/noontide-co/mainbranch/issues/137).
 
 **New to Claude Code, git, or terminal?** Read [docs/BEGINNER-SETUP.md](docs/BEGINNER-SETUP.md) — it covers everything step-by-step, including common errors.
 
@@ -160,15 +160,16 @@ Skills are pre-built workflows you invoke with slash prompts. Instead of figurin
 | `/wiki` | Personal wiki with atomic notes |
 | `/end` | Close session — summary, crystallize, commit |
 | `/help` | Get answers, troubleshoot, learn the system |
-| `/pull` | Quick update — pulls latest skills from GitHub |
+| `/pull` | Quick update — delegates install-mode refresh to `mb update` and summarizes what's new |
 
 ---
 
-## Honest current state (v0.1)
+## Honest Current State
 
-- **Built for Claude Code today.** Portable runtime support is a v0.2+ commitment.
-- **Schema is v1; will evolve.** Frontmatter shapes covered by `mb validate` are stable for v0.1.x; breaking changes bump the major.
-- **Runtime compatibility matrix lands at v0.2.** Codex, Cursor, OpenClaw, Hermes, and local LLMs are not first-class targets in v0.1.
+- **Built for Claude Code today.** `mb` is runtime-agnostic by design, but Claude Code is the only first-class runtime currently supported end to end.
+- **The terminal front door is live.** Bare `mb`, `mb onboard`, `mb status`, `mb start`, and `mb update` are in the public package.
+- **Schema is v1; will evolve.** Frontmatter shapes covered by `mb validate` are stable for the current major; breaking changes bump the major.
+- **Runtime compatibility is still ahead.** Codex, Cursor, OpenClaw, Hermes, and local LLMs are roadmap targets, not supported adapters yet.
 
 The engine v0.1.0 decision lives at [`decisions/2026-04-29-mb-vip-v0-1-0-master.md`](decisions/2026-04-29-mb-vip-v0-1-0-master.md). The business-side master plan is tracked in [`noontide-co/projects#119`](https://github.com/noontide-co/projects/pull/119).
 
@@ -176,7 +177,7 @@ The engine v0.1.0 decision lives at [`decisions/2026-04-29-mb-vip-v0-1-0-master.
 
 ## Roadmap
 
-v0.1 is the CLI + Claude Code adapter foundation; v0.2+ broadens runtime compatibility and deepens the workflow surfaces. Direction, not promises.
+The current package is the CLI + Claude Code first-run foundation. Next work deepens GitHub activity, credential/config foundations, graph/indexing, and runtime compatibility. Direction, not promises.
 
 The proposed long-range product direction is captured in
 [`decisions/2026-05-02-github-native-business-os.md`](decisions/2026-05-02-github-native-business-os.md):
@@ -186,10 +187,10 @@ intelligence layer, and agent runtimes as execution.
 
 - `mb books` — BeanCount integration for ledger workflows ([#128](https://github.com/noontide-co/mainbranch/issues/128))
 - `mb fulfillment` — agency-arm tooling for delivery ops
-- Runtime compatibility — Codex, Cursor, OpenClaw, Hermes, local LLMs (v0.2+)
+- Runtime compatibility — Codex, Cursor, OpenClaw, Hermes, local LLMs
 - Deeper `/site` workflows — lander → minisite → website graduation
-- Dashboard — visual operating loop for your bets and decisions, ships **free as part of `mb`** (v0.2–v0.3)
-- Skool → GitHub webhook automation (v0.2)
+- Dashboard — visual operating loop for your bets and decisions, ships **free as part of `mb`** when the graph/sync substrate is ready
+- Skool → GitHub webhook automation
 
 See [CHANGELOG.md](CHANGELOG.md) for what's in this release. Each release ships a "What this means for you" plain-English section above the technical detail.
 

--- a/docs/BEGINNER-SETUP.md
+++ b/docs/BEGINNER-SETUP.md
@@ -41,7 +41,7 @@ Same flow as macOS — use `apt install pipx` (Debian/Ubuntu) or `dnf install pi
 
 ### Windows
 
-> **Windows is experimental in v0.1.** It may work but isn't tested in CI; expect rough edges. See [compatibility](compatibility.md) and track [issue #151](https://github.com/noontide-co/mainbranch/issues/151) for status. Power users are welcome to try the steps below.
+> **Windows is experimental.** It may work but isn't tested in CI; expect rough edges. See [compatibility](compatibility.md) and track [issue #137](https://github.com/noontide-co/mainbranch/issues/137) for status. Power users are welcome to try the steps below.
 
 ```powershell
 # 1. Install Claude Code
@@ -61,7 +61,7 @@ pipx install mainbranch
 After install, verify:
 
 ```bash
-mb --version    # should print "mb 0.1.1" or higher
+mb --version    # should print something like "mb X.Y.Z"
 claude doctor   # should report Claude Code is healthy
 ```
 
@@ -145,6 +145,9 @@ Or just run `/pull` inside Claude Code — it figures out which install you have
 |---|---|
 | `mb onboard` | Guided setup for humans. Creates or connects a business repo and shows the next `/start` step. |
 | `mb init` | Scaffold a fresh business repo. |
+| `mb status` | Show a daily repo/runtime/GitHub briefing. |
+| `mb start` | Check runtime handoff readiness and print or launch Claude Code. |
+| `mb update` | Update Main Branch based on pipx vs clone install mode. |
 | `mb doctor` | Check that everything is set up correctly. Walks you through fixes. |
 | `mb skill link --repo .` | Repair Claude Code skill discovery if `/start` doesn't show up. |
 | `mb validate` | Check your reference files have correct frontmatter. |

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,20 +1,20 @@
 # Compatibility
 
-Main Branch v0.1.x is intentionally narrow: `mb` plus bundled Claude Code skills as the first adapter for portable agent workflows.
+Main Branch is intentionally narrow today: `mb` plus bundled Claude Code skills as the first adapter for portable agent workflows.
 This page is the public compatibility contract for that surface.
 
 ## Supported matrix
 
-| Surface | v0.1.x status | Notes |
+| Surface | Current status | Notes |
 |---|---|---|
 | macOS | Supported | Primary development path. Recommended for beginners. |
 | Linux | Supported for `mb`; supported when Claude Code is installed | CI runs the Python package on Linux. Claude Code must be installed separately. |
-| Windows | Experimental | Not tested in CI for v0.1.x. Track [#137](https://github.com/noontide-co/mainbranch/issues/137). |
+| Windows | Experimental | Not tested in CI. Track [#137](https://github.com/noontide-co/mainbranch/issues/137). |
 | Python | 3.10, 3.11, 3.12 | CI gates all three versions. |
 | Install mode | `pipx install mainbranch` | Canonical public install path. |
 | Developer mode | Git clone | For contributors who want to edit the engine or skills. |
-| Agent runtime | Claude Code | First-class in v0.1.x. |
-| Codex, Cursor, OpenClaw, Hermes, local LLMs | Roadmap | Runtime support is v0.2+. `mb` is runtime-agnostic by design. |
+| Agent runtime | Claude Code | First-class today. |
+| Codex, Cursor, OpenClaw, Hermes, local LLMs | Roadmap | `mb` is runtime-agnostic by design, but these adapters are not supported yet. |
 
 **Windows tip — try WSL2.** If you're on Windows and want a working setup today, use [Windows Subsystem for Linux 2 (WSL2)](https://learn.microsoft.com/en-us/windows/wsl/install). Inside WSL2, follow the supported Linux flow. The pipx install path works there.
 
@@ -30,7 +30,7 @@ Supported means:
 Experimental means:
 
 - The path may work for power users.
-- It is not part of the v0.1.x release gate.
+- It is not part of the release gate.
 - Workarounds are welcome, but breakage is not treated as a launch blocker.
 
 ## Recommended setup
@@ -70,12 +70,12 @@ runs the appropriate update path, and refreshes skill links. Use
 Inside Claude Code, `/pull` calls `mb update` for this mechanical step and keeps
 ownership of the human-readable "what's new" summary.
 
-## Known v0.1.x limits
+## Known Limits
 
-- Claude Code is the only first-class agent runtime in v0.1.x.
+- Claude Code is the only first-class agent runtime today.
 - Windows is experimental.
 - Skills are bundled into the installed Python package, so public users update
   skills by upgrading `mainbranch`.
 - The CLI scaffolds, validates, graphs, resolves, and links the current Claude
   Code skill adapter. Most business workflows still happen through Claude Code
-  slash commands in v0.1.x.
+  slash commands.

--- a/docs/prd/v0-2-first-run-daily-briefing.md
+++ b/docs/prd/v0-2-first-run-daily-briefing.md
@@ -1,6 +1,6 @@
 ---
 title: "PRD: v0.2 First-Run + Daily Briefing"
-status: draft
+status: shipped
 date: 2026-05-02
 release: v0.2.0
 linked_decision: decisions/2026-05-02-github-native-business-os.md
@@ -18,11 +18,11 @@ related_prds:
 
 ## Summary
 
-Main Branch v0.2.0 should prove the new product shape without building a
-dashboard first.
+Main Branch v0.2.0 proved the new product shape without building a dashboard
+first.
 
-The release should make `mb` feel like the front door to a GitHub-native
-business operating system:
+The release made `mb` feel like the front door to a GitHub-native business
+operating system:
 
 1. bare `mb` gives a polished interactive launch screen;
 2. `mb onboard` guides humans through setup or repo connection;
@@ -30,22 +30,23 @@ business operating system:
 4. `mb start` makes the handoff to Claude Code explicit and repairable;
 5. `mb update` keeps the install and bundled workflows current.
 
-This release does not need full integrations, a live dashboard, autonomous
-agents, or multi-runtime execution. It needs to turn the first-run and daily-run
-loops into a coherent product.
+This release did not add full integrations, a live dashboard, autonomous agents,
+or multi-runtime execution. It turned the first-run and daily-run loops into a
+coherent terminal product.
 
 ## Problem
 
-The v0.1 CLI works, but it assumes the user already understands the system.
+Before this release, the CLI worked, but it assumed the user already understood
+the system.
 
 Current behavior:
 
-- `mb init` scaffolds a repo but does not teach or adapt.
-- Bare `mb` behaves like a traditional command reference.
-- The handoff to Claude Code is mostly copy/paste guidance.
-- `/start` carries the daily entry surface, but `mb` does not yet give a
+- `mb init` scaffolded a repo but did not teach or adapt.
+- Bare `mb` behaved like a traditional command reference.
+- The handoff to Claude Code was mostly copy/paste guidance.
+- `/start` carried the daily entry surface, but `mb` did not give a
   pre-runtime status view.
-- GitHub is present, but not yet reframed as the business team layer.
+- GitHub was present, but not yet reframed as the business team layer.
 
 This is enough for technical early adopters. It is not enough for the operator
 who needs to be taught why git, GitHub, Claude Code, and local files matter.
@@ -302,7 +303,7 @@ Acceptance:
 
 ## Data and State
 
-v0.2.0 should use only:
+The shipped v0.2.0 scope used only:
 
 - repo files;
 - git metadata;
@@ -451,7 +452,7 @@ Everything not listed above stays backlog unless explicitly pulled forward.
 
 ## Definition of Done
 
-v0.2.0 is done when a fresh user can:
+v0.2.0 was done when a fresh user could:
 
 1. install Main Branch;
 2. run `mb`;

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -1,5 +1,12 @@
 # System Architecture
 
+> **Status:** Legacy architecture reference. This file still contains
+> pre-package-era paths such as `reference/core/` and `.vip/local.yaml`.
+> For the current public repo shape, use `mb onboard`, `mb status`, and
+> the tree in `README.md`. Treat this document as historical design context
+> until it is rewritten around the shipped `core/`, `research/`,
+> `decisions/`, `log/`, `campaigns/`, and `documents/` taxonomy.
+
 Complete technical reference for how Main Branch works as an AI-native business operating system.
 
 ---

--- a/mb/README.md
+++ b/mb/README.md
@@ -2,7 +2,7 @@
 
 Engine umbrella for [Main Branch](https://github.com/noontide-co/mainbranch) — scaffolds, validates, and graphs business-as-files repos.
 
-This package is the Python entry point. Workflows, playbooks, educational content, and consumer-repo templates ship as bundled package data. In v0.1.x, the day-to-day "do work" surfaces are packaged as Claude Code skills (markdown), invoked from inside Claude Code. The `mb` CLI is runtime-agnostic by design: future adapters should let Codex, Cursor, OpenClaw, Hermes, and local runtimes operate against the same business-as-files repo.
+This package is the Python entry point. Workflows, playbooks, educational content, and consumer-repo templates ship as bundled package data. Today, the day-to-day "do work" surfaces are packaged as Claude Code skills (markdown), invoked from inside Claude Code. The `mb` CLI is runtime-agnostic by design: future adapters should let Codex, Cursor, OpenClaw, Hermes, and local runtimes operate against the same business-as-files repo.
 
 The source tree keeps the engine payload in one place: repo-root `.claude/`. During sdist/wheel builds, `setup.py` copies that tree into `mb/_engine/.claude/` inside the build artifact so installed wheels can resolve skills, playbooks, reference files, lenses, and educational prompts without a source checkout.
 
@@ -38,7 +38,7 @@ mb --version
 
 ## Status
 
-v0.1 is **Claude Code first**. Runtime compatibility for Codex, Cursor, OpenClaw, Hermes, and local runtimes is a v0.2+ commitment. The schema is v1 and will evolve. The runtime boundary decision lives at `decisions/2026-05-01-mb-cli-vs-agent-workflows-boundary.md`; the engine master decision lives at `decisions/2026-04-29-mb-vip-v0-1-0-master.md`.
+Main Branch is **Claude Code first** with a strong CLI front door: `mb onboard`, `mb status`, `mb start`, and `mb update` are public package surfaces. Runtime compatibility for Codex, Cursor, OpenClaw, Hermes, and local runtimes remains roadmap work. The schema is v1 and will evolve. The runtime boundary decision lives at `decisions/2026-05-01-mb-cli-vs-agent-workflows-boundary.md`; the engine master decision lives at `decisions/2026-04-29-mb-vip-v0-1-0-master.md`.
 
 ## License
 


### PR DESCRIPTION
## Summary
- Replaces version-specific claims in evergreen docs with current product-state language so README, compatibility, and beginner setup survive patch releases.
- Updates public setup docs to reflect the shipped CLI front door: bare `mb`, `mb onboard`, `mb status`, `mb start`, and `mb update`.
- Marks the v0.2 first-run PRD as shipped while keeping exact versions in release/history artifacts where they belong.
- Points contributor checklists at the repo-root `scripts/check.sh` gate instead of duplicating stale command lists.

## Scope
- In: evergreen docs, support/contributor templates, PR checklist, v0.2 PRD status, and a legacy warning on the old system architecture reference.
- Out: package version changes, command behavior changes, release publishing, Linear release changes, and rewriting historical changelog/versioned PRD history.

## Commits
- `a631dfc` — `[docs] Reduce stale release references`.

## Release / Issues
- Release: none; post-0.2.0 documentation cleanup.
- Linear ID(s): none.
- Closes: none.
- Refs: none.
- Follow-ups: rewrite or replace `docs/system-architecture.md` with a current architecture reference when the next architecture-doc pass is scheduled.

## Success Metric
Evergreen public docs describe the current product surface without hard-coding patch/minor version claims that will go stale on the next release, while release-history files still preserve exact version history.

## Validation
- Level 0 docs/decision: reviewed `README.md`, `docs/BEGINNER-SETUP.md`, `docs/compatibility.md`, `mb/README.md`, `CHANGELOG.md`, and `docs/prd/v0-2-first-run-daily-briefing.md` for stale current-state language.
- Level 1 static: `git diff --check` passed; `scripts/check.sh` static gates passed (`ruff format --check`, `ruff check`, `mypy mb`).
- Level 2 CLI: `scripts/check.sh` passed (`73 passed`, coverage `79.86%`).
- Level 3 package/install: not run; no package metadata or install behavior changed.
- Level 4 fixture repo: not run; docs/template-only cleanup.
- Level 5 runtime smoke: not run; no runtime handoff or Claude Code behavior changed.

## Public / Private Boundary
- Public docs keep product behavior and public contribution process only.
- Private Devon/Conductor orchestration details stayed out of the public repo.
