### PR TITLE
[add] mb migrate schema machinery

### DIFF
--- a/docs/MIGRATING.md
+++ b/docs/MIGRATING.md
@@ -66,7 +66,43 @@ pipx upgrade mainbranch
 mb skill link --repo /path/to/your-business
 ```
 
-## Optional Manual Layout Migration
+## Automated Layout Migration
+
+Use `mb migrate` on a clean branch when you are ready to move a legacy v0.1 repo
+from `reference/core/` and `reference/offers/` into the current v0.2 paths.
+
+Inspect the current schema state:
+
+```bash
+mb migrate status
+```
+
+Preview the exact filesystem changes as a unified diff:
+
+```bash
+mb migrate --check
+mb migrate --check --json
+```
+
+`--check` exits non-zero when migrations are pending so scripts and agents can
+detect drift without writing files.
+
+Apply only after reading the diff:
+
+```bash
+mb migrate --apply
+```
+
+`--apply` creates a repo-local backup under `.mb/backups/` before changing files,
+moves legacy core files into `core/`, moves legacy offer files into
+`core/offers/`, leaves compatibility links under `reference/`, updates stale
+`CLAUDE.md` path references, writes a migration decision artifact, and stamps
+`.mb/schema_version`.
+
+## Manual Layout Migration
+
+The automated command above is preferred. Keep this manual process only as a
+fallback when you need to inspect or repair a repo by hand.
 
 Only do this on a clean branch with everything committed:
 
@@ -112,8 +148,7 @@ mb start --json
 git diff --stat
 ```
 
-If anything looks wrong, stop and keep the legacy layout. Legacy layout support
-is intentional while `mb migrate` is still manual.
+If anything looks wrong, stop and keep the legacy layout.
 
 ## What About `.vip/config.yaml` and `~/.config/vip/local.yaml`?
 
@@ -130,13 +165,13 @@ the old config files yet.
 
 ## Current Recommendation
 
-For old repos such as `noontide-projects`:
+For old business repos:
 
 1. Upgrade Main Branch with `pipx upgrade mainbranch`.
 2. Run `mb skill link --repo /path/to/repo`.
 3. Run `mb doctor` and `mb status`.
-4. Keep `reference/core/` until an automated `mb migrate --check` exists or
-   you intentionally run the manual branch process above.
+4. Run `mb migrate --check`, read the diff, then run `mb migrate --apply` on a
+   clean branch when you are ready.
 
 For personal knowledge repos that do not have `reference/core/`, treat them as
 GitHub-native repos that Main Branch can brief, not as fully migrated business

--- a/mb/README.md
+++ b/mb/README.md
@@ -30,6 +30,7 @@ mb --version
 | `mb validate` | Frontmatter shape check across `decisions/`, `core/offers/`, `research/`, `log/`, `campaigns/`, `documents/`. Exit 1 on any fail. |
 | `mb graph` | Walk linked_research / linked_decisions / supersedes; emit Graphviz DOT to stdout. `--open` shells to `dot` + `open`. |
 | `mb update` | Refresh the Main Branch engine according to install mode (`pipx` upgrade or clone `git pull`) and repair skill links. `--check` dry-runs; `--json` emits an envelope. |
+| `mb migrate` | Inspect and apply numbered repo schema migrations. `status`, `--check`, and `--apply` support `--json`; `--check` prints a unified diff before writes. |
 | `mb think <topic>` | Print the /think workflow invocation hint for the currently supported runtime. |
 | `mb resolve <key>` | Resolve a reference path (checks free first, then paid). |
 | `mb skill path <name>` | Print the on-disk path to a bundled skill. |

--- a/mb/mb/_data/templates/.gitignore.tmpl
+++ b/mb/mb/_data/templates/.gitignore.tmpl
@@ -9,3 +9,4 @@ __pycache__/
 .pytest_cache/
 node_modules/
 .venv/
+.mb/backups/

--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -18,6 +18,7 @@ from mb import doctor as doctor_mod
 from mb import educational as educational_mod
 from mb import graph as graph_mod
 from mb import init as init_mod
+from mb import migrate as migrate_mod
 from mb import onboard as onboard_mod
 from mb import resolve as resolve_mod
 from mb import start as start_mod
@@ -43,6 +44,14 @@ skill_app = typer.Typer(
     no_args_is_help=True,
 )
 app.add_typer(skill_app, name="skill")
+
+migrate_app = typer.Typer(
+    name="migrate",
+    help="Inspect and apply repo schema migrations.",
+    no_args_is_help=False,
+    invoke_without_command=True,
+)
+app.add_typer(migrate_app, name="migrate")
 
 
 def _version_callback(value: bool) -> None:
@@ -407,6 +416,56 @@ def update_cmd(
     else:
         update_mod.render_human(result)
     raise typer.Exit(0 if result["ok"] else 1)
+
+
+@migrate_app.callback()
+def migrate_cmd(
+    ctx: typer.Context,
+    repo: str = typer.Option(".", "--repo", help="Business repo to migrate."),
+    check: bool = typer.Option(False, "--check", help="Dry-run pending migrations."),
+    apply_changes: bool = typer.Option(False, "--apply", help="Apply pending migrations."),
+    json_out: bool = typer.Option(False, "--json", help="Machine-readable output."),
+) -> None:
+    """Run `mb migrate --check` or `mb migrate --apply`; defaults to status."""
+    if ctx.invoked_subcommand is not None:
+        return
+    if check and apply_changes:
+        typer.echo("mb migrate: choose only one of --check or --apply", err=True)
+        raise typer.Exit(2)
+    if apply_changes:
+        result = migrate_mod.apply(repo)
+        if json_out:
+            typer.echo(json.dumps(result, indent=2))
+        else:
+            migrate_mod.render_apply(result)
+        raise typer.Exit(0 if result["ok"] else 1)
+    if check:
+        result = migrate_mod.check(repo)
+        if json_out:
+            typer.echo(json.dumps(result, indent=2))
+        else:
+            migrate_mod.render_check(result)
+        pending = bool(result.get("pending"))
+        raise typer.Exit(1 if pending or not result["ok"] else 0)
+
+    result = migrate_mod.status(repo)
+    if json_out:
+        typer.echo(json.dumps(result, indent=2))
+    else:
+        migrate_mod.render_status(result)
+
+
+@migrate_app.command("status")
+def migrate_status_cmd(
+    repo: str = typer.Option(".", "--repo", help="Business repo to inspect."),
+    json_out: bool = typer.Option(False, "--json", help="Machine-readable output."),
+) -> None:
+    """Show current schema version and pending migrations."""
+    result = migrate_mod.status(repo)
+    if json_out:
+        typer.echo(json.dumps(result, indent=2))
+    else:
+        migrate_mod.render_status(result)
 
 
 @skill_app.command("path")

--- a/mb/mb/doctor.py
+++ b/mb/mb/doctor.py
@@ -21,6 +21,7 @@ from typing import Any
 
 from mb import __version__
 from mb.engine import install_mode, link_status
+from mb.migrate import LATEST_SCHEMA_VERSION, pending_migrations, read_schema_version
 
 CLOUD_PREFIXES = (
     "Library/Mobile Documents",  # iCloud Drive
@@ -192,6 +193,34 @@ def _repo_layout_check(repo: Path) -> dict[str, Any]:
     }
 
 
+def _schema_version_check(repo: Path) -> dict[str, Any]:
+    current = read_schema_version(repo)
+    pending = pending_migrations(repo)
+    if pending:
+        names = ", ".join(info.name for info, _module in pending)
+        return {
+            "name": "schema-version",
+            "ok": False,
+            "detail": (
+                f"schema {current}; pending migration(s): {names}. "
+                "Run `mb migrate --check` before `mb migrate --apply`."
+            ),
+            "severity": "warn",
+        }
+    if current == "unknown":
+        return {
+            "name": "schema-version",
+            "ok": False,
+            "detail": "schema version unknown; run `mb migrate status` from the repo root.",
+            "severity": "warn",
+        }
+    return {
+        "name": "schema-version",
+        "ok": True,
+        "detail": f"schema {current} (latest {LATEST_SCHEMA_VERSION})",
+    }
+
+
 def run(path: str) -> dict[str, Any]:
     """Run all checks, return a structured report dict."""
     repo = Path(path).resolve()
@@ -250,6 +279,7 @@ def run(path: str) -> dict[str, Any]:
 
     checks.append(_mainbranch_version_check())
     checks.append(_repo_layout_check(repo))
+    checks.append(_schema_version_check(repo))
 
     cloud_hits = _detect_cloud_paths(repo)
     cloud_ok = not cloud_hits

--- a/mb/mb/init.py
+++ b/mb/mb/init.py
@@ -41,6 +41,7 @@ __pycache__/
 .pytest_cache/
 node_modules/
 .venv/
+.mb/backups/
 """
 
 

--- a/mb/mb/init.py
+++ b/mb/mb/init.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Any
 
 from mb.engine import link_skills
+from mb.migrate import LATEST_SCHEMA_VERSION, SCHEMA_MARKER
 
 # The canonical six. v0.1 lock; v0.2 unlocks via .vip/config.yaml paths block.
 DATA_FOLDERS = [
@@ -152,6 +153,11 @@ def run(path: str, name: str) -> dict[str, Any]:
         mode = _link_or_mkdir(target / source_name, target / dest_name)
         if mode != "exists":
             created.append(dest_name + ("/" if mode == "directory" else ""))
+
+    marker = target / SCHEMA_MARKER
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.write_text(LATEST_SCHEMA_VERSION + "\n", encoding="utf-8")
+    created.append(SCHEMA_MARKER)
 
     mapping = {
         "BUSINESS_NAME": business_name,

--- a/mb/mb/migrate.py
+++ b/mb/mb/migrate.py
@@ -1,0 +1,349 @@
+"""Schema-versioned repo migrations for ``mb migrate``."""
+
+from __future__ import annotations
+
+import difflib
+import json
+import shutil
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from mb import migrations
+from mb.migrations.base import MigrationInfo, MigrationPlan, PlannedChange
+
+ENVELOPE_SCHEMA = "mb.migrate"
+ENVELOPE_SCHEMA_VERSION = 1
+LATEST_SCHEMA_VERSION = "0.2"
+SCHEMA_MARKER = ".mb/schema_version"
+
+
+def _marker_path(repo: Path) -> Path:
+    return repo / SCHEMA_MARKER
+
+
+def read_schema_version(repo: str | Path) -> str:
+    """Read or infer the business-repo schema version."""
+    target = Path(repo).resolve()
+    marker = _marker_path(target)
+    if marker.exists():
+        value = marker.read_text(encoding="utf-8").strip()
+        return value or "unknown"
+    if (target / "reference" / "core").exists() and not (
+        target / "reference" / "core"
+    ).is_symlink():
+        return "0.1"
+    if (target / "reference" / "offers").exists() and not (
+        target / "reference" / "offers"
+    ).is_symlink():
+        return "0.1"
+    if (target / "core").is_dir():
+        return LATEST_SCHEMA_VERSION
+    return "unknown"
+
+
+def _migration_dict(info: MigrationInfo) -> dict[str, str]:
+    return {
+        "id": info.id,
+        "name": info.name,
+        "from_version": info.from_version,
+        "to_version": info.to_version,
+        "description": info.description,
+    }
+
+
+def pending_migrations(repo: str | Path) -> list[tuple[MigrationInfo, Any]]:
+    """Return registered migrations pending for ``repo``."""
+    version = read_schema_version(repo)
+    pending: list[tuple[MigrationInfo, Any]] = []
+    for info, module in migrations.registered():
+        registered_module = migrations.VERSION_MAP.get(version)
+        if version == info.from_version and registered_module == module.__name__:
+            pending.append((info, module))
+            version = info.to_version
+    return pending
+
+
+def _read_text_for_diff(path: Path) -> list[str]:
+    if not path.exists() or not path.is_file():
+        return []
+    return path.read_text(encoding="utf-8", errors="replace").splitlines(keepends=True)
+
+
+def _diff_for_change(repo: Path, change: PlannedChange) -> list[str]:
+    if change.kind == "move_file":
+        source = repo / change.source
+        old_lines = _read_text_for_diff(source)
+        new_lines = old_lines
+        delete_diff = list(
+            difflib.unified_diff(
+                old_lines,
+                [],
+                fromfile=f"a/{change.source}",
+                tofile="/dev/null",
+                lineterm="",
+            )
+        )
+        add_diff = list(
+            difflib.unified_diff(
+                [],
+                new_lines,
+                fromfile="/dev/null",
+                tofile=f"b/{change.target}",
+                lineterm="",
+            )
+        )
+        return delete_diff + add_diff
+    if change.kind == "delete_file":
+        old_lines = _read_text_for_diff(repo / change.path)
+        return list(
+            difflib.unified_diff(
+                old_lines,
+                [],
+                fromfile=f"a/{change.path}",
+                tofile="/dev/null",
+                lineterm="",
+            )
+        )
+    if change.kind == "write_file":
+        old_lines = _read_text_for_diff(repo / change.path)
+        new_lines = change.content.splitlines(keepends=True)
+        return list(
+            difflib.unified_diff(
+                old_lines,
+                new_lines,
+                fromfile=f"a/{change.path}" if old_lines else "/dev/null",
+                tofile=f"b/{change.path}",
+                lineterm="",
+            )
+        )
+    if change.kind == "symlink":
+        new_lines = [f"symlink -> {change.target}\n"]
+        return list(
+            difflib.unified_diff(
+                [],
+                new_lines,
+                fromfile="/dev/null",
+                tofile=f"b/{change.path}",
+                lineterm="",
+            )
+        )
+    return []
+
+
+def _unified_diff(repo: Path, plans: list[MigrationPlan], include_marker: bool) -> str:
+    lines: list[str] = []
+    for plan in plans:
+        for change in plan.changes:
+            lines.extend(_diff_for_change(repo, change))
+    if include_marker:
+        marker_change = PlannedChange(
+            kind="write_file",
+            path=SCHEMA_MARKER,
+            content=LATEST_SCHEMA_VERSION + "\n",
+        )
+        lines.extend(_diff_for_change(repo, marker_change))
+    return "\n".join(lines) + ("\n" if lines else "")
+
+
+def _plan_dict(plan: MigrationPlan) -> dict[str, Any]:
+    return {
+        "migration": _migration_dict(plan.migration),
+        "has_changes": plan.has_changes,
+        "changes": [
+            {
+                "kind": change.kind,
+                "path": change.path,
+                "source": change.source,
+                "target": change.target,
+            }
+            for change in plan.changes
+        ],
+        "errors": plan.errors,
+    }
+
+
+def _base_envelope(repo: Path, action: str) -> dict[str, Any]:
+    pending = pending_migrations(repo)
+    return {
+        "schema": ENVELOPE_SCHEMA,
+        "schema_version": ENVELOPE_SCHEMA_VERSION,
+        "ok": True,
+        "action": action,
+        "repo": str(repo),
+        "current_version": read_schema_version(repo),
+        "latest_version": LATEST_SCHEMA_VERSION,
+        "pending": [_migration_dict(info) for info, _module in pending],
+        "plan": None,
+        "applied": [],
+        "backup": None,
+        "errors": [],
+    }
+
+
+def status(repo: str | Path = ".") -> dict[str, Any]:
+    """Return current schema version and pending migrations."""
+    target = Path(repo).resolve()
+    return _base_envelope(target, "status")
+
+
+def check(repo: str | Path = ".") -> dict[str, Any]:
+    """Plan pending migrations without writing files."""
+    target = Path(repo).resolve()
+    result = _base_envelope(target, "check")
+    pending = pending_migrations(target)
+    plans = [migrations.plan_for(info, module, target) for info, module in pending]
+    errors = [error for plan in plans for error in plan.errors]
+    result["ok"] = not errors
+    result["plan"] = {
+        "has_changes": any(plan.has_changes for plan in plans),
+        "migrations": [_plan_dict(plan) for plan in plans],
+        "diff": _unified_diff(target, plans, include_marker=bool(pending)),
+        "errors": errors,
+    }
+    result["errors"] = errors
+    return result
+
+
+def _backup_path(repo: Path, migration_ids: list[str]) -> Path:
+    stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    suffix = "-".join(migration_ids) if migration_ids else "noop"
+    return repo / ".mb" / "backups" / f"{stamp}-{suffix}"
+
+
+def _backup_existing_paths(repo: Path, backup_dir: Path, plans: list[MigrationPlan]) -> list[str]:
+    copied: list[str] = []
+    paths: set[str] = {SCHEMA_MARKER}
+    for plan in plans:
+        for change in plan.changes:
+            if change.kind in {"move_file", "delete_file"} and change.source:
+                paths.add(change.source)
+            elif change.kind in {"write_file", "symlink"}:
+                paths.add(change.path)
+
+    for rel in sorted(paths):
+        source = repo / rel
+        if not source.exists() and not source.is_symlink():
+            continue
+        dest = backup_dir / rel
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        if source.is_symlink():
+            dest.write_text(f"symlink -> {source.readlink().as_posix()}\n", encoding="utf-8")
+        elif source.is_dir():
+            shutil.copytree(source, dest, symlinks=True, dirs_exist_ok=True)
+        else:
+            shutil.copy2(source, dest)
+        copied.append(rel)
+    return copied
+
+
+def _apply_change(repo: Path, change: PlannedChange) -> None:
+    path = repo / change.path
+    if change.kind == "mkdir":
+        path.mkdir(parents=True, exist_ok=True)
+        return
+    if change.kind == "move_file":
+        source = repo / change.source
+        target = repo / change.target
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if target.exists() and source.exists() and source.read_bytes() == target.read_bytes():
+            source.unlink()
+            return
+        source.rename(target)
+        return
+    if change.kind == "delete_file":
+        if path.exists():
+            path.unlink()
+        return
+    if change.kind == "write_file":
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(change.content, encoding="utf-8")
+        return
+    if change.kind == "remove_empty_dir":
+        if path.is_dir() and not any(path.iterdir()):
+            path.rmdir()
+        return
+    if change.kind == "symlink":
+        if path.is_symlink() and path.readlink().as_posix() == change.target:
+            return
+        path.symlink_to(change.target, target_is_directory=True)
+
+
+def apply(repo: str | Path = ".") -> dict[str, Any]:
+    """Apply pending migrations after creating a repo-local backup."""
+    target = Path(repo).resolve()
+    result = check(target)
+    result["action"] = "apply"
+    plans = [
+        migrations.plan_for(info, module, target) for info, module in pending_migrations(target)
+    ]
+    if result["errors"]:
+        result["ok"] = False
+        return result
+    if not plans:
+        result["ok"] = True
+        return result
+
+    backup_dir = _backup_path(target, [plan.migration.id for plan in plans])
+    backup_dir.mkdir(parents=True, exist_ok=False)
+    copied = _backup_existing_paths(target, backup_dir, plans)
+    (backup_dir / "manifest.json").write_text(
+        json.dumps({"schema_version": 1, "copied": copied}, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    for plan in plans:
+        for change in plan.changes:
+            _apply_change(target, change)
+
+    marker = _marker_path(target)
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.write_text(LATEST_SCHEMA_VERSION + "\n", encoding="utf-8")
+
+    result["ok"] = True
+    result["current_version"] = LATEST_SCHEMA_VERSION
+    result["pending"] = []
+    result["applied"] = [_migration_dict(plan.migration) for plan in plans]
+    result["backup"] = {"path": str(backup_dir), "copied": copied}
+    return result
+
+
+def render_status(result: dict[str, Any]) -> None:
+    print(f"schema version: {result['current_version']}")
+    pending = result.get("pending", [])
+    if pending:
+        print("pending migrations:")
+        for item in pending:
+            print(f"  {item['id']} {item['name']} ({item['from_version']} -> {item['to_version']})")
+    else:
+        print("pending migrations: none")
+
+
+def render_check(result: dict[str, Any]) -> None:
+    plan = result.get("plan") or {}
+    errors = result.get("errors", [])
+    if errors:
+        for error in errors:
+            print(f"error: {error}")
+        return
+    diff = str(plan.get("diff", ""))
+    if diff:
+        print(diff, end="")
+    else:
+        print("no migrations pending")
+
+
+def render_apply(result: dict[str, Any]) -> None:
+    if result.get("errors"):
+        for error in result["errors"]:
+            print(f"error: {error}")
+        return
+    applied = result.get("applied", [])
+    if not applied:
+        print("no migrations pending")
+        return
+    print(f"applied {len(applied)} migration(s)")
+    backup = result.get("backup") or {}
+    if backup.get("path"):
+        print(f"backup: {backup['path']}")
+    print(f"schema version: {result['current_version']}")

--- a/mb/mb/migrate.py
+++ b/mb/mb/migrate.py
@@ -16,6 +16,11 @@ ENVELOPE_SCHEMA = "mb.migrate"
 ENVELOPE_SCHEMA_VERSION = 1
 LATEST_SCHEMA_VERSION = "0.2"
 SCHEMA_MARKER = ".mb/schema_version"
+BACKUPS_GITIGNORE_ENTRY = ".mb/backups/"
+
+
+class MigrationApplyError(RuntimeError):
+    """Raised when the filesystem changes after a successful dry-run plan."""
 
 
 def _marker_path(repo: Path) -> Path:
@@ -56,8 +61,9 @@ def pending_migrations(repo: str | Path) -> list[tuple[MigrationInfo, Any]]:
     """Return registered migrations pending for ``repo``."""
     version = read_schema_version(repo)
     pending: list[tuple[MigrationInfo, Any]] = []
+    version_map = migrations.version_map()
     for info, module in migrations.registered():
-        registered_module = migrations.VERSION_MAP.get(version)
+        registered_module = version_map.get(version)
         if version == info.from_version and registered_module == module.__name__:
             pending.append((info, module))
             version = info.to_version
@@ -193,6 +199,7 @@ def check(repo: str | Path = ".") -> dict[str, Any]:
     result = _base_envelope(target, "check")
     pending = pending_migrations(target)
     plans = [migrations.plan_for(info, module, target) for info, module in pending]
+    _ensure_gitignore_plan(target, plans)
     errors = [error for plan in plans for error in plan.errors]
     result["ok"] = not errors
     result["plan"] = {
@@ -209,6 +216,25 @@ def _backup_path(repo: Path, migration_ids: list[str]) -> Path:
     stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
     suffix = "-".join(migration_ids) if migration_ids else "noop"
     return repo / ".mb" / "backups" / f"{stamp}-{suffix}"
+
+
+def _gitignore_content_with_backups(text: str) -> str:
+    lines = text.splitlines()
+    if BACKUPS_GITIGNORE_ENTRY in {line.strip() for line in lines}:
+        return text
+    prefix = text if text.endswith("\n") or not text else text + "\n"
+    return prefix + BACKUPS_GITIGNORE_ENTRY + "\n"
+
+
+def _ensure_gitignore_plan(repo: Path, plans: list[MigrationPlan]) -> None:
+    if not plans:
+        return
+    gitignore = repo / ".gitignore"
+    text = gitignore.read_text(encoding="utf-8") if gitignore.exists() else ""
+    updated = _gitignore_content_with_backups(text)
+    if updated == text:
+        return
+    plans[0].changes.append(PlannedChange(kind="write_file", path=".gitignore", content=updated))
 
 
 def _backup_existing_paths(repo: Path, backup_dir: Path, plans: list[MigrationPlan]) -> list[str]:
@@ -262,10 +288,14 @@ def _apply_change(repo: Path, change: PlannedChange) -> None:
     if change.kind == "remove_empty_dir":
         if path.is_dir() and not any(path.iterdir()):
             path.rmdir()
+        elif path.exists():
+            raise MigrationApplyError(f"{change.path} is not empty; aborting before replacement")
         return
     if change.kind == "symlink":
         if path.is_symlink() and path.readlink().as_posix() == change.target:
             return
+        if path.exists() or path.is_symlink():
+            raise MigrationApplyError(f"{change.path} already exists; cannot create symlink")
         path.symlink_to(change.target, target_is_directory=True)
 
 
@@ -277,6 +307,7 @@ def apply(repo: str | Path = ".") -> dict[str, Any]:
     plans = [
         migrations.plan_for(info, module, target) for info, module in pending_migrations(target)
     ]
+    _ensure_gitignore_plan(target, plans)
     if result["errors"]:
         result["ok"] = False
         return result
@@ -294,7 +325,13 @@ def apply(repo: str | Path = ".") -> dict[str, Any]:
 
     for plan in plans:
         for change in plan.changes:
-            _apply_change(target, change)
+            try:
+                _apply_change(target, change)
+            except (OSError, MigrationApplyError) as exc:
+                result["ok"] = False
+                result["errors"].append(str(exc))
+                result["backup"] = {"path": str(backup_dir), "copied": copied}
+                return result
 
     marker = _marker_path(target)
     marker.parent.mkdir(parents=True, exist_ok=True)

--- a/mb/mb/migrations/001_v01_to_v02_path_config.py
+++ b/mb/mb/migrations/001_v01_to_v02_path_config.py
@@ -1,0 +1,203 @@
+"""001: migrate v0.1 reference paths to the v0.2 repo layout."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from mb.migrations.base import MigrationInfo, MigrationPlan, PlannedChange
+
+INFO = MigrationInfo(
+    id="001",
+    name="001_v01_to_v02_path_config",
+    from_version="0.1",
+    to_version="0.2",
+    description="Move legacy reference/core paths into current core paths.",
+)
+
+CURRENT_DIRS = (
+    "core",
+    "core/offers",
+    "core/finance",
+    "research",
+    "decisions",
+    "log",
+    "campaigns",
+    "documents",
+)
+LEGACY_MOVES = (
+    ("reference/core", "core"),
+    ("reference/offers", "core/offers"),
+)
+DECISION_PATH = "decisions/2026-05-02-mainbranch-v02-path-migration.md"
+DECISION_CONTENT = """\
+---
+type: decision
+date: 2026-05-02
+status: accepted
+topic: Main Branch v0.2 path migration
+linked_issues:
+  - https://github.com/noontide-co/mainbranch/issues/175
+---
+
+# Main Branch v0.2 Path Migration
+
+This repo was migrated by `mb migrate` from the legacy v0.1 reference layout to
+the current v0.2 layout.
+
+## Changes
+
+- Moved `reference/core/*` into `core/`.
+- Moved `reference/offers/*` into `core/offers/` when present.
+- Kept `reference/core` and `reference/offers` as compatibility links.
+- Added current Main Branch working folders.
+- Wrote `.mb/schema_version`.
+"""
+
+
+def _is_correct_symlink(path: Path, target: str) -> bool:
+    return path.is_symlink() and path.readlink().as_posix() == target
+
+
+def _is_empty_dir(path: Path) -> bool:
+    return path.is_dir() and not any(path.iterdir())
+
+
+def _bytes_equal(left: Path, right: Path) -> bool:
+    try:
+        return left.read_bytes() == right.read_bytes()
+    except OSError:
+        return False
+
+
+def _relative_files(root: Path) -> list[Path]:
+    if not root.exists() or root.is_symlink():
+        return []
+    return sorted(path for path in root.rglob("*") if path.is_file() and not path.is_symlink())
+
+
+def _plan_move_tree(
+    repo: Path,
+    plan: MigrationPlan,
+    source_rel: str,
+    target_rel: str,
+) -> None:
+    source_root = repo / source_rel
+    target_root = repo / target_rel
+    if not source_root.exists() or source_root.is_symlink():
+        return
+    if not source_root.is_dir():
+        plan.errors.append(f"{source_rel} exists but is not a directory")
+        return
+
+    files = _relative_files(source_root)
+    for source in files:
+        rel = source.relative_to(source_root)
+        target = target_root / rel
+        source_path = source.relative_to(repo).as_posix()
+        target_path = target.relative_to(repo).as_posix()
+        if target.exists():
+            if _bytes_equal(source, target):
+                plan.changes.append(
+                    PlannedChange(kind="delete_file", path=source_path, source=source_path)
+                )
+                continue
+            plan.errors.append(f"{target_path} already exists with different contents")
+            continue
+        plan.changes.append(
+            PlannedChange(
+                kind="move_file",
+                path=target_path,
+                source=source_path,
+                target=target_path,
+            )
+        )
+
+    # These remove operations are applied after file moves, deepest first.
+    for directory in sorted(
+        (path for path in source_root.rglob("*") if path.is_dir()),
+        key=lambda path: len(path.parts),
+        reverse=True,
+    ):
+        plan.changes.append(
+            PlannedChange(
+                kind="remove_empty_dir",
+                path=directory.relative_to(repo).as_posix(),
+            )
+        )
+    plan.changes.append(PlannedChange(kind="remove_empty_dir", path=source_rel))
+
+
+def _plan_compat_link(repo: Path, plan: MigrationPlan, path_rel: str, target: str) -> None:
+    path = repo / path_rel
+    if _is_correct_symlink(path, target):
+        return
+    if any(path_rel == source for source, _target in LEGACY_MOVES) and path.is_dir():
+        plan.changes.append(PlannedChange(kind="symlink", path=path_rel, target=target))
+        return
+    if path.exists() or path.is_symlink():
+        if _is_empty_dir(path):
+            plan.changes.append(PlannedChange(kind="remove_empty_dir", path=path_rel))
+        else:
+            plan.errors.append(f"{path_rel} must be empty before creating compatibility link")
+            return
+    plan.changes.append(PlannedChange(kind="symlink", path=path_rel, target=target))
+
+
+def _updated_claude_text(text: str) -> str:
+    replacements = (
+        ("reference/core/*.md", "core/*.md"),
+        ("reference/core/", "core/"),
+        ("reference/offers/", "core/offers/"),
+        ("reference/core", "core"),
+        ("reference/offers", "core/offers"),
+    )
+    updated = text
+    for old, new in replacements:
+        updated = updated.replace(old, new)
+    return updated
+
+
+def _plan_claude_update(repo: Path, plan: MigrationPlan) -> None:
+    path = repo / "CLAUDE.md"
+    if not path.exists() or not path.is_file():
+        return
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        plan.errors.append(f"could not read CLAUDE.md: {exc}")
+        return
+    updated = _updated_claude_text(text)
+    if updated != text:
+        plan.changes.append(PlannedChange(kind="write_file", path="CLAUDE.md", content=updated))
+
+
+def _plan_decision(repo: Path, plan: MigrationPlan) -> None:
+    path = repo / DECISION_PATH
+    if path.exists():
+        return
+    plan.changes.append(
+        PlannedChange(kind="write_file", path=DECISION_PATH, content=DECISION_CONTENT)
+    )
+
+
+def plan(repo: Path) -> MigrationPlan:
+    """Return the deterministic v0.1 -> v0.2 migration plan."""
+    result = MigrationPlan(migration=INFO)
+
+    for directory in CURRENT_DIRS:
+        path = repo / directory
+        if not path.exists():
+            result.changes.append(PlannedChange(kind="mkdir", path=directory))
+            result.changes.append(
+                PlannedChange(kind="write_file", path=f"{directory}/.gitkeep", content="")
+            )
+
+    for source, target in LEGACY_MOVES:
+        _plan_move_tree(repo, result, source, target)
+
+    _plan_compat_link(repo, result, "reference/core", "../core")
+    _plan_compat_link(repo, result, "reference/offers", "../core/offers")
+    _plan_claude_update(repo, result)
+    _plan_decision(repo, result)
+
+    return result

--- a/mb/mb/migrations/__init__.py
+++ b/mb/mb/migrations/__init__.py
@@ -1,0 +1,26 @@
+"""Numbered Main Branch repo migrations."""
+
+from __future__ import annotations
+
+from importlib import import_module
+from pathlib import Path
+from types import ModuleType
+
+from mb.migrations.base import MigrationInfo, MigrationPlan
+
+MIGRATION_MODULES = ("mb.migrations.001_v01_to_v02_path_config",)
+VERSION_MAP = {"0.1": "mb.migrations.001_v01_to_v02_path_config"}
+
+
+def registered() -> list[tuple[MigrationInfo, ModuleType]]:
+    """Return migrations in apply order."""
+    modules = [import_module(name) for name in MIGRATION_MODULES]
+    return [(module.INFO, module) for module in modules]
+
+
+def plan_for(info: MigrationInfo, module: ModuleType, repo: Path) -> MigrationPlan:
+    """Call a migration module's plan function with a typed return value."""
+    raw_plan = module.plan(repo)
+    if not isinstance(raw_plan, MigrationPlan):
+        raise TypeError(f"{info.name} returned an invalid migration plan")
+    return raw_plan

--- a/mb/mb/migrations/__init__.py
+++ b/mb/mb/migrations/__init__.py
@@ -9,13 +9,17 @@ from types import ModuleType
 from mb.migrations.base import MigrationInfo, MigrationPlan
 
 MIGRATION_MODULES = ("mb.migrations.001_v01_to_v02_path_config",)
-VERSION_MAP = {"0.1": "mb.migrations.001_v01_to_v02_path_config"}
 
 
 def registered() -> list[tuple[MigrationInfo, ModuleType]]:
     """Return migrations in apply order."""
     modules = [import_module(name) for name in MIGRATION_MODULES]
     return [(module.INFO, module) for module in modules]
+
+
+def version_map() -> dict[str, str]:
+    """Return the registered from-version -> module map."""
+    return {info.from_version: module.__name__ for info, module in registered()}
 
 
 def plan_for(info: MigrationInfo, module: ModuleType, repo: Path) -> MigrationPlan:

--- a/mb/mb/migrations/base.py
+++ b/mb/mb/migrations/base.py
@@ -1,0 +1,50 @@
+"""Shared migration planning primitives."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+ChangeKind = Literal[
+    "mkdir",
+    "move_file",
+    "delete_file",
+    "write_file",
+    "remove_empty_dir",
+    "symlink",
+]
+
+
+@dataclass(frozen=True)
+class MigrationInfo:
+    """Registered migration metadata."""
+
+    id: str
+    name: str
+    from_version: str
+    to_version: str
+    description: str
+
+
+@dataclass(frozen=True)
+class PlannedChange:
+    """One filesystem change relative to a business repo."""
+
+    kind: ChangeKind
+    path: str
+    source: str = ""
+    target: str = ""
+    content: str = ""
+
+
+@dataclass
+class MigrationPlan:
+    """Dry-run plan for a migration."""
+
+    migration: MigrationInfo
+    changes: list[PlannedChange] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+
+    @property
+    def has_changes(self) -> bool:
+        return bool(self.changes)

--- a/mb/pyproject.toml
+++ b/mb/pyproject.toml
@@ -67,7 +67,13 @@ include = ["mb*"]
 exclude = ["tests*"]
 
 [tool.setuptools.package-data]
-mb = ["_data/**/*", "_engine/**/*", "_engine/.claude/**/*", "py.typed"]
+mb = [
+  "_data/**/*",
+  "_data/templates/.gitignore.tmpl",
+  "_engine/**/*",
+  "_engine/.claude/**/*",
+  "py.typed",
+]
 
 [tool.ruff]
 line-length = 100

--- a/mb/tests/test_doctor.py
+++ b/mb/tests/test_doctor.py
@@ -16,6 +16,7 @@ def test_doctor_runs_on_empty_dir(tmp_path: Path) -> None:
     assert "skill-wiring" in names
     assert "mainbranch-version" in names
     assert "repo-layout" in names
+    assert "schema-version" in names
 
 
 def test_cloud_path_detection_via_symlink(tmp_path: Path, monkeypatch) -> None:
@@ -68,3 +69,15 @@ def test_repo_layout_accepts_current_core(tmp_path: Path) -> None:
 
     assert check["ok"] is True
     assert "current core/" in check["detail"]
+
+
+def test_doctor_warns_on_schema_drift(tmp_path: Path) -> None:
+    repo = tmp_path / "legacy"
+    (repo / "reference" / "core").mkdir(parents=True)
+
+    report = run(path=str(repo))
+
+    check = next(c for c in report["checks"] if c["name"] == "schema-version")
+    assert check["ok"] is False
+    assert check["severity"] == "warn"
+    assert "mb migrate --check" in check["detail"]

--- a/mb/tests/test_init.py
+++ b/mb/tests/test_init.py
@@ -34,6 +34,7 @@ def test_init_scaffolds_folders(tmp_path: Path) -> None:
     gitignore = (target / ".gitignore").read_text()
     assert ".claude/settings.local.json" in gitignore
     assert ".claude/skills/start" in gitignore
+    assert ".mb/backups/" in gitignore
     assert "Acme Brewing" in (target / "CLAUDE.md").read_text()
 
 

--- a/mb/tests/test_init.py
+++ b/mb/tests/test_init.py
@@ -22,6 +22,7 @@ def test_init_scaffolds_folders(tmp_path: Path) -> None:
     assert (target / "CLAUDE.md").exists()
     assert (target / ".github" / "CODEOWNERS").exists()
     assert (target / ".gitignore").exists()
+    assert (target / ".mb" / "schema_version").read_text(encoding="utf-8") == "0.2\n"
     assert (target / ".claude" / "settings.local.json").exists()
     assert (target / ".claude" / "skills" / "start" / "SKILL.md").exists()
 

--- a/mb/tests/test_migrate.py
+++ b/mb/tests/test_migrate.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typer.testing import CliRunner
 
 from mb import migrate as migrate_mod
+from mb import migrations
 from mb.cli import app
 
 runner = CliRunner()
@@ -29,6 +30,7 @@ def _legacy_repo(tmp_path: Path) -> Path:
         "Read `reference/core/*.md` and `reference/offers/flagship/offer.md`.\n",
         encoding="utf-8",
     )
+    (repo / ".gitignore").write_text(".env\n", encoding="utf-8")
     return repo
 
 
@@ -55,6 +57,8 @@ def test_migrate_check_prints_diff_and_exits_nonzero_when_pending(tmp_path: Path
     assert "--- a/reference/core/offer.md" in result.stdout
     assert "+++ b/core/offer.md" in result.stdout
     assert "+++ b/core/offers/flagship/offer.md" in result.stdout
+    assert "+++ b/.gitignore" in result.stdout
+    assert "+.mb/backups/" in result.stdout
     assert "+++ b/.mb/schema_version" in result.stdout
     assert "+++ b/decisions/2026-05-02-mainbranch-v02-path-migration.md" in result.stdout
 
@@ -85,7 +89,9 @@ def test_migrate_apply_moves_files_backs_up_and_is_idempotent(tmp_path: Path) ->
     backup = Path(payload["backup"]["path"])
     assert backup.is_dir()
     assert (backup / "reference" / "core" / "offer.md").exists()
+    assert (backup / ".gitignore").exists()
     assert (repo / ".mb" / "schema_version").read_text(encoding="utf-8") == "0.2\n"
+    assert ".mb/backups/" in (repo / ".gitignore").read_text(encoding="utf-8")
     assert (repo / "core" / "offer.md").read_text(encoding="utf-8") == "# Offer\n"
     assert (repo / "core" / "offers" / "flagship" / "offer.md").exists()
     assert (repo / "reference" / "core").is_symlink()
@@ -115,6 +121,21 @@ def test_migrate_apply_aborts_before_writes_on_conflict(tmp_path: Path) -> None:
     assert (repo / "reference" / "core" / "offer.md").exists()
 
 
+def test_migrate_apply_reports_structured_error_when_legacy_dir_is_not_empty(
+    tmp_path: Path,
+) -> None:
+    repo = _legacy_repo(tmp_path)
+    (repo / "reference" / "core" / "linked").symlink_to(repo / "outside")
+
+    result = runner.invoke(app, ["migrate", "--repo", str(repo), "--apply", "--json"])
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False
+    assert "reference/core is not empty" in payload["errors"][0]
+    assert payload["backup"]["path"]
+
+
 def test_migrate_status_clean_current_repo(tmp_path: Path) -> None:
     repo = tmp_path / "current"
     (repo / "core").mkdir(parents=True)
@@ -125,3 +146,7 @@ def test_migrate_status_clean_current_repo(tmp_path: Path) -> None:
 
     assert result["current_version"] == "0.2"
     assert result["pending"] == []
+
+
+def test_migration_version_map_is_derived_from_registered_metadata() -> None:
+    assert migrations.version_map()["0.1"] == "mb.migrations.001_v01_to_v02_path_config"

--- a/mb/tests/test_migrate.py
+++ b/mb/tests/test_migrate.py
@@ -1,0 +1,127 @@
+"""``mb migrate`` schema migration contract tests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from mb import migrate as migrate_mod
+from mb.cli import app
+
+runner = CliRunner()
+
+
+def _legacy_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "legacy"
+    (repo / "reference" / "core").mkdir(parents=True)
+    (repo / "reference" / "offers" / "flagship").mkdir(parents=True)
+    (repo / "research").mkdir()
+    (repo / "decisions").mkdir()
+    (repo / "reference" / "core" / "offer.md").write_text("# Offer\n", encoding="utf-8")
+    (repo / "reference" / "core" / "audience.md").write_text("# Audience\n", encoding="utf-8")
+    (repo / "reference" / "offers" / "flagship" / "offer.md").write_text(
+        "# Flagship\n",
+        encoding="utf-8",
+    )
+    (repo / "CLAUDE.md").write_text(
+        "Read `reference/core/*.md` and `reference/offers/flagship/offer.md`.\n",
+        encoding="utf-8",
+    )
+    return repo
+
+
+def test_migrate_status_reports_pending_legacy_schema(tmp_path: Path) -> None:
+    repo = _legacy_repo(tmp_path)
+
+    result = runner.invoke(app, ["migrate", "status", "--repo", str(repo), "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["schema"] == "mb.migrate"
+    assert payload["schema_version"] == 1
+    assert payload["current_version"] == "0.1"
+    assert payload["latest_version"] == "0.2"
+    assert payload["pending"][0]["name"] == "001_v01_to_v02_path_config"
+
+
+def test_migrate_check_prints_diff_and_exits_nonzero_when_pending(tmp_path: Path) -> None:
+    repo = _legacy_repo(tmp_path)
+
+    result = runner.invoke(app, ["migrate", "--repo", str(repo), "--check"])
+
+    assert result.exit_code == 1
+    assert "--- a/reference/core/offer.md" in result.stdout
+    assert "+++ b/core/offer.md" in result.stdout
+    assert "+++ b/core/offers/flagship/offer.md" in result.stdout
+    assert "+++ b/.mb/schema_version" in result.stdout
+    assert "+++ b/decisions/2026-05-02-mainbranch-v02-path-migration.md" in result.stdout
+
+
+def test_migrate_check_json_exposes_same_plan(tmp_path: Path) -> None:
+    repo = _legacy_repo(tmp_path)
+
+    result = runner.invoke(app, ["migrate", "--repo", str(repo), "--check", "--json"])
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["action"] == "check"
+    assert payload["plan"]["has_changes"] is True
+    assert "b/core/offer.md" in payload["plan"]["diff"]
+    assert payload["plan"]["migrations"][0]["migration"]["id"] == "001"
+
+
+def test_migrate_apply_moves_files_backs_up_and_is_idempotent(tmp_path: Path) -> None:
+    repo = _legacy_repo(tmp_path)
+
+    result = runner.invoke(app, ["migrate", "--repo", str(repo), "--apply", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["current_version"] == "0.2"
+    assert payload["applied"][0]["id"] == "001"
+    backup = Path(payload["backup"]["path"])
+    assert backup.is_dir()
+    assert (backup / "reference" / "core" / "offer.md").exists()
+    assert (repo / ".mb" / "schema_version").read_text(encoding="utf-8") == "0.2\n"
+    assert (repo / "core" / "offer.md").read_text(encoding="utf-8") == "# Offer\n"
+    assert (repo / "core" / "offers" / "flagship" / "offer.md").exists()
+    assert (repo / "reference" / "core").is_symlink()
+    assert (repo / "reference" / "offers").is_symlink()
+    assert "core/*.md" in (repo / "CLAUDE.md").read_text(encoding="utf-8")
+    assert (repo / "decisions" / "2026-05-02-mainbranch-v02-path-migration.md").exists()
+
+    rerun = runner.invoke(app, ["migrate", "--repo", str(repo), "--apply", "--json"])
+    assert rerun.exit_code == 0
+    rerun_payload = json.loads(rerun.stdout)
+    assert rerun_payload["applied"] == []
+    assert rerun_payload["pending"] == []
+
+
+def test_migrate_apply_aborts_before_writes_on_conflict(tmp_path: Path) -> None:
+    repo = _legacy_repo(tmp_path)
+    (repo / "core").mkdir()
+    (repo / "core" / "offer.md").write_text("# Different\n", encoding="utf-8")
+
+    result = runner.invoke(app, ["migrate", "--repo", str(repo), "--apply", "--json"])
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False
+    assert "core/offer.md already exists with different contents" in payload["errors"]
+    assert not (repo / ".mb" / "backups").exists()
+    assert (repo / "reference" / "core" / "offer.md").exists()
+
+
+def test_migrate_status_clean_current_repo(tmp_path: Path) -> None:
+    repo = tmp_path / "current"
+    (repo / "core").mkdir(parents=True)
+    (repo / ".mb").mkdir()
+    (repo / ".mb" / "schema_version").write_text("0.2\n", encoding="utf-8")
+
+    result = migrate_mod.status(repo)
+
+    assert result["current_version"] == "0.2"
+    assert result["pending"] == []


### PR DESCRIPTION
## Summary
- Adds `mb migrate` as the deterministic CLI surface for schema-versioned repo migrations.
- Introduces `status`, `--check`, and `--apply` with JSON envelopes, dry-run unified diffs, backup-first apply, and idempotent reruns.
- Migrates legacy `reference/core` and `reference/offers` layouts into current `core` paths while preserving compatibility links and writing `.mb/schema_version`.
- Teaches `mb doctor` to detect schema drift and points operators at `mb migrate`.
- Documents the automated migration path for existing repos.

## Scope
- In: numbered migration registry, v0.1-to-v0.2 migration machinery, CLI wiring, doctor schema drift detection, init schema marker, backup gitignore handling, docs, and tests.
- Out: final path-config schema design, backward/revert migrations, runtime adapter behavior, and private repo data movement.

## Commits
- `eadec63` — `[add] Add schema migration command machinery`.
- `b8872a8` — `[add] Cover migrate schema contracts`.
- `10fe8b6` — `[update] Document automated repo migrations`.
- `02ac509` — `[fix] Keep migration backups out of git`.

## Release / Issues
- Release: Main Branch 0.2.1 / `oe-v0.2.1`.
- Linear ID(s): MAIN-175.
- Closes: #175.
- Refs: #119.
- Follow-ups: none required from this slice; actual future path-config schema design remains out of scope.

## Success Metric
- Existing v0.1 repos can run `mb migrate --check` to inspect planned changes, then `mb migrate --apply` to safely migrate layout with backups ignored by git and `.mb/schema_version` tracked.

## Validation
- Level 0 docs/decision: updated `docs/MIGRATING.md` and `mb/README.md`; followed `decisions/2026-05-01-mb-cli-vs-agent-workflows-boundary.md`.
- Level 1 static: `scripts/check.sh` passed from repo root, including format, ruff, mypy, pytest, and coverage.
- Level 2 CLI: `pytest tests/test_migrate.py tests/test_init.py` passed; full gate passed with 85 tests.
- Level 3 package/install: built wheel, installed into a temp venv, verified installed `mb migrate status --json`, `--check`, and `--apply`; confirmed the wheel contains `mb/_data/templates/.gitignore.tmpl`.
- Level 4 fixture repo: temp legacy repo with `reference/core` and `reference/offers` migrated successfully; verified `.mb/schema_version`, backup directory, compatibility links, and `.mb/backups/` ignore rule.
- Level 5 runtime smoke: not required because this changes deterministic CLI migration machinery, not runtime or skill discovery behavior.

## Public / Private Boundary
- No private repo contents or paths are committed. Private legacy-repo validation was dry-run only and recorded only as aggregate evidence in local `.context/` notes.
