### PR TITLE
[add] mb validate cross-reference checks

### DIFF
--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -331,10 +331,21 @@ def start_cmd(
 def validate_cmd(
     path: str = typer.Argument(".", help="Repo to validate."),
     verbose: bool = typer.Option(False, "-v", "--verbose"),
+    cross_refs: bool = typer.Option(
+        False,
+        "--cross-refs",
+        help="Check known frontmatter links and offer directory references.",
+    ),
+    strict: bool = typer.Option(False, "--strict", help="Fail on warnings."),
     json_out: bool = typer.Option(False, "--json"),
 ) -> None:
-    """Check the metadata at the top of your files (frontmatter shape)."""
-    report = validate_mod.run(path=path, verbose=verbose)
+    """Check frontmatter shape and optional cross-references."""
+    report = validate_mod.run(
+        path=path,
+        verbose=verbose,
+        cross_refs=cross_refs,
+        strict=strict,
+    )
     if json_out:
         typer.echo(json.dumps(report, indent=2))
     else:

--- a/mb/mb/validate.py
+++ b/mb/mb/validate.py
@@ -38,6 +38,18 @@ LINK_FIELDS = (
     "supersedes",
 )
 
+LOCAL_REF_ROOTS = {
+    "campaigns",
+    "core",
+    "decisions",
+    "docs",
+    "documents",
+    "log",
+    "outputs",
+    "reference",
+    "research",
+}
+
 DECISION_STATUS_ORDER = {
     "proposed": 0,
     "running": 1,
@@ -129,9 +141,13 @@ def _check_one(path: Path, schema: dict[str, Any]) -> dict[str, Any]:
 
 def _is_hidden_or_generated(path: Path, repo: Path) -> bool:
     rel_parts = path.relative_to(repo).parts
-    return any(
-        part.startswith(".") or part in {"__pycache__", "node_modules", ".venv", "venv"}
-        for part in rel_parts
+    is_bundled_data = rel_parts[:2] == ("mb", "_data") or rel_parts[:1] == ("_data",)
+    return (
+        any(
+            part.startswith(".") or part in {"__pycache__", "node_modules", ".venv", "venv"}
+            for part in rel_parts
+        )
+        or is_bundled_data
     )
 
 
@@ -157,7 +173,15 @@ def _coerce_refs(value: Any) -> tuple[list[str], bool]:
 
 def _is_external_ref(ref: str) -> bool:
     parsed = urlparse(ref)
-    return bool(parsed.scheme) or ref.startswith("#")
+    if bool(parsed.scheme) or ref.startswith("#"):
+        return True
+    parts = Path(_clean_ref(ref)).parts
+    return (
+        len(parts) > 1
+        and parts[0] not in {".", ".."}
+        and parts[0] not in LOCAL_REF_ROOTS
+        and parts[1] in LOCAL_REF_ROOTS
+    )
 
 
 def _clean_ref(ref: str) -> str:
@@ -392,6 +416,10 @@ def run(
     warning_count = sum(len(f.get("warnings", [])) for f in files)
     error_count = sum(len(f.get("errors", [])) for f in files)
     ok = error_count == 0 and (warning_count == 0 or not strict)
+    if strict:
+        for file_result in files:
+            if file_result.get("warnings"):
+                file_result["ok"] = False
     return {
         "ok": ok,
         "files": files,

--- a/mb/mb/validate.py
+++ b/mb/mb/validate.py
@@ -1,7 +1,8 @@
-"""``mb validate`` — frontmatter shape only (v0.1).
+"""``mb validate`` — frontmatter and optional cross-reference checks.
 
-Hard-coded schema per the master decision. No cross-reference validation.
-No content rules. Per-file pass/fail. Exit 1 on any fail.
+Hard-coded schema per the master decision. Cross-reference validation is
+opt-in because local authoring should warn by default and CI can opt into
+strict mode. Per-file frontmatter errors always fail.
 
 The schemas tolerate extras; only listed required keys are checked.
 """
@@ -10,6 +11,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
 import yaml
 
@@ -25,6 +27,34 @@ OFFER_STATUS = {
     "rejected",
 }
 RESEARCH_STATUS = {"complete", "in-progress", "stale"}
+
+LINK_FIELDS = (
+    "linked_research",
+    "linked_decision",
+    "linked_decisions",
+    "linked_prd",
+    "linked_prds",
+    "related_prds",
+    "supersedes",
+)
+
+DECISION_STATUS_ORDER = {
+    "proposed": 0,
+    "running": 1,
+    "accepted": 2,
+    "rejected": 2,
+    "superseded": 2,
+}
+OFFER_STATUS_ORDER = {
+    "proposed": 0,
+    "running": 1,
+    "accepted": 1,
+    "rejected": 1,
+    "scaling": 2,
+    "killed": 3,
+    "graduated": 3,
+    "died": 3,
+}
 
 SCHEMAS: dict[str, dict[str, Any]] = {
     "decisions": {
@@ -85,7 +115,7 @@ def _read_frontmatter(path: Path) -> tuple[dict[str, Any] | None, str | None]:
 def _check_one(path: Path, schema: dict[str, Any]) -> dict[str, Any]:
     fm, err = _read_frontmatter(path)
     if err is not None:
-        return {"path": str(path), "ok": False, "errors": [err]}
+        return {"path": str(path), "ok": False, "errors": [err], "warnings": []}
     assert fm is not None
     errors: list[str] = []
     for k in schema["required"]:
@@ -94,23 +124,282 @@ def _check_one(path: Path, schema: dict[str, Any]) -> dict[str, Any]:
     for k, allowed in schema.get("enums", {}).items():
         if k in fm and fm[k] not in allowed:
             errors.append(f"{k}={fm[k]!r} not in {sorted(allowed)}")
-    return {"path": str(path), "ok": not errors, "errors": errors}
+    return {"path": str(path), "ok": not errors, "errors": errors, "warnings": []}
 
 
-def run(path: str, verbose: bool = False) -> dict[str, Any]:
+def _is_hidden_or_generated(path: Path, repo: Path) -> bool:
+    rel_parts = path.relative_to(repo).parts
+    return any(
+        part.startswith(".") or part in {"__pycache__", "node_modules", ".venv", "venv"}
+        for part in rel_parts
+    )
+
+
+def _iter_frontmatter_files(repo: Path) -> list[Path]:
+    return [
+        f
+        for f in sorted(repo.rglob("*.md"))
+        if f.is_file() and not _is_hidden_or_generated(f, repo)
+    ]
+
+
+def _coerce_refs(value: Any) -> tuple[list[str], bool]:
+    if value is None:
+        return [], True
+    if isinstance(value, str):
+        return [value], True
+    if isinstance(value, list):
+        return [item for item in value if isinstance(item, str)], all(
+            isinstance(item, str) for item in value
+        )
+    return [], False
+
+
+def _is_external_ref(ref: str) -> bool:
+    parsed = urlparse(ref)
+    return bool(parsed.scheme) or ref.startswith("#")
+
+
+def _clean_ref(ref: str) -> str:
+    without_anchor = ref.split("#", 1)[0]
+    return without_anchor.split("?", 1)[0].strip()
+
+
+def _status_order_for(path: Path) -> dict[str, int] | None:
+    parts = path.parts
+    if "decisions" in parts:
+        return DECISION_STATUS_ORDER
+    if "offers" in parts or "campaigns" in parts:
+        return OFFER_STATUS_ORDER
+    return None
+
+
+def _finding(
+    *,
+    code: str,
+    source: Path,
+    repo: Path,
+    field: str,
+    target: str,
+    message: str,
+) -> dict[str, str]:
+    return {
+        "code": code,
+        "path": str(source.relative_to(repo)),
+        "field": field,
+        "target": target,
+        "message": message,
+    }
+
+
+def _add_file_warning(
+    files_by_path: dict[str, dict[str, Any]],
+    *,
+    repo: Path,
+    source: Path,
+    message: str,
+) -> None:
+    rel = str(source.relative_to(repo))
+    if rel not in files_by_path:
+        files_by_path[rel] = {
+            "path": rel,
+            "ok": True,
+            "errors": [],
+            "warnings": [],
+            "schema": "cross-refs",
+        }
+    files_by_path[rel].setdefault("warnings", []).append(message)
+
+
+def _check_status_transition(
+    *,
+    source: Path,
+    target: Path,
+    repo: Path,
+    field: str,
+    ref: str,
+    source_fm: dict[str, Any],
+    findings: list[dict[str, str]],
+) -> None:
+    if field != "supersedes":
+        return
+    source_order = _status_order_for(source.relative_to(repo))
+    target_order = _status_order_for(target.relative_to(repo))
+    if source_order is None or target_order is None or source_order is not target_order:
+        return
+    source_status = source_fm.get("status")
+    target_fm, target_err = _read_frontmatter(target)
+    if target_err is not None or target_fm is None:
+        return
+    target_status = target_fm.get("status")
+    if not isinstance(source_status, str) or not isinstance(target_status, str):
+        return
+    if source_status not in source_order or target_status not in source_order:
+        return
+    if source_order[source_status] < source_order[target_status]:
+        findings.append(
+            _finding(
+                code="status-transition",
+                source=source,
+                repo=repo,
+                field=field,
+                target=ref,
+                message=(
+                    f"{field} target {ref!r} is status {target_status!r}; "
+                    f"source status {source_status!r} would move backward"
+                ),
+            )
+        )
+
+
+def _check_cross_refs(
+    repo: Path,
+    files_by_path: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    findings: list[dict[str, str]] = []
+    orphan_offers: list[dict[str, str]] = []
+
+    for source in _iter_frontmatter_files(repo):
+        fm, err = _read_frontmatter(source)
+        if err is not None or fm is None:
+            continue
+        for field in LINK_FIELDS:
+            if field not in fm:
+                continue
+            refs, valid_type = _coerce_refs(fm.get(field))
+            if not valid_type:
+                findings.append(
+                    _finding(
+                        code="invalid-link-field",
+                        source=source,
+                        repo=repo,
+                        field=field,
+                        target="",
+                        message=f"{field} must be a string or list of strings",
+                    )
+                )
+                continue
+            for ref in refs:
+                if _is_external_ref(ref):
+                    continue
+                clean_ref = _clean_ref(ref)
+                if not clean_ref:
+                    continue
+                target = (repo / clean_ref).resolve()
+                try:
+                    target.relative_to(repo)
+                except ValueError:
+                    findings.append(
+                        _finding(
+                            code="target-outside-repo",
+                            source=source,
+                            repo=repo,
+                            field=field,
+                            target=ref,
+                            message=f"{field} target {ref!r} resolves outside the repo",
+                        )
+                    )
+                    continue
+                if not target.exists():
+                    findings.append(
+                        _finding(
+                            code="missing-target",
+                            source=source,
+                            repo=repo,
+                            field=field,
+                            target=ref,
+                            message=f"{field} target {ref!r} does not exist",
+                        )
+                    )
+                    continue
+                _check_status_transition(
+                    source=source,
+                    target=target,
+                    repo=repo,
+                    field=field,
+                    ref=ref,
+                    source_fm=fm,
+                    findings=findings,
+                )
+
+    offers_root = repo / "core" / "offers"
+    if offers_root.exists():
+        for offer_dir in sorted(p for p in offers_root.iterdir() if p.is_dir()):
+            if (offer_dir / "offer.md").exists():
+                continue
+            rel = str(offer_dir.relative_to(repo))
+            orphan_offers.append(
+                {
+                    "code": "orphan-offer",
+                    "path": rel,
+                    "field": "core/offers",
+                    "target": "offer.md",
+                    "message": f"{rel}/ is missing offer.md",
+                }
+            )
+
+    for finding in findings:
+        _add_file_warning(
+            files_by_path,
+            repo=repo,
+            source=repo / finding["path"],
+            message=finding["message"],
+        )
+    for finding in orphan_offers:
+        rel = finding["path"]
+        files_by_path.setdefault(
+            rel,
+            {
+                "path": rel,
+                "ok": True,
+                "errors": [],
+                "warnings": [],
+                "schema": "core/offers",
+            },
+        )
+        files_by_path[rel].setdefault("warnings", []).append(finding["message"])
+
+    return {
+        "enabled": True,
+        "checked_fields": list(LINK_FIELDS),
+        "warnings": findings + orphan_offers,
+        "orphan_offers": orphan_offers,
+    }
+
+
+def run(
+    path: str,
+    verbose: bool = False,
+    cross_refs: bool = False,
+    strict: bool = False,
+) -> dict[str, Any]:
     """Run validation across all known schemas. Verbose adds key dumps."""
     repo = Path(path).resolve()
-    files: list[dict[str, Any]] = []
+    files_by_path: dict[str, dict[str, Any]] = {}
     for schema_name, schema in SCHEMAS.items():
         glob = schema["glob"]
         for f in sorted(repo.glob(glob)):
             r = _check_one(f, schema)
             r["schema"] = schema_name
             r["path"] = str(f.relative_to(repo))
-            files.append(r)
+            files_by_path[r["path"]] = r
 
-    ok = all(f["ok"] for f in files)
-    return {"ok": ok, "files": files, "repo": str(repo)}
+    cross_ref_report = {"enabled": False, "checked_fields": [], "warnings": [], "orphan_offers": []}
+    if cross_refs:
+        cross_ref_report = _check_cross_refs(repo, files_by_path)
+
+    files = list(files_by_path.values())
+    warning_count = sum(len(f.get("warnings", [])) for f in files)
+    error_count = sum(len(f.get("errors", [])) for f in files)
+    ok = error_count == 0 and (warning_count == 0 or not strict)
+    return {
+        "ok": ok,
+        "files": files,
+        "repo": str(repo),
+        "strict": strict,
+        "cross_refs": cross_ref_report,
+        "summary": {"errors": error_count, "warnings": warning_count},
+    }
 
 
 def render_human(report: dict[str, Any], verbose: bool = False) -> None:
@@ -127,14 +416,32 @@ def render_human(report: dict[str, Any], verbose: bool = False) -> None:
     for schema, items in by_schema.items():
         console.print(f"\n[bold]{schema}[/bold]")
         for f in items:
-            mark = "[green]ok[/green]" if f["ok"] else "[red]fail[/red]"
+            if f["errors"]:
+                mark = "[red]fail[/red]"
+            elif f.get("warnings"):
+                mark = "[yellow]warn[/yellow]"
+            else:
+                mark = "[green]ok[/green]"
             console.print(f"  {mark}  {f['path']}")
-            if not f["ok"] or verbose:
+            if f["errors"] or f.get("warnings") or verbose:
                 for e in f["errors"]:
                     console.print(f"        - {e}")
+                for warning in f.get("warnings", []):
+                    console.print(f"        - {warning}")
     console.print()
     if report["ok"]:
-        console.print("[green]all metadata looks right.[/green]")
+        if report["summary"]["warnings"]:
+            console.print(
+                f"[yellow]{report['summary']['warnings']} warning(s) found; "
+                "use --strict to fail on warnings.[/yellow]"
+            )
+        else:
+            console.print("[green]all metadata looks right.[/green]")
     else:
-        bad = sum(1 for f in report["files"] if not f["ok"])
-        console.print(f"[red]{bad} file(s) need fixing — see above.[/red]")
+        if report["summary"]["errors"]:
+            bad = sum(1 for f in report["files"] if f["errors"])
+            console.print(f"[red]{bad} file(s) need fixing — see above.[/red]")
+        else:
+            console.print(
+                f"[red]{report['summary']['warnings']} warning(s) fail in strict mode.[/red]"
+            )

--- a/mb/tests/test_validate.py
+++ b/mb/tests/test_validate.py
@@ -2,9 +2,15 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
+from typer.testing import CliRunner
+
+from mb.cli import app
 from mb.validate import run
+
+runner = CliRunner()
 
 
 def _write(p: Path, body: str) -> None:
@@ -50,3 +56,145 @@ def test_validate_handles_no_frontmatter(tmp_path: Path) -> None:
     _write(tmp_path / "decisions" / "2026-04-29-naked.md", "no frontmatter here\n")
     report = run(path=str(tmp_path))
     assert report["ok"] is False
+
+
+def test_cross_refs_pass_when_targets_exist(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "decisions" / "2026-04-29-ok.md",
+        (
+            "---\n"
+            "date: 2026-04-29\n"
+            "status: accepted\n"
+            "linked_research:\n"
+            "  - research/2026-04-29-topic-source.md\n"
+            "---\n"
+            "# ok\n"
+        ),
+    )
+    _write(
+        tmp_path / "research" / "2026-04-29-topic-source.md",
+        "---\ndate: 2026-04-29\ntopic: topic\nsource: source\n---\n# r\n",
+    )
+
+    report = run(path=str(tmp_path), cross_refs=True)
+
+    assert report["ok"] is True
+    assert report["cross_refs"]["enabled"] is True
+    assert report["summary"]["warnings"] == 0
+
+
+def test_cross_refs_warn_on_missing_targets_without_strict(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "decisions" / "2026-04-29-broken.md",
+        (
+            "---\n"
+            "date: 2026-04-29\n"
+            "status: accepted\n"
+            "linked_decisions:\n"
+            "  - decisions/missing.md\n"
+            "---\n"
+            "# broken\n"
+        ),
+    )
+
+    report = run(path=str(tmp_path), cross_refs=True)
+
+    assert report["ok"] is True
+    assert report["summary"]["warnings"] == 1
+    finding = report["cross_refs"]["warnings"][0]
+    assert finding == {
+        "code": "missing-target",
+        "path": "decisions/2026-04-29-broken.md",
+        "field": "linked_decisions",
+        "target": "decisions/missing.md",
+        "message": "linked_decisions target 'decisions/missing.md' does not exist",
+    }
+
+
+def test_cross_refs_strict_fails_on_warnings(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "decisions" / "2026-04-29-broken.md",
+        (
+            "---\n"
+            "date: 2026-04-29\n"
+            "status: accepted\n"
+            "linked_research: research/missing.md\n"
+            "---\n"
+            "# broken\n"
+        ),
+    )
+
+    report = run(path=str(tmp_path), cross_refs=True, strict=True)
+
+    assert report["ok"] is False
+    assert report["summary"] == {"errors": 0, "warnings": 1}
+
+
+def test_cross_refs_flag_status_transition_regressions(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "decisions" / "2026-04-28-old.md",
+        "---\ndate: 2026-04-28\nstatus: running\n---\n# old\n",
+    )
+    _write(
+        tmp_path / "decisions" / "2026-04-29-new.md",
+        (
+            "---\n"
+            "date: 2026-04-29\n"
+            "status: proposed\n"
+            "supersedes: decisions/2026-04-28-old.md\n"
+            "---\n"
+            "# new\n"
+        ),
+    )
+
+    report = run(path=str(tmp_path), cross_refs=True)
+
+    assert report["summary"]["warnings"] == 1
+    assert report["cross_refs"]["warnings"][0]["code"] == "status-transition"
+    assert "move backward" in report["cross_refs"]["warnings"][0]["message"]
+
+
+def test_cross_refs_flag_orphan_offer_dirs(tmp_path: Path) -> None:
+    (tmp_path / "core" / "offers" / "alpha").mkdir(parents=True)
+
+    report = run(path=str(tmp_path), cross_refs=True)
+
+    assert report["ok"] is True
+    assert report["summary"]["warnings"] == 1
+    assert report["cross_refs"]["orphan_offers"] == [
+        {
+            "code": "orphan-offer",
+            "path": "core/offers/alpha",
+            "field": "core/offers",
+            "target": "offer.md",
+            "message": "core/offers/alpha/ is missing offer.md",
+        }
+    ]
+
+
+def test_validate_cli_cross_refs_default_warns_strict_fails(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "decisions" / "2026-04-29-broken.md",
+        (
+            "---\n"
+            "date: 2026-04-29\n"
+            "status: accepted\n"
+            "linked_research: research/missing.md\n"
+            "---\n"
+            "# broken\n"
+        ),
+    )
+
+    result = runner.invoke(app, ["validate", str(tmp_path), "--cross-refs", "--json"])
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["summary"]["warnings"] == 1
+
+    result = runner.invoke(
+        app,
+        ["validate", str(tmp_path), "--cross-refs", "--strict", "--json"],
+    )
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False

--- a/mb/tests/test_validate.py
+++ b/mb/tests/test_validate.py
@@ -102,13 +102,10 @@ def test_cross_refs_warn_on_missing_targets_without_strict(tmp_path: Path) -> No
     assert report["ok"] is True
     assert report["summary"]["warnings"] == 1
     finding = report["cross_refs"]["warnings"][0]
-    assert finding == {
-        "code": "missing-target",
-        "path": "decisions/2026-04-29-broken.md",
-        "field": "linked_decisions",
-        "target": "decisions/missing.md",
-        "message": "linked_decisions target 'decisions/missing.md' does not exist",
-    }
+    assert finding["code"] == "missing-target"
+    assert finding["path"] == "decisions/2026-04-29-broken.md"
+    assert finding["field"] == "linked_decisions"
+    assert finding["target"] == "decisions/missing.md"
 
 
 def test_cross_refs_strict_fails_on_warnings(tmp_path: Path) -> None:
@@ -128,6 +125,48 @@ def test_cross_refs_strict_fails_on_warnings(tmp_path: Path) -> None:
 
     assert report["ok"] is False
     assert report["summary"] == {"errors": 0, "warnings": 1}
+    assert report["files"][0]["ok"] is False
+
+
+def test_cross_refs_skip_explicit_cross_repo_refs(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "decisions" / "2026-04-29-cross-repo.md",
+        (
+            "---\n"
+            "date: 2026-04-29\n"
+            "status: accepted\n"
+            "linked_research:\n"
+            "  - noontide-projects/research/2026-04-29-note.md\n"
+            "linked_decisions:\n"
+            "  - repo:noontide-projects/decisions/2026-04-29-choice.md\n"
+            "---\n"
+            "# cross repo\n"
+        ),
+    )
+
+    report = run(path=str(tmp_path), cross_refs=True, strict=True)
+
+    assert report["ok"] is True
+    assert report["summary"]["warnings"] == 0
+
+
+def test_cross_refs_skip_bundled_package_data(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "mb" / "_data" / "fixtures" / "decisions" / "fixture.md",
+        (
+            "---\n"
+            "date: 2026-04-29\n"
+            "status: accepted\n"
+            "linked_research: research/missing.md\n"
+            "---\n"
+            "# fixture\n"
+        ),
+    )
+
+    report = run(path=str(tmp_path), cross_refs=True, strict=True)
+
+    assert report["ok"] is True
+    assert report["summary"]["warnings"] == 0
 
 
 def test_cross_refs_flag_status_transition_regressions(tmp_path: Path) -> None:
@@ -198,3 +237,4 @@ def test_validate_cli_cross_refs_default_warns_strict_fails(tmp_path: Path) -> N
     assert result.exit_code == 1
     payload = json.loads(result.stdout)
     assert payload["ok"] is False
+    assert payload["files"][0]["ok"] is False


### PR DESCRIPTION
## Summary
- Adds opt-in `mb validate --cross-refs` checks for known local frontmatter links and orphan offer directories.
- Reports cross-reference findings in stable JSON with exact file, field, target, code, and message.
- Keeps default validation warning-oriented for local authoring while `--strict` fails on warnings for CI use.
- Handles explicit cross-repo references and skips bundled package data so engine-repo strict validation stays clean.

## Scope
- In: `linked_research`, `linked_decision(s)`, PRD-related link fields, `supersedes`, status-regression warnings, `core/offers/<slug>/offer.md` presence, `--json`, and strict-mode file/aggregate status.
- Out: graph index, interactive graph view, schema plugin framework, runtime adapter changes, and skill behavior changes.

## Commits
- `ee46dfd` — `[add] Cross-reference validation`.
- `571270b` — `[fix] Handle external validation refs`.

## Release / Issues
- Release: `oe-v0.2.1` / Main Branch 0.2.1.
- Linear ID(s): MAIN-122.
- Closes: #122.
- Refs: #121 for the intentionally deferred graph/index work.
- Follow-ups: none from this slice.

## Success Metric
- Stale local links in decisions, research, PRDs, and offer directories are caught by `mb validate --cross-refs` before they pollute `mb status`, graphing, or future dashboard views.

## Validation
- Level 0 docs/decision: read issue context, v0.2 direction docs, compatibility docs, and `.context/cold-start.md` for scope alignment.
- Level 1 static: `scripts/check.sh` passed from repo root.
- Level 2 CLI: validator tests cover clean links, missing targets, strict failure, JSON file status, status regressions, orphan offer dirs, cross-repo refs, bundled data exclusion, and CLI warning vs strict behavior.
- Level 3 package/install: not run; packaging and install flows were not touched.
- Level 4 fixture repo: not run; focused CLI tests and engine-repo smoke cover the opt-in validator path.
- Level 5 runtime smoke: not run; this is deterministic CLI validation only.

Manual smoke: `python3 -m mb validate .. --cross-refs --strict --json` from `mb/` passes on the engine repo with zero warnings.

## Public / Private Boundary
- No private Devon, Conductor, customer, or runtime details were added to committed files; `.context/` remained scratch-only.
