### PR TITLE
[add] mb graph index substrate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+### Added
+
+- Added `mb graph --json` as a deterministic repo graph index for files,
+  frontmatter links, wikilinks, and first-class people, companies, offers,
+  channels, competitors, and metrics entity nodes while keeping DOT output as
+  the default scriptable view.
+
 ## [0.2.2] - 2026-05-03
 
 v0.2.2 turns the v0.2 command surface into a better operating foundation. It

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ The CLI surface for the engine. Built for Claude Code first; runtime-agnostic by
 | `mb doctor` | Check the environment — repo shape, frontmatter sanity, settings on disk. Walks you through fixes. |
 | `mb connect` | Register provider credentials and integration metadata without committing secrets. |
 | `mb validate` | Frontmatter shape check across `core/`, `research/`, `decisions/`, `log/`, `campaigns/`, `documents/`. Pass/fail per file. |
-| `mb graph` | Walk the link graph (`linked_research` / `linked_decisions` / `supersedes`) and emit Graphviz DOT. `--open` renders to PNG and opens it. |
+| `mb graph` | Build a repo graph index from frontmatter links, wikilinks, and entity tags. Emits Graphviz DOT by default, `--json` for agents/dashboards, and `--open` to render a PNG view. |
 | `mb think <topic>` | Print the `/think` invocation hint. Run inside Claude Code for the full flow. |
 | `mb resolve <key>` | Resolve a reference path (checks free first, then paid). |
 | `mb educational <topic>` | Print an educational triage file (powers `mb doctor`'s "tell me more" prompts). |

--- a/docs/BEGINNER-SETUP.md
+++ b/docs/BEGINNER-SETUP.md
@@ -163,7 +163,7 @@ do not need to move files immediately.
 | `mb doctor` | Check that everything is set up correctly. Walks you through fixes. |
 | `mb skill link --repo .` | Repair Claude Code skill discovery if `/start` doesn't show up. |
 | `mb validate` | Check your reference files have correct frontmatter. |
-| `mb graph` | Visualize the link graph between research and decisions. |
+| `mb graph` | Visualize or export the graph of files, links, wikilinks, and business entity tags. |
 | `mb skill list` | Show which skills your installed Main Branch ships. |
 
 For the full list: `mb --help`.

--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -508,10 +508,10 @@ def graph_cmd(
     json_out: bool = typer.Option(False, "--json", help="Emit the machine-readable graph index."),
 ) -> None:
     """Build the repo graph index; emit DOT by default or JSON with --json."""
+    if json_out and open_after:
+        raise typer.BadParameter("--open cannot be combined with --json")
     index = graph_mod.build_index(path=path)
     if json_out:
-        if open_after:
-            raise typer.BadParameter("--open cannot be combined with --json")
         typer.echo(json.dumps(index, indent=2))
         return
     dot = graph_mod.index_to_dot(index)

--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -505,9 +505,16 @@ def validate_cmd(
 def graph_cmd(
     path: str = typer.Argument(".", help="Repo to graph."),
     open_after: bool = typer.Option(False, "--open", help="Render to PNG and open."),
+    json_out: bool = typer.Option(False, "--json", help="Emit the machine-readable graph index."),
 ) -> None:
-    """Walk linked_research / linked_decisions / supersedes; emit Graphviz DOT."""
-    dot = graph_mod.build_dot(path=path)
+    """Build the repo graph index; emit DOT by default or JSON with --json."""
+    index = graph_mod.build_index(path=path)
+    if json_out:
+        if open_after:
+            raise typer.BadParameter("--open cannot be combined with --json")
+        typer.echo(json.dumps(index, indent=2))
+        return
+    dot = graph_mod.index_to_dot(index)
     if open_after:
         graph_mod.open_dot(dot)
     else:

--- a/mb/mb/graph.py
+++ b/mb/mb/graph.py
@@ -1,102 +1,491 @@
-"""``mb graph`` — emit Graphviz DOT for the repo's link graph.
-
-v0.1 walks frontmatter for ``linked_research:``, ``linked_decisions:``,
-and ``supersedes:`` keys. Builds an adjacency list. Outputs DOT to stdout
-or, with ``--open``, shells to ``dot -Tpng`` and ``open``/``xdg-open``.
-"""
+"""``mb graph`` — build a deterministic repo graph index and DOT view."""
 
 from __future__ import annotations
 
 import platform
+import re
 import shutil
 import subprocess
 import tempfile
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
 import yaml
 
-LINK_KEYS = ("linked_research", "linked_decisions", "supersedes")
+INDEX_VERSION = 1
+
+LINK_FIELDS = (
+    "linked_research",
+    "linked_decision",
+    "linked_decisions",
+    "linked_prd",
+    "linked_prds",
+    "related_prds",
+    "supersedes",
+)
+
+ENTITY_FIELDS = {
+    "people": "person",
+    "person": "person",
+    "companies": "company",
+    "company": "company",
+    "offers": "offer",
+    "offer": "offer",
+    "channels": "channel",
+    "channel": "channel",
+    "competitors": "competitor",
+    "competitor": "competitor",
+    "metrics": "metric",
+    "metric": "metric",
+}
+
+ENTITY_TAG_TYPES = {
+    "person": "person",
+    "people": "person",
+    "company": "company",
+    "companies": "company",
+    "offer": "offer",
+    "offers": "offer",
+    "channel": "channel",
+    "channels": "channel",
+    "competitor": "competitor",
+    "competitors": "competitor",
+    "metric": "metric",
+    "metrics": "metric",
+}
+
+LOCAL_REF_ROOTS = {
+    "campaigns",
+    "core",
+    "decisions",
+    "docs",
+    "documents",
+    "log",
+    "outputs",
+    "reference",
+    "research",
+}
+
+WIKILINK_RE = re.compile(r"(?<!!)\[\[([^\]\n]+)\]\]")
+ENTITY_HASHTAG_RE = re.compile(
+    r"(?<![\w/])#("
+    + "|".join(sorted(ENTITY_TAG_TYPES))
+    + r")/([A-Za-z0-9][A-Za-z0-9_-]*(?:/[A-Za-z0-9][A-Za-z0-9_-]*)*)"
+)
 
 
-def _read_frontmatter(path: Path) -> dict[str, Any] | None:
+def _read_text(path: Path) -> str | None:
     try:
-        text = path.read_text(encoding="utf-8")
+        return path.read_text(encoding="utf-8")
     except OSError:
         return None
+
+
+def _split_frontmatter(text: str) -> tuple[dict[str, Any], str]:
     if not text.startswith("---"):
-        return None
+        return {}, text
     try:
         end = text.index("\n---", 3)
     except ValueError:
-        return None
+        return {}, text
     try:
         data = yaml.safe_load(text[3:end].lstrip("\n")) or {}
     except yaml.YAMLError:
+        return {}, text
+    body = text[end + len("\n---") :]
+    return data if isinstance(data, dict) else {}, body
+
+
+def _is_hidden_or_generated(path: Path, repo: Path) -> bool:
+    rel_parts = path.relative_to(repo).parts
+    is_bundled_data = rel_parts[:2] == ("mb", "_data") or rel_parts[:1] == ("_data",)
+    return (
+        any(
+            part.startswith(".") or part in {"__pycache__", "node_modules", ".venv", "venv"}
+            for part in rel_parts
+        )
+        or is_bundled_data
+    )
+
+
+def _iter_markdown_files(repo: Path) -> list[Path]:
+    return [
+        path
+        for path in sorted(repo.rglob("*.md"))
+        if path.is_file() and not _is_hidden_or_generated(path, repo)
+    ]
+
+
+def _clean_ref(ref: str) -> str:
+    without_anchor = ref.split("#", 1)[0]
+    return without_anchor.split("?", 1)[0].strip()
+
+
+def _coerce_strings(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, list):
+        return [item for item in value if isinstance(item, str)]
+    return []
+
+
+def _is_external_ref(ref: str) -> bool:
+    parsed = urlparse(ref)
+    if bool(parsed.scheme) or ref.startswith("#"):
+        return True
+    parts = Path(_clean_ref(ref)).parts
+    return (
+        len(parts) > 1
+        and parts[0] not in {".", ".."}
+        and parts[0] not in LOCAL_REF_ROOTS
+        and parts[1] in LOCAL_REF_ROOTS
+    )
+
+
+def _file_id(path: Path, repo: Path) -> str:
+    return f"file:{path.relative_to(repo).as_posix()}"
+
+
+def _external_id(ref: str) -> str:
+    return f"external:{_slug(ref)}"
+
+
+def _entity_id(entity_type: str, value: str) -> str:
+    return f"{entity_type}:{_slug(value)}"
+
+
+def _slug(value: str) -> str:
+    lowered = value.strip().lower()
+    slug = re.sub(r"[^a-z0-9]+", "-", lowered).strip("-")
+    return slug or "unknown"
+
+
+def _label_from_value(value: str) -> str:
+    clean = value.strip().replace("_", " ").replace("-", " ")
+    return re.sub(r"\s+", " ", clean).strip() or "unknown"
+
+
+def _node_sort_key(node: dict[str, Any]) -> tuple[str, str]:
+    return (str(node["type"]), str(node["id"]))
+
+
+def _edge_sort_key(edge: dict[str, Any]) -> tuple[str, str, str]:
+    return (str(edge["source"]), str(edge["target"]), str(edge["type"]))
+
+
+def _add_node(nodes: dict[str, dict[str, Any]], node: dict[str, Any]) -> None:
+    existing = nodes.get(str(node["id"]))
+    if existing is None:
+        nodes[str(node["id"])] = node
+        return
+    existing_metadata = existing.setdefault("metadata", {})
+    for key, value in node.get("metadata", {}).items():
+        if key not in existing_metadata:
+            existing_metadata[key] = value
+
+
+def _add_edge(
+    edges: list[dict[str, Any]],
+    *,
+    source: str,
+    target: str,
+    edge_type: str,
+    evidence: dict[str, str],
+) -> None:
+    edge = {
+        "source": source,
+        "target": target,
+        "type": edge_type,
+        "evidence": evidence,
+    }
+    if edge not in edges:
+        edges.append(edge)
+
+
+def _frontmatter_summary(frontmatter: dict[str, Any]) -> dict[str, Any]:
+    summary: dict[str, Any] = {}
+    for key in ("title", "topic", "slug", "status", "date", "source"):
+        if key in frontmatter and isinstance(frontmatter[key], str):
+            summary[key] = frontmatter[key]
+    return summary
+
+
+def _label_for_file(path: Path, repo: Path, frontmatter: dict[str, Any]) -> str:
+    for key in ("title", "topic", "slug"):
+        value = frontmatter.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return path.relative_to(repo).as_posix()
+
+
+def _resolve_repo_ref(repo: Path, ref: str) -> Path | None:
+    clean_ref = _clean_ref(ref)
+    if not clean_ref:
         return None
-    return data if isinstance(data, dict) else None
+    target = (repo / clean_ref).resolve()
+    try:
+        target.relative_to(repo)
+    except ValueError:
+        return None
+    return target
 
 
-def _node_id(p: Path, root: Path) -> str:
-    rel = str(p.relative_to(root))
-    return rel.replace("/", "_").replace(".", "_").replace("-", "_")
+def _wikilink_target(raw_target: str) -> str:
+    target = raw_target.split("|", 1)[0].strip()
+    target = target.split("#", 1)[0].strip()
+    return target
 
 
-def _node_label(p: Path, root: Path) -> str:
-    return str(p.relative_to(root))
+def _resolve_wikilink(
+    *,
+    repo: Path,
+    target: str,
+    files_by_stem: dict[str, list[Path]],
+    files_by_rel: dict[str, Path],
+) -> Path | None:
+    clean = _wikilink_target(target)
+    if not clean:
+        return None
+    candidates = [clean]
+    if not clean.endswith(".md"):
+        candidates.append(f"{clean}.md")
+    for candidate in candidates:
+        direct = files_by_rel.get(candidate)
+        if direct is not None:
+            return direct
+        repo_direct = _resolve_repo_ref(repo, candidate)
+        if repo_direct is not None and repo_direct.exists():
+            return repo_direct
+    stem = Path(clean).stem
+    matches = files_by_stem.get(stem, [])
+    if len(matches) == 1:
+        return matches[0]
+    return None
+
+
+def _add_reference_edge(
+    *,
+    repo: Path,
+    nodes: dict[str, dict[str, Any]],
+    edges: list[dict[str, Any]],
+    source_id: str,
+    ref: str,
+    edge_type: str,
+    evidence: dict[str, str],
+) -> None:
+    if _is_external_ref(ref):
+        target_id = _external_id(ref)
+        _add_node(
+            nodes,
+            {
+                "id": target_id,
+                "type": "external",
+                "label": ref,
+                "metadata": {"ref": ref},
+            },
+        )
+    else:
+        target = _resolve_repo_ref(repo, ref)
+        if target is not None and target.exists():
+            target_id = _file_id(target, repo)
+            if target_id not in nodes:
+                _add_node(
+                    nodes,
+                    {
+                        "id": target_id,
+                        "type": "file",
+                        "label": target.relative_to(repo).as_posix(),
+                        "path": target.relative_to(repo).as_posix(),
+                        "metadata": {},
+                    },
+                )
+        else:
+            target_id = f"missing:{_slug(ref)}"
+            _add_node(
+                nodes,
+                {
+                    "id": target_id,
+                    "type": "missing",
+                    "label": ref,
+                    "metadata": {"ref": ref},
+                },
+            )
+    _add_edge(edges, source=source_id, target=target_id, edge_type=edge_type, evidence=evidence)
+
+
+def _iter_entity_values(frontmatter: dict[str, Any], body: str) -> list[tuple[str, str, str]]:
+    found: list[tuple[str, str, str]] = []
+    for field, entity_type in ENTITY_FIELDS.items():
+        for value in _coerce_strings(frontmatter.get(field)):
+            found.append((entity_type, value, field))
+    for tag in _coerce_strings(frontmatter.get("tags")):
+        if ":" not in tag:
+            continue
+        prefix, value = tag.split(":", 1)
+        tag_entity_type = ENTITY_TAG_TYPES.get(prefix.strip().lower())
+        if tag_entity_type is not None and value.strip():
+            found.append((tag_entity_type, value, "tags"))
+    for match in ENTITY_HASHTAG_RE.finditer(body):
+        entity_type = ENTITY_TAG_TYPES[match.group(1).lower()]
+        value = match.group(2).replace("/", " ")
+        found.append((entity_type, value, "hashtag"))
+    return found
+
+
+def build_index(path: str) -> dict[str, Any]:
+    """Build the machine-readable repo graph index."""
+    repo = Path(path).resolve()
+    nodes: dict[str, dict[str, Any]] = {}
+    edges: list[dict[str, Any]] = []
+    files = _iter_markdown_files(repo) if repo.exists() else []
+    files_by_stem: dict[str, list[Path]] = {}
+    files_by_rel: dict[str, Path] = {}
+
+    for file_path in files:
+        rel = file_path.relative_to(repo).as_posix()
+        files_by_rel[rel] = file_path
+        files_by_stem.setdefault(file_path.stem, []).append(file_path)
+
+    file_records: dict[Path, tuple[dict[str, Any], str]] = {}
+    for file_path in files:
+        text = _read_text(file_path)
+        if text is None:
+            continue
+        frontmatter, body = _split_frontmatter(text)
+        file_records[file_path] = (frontmatter, body)
+        file_id = _file_id(file_path, repo)
+        rel = file_path.relative_to(repo).as_posix()
+        _add_node(
+            nodes,
+            {
+                "id": file_id,
+                "type": "file",
+                "label": _label_for_file(file_path, repo, frontmatter),
+                "path": rel,
+                "metadata": {
+                    "frontmatter": _frontmatter_summary(frontmatter),
+                    "section": file_path.relative_to(repo).parts[0],
+                },
+            },
+        )
+
+    for file_path, (frontmatter, body) in file_records.items():
+        source_id = _file_id(file_path, repo)
+        source_rel = file_path.relative_to(repo).as_posix()
+
+        for field in LINK_FIELDS:
+            for ref in _coerce_strings(frontmatter.get(field)):
+                _add_reference_edge(
+                    repo=repo,
+                    nodes=nodes,
+                    edges=edges,
+                    source_id=source_id,
+                    ref=ref,
+                    edge_type=field,
+                    evidence={"kind": "frontmatter", "field": field, "path": source_rel},
+                )
+
+        for match in WIKILINK_RE.finditer(body):
+            raw_target = match.group(1)
+            resolved = _resolve_wikilink(
+                repo=repo,
+                target=raw_target,
+                files_by_stem=files_by_stem,
+                files_by_rel=files_by_rel,
+            )
+            if resolved is None:
+                target_ref = _wikilink_target(raw_target)
+                target_id = f"wikilink:{_slug(target_ref)}"
+                _add_node(
+                    nodes,
+                    {
+                        "id": target_id,
+                        "type": "wikilink",
+                        "label": target_ref,
+                        "metadata": {"ref": target_ref},
+                    },
+                )
+            else:
+                target_id = _file_id(resolved, repo)
+            _add_edge(
+                edges,
+                source=source_id,
+                target=target_id,
+                edge_type="wikilink",
+                evidence={"kind": "wikilink", "target": raw_target, "path": source_rel},
+            )
+
+        for entity_type, value, source in _iter_entity_values(frontmatter, body):
+            target_id = _entity_id(entity_type, value)
+            _add_node(
+                nodes,
+                {
+                    "id": target_id,
+                    "type": entity_type,
+                    "label": _label_from_value(value),
+                    "metadata": {"canonical": _slug(value)},
+                },
+            )
+            _add_edge(
+                edges,
+                source=source_id,
+                target=target_id,
+                edge_type="mentions",
+                evidence={"kind": "entity", "field": source, "path": source_rel},
+            )
+
+    sorted_nodes = sorted(nodes.values(), key=_node_sort_key)
+    sorted_edges = sorted(edges, key=_edge_sort_key)
+    entity_counts = {
+        entity_type: sum(1 for node in sorted_nodes if node["type"] == entity_type)
+        for entity_type in sorted(set(ENTITY_TAG_TYPES.values()))
+    }
+    return {
+        "version": INDEX_VERSION,
+        "repo": str(repo),
+        "nodes": sorted_nodes,
+        "edges": sorted_edges,
+        "summary": {
+            "files": sum(1 for node in sorted_nodes if node["type"] == "file"),
+            "nodes": len(sorted_nodes),
+            "edges": len(sorted_edges),
+            "entities": entity_counts,
+        },
+    }
+
+
+def _dot_id(node_id: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_]", "_", node_id)
+
+
+def _dot_quote(value: str) -> str:
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
+    return f'"{escaped}"'
 
 
 def build_dot(path: str) -> str:
     """Build DOT output as a string."""
-    root = Path(path).resolve()
-    edges: list[tuple[str, str, str]] = []
-    nodes: dict[str, str] = {}
+    return index_to_dot(build_index(path))
 
-    targets: list[Path] = []
-    for sub in ("decisions", "research"):
-        d = root / sub
-        if d.exists():
-            targets.extend(sorted(d.glob("*.md")))
-    for offer in (root / "core" / "offers").glob("*/offer.md"):
-        targets.append(offer)
 
-    for p in targets:
-        nid = _node_id(p, root)
-        nodes[nid] = _node_label(p, root)
-
-    for p in targets:
-        fm = _read_frontmatter(p)
-        if not fm:
-            continue
-        src_id = _node_id(p, root)
-        for key in LINK_KEYS:
-            val = fm.get(key)
-            if not val:
-                continue
-            if isinstance(val, str):
-                val = [val]
-            if not isinstance(val, list):
-                continue
-            for ref in val:
-                if not isinstance(ref, str):
-                    continue
-                target_path = (root / ref).resolve()
-                if target_path.exists():
-                    tid = _node_id(target_path, root)
-                    if tid not in nodes:
-                        nodes[tid] = ref
-                else:
-                    # external / unresolved reference — keep as a stub node
-                    tid = ref.replace("/", "_").replace(".", "_").replace("-", "_")
-                    nodes.setdefault(tid, ref)
-                edges.append((src_id, tid, key))
-
+def index_to_dot(index: dict[str, Any]) -> str:
+    """Render a graph index as Graphviz DOT."""
     lines = ["digraph mb {", '  rankdir="LR";', '  node [shape=box, fontname="Helvetica"];']
-    for nid, label in sorted(nodes.items()):
-        lines.append(f'  {nid} [label="{label}"];')
-    for src, tgt, kind in edges:
-        style = "solid" if kind != "supersedes" else "dashed"
-        lines.append(f'  {src} -> {tgt} [label="{kind}", style={style}];')
+    for node in index["nodes"]:
+        attrs = [f"label={_dot_quote(str(node['label']))}"]
+        if node["type"] != "file":
+            attrs.append("shape=ellipse")
+        lines.append(f"  {_dot_id(str(node['id']))} [{', '.join(attrs)}];")
+    for edge in index["edges"]:
+        style = "dashed" if edge["type"] == "supersedes" else "solid"
+        lines.append(
+            "  "
+            f"{_dot_id(str(edge['source']))} -> {_dot_id(str(edge['target']))} "
+            f"[label={_dot_quote(str(edge['type']))}, style={style}];"
+        )
     lines.append("}")
     return "\n".join(lines) + "\n"
 
@@ -106,7 +495,7 @@ def open_dot(dot: str) -> None:
     if not shutil.which("dot"):
         raise RuntimeError("graphviz `dot` not on PATH (brew install graphviz)")
     if platform.system() == "Windows":
-        raise RuntimeError("--open is unsupported on Windows in v0.1")
+        raise RuntimeError("--open is unsupported on Windows")
 
     with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as f:
         png_path = f.name
@@ -115,6 +504,7 @@ def open_dot(dot: str) -> None:
         input=dot,
         text=True,
         capture_output=True,
+        check=False,
     )
     if proc.returncode != 0:
         raise RuntimeError(f"dot failed: {proc.stderr}")

--- a/mb/mb/graph.py
+++ b/mb/mb/graph.py
@@ -14,6 +14,7 @@ from urllib.parse import urlparse
 import yaml
 
 INDEX_VERSION = 1
+EdgeKey = tuple[str, str, str, tuple[tuple[str, str], ...]]
 
 LINK_FIELDS = (
     "linked_research",
@@ -189,20 +190,24 @@ def _add_node(nodes: dict[str, dict[str, Any]], node: dict[str, Any]) -> None:
 
 def _add_edge(
     edges: list[dict[str, Any]],
+    seen_edges: set[EdgeKey],
     *,
     source: str,
     target: str,
     edge_type: str,
     evidence: dict[str, str],
 ) -> None:
+    key = (source, target, edge_type, tuple(sorted(evidence.items())))
+    if key in seen_edges:
+        return
+    seen_edges.add(key)
     edge = {
         "source": source,
         "target": target,
         "type": edge_type,
         "evidence": evidence,
     }
-    if edge not in edges:
-        edges.append(edge)
+    edges.append(edge)
 
 
 def _frontmatter_summary(frontmatter: dict[str, Any]) -> dict[str, Any]:
@@ -271,12 +276,27 @@ def _add_reference_edge(
     repo: Path,
     nodes: dict[str, dict[str, Any]],
     edges: list[dict[str, Any]],
+    seen_edges: set[EdgeKey],
     source_id: str,
     ref: str,
     edge_type: str,
     evidence: dict[str, str],
 ) -> None:
-    if _is_external_ref(ref):
+    target = _resolve_repo_ref(repo, ref)
+    if target is not None and target.exists():
+        target_id = _file_id(target, repo)
+        if target_id not in nodes:
+            _add_node(
+                nodes,
+                {
+                    "id": target_id,
+                    "type": "file",
+                    "label": target.relative_to(repo).as_posix(),
+                    "path": target.relative_to(repo).as_posix(),
+                    "metadata": {},
+                },
+            )
+    elif _is_external_ref(ref):
         target_id = _external_id(ref)
         _add_node(
             nodes,
@@ -288,32 +308,24 @@ def _add_reference_edge(
             },
         )
     else:
-        target = _resolve_repo_ref(repo, ref)
-        if target is not None and target.exists():
-            target_id = _file_id(target, repo)
-            if target_id not in nodes:
-                _add_node(
-                    nodes,
-                    {
-                        "id": target_id,
-                        "type": "file",
-                        "label": target.relative_to(repo).as_posix(),
-                        "path": target.relative_to(repo).as_posix(),
-                        "metadata": {},
-                    },
-                )
-        else:
-            target_id = f"missing:{_slug(ref)}"
-            _add_node(
-                nodes,
-                {
-                    "id": target_id,
-                    "type": "missing",
-                    "label": ref,
-                    "metadata": {"ref": ref},
-                },
-            )
-    _add_edge(edges, source=source_id, target=target_id, edge_type=edge_type, evidence=evidence)
+        target_id = f"missing:{_slug(ref)}"
+        _add_node(
+            nodes,
+            {
+                "id": target_id,
+                "type": "missing",
+                "label": ref,
+                "metadata": {"ref": ref},
+            },
+        )
+    _add_edge(
+        edges,
+        seen_edges,
+        source=source_id,
+        target=target_id,
+        edge_type=edge_type,
+        evidence=evidence,
+    )
 
 
 def _iter_entity_values(frontmatter: dict[str, Any], body: str) -> list[tuple[str, str, str]]:
@@ -340,6 +352,7 @@ def build_index(path: str) -> dict[str, Any]:
     repo = Path(path).resolve()
     nodes: dict[str, dict[str, Any]] = {}
     edges: list[dict[str, Any]] = []
+    seen_edges: set[EdgeKey] = set()
     files = _iter_markdown_files(repo) if repo.exists() else []
     files_by_stem: dict[str, list[Path]] = {}
     files_by_rel: dict[str, Path] = {}
@@ -382,6 +395,7 @@ def build_index(path: str) -> dict[str, Any]:
                     repo=repo,
                     nodes=nodes,
                     edges=edges,
+                    seen_edges=seen_edges,
                     source_id=source_id,
                     ref=ref,
                     edge_type=field,
@@ -412,6 +426,7 @@ def build_index(path: str) -> dict[str, Any]:
                 target_id = _file_id(resolved, repo)
             _add_edge(
                 edges,
+                seen_edges,
                 source=source_id,
                 target=target_id,
                 edge_type="wikilink",
@@ -431,6 +446,7 @@ def build_index(path: str) -> dict[str, Any]:
             )
             _add_edge(
                 edges,
+                seen_edges,
                 source=source_id,
                 target=target_id,
                 edge_type="mentions",

--- a/mb/tests/test_graph.py
+++ b/mb/tests/test_graph.py
@@ -98,3 +98,47 @@ def test_graph_json_rejects_open_flag(tmp_path: Path) -> None:
 
     assert result.exit_code != 0
     assert "--open cannot be combined with --json" in result.output
+
+
+def test_existing_repo_paths_are_not_marked_external_by_root_heuristic(tmp_path: Path) -> None:
+    decisions = tmp_path / "decisions"
+    nested = tmp_path / "tools" / "research"
+    decisions.mkdir()
+    nested.mkdir(parents=True)
+    (nested / "notes.md").write_text("---\ntitle: Tool Notes\n---\n", encoding="utf-8")
+    (decisions / "decision.md").write_text(
+        "---\ntitle: Decision\nstatus: accepted\n"
+        "linked_research:\n  - tools/research/notes.md\n---\n",
+        encoding="utf-8",
+    )
+
+    index = build_index(path=str(tmp_path))
+
+    assert any(node["id"] == "file:tools/research/notes.md" for node in index["nodes"])
+    assert not any(node["id"] == "external:tools-research-notes-md" for node in index["nodes"])
+    assert any(
+        edge["source"] == "file:decisions/decision.md"
+        and edge["target"] == "file:tools/research/notes.md"
+        and edge["type"] == "linked_research"
+        for edge in index["edges"]
+    )
+
+
+def test_duplicate_entity_mentions_are_deduped(tmp_path: Path) -> None:
+    research = tmp_path / "research"
+    research.mkdir()
+    (research / "audience.md").write_text(
+        "---\ntitle: Audience\n---\n#channel/github appears twice: #channel/github\n",
+        encoding="utf-8",
+    )
+
+    index = build_index(path=str(tmp_path))
+    channel_edges = [
+        edge
+        for edge in index["edges"]
+        if edge["source"] == "file:research/audience.md"
+        and edge["target"] == "channel:github"
+        and edge["type"] == "mentions"
+    ]
+
+    assert len(channel_edges) == 1

--- a/mb/tests/test_graph.py
+++ b/mb/tests/test_graph.py
@@ -97,7 +97,7 @@ def test_graph_json_rejects_open_flag(tmp_path: Path) -> None:
     result = runner.invoke(app, ["graph", str(tmp_path), "--json", "--open"])
 
     assert result.exit_code != 0
-    assert "--open cannot be combined with --json" in result.output
+    assert "cannot be combined" in result.output
 
 
 def test_existing_repo_paths_are_not_marked_external_by_root_heuristic(tmp_path: Path) -> None:

--- a/mb/tests/test_graph.py
+++ b/mb/tests/test_graph.py
@@ -1,10 +1,16 @@
-"""``mb graph`` DOT emission."""
+"""``mb graph`` index and DOT emission."""
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
-from mb.graph import build_dot
+from typer.testing import CliRunner
+
+from mb.cli import app
+from mb.graph import build_dot, build_index
+
+runner = CliRunner()
 
 
 def test_empty_repo_emits_valid_dot(tmp_path: Path) -> None:
@@ -28,3 +34,67 @@ def test_links_become_edges(tmp_path: Path) -> None:
     out = build_dot(path=str(tmp_path))
     assert "linked_research" in out
     assert "->" in out
+
+
+def test_build_index_includes_frontmatter_links_wikilinks_and_entities(tmp_path: Path) -> None:
+    decisions = tmp_path / "decisions"
+    research = tmp_path / "research"
+    decisions.mkdir()
+    research.mkdir()
+    (research / "audience.md").write_text(
+        "---\ntitle: Audience Research\npeople:\n  - Devon Meadows\n---\n"
+        "Mentions #company/noontide-co and [[growth-decision]].\n",
+        encoding="utf-8",
+    )
+    (decisions / "growth-decision.md").write_text(
+        "---\ntitle: Growth Decision\nstatus: accepted\n"
+        "linked_research:\n  - research/audience.md\n"
+        "tags:\n  - offer:Main Branch\n  - channel:GitHub\n---\n"
+        "Track #metric/activation-rate against #competitor/status-quo.\n",
+        encoding="utf-8",
+    )
+
+    index = build_index(path=str(tmp_path))
+    node_ids = {node["id"] for node in index["nodes"]}
+    edge_types = {edge["type"] for edge in index["edges"]}
+
+    assert "file:research/audience.md" in node_ids
+    assert "file:decisions/growth-decision.md" in node_ids
+    assert "person:devon-meadows" in node_ids
+    assert "company:noontide-co" in node_ids
+    assert "offer:main-branch" in node_ids
+    assert "channel:github" in node_ids
+    assert "metric:activation-rate" in node_ids
+    assert "competitor:status-quo" in node_ids
+    assert any(
+        node["id"] == "competitor:status-quo" and node["label"] == "status quo"
+        for node in index["nodes"]
+    )
+    assert "linked_research" in edge_types
+    assert "wikilink" in edge_types
+    assert "mentions" in edge_types
+    assert index["summary"]["entities"]["person"] == 1
+
+
+def test_graph_json_cli_emits_machine_readable_index(tmp_path: Path) -> None:
+    research = tmp_path / "research"
+    research.mkdir()
+    (research / "audience.md").write_text(
+        "---\ntitle: Audience Research\ncompanies:\n  - Acme\n---\n",
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["graph", str(tmp_path), "--json"])
+
+    assert result.exit_code == 0
+    index = json.loads(result.stdout)
+    assert index["version"] == 1
+    assert index["summary"]["files"] == 1
+    assert any(node["id"] == "company:acme" for node in index["nodes"])
+
+
+def test_graph_json_rejects_open_flag(tmp_path: Path) -> None:
+    result = runner.invoke(app, ["graph", str(tmp_path), "--json", "--open"])
+
+    assert result.exit_code != 0
+    assert "--open cannot be combined with --json" in result.output


### PR DESCRIPTION
## Summary
- Adds `mb graph --json` as a deterministic repo graph index for downstream agents, status/start consumers, and future dashboard work.
- Expands graph indexing from DOT-only frontmatter links to markdown files, frontmatter references, wikilinks, and first-class business entity nodes.
- Keeps DOT as the default scriptable output and preserves `--open` rendering from the same index.
- Documents the new graph surface in the README, beginner setup guide, and changelog.

## Scope
- In: `mb graph` index substrate, JSON output, DOT compatibility, frontmatter links, wikilinks, entity tags/fields, regression tests, and public docs.
- Out: dashboard/server mode, vector or semantic search, replacing markdown as source of truth, and runtime compatibility claims.

## Commits
- `cf5f378` — `[add] MAIN-121 graph index substrate`.
- `57877be` — `[fix] MAIN-121 tighten graph indexing`.

## Release / Issues
- Release: v0.2.2 candidate.
- Linear ID(s): MAIN-121.
- Closes: none.
- Refs: #121.
- Follow-ups: full interactive graph view remains in #121 scope; similar-bets graph query remains #143.

## Success Metric
- `mb graph` can deterministically emit a machine-readable index of repo files, links, wikilinks, and first-class entity nodes while preserving existing DOT scriptability.

## Validation
- Level 0 docs/decision: README, docs/BEGINNER-SETUP.md, and CHANGELOG.md updated with no new runtime claims.
- Level 1 static: `scripts/check.sh` passed.
- Level 2 CLI: `cd mb && pytest tests/test_graph.py tests/test_cli.py -q`; `cd mb && mypy mb/graph.py mb/cli.py`.
- Level 3 package/install: `python3 -m build`, temp venv install, installed `mb --version`, installed `mb onboard --yes`, installed `mb graph --json` passed; build emitted existing setuptools license metadata deprecation warnings.
- Level 4 fixture repo: source `mb onboard --yes` to `mb graph --json` smoke passed.
- Level 5 runtime smoke: not run; this changes deterministic CLI graph behavior only, with no skill discovery or runtime handoff changes.

## Public / Private Boundary
- No private Devon, Conductor, customer, credential, or runtime-local details were added to committed files; local validation notes stayed in `.context/`.
