### PR TITLE
[add] Required stale install alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,8 +231,10 @@ Create a separate repo for each brand. If they share the same soul and voice, th
 `pipx upgrade mainbranch`, or run `/pull` inside Claude Code.
 
 If `mb --version` still says `0.1.x`, run `pipx upgrade mainbranch` once before
-using `mb update`. Existing business repos should then run
-`mb skill link --repo .` from the repo root. See
+using `mb update`; old installs now surface this as an in-product
+"Update required" alert on the main launch, doctor, status, and start
+surfaces. Existing business repos should then run `mb skill link --repo .` and
+`mb doctor` from the repo root. See
 [docs/MIGRATING.md](docs/MIGRATING.md) for the old-repo path.
 
 **Can I edit the skills?**

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -70,6 +70,20 @@ runs the appropriate update path, and refreshes skill links. Use
 Inside Claude Code, `/pull` calls `mb update` for this mechanical step and keeps
 ownership of the human-readable "what's new" summary.
 
+Early `0.1.x` installs do not have `mb update` yet. If `mb`, `mb doctor`,
+`mb status`, or `mb start` says "Update required", run this once first:
+
+```bash
+pipx upgrade mainbranch
+```
+
+Then run these from your business repo:
+
+```bash
+mb skill link --repo .
+mb doctor
+```
+
 ## Known Limits
 
 - Claude Code is the only first-class agent runtime today.

--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import sys
+from pathlib import Path
 from typing import Any
 
 import typer
@@ -25,6 +26,7 @@ from mb import status as status_mod
 from mb import think as think_mod
 from mb import update as update_mod
 from mb import validate as validate_mod
