### PR TITLE
[docs] Codify per-repo tool tethering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+### Changed
+
+- Documented per-repo connected-account boundaries in the generated business
+  `CLAUDE.md`, README, and `mb init` output so users keep Stripe, ads, pixels,
+  and MCP tool access tethered to the active business repo without committing
+  secrets.
+
 ## [0.2.1] - 2026-05-02
 
 v0.2.1 is the first post-0.2 durability release. It makes the new CLI front

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,9 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 ### Changed
 
 - Documented per-repo connected-account boundaries in the generated business
-  `CLAUDE.md`, README, and `mb init` output so users keep Stripe, ads, pixels,
-  and MCP tool access tethered to the active business repo without committing
-  secrets.
+  `CLAUDE.md`, README, `mb init`, and `mb onboard` output so users keep Stripe,
+  ads, pixels, and MCP tool access tethered to the active business repo without
+  committing secrets.
 
 ## [0.2.1] - 2026-05-02
 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,23 @@ my-business/
 
 You fill in the reference files inside `core/`. Claude reads them when generating.
 
+### Connected accounts live with the business repo
+
+Your business repo carries the boundaries for connected accounts. A repo for
+one business can point at one Stripe account, Google Ads customer, ad pixel set,
+and MCP server set; a different business repo should point at different ones.
+Switching repos should switch the tools that can spend money, publish, email,
+or mutate customer accounts.
+
+The repo should keep useful non-secret identifiers where agents can inspect
+them: Stripe account/product/price IDs in offer or finance notes, Google Ads
+customer and campaign IDs in `campaigns/`, ad pixel IDs beside the site or
+campaign files they belong to, and MCP server names/scopes in `CLAUDE.md` or
+local setup notes. Do not commit API keys, OAuth refresh tokens,
+service-account JSON, webhook secrets, MCP tokens, or bearer tokens. Keep
+secrets in a runtime's local config, the OS keychain, 1Password, `.env`, or
+`.claude/settings.local.json`, and keep those files gitignored.
+
 ---
 
 ## The `mb` CLI

--- a/mb/mb/_data/templates/CLAUDE.md.tmpl
+++ b/mb/mb/_data/templates/CLAUDE.md.tmpl
@@ -25,6 +25,31 @@ Your business as files. Claude reads these; you edit them; git remembers them.
 - One owner per file via `.github/CODEOWNERS`.
 - Pull request titles use Conventional Commits.
 
+## Connected accounts
+
+Treat this repo as the boundary for connected business tools. When you switch
+business repos, you should also switch the accounts, tokens, and MCP servers
+that can act on that business.
+
+Keep public or non-secret account identifiers in repo files when they help
+agents choose the right account:
+
+- Stripe account IDs, product IDs, and price IDs can live in offer or finance
+  notes such as `core/offers/<offer>/stripe.md`.
+- Google Ads customer IDs and campaign IDs can live in campaign plans under
+  `campaigns/`.
+- Meta, TikTok, Google, or other ad pixel IDs can live beside the site or
+  campaign files they belong to.
+- MCP server names and intended scopes can live in `CLAUDE.md` or a local setup
+  note when they are not secret.
+
+Never commit API keys, OAuth refresh tokens, service-account JSON, webhook
+secrets, MCP tokens, or bearer tokens. Put secrets in the runtime's local
+config, an OS keychain, 1Password, `.env`, or `.claude/settings.local.json`;
+those files should stay gitignored. If a tool can spend money, publish, email,
+or mutate a customer account, verify that it is tethered to this repo before
+using it.
+
 ## Helpful commands
 
 ```

--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -140,6 +140,12 @@ def init_cmd(
             typer.echo(f"  cd {result['path']}")
             typer.echo("  claude")
             typer.echo("  /start")
+            typer.echo("")
+            typer.echo("connected accounts:")
+            typer.echo(
+                "  See CLAUDE.md -> Connected accounts before wiring tools that "
+                "spend, publish, or mutate customer accounts."
+            )
         else:
             typer.echo(f"could not set up: {result.get('error')}", err=True)
             raise typer.Exit(1)

--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -214,6 +214,11 @@ def _render_onboard_human(result: dict[str, Any]) -> None:
     console.print("\n[bold]Next[/bold]")
     for step in result["next_steps"]:
         console.print(f"  {step}")
+    console.print(
+        "\n[bold]Connected accounts[/bold]\n"
+        "  See CLAUDE.md -> Connected accounts before wiring tools that spend, "
+        "publish, or mutate customer accounts."
+    )
     if warnings:
         console.print(f"\nFor a full setup check, run `{result['doctor_command']}`.")
     console.print()

--- a/mb/mb/init.py
+++ b/mb/mb/init.py
@@ -231,6 +231,24 @@ Your business as files. Claude reads these; you edit them; git remembers them.
 - Status field: proposed | running | scaling | killed | graduated | died.
 - One owner per file (CODEOWNERS pattern).
 
+## Connected accounts
+
+Treat this repo as the boundary for connected business tools. When you switch
+business repos, switch the accounts, tokens, and MCP servers that can act on
+that business.
+
+Keep non-secret IDs in repo files when they help agents choose the right
+account: Stripe account/product/price IDs in `core/offers/<offer>/stripe.md`,
+Google Ads customer and campaign IDs in `campaigns/`, ad pixel IDs beside the
+site or campaign files they belong to, and MCP server names/scopes in local
+setup notes.
+
+Never commit API keys, OAuth refresh tokens, service-account JSON, webhook
+secrets, MCP tokens, or bearer tokens. Put secrets in a runtime local config,
+OS keychain, 1Password, `.env`, or `.claude/settings.local.json`; those files
+should stay gitignored. If a tool can spend money, publish, email, or mutate a
+customer account, verify it is tethered to this repo before using it.
+
 ## Helpful commands
 
 ```

