### PR TITLE
[add] GitHub activity briefing primitives

### DIFF
--- a/mb/mb/github_activity.py
+++ b/mb/mb/github_activity.py
@@ -247,6 +247,7 @@ def collect(
     report["degraded"] = bool(errors)
     report["sections"] = sections
     report["summary"] = _summary(sections)
+    report["summary"]["shipped_this_week"] = len(merged)
     report["assigned_issues"] = assigned
     report["review_requests"] = review_requests
     report["recent_merged_prs"] = shipped_this_week

--- a/mb/mb/github_activity.py
+++ b/mb/mb/github_activity.py
@@ -1,0 +1,445 @@
+"""Reusable GitHub activity primitives backed by the GitHub CLI."""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+from collections.abc import Callable
+from datetime import date, timedelta
+from pathlib import Path
+from typing import Any
+
+CommandResult = dict[str, Any]
+CommandRunner = Callable[[list[str], Path | None, float], CommandResult]
+JsonRunner = Callable[[list[str], Path], tuple[bool, Any, str]]
+Which = Callable[[str], str]
+
+ISSUE_FIELDS = "number,title,url,updatedAt,closedAt,labels,state"
+PR_FIELDS = "number,title,url,updatedAt,mergedAt,author,isDraft,reviewDecision,body,state"
+
+
+def which(name: str) -> str:
+    return shutil.which(name) or ""
+
+
+def run_command(args: list[str], cwd: Path | None = None, timeout: float = 5.0) -> CommandResult:
+    try:
+        result = subprocess.run(
+            args,
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except FileNotFoundError:
+        return {"ok": False, "returncode": 127, "stdout": "", "stderr": f"{args[0]} not found"}
+    except subprocess.TimeoutExpired:
+        return {"ok": False, "returncode": 124, "stdout": "", "stderr": "command timed out"}
+    except subprocess.SubprocessError as exc:
+        return {"ok": False, "returncode": 1, "stdout": "", "stderr": str(exc)}
+    return {
+        "ok": result.returncode == 0,
+        "returncode": result.returncode,
+        "stdout": result.stdout,
+        "stderr": result.stderr,
+    }
+
+
+def gh_json(args: list[str], repo: Path) -> tuple[bool, Any, str]:
+    result = run_command(args, cwd=repo, timeout=5.0)
+    if not result["ok"]:
+        return False, None, str(result["stderr"]).strip() or str(result["stdout"]).strip()
+    try:
+        return True, json.loads(str(result["stdout"]) or "[]"), ""
+    except json.JSONDecodeError:
+        return False, None, "gh returned invalid JSON"
+
+
+def repo_full_name(remote: str) -> str:
+    if not remote:
+        return ""
+    match = re.search(r"github\.com[:/](?P<owner>[^/]+)/(?P<repo>[^/]+?)(?:\.git)?/?$", remote)
+    if not match:
+        return ""
+    return f"{match.group('owner')}/{match.group('repo')}"
+
+
+def collect(
+    repo: Path,
+    *,
+    remote: str = "",
+    today: date | None = None,
+    which_func: Which = which,
+    command_runner: CommandRunner = run_command,
+    json_runner: JsonRunner = gh_json,
+) -> dict[str, Any]:
+    """Collect business-language GitHub activity through `gh`.
+
+    The returned shape is intentionally stable for CLI JSON consumers. Legacy
+    aliases are included for `mb status` callers that already read v0.2.0 keys.
+    """
+    repo_name = repo_full_name(remote)
+    if not which_func("gh"):
+        return _empty_report(
+            repo_name=repo_name,
+            available=False,
+            authenticated=False,
+            errors=["gh not on PATH"],
+        )
+
+    auth = command_runner(["gh", "auth", "status"], repo, 5.0)
+    if not auth["ok"]:
+        return _empty_report(
+            repo_name=repo_name,
+            available=True,
+            authenticated=False,
+            errors=["gh not authenticated"],
+        )
+
+    today_value = today or date.today()
+    week_start = today_value - timedelta(days=today_value.weekday())
+    errors: list[str] = []
+
+    assigned = _query(
+        "assigned tasks",
+        _issue_list_args(repo_name, ["--state", "open", "--assignee", "@me"]),
+        repo,
+        json_runner,
+        errors,
+    )
+    review_requests = _query(
+        "review requests",
+        _pr_list_args(repo_name, ["--state", "open", "--search", "review-requested:@me"]),
+        repo,
+        json_runner,
+        errors,
+    )
+    mentioned_issues = _query(
+        "mentioned tasks",
+        _issue_list_args(repo_name, ["--state", "open", "--search", "mentions:@me"]),
+        repo,
+        json_runner,
+        errors,
+    )
+    mentioned_prs = _query(
+        "mentioned proposals",
+        _pr_list_args(repo_name, ["--state", "open", "--search", "mentions:@me"]),
+        repo,
+        json_runner,
+        errors,
+    )
+    open_prs = _query(
+        "open proposals",
+        _pr_list_args(repo_name, ["--state", "open", "--author", "@me"]),
+        repo,
+        json_runner,
+        errors,
+    )
+    merged = _query(
+        "shipped proposals",
+        _pr_list_args(repo_name, ["--state", "merged", "--search", f"merged:>={week_start}"]),
+        repo,
+        json_runner,
+        errors,
+        limit="20",
+    )
+    closed = _query(
+        "closed tasks",
+        _issue_list_args(repo_name, ["--state", "closed"]),
+        repo,
+        json_runner,
+        errors,
+        limit="10",
+    )
+    blocked = _query(
+        "blocked tasks",
+        _issue_list_args(repo_name, ["--state", "open", "--search", "label:blocked"]),
+        repo,
+        json_runner,
+        errors,
+    )
+    stale = _query(
+        "stale tasks",
+        _issue_list_args(repo_name, ["--state", "open", "--search", "label:stale"]),
+        repo,
+        json_runner,
+        errors,
+    )
+
+    assigned_tasks = [
+        _task_item(item, repo_name, business_status="assigned", reason="Assigned to you")
+        for item in assigned
+    ]
+    attention_requests = _dedupe(
+        [
+            *[
+                _proposal_item(
+                    item,
+                    repo_name,
+                    business_status="needs_review",
+                    reason="Your review is requested",
+                )
+                for item in review_requests
+            ],
+            *[
+                _task_item(
+                    item,
+                    repo_name,
+                    business_status="mentioned",
+                    reason="You were mentioned",
+                )
+                for item in mentioned_issues
+            ],
+            *[
+                _proposal_item(
+                    item,
+                    repo_name,
+                    business_status="mentioned",
+                    reason="You were mentioned",
+                )
+                for item in mentioned_prs
+            ],
+        ]
+    )
+    open_proposals = [
+        _proposal_item(
+            item,
+            repo_name,
+            business_status="open_proposal",
+            reason="Your open proposal may need follow-up",
+        )
+        for item in open_prs
+    ]
+    shipped_this_week = recent_merged_prs(merged, repo_name=repo_name)
+    recently_closed_tasks = [
+        _task_item(item, repo_name, business_status="closed", reason="Recently closed")
+        for item in closed
+    ]
+    blocked_or_stale_tasks = _dedupe(
+        [
+            *[
+                _task_item(item, repo_name, business_status="blocked", reason="Blocked label")
+                for item in blocked
+            ],
+            *[
+                _task_item(item, repo_name, business_status="stale", reason="Stale label")
+                for item in stale
+            ],
+        ]
+    )
+
+    sections = {
+        "assigned_tasks": assigned_tasks,
+        "attention_requests": attention_requests,
+        "open_proposals": open_proposals,
+        "shipped_this_week": shipped_this_week,
+        "recently_closed_tasks": recently_closed_tasks,
+        "blocked_or_stale_tasks": blocked_or_stale_tasks,
+    }
+    report = _empty_report(
+        repo_name=repo_name,
+        available=True,
+        authenticated=True,
+        errors=errors,
+    )
+    report["degraded"] = bool(errors)
+    report["sections"] = sections
+    report["summary"] = _summary(sections)
+    report["assigned_issues"] = assigned
+    report["review_requests"] = review_requests
+    report["recent_merged_prs"] = shipped_this_week
+    return report
+
+
+def recent_merged_prs(prs: list[dict[str, Any]], repo_name: str = "") -> list[dict[str, Any]]:
+    sorted_prs = sorted(prs, key=lambda pr: str(pr.get("mergedAt", "") or ""), reverse=True)
+    return [summarize_pr(pr, repo_name=repo_name) for pr in sorted_prs[:5]]
+
+
+def summarize_pr(pr: dict[str, Any], repo_name: str = "") -> dict[str, Any]:
+    title = str(pr.get("title", "") or "")
+    body = str(pr.get("body", "") or "")
+    summary = ""
+    for line in body.splitlines():
+        stripped = line.strip().strip("-* ")
+        if stripped and not stripped.startswith("#"):
+            summary = stripped
+            break
+    if not summary:
+        summary = title
+
+    item = _proposal_item(
+        pr,
+        repo_name=repo_name,
+        business_status="shipped",
+        reason="Merged this week",
+    )
+    item["what_shipped"] = summary[:220]
+    item["mergedAt"] = item["merged_at"]
+    return item
+
+
+def _empty_report(
+    *,
+    repo_name: str,
+    available: bool,
+    authenticated: bool,
+    errors: list[str],
+) -> dict[str, Any]:
+    sections: dict[str, list[dict[str, Any]]] = {
+        "assigned_tasks": [],
+        "attention_requests": [],
+        "open_proposals": [],
+        "shipped_this_week": [],
+        "recently_closed_tasks": [],
+        "blocked_or_stale_tasks": [],
+    }
+    return {
+        "available": available,
+        "authenticated": authenticated,
+        "degraded": bool(errors) or not available or not authenticated,
+        "source": "gh",
+        "repo": repo_name,
+        "summary": _summary(sections),
+        "sections": sections,
+        "errors": errors,
+        "assigned_issues": [],
+        "review_requests": [],
+        "recent_merged_prs": [],
+    }
+
+
+def _summary(sections: dict[str, list[dict[str, Any]]]) -> dict[str, Any]:
+    return {
+        "assigned_tasks": len(sections["assigned_tasks"]),
+        "attention_requests": len(sections["attention_requests"]),
+        "open_proposals": len(sections["open_proposals"]),
+        "shipped_this_week": len(sections["shipped_this_week"]),
+        "recently_closed_tasks": len(sections["recently_closed_tasks"]),
+        "blocked_or_stale_tasks": len(sections["blocked_or_stale_tasks"]),
+    }
+
+
+def _query(
+    label: str,
+    args: list[str],
+    repo: Path,
+    json_runner: JsonRunner,
+    errors: list[str],
+    *,
+    limit: str = "10",
+) -> list[dict[str, Any]]:
+    full_args = [*args, "--limit", limit]
+    ok, payload, error = json_runner(full_args, repo)
+    if not ok:
+        errors.append(f"{label}: {error}")
+        return []
+    if not isinstance(payload, list):
+        errors.append(f"{label}: gh returned non-list JSON")
+        return []
+    return [item for item in payload if isinstance(item, dict)]
+
+
+def _issue_list_args(repo_name: str, filters: list[str]) -> list[str]:
+    args = ["gh", "issue", "list", *filters, "--json", ISSUE_FIELDS]
+    return _with_repo(args, repo_name)
+
+
+def _pr_list_args(repo_name: str, filters: list[str]) -> list[str]:
+    args = ["gh", "pr", "list", *filters, "--json", PR_FIELDS]
+    return _with_repo(args, repo_name)
+
+
+def _with_repo(args: list[str], repo_name: str) -> list[str]:
+    if repo_name:
+        return [*args, "--repo", repo_name]
+    return args
+
+
+def _task_item(
+    issue: dict[str, Any],
+    repo_name: str,
+    *,
+    business_status: str,
+    reason: str,
+) -> dict[str, Any]:
+    labels = _label_names(issue.get("labels"))
+    return {
+        "type": "task",
+        "github_type": "issue",
+        "business_status": business_status,
+        "reason": reason,
+        "number": issue.get("number"),
+        "title": str(issue.get("title", "") or ""),
+        "url": str(issue.get("url", "") or ""),
+        "repo": repo_name,
+        "state": str(issue.get("state", "") or ""),
+        "updated_at": str(issue.get("updatedAt", "") or ""),
+        "closed_at": str(issue.get("closedAt", "") or ""),
+        "labels": labels,
+    }
+
+
+def _proposal_item(
+    pr: dict[str, Any],
+    repo_name: str,
+    *,
+    business_status: str,
+    reason: str,
+) -> dict[str, Any]:
+    return {
+        "type": "proposal",
+        "github_type": "pull_request",
+        "business_status": business_status,
+        "reason": reason,
+        "number": pr.get("number"),
+        "title": str(pr.get("title", "") or ""),
+        "url": str(pr.get("url", "") or ""),
+        "repo": repo_name,
+        "state": str(pr.get("state", "") or ""),
+        "updated_at": str(pr.get("updatedAt", "") or ""),
+        "merged_at": str(pr.get("mergedAt", "") or ""),
+        "author": _author_login(pr.get("author")),
+        "is_draft": bool(pr.get("isDraft", False)),
+        "review_decision": str(pr.get("reviewDecision", "") or ""),
+    }
+
+
+def _label_names(labels: Any) -> list[str]:
+    if not isinstance(labels, list):
+        return []
+    names: list[str] = []
+    for label in labels:
+        if isinstance(label, dict):
+            name = label.get("name")
+            if isinstance(name, str):
+                names.append(name)
+        elif isinstance(label, str):
+            names.append(label)
+    return names
+
+
+def _author_login(author: Any) -> str:
+    if isinstance(author, dict):
+        login = author.get("login")
+        if isinstance(login, str):
+            return login
+    return ""
+
+
+def _dedupe(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    seen: set[tuple[str, str, str]] = set()
+    deduped: list[dict[str, Any]] = []
+    for item in items:
+        key = (
+            str(item.get("github_type", "")),
+            str(item.get("repo", "")),
+            str(item.get("number", "")),
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(item)
+    return deduped

--- a/mb/mb/status.py
+++ b/mb/mb/status.py
@@ -12,7 +12,7 @@ from typing import Any
 
 import yaml
 
-from mb import __version__
+from mb import __version__, github_activity
 from mb.engine import install_mode, link_status
 
 IMPORTANT_DIRS = (
@@ -265,12 +265,7 @@ def _brain(repo: Path) -> dict[str, Any]:
 
 
 def _repo_full_name(remote: str) -> str:
-    if not remote:
-        return ""
-    match = re.search(r"github\.com[:/](?P<owner>[^/]+)/(?P<repo>[^/]+?)(?:\.git)?/?$", remote)
-    if not match:
-        return ""
-    return f"{match.group('owner')}/{match.group('repo')}"
+    return github_activity.repo_full_name(remote)
 
 
 def _gh_json(args: list[str], repo: Path) -> tuple[bool, Any, str]:
@@ -284,121 +279,21 @@ def _gh_json(args: list[str], repo: Path) -> tuple[bool, Any, str]:
 
 
 def _github(repo: Path, git: dict[str, Any]) -> dict[str, Any]:
-    if not _which("gh"):
-        return {
-            "available": False,
-            "authenticated": False,
-            "repo": _repo_full_name(str(git.get("remote", ""))),
-            "assigned_issues": [],
-            "review_requests": [],
-            "recent_merged_prs": [],
-            "errors": ["gh not on PATH"],
-        }
-
-    auth = _run_command(["gh", "auth", "status"], cwd=repo, timeout=5.0)
-    if not auth["ok"]:
-        return {
-            "available": True,
-            "authenticated": False,
-            "repo": _repo_full_name(str(git.get("remote", ""))),
-            "assigned_issues": [],
-            "review_requests": [],
-            "recent_merged_prs": [],
-            "errors": ["gh not authenticated"],
-        }
-
-    errors: list[str] = []
-    repo_name = _repo_full_name(str(git.get("remote", "")))
-    assigned_ok, assigned, assigned_error = _gh_json(
-        [
-            "gh",
-            "issue",
-            "list",
-            "--state",
-            "open",
-            "--assignee",
-            "@me",
-            "--limit",
-            "5",
-            "--json",
-            "number,title,url,updatedAt,labels",
-        ],
+    return github_activity.collect(
         repo,
+        remote=str(git.get("remote", "")),
+        which_func=_which,
+        command_runner=_run_command,
+        json_runner=_gh_json,
     )
-    if not assigned_ok:
-        errors.append(f"issues: {assigned_error}")
-
-    reviews_ok, reviews, reviews_error = _gh_json(
-        [
-            "gh",
-            "pr",
-            "list",
-            "--state",
-            "open",
-            "--search",
-            "review-requested:@me",
-            "--limit",
-            "5",
-            "--json",
-            "number,title,url,updatedAt,author",
-        ],
-        repo,
-    )
-    if not reviews_ok:
-        errors.append(f"review requests: {reviews_error}")
-
-    merged_ok, merged, merged_error = _gh_json(
-        [
-            "gh",
-            "pr",
-            "list",
-            "--state",
-            "merged",
-            "--limit",
-            "20",
-            "--json",
-            "number,title,url,mergedAt,body",
-        ],
-        repo,
-    )
-    if not merged_ok:
-        errors.append(f"merged PRs: {merged_error}")
-
-    merged_prs = _recent_merged_prs(merged) if isinstance(merged, list) else []
-    return {
-        "available": True,
-        "authenticated": True,
-        "repo": repo_name,
-        "assigned_issues": assigned if isinstance(assigned, list) else [],
-        "review_requests": reviews if isinstance(reviews, list) else [],
-        "recent_merged_prs": merged_prs,
-        "errors": errors,
-    }
 
 
 def _recent_merged_prs(prs: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    sorted_prs = sorted(prs, key=lambda pr: str(pr.get("mergedAt", "") or ""), reverse=True)
-    return [_summarize_pr(pr) for pr in sorted_prs[:5]]
+    return github_activity.recent_merged_prs(prs)
 
 
 def _summarize_pr(pr: dict[str, Any]) -> dict[str, Any]:
-    title = str(pr.get("title", "") or "")
-    body = str(pr.get("body", "") or "")
-    summary = ""
-    for line in body.splitlines():
-        stripped = line.strip().strip("-* ")
-        if stripped and not stripped.startswith("#"):
-            summary = stripped
-            break
-    if not summary:
-        summary = title
-    return {
-        "number": pr.get("number"),
-        "title": title,
-        "url": pr.get("url", ""),
-        "mergedAt": pr.get("mergedAt", ""),
-        "what_shipped": summary[:220],
-    }
+    return github_activity.summarize_pr(pr)
 
 
 def _runtime(repo: Path) -> dict[str, Any]:
@@ -584,15 +479,31 @@ def render_human(report: dict[str, Any]) -> None:
     elif not github["authenticated"]:
         console.print("  gh not authenticated; run `gh auth login` to include business tasks.")
     else:
+        summary = github.get("summary") or {}
+        sections = github.get("sections") or {}
         console.print(
-            f"  assigned issues: {len(github['assigned_issues'])}  "
-            f"review requests: {len(github['review_requests'])}  "
-            f"recent merged PRs: {len(github['recent_merged_prs'])}"
+            f"  tasks assigned: {summary.get('assigned_tasks', len(github['assigned_issues']))}  "
+            f"attention: {summary.get('attention_requests', len(github['review_requests']))}  "
+            f"open proposals: {summary.get('open_proposals', 0)}  "
+            "shipped this week: "
+            f"{summary.get('shipped_this_week', len(github['recent_merged_prs']))}"
         )
-        for issue in github["assigned_issues"][:3]:
-            console.print(f"  - issue #{issue['number']}: {issue['title']}")
-        for pr in github["recent_merged_prs"][:3]:
+        assigned_tasks = sections.get("assigned_tasks") or github["assigned_issues"]
+        attention_requests = sections.get("attention_requests") or github["review_requests"]
+        open_proposals = sections.get("open_proposals") or []
+        shipped = sections.get("shipped_this_week") or github["recent_merged_prs"]
+        blocked_or_stale = sections.get("blocked_or_stale_tasks") or []
+        for issue in assigned_tasks[:3]:
+            console.print(f"  - task #{issue['number']}: {issue['title']}")
+        for item in attention_requests[:3]:
+            reason = item.get("reason", "Needs attention")
+            console.print(f"  - attention #{item['number']}: {item['title']} ({reason})")
+        for pr in open_proposals[:3]:
+            console.print(f"  - proposal #{pr['number']}: {pr['title']}")
+        for pr in shipped[:3]:
             console.print(f"  - shipped #{pr['number']}: {pr['what_shipped']}")
+        for issue in blocked_or_stale[:3]:
+            console.print(f"  - blocked/stale #{issue['number']}: {issue['title']}")
         for error in github["errors"][:2]:
             console.print(f"  [yellow]degraded:[/yellow] {error}")
 

--- a/mb/tests/test_status.py
+++ b/mb/tests/test_status.py
@@ -305,7 +305,19 @@ def test_status_github_activity_business_sections(tmp_path: Path, monkeypatch) -
             if "--author" in args:
                 return True, [{"number": 8, "title": "Open proposal"}], ""
             if state == "merged":
-                return True, [{"number": 9, "title": "Merged", "body": "- Launched"}], ""
+                return (
+                    True,
+                    [
+                        {
+                            "number": index,
+                            "title": f"Merged {index}",
+                            "body": f"- Launched {index}",
+                            "mergedAt": f"2026-05-0{index}T00:00:00Z",
+                        }
+                        for index in range(1, 8)
+                    ],
+                    "",
+                )
         return True, [], ""
 
     monkeypatch.setattr(status_mod, "_gh_json", fake_gh_json)
@@ -319,14 +331,16 @@ def test_status_github_activity_business_sections(tmp_path: Path, monkeypatch) -
         "assigned_tasks": 1,
         "attention_requests": 3,
         "open_proposals": 1,
-        "shipped_this_week": 1,
+        "shipped_this_week": 7,
         "recently_closed_tasks": 1,
         "blocked_or_stale_tasks": 2,
     }
     assert sections["assigned_tasks"][0]["business_status"] == "assigned"
     assert sections["attention_requests"][0]["type"] == "proposal"
     assert sections["open_proposals"][0]["business_status"] == "open_proposal"
-    assert sections["shipped_this_week"][0]["what_shipped"] == "Launched"
+    assert len(sections["shipped_this_week"]) == 5
+    assert sections["shipped_this_week"][0]["number"] == 7
+    assert sections["shipped_this_week"][0]["what_shipped"] == "Launched 7"
     assert sections["recently_closed_tasks"][0]["business_status"] == "closed"
     assert sections["blocked_or_stale_tasks"][0]["labels"] == ["blocked"]
 
@@ -388,5 +402,7 @@ def test_status_renderer_prints_optional_sections(capsys) -> None:
     assert "Stale proposed/running decisions" in output
     assert "Recent research" in output
     assert "Recent git activity" in output
+    assert "tasks assigned: 1" in output
+    assert "shipped this week: 1" in output
     assert "task #173" in output
     assert "shipped #192" in output

--- a/mb/tests/test_status.py
+++ b/mb/tests/test_status.py
@@ -44,6 +44,8 @@ def test_status_json_degrades_without_github(tmp_path: Path, monkeypatch) -> Non
     assert report["repo"]["looks_like_mainbranch_repo"] is True
     assert report["runtime"]["skill_wiring"]["ok"] is True
     assert report["github"]["authenticated"] is False
+    assert report["github"]["source"] == "gh"
+    assert "assigned_tasks" in report["github"]["sections"]
     assert report["brain"]["counts"]["decisions"] == 1
     assert report["brain"]["recent_research"][0]["title"] == "Market"
     assert "readiness" in report
@@ -200,10 +202,14 @@ def test_status_github_authenticated_branches(tmp_path: Path, monkeypatch) -> No
     )
 
     def fake_gh_json(args: list[str], repo: Path) -> tuple[bool, Any, str]:
-        if args[1:3] == ["issue", "list"]:
+        if args[1:3] == ["issue", "list"] and "--assignee" in args:
             return True, [{"number": 173, "title": "Status", "url": "u"}], ""
-        if args[1:3] == ["pr", "list"] and "--search" in args:
+        if args[1:3] == ["pr", "list"] and "review-requested:@me" in args:
             return False, None, "search failed"
+        if args[1:3] == ["issue", "list"]:
+            return True, [], ""
+        if args[1:3] == ["pr", "list"] and "--state" in args and "open" in args:
+            return True, [], ""
         return (
             True,
             [
@@ -232,6 +238,8 @@ def test_status_github_authenticated_branches(tmp_path: Path, monkeypatch) -> No
     assert github["authenticated"] is True
     assert github["repo"] == "noontide-co/mainbranch"
     assert github["assigned_issues"][0]["number"] == 173
+    assert github["sections"]["assigned_tasks"][0]["type"] == "task"
+    assert github["summary"]["assigned_tasks"] == 1
     assert github["recent_merged_prs"][0]["number"] == 192
     assert github["recent_merged_prs"][0]["what_shipped"] == "Shipped status"
     assert github["errors"] == ["review requests: search failed"]
@@ -256,6 +264,71 @@ def test_status_github_authenticated_branches(tmp_path: Path, monkeypatch) -> No
         lambda args, cwd=None, timeout=3.0: {"ok": False, "stdout": "", "stderr": "no auth"},
     )
     assert status_mod._github(tmp_path, {"remote": ""})["authenticated"] is False
+
+
+def test_status_github_activity_business_sections(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(status_mod, "_which", lambda name: "/usr/bin/gh" if name == "gh" else "")
+    monkeypatch.setattr(
+        status_mod,
+        "_run_command",
+        lambda args, cwd=None, timeout=3.0: {"ok": True, "stdout": "", "stderr": ""},
+    )
+
+    def value_after(args: list[str], flag: str) -> str:
+        if flag not in args:
+            return ""
+        return args[args.index(flag) + 1]
+
+    def fake_gh_json(args: list[str], repo: Path) -> tuple[bool, Any, str]:
+        state = value_after(args, "--state")
+        search = value_after(args, "--search")
+        if args[1:3] == ["issue", "list"]:
+            if "--assignee" in args:
+                return True, [{"number": 1, "title": "Assigned", "labels": []}], ""
+            if state == "closed":
+                return True, [{"number": 2, "title": "Closed", "closedAt": "2026-05-02"}], ""
+            if search == "mentions:@me":
+                return True, [{"number": 3, "title": "Mentioned task"}], ""
+            if search == "label:blocked":
+                return (
+                    True,
+                    [{"number": 4, "title": "Blocked", "labels": [{"name": "blocked"}]}],
+                    "",
+                )
+            if search == "label:stale":
+                return True, [{"number": 5, "title": "Stale", "labels": [{"name": "stale"}]}], ""
+        if args[1:3] == ["pr", "list"]:
+            if search == "review-requested:@me":
+                return True, [{"number": 6, "title": "Review me", "author": {"login": "devon"}}], ""
+            if search == "mentions:@me":
+                return True, [{"number": 7, "title": "Mentioned proposal"}], ""
+            if "--author" in args:
+                return True, [{"number": 8, "title": "Open proposal"}], ""
+            if state == "merged":
+                return True, [{"number": 9, "title": "Merged", "body": "- Launched"}], ""
+        return True, [], ""
+
+    monkeypatch.setattr(status_mod, "_gh_json", fake_gh_json)
+    github = status_mod._github(
+        tmp_path,
+        {"remote": "https://github.com/noontide-co/mainbranch.git"},
+    )
+
+    sections = github["sections"]
+    assert github["summary"] == {
+        "assigned_tasks": 1,
+        "attention_requests": 3,
+        "open_proposals": 1,
+        "shipped_this_week": 1,
+        "recently_closed_tasks": 1,
+        "blocked_or_stale_tasks": 2,
+    }
+    assert sections["assigned_tasks"][0]["business_status"] == "assigned"
+    assert sections["attention_requests"][0]["type"] == "proposal"
+    assert sections["open_proposals"][0]["business_status"] == "open_proposal"
+    assert sections["shipped_this_week"][0]["what_shipped"] == "Launched"
+    assert sections["recently_closed_tasks"][0]["business_status"] == "closed"
+    assert sections["blocked_or_stale_tasks"][0]["labels"] == ["blocked"]
 
 
 def test_status_renderer_prints_optional_sections(capsys) -> None:
@@ -315,5 +388,5 @@ def test_status_renderer_prints_optional_sections(capsys) -> None:
     assert "Stale proposed/running decisions" in output
     assert "Recent research" in output
     assert "Recent git activity" in output
-    assert "issue #173" in output
+    assert "task #173" in output
     assert "shipped #192" in output


### PR DESCRIPTION
## Summary
- Adds reusable `gh`-backed GitHub activity primitives for `mb status` and downstream `/start` or dashboard consumers.
- Expands `mb status --json` with business-language sections for assigned tasks, attention requests, open proposals, shipped proposals this week, recently closed tasks, and blocked/stale task signals.
- Preserves degraded output for missing or unauthenticated `gh`, plus legacy JSON aliases for existing status consumers.
- Updates human `mb status` output to summarize GitHub work as tasks, attention, proposals, and shipped activity.

## Scope
- In: model-free GitHub activity collection through `gh`, stable JSON sections, business-language summaries, degraded auth/missing-tool output, and status tests.
- Out: Slack, background sync, dashboard UI, model-generated summaries, and new credential storage beyond `gh` auth.

## Commits
- `ed98d17` — `[add] GitHub activity briefing primitives`.
- `ee3c08b` — `[fix] Count all shipped activity`.

## Release / Issues
- Release: v0.2.1
- Linear ID(s): MAIN-182
- Closes: #188
- Refs: #173
- Follow-ups: none required from this slice.

## Success Metric
- `mb status --json` exposes business-relevant GitHub work without requiring an agent to scrape raw GitHub state every time.

## Validation
- Level 0 docs/decision: read `decisions/2026-05-02-github-native-business-os.md`, `docs/prd/v0-2-first-run-daily-briefing.md`, `docs/prd/v0-2-agent-workflow-and-evals.md`, and `docs/compatibility.md`; no durable docs changed.
- Level 1 static: `scripts/check.sh` passed from repo root.
- Level 2 CLI: `cd mb && pytest tests/test_status.py -q` passed; `cd mb && python3 -m mb status mb/_data/fixtures/acme-brewing --json` passed.
- Level 3 package/install: not run; package/install behavior was not changed.
- Level 4 fixture repo: fixture status JSON smoke passed against `mb/_data/fixtures/acme-brewing`.
- Level 5 runtime smoke: not run; this changes deterministic CLI primitives only and does not alter runtime launch or Claude Code skill discovery.

## Public / Private Boundary
- No private Devon, Conductor, customer, or runtime-specific details were added to committed files.
- `.context/cold-start.md` remained gitignored scratch context only.