+from mb.freshness import format_update_alert, looks_like_business_repo, package_update_status
 
 app = typer.Typer(
     name="mb",
@@ -56,25 +58,29 @@ def _is_interactive_terminal() -> bool:
 
 
 def _render_launch_screen() -> None:
-    typer.echo(
-        "\n".join(
-            [
-                "",
-                "Main Branch",
-                "Stay connected to the business while agents handle execution.",
-                "",
-                "Choose a trail:",
-                "  New here      mb onboard       guided setup",
-                "  Daily work    mb status        business/repo briefing",
-                "                mb start         open the agent runtime",
-                "  Broken setup  mb doctor        check git, GitHub, Claude Code, and skills",
-                "  Power user    mb --help        full command list",
-                "",
-                "Plain command reference: mb --plain",
-                "",
-            ]
-        )
+    cwd = Path.cwd().resolve()
+    repo = cwd if looks_like_business_repo(cwd) else None
+    alert = format_update_alert(package_update_status(repo))
+    lines = [""]
+    if alert:
+        lines.extend([alert, ""])
+    lines.extend(
+        [
+            "Main Branch",
+            "Stay connected to the business while agents handle execution.",
+            "",
+            "Choose a trail:",
+            "  New here      mb onboard       guided setup",
+            "  Daily work    mb status        business/repo briefing",
+            "                mb start         open the agent runtime",
+            "  Broken setup  mb doctor        check git, GitHub, Claude Code, and skills",
+            "  Power user    mb --help        full command list",
+            "",
+            "Plain command reference: mb --plain",
+            "",
+        ]
     )
+    typer.echo("\n".join(lines))
 
 
 @app.callback()

--- a/mb/mb/doctor.py
+++ b/mb/mb/doctor.py
@@ -14,13 +14,11 @@ import shutil
 import socket
 import subprocess
 import sys
-import urllib.error
-import urllib.request
 from pathlib import Path
 from typing import Any
 
-from mb import __version__
 from mb.engine import install_mode, link_status
+from mb.freshness import format_update_alert, package_update_status, version_key
 
 CLOUD_PREFIXES = (
     "Library/Mobile Documents",  # iCloud Drive
@@ -70,63 +68,53 @@ def _rsvg() -> tuple[bool, str]:
     return False, "rsvg-convert missing (brew install librsvg)"
 
 
-def _version_key(version: str) -> tuple[int, ...]:
-    parts: list[int] = []
-    for piece in version.split("."):
-        digits = ""
-        for char in piece:
-            if not char.isdigit():
-                break
-            digits += char
-        parts.append(int(digits or "0"))
-    return tuple(parts)
-
-
-def _latest_pypi_version(timeout: float = 3.0) -> str:
-    with urllib.request.urlopen("https://pypi.org/pypi/mainbranch/json", timeout=timeout) as resp:
-        data = resp.read().decode("utf-8")
-    import json
-
-    parsed = json.loads(data)
-    version = parsed.get("info", {}).get("version", "")
-    return version if isinstance(version, str) else ""
-
-
-def _mainbranch_version_check() -> dict[str, Any]:
+def _mainbranch_version_check(update: dict[str, Any]) -> dict[str, Any]:
     mode = install_mode()
-    if mode in {"clone", "source"}:
+    severity = str(update["severity"])
+    latest = str(update["latest"])
+    installed = str(update["installed"])
+
+    if mode in {"clone", "source"} and severity not in {"required", "recommended"}:
         return {
             "name": "mainbranch-version",
             "ok": True,
-            "detail": f"{__version__} ({mode} mode)",
+            "detail": f"{update['installed']} ({mode} mode)",
             "severity": "info",
         }
 
-    try:
-        latest = _latest_pypi_version()
-    except (OSError, TimeoutError, urllib.error.URLError):
+    if severity == "unknown":
         return {
             "name": "mainbranch-version",
             "ok": True,
-            "detail": f"{__version__}; could not check PyPI for latest",
+            "detail": f"{installed}; could not check PyPI for latest",
             "severity": "info",
         }
 
-    if latest and _version_key(latest) > _version_key(__version__):
+    if severity == "required":
         return {
             "name": "mainbranch-version",
             "ok": False,
             "detail": (
-                f"installed {__version__}, latest is {latest}. "
-                "Run `pipx upgrade mainbranch`; for context run "
-                "`mb educational upgrading-mainbranch`."
+                f"installed {installed}; minimum supported is {update['minimum_supported']}. "
+                f"Run `{update['command']}`."
+            ),
+            "severity": "error",
+        }
+
+    if severity == "recommended" or (latest and version_key(latest) > version_key(installed)):
+        return {
+            "name": "mainbranch-version",
+            "ok": False,
+            "detail": (
+                f"installed {installed}, latest is {latest}. "
+                f"Run `{update['command']}` when you can."
             ),
             "severity": "warn",
         }
     return {
         "name": "mainbranch-version",
         "ok": True,
-        "detail": f"{__version__} is current" if latest else __version__,
+        "detail": f"{installed} is current" if latest else installed,
     }
 
 
@@ -196,6 +184,7 @@ def run(path: str) -> dict[str, Any]:
     """Run all checks, return a structured report dict."""
     repo = Path(path).resolve()
     checks: list[dict[str, Any]] = []
+    update = package_update_status(repo)
 
     cc_path = _which("claude")
     checks.append(
@@ -248,7 +237,7 @@ def run(path: str) -> dict[str, Any]:
         }
     )
 
-    checks.append(_mainbranch_version_check())
+    checks.append(_mainbranch_version_check(update))
     checks.append(_repo_layout_check(repo))
 
     cloud_hits = _detect_cloud_paths(repo)
@@ -286,6 +275,7 @@ def run(path: str) -> dict[str, Any]:
         "ok": overall and not hard_fail,
         "checks": checks,
         "repo": str(repo),
+        "update": update,
         "python": sys.version.split()[0],
     }
 
@@ -296,6 +286,10 @@ def render_human(report: dict[str, Any]) -> None:
 
     console = Console()
     console.print(f"\n[bold]mb doctor[/bold]  {report['repo']}\n")
+    alert = format_update_alert(report.get("update", {}))
+    if alert:
+        console.print(alert)
+        console.print()
     for c in report["checks"]:
         sev = c.get("severity", "ok")
         if c["ok"]:

--- a/mb/mb/freshness.py
+++ b/mb/mb/freshness.py
@@ -12,6 +12,7 @@ from mb import __version__
 from mb.engine import install_mode
 
 MINIMUM_SUPPORTED_VERSION = "0.2.0"
+# `mb update` first shipped in the same release as the current support floor.
 MB_UPDATE_AVAILABLE_VERSION = "0.2.0"
 PYPI_PACKAGE_URL = "https://pypi.org/pypi/mainbranch/json"
 _LATEST_AUTO = object()
@@ -50,8 +51,7 @@ def looks_like_business_repo(repo: Path) -> bool:
 
 
 def _post_update_commands(repo: str | Path | None) -> list[str]:
-    if repo is None:
-        return []
+    _ = repo
     return ["mb skill link --repo .", "mb doctor"]
 
 

--- a/mb/mb/freshness.py
+++ b/mb/mb/freshness.py
@@ -1,0 +1,158 @@
+"""Shared package freshness metadata and beginner-safe update copy."""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+from mb import __version__
+from mb.engine import install_mode
+
+MINIMUM_SUPPORTED_VERSION = "0.2.0"
+MB_UPDATE_AVAILABLE_VERSION = "0.2.0"
+PYPI_PACKAGE_URL = "https://pypi.org/pypi/mainbranch/json"
+_LATEST_AUTO = object()
+
+
+def version_key(version: str) -> tuple[int, ...]:
+    parts: list[int] = []
+    for piece in version.split("."):
+        digits = ""
+        for char in piece:
+            if not char.isdigit():
+                break
+            digits += char
+        parts.append(int(digits or "0"))
+    return tuple(parts)
+
+
+def latest_pypi_version(timeout: float = 3.0) -> str | None:
+    try:
+        with urllib.request.urlopen(PYPI_PACKAGE_URL, timeout=timeout) as response:
+            data = json.loads(response.read().decode("utf-8"))
+    except (OSError, TimeoutError, urllib.error.URLError, json.JSONDecodeError):
+        return None
+    info = data.get("info", {})
+    version = info.get("version") if isinstance(info, dict) else None
+    return version if isinstance(version, str) and version else None
+
+
+def looks_like_business_repo(repo: Path) -> bool:
+    return (repo / "CLAUDE.md").is_file() and (
+        (repo / "core").is_dir()
+        or (repo / "reference" / "core").exists()
+        or (repo / "research").is_dir()
+        or (repo / "decisions").is_dir()
+    )
+
+
+def _post_update_commands(repo: str | Path | None) -> list[str]:
+    if repo is None:
+        return []
+    return ["mb skill link --repo .", "mb doctor"]
+
+
+def package_update_status(
+    repo: str | Path | None = None,
+    *,
+    installed_version: str = __version__,
+    latest_version: Any = _LATEST_AUTO,
+    minimum_supported: str = MINIMUM_SUPPORTED_VERSION,
+    mode: str | None = None,
+) -> dict[str, Any]:
+    """Return stable update metadata for CLI JSON and skill consumers."""
+    mode = install_mode() if mode is None else mode
+    latest = (
+        latest_pypi_version()
+        if latest_version is _LATEST_AUTO and mode not in {"clone", "source"}
+        else latest_version
+    )
+    if latest is _LATEST_AUTO:
+        latest = None
+    latest_text = latest if isinstance(latest, str) else ""
+
+    installed_key = version_key(installed_version)
+    minimum_key = version_key(minimum_supported)
+    latest_key = version_key(latest_text) if latest_text else ()
+
+    severity = "current"
+    command = ""
+    reason = "Installed version is supported."
+
+    if mode in {"clone", "source"}:
+        reason = f"Package freshness does not apply in {mode} mode."
+    elif installed_key < minimum_key:
+        severity = "required"
+        command = "pipx upgrade mainbranch"
+        if installed_key < version_key(MB_UPDATE_AVAILABLE_VERSION):
+            reason = "Installed version predates mb update and the current skill-link repair flow."
+        else:
+            reason = "Installed version is below the minimum supported Main Branch version."
+    elif latest_text and latest_key > installed_key:
+        severity = "recommended"
+        command = "mb update"
+        reason = "A newer compatible Main Branch package is available."
+    elif latest_version is _LATEST_AUTO and mode not in {"clone", "source"} and not latest_text:
+        severity = "unknown"
+        reason = "Could not check PyPI for the latest Main Branch version."
+    elif latest_text:
+        reason = "Installed version is current."
+
+    return {
+        "installed": installed_version,
+        "latest": latest_text,
+        "minimum_supported": minimum_supported,
+        "severity": severity,
+        "command": command,
+        "post_update_commands": _post_update_commands(repo),
+        "reason": reason,
+    }
+
+
+def format_update_alert(update: dict[str, Any]) -> str:
+    """Render the shared update object as direct beginner-safe terminal copy."""
+    severity = str(update.get("severity", ""))
+    if severity not in {"required", "recommended"}:
+        return ""
+
+    command = str(update.get("command") or "pipx upgrade mainbranch")
+    post_update = [str(cmd) for cmd in update.get("post_update_commands", [])]
+    installed = str(update.get("installed") or "")
+    minimum_supported = str(update.get("minimum_supported") or "")
+
+    if severity == "required":
+        lines = [
+            "Update required.",
+            "",
+            "Your Main Branch install is old enough that setup and skills may not work correctly.",
+            "",
+            "Run this first:",
+            f"  {command}",
+        ]
+        if installed and version_key(installed) < version_key(MB_UPDATE_AVAILABLE_VERSION):
+            lines.extend(
+                [
+                    "",
+                    f"mb update is not available in {installed}; this first update must use pipx.",
+                ]
+            )
+    else:
+        lines = [
+            "Update recommended.",
+            "",
+            "A newer Main Branch version is available. Your install is still supported.",
+            "",
+            "Run:",
+            f"  {command}",
+        ]
+
+    if post_update:
+        lines.extend(["", "Then, from your business repo:"])
+        lines.extend(f"  {cmd}" for cmd in post_update)
+    elif severity == "required" and minimum_supported:
+        lines.extend(["", f"Minimum supported version: {minimum_supported}."])
+
+    return "\n".join(lines)

--- a/mb/mb/start.py
+++ b/mb/mb/start.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any
 
 from mb.engine import install_mode, link_status
+from mb.freshness import format_update_alert, package_update_status
 from mb.status import _looks_like_mainbranch_repo
 
 
@@ -112,10 +113,17 @@ def _build_checks(
     git: dict[str, Any],
     claude_path: str,
     wiring: dict[str, Any],
+    update: dict[str, Any],
 ) -> list[dict[str, Any]]:
     dirty_detail = (
         f"{git['dirty_count']} changed file(s)" if git.get("dirty") else "clean working tree"
     )
+    update_severity = str(update["severity"])
+    update_check_severity = {
+        "required": "error",
+        "recommended": "warn",
+        "unknown": "info",
+    }.get(update_severity, "info")
     return [
         {
             "name": "mainbranch_repo",
@@ -142,6 +150,13 @@ def _build_checks(
                 "Review, commit, or stash local changes before handing substantive work "
                 "to an agent."
             ),
+        },
+        {
+            "name": "mainbranch_update",
+            "ok": update_severity not in {"required", "recommended"},
+            "severity": update_check_severity,
+            "detail": update["reason"],
+            "repair": update["command"],
         },
         {
             "name": "claude_code",
@@ -195,7 +210,8 @@ def run(repo: str = ".", launch: bool = False) -> dict[str, Any]:
     git = _git_status(repo_path)
     claude_path = _which("claude")
     wiring = link_status(repo_path)
-    checks = _build_checks(repo_shape, git, claude_path, wiring)
+    update = package_update_status(repo_path)
+    checks = _build_checks(repo_shape, git, claude_path, wiring, update)
     hard_failures = _hard_failures(checks)
     handoff_ready = not hard_failures
 
@@ -224,6 +240,7 @@ def run(repo: str = ".", launch: bool = False) -> dict[str, Any]:
         "ok": ok,
         "handoff_ready": handoff_ready,
         "repo": {"path": str(repo_path), **repo_shape},
+        "update": update,
         "git": git,
         "runtime": {
             "name": "claude-code",
@@ -257,6 +274,10 @@ def render_human(report: dict[str, Any]) -> None:
     launch = report["launch"]
 
     console.print(f"\n[bold]mb start[/bold]  {repo['path']}\n")
+    alert = format_update_alert(report.get("update", {}))
+    if alert:
+        console.print(alert)
+        console.print()
     console.print(
         "[bold]Repo[/bold] "
         + ("[green]ok[/green]" if repo["looks_like_mainbranch_repo"] else "[red]missing[/red]")

--- a/mb/mb/status.py
+++ b/mb/mb/status.py
@@ -14,6 +14,7 @@ import yaml
 
 from mb import __version__
 from mb.engine import install_mode, link_status
+from mb.freshness import format_update_alert, package_update_status
 
 IMPORTANT_DIRS = (
     "core",
@@ -445,9 +446,11 @@ def _readiness(report: dict[str, Any]) -> dict[str, Any]:
         },
         {
             "name": "install",
-            "ok": bool(report["install"]["ok"]),
+            "ok": bool(report["install"]["ok"]) and report["update"]["severity"] != "required",
             "weight": 15,
-            "repair": "Reinstall Main Branch with `pipx install mainbranch`.",
+            "repair": report["update"]["command"]
+            if report["update"]["severity"] == "required"
+            else "Reinstall Main Branch with `pipx install mainbranch`.",
         },
         {
             "name": "skill_wiring",
@@ -497,10 +500,12 @@ def run(path: str = ".") -> dict[str, Any]:
     repo_path = Path(path).resolve()
     repo_shape = _looks_like_mainbranch_repo(repo_path)
     git = _git_info(repo_path)
+    update = package_update_status(repo_path)
     report: dict[str, Any] = {
         "ok": True,
         "repo": {"path": str(repo_path), **repo_shape},
         "install": _install(),
+        "update": update,
         "runtime": _runtime(repo_path),
         "git": git,
         "git_activity": _git_recent_activity(repo_path, git),
@@ -525,6 +530,10 @@ def render_human(report: dict[str, Any]) -> None:
     readiness = report["readiness"]
 
     console.print(f"\n[bold]mb status[/bold]  {repo['path']}")
+    alert = format_update_alert(report.get("update", {}))
+    if alert:
+        console.print(alert)
+        console.print()
     console.print(
         f"[bold]{readiness['level'].replace('_', ' ')}[/bold]  {readiness['score']}/100\n"
     )

--- a/mb/mb/update.py
+++ b/mb/mb/update.py
@@ -6,13 +6,12 @@ import json
 import re
 import shutil
 import subprocess
-import urllib.error
-import urllib.request
 from pathlib import Path
 from typing import Any
 
 from mb import __version__
 from mb.engine import bundled_skills, engine_root, install_mode
+from mb.freshness import latest_pypi_version
 
 VERSION_RE = re.compile(r'__version__\s*=\s*["\']([^"\']+)["\']')
 CLONE_UPDATE_COMMAND = ["git", "pull", "--ff-only", "origin", "main"]
@@ -47,15 +46,7 @@ def _engine_version(root: Path | None = None) -> str:
 
 
 def _latest_pypi_version(timeout: float = 3.0) -> str | None:
-    url = "https://pypi.org/pypi/mainbranch/json"
-    try:
-        with urllib.request.urlopen(url, timeout=timeout) as response:
-            data = json.loads(response.read().decode("utf-8"))
-    except (OSError, TimeoutError, urllib.error.URLError, json.JSONDecodeError):
-        return None
-    info = data.get("info", {})
-    version = info.get("version") if isinstance(info, dict) else None
-    return version if isinstance(version, str) and version else None
+    return latest_pypi_version(timeout=timeout)
 
 
 def _version_from_git_ref(root: Path, ref: str) -> str | None:

--- a/mb/mb/update.py
+++ b/mb/mb/update.py
@@ -11,7 +11,7 @@ from typing import Any
 
 from mb import __version__
 from mb.engine import bundled_skills, engine_root, install_mode
-from mb.freshness import latest_pypi_version
+from mb.freshness import latest_pypi_version as _latest_pypi_version
 
 VERSION_RE = re.compile(r'__version__\s*=\s*["\']([^"\']+)["\']')
 CLONE_UPDATE_COMMAND = ["git", "pull", "--ff-only", "origin", "main"]
@@ -43,10 +43,6 @@ def _engine_version(root: Path | None = None) -> str:
         if match:
             return match.group(1)
     return __version__
-
-
-def _latest_pypi_version(timeout: float = 3.0) -> str | None:
-    return latest_pypi_version(timeout=timeout)
 
 
 def _version_from_git_ref(root: Path, ref: str) -> str | None:

--- a/mb/tests/test_cli.py
+++ b/mb/tests/test_cli.py
@@ -51,6 +51,34 @@ def test_bare_mb_tty_shows_launch_screen(monkeypatch: pytest.MonkeyPatch) -> Non
     assert "Usage:" not in result.stdout
 
 
+def test_bare_mb_tty_shows_required_update_alert(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cli_mod, "_is_interactive_terminal", lambda: True)
+    monkeypatch.setattr(
+        cli_mod,
+        "package_update_status",
+        lambda repo=None: {
+            "installed": "0.1.0",
+            "latest": "0.2.1",
+            "minimum_supported": "0.2.0",
+            "severity": "required",
+            "command": "pipx upgrade mainbranch",
+            "post_update_commands": [],
+            "reason": (
+                "Installed version predates mb update and the current skill-link repair flow."
+            ),
+        },
+    )
+
+    result = runner.invoke(app, [])
+
+    assert result.exit_code == 0
+    assert result.stdout.index("Update required.") < result.stdout.index("Choose a trail")
+    assert "Your Main Branch install is old enough" in result.stdout
+    assert "pipx upgrade mainbranch" in result.stdout
+    assert "mb update is not available in 0.1.0" in result.stdout
+    assert "Usage:" not in result.stdout
+
+
 def test_plain_escape_hatch_keeps_help_in_tty(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(cli_mod, "_is_interactive_terminal", lambda: True)
 

--- a/mb/tests/test_cli.py
+++ b/mb/tests/test_cli.py
@@ -62,7 +62,7 @@ def test_bare_mb_tty_shows_required_update_alert(monkeypatch: pytest.MonkeyPatch
             "minimum_supported": "0.2.0",
             "severity": "required",
             "command": "pipx upgrade mainbranch",
-            "post_update_commands": [],
+            "post_update_commands": ["mb skill link --repo .", "mb doctor"],
             "reason": (
                 "Installed version predates mb update and the current skill-link repair flow."
             ),
@@ -76,6 +76,8 @@ def test_bare_mb_tty_shows_required_update_alert(monkeypatch: pytest.MonkeyPatch
     assert "Your Main Branch install is old enough" in result.stdout
     assert "pipx upgrade mainbranch" in result.stdout
     assert "mb update is not available in 0.1.0" in result.stdout
+    assert "mb skill link --repo ." in result.stdout
+    assert "mb doctor" in result.stdout
     assert "Usage:" not in result.stdout
 
 

--- a/mb/tests/test_doctor.py
+++ b/mb/tests/test_doctor.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from mb import doctor as doctor_mod
 from mb.doctor import _detect_cloud_paths, _repo_layout_check, run
 from mb.init import run as init_run
 
@@ -16,6 +17,7 @@ def test_doctor_runs_on_empty_dir(tmp_path: Path) -> None:
     assert "skill-wiring" in names
     assert "mainbranch-version" in names
     assert "repo-layout" in names
+    assert "update" in report
 
 
 def test_cloud_path_detection_via_symlink(tmp_path: Path, monkeypatch) -> None:
@@ -68,3 +70,38 @@ def test_repo_layout_accepts_current_core(tmp_path: Path) -> None:
 
     assert check["ok"] is True
     assert "current core/" in check["detail"]
+
+
+def test_doctor_json_and_human_output_include_required_update(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    monkeypatch.setattr(
+        doctor_mod,
+        "package_update_status",
+        lambda repo: {
+            "installed": "0.1.0",
+            "latest": "0.2.1",
+            "minimum_supported": "0.2.0",
+            "severity": "required",
+            "command": "pipx upgrade mainbranch",
+            "post_update_commands": ["mb skill link --repo .", "mb doctor"],
+            "reason": (
+                "Installed version predates mb update and the current skill-link repair flow."
+            ),
+        },
+    )
+
+    report = doctor_mod.run(path=str(tmp_path))
+
+    assert report["ok"] is False
+    assert report["update"]["severity"] == "required"
+    version_check = next(
+        check for check in report["checks"] if check["name"] == "mainbranch-version"
+    )
+    assert version_check["severity"] == "error"
+    assert "minimum supported" in version_check["detail"]
+
+    doctor_mod.render_human(report)
+    output = capsys.readouterr().out
+    assert "Update required." in output
+    assert "pipx upgrade mainbranch" in output

--- a/mb/tests/test_freshness.py
+++ b/mb/tests/test_freshness.py
@@ -34,6 +34,21 @@ def test_required_update_status_for_version_below_minimum(tmp_path: Path) -> Non
     assert "mb doctor" in alert
 
 
+def test_required_update_without_repo_still_has_generic_repair_commands() -> None:
+    update = package_update_status(
+        None,
+        installed_version="0.1.2",
+        latest_version="0.2.1",
+        mode="pipx",
+    )
+
+    assert update["post_update_commands"] == ["mb skill link --repo .", "mb doctor"]
+    alert = format_update_alert(update)
+    assert "Then, from your business repo:" in alert
+    assert "mb skill link --repo ." in alert
+    assert "mb doctor" in alert
+
+
 def test_recommended_update_status_for_supported_stale_version(tmp_path: Path) -> None:
     update = package_update_status(
         tmp_path,

--- a/mb/tests/test_freshness.py
+++ b/mb/tests/test_freshness.py
@@ -1,0 +1,67 @@
+"""Package freshness metadata and update alert copy."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from mb.freshness import format_update_alert, package_update_status
+
+
+def test_required_update_status_for_version_below_minimum(tmp_path: Path) -> None:
+    update = package_update_status(
+        tmp_path,
+        installed_version="0.1.2",
+        latest_version="0.2.1",
+        mode="pipx",
+    )
+
+    assert update == {
+        "installed": "0.1.2",
+        "latest": "0.2.1",
+        "minimum_supported": "0.2.0",
+        "severity": "required",
+        "command": "pipx upgrade mainbranch",
+        "post_update_commands": ["mb skill link --repo .", "mb doctor"],
+        "reason": "Installed version predates mb update and the current skill-link repair flow.",
+    }
+
+    alert = format_update_alert(update)
+    assert "Update required." in alert
+    assert "setup and skills may not work correctly" in alert
+    assert "pipx upgrade mainbranch" in alert
+    assert "mb update is not available in 0.1.2" in alert
+    assert "mb skill link --repo ." in alert
+    assert "mb doctor" in alert
+
+
+def test_recommended_update_status_for_supported_stale_version(tmp_path: Path) -> None:
+    update = package_update_status(
+        tmp_path,
+        installed_version="0.2.0",
+        latest_version="0.2.1",
+        mode="pipx",
+    )
+
+    assert update["severity"] == "recommended"
+    assert update["command"] == "mb update"
+    assert update["installed"] == "0.2.0"
+    assert update["latest"] == "0.2.1"
+    assert update["minimum_supported"] == "0.2.0"
+
+    alert = format_update_alert(update)
+    assert "Update recommended." in alert
+    assert "Your install is still supported" in alert
+    assert "mb update" in alert
+
+
+def test_current_source_install_does_not_render_alert(tmp_path: Path) -> None:
+    update = package_update_status(
+        tmp_path,
+        installed_version="0.2.0",
+        latest_version="0.2.1",
+        mode="source",
+    )
+
+    assert update["severity"] == "current"
+    assert update["latest"] == "0.2.1"
+    assert format_update_alert(update) == ""

--- a/mb/tests/test_start.py
+++ b/mb/tests/test_start.py
@@ -45,6 +45,7 @@ def test_start_json_prints_ready_handoff(tmp_path: Path, monkeypatch) -> None:
     assert report["command"]["display"].endswith(" && claude")
     assert report["command"]["follow_up"] == "/start"
     assert report["launch"]["requested"] is False
+    assert "update" in report
 
 
 def test_start_degrades_when_claude_is_missing(tmp_path: Path, monkeypatch) -> None:
@@ -60,6 +61,72 @@ def test_start_degrades_when_claude_is_missing(tmp_path: Path, monkeypatch) -> N
     claude_check = next(check for check in report["checks"] if check["name"] == "claude_code")
     assert claude_check["ok"] is False
     assert "Install Claude Code" in claude_check["repair"]
+
+
+def test_start_required_update_blocks_handoff_and_surfaces_json(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(start_mod, "_which", _with_claude)
+    monkeypatch.setattr(
+        start_mod,
+        "package_update_status",
+        lambda repo: {
+            "installed": "0.1.0",
+            "latest": "0.2.1",
+            "minimum_supported": "0.2.0",
+            "severity": "required",
+            "command": "pipx upgrade mainbranch",
+            "post_update_commands": ["mb skill link --repo .", "mb doctor"],
+            "reason": (
+                "Installed version predates mb update and the current skill-link repair flow."
+            ),
+        },
+    )
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+
+    result = runner.invoke(app, ["start", "--repo", str(repo), "--json"])
+
+    assert result.exit_code == 1
+    report = json.loads(result.stdout)
+    assert report["handoff_ready"] is False
+    assert report["update"]["severity"] == "required"
+    update_check = next(check for check in report["checks"] if check["name"] == "mainbranch_update")
+    assert update_check["severity"] == "error"
+    assert update_check["repair"] == "pipx upgrade mainbranch"
+
+    human_result = runner.invoke(app, ["start", "--repo", str(repo)])
+    assert human_result.exit_code == 1
+    assert "Update required." in human_result.stdout
+    assert "pipx upgrade mainbranch" in human_result.stdout
+
+
+def test_start_recommended_update_keeps_handoff_ready(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(start_mod, "_which", _with_claude)
+    monkeypatch.setattr(
+        start_mod,
+        "package_update_status",
+        lambda repo: {
+            "installed": "0.2.0",
+            "latest": "0.2.1",
+            "minimum_supported": "0.2.0",
+            "severity": "recommended",
+            "command": "mb update",
+            "post_update_commands": ["mb skill link --repo .", "mb doctor"],
+            "reason": "A newer compatible Main Branch package is available.",
+        },
+    )
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+
+    result = runner.invoke(app, ["start", "--repo", str(repo), "--json"])
+
+    assert result.exit_code == 0
+    report = json.loads(result.stdout)
+    assert report["handoff_ready"] is True
+    assert report["update"]["severity"] == "recommended"
+    update_check = next(check for check in report["checks"] if check["name"] == "mainbranch_update")
+    assert update_check["severity"] == "warn"
 
 
 def test_start_asks_for_repo_when_path_is_not_business_repo(tmp_path: Path, monkeypatch) -> None:

--- a/mb/tests/test_status.py
+++ b/mb/tests/test_status.py
@@ -47,6 +47,7 @@ def test_status_json_degrades_without_github(tmp_path: Path, monkeypatch) -> Non
     assert report["brain"]["counts"]["decisions"] == 1
     assert report["brain"]["recent_research"][0]["title"] == "Market"
     assert "readiness" in report
+    assert "update" in report
 
 
 def test_status_human_output_mentions_core_sections(tmp_path: Path, monkeypatch) -> None:
@@ -62,6 +63,44 @@ def test_status_human_output_mentions_core_sections(tmp_path: Path, monkeypatch)
     assert "Runtime" in result.stdout
     assert "GitHub" in result.stdout
     assert "Next" in result.stdout
+
+
+def test_status_required_update_json_and_human_copy(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
+    monkeypatch.setattr(
+        status_mod,
+        "package_update_status",
+        lambda repo: {
+            "installed": "0.1.0",
+            "latest": "0.2.1",
+            "minimum_supported": "0.2.0",
+            "severity": "required",
+            "command": "pipx upgrade mainbranch",
+            "post_update_commands": ["mb skill link --repo .", "mb doctor"],
+            "reason": (
+                "Installed version predates mb update and the current skill-link repair flow."
+            ),
+        },
+    )
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+
+    json_result = runner.invoke(app, ["status", str(repo), "--json"])
+
+    assert json_result.exit_code == 0
+    payload = json.loads(json_result.stdout)
+    assert payload["update"]["severity"] == "required"
+    assert payload["update"]["command"] == "pipx upgrade mainbranch"
+    assert any(
+        "pipx upgrade mainbranch" in action for action in payload["readiness"]["next_actions"]
+    )
+
+    human_result = runner.invoke(app, ["status", str(repo)])
+
+    assert human_result.exit_code == 0
+    assert "Update required." in human_result.stdout
+    assert "pipx upgrade mainbranch" in human_result.stdout
+    assert "mb skill link --repo ." in human_result.stdout
 
 
 def test_status_detects_non_business_repo(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- Adds shared stale-install freshness metadata for CLI and agent-facing JSON consumers.
- Shows beginner-safe required/recommended update alerts on bare interactive `mb`, `mb doctor`, `mb status`, and `mb start`.
- Keeps non-TTY, `--help`, `--version`, `--plain`, and JSON surfaces scriptable.
- Documents the `0.1.x` bootstrap path through `pipx upgrade mainbranch`, followed by skill relink and doctor.

## Scope
- In: stable `update` metadata, human alert rendering, launch/doctor/status/start integration, docs, and tests.
- Out: auto-running updates, broad package-manager support, off-product announcement copy, and runtime adapter changes.

## Commits
- `864676e` — `[add] Noob-safe stale install alert`.
- `912c3c4` — `[fix] Include repair steps in launch update alert`.

## Release / Issues
- Release: `oe-v0.2.1` / v0.2.1.
- Linear ID(s): `MAIN-185`.
- Closes: #202.
- Refs: none.
- Follow-ups: packaging metadata currently emits setuptools license deprecation warnings during build; unrelated cleanup can be tracked separately.

## Success Metric
A stale `0.1.x` install sees `Update required`, the exact `pipx upgrade mainbranch` command, and the post-update `mb skill link --repo .` / `mb doctor` repair steps on the beginner-facing `mb` surfaces and in stable JSON.

## Validation
- Level 0 docs/decision: updated README and `docs/compatibility.md` with the `0.1.x` bootstrap path.
- Level 1 static: `scripts/check.sh` passed from repo root; ruff format/check, mypy, 85 tests, 82.53% coverage.
- Level 2 CLI: focused tests passed for freshness, bare `mb`, doctor/status/start JSON, required/recommended severity, and update behavior.
- Level 3 package/install: `python3 -m build` passed; fresh venv wheel smoke passed; direct pipx binary smoke passed with `mb --version` and `mb doctor --json`.
- Level 4 fixture repo: fresh business repo smoke passed with `mb onboard`, `mb doctor`, `mb status`, `mb start --json`, and `mb validate`; required-update human-copy fixture smoke passed for bare `mb`, doctor, status, and start.
- Level 5 runtime smoke: not run; this change stays in deterministic CLI freshness/status/start surfaces and does not change runtime adapter execution.

## Public / Private Boundary
- No private Devon, Conductor, customer/member, or untested runtime details were added to public docs or product copy.
