### PR TITLE
[update] Clarify old repo migration path

### DIFF
--- a/.claude/educational/upgrading-mainbranch.md
+++ b/.claude/educational/upgrading-mainbranch.md
@@ -7,6 +7,35 @@ last-updated: 2026-05-01
 
 # How Main Branch updates work after pipx install
 
+## If `mb --version` says `0.1.x`
+
+Run the bootstrap upgrade once:
+
+```bash
+pipx upgrade mainbranch
+mb --version
+```
+
+`mb update` was added after the earliest public package, so old installs cannot
+run it yet. After the pipx upgrade, `mb update` and `/pull` become the normal
+path.
+
+## If you already have a business repo
+
+Repair Claude Code skill discovery from inside that repo:
+
+```bash
+cd /path/to/your-business
+mb skill link --repo .
+mb doctor
+mb start
+```
+
+This rewrites `.claude/settings.local.json` and the local skill links so Claude
+Code sees the bundled skills from the installed package.
+
+## Why this changed
+
 If you installed Main Branch with `pipx install mainbranch`, your skills live
 inside the installed Python package. That is good for clean setup: there is no
 engine repo to clone, and `mb init` can link Claude Code directly to the
@@ -23,6 +52,10 @@ Then re-link your business repo if needed:
 ```bash
 mb skill link --repo /path/to/your-business
 ```
+
+For old repos with `reference/core/`, do not move files first. That legacy
+layout is still supported while the automated `mb migrate` command is pending.
+Read `docs/MIGRATING.md` in the engine repo before doing any layout migration.
 
 If you use the older clone-based setup, updates still come from Git:
 

--- a/README.md
+++ b/README.md
@@ -230,6 +230,11 @@ Create a separate repo for each brand. If they share the same soul and voice, th
 **How do I update when new skills come out?**
 `pipx upgrade mainbranch`, or run `/pull` inside Claude Code.
 
+If `mb --version` still says `0.1.x`, run `pipx upgrade mainbranch` once before
+using `mb update`. Existing business repos should then run
+`mb skill link --repo .` from the repo root. See
+[docs/MIGRATING.md](docs/MIGRATING.md) for the old-repo path.
+
 **Can I edit the skills?**
 You can, but you don't need to. They're designed to work out of the box.
 

--- a/docs/BEGINNER-SETUP.md
+++ b/docs/BEGINNER-SETUP.md
@@ -120,6 +120,18 @@ pipx upgrade mainbranch
 
 Or just run `/pull` inside Claude Code — it figures out which install you have and runs the right thing. The CHANGELOG entry for the new version surfaces as a banner the next time you run `/start`.
 
+If you installed an early `0.1.x` version, upgrade once with
+`pipx upgrade mainbranch` before trying `mb update`. If you already had a
+business repo from the old setup, run this from that repo afterward:
+
+```bash
+mb skill link --repo .
+mb doctor
+```
+
+For old `reference/core/` repos, read [MIGRATING.md](MIGRATING.md). You usually
+do not need to move files immediately.
+
 ---
 
 ## Available Skills

