### PR TITLE
[add] mb connect credential foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,9 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 ### Added
 
 - Added `mb connect` with a provider registry, `list` and `status` views,
-  local secret storage outside git, repo-safe `.mb/connect.yaml` metadata, and
-  doctor/status integration health reporting.
+  explicit `--from-env` credential import, local secret storage outside git,
+  repo-safe `.mb/connect.yaml` metadata, and doctor/status integration health
+  reporting.
 
 ## [0.2.1] - 2026-05-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+### Added
+
+- Added `mb connect` with a provider registry, `list` and `status` views,
+  local secret storage outside git, repo-safe `.mb/connect.yaml` metadata, and
+  doctor/status integration health reporting.
+
 ## [0.2.1] - 2026-05-02
 
 v0.2.1 is the first post-0.2 durability release. It makes the new CLI front

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ The CLI surface for the engine. Built for Claude Code first; runtime-agnostic by
 | `mb init` | Set up a fresh business repo (six folders, CLAUDE.md, git init). |
 | `mb status` | Show a local-first daily briefing: repo health, runtime wiring, recent decisions/research/git activity, and GitHub tasks when `gh` is authenticated. |
 | `mb doctor` | Check the environment — repo shape, frontmatter sanity, settings on disk. Walks you through fixes. |
+| `mb connect` | Register provider credentials and integration metadata without committing secrets. |
 | `mb validate` | Frontmatter shape check across `core/`, `research/`, `decisions/`, `log/`, `campaigns/`, `documents/`. Pass/fail per file. |
 | `mb graph` | Walk the link graph (`linked_research` / `linked_decisions` / `supersedes`) and emit Graphviz DOT. `--open` renders to PNG and opens it. |
 | `mb think <topic>` | Print the `/think` invocation hint. Run inside Claude Code for the full flow. |
@@ -141,6 +142,24 @@ The CLI surface for the engine. Built for Claude Code first; runtime-agnostic by
 | `mb skill link --repo .` | Repair Claude Code skill discovery in a business repo. |
 
 Full list: `mb --help`.
+
+### Provider Connections
+
+`mb connect` is the local-first foundation for integrations such as Google,
+Meta, Cloudflare, Postiz, Apify, Beancount, and transcription providers.
+
+```bash
+mb connect list
+printf '%s' "$CLOUDFLARE_API_TOKEN" | mb connect cloudflare --token-stdin --metadata account_id=...
+mb connect status --json
+```
+
+Secrets are stored outside the business repo, using the macOS Keychain when
+available and a local `~/.mainbranch/secrets/connect.json` fallback otherwise.
+The business repo only receives non-sensitive metadata in `.mb/connect.yaml`,
+such as the provider id, account label, credential backend, and last check time.
+Skills and future dashboards should read `mb connect status --json` or
+`.mb/connect.yaml`; they should never ask users to commit tokens.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Meta, Cloudflare, Postiz, Apify, Beancount, and transcription providers.
 ```bash
 mb connect list
 printf '%s' "$CLOUDFLARE_API_TOKEN" | mb connect cloudflare --token-stdin --metadata account_id=...
+mb connect meta --from-env
 mb connect status --json
 ```
 
@@ -160,6 +161,8 @@ The business repo only receives non-sensitive metadata in `.mb/connect.yaml`,
 such as the provider id, account label, credential backend, and last check time.
 Skills and future dashboards should read `mb connect status --json` or
 `.mb/connect.yaml`; they should never ask users to commit tokens.
+`--from-env` is explicit: `mb connect` does not silently import general-purpose
+environment variables.
 
 ---
 

--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -8,6 +8,7 @@ because that's the working pattern.
 from __future__ import annotations
 
 import json
+import os
 import sys
 from pathlib import Path
 from typing import Any
@@ -15,6 +16,7 @@ from typing import Any
 import typer
 
 from mb import __version__
+from mb import connect as connect_mod
 from mb import doctor as doctor_mod
 from mb import educational as educational_mod
 from mb import graph as graph_mod
@@ -54,6 +56,13 @@ migrate_app = typer.Typer(
     invoke_without_command=True,
 )
 app.add_typer(migrate_app, name="migrate")
+
+CONNECT_METADATA_OPTION = typer.Option(
+    [],
+    "--metadata",
+    "-m",
+    help="Non-sensitive provider metadata as key=value. Repeat as needed.",
+)
 
 
 def _version_callback(value: bool) -> None:
@@ -292,6 +301,99 @@ def doctor_cmd(
     else:
         doctor_mod.render_human(report)
     raise typer.Exit(0 if report["ok"] else 1)
+
+
+@app.command("connect")
+def connect_cmd(
+    target: str = typer.Argument(
+        "",
+        help="Provider to connect, or `list` / `status`.",
+    ),
+    repo: str = typer.Option(".", "--repo", help="Business repo whose metadata is updated."),
+    account_label: str = typer.Option("", "--account", "--label", help="Human account label."),
+    token: str = typer.Option(
+        "",
+        "--token",
+        help="Secret token or key. Prefer --token-stdin for real credentials.",
+    ),
+    token_stdin: bool = typer.Option(
+        False,
+        "--token-stdin",
+        help="Read the secret token or key from stdin.",
+    ),
+    metadata: list[str] = CONNECT_METADATA_OPTION,
+    all_providers: bool = typer.Option(
+        False,
+        "--all",
+        help="With `mb connect status`, include providers not connected yet.",
+    ),
+    json_out: bool = typer.Option(False, "--json", help="Machine-readable output."),
+) -> None:
+    """Connect provider credentials without committing secrets."""
+    if not target:
+        result = connect_mod.list_providers(repo)
+        if json_out:
+            typer.echo(json.dumps(result, indent=2))
+        else:
+            connect_mod.render_list(result)
+        raise typer.Exit(0)
+    if target == "list":
+        result = connect_mod.list_providers(repo)
+        if json_out:
+            typer.echo(json.dumps(result, indent=2))
+        else:
+            connect_mod.render_list(result)
+        raise typer.Exit(0)
+    if target == "status":
+        result = connect_mod.status_all(repo, include_all=all_providers)
+        if json_out:
+            typer.echo(json.dumps(result, indent=2))
+        else:
+            connect_mod.render_status(result)
+        raise typer.Exit(0 if result["ok"] else 1)
+
+    try:
+        provider_info = connect_mod.normalize_provider(target)
+    except ValueError as exc:
+        typer.echo(f"mb connect: {exc}", err=True)
+        raise typer.Exit(2) from exc
+
+    secret_value = token
+    if token_stdin:
+        secret_value = connect_mod.read_stdin_token()
+    if not secret_value and provider_info.required_secrets:
+        for env_var in provider_info.env_vars:
+            value = os.environ.get(env_var, "").strip()
+            if value:
+                secret_value = value
+                break
+    if not secret_value and provider_info.required_secrets and sys.stdin.isatty():
+        secret_value = typer.prompt(
+            f"{provider_info.name} {provider_info.required_secrets[0]}",
+            hide_input=True,
+            default="",
+            show_default=False,
+        )
+
+    try:
+        result = connect_mod.connect_provider(
+            provider_info.id,
+            repo=repo,
+            token=secret_value,
+            account_label=account_label,
+            metadata_pairs=metadata,
+        )
+    except ValueError as exc:
+        typer.echo(f"mb connect: {exc}", err=True)
+        raise typer.Exit(2) from exc
+    except RuntimeError as exc:
+        typer.echo(f"mb connect: {exc}", err=True)
+        raise typer.Exit(1) from exc
+    if json_out:
+        typer.echo(json.dumps(result, indent=2))
+    else:
+        connect_mod.render_connect_result(result)
+    raise typer.Exit(0 if result["ok"] else 1)
 
 
 @app.command("status")

--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -321,6 +321,11 @@ def connect_cmd(
         "--token-stdin",
         help="Read the secret token or key from stdin.",
     ),
+    from_env: bool = typer.Option(
+        False,
+        "--from-env",
+        help="Read the provider credential from a known environment variable.",
+    ),
     metadata: list[str] = CONNECT_METADATA_OPTION,
     all_providers: bool = typer.Option(
         False,
@@ -361,12 +366,22 @@ def connect_cmd(
     secret_value = token
     if token_stdin:
         secret_value = connect_mod.read_stdin_token()
-    if not secret_value and provider_info.required_secrets:
+    credential_source = "prompt" if not secret_value else "token"
+    consumed_env_var = ""
+    if token_stdin:
+        credential_source = "stdin"
+    if from_env and not secret_value and provider_info.required_secrets:
         for env_var in provider_info.env_vars:
             value = os.environ.get(env_var, "").strip()
             if value:
                 secret_value = value
+                credential_source = "env"
+                consumed_env_var = env_var
                 break
+        if not secret_value:
+            names = ", ".join(provider_info.env_vars) or "(none registered)"
+            typer.echo(f"mb connect: no credential found in env vars: {names}", err=True)
+            raise typer.Exit(1)
     if not secret_value and provider_info.required_secrets and sys.stdin.isatty():
         secret_value = typer.prompt(
             f"{provider_info.name} {provider_info.required_secrets[0]}",
@@ -383,6 +398,10 @@ def connect_cmd(
             account_label=account_label,
             metadata_pairs=metadata,
         )
+        result["credential_source"] = {
+            "type": credential_source if secret_value else "missing",
+            "env_var": consumed_env_var,
+        }
     except ValueError as exc:
         typer.echo(f"mb connect: {exc}", err=True)
         raise typer.Exit(2) from exc

--- a/mb/mb/connect.py
+++ b/mb/mb/connect.py
@@ -325,6 +325,8 @@ def _read_local_secrets() -> dict[str, str]:
 def _write_local_secrets(data: dict[str, str]) -> None:
     path = _local_secret_path()
     path.parent.mkdir(parents=True, exist_ok=True)
+    with suppress(OSError):
+        path.parent.chmod(0o700)
     path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     with suppress(OSError):
         path.chmod(0o600)
@@ -553,6 +555,9 @@ def render_connect_result(result: dict[str, Any]) -> None:
         print(f"connected {result['provider']} metadata; credential still needs repair")
     print(f"metadata: {result['config_path']}")
     print(f"secrets: {result['credential_boundary']}")
+    source = result.get("credential_source") or {}
+    if source.get("type") == "env" and source.get("env_var"):
+        print(f"credential source: env {source['env_var']}")
     if status["state"] != "connected":
         print("next: rerun with --token-stdin or --token to store the required credential")
 

--- a/mb/mb/connect.py
+++ b/mb/mb/connect.py
@@ -176,8 +176,12 @@ def _read_config(repo: Path) -> dict[str, Any]:
     providers = raw.get("providers")
     if not isinstance(providers, dict):
         providers = {}
+    try:
+        version = int(raw.get("version") or 1)
+    except (TypeError, ValueError):
+        version = 1
     return {
-        "version": int(raw.get("version") or 1),
+        "version": version,
         "repo_id": str(raw.get("repo_id") or ""),
         "providers": providers,
     }

--- a/mb/mb/connect.py
+++ b/mb/mb/connect.py
@@ -1,0 +1,561 @@
+"""Integration registry and credential metadata for ``mb connect``."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib
+import json
+import os
+import platform
+import shutil
+import subprocess
+import sys
+import uuid
+from contextlib import suppress
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+CONFIG_RELATIVE_PATH = Path(".mb") / "connect.yaml"
+SERVICE_NAME = "mainbranch"
+SENSITIVE_KEY_PARTS = ("token", "secret", "password", "credential", "api_key", "apikey", "key")
+
+
+@dataclass(frozen=True)
+class Provider:
+    """Provider registry entry.
+
+    ``required_secrets`` names are local credential slots, not values. They are
+    safe to write into repo metadata because actual secret material is stored
+    through ``SecretStore``.
+    """
+
+    id: str
+    name: str
+    category: str
+    auth: str
+    required_secrets: tuple[str, ...]
+    metadata_fields: tuple[str, ...]
+    description: str
+    env_vars: tuple[str, ...] = ()
+
+
+PROVIDERS: tuple[Provider, ...] = (
+    Provider(
+        id="google",
+        name="Google",
+        category="workspace",
+        auth="oauth_or_service_account",
+        required_secrets=("access_token",),
+        metadata_fields=("account_email", "workspace"),
+        description="Google Workspace, Drive, Docs, Sheets, Slides, and future analytics sync.",
+        env_vars=("GOOGLE_APPLICATION_CREDENTIALS", "GOOGLE_OAUTH_TOKEN"),
+    ),
+    Provider(
+        id="meta",
+        name="Meta",
+        category="ads",
+        auth="access_token",
+        required_secrets=("access_token",),
+        metadata_fields=("ad_account_id", "business_id"),
+        description="Meta ads accounts, campaign review, and future performance sync.",
+        env_vars=("META_ACCESS_TOKEN",),
+    ),
+    Provider(
+        id="cloudflare",
+        name="Cloudflare",
+        category="site",
+        auth="api_token",
+        required_secrets=("api_token",),
+        metadata_fields=("account_id", "zone_id"),
+        description="Cloudflare Pages, DNS, Workers, and deployment metadata.",
+        env_vars=("CLOUDFLARE_API_TOKEN",),
+    ),
+    Provider(
+        id="postiz",
+        name="Postiz",
+        category="social",
+        auth="api_key",
+        required_secrets=("api_key",),
+        metadata_fields=("workspace",),
+        description="Postiz social scheduling and publishing workflows.",
+        env_vars=("POSTIZ_API_KEY",),
+    ),
+    Provider(
+        id="apify",
+        name="Apify",
+        category="research",
+        auth="api_token",
+        required_secrets=("api_token",),
+        metadata_fields=("default_actor",),
+        description="Apify research actors and scrape jobs.",
+        env_vars=("APIFY_TOKEN",),
+    ),
+    Provider(
+        id="beancount",
+        name="Beancount",
+        category="finance",
+        auth="local_file",
+        required_secrets=(),
+        metadata_fields=("ledger_path",),
+        description="Local ledger paths and finance workflow metadata.",
+    ),
+    Provider(
+        id="transcription",
+        name="Whisper / transcription",
+        category="media",
+        auth="api_key_or_local",
+        required_secrets=("api_key",),
+        metadata_fields=("engine", "model"),
+        description="Whisper-compatible transcription provider or local transcription engine.",
+        env_vars=("OPENAI_API_KEY", "WHISPER_API_KEY"),
+    ),
+)
+
+
+def provider_map() -> dict[str, Provider]:
+    return {provider.id: provider for provider in PROVIDERS}
+
+
+def provider_registry() -> list[dict[str, Any]]:
+    return [
+        {
+            "id": provider.id,
+            "name": provider.name,
+            "category": provider.category,
+            "auth": provider.auth,
+            "required_secrets": list(provider.required_secrets),
+            "metadata_fields": list(provider.metadata_fields),
+            "description": provider.description,
+            "env_vars": list(provider.env_vars),
+        }
+        for provider in PROVIDERS
+    ]
+
+
+def normalize_provider(provider_id: str) -> Provider:
+    key = provider_id.strip().lower().replace("_", "-")
+    aliases = {"whisper": "transcription", "cloudflare-pages": "cloudflare"}
+    key = aliases.get(key, key)
+    providers = provider_map()
+    if key not in providers:
+        supported = ", ".join(sorted(providers))
+        raise ValueError(f"unknown provider {provider_id!r}; supported providers: {supported}")
+    return providers[key]
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _home() -> Path:
+    return Path(os.environ.get("MAINBRANCH_HOME", Path.home() / ".mainbranch")).expanduser()
+
+
+def _config_path(repo: Path) -> Path:
+    return repo / CONFIG_RELATIVE_PATH
+
+
+def _empty_config() -> dict[str, Any]:
+    return {"version": 1, "repo_id": "", "providers": {}}
+
+
+def _read_config(repo: Path) -> dict[str, Any]:
+    path = _config_path(repo)
+    if not path.exists():
+        return _empty_config()
+    try:
+        raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except (OSError, yaml.YAMLError):
+        raw = {}
+    if not isinstance(raw, dict):
+        raw = {}
+    providers = raw.get("providers")
+    if not isinstance(providers, dict):
+        providers = {}
+    return {
+        "version": int(raw.get("version") or 1),
+        "repo_id": str(raw.get("repo_id") or ""),
+        "providers": providers,
+    }
+
+
+def _ensure_repo_id(config: dict[str, Any]) -> str:
+    repo_id = str(config.get("repo_id") or "")
+    if repo_id:
+        return repo_id
+    repo_id = uuid.uuid4().hex
+    config["repo_id"] = repo_id
+    return repo_id
+
+
+def _write_config(repo: Path, config: dict[str, Any]) -> Path:
+    path = _config_path(repo)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = yaml.safe_dump(config, sort_keys=False)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _secret_ref(repo_id: str, provider_id: str, field: str) -> str:
+    digest = hashlib.sha256(f"{repo_id}:{provider_id}:{field}".encode()).hexdigest()[:24]
+    return f"mainbranch://{digest}/{provider_id}/{field}"
+
+
+class SecretStore:
+    """Best-effort local secret storage outside the repo."""
+
+    def __init__(self, backend: str | None = None) -> None:
+        self.backend = backend or _select_secret_backend()
+
+    def set(self, ref: str, value: str) -> None:
+        if self.backend == "macos-keychain":
+            try:
+                _macos_set(ref, value)
+            except (OSError, subprocess.SubprocessError) as exc:
+                raise RuntimeError("macOS Keychain credential write failed") from exc
+            return
+        if self.backend == "keyring":
+            module = _keyring_module()
+            if module is None:
+                raise RuntimeError("Python keyring backend is unavailable")
+            try:
+                module.set_password(SERVICE_NAME, ref, value)
+            except Exception as exc:
+                raise RuntimeError("Python keyring credential write failed") from exc
+            return
+        _local_set(ref, value)
+
+    def get(self, ref: str) -> str:
+        if self.backend == "macos-keychain":
+            return _macos_get(ref)
+        if self.backend == "keyring":
+            module = _keyring_module()
+            if module is None:
+                return ""
+            try:
+                value = module.get_password(SERVICE_NAME, ref)
+            except Exception:
+                return ""
+            return str(value or "")
+        return _local_get(ref)
+
+    def boundary(self) -> str:
+        if self.backend == "macos-keychain":
+            return "stored in the macOS Keychain"
+        if self.backend == "keyring":
+            return "stored through the Python keyring backend"
+        return f"stored outside the repo in {_local_secret_path()}"
+
+
+def _select_secret_backend() -> str:
+    requested = os.environ.get("MB_CONNECT_SECRET_BACKEND", "auto").strip().lower()
+    if requested in {"macos-keychain", "keyring", "local-file"}:
+        return requested
+    if platform.system() == "Darwin" and shutil.which("security"):
+        return "macos-keychain"
+    if _keyring_module() is not None:
+        return "keyring"
+    return "local-file"
+
+
+def _keyring_module() -> Any | None:
+    try:
+        return importlib.import_module("keyring")
+    except ImportError:
+        return None
+
+
+def _macos_set(ref: str, value: str) -> None:
+    subprocess.run(
+        [
+            "security",
+            "add-generic-password",
+            "-a",
+            ref,
+            "-s",
+            SERVICE_NAME,
+            "-w",
+            value,
+            "-U",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+
+def _macos_get(ref: str) -> str:
+    try:
+        result = subprocess.run(
+            ["security", "find-generic-password", "-a", ref, "-s", SERVICE_NAME, "-w"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    if result.returncode != 0:
+        return ""
+    return result.stdout.rstrip("\n")
+
+
+def _local_secret_path() -> Path:
+    return _home() / "secrets" / "connect.json"
+
+
+def _read_local_secrets() -> dict[str, str]:
+    path = _local_secret_path()
+    if not path.exists():
+        return {}
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    if not isinstance(raw, dict):
+        return {}
+    return {str(key): str(value) for key, value in raw.items()}
+
+
+def _write_local_secrets(data: dict[str, str]) -> None:
+    path = _local_secret_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    with suppress(OSError):
+        path.chmod(0o600)
+
+
+def _local_set(ref: str, value: str) -> None:
+    data = _read_local_secrets()
+    data[ref] = value
+    _write_local_secrets(data)
+
+
+def _local_get(ref: str) -> str:
+    return _read_local_secrets().get(ref, "")
+
+
+def _parse_metadata(pairs: list[str]) -> dict[str, str]:
+    metadata: dict[str, str] = {}
+    for pair in pairs:
+        if "=" not in pair:
+            raise ValueError(f"metadata must be key=value, got {pair!r}")
+        key, value = pair.split("=", 1)
+        key = key.strip()
+        value = value.strip()
+        if not key:
+            raise ValueError("metadata keys cannot be empty")
+        lowered = key.lower().replace("-", "_")
+        if any(part in lowered for part in SENSITIVE_KEY_PARTS):
+            raise ValueError(f"metadata key {key!r} looks sensitive; use --token/--token-stdin")
+        metadata[key] = value
+    return metadata
+
+
+def connect_provider(
+    provider_id: str,
+    repo: str | Path = ".",
+    *,
+    token: str = "",
+    account_label: str = "",
+    metadata_pairs: list[str] | None = None,
+    secret_backend: str | None = None,
+) -> dict[str, Any]:
+    """Connect a provider by writing repo metadata and local secrets."""
+
+    provider = normalize_provider(provider_id)
+    target = Path(repo).resolve()
+    config = _read_config(target)
+    repo_id = _ensure_repo_id(config)
+    metadata = _parse_metadata(metadata_pairs or [])
+    store = SecretStore(secret_backend)
+
+    secrets: dict[str, dict[str, str]] = {}
+    required = list(provider.required_secrets)
+    if required:
+        primary = required[0]
+        if token:
+            ref = _secret_ref(repo_id, provider.id, primary)
+            store.set(ref, token)
+            secrets[primary] = {"ref": ref, "backend": store.backend}
+        else:
+            secrets[primary] = {
+                "ref": _secret_ref(repo_id, provider.id, primary),
+                "backend": store.backend,
+            }
+
+    providers = config["providers"]
+    providers[provider.id] = {
+        "provider": provider.id,
+        "connected": True,
+        "account_label": account_label.strip(),
+        "connected_at": _now(),
+        "last_checked_at": _now(),
+        "auth": provider.auth,
+        "secrets": secrets,
+        "metadata": metadata,
+    }
+    path = _write_config(target, config)
+    status = status_provider(provider.id, target)
+    return {
+        "ok": bool(status["ok"]),
+        "provider": provider.id,
+        "config_path": str(path),
+        "credential_backend": store.backend,
+        "credential_boundary": store.boundary(),
+        "status": status,
+    }
+
+
+def status_provider(provider_id: str, repo: str | Path = ".") -> dict[str, Any]:
+    provider = normalize_provider(provider_id)
+    target = Path(repo).resolve()
+    config = _read_config(target)
+    entry = config["providers"].get(provider.id)
+    if not isinstance(entry, dict):
+        return {
+            "provider": provider.id,
+            "name": provider.name,
+            "connected": False,
+            "ok": False,
+            "state": "not_connected",
+            "account_label": "",
+            "metadata": {},
+            "secrets": {},
+            "last_checked_at": "",
+        }
+
+    secrets: dict[str, dict[str, Any]] = {}
+    missing: list[str] = []
+    stored_secrets = entry.get("secrets") if isinstance(entry.get("secrets"), dict) else {}
+    for field in provider.required_secrets:
+        raw = stored_secrets.get(field) if isinstance(stored_secrets, dict) else None
+        raw = raw if isinstance(raw, dict) else {}
+        ref = str(raw.get("ref") or "")
+        backend = str(raw.get("backend") or "local-file")
+        present = bool(ref and SecretStore(backend).get(ref))
+        if not present:
+            missing.append(field)
+        secrets[field] = {"present": present, "ref": ref, "backend": backend}
+
+    metadata = entry.get("metadata") if isinstance(entry.get("metadata"), dict) else {}
+    ok = not missing
+    state = "connected" if ok else "missing_secret"
+    return {
+        "provider": provider.id,
+        "name": provider.name,
+        "connected": bool(entry.get("connected", False)),
+        "ok": ok,
+        "state": state,
+        "account_label": str(entry.get("account_label") or ""),
+        "metadata": metadata,
+        "secrets": secrets,
+        "last_checked_at": str(entry.get("last_checked_at") or ""),
+    }
+
+
+def status_all(repo: str | Path = ".", *, include_all: bool = False) -> dict[str, Any]:
+    target = Path(repo).resolve()
+    config = _read_config(target)
+    configured = set(config["providers"].keys())
+    providers = []
+    for provider in PROVIDERS:
+        if include_all or provider.id in configured:
+            providers.append(status_provider(provider.id, target))
+    connected = [item for item in providers if item["connected"]]
+    broken = [item for item in connected if not item["ok"]]
+    return {
+        "ok": not broken,
+        "repo": str(target),
+        "config_path": str(_config_path(target)),
+        "repo_id": str(config.get("repo_id") or ""),
+        "providers": providers,
+        "summary": {
+            "configured": len(connected),
+            "healthy": len([item for item in connected if item["ok"]]),
+            "needs_repair": len(broken),
+        },
+    }
+
+
+def list_providers(repo: str | Path = ".") -> dict[str, Any]:
+    status = status_all(repo, include_all=True)
+    by_id = {item["provider"]: item for item in status["providers"]}
+    providers = []
+    for provider in provider_registry():
+        state = by_id[provider["id"]]["state"]
+        providers.append({**provider, "state": state})
+    return {"ok": True, "providers": providers, "config_path": status["config_path"]}
+
+
+def doctor_check(repo: str | Path = ".") -> dict[str, Any]:
+    status = status_all(repo)
+    summary = status["summary"]
+    if summary["configured"] == 0:
+        return {
+            "name": "integration-credentials",
+            "ok": True,
+            "detail": "no providers connected",
+            "severity": "info",
+        }
+    if summary["needs_repair"]:
+        return {
+            "name": "integration-credentials",
+            "ok": False,
+            "detail": (
+                f"{summary['needs_repair']} of {summary['configured']} connected provider(s) "
+                "need credential repair; run `mb connect status`."
+            ),
+            "severity": "warn",
+        }
+    return {
+        "name": "integration-credentials",
+        "ok": True,
+        "detail": f"{summary['healthy']} connected provider(s) ready",
+        "severity": "ok",
+    }
+
+
+def render_list(result: dict[str, Any]) -> None:
+    for provider in result["providers"]:
+        print(
+            f"{provider['id']:<14} {provider['state']:<14} "
+            f"{provider['auth']:<22} {provider['description']}"
+        )
+
+
+def render_status(result: dict[str, Any]) -> None:
+    summary = result["summary"]
+    print(f"mb connect status  {result['repo']}")
+    print(
+        f"configured: {summary['configured']}  "
+        f"healthy: {summary['healthy']}  needs repair: {summary['needs_repair']}"
+    )
+    if not result["providers"]:
+        print("no providers connected")
+        return
+    for item in result["providers"]:
+        state = "ok" if item["ok"] else "warn"
+        label = f" ({item['account_label']})" if item["account_label"] else ""
+        print(f"  {state}  {item['provider']}{label}: {item['state']}")
+
+
+def render_connect_result(result: dict[str, Any]) -> None:
+    status = result["status"]
+    if result["ok"]:
+        print(f"connected {result['provider']}")
+    else:
+        print(f"connected {result['provider']} metadata; credential still needs repair")
+    print(f"metadata: {result['config_path']}")
+    print(f"secrets: {result['credential_boundary']}")
+    if status["state"] != "connected":
+        print("next: rerun with --token-stdin or --token to store the required credential")
+
+
+def read_stdin_token() -> str:
+    return sys.stdin.read().strip()

--- a/mb/mb/doctor.py
+++ b/mb/mb/doctor.py
@@ -17,6 +17,7 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from mb import connect as connect_mod
 from mb.engine import install_mode, link_status
 from mb.freshness import format_update_alert, package_update_status, version_key
 from mb.migrate import LATEST_SCHEMA_VERSION, pending_migrations, read_schema_version
@@ -269,6 +270,7 @@ def run(path: str) -> dict[str, Any]:
     checks.append(_mainbranch_version_check(update))
     checks.append(_repo_layout_check(repo))
     checks.append(_schema_version_check(repo))
+    checks.append(connect_mod.doctor_check(repo))
 
     cloud_hits = _detect_cloud_paths(repo)
     cloud_ok = not cloud_hits
@@ -305,6 +307,7 @@ def run(path: str) -> dict[str, Any]:
         "ok": overall and not hard_fail,
         "checks": checks,
         "repo": str(repo),
+        "integrations": connect_mod.status_all(repo),
         "update": update,
         "python": sys.version.split()[0],
     }

--- a/mb/mb/status.py
+++ b/mb/mb/status.py
@@ -13,6 +13,7 @@ from typing import Any
 import yaml
 
 from mb import __version__, github_activity
+from mb import connect as connect_mod
 from mb.engine import install_mode, link_status
 from mb.freshness import format_update_alert, package_update_status
 
@@ -405,6 +406,7 @@ def run(path: str = ".") -> dict[str, Any]:
         "git": git,
         "git_activity": _git_recent_activity(repo_path, git),
         "brain": _brain(repo_path),
+        "integrations": connect_mod.status_all(repo_path),
         "github": _github(repo_path, git),
     }
     report["readiness"] = _readiness(report)
@@ -421,6 +423,10 @@ def render_human(report: dict[str, Any]) -> None:
     git = report["git"]
     runtime = report["runtime"]
     brain = report["brain"]
+    integrations = report.get(
+        "integrations",
+        {"summary": {"configured": 0, "healthy": 0, "needs_repair": 0}, "providers": []},
+    )
     github = report["github"]
     readiness = report["readiness"]
 
@@ -451,6 +457,15 @@ def render_human(report: dict[str, Any]) -> None:
     claude_mark = "[green]found[/green]" if claude["found"] else "[yellow]missing[/yellow]"
     skill_mark = "[green]wired[/green]" if skills["ok"] else "[yellow]missing[/yellow]"
     console.print(f"[bold]Runtime[/bold] Claude Code: {claude_mark}  skills: {skill_mark}")
+
+    integration_summary = integrations["summary"]
+    if integration_summary["configured"]:
+        console.print(
+            "[bold]Integrations[/bold] "
+            f"configured {integration_summary['configured']}  "
+            f"healthy {integration_summary['healthy']}  "
+            f"needs repair {integration_summary['needs_repair']}"
+        )
 
     counts = brain["counts"]
     console.print(

--- a/mb/tests/test_connect.py
+++ b/mb/tests/test_connect.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import json
+import stat
 from pathlib import Path
+from typing import Any
 
 import yaml
 from typer.testing import CliRunner
@@ -17,6 +19,9 @@ runner = CliRunner()
 def _local_secret_env(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setenv("MB_CONNECT_SECRET_BACKEND", "local-file")
     monkeypatch.setenv("MAINBRANCH_HOME", str(tmp_path / "home"))
+    for provider in connect_mod.PROVIDERS:
+        for env_var in provider.env_vars:
+            monkeypatch.delenv(env_var, raising=False)
 
 
 def test_provider_registry_includes_initial_foundation() -> None:
@@ -84,6 +89,34 @@ def test_connect_provider_stores_secret_outside_repo(tmp_path: Path, monkeypatch
 
     secret_file = tmp_path / "home" / "secrets" / "connect.json"
     assert "cf-test-token" in secret_file.read_text(encoding="utf-8")
+    assert stat.S_IMODE(secret_file.parent.stat().st_mode) == 0o700
+    assert stat.S_IMODE(secret_file.stat().st_mode) == 0o600
+
+
+def test_connect_provider_only_reads_env_when_explicit(tmp_path: Path, monkeypatch) -> None:
+    _local_secret_env(monkeypatch, tmp_path)
+    monkeypatch.setenv("META_ACCESS_TOKEN", "meta-test-token")
+    repo = tmp_path / "biz"
+    repo.mkdir()
+
+    implicit = runner.invoke(app, ["connect", "meta", "--repo", str(repo), "--json"])
+
+    assert implicit.exit_code == 1
+    implicit_payload = json.loads(implicit.stdout)
+    assert implicit_payload["status"]["state"] == "missing_secret"
+
+    explicit = runner.invoke(
+        app,
+        ["connect", "meta", "--repo", str(repo), "--from-env", "--json"],
+    )
+
+    assert explicit.exit_code == 0
+    explicit_payload = json.loads(explicit.stdout)
+    assert explicit_payload["credential_source"] == {
+        "type": "env",
+        "env_var": "META_ACCESS_TOKEN",
+    }
+    assert "meta-test-token" not in (repo / ".mb" / "connect.yaml").read_text(encoding="utf-8")
 
 
 def test_connect_status_reports_missing_secret_as_repair_not_hard_crash(
@@ -115,7 +148,6 @@ def test_doctor_and_status_include_integration_state(tmp_path: Path, monkeypatch
     )
 
     doctor_report = runner.invoke(app, ["doctor", str(repo), "--json"])
-    assert doctor_report.exit_code in {0, 1}
     doctor_payload = json.loads(doctor_report.stdout)
     assert doctor_payload["integrations"]["summary"]["configured"] == 1
     assert "integration-credentials" in {check["name"] for check in doctor_payload["checks"]}
@@ -124,3 +156,25 @@ def test_doctor_and_status_include_integration_state(tmp_path: Path, monkeypatch
     assert status_report.exit_code == 0
     status_payload = json.loads(status_report.stdout)
     assert status_payload["integrations"]["summary"]["healthy"] == 1
+
+
+def test_macos_keychain_backend_uses_security(monkeypatch) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(args: list[str], **kwargs: Any) -> Any:
+        calls.append(args)
+
+        class Result:
+            returncode = 0
+            stdout = ""
+
+        return Result()
+
+    monkeypatch.setattr(connect_mod.subprocess, "run", fake_run)
+
+    store = connect_mod.SecretStore("macos-keychain")
+    store.set("mainbranch://test/cloudflare/api_token", "cf-token")
+
+    assert calls
+    assert calls[0][:3] == ["security", "add-generic-password", "-a"]
+    assert "cf-token" in calls[0]

--- a/mb/tests/test_connect.py
+++ b/mb/tests/test_connect.py
@@ -1,0 +1,126 @@
+"""``mb connect`` provider and credential foundation."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import yaml
+from typer.testing import CliRunner
+
+from mb import connect as connect_mod
+from mb.cli import app
+
+runner = CliRunner()
+
+
+def _local_secret_env(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("MB_CONNECT_SECRET_BACKEND", "local-file")
+    monkeypatch.setenv("MAINBRANCH_HOME", str(tmp_path / "home"))
+
+
+def test_provider_registry_includes_initial_foundation() -> None:
+    providers = {provider["id"]: provider for provider in connect_mod.provider_registry()}
+
+    assert {
+        "google",
+        "meta",
+        "cloudflare",
+        "postiz",
+        "apify",
+        "beancount",
+        "transcription",
+    }.issubset(providers)
+    assert providers["cloudflare"]["required_secrets"] == ["api_token"]
+    assert providers["beancount"]["required_secrets"] == []
+
+
+def test_connect_list_json_does_not_create_repo_metadata(tmp_path: Path) -> None:
+    repo = tmp_path / "biz"
+    repo.mkdir()
+
+    result = runner.invoke(app, ["connect", "list", "--repo", str(repo), "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert any(provider["id"] == "cloudflare" for provider in payload["providers"])
+    assert not (repo / ".mb" / "connect.yaml").exists()
+
+
+def test_connect_provider_stores_secret_outside_repo(tmp_path: Path, monkeypatch) -> None:
+    _local_secret_env(monkeypatch, tmp_path)
+    repo = tmp_path / "biz"
+    repo.mkdir()
+
+    result = runner.invoke(
+        app,
+        [
+            "connect",
+            "cloudflare",
+            "--repo",
+            str(repo),
+            "--account",
+            "Acme CF",
+            "--token",
+            "cf-test-token",
+            "--metadata",
+            "account_id=acct_123",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["credential_backend"] == "local-file"
+
+    config_path = repo / ".mb" / "connect.yaml"
+    config_text = config_path.read_text(encoding="utf-8")
+    assert "cf-test-token" not in config_text
+    config = yaml.safe_load(config_text)
+    cloudflare = config["providers"]["cloudflare"]
+    assert cloudflare["metadata"] == {"account_id": "acct_123"}
+    assert cloudflare["account_label"] == "Acme CF"
+
+    secret_file = tmp_path / "home" / "secrets" / "connect.json"
+    assert "cf-test-token" in secret_file.read_text(encoding="utf-8")
+
+
+def test_connect_status_reports_missing_secret_as_repair_not_hard_crash(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _local_secret_env(monkeypatch, tmp_path)
+    repo = tmp_path / "biz"
+    repo.mkdir()
+
+    result = runner.invoke(app, ["connect", "meta", "--repo", str(repo), "--json"])
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["status"]["state"] == "missing_secret"
+
+    status = runner.invoke(app, ["connect", "status", "--repo", str(repo), "--json"])
+    assert status.exit_code == 1
+    status_payload = json.loads(status.stdout)
+    assert status_payload["summary"]["needs_repair"] == 1
+    assert status_payload["providers"][0]["secrets"]["access_token"]["present"] is False
+
+
+def test_doctor_and_status_include_integration_state(tmp_path: Path, monkeypatch) -> None:
+    _local_secret_env(monkeypatch, tmp_path)
+    repo = tmp_path / "biz"
+    repo.mkdir()
+    connect_mod.connect_provider(
+        "beancount", repo=repo, metadata_pairs=["ledger_path=core/finance/main.bean"]
+    )
+
+    doctor_report = runner.invoke(app, ["doctor", str(repo), "--json"])
+    assert doctor_report.exit_code in {0, 1}
+    doctor_payload = json.loads(doctor_report.stdout)
+    assert doctor_payload["integrations"]["summary"]["configured"] == 1
+    assert "integration-credentials" in {check["name"] for check in doctor_payload["checks"]}
+
+    status_report = runner.invoke(app, ["status", str(repo), "--json"])
+    assert status_report.exit_code == 0
+    status_payload = json.loads(status_report.stdout)
+    assert status_payload["integrations"]["summary"]["healthy"] == 1

--- a/mb/tests/test_connect.py
+++ b/mb/tests/test_connect.py
@@ -139,6 +139,23 @@ def test_connect_status_reports_missing_secret_as_repair_not_hard_crash(
     assert status_payload["providers"][0]["secrets"]["access_token"]["present"] is False
 
 
+def test_connect_status_tolerates_malformed_config_version(tmp_path: Path, monkeypatch) -> None:
+    _local_secret_env(monkeypatch, tmp_path)
+    repo = tmp_path / "biz"
+    repo.mkdir()
+    (repo / ".mb").mkdir()
+    (repo / ".mb" / "connect.yaml").write_text(
+        "version: not-a-number\nproviders: []\n",
+        encoding="utf-8",
+    )
+
+    status = runner.invoke(app, ["connect", "status", "--repo", str(repo), "--json"])
+
+    assert status.exit_code == 0
+    status_payload = json.loads(status.stdout)
+    assert status_payload["summary"]["configured"] == 0
+
+
 def test_doctor_and_status_include_integration_state(tmp_path: Path, monkeypatch) -> None:
     _local_secret_env(monkeypatch, tmp_path)
     repo = tmp_path / "biz"


### PR DESCRIPTION
## Summary
- Adds `mb connect` as the local-first credential and integration foundation.
- Defines an initial provider registry for Google, Meta, Cloudflare, Postiz, Apify, Beancount, and transcription providers.
- Stores secrets outside git while writing only non-sensitive `.mb/connect.yaml` metadata and JSON status for skills/dashboard consumers.
- Surfaces integration health in `mb doctor` and `mb status` without making unconfigured repos fail.

## Scope
- In: provider registry, `mb connect list`, `mb connect status`, minimal `mb connect <provider>`, explicit `--from-env`, local secret storage, doctor/status reporting, README/CHANGELOG, and focused tests.
- Out: full OAuth, real provider API sync, background sync daemon, dashboard UI, and new runtime support claims.

## Commits
- `537de7f` — `[add] MAIN-181 connect credential foundation`.
- `16a4485` — `[fix] MAIN-181 require explicit env credential import`.

## Release / Issues
- Release: v0.2.2 target.
- Linear ID(s): MAIN-181.
- Closes: #187.
- Refs: MAIN-130.
- Follow-ups: provider-specific OAuth/API sync and encrypted fallback policy if plaintext local fallback is not enough.

## Success Metric
- Future Google, Meta, Cloudflare, Postiz, Apify, Beancount, and transcription work has one durable credential/config contract instead of each skill inventing its own env-var ritual.

## Validation
- Level 0 docs/decision: README and CHANGELOG updated; no product claims beyond the credential foundation.
- Level 1 static: `scripts/check.sh` passed.
- Level 2 CLI: `pytest tests/test_connect.py -q` passed; full `scripts/check.sh` ran 114 tests.
- Level 3 package/install: `python3 -m build`, wheel install into `/tmp/mainbranch-smoke`, installed `mb --version`, `mb skill list`, `mb connect list --json`, installed `mb onboard`, `mb connect beancount`, `mb connect status --json`, and `mb start --json` passed.
- Level 4 fixture repo: temp business repo smoke passed with `mb init`, `mb connect beancount`, `mb connect status --json`, `mb doctor --json`, and `mb status --json`.
- Level 5 runtime smoke: not run; no bundled skill invocation or runtime discovery behavior changed.

## Public / Private Boundary
- No secrets, customer/member data, private Conductor preferences, or runtime-private details were committed.
- Repo metadata is non-sensitive only; credentials stay in OS/local operational storage outside git.