--- a/mb/tests/test_cli.py
+++ b/mb/tests/test_cli.py
@@ -104,3 +104,13 @@ def test_skill_link_wires_repo(tmp_path) -> None:
     assert result.exit_code == 0
     assert (repo / ".claude" / "settings.local.json").exists()
     assert (repo / ".claude" / "skills" / "start" / "SKILL.md").exists()
+
+
+def test_init_output_points_to_connected_accounts_guidance(tmp_path) -> None:
+    repo = tmp_path / "biz"
+
+    result = runner.invoke(app, ["init", str(repo), "--name", "Acme"])
+
+    assert result.exit_code == 0
+    assert "connected accounts:" in result.stdout
+    assert "CLAUDE.md -> Connected accounts" in result.stdout

--- a/mb/tests/test_init.py
+++ b/mb/tests/test_init.py
@@ -35,7 +35,14 @@ def test_init_scaffolds_folders(tmp_path: Path) -> None:
     assert ".claude/settings.local.json" in gitignore
     assert ".claude/skills/start" in gitignore
     assert ".mb/backups/" in gitignore
-    assert "Acme Brewing" in (target / "CLAUDE.md").read_text()
+    claude_md = (target / "CLAUDE.md").read_text()
+    assert "Acme Brewing" in claude_md
+    assert "## Connected accounts" in claude_md
+    assert "Stripe account IDs" in claude_md
+    assert "Google Ads customer IDs" in claude_md
+    assert "MCP server names" in claude_md
+    assert "MCP tokens" in claude_md
+    assert "Never commit API keys" in claude_md
 
 
 def test_init_idempotent(tmp_path: Path) -> None:

--- a/mb/tests/test_onboard.py
+++ b/mb/tests/test_onboard.py
@@ -152,4 +152,6 @@ def test_onboard_cli_interactive_path_renders_clear_labels(tmp_path: Path, monke
     assert "interactive" in result.stdout
     assert "level / action: beginner / created" in result.stdout
     assert "path: beginner / created" not in result.stdout
+    assert "Connected accounts" in result.stdout
+    assert "CLAUDE.md -> Connected accounts" in result.stdout
     assert "Show the short why" not in result.stdout


### PR DESCRIPTION
## Summary
- Documents that each business repo carries its own connected-account boundaries.
- Adds safe/non-secret examples for Stripe IDs, Google Ads IDs, ad pixels, and MCP server names/scopes.
- Points `mb init` and human `mb onboard` output at the generated `CLAUDE.md -> Connected accounts` guidance.

## Scope
- In: README guidance, generated business `CLAUDE.md` template guidance, embedded fallback guidance, CLI output hints, focused tests, and changelog entry.
- Out: credential storage, `mb connect`, runtime adapter changes, and new compatibility claims.

## Commits
- `3e49a99` — `[update] MAIN-130 document per-repo tool tethering`.
- `e593e0d` — `[update] MAIN-130 mirror tethering hint in onboard`.

## Release / Issues
- Release: v0.2.2 target.
- Linear ID(s): MAIN-130.
- Closes: #130.
- Refs: MAIN-181.
- Follow-ups: collapse duplicated `CLAUDE.md` template/fallback prose once template resolution is reliable enough to remove the embedded copy.

## Success Metric
A new or onboarded business repo tells operators which connected-account identifiers belong in repo files, which secrets must stay local, and where to check before wiring tools that spend, publish, email, or mutate customer accounts.

## Validation
- Level 0 docs/decision: reviewed README, generated template, fallback text, changelog, and public/private boundary for generic examples only.
- Level 1 static: `scripts/check.sh` passed: formatting, ruff, mypy, 108 tests, coverage 83.88%.
- Level 2 CLI: `python3 -m pytest tests/test_onboard.py tests/test_cli.py tests/test_init.py -q` passed: 20 tests.
- Level 3 package/install: built wheel installed in `/tmp/mainbranch-smoke`; `mb --version`, `mb skill list`, `mb onboard --yes --json`, and `mb start --json` passed.
- Level 4 fixture repo: installed-wheel fixture smoke passed with `mb doctor`, `mb status`, `mb start --json`, and `mb validate`.
- Level 5 runtime smoke: not run; no Claude Code discovery or skill invocation behavior changed.

## Public / Private Boundary
- Kept the examples generic and public-safe; no Devon-specific Conductor preferences, private repo details, customer data, or credentials were added.