--- a/docs/MIGRATING.md
+++ b/docs/MIGRATING.md
@@ -1,0 +1,143 @@
+# Migrating Existing Main Branch Repos
+
+Main Branch has two repo shapes in the wild:
+
+- **Legacy shape:** `reference/core/`, `reference/domain/`, `reference/proof/`,
+  and `outputs/`.
+- **Current shape:** `core/`, `research/`, `decisions/`, `log/`, `campaigns/`,
+  and `documents/`, with `reference/` kept as a compatibility layer for
+  agent-runtime skills.
+
+Existing repos do not need an urgent file move. The safe path is to update the
+engine first, repair skill discovery, and only migrate file layout on a clean
+branch when you need the new shape.
+
+## If You Are On `mb 0.1.x`
+
+Old `mb` versions do not have `mb update` yet. Run the bootstrap upgrade once:
+
+```bash
+pipx upgrade mainbranch
+mb --version
+```
+
+After that, use the current update path:
+
+```bash
+mb update --repo /path/to/your-business
+```
+
+or, from inside Claude Code:
+
+```text
+/pull
+```
+
+## Repair An Existing Business Repo
+
+From the business repo:
+
+```bash
+cd /path/to/your-business
+mb skill link --repo .
+mb doctor
+mb status
+mb start
+```
+
+`mb skill link --repo .` rewrites the local Claude Code wiring so `/start`,
+`/think`, `/ads`, and the other bundled skills point at the installed
+Main Branch package instead of an old clone path.
+
+## Do Not Start By Moving Files
+
+If your repo has `reference/core/`, leave it alone until the setup works again.
+Current Main Branch commands understand that legacy shape:
+
+- `mb status` counts `reference/core/`.
+- `mb start` treats a repo with `reference/core/`, `research/`, and
+  `decisions/` as a business repo.
+- Claude Code skills still read compatibility paths under `reference/`.
+
+The only thing legacy users usually need immediately is:
+
+```bash
+pipx upgrade mainbranch
+mb skill link --repo /path/to/your-business
+```
+
+## Optional Manual Layout Migration
+
+Only do this on a clean branch with everything committed:
+
+```bash
+cd /path/to/your-business
+git status --short
+git switch -c migrate-mainbranch-layout
+```
+
+For repos with `reference/core/`, move the core files to the current root
+`core/` folder and leave a compatibility link behind:
+
+```bash
+mkdir -p core
+git mv reference/core/* core/
+rmdir reference/core
+ln -s ../core reference/core
+```
+
+For repos with `reference/offers/`, do the same for offer-specific files:
+
+```bash
+mkdir -p core/offers
+git mv reference/offers/* core/offers/
+rmdir reference/offers
+ln -s ../core/offers reference/offers
+```
+
+Then add the current empty working folders:
+
+```bash
+mkdir -p log campaigns documents core/finance
+touch log/.gitkeep campaigns/.gitkeep documents/.gitkeep core/finance/.gitkeep
+```
+
+Validate before merging the branch:
+
+```bash
+mb doctor
+mb status
+mb validate
+mb start --json
+git diff --stat
+```
+
+If anything looks wrong, stop and keep the legacy layout. Legacy layout support
+is intentional while `mb migrate` is still manual.
+
+## What About `.vip/config.yaml` and `~/.config/vip/local.yaml`?
+
+Keep them for now.
+
+- `~/.config/vip/local.yaml` is machine-local memory: default repo, recent
+  repos, experience level, and last-seen changelog version.
+- `.vip/config.yaml` is repo-local configuration used by older skills and
+  future path/config work.
+
+Do not delete either file as part of a layout migration. `mb skill link` writes
+Claude Code discovery into `.claude/settings.local.json`; it does not replace
+the old config files yet.
+
+## Current Recommendation
+
+For old repos such as `noontide-projects`:
+
+1. Upgrade Main Branch with `pipx upgrade mainbranch`.
+2. Run `mb skill link --repo /path/to/repo`.
+3. Run `mb doctor` and `mb status`.
+4. Keep `reference/core/` until an automated `mb migrate --check` exists or
+   you intentionally run the manual branch process above.
+
+For personal knowledge repos that do not have `reference/core/`, treat them as
+GitHub-native repos that Main Branch can brief, not as fully migrated business
+repos yet.

--- a/mb/README.md
+++ b/mb/README.md
@@ -36,6 +36,10 @@ mb --version
 | `mb skill link --repo <path>` | Wire or repair Claude Code skill discovery for a business repo. Future runtime adapters should get equivalent wiring commands. |
 | `mb educational <topic>` | Print an educational triage file. Powers `mb doctor`'s "tell me more" prompts. |
 
