### PR TITLE
[update] Prepare 0.2.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,28 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+## [0.2.2] - 2026-05-03
+
+v0.2.2 turns the v0.2 command surface into a better operating foundation. It
+adds the first credential/integration registry, validates bundled skills as
+product code, and clarifies how per-repo connected accounts should stay tied to
+the active business repo.
+
+### What this means for you (plain English)
+
+- **`mb connect` now has a foundation.** You can list known providers, check
+  connected status, and import credentials explicitly from environment
+  variables into local storage without committing secrets.
+- **Skill packaging is checked before release.** `mb skill validate --all`
+  verifies bundled skills are self-contained, have valid frontmatter, and stay
+  under the line-count gate.
+- **`mb doctor` can catch more broken installs.** Doctor and CI now run bundled
+  skill validation, so missing skill references surface before users hit them.
+- **Connected tools stay repo-tethered.** Main Branch docs and generated
+  `CLAUDE.md` now tell users to keep ads, Stripe, pixels, MCP tools, and other
+  accounts connected to the active business repo instead of treating them as
+  global magic.
+
 ### Added
 
 - Added `mb skill validate <name>` and `mb skill validate --all` to check

--- a/mb/mb/__init__.py
+++ b/mb/mb/__init__.py
@@ -7,6 +7,6 @@ file stays a thin dispatcher.
 
 from __future__ import annotations
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 
 __all__ = ["__version__"]

--- a/mb/pyproject.toml
+++ b/mb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mainbranch"
-version = "0.2.1"
+version = "0.2.2"
 description = "Main Branch engine umbrella - scaffolds, validates, and graphs business-as-files repos. Claude Code first, runtime-agnostic by design."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- Promotes the current unreleased `mb connect`, `mb skill validate`, and per-repo tool tethering work into `0.2.2`.
- Bumps both package metadata and runtime `mb --version` to `0.2.2`.
- Adds plain-English release notes for users upgrading from `0.2.1`.

## Scope
- In: `CHANGELOG.md`, `mb/pyproject.toml`, `mb/mb/__init__.py`.
- Out: product code, packaging metadata modernization, PyPI publish, GitHub Release creation.

## Commits
- `40a5f43` — `[update] Prepare 0.2.2 release`.

## Release / Issues
- Release: `0.2.2` / `oe-v0.2.2`.
- Linear ID(s): none for this release-prep branch.
- Closes: none.
- Refs: #130, #176, #187.
- Follow-ups: #217 / MAIN-189 for non-blocking setuptools license metadata modernization.

## Success Metric
- A built wheel reports `mb 0.2.2` and includes the merged `mb connect` and `mb skill validate` release notes.

## Validation
- Level 0 docs/decision: changelog promoted from `[Unreleased]` to `[0.2.2] - 2026-05-03`.
- Level 1 static: `scripts/check.sh` passed: 127 tests, coverage 82.90%.
- Level 2 CLI: covered by `scripts/check.sh`; package smoke verified `mb --version`.
- Level 3 package/install: rebuilt clean wheel, installed `mainbranch-0.2.2-py3-none-any.whl` in `/tmp/mainbranch-022-smoke`, verified `mb 0.2.2` and `mb skill validate --all --json` summary `skills=14 passed=14 errors=0`.
- Level 4 fixture repo: not needed; release-prep only.
- Level 5 runtime smoke: not needed; release-prep only.

## Public / Private Boundary
- Public release metadata only. No private Devon/Conductor/runtime details added.

## Notes
- `python -m build` still emits the known setuptools license metadata deprecation warning; tracked separately in #217 / MAIN-189 and not blocking this release.