### PR TITLE
[docs] Add public agent instructions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,11 +22,11 @@ Closes #
 
 ## Commits by concern
 
-<!-- One logical change per commit. Conventional commit prefixes. -->
+<!-- One logical change per commit. Use this repo's bracketed vocabulary. -->
 
 - [ ] Each commit body bullet-lists the changes in that commit
 - [ ] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
-- [ ] Conventional Commits format: `feat:`, `fix:`, `docs:`, `chore:`, `test:`, `refactor:`, `ci:`
+- [ ] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`
 
 ## Test plan
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,67 @@ Paperclip-adjacent orchestration, and local runtimes are compatibility targets
 only when tested. Do not claim support before there is an adapter or smoke
 evidence.
 
+## Quick Start
+
+For normal repo validation:
+
+```bash
+scripts/check.sh
+```
+
+For focused CLI work:
+
+```bash
+cd mb
+pytest tests/test_<area>.py -q
+```
+
+For package/install changes:
+
+```bash
+(cd mb && python -m build)
+python -m venv /tmp/mainbranch-smoke
+/tmp/mainbranch-smoke/bin/pip install mb/dist/*.whl
+/tmp/mainbranch-smoke/bin/mb --version
+/tmp/mainbranch-smoke/bin/mb skill list
+```
+
+## Repository Layout
+
+```
+.
++-- AGENTS.md          # shared instructions for repo agents
++-- CLAUDE.md          # Claude Code adapter instructions
++-- README.md          # public user-facing entrypoint
++-- CHANGELOG.md       # public release truth
++-- CONTRIBUTING.md    # contributor workflow
++-- decisions/         # dated product/architecture decisions
++-- docs/              # setup, compatibility, PRDs, migration docs
++-- mb/                # Python package, CLI, tests, bundled data
++-- .claude/skills/    # bundled Claude Code skill source
++-- templates/         # files copied into created business repos
++-- tools/             # experimental helper tools
++-- scripts/           # repo-level validation helpers
+```
+
+## Repo Surfaces
+
+Changes may affect one or more public surfaces:
+
+- CLI behavior in `mb/mb/` and `mb/tests/`;
+- packaged data under `mb/mb/_data/`;
+- bundled skills under `.claude/skills/`;
+- business-repo scaffolding under `templates/` and `mb/mb/init.py`;
+- user docs in `README.md`, `docs/BEGINNER-SETUP.md`, `docs/MIGRATING.md`,
+  `SUPPORT.md`, and `docs/compatibility.md`;
+- contributor/agent docs in `AGENTS.md`, `CLAUDE.md`, `CONTRIBUTING.md`, and
+  `.github/`;
+- release surfaces in `CHANGELOG.md`, GitHub Releases, PyPI metadata, and
+  Linear Releases.
+
+Do not assume a change is "just docs" when it changes instructions that agents,
+skills, users, or release automation follow.
+
 ## Public / Private Boundary
 
 This repository is public. Every committed file should be safe for a stranger to
@@ -42,9 +103,11 @@ Do not commit:
 - private community operations, launch plans, or partner/customer strategy;
 - untested runtime compatibility claims.
 
-Use `.context/` for local scratch and handoff notes. It is gitignored and is not
-durable product truth. Durable truth belongs in code, tests, docs, decisions,
-fixtures, or GitHub issues.
+Use OS temp for throwaway build artifacts, scratch repos, and smoke-test output.
+Use `.context/` only for repo-bound handoff notes such as `cold-start.md` or
+branch-specific collaboration state. It is gitignored and is not durable product
+truth. Durable truth belongs in code, tests, docs, decisions, fixtures, or GitHub
+issues.
 
 ## Start Protocol
 
@@ -128,6 +191,27 @@ GitHub remains the public durable issue thread:
   for review;
 - keep target release and priority visible in `.context/cold-start.md` and PR
   bodies for release-bearing work.
+
+## Linear-Hosted Agents
+
+When launched from Linear or assigned a Linear issue:
+
+- treat the Linear issue as the task brief, but verify durable details in this
+  repository before editing;
+- use the official Linear branch name if the task runner provides it;
+- preserve the Linear ID in branch, commit, and PR metadata;
+- map Linear status honestly: move to started/in progress only when coding or
+  writing actually begins, and do not mark shipped until release verification
+  proves users can install it;
+- keep GitHub issue closure accurate with `Closes #N` only for fully completed
+  GitHub issues;
+- comment when scope changes, blockers appear, or validation cannot reach the
+  required level;
+- open a PR when the hosted-agent workflow expects it, but never merge it unless
+  explicitly instructed.
+
+Workspace-level Linear guidance should stay short and point agents back here.
+This file is the detailed contract.
 
 ## GitHub Workflow
 
@@ -235,6 +319,27 @@ Level 5, runtime smoke:
 If a runtime cannot be launched because of auth or UI constraints, say that
 explicitly and describe the closest verified fallback. Do not pretend CLI tests
 cover runtime discovery.
+
+## Skill Maintenance
+
+Bundled skills are product code even when implemented as Markdown.
+
+When changing `.claude/skills/<name>/`:
+
+- keep each skill directory self-contained;
+- reference `references/`, `scripts/`, and `assets/` using paths relative to the
+  skill directory;
+- do not reference sibling skills with `../` paths or absolute local paths;
+- keep shared helper content small enough to duplicate when two skills need it;
+- keep `SKILL.md` under the line-count gate and move detail into
+  `references/`;
+- avoid platform-specific shell interpolation in cross-runtime skill content
+  unless there is a documented fallback;
+- test behavior with the relevant runtime smoke when discovery or invocation
+  changes.
+
+Mechanical Python tests do not prove LLM-facing skill behavior. If the prose or
+workflow changed, include a runtime/manual validation note.
 
 ## State Model
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,278 @@
+# Agent Instructions
+
+Main Branch is public open-source infrastructure. Treat this file as the
+repo-level operating contract for Codex, Claude Code, and any other agent or
+human contributor working in this repository.
+
+## Product Shape
+
+Main Branch is a CLI plus agent-runtime skill system for running a business from
+markdown files in git.
+
+- `mb` is the deterministic, inspectable, scriptable control plane.
+- Agent-runtime skills are the judgment-heavy execution layer.
+- GitHub issues are tasks.
+- Pull requests are proposals and review conversations.
+- Git history is the evolution story.
+- A user's business repo is the durable business brain.
+
+Claude Code is the first-class runtime today. Codex, Cursor, OpenClaw, Hermes,
+Paperclip-adjacent orchestration, and local runtimes are compatibility targets
+only when tested. Do not claim support before there is an adapter or smoke
+evidence.
+
+## Public / Private Boundary
+
+This repository is public. Every committed file should be safe for a stranger to
+read forever.
+
+Public is appropriate for:
+
+- deterministic CLI behavior;
+- runtime-agnostic skill contracts;
+- product decisions, PRDs, and release criteria;
+- sanitized examples and fixtures;
+- open-source support, security, and contribution docs.
+
+Do not commit:
+
+- secrets, tokens, credentials, raw account data, or customer/member data;
+- private local paths, personal operating preferences, or machine-specific
+  automation details;
+- private community operations, launch plans, or partner/customer strategy;
+- untested runtime compatibility claims.
+
+Use `.context/` for local scratch and handoff notes. It is gitignored and is not
+durable product truth. Durable truth belongs in code, tests, docs, decisions,
+fixtures, or GitHub issues.
+
+## Start Protocol
+
+Before editing:
+
+1. Read this file.
+2. Read `README.md`.
+3. Read the assigned GitHub/Linear issue and all comments.
+4. If the work touches v0.2 product direction, read:
+   - `decisions/2026-05-02-github-native-business-os.md`
+   - `docs/prd/v0-2-first-run-daily-briefing.md`
+   - `docs/prd/v0-2-agent-workflow-and-evals.md`
+5. If the work touches the CLI/runtime boundary, read:
+   - `decisions/2026-05-01-mb-cli-vs-agent-workflows-boundary.md`
+   - `docs/compatibility.md`
+6. If the work touches skills, inspect the relevant
+   `.claude/skills/<name>/SKILL.md` and nearby tests or fixtures.
+7. Check open PRs for overlapping files before making broad edits.
+
+For substantial branches, write `.context/cold-start.md` before editing:
+
+```md
+# Cold Start
+
+Issue:
+Linear ID:
+Release:
+Priority:
+Status:
+
+## Scope
+
+In:
+
+Out:
+
+## Risks
+
+- 
+
+## Validation Plan
+
+- Static:
+- CLI:
+- Package/install:
+- Fixture repo:
+- Runtime/manual:
+```
+
+## Work Shape
+
+Prefer one coherent user loop per branch. Do not broaden scope silently. If you
+find adjacent work, open or comment on a follow-up issue instead of burying it in
+the current PR.
+
+Good issue slices look like:
+
+- one command surface, such as `mb status`;
+- one repair loop, such as `mb update`;
+- one validator, such as cross-reference validation;
+- one runtime proof, such as Claude Code `/start` discovery from a fresh repo.
+
+Avoid tiny PRs that cost more in cold start, review, CI, and merge overhead than
+they return. Large PRs are fine when they have one success metric and
+concern-organized commits.
+
+## Branches, Issues, and Releases
+
+If a Linear issue exists, use Linear's official branch name when it is provided
+by the issue or task runner. Preserve Linear IDs in branch names, commit
+messages, and PR metadata so Linear Releases can attach work correctly.
+
+If no Linear issue exists, use a short concrete branch name such as
+`dmthepm/status-briefing` or `dmthepm/runtime-smoke`.
+
+GitHub remains the public durable issue thread:
+
+- use `Closes #N` only when the PR fully completes the GitHub issue;
+- use `Refs #N` for partial slices or related context;
+- comment on issues when scope changes, blockers appear, or a branch is ready
+  for review;
+- keep target release and priority visible in `.context/cold-start.md` and PR
+  bodies for release-bearing work.
+
+## GitHub Workflow
+
+Prefer the GitHub CLI for GitHub truth and mutations:
+
+```bash
+gh config set pager cat
+gh config set prompt disabled
+```
+
+Use `gh issue view`, `gh issue list`, `gh pr view`, `gh pr diff`,
+`gh pr checks`, `gh pr create`, and `gh pr edit` when GitHub work is needed.
+Do not merge a PR unless the maintainer explicitly asks for merge.
+
+Hosted agents that are assigned an issue may open a PR when their task runner
+expects it. Local branch-author agents should follow the current prompt: if it
+says to stop before PR creation, push the branch and report that it is ready.
+
+## Commit Discipline
+
+Use concern-based commits. A reviewer should understand the branch from:
+
+```bash
+git log --oneline main..HEAD
+git diff main..HEAD --stat
+```
+
+This repo commonly uses:
+
+- `[add] Brief description`
+- `[update] Brief description`
+- `[fix] Brief description`
+- `[remove] Brief description`
+- `[refactor] Brief description`
+
+Do not rewrite pushed history unless the maintainer explicitly asks.
+
+## Validation Ladder
+
+Use the lightest eval that proves the behavior. Do not ship first-run,
+runtime-discovery, update, packaging, or skill changes on unit tests alone.
+
+Level 0, docs/decision:
+
+- frontmatter where expected;
+- links resolve;
+- no stale product claims;
+- no private details in public docs.
+
+Level 1, static:
+
+```bash
+scripts/check.sh
+```
+
+Run this from the repo root before pushing. It mirrors CI's package working
+directory; do not substitute root-level `mypy mb` unless you also pass the right
+config.
+
+Level 2, CLI contract:
+
+- focused Typer/CliRunner tests;
+- exit codes;
+- `--json` behavior where present;
+- TTY vs non-TTY behavior for launch and onboarding UI;
+- no hangs in scripts or CI.
+
+Level 3, package/install smoke:
+
+Run when packaging, entrypoints, bundled data, skill discovery, or update paths
+change.
+
+```bash
+(cd mb && python -m build)
+python -m venv /tmp/mainbranch-smoke
+/tmp/mainbranch-smoke/bin/pip install mb/dist/*.whl
+/tmp/mainbranch-smoke/bin/mb --version
+/tmp/mainbranch-smoke/bin/mb skill list
+```
+
+Use `pipx install --force ...` or `pipx upgrade ...` smoke when install/update
+behavior changed.
+
+Level 4, fixture repo:
+
+```bash
+tmpdir="$(mktemp -d)"
+mb onboard --yes --name "Test Business" --path "$tmpdir/test-business"
+cd "$tmpdir/test-business"
+mb doctor
+mb status
+mb start --json
+mb validate
+```
+
+Level 5, runtime smoke:
+
+- create a fresh business repo;
+- launch the relevant runtime from that repo;
+- verify `/start` or the equivalent runtime entrypoint is discoverable;
+- verify the skill reads the business repo and does not write into the engine
+  repo;
+- record the evidence in the PR.
+
+If a runtime cannot be launched because of auth or UI constraints, say that
+explicitly and describe the closest verified fallback. Do not pretend CLI tests
+cover runtime discovery.
+
+## State Model
+
+- Canonical business state stays in git.
+- Local operational state stays out of git.
+- Secrets stay in the OS keychain, environment, or runtime-specific secret
+  stores, never in repo files or frontmatter.
+- Dashboard/server/process state must be explicit, local-first, optional, and
+  documented before it is added.
+
+## PR Expectations
+
+PR bodies should give reviewers product scope and validation evidence:
+
+- summary of the user loop or product truth changed;
+- in-scope and out-of-scope bullets;
+- commit list, oldest first;
+- release, Linear IDs, `Closes`/`Refs`, and follow-ups;
+- success metric;
+- validation by ladder level;
+- public/private boundary note.
+
+Update `CHANGELOG.md` for user-visible CLI, skill, packaging, compatibility, or
+workflow changes. Skip it only for invisible maintenance.
+
+## Review Focus
+
+When reviewing, lead with findings:
+
+- public/private boundary;
+- product direction;
+- state model;
+- runtime claims;
+- CLI contract;
+- validation evidence;
+- issue/release fit;
+- stale language;
+- test quality;
+- truncated files.
+
+Verdicts should be explicit: approve, request changes, or needs discussion.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,7 +146,7 @@ Out:
 
 ## Risks
 
-- 
+-
 
 ## Validation Plan
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,7 +181,7 @@ by the issue or task runner. Preserve Linear IDs in branch names, commit
 messages, and PR metadata so Linear Releases can attach work correctly.
 
 If no Linear issue exists, use a short concrete branch name such as
-`dmthepm/status-briefing` or `dmthepm/runtime-smoke`.
+`<gh-username>/status-briefing` or `<gh-username>/runtime-smoke`.
 
 GitHub remains the public durable issue thread:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,299 +1,57 @@
-# Main Branch
+# Claude Code Instructions
 
-**The system for staying connected to your work while AI handles the execution.**
+Read `AGENTS.md` first. It is the shared operating contract for all agents
+working in this repository.
 
----
+This file only adds Claude Code-specific guidance for the Main Branch engine
+repo.
 
-> **FOR CLAUDE: This is the ENGINE repository (vip). Do NOT write files here.**
->
-> - Users have READ-ONLY access — they cannot push changes
-> - All business data belongs in the USER'S OWN repository
-> - If asked to save files, create them in the user's business repo, not here
-> - Run `/start` to help users set up their own repo if they don't have one
->
-> **For humans:** Your business files go in YOUR OWN repository, not vip. See `docs/BEGINNER-SETUP.md`.
+## Repository Role
 
----
+This is the public `noontide-co/mainbranch` engine repository. It contains the
+`mb` CLI, bundled agent-runtime skills, docs, fixtures, tests, and release
+metadata.
 
-## What Is Main Branch?
+It is not a user's business repo. Business data belongs in the repo created by
+`mb onboard` or `mb init`, not in this engine checkout.
 
-**Active Reference Management.** You learn by building your reference. No magic passive memory. You:
+## How to Work Here
 
-- **Actively manage** what Claude knows
-- **See files change** as decisions get made
-- **Synthesize research** into evergreen reference
-- **Control** exactly what informs every output
+- Follow `AGENTS.md` for product shape, scope, public/private boundaries, branch
+  discipline, validation, and PR expectations.
+- Use `README.md`, `docs/`, `decisions/`, tests, and GitHub issues as durable
+  context.
+- Keep `.context/` as local scratch only.
+- Run `scripts/check.sh` from the repo root before pushing code or docs that
+  could affect packaged behavior.
+- If you change first-run, skill discovery, `mb init`, `mb onboard`,
+  `mb start`, `mb status`, `mb update`, or bundled skills, add the relevant
+  fixture/package/runtime smoke evidence described in `AGENTS.md`.
 
-Your repo is a precision instrument, not a dumping ground. The purpose is not to cram everything in — it's to filter context so LLMs produce great outcomes. Every file should earn its place.
+## Engine vs Business Repo
 
-Two pillars power every business: **ads that convert** (immediate ROI) and **content that runs itself** (long game). Both are driven by the same reference files -- your offer, audience, voice, and proof inform everything from a static ad to a newsletter-first content pipeline.
+When a user is operating Main Branch, they should be in their business repo:
 
-This engagement is the learning. Articulating your offer, audience, angles — you understand your business more deeply than passive memory allows.
-
-**Reference files as reconnection:** The act of writing and refining reference files isn't just documentation — it's identity work. It keeps you associated with WHY you do this, not dissociated into pure execution.
-
-See @docs/philosophy.md for the full explanation.
-
----
-
-## How to Be
-
-You're a thoughtful friend helping them build their business, not a task executor.
-
-**Guide, don't just do:**
-- Ask good questions — "What's the real problem here?" "Who is this actually for?"
-- Challenge when it matters — Not always agreeable, not always questioning. Push back when something feels off, but don't interrogate everything.
-- Surface the why — When updating reference, help them articulate what they're learning
-- Checkpoint progress — "Ready to move on?" before big transitions
-
-**Move them through /think:**
-- Research without decision = stuck. Ask: "Ready to decide?"
-- Decision without codify = wasted. Ask: "What goes into reference?"
-- Keep asking: "What needs to happen to get this into reference?"
-
-**Write reference in enduring language:**
-- Core beliefs, offer thesis, audience truths — these read like they've always been true
-- Never write reference that reacts to a specific event, tool, or session
-- Event-specific context goes in evolution markers (soul.md) and decision files
-- Test: would this line make sense to someone reading it in 6 months with no context?
-
-**Connect to soul:**
-- If they're grinding without feeling it, point back to soul.md
-- If the think cycle feels like pushing, they might have the wrong offer
-- The goal is they stay *associated*, not dissociated into execution mode
-
-**Connect to content strategy:**
-- If they have reference files but no content strategy, suggest building one through /think
-- If they're creating content without a plan, route to /think to build content-strategy.md first
-
----
-
-## When to Route
-
-Take inventory. Notice what's missing. Proactively suggest skills they haven't invoked:
-
-| If they're... | Route to |
-|---------------|----------|
-| Lost, confused, returning | `/start` |
-| Brand new, need repo setup | `/setup` |
-| Exploring, researching, deciding | `/think` |
-| Building content pillars, planning platforms | `/think` |
-| Ready to create paid ads | `/ads` |
-| Need a sales video script | `/vsl` |
-| Want organic content (reels, tiktok) | `/organic` |
-| Want to write a newsletter | `/newsletter` (coming soon -- use `/think` for now) |
-| Building a wiki or notes | `/wiki` |
-| Need a landing page or website | `/site` |
-| Asking questions, troubleshooting | `/help` |
-| Wrapping up, done for today, closing out | `/end` |
-
-**Quick triggers:** "research/decide" → `/think` · "ads/copy" → `/ads` · "organic/reels" → `/organic` · "newsletter/email" → `/newsletter` · "site/landing page/website" → `/site` · "content strategy/pillars" → `/think` · "help/stuck" → `/help` · "done/wrapping up/end my day" → `/end`
-
----
-
-## How It Works
-
-**Engine + Data = Output**
-
-```
-vip (ENGINE)                          your-repo (DATA)
-├── .claude/skills/                   ├── .vip/
-├── .claude/lenses/                   │   ├── config.yaml        # User preferences (git-tracked)
-├── .claude/reference/compliance/     │   └── local.yaml         # Session state (git-ignored)
-└── .claude/reference/domain-rubrics/ ├── reference/
-                                      │   ├── core/
-                                      │   │   ├── soul.md
-                                      │   │   ├── offer.md
-                                      │   │   ├── audience.md
-                                      │   │   └── voice.md
-                                      │   ├── offers/               # (multi-offer only)
-                                      │   │   └── [name]/
-                                      │   │       └── offer.md
-                                      │   ├── brand/
-                                      │   ├── proof/
-                                      │   └── domain/
-                                      │       ├── product-ladder.md  # (multi-offer only)
-                                      │       └── content-strategy.md
-                                      ├── research/
-                                      ├── decisions/
-                                      └── outputs/
+```bash
+cd path/to/my-business
+mb status
+mb start --launch
 ```
 
-Skills read from `reference/`, output to `outputs/`. Some skills (`/wiki`, `/site`) produce separate repos instead of writing to `outputs/`. Same engine + different data = different outputs per business.
-
----
-
-## Multi-Offer vs Multi-Business
-
-**Multi-offer** = multiple products under one brand, one repo. A coaching community and a digital course sold under the same brand share `soul.md` and `voice.md`, so they live together. Each offer gets its own `offers/[name]/offer.md` with offer-specific details.
-
-**Multi-business** = separate brands with separate souls, separate repos. A coaching practice and an unrelated e-commerce store have different identities, different audiences, different voices. They need separate repos.
-
-**The test:** If products share `soul.md` and `voice.md`, one repo. Otherwise separate repos.
-
-Single-offer repos work exactly as before -- no `offers/` folder, everything in `core/`. Multi-offer is additive, not breaking. See `.claude/reference/domain-rubrics/multi-offer.md` for the complete rubric.
-
----
-
-## Core Reference Files
-
-| File | Purpose |
-|------|---------|
-| `soul.md` | WHY you exist — reconnection fuel |
-| `offer.md` | WHAT you sell — brand-level thesis (see `offers/` for per-offer details in multi-offer setups) |
-| `audience.md` | WHO buys — real people, not avatars |
-| `voice.md` | HOW you sound — tone, phrases, personality |
-| `content-strategy.md` | HOW you distribute — pillars, platforms, cadence, metrics (domain -- emerges through /think, not required at setup) |
-| `product-ladder.md` | HOW offers relate — strategic relationship between products (domain -- multi-offer only) |
-| `skool-surfaces.md` | WHAT cold traffic sees — live Skool about page + pricing card copy (domain/funnel -- congruence anchor for ads, organic, VSLs) |
-
-First four live in `reference/core/` and are required for all businesses. `content-strategy.md` and `product-ladder.md` live in `reference/domain/`. `skool-surfaces.md` lives in `reference/domain/funnel/` (Skool communities only). All emerge over time.
-
----
-
-## The Path
-
-The more you lean on big tech, the more you realize what you're trading — data for convenience, control for ease. As AI gets more powerful, everything on someone else's server is risk. They have your data; they have the advantage.
-
-Learn the terminal. Learn to manage your own systems. You flip who has the edge.
-
-| Phase | What | You Learn |
-|-------|------|-----------|
-| **1. Terminal** | Claude Code + skills | How to think with AI |
-| **2. Personal Cloud** | Railway + Postiz | How to run infrastructure |
-| **3. Local** | Your own box | How to depend on no one |
-
-Not everyone goes all the way. Most stay at Phase 2. The path exists for those who want it.
-
----
-
-## Two Modes of Work
-
-| Mode | Direction | Skills |
-|------|-----------|--------|
-| **Enriching the core** | Insights → reference files (including content-strategy.md — your distribution backbone) | `/think` |
-| **Creating for the world** | Reference files → output | `/ads`, `/vsl`, `/organic`, `/site` |
-
----
-
-## Folder Structure (User Repos)
-
-```
-[business]/
-├── CLAUDE.md
-├── .vip/
-│   └── local.yaml      # Session state (git-ignored)
-├── reference/
-│   ├── core/           # soul.md, offer.md, audience.md, voice.md
-│   ├── offers/         # (multi-offer only) [name]/offer.md, [name]/audience.md
-│   ├── brand/          # voice-system.md, guardrails.md
-│   ├── proof/          # testimonials.md, angles/
-│   └── domain/         # business-type specific + product-ladder.md
-├── research/           # YYYY-MM-DD-topic-[source].md
-├── decisions/          # YYYY-MM-DD-topic.md
-└── outputs/            # generated batches
-```
-
-See @docs/system-architecture.md for complete structure details.
-
----
-
-## Domain Rubrics
-
-Every business has a `reference/domain/` folder. Contents depend on business type:
-
-| Business Type | Domain Contents | Rubric |
-|---------------|-----------------|--------|
-| **E-commerce** | `products/`, `materials/`, `sizing/` | `.claude/reference/domain-rubrics/ecommerce.md` |
-| **Community** | `classroom/`, `funnel/`, `membership/` | `.claude/reference/domain-rubrics/community.md` |
-| **Multi-Offer** | `offers/`, `product-ladder.md` | `.claude/reference/domain-rubrics/multi-offer.md` |
-
-Use `/setup` to scaffold the correct structure for your business type.
-
----
-
-## Reference Tiers
-
-Skills load reference progressively to stay token-efficient:
-
-| Tier | What | When Loaded |
-|------|------|-------------|
-| **Always** | CLAUDE.md | Every session |
-| **Core** | reference/core/*.md | When generating |
-| **On-demand** | research/, decisions/, content-strategy.md, skool-surfaces.md, offers/[active]/ | When reasoning about choices or generating content |
-| **Deep reference** | reference/visual-identity/, reference/proof/ | When writing copy |
-| **Domain** | reference/domain/ | When business-type matters |
-
----
-
-## Naming Conventions
-
-| Type | Format | Example |
-|------|--------|---------|
-| Core reference | `slug.md` | `soul.md`, `offer.md` |
-| Research | `YYYY-MM-DD-slug-[source].md` | `2026-01-15-pricing-gemini.md` |
-| Decisions | `YYYY-MM-DD-slug.md` | `2026-01-16-angle-strategy.md` |
-| Output batches | `YYYY-MM-DD-batch-name/` | `2026-01-20-january-launch/` |
-
-**Research source suffixes:** `-gemini.md`, `-gpt.md`, `-claude-code.md`, `-claude-web.md`, `-mining.md`, `-transcript.txt`, `-audit.md`
-
----
-
-## Frontmatter (All Files)
-
-```yaml
----
-type: research | decision | reference | output
-status: draft | active | complete | archived
-date: 2026-01-16
-source: gemini | gpt | claude-code | claude-web | mining  # research only
-model: opus-4.5 | sonnet-4  # when relevant
----
-```
-
-Research files also add: `linked_decisions: []`
-
-Decision lifecycle metrics must use `.claude/scripts/decision_lifecycle_audit.sh` (shared by `/start` and `/end`), not ad-hoc `grep`/`awk` rewrites in skill prose.
-
----
+When contributing to the engine, work in this repository and keep changes
+scoped to the assigned issue or PR.
 
 ## Skills
 
-| Skill | Purpose |
-|-------|---------|
-| `/start` | Entry point — detects state, routes to right skill |
-| `/setup` | Bootstrap new repo with correct structure |
-| `/think` | Research → decide → codify into reference |
-| `/ads` | Create and review ads with flexible entry points: static, video, video repurpose, creative variations, copy-only, images-only, account check, or compliance review |
-| `/vsl` | VSL scripts (Skool 18-section or B2B Haynes 7-step) |
-| `/organic` | Generate organic content from reference + research |
-| `/wiki` | Personal wiki with atomic notes |
-| `/site` | Build and deploy landing pages, minisites, and websites from reference files. One-flow brief→site: research → brief → review → lock → setup → conversion endpoint (Stripe / lead form / appointment / webhook) → concept variations on localhost → publish raw → build out → publish |
-| `/help` | Answer questions, troubleshoot, explain |
-| `/newsletter` | Generate weekly newsletter from thinking work (coming soon) |
-| `/end` | Close session intentionally — summary, crystallize, commit |
-| `/pull` | Quick update vip (auto in /start) |
+Bundled Claude Code skills live in `.claude/skills/`. If you edit a skill:
 
----
+- read the skill's `SKILL.md` before changing it;
+- keep `SKILL.md` under the repo's line-count gate;
+- update tests, fixtures, or docs when behavior changes;
+- do not write outputs into this engine repo unless the test/fixture explicitly
+  requires it;
+- avoid private member data, private launch strategy, or machine-specific paths
+  in examples.
 
-## Compliance (for `/ads`)
-
-**Planning:** Check `.claude/reference/compliance/` before creating (FTC tiers, angle playbook, testimonial rubric).
-
-**Review:** `/ads review` runs 6 lenses from `.claude/lenses/`.
-
----
-
-## Git Convention
-
-`[type] Brief description`
-
-Types: `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`
-
----
-
-## See Also
-
-- @docs/philosophy.md — Why Main Branch exists
-- @docs/system-architecture.md — Technical details
-- @docs/BEGINNER-SETUP.md — Quick start guide
+Claude Code is first-class today. Other runtimes are roadmap targets until an
+adapter and smoke evidence exist, so do not overclaim compatibility in docs.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,9 +10,15 @@ These rules are **tool-agnostic.** Conductor users, Codex users, Cursor users, a
 
 **One workspace = one branch = one PR.** Hard rule. Cross-cutting work that "feels obvious" gets flagged and stopped. Never reuse a branch.
 
-**Branch convention** (current — Linear sync OFF): `<gh-username>/<short-descriptor>`. Descriptor is kebab-case, under 40 chars, no leading verbs (`fix-`, `add-`).
+**Branch convention:** if a Linear issue exists, use Linear's official branch
+name so Linear Releases can attach the work. Otherwise use
+`<gh-username>/<short-descriptor>`. Descriptor is kebab-case, under 40 chars,
+and concrete.
 
-**PR titles** use Conventional Commits: `feat(scope): ...`, `fix(scope): ...`, `docs: ...`, `test: ...`, `refactor: ...`, `chore: ...`, `ci: ...`. Breaking changes append `!` and a `BREAKING CHANGE:` footer.
+**PR titles** use this repo's bracketed vocabulary when useful:
+`[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or
+`[chore]`. Keep titles product-shaped, for example
+`[add] mb status daily briefing`.
 
 ---
 
@@ -22,29 +28,31 @@ Each commit body bullet-lists changes in THAT commit. A reviewer reading `git lo
 
 | Commit type | What goes in it |
 |---|---|
-| `feat(scope): ...` | Core behavior change |
-| `test(scope): ...` | Tests for new behavior (combine with feat if small) |
-| `docs: ...` | README, SPEC, SCHEMA, SKILL.md, CHANGELOG, examples |
-| `ci: ...` | Workflow edits, gate additions |
-| `chore(scope): ...` | Dep bumps, package metadata, mechanical renames |
-| `refactor(scope): ...` | Non-behavioral moves |
-| `fix(scope): ...` | Bug fixes mid-work |
+| `[add] ...` | New command, skill, docs surface, or capability |
+| `[update] ...` | Existing behavior or docs changed |
+| `[fix] ...` | Bug fix |
+| `[remove] ...` | Deleted stale behavior, docs, or metadata |
+| `[refactor] ...` | Non-behavioral code movement |
+| `[docs] ...` | Documentation-only change |
+| `[chore] ...` | Dependency, package metadata, or mechanical maintenance |
 
 ---
 
-## Pre-push gates (multi-gate, separate)
+## Pre-push gate
 
-The Python umbrella (`mb/`) has four distinct gates:
+Run the repo gate from the repository root before pushing:
 
 ```bash
-cd mb
-ruff format --check .   # formatter — separate gate
-ruff check .            # linter — separate gate
-mypy mb                 # type check
-pytest -q               # tests
+scripts/check.sh
 ```
 
-`ruff check` (linter) and `ruff format --check` (formatter) are DISTINCT. Local lint passing does NOT imply format is clean.
+It runs formatting, lint, type checks, tests, and the skill line-count gate from
+the same working directories CI uses. Do not replace it with root-level
+`mypy mb`; that can read the wrong configuration.
+
+When a change touches packaging, entrypoints, bundled data, first-run flows, or
+runtime wiring, add the relevant smoke from [AGENTS.md](AGENTS.md): package
+install, fixture repo, pipx/update, or runtime discovery.
 
 For Go tools (Phase 2):
 
@@ -55,8 +63,6 @@ go vet ./...
 golangci-lint run
 go test ./...
 ```
-
-For skill regression: run `bash ~/.claude/skills/test-skills/test-skills.sh` against your modified skill before pushing.
 
 **No `--no-verify`. No `git commit --no-verify`. No skipping.**
 
@@ -119,7 +125,10 @@ PR reviews use this shape:
 
 ## How to find the work
 
-The engine v0.1.0 decision is `decisions/2026-04-29-mb-vip-v0-1-0-master.md`. It locks vocabulary, repo shape, ship list, /site upgrade scope, and the conductor preferences encoded above.
+Start with [AGENTS.md](AGENTS.md). It is the shared operating contract for
+Codex, Claude Code, and other agents.
+
+The engine v0.1.0 decision is `decisions/2026-04-29-mb-vip-v0-1-0-master.md`. It locks the first public ship list and historical launch vocabulary.
 
 The companion business-side master plan is tracked in `noontide-co/projects#119`. Read it when a contribution touches product positioning, public launch sequencing, pricing, the agency arm, or the four CLI pillars.
 

--- a/README.md
+++ b/README.md
@@ -268,7 +268,9 @@ For platform support and security reporting, see [SUPPORT.md](SUPPORT.md), [SECU
 
 ## Technical details
 
-Looking for the full system documentation? See [CLAUDE.md](CLAUDE.md) — folder structure, file naming conventions, domain rubrics by business type, compliance frameworks, git commit conventions. You don't need to read it to get started.
+Contributors should start with [AGENTS.md](AGENTS.md) and
+[CONTRIBUTING.md](CONTRIBUTING.md). Claude Code-specific repo guidance lives in
+[CLAUDE.md](CLAUDE.md). You don't need any of these to get started as a user.
 
 All shipping decisions are dated, versioned, and committed alongside the code that implements them.
 

--- a/docs/prd/v0-2-agent-workflow-and-evals.md
+++ b/docs/prd/v0-2-agent-workflow-and-evals.md
@@ -79,12 +79,13 @@ silently. If you find adjacent work, open or comment on a follow-up issue.
 
 ## Start Here
 
-1. Read `CLAUDE.md`.
-2. Read `decisions/2026-05-02-github-native-business-os.md`.
-3. Read `docs/prd/v0-2-first-run-daily-briefing.md`.
-4. Read `docs/prd/v0-2-agent-workflow-and-evals.md`.
-5. Read the assigned GitHub issue and all comments.
-6. Check open PRs that may touch the same files.
+1. Read `AGENTS.md`.
+2. Read runtime-specific instructions if present (`CLAUDE.md` for Claude Code).
+3. Read `decisions/2026-05-02-github-native-business-os.md`.
+4. Read `docs/prd/v0-2-first-run-daily-briefing.md`.
+5. Read `docs/prd/v0-2-agent-workflow-and-evals.md`.
+6. Read the assigned GitHub or Linear issue and all comments.
+7. Check open PRs that may touch the same files.
 
 ## North Star
 
@@ -146,7 +147,8 @@ Status:
 
 ## Read
 
-- [ ] CLAUDE.md
+- [ ] AGENTS.md
+- [ ] Runtime-specific instructions if present
 - [ ] Business OS decision
 - [ ] v0.2 PRD
 - [ ] Assigned issue/comments
@@ -317,9 +319,9 @@ Use for packaging, bundled skills, update, skill-linking, or first-run changes.
 Required:
 
 ```bash
-python -m build
+(cd mb && python -m build)
 python -m venv /tmp/mainbranch-smoke
-/tmp/mainbranch-smoke/bin/pip install dist/*.whl
+/tmp/mainbranch-smoke/bin/pip install mb/dist/*.whl
 /tmp/mainbranch-smoke/bin/mb --version
 /tmp/mainbranch-smoke/bin/mb skill list
 ```


### PR DESCRIPTION
## Summary
- Adds `AGENTS.md` as the public operating contract for Codex, Claude Code, Linear-hosted agents, and future runtime agents working in this repo.
- Replaces stale root `CLAUDE.md` content with a short Claude Code adapter that points to the shared agent contract.
- Aligns contributor, PR, README, and v0.2 agent-workflow docs around current branch naming, validation, GitHub/Linear, and public/private rules.
- Tightens skill-maintenance and Linear-hosted-agent guidance using the durable parts of the private Conductor workflow without publishing private local details.

## Scope
- In: `AGENTS.md`, root `CLAUDE.md`, contributor/PR docs, README technical-details pointer, and v0.2 agent workflow PRD updates.
- Out: Linear workspace setting mutation, private homelab/Conductor preference updates, runtime adapter implementation, and any CLI/package behavior changes.

## Commits
- `80db0e0` — `[docs] Add public agent instructions`
- `e8bf2c7` — `[docs] Tighten agent operating contract`
- `5b6fe27` — `[docs] Use generic branch examples`
- `0709b9d` — `[docs] Remove template trailing space`

## Release / Issues
- Release: Main Branch 0.2.2 documentation/supporting workflow candidate
- Linear ID(s): pending Linear issue for public agent instructions
- Closes: none
- Refs: none
- Follow-ups: paste the workspace guidance from `.context/linear-workspace-guidance.md` into Linear AI & Agents workspace guidance.

## Success Metric
A hosted or local agent assigned Main Branch work can understand the product boundary, public/private rules, branch/issue/release behavior, validation ladder, and PR expectations from public repo files without relying on Devon's private Conductor preferences.

## Validation
- Level 0 docs/decision: stale prompt scan and review pass completed; old root `CLAUDE.md` VIP/reference/newsletter guidance removed from active agent docs.
- Level 1 static: `git diff --check`; `scripts/check.sh` passed with 107 tests and 83.34% coverage.
- Level 2 CLI: not required; docs-only change.
- Level 3 package/install: not required; docs-only change.
- Level 4 fixture repo: not required; docs-only change.
- Level 5 runtime smoke: not required; docs-only change.

## Public / Private Boundary
Reusable operating lessons from Conductor preferences were generalized into public agent guidance. Private Devon paths, private runtime details, private community operations, and machine-specific instructions stayed out of committed files.