+Users on early `0.1.x` installs must bootstrap once with
+`pipx upgrade mainbranch` before `mb update` exists locally. Existing business
+repos should run `mb skill link --repo .` after upgrading.
+
 ## Status
 
 Main Branch is **Claude Code first** with a strong CLI front door: `mb onboard`, `mb status`, `mb start`, and `mb update` are public package surfaces. Runtime compatibility for Codex, Cursor, OpenClaw, Hermes, and local runtimes remains roadmap work. The schema is v1 and will evolve. The runtime boundary decision lives at `decisions/2026-05-01-mb-cli-vs-agent-workflows-boundary.md`; the engine master decision lives at `decisions/2026-04-29-mb-vip-v0-1-0-master.md`.

--- a/mb/mb/_data/educational/upgrading-mainbranch.md
+++ b/mb/mb/_data/educational/upgrading-mainbranch.md
@@ -1,0 +1,33 @@
+---
+type: educational
+topic: upgrading-mainbranch
+status: stub
+last-updated: 2026-05-02
+---
+
+# How Main Branch updates work after pipx install
+
+If `mb --version` says `0.1.x`, run the bootstrap upgrade once:
+
+```bash
+pipx upgrade mainbranch
+mb --version
+```
+
+`mb update` was added after the earliest public package, so old installs cannot
+run it yet. After the pipx upgrade, `mb update` and `/pull` become the normal
+path.
+
+If you already have a business repo, repair Claude Code skill discovery from
+inside that repo:
+
+```bash
+cd /path/to/your-business
+mb skill link --repo .
+mb doctor
+mb start
+```
+
+Old repos with `reference/core/` do not need an urgent file move. That layout is
+still supported while automated migration is pending. Read `docs/MIGRATING.md`
+before moving files.

--- a/mb/mb/doctor.py
+++ b/mb/mb/doctor.py
@@ -148,6 +148,50 @@ def _detect_cloud_paths(repo: Path) -> list[str]:
     return hits
 
 
+def _repo_layout_check(repo: Path) -> dict[str, Any]:
+    has_core = (repo / "core").is_dir()
+    has_reference_core = (repo / "reference" / "core").exists()
+    has_reference = (repo / "reference").is_dir()
+
+    if has_core:
+        return {
+            "name": "repo-layout",
+            "ok": True,
+            "detail": "current core/ layout present",
+        }
+
+    if has_reference_core:
+        return {
+            "name": "repo-layout",
+            "ok": False,
+            "detail": (
+                "legacy reference/core layout detected. This still works, but "
+                "run `mb skill link --repo .` after upgrading and read "
+                "`docs/MIGRATING.md` before moving files."
+            ),
+            "severity": "warn",
+        }
+
+    if has_reference:
+        return {
+            "name": "repo-layout",
+            "ok": False,
+            "detail": (
+                "legacy reference/ layout detected without core/. Main Branch can "
+                "brief this repo, but current six-folder features may be limited. "
+                "Read `docs/MIGRATING.md` before moving files."
+            ),
+            "severity": "warn",
+        }
+
+    return {
+        "name": "repo-layout",
+        "ok": False,
+        "detail": "no core/ or reference/ layout found",
+        "severity": "warn",
+    }
+
+
 def run(path: str) -> dict[str, Any]:
     """Run all checks, return a structured report dict."""
     repo = Path(path).resolve()
@@ -205,6 +249,7 @@ def run(path: str) -> dict[str, Any]:
     )
 
     checks.append(_mainbranch_version_check())
+    checks.append(_repo_layout_check(repo))
 
     cloud_hits = _detect_cloud_paths(repo)
     cloud_ok = not cloud_hits

--- a/mb/tests/test_doctor.py
+++ b/mb/tests/test_doctor.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from mb.doctor import _detect_cloud_paths, run
+from mb.doctor import _detect_cloud_paths, _repo_layout_check, run
 from mb.init import run as init_run
 
 
@@ -15,6 +15,7 @@ def test_doctor_runs_on_empty_dir(tmp_path: Path) -> None:
     assert {"claude-code", "gh-auth", "network", "anti-cloud-backup"}.issubset(names)
     assert "skill-wiring" in names
     assert "mainbranch-version" in names
+    assert "repo-layout" in names
 
 
 def test_cloud_path_detection_via_symlink(tmp_path: Path, monkeypatch) -> None:
@@ -46,3 +47,24 @@ def test_doctor_skill_wiring_passes_after_init(tmp_path: Path) -> None:
     report = run(path=str(repo))
     wiring = next(c for c in report["checks"] if c["name"] == "skill-wiring")
     assert wiring["ok"] is True
+
+
+def test_repo_layout_warns_on_legacy_reference_core(tmp_path: Path) -> None:
+    repo = tmp_path / "legacy"
+    (repo / "reference" / "core").mkdir(parents=True)
+
+    check = _repo_layout_check(repo)
+
+    assert check["ok"] is False
+    assert check["severity"] == "warn"
+    assert "legacy reference/core" in check["detail"]
+
+
+def test_repo_layout_accepts_current_core(tmp_path: Path) -> None:
+    repo = tmp_path / "current"
+    (repo / "core").mkdir(parents=True)
+
+    check = _repo_layout_check(repo)
+
+    assert check["ok"] is True
+    assert "current core/" in check["detail"]

--- a/mb/tests/test_smoke_coverage.py
+++ b/mb/tests/test_smoke_coverage.py
@@ -40,6 +40,15 @@ def test_educational_load_known_topic_returns_text(tmp_path: Path) -> None:
     assert result is None or isinstance(result, str)
 
 
+def test_educational_upgrading_mainbranch_exists() -> None:
+    from mb.educational import load
+
+    result = load("upgrading-mainbranch")
+
+    assert result is not None
+    assert "pipx upgrade mainbranch" in result
+
+
 # ------------------------------------------------------------------------ think
 
 


### PR DESCRIPTION
## Summary
- Documents the safe update path for users still on `mb 0.1.x`: bootstrap once with `pipx upgrade mainbranch`, then use `mb update` or `/pull` going forward.
- Adds an old-repo migration guide that keeps `reference/core/` repos working while automated `mb migrate` remains pending.
- Teaches `mb doctor` to warn on legacy repo layouts without hard-failing them.
- Adds the missing `upgrading-mainbranch` educational topic that `mb doctor` already points users toward.

## Scope
- In: old-user update docs, `docs/MIGRATING.md`, `mb doctor` layout warning, bundled educational topic, and focused tests.
- Out: automated file-moving migration, `mb migrate --apply`, credential integrations, dashboard work, SQL/state layer, and `mb shell`.

## Commits
- `cf30310` — `[update] Clarify old repo migration path`.

## Release / Issues
- Release: v0.2.1 candidate / migration-safety patch.
- Linear ID(s): none.
- Closes: none.
- Refs: #119, #175.
- Follow-ups: implement real `mb migrate --check` / `--apply` machinery after this manual safety path is validated against existing repos.

## Success Metric
A user with an early `mb 0.1.x` install or legacy `reference/core/` business repo can recover by following documented commands, and `mb doctor` explicitly tells them legacy layout is supported while pointing them away from unsafe file moves.

## Validation
- Level 0 docs/decision: reviewed update/migration language in `README.md`, `docs/BEGINNER-SETUP.md`, `docs/MIGRATING.md`, `mb/README.md`, and the educational topic.
- Level 1 static: `scripts/check.sh` passed (`ruff format --check`, `ruff check`, `mypy mb`).
- Level 2 CLI: `scripts/check.sh` passed (`76 passed`, coverage `79.95%`); manually ran `python3 -m mb educational upgrading-mainbranch`; manually ran `python3 -m mb doctor /Users/devonmeadows/Documents/GitHub/noontide-projects --json` and confirmed the legacy layout warning.
- Level 3 package/install: not run; no package metadata or install mechanism changed.
- Level 4 fixture repo: not run separately; targeted tests cover legacy/current layout classification.
- Level 5 runtime smoke: not run; no Claude Code runtime handoff behavior changed.

## Public / Private Boundary
- Public docs use generic repo paths and migration guidance only.
- Devon-specific paths were used only as local smoke evidence and were not committed into public docs.
