### PR TITLE
[add] mb onboard progress state

### DIFF
--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -5,7 +5,9 @@ description: "Bootstrap a new business repo with Main Branch structure, or migra
 
 # Repo Setup
 
-Get a new user fully configured with Claude Code and their business repo.
+Get a new user fully configured with Claude Code and their business repo. Use
+`mb onboard status --json` and `mb onboard plan` as the durable progress
+contract; do not keep onboarding state only in chat prose.
 
 ---
 
@@ -114,9 +116,27 @@ After business type, determine offer structure:
 
 This check is simple and non-intrusive. If they say yes, note it and move on — they can run `/setup` again in the other repo later.
 
-### 3. Gather Context (Be a Ruthless Journalist)
+### 3. Gather Bounded Context
 
-Your job: extract every fact possible. Don't settle for partial info. Users provide context in batches — keep asking until YOU say "we have enough."
+Your job is to collect enough to create a useful core reference, not every fact
+possible. Users provide context in batches. Keep the first pass bounded by
+`mb onboard status --json` and its missing inputs.
+
+Before asking for data, run:
+
+```bash
+mb onboard status --repo "$REPO_PATH" --json
+```
+
+If business type, team size, success stage, or desired outcome are missing, ask
+briefly and save them:
+
+```bash
+mb onboard plan --repo "$REPO_PATH" --team-size solo --success-stage working
+```
+
+Do not ask for full finances, credentials, raw customer/member exports, or
+exhaustive operations details during first-pass onboarding.
 
 See **[references/context-gathering.md](references/context-gathering.md)** for:
 - URL fetching fallback chain (WebFetch → Chrome → Playwright → manual)
@@ -124,7 +144,8 @@ See **[references/context-gathering.md](references/context-gathering.md)** for:
 - Completeness criteria
 
 **Opening prompt:**
-> Dump everything about this business — sales pages, offer details, testimonials, notes, whatever exists.
+> Share the essentials for the core reference: what you sell, who it helps, why
+> it works, proof you can share, and a few voice samples.
 >
 > **Pro tip:** You can drag screenshots directly into this terminal window and I'll read them. If you have a Skool community, screenshot your about page, classroom, pricing — drag them all in. Fastest way to get me up to speed.
 >

--- a/.claude/skills/start/SKILL.md
+++ b/.claude/skills/start/SKILL.md
@@ -80,6 +80,10 @@ Apply to: business repo selection, skill routing, any multiple choice.
 │
 ├── Pull business repo updates ───────→ (your repo, silently)
 │
+├── Onboarding progress check ────────→ `mb onboard status --json`
+│   ├── missing core reference? ──────→ collect only current missing inputs
+│   └── complete? ───────────────────→ continue to readiness/menu
+│
 ├── Offer detection ──────────────────→ (multi-offer only, see Step 8)
 │   ├── offers/ exists? ─────────────→ Prompt or restore from .vip/local.yaml
 │   └── no offers/ ──────────────────→ Single-offer mode, skip
@@ -139,6 +143,34 @@ See **[references/repo-detection.md](references/repo-detection.md)** for the ful
 ## Step 3: Pull Business Repo Updates
 
 Once business repo is confirmed, pull its latest updates from `REPO_PATH`. See **[references/pull-engine-updates.md](references/pull-engine-updates.md)** "Pull Business Repo Updates" section for the pull command and the result-handling table.
+
+---
+
+## Step 3a: Resume Onboarding Progress
+
+Run:
+
+```bash
+mb onboard status --repo "$REPO_PATH" --json
+```
+
+Use the JSON envelope as the source of truth for onboarding progress:
+
+- `summary.next_recommended_action` tells you what to do next
+- `checklist[].missing_inputs` names the bounded inputs to collect
+- `profile.team_size` distinguishes solo, small-team, and larger-team setup
+- `boundaries.defer_until_needed` names data to avoid collecting in the first context window
+
+If `core_reference` is pending, collect only enough to draft the missing core
+files. Do not ask for full finances, credentials, raw customer/member exports,
+or exhaustive operations details before the core reference exists.
+
+If the user's team size or current success stage is missing, ask briefly and
+update the plan:
+
+```bash
+mb onboard plan --repo "$REPO_PATH" --team-size solo --success-stage working
+```
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+### Added
+
+- Added `.mb/onboarding.json` as the lightweight onboarding progress contract,
+  plus `mb onboard status` and `mb onboard plan` for human and JSON resume
+  surfaces.
+
+### Changed
+
+- `mb status` and `mb doctor` now surface incomplete onboarding progress so
+  agents can resume setup without relying on the previous chat transcript.
+
 ## [0.2.2] - 2026-05-03
 
 v0.2.2 turns the v0.2 command surface into a better operating foundation. It

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 - `mb status` and `mb doctor` now surface incomplete onboarding progress so
   agents can resume setup without relying on the previous chat transcript.
+- New and repaired business repos now gitignore `.mb/onboarding.json`; use
+  `--path` for scripted `mb onboard` repo paths now that `onboard` also has
+  `status` and `plan` subcommands.
 
 ## [0.2.2] - 2026-05-03
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ The CLI surface for the engine. Built for Claude Code first; runtime-agnostic by
 | Command | What it does |
 |---|---|
 | `mb onboard` | Human setup flow: create or connect a business repo, explain the substrate, wire Claude Code skills, and show the next `/start` step. |
+| `mb onboard status` | Show durable onboarding progress from `.mb/onboarding.json`, including missing core-reference inputs and the next recommended action. |
 | `mb init` | Set up a fresh business repo (six folders, CLAUDE.md, git init). |
 | `mb status` | Show a local-first daily briefing: repo health, runtime wiring, recent decisions/research/git activity, and GitHub tasks when `gh` is authenticated. |
 | `mb doctor` | Check the environment — repo shape, frontmatter sanity, settings on disk. Walks you through fixes. |

--- a/docs/onboarding-progress.md
+++ b/docs/onboarding-progress.md
@@ -1,0 +1,84 @@
+# Onboarding Progress State
+
+`mb` owns the durable onboarding progress contract. Agent runtimes own the
+conversation and judgment around the user's answers.
+
+## Storage
+
+The progress file lives in the business repo:
+
+```text
+.mb/onboarding.json
+```
+
+This file is lightweight operational progress. It is meant to help a second
+agent/runtime session resume without rereading a long transcript.
+
+## State Boundary
+
+Canonical business truth belongs in git as normal business files:
+
+- accepted offer, audience, voice, proof, and finance summaries in `core/`;
+- research notes in `research/`;
+- durable choices in `decisions/`;
+- campaign, document, and log artifacts in their matching folders.
+
+`.mb/onboarding.json` stores operational progress only:
+
+- checklist step status;
+- missing input labels;
+- onboarding persona such as `solo`, `small_team`, or `larger_team`;
+- bounded collection guidance and the next recommended action.
+
+Do not store secrets, credentials, raw customer/member exports, full finances,
+chat transcripts, or large pasted source dumps in this file.
+
+## Commands
+
+Inspect progress:
+
+```bash
+mb onboard status --repo . --json
+```
+
+Create or update the lightweight plan:
+
+```bash
+mb onboard plan \
+  --repo . \
+  --team-size solo \
+  --business-type coaching \
+  --success-stage working \
+  --desired-outcome "usable core reference"
+```
+
+`mb onboard` also writes the initial plan when it creates or connects a repo.
+
+## Resume Rules
+
+On resume, agents should:
+
+1. run `mb onboard status --json`;
+2. read the checklist and `summary.next_recommended_action`;
+3. collect only the missing inputs for the current step;
+4. write accepted business truth to the normal repo files;
+5. run `mb onboard status --json` again to verify progress.
+
+Solo onboarding can keep the GitHub/team layer lightweight. Small-team and
+larger-team onboarding should document owners, review expectations, and where
+team tasks and proposals live before the repo becomes the shared operating
+surface.
+
+## Claude Code Smoke Plan
+
+Manual runtime smoke for onboarding resume:
+
+1. create a fresh repo with `mb onboard --yes --name "Smoke Business" --path /tmp/mainbranch-onboard-smoke`;
+2. run `mb onboard plan --repo /tmp/mainbranch-onboard-smoke --team-size small-team --business-type agency --success-stage working --desired-outcome "usable core reference"`;
+3. `cd /tmp/mainbranch-onboard-smoke`;
+4. run `mb onboard status --json` and confirm missing core inputs are reported;
+5. launch `claude`;
+6. run `/start`;
+7. verify `/start` uses `mb onboard status --json` to resume and does not ask
+   for full finances, credentials, or exhaustive operations details before the
+   core reference exists.

--- a/mb/mb/_data/templates/.gitignore.tmpl
+++ b/mb/mb/_data/templates/.gitignore.tmpl
@@ -10,3 +10,4 @@ __pycache__/
 node_modules/
 .venv/
 .mb/backups/
+.mb/onboarding.json

--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -58,6 +58,14 @@ migrate_app = typer.Typer(
 )
 app.add_typer(migrate_app, name="migrate")
 
+onboard_app = typer.Typer(
+    name="onboard",
+    help="Create, connect, and resume business repo onboarding.",
+    no_args_is_help=False,
+    invoke_without_command=True,
+)
+app.add_typer(onboard_app, name="onboard")
+
 CONNECT_METADATA_OPTION = typer.Option(
     [],
     "--metadata",
@@ -234,9 +242,9 @@ def _render_onboard_human(result: dict[str, Any]) -> None:
     console.print()
 
 
-@app.command("onboard")
+@onboard_app.callback()
 def onboard_cmd(
-    path_arg: str = typer.Argument("", help="Repo path to create or connect."),
+    ctx: typer.Context,
     path_opt: str = typer.Option("", "--path", help="Repo path to create or connect."),
     name: str = typer.Option("", "--name", help="Business name."),
     mode: str = typer.Option(
@@ -249,10 +257,32 @@ def onboard_cmd(
         "--level",
         help="Experience level: auto, beginner, intermediate, or power.",
     ),
+    team_size: str = typer.Option(
+        "solo",
+        "--team-size",
+        help="Onboarding persona: solo, small-team, larger-team, or unknown.",
+    ),
+    business_type: str = typer.Option(
+        "",
+        "--business-type",
+        help="Short business category for onboarding progress.",
+    ),
+    success_stage: str = typer.Option(
+        "unknown",
+        "--success-stage",
+        help="Current success stage: prelaunch, working, successful, scaling, or unknown.",
+    ),
+    desired_outcome: str = typer.Option(
+        "",
+        "--desired-outcome",
+        help="Short target outcome for onboarding progress.",
+    ),
     yes: bool = typer.Option(False, "--yes", "-y", help="Use defaults and never prompt."),
     json_out: bool = typer.Option(False, "--json", help="Machine-readable output."),
 ) -> None:
     """Guide a human through first setup or reconnect an existing repo."""
+    if ctx.invoked_subcommand is not None:
+        return
     interactive = onboard_mod.is_interactive()
     if not yes and not interactive:
         typer.echo(
@@ -262,7 +292,7 @@ def onboard_cmd(
 
     selected_level = level
     selected_mode = mode
-    target = _onboard_target_path(path_arg, path_opt, name)
+    target = _onboard_target_path("", path_opt, name)
     business_name = name
 
     if not yes:
@@ -290,6 +320,10 @@ def onboard_cmd(
             name=business_name,
             mode=selected_mode,
             level=selected_level,
+            team_size=team_size,
+            business_type=business_type,
+            success_stage=success_stage,
+            desired_outcome=desired_outcome,
         )
     except ValueError as exc:
         typer.echo(f"mb onboard: {exc}", err=True)
@@ -298,6 +332,88 @@ def onboard_cmd(
         typer.echo(json.dumps(result, indent=2))
     else:
         _render_onboard_human(result)
+    raise typer.Exit(0 if result["ok"] else 1)
+
+
+def _render_onboard_status_human(result: dict[str, Any]) -> None:
+    from rich.console import Console
+
+    console = Console()
+    summary = result["summary"]
+    console.print(f"\n[bold]mb onboard status[/bold]  {result['repo']}")
+    console.print(
+        f"{summary['status'].replace('_', ' ')}  "
+        f"{summary['completed_required']}/{summary['total_required']} required steps complete"
+    )
+    if not result["state_exists"]:
+        console.print("[yellow]No saved onboarding plan yet.[/yellow] Run `mb onboard plan`.")
+    profile = result["profile"]
+    console.print(
+        "\n[bold]Profile[/bold] "
+        f"team: {profile.get('team_size', 'unknown')}  "
+        f"type: {profile.get('business_type') or 'unknown'}  "
+        f"stage: {profile.get('success_stage', 'unknown')}"
+    )
+    console.print("\n[bold]Checklist[/bold]")
+    for step in result["checklist"]:
+        mark = "ok" if step["status"] == "complete" else "todo"
+        missing = ", ".join(step["missing_inputs"])
+        suffix = f" ({missing})" if missing else ""
+        console.print(f"  {mark:<4} {step['title']}{suffix}")
+    console.print("\n[bold]Next[/bold]")
+    console.print(f"  {summary['next_recommended_action']}")
+    console.print()
+
+
+@onboard_app.command("status")
+def onboard_status_cmd(
+    repo: str = typer.Option(".", "--repo", help="Business repo to inspect."),
+    json_out: bool = typer.Option(False, "--json", help="Machine-readable output."),
+) -> None:
+    """Show saved onboarding progress and inferred missing core inputs."""
+    result = onboard_mod.onboarding_status(repo)
+    if json_out:
+        typer.echo(json.dumps(result, indent=2))
+    else:
+        _render_onboard_status_human(result)
+    raise typer.Exit(0 if result["ok"] else 1)
+
+
+@onboard_app.command("plan")
+def onboard_plan_cmd(
+    repo: str = typer.Option(".", "--repo", help="Business repo whose plan is updated."),
+    name: str = typer.Option("", "--name", help="Business name."),
+    team_size: str = typer.Option(
+        "unknown",
+        "--team-size",
+        help="Onboarding persona: solo, small-team, larger-team, or unknown.",
+    ),
+    business_type: str = typer.Option("", "--business-type", help="Short business category."),
+    success_stage: str = typer.Option(
+        "unknown",
+        "--success-stage",
+        help="Current success stage: prelaunch, working, successful, scaling, or unknown.",
+    ),
+    desired_outcome: str = typer.Option("", "--desired-outcome", help="Short target outcome."),
+    json_out: bool = typer.Option(False, "--json", help="Machine-readable output."),
+) -> None:
+    """Create or update the lightweight onboarding progress plan."""
+    try:
+        result = onboard_mod.write_plan(
+            repo,
+            business_name=name,
+            team_size=team_size,
+            business_type=business_type,
+            success_stage=success_stage,
+            desired_outcome=desired_outcome,
+        )
+    except ValueError as exc:
+        typer.echo(f"mb onboard plan: {exc}", err=True)
+        raise typer.Exit(2) from exc
+    if json_out:
+        typer.echo(json.dumps(result, indent=2))
+    else:
+        _render_onboard_status_human(result)
     raise typer.Exit(0 if result["ok"] else 1)
 
 

--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -258,7 +258,7 @@ def onboard_cmd(
         help="Experience level: auto, beginner, intermediate, or power.",
     ),
     team_size: str = typer.Option(
-        "solo",
+        "unknown",
         "--team-size",
         help="Onboarding persona: solo, small-team, larger-team, or unknown.",
     ),

--- a/mb/mb/doctor.py
+++ b/mb/mb/doctor.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import Any
 
 from mb import connect as connect_mod
+from mb import onboard as onboard_mod
 from mb.engine import install_mode, link_status
 from mb.freshness import format_update_alert, package_update_status, version_key
 from mb.migrate import LATEST_SCHEMA_VERSION, pending_migrations, read_schema_version
@@ -289,6 +290,24 @@ def run(path: str) -> dict[str, Any]:
     checks.append(_repo_layout_check(repo))
     checks.append(_schema_version_check(repo))
     checks.append(connect_mod.doctor_check(repo))
+    onboarding = onboard_mod.onboarding_status(repo)
+    onboarding_summary = onboarding["summary"]
+    checks.append(
+        {
+            "name": "onboarding-progress",
+            "ok": onboarding_summary["status"] == "ready",
+            "detail": (
+                "core onboarding complete"
+                if onboarding_summary["status"] == "ready"
+                else (
+                    f"{onboarding_summary['completed_required']}/"
+                    f"{onboarding_summary['total_required']} required steps complete; "
+                    "run `mb onboard status`."
+                )
+            ),
+            "severity": "warn",
+        }
+    )
 
     cloud_hits = _detect_cloud_paths(repo)
     cloud_ok = not cloud_hits
@@ -326,6 +345,7 @@ def run(path: str) -> dict[str, Any]:
         "checks": checks,
         "repo": str(repo),
         "integrations": connect_mod.status_all(repo),
+        "onboarding": onboarding,
         "update": update,
         "python": sys.version.split()[0],
     }

--- a/mb/mb/init.py
+++ b/mb/mb/init.py
@@ -42,6 +42,7 @@ __pycache__/
 node_modules/
 .venv/
 .mb/backups/
+.mb/onboarding.json
 """
 
 

--- a/mb/mb/onboard.py
+++ b/mb/mb/onboard.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import json
 import re
 import shutil
 import subprocess
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -14,6 +16,25 @@ from mb.engine import link_skills, link_status
 
 LEVELS = {"beginner", "intermediate", "power"}
 MODES = {"new", "connect", "auto"}
+ONBOARDING_STATE_RELATIVE_PATH = Path(".mb") / "onboarding.json"
+ONBOARDING_STATE_VERSION = 1
+TEAM_SIZES = {"unknown", "solo", "small_team", "larger_team"}
+SUCCESS_STAGES = {"unknown", "prelaunch", "working", "successful", "scaling"}
+
+BOUNDARIES = {
+    "collect_now": [
+        "business type and team size",
+        "current success stage and desired direction",
+        "primary offer, audience, voice, proof, and operating constraints",
+        "GitHub/team workflow needs for this business size",
+    ],
+    "defer_until_needed": [
+        "full finances or ledgers",
+        "raw customer/member exports",
+        "credentials, tokens, and private account secrets",
+        "exhaustive operations documentation outside the core reference",
+    ],
+}
 
 
 def _which(name: str) -> str:
@@ -46,6 +67,158 @@ def _run_command(args: list[str], cwd: Path | None = None, timeout: float = 5.0)
 def _slug(value: str) -> str:
     slug = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
     return slug or "my-business"
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _state_path(repo: Path) -> Path:
+    return repo / ONBOARDING_STATE_RELATIVE_PATH
+
+
+def _normalize_team_size(value: str) -> str:
+    normalized = value.strip().lower().replace("-", "_").replace(" ", "_")
+    aliases = {
+        "": "unknown",
+        "one": "solo",
+        "one_person": "solo",
+        "1": "solo",
+        "solo_operator": "solo",
+        "small": "small_team",
+        "team": "small_team",
+        "2_5": "small_team",
+        "2_to_5": "small_team",
+        "larger": "larger_team",
+        "large": "larger_team",
+        "6_plus": "larger_team",
+        "20_person": "larger_team",
+    }
+    normalized = aliases.get(normalized, normalized)
+    if normalized not in TEAM_SIZES:
+        raise ValueError("team-size must be solo, small-team, larger-team, or unknown")
+    return normalized
+
+
+def _normalize_success_stage(value: str) -> str:
+    normalized = value.strip().lower().replace("-", "_").replace(" ", "_")
+    aliases = {
+        "": "unknown",
+        "not_started": "prelaunch",
+        "already_successful": "successful",
+        "success": "successful",
+    }
+    normalized = aliases.get(normalized, normalized)
+    if normalized not in SUCCESS_STAGES:
+        raise ValueError(
+            "success-stage must be prelaunch, working, successful, scaling, or unknown"
+        )
+    return normalized
+
+
+def _load_state(repo: Path) -> dict[str, Any] | None:
+    path = _state_path(repo)
+    if not path.exists():
+        return None
+    try:
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return loaded if isinstance(loaded, dict) else None
+
+
+def _initial_state(
+    *,
+    repo: Path,
+    business_name: str = "",
+    team_size: str = "unknown",
+    business_type: str = "",
+    success_stage: str = "unknown",
+    desired_outcome: str = "",
+) -> dict[str, Any]:
+    now = _now()
+    return {
+        "schema_version": ONBOARDING_STATE_VERSION,
+        "kind": "mainbranch.onboarding",
+        "created_at": now,
+        "updated_at": now,
+        "profile": {
+            "business_name": business_name.strip(),
+            "business_type": business_type.strip(),
+            "team_size": _normalize_team_size(team_size),
+            "success_stage": _normalize_success_stage(success_stage),
+            "desired_outcome": desired_outcome.strip(),
+        },
+        "contract": {
+            "state_path": str(ONBOARDING_STATE_RELATIVE_PATH),
+            "canonical_business_truth": [
+                "accepted offer, audience, voice, proof, decisions, and durable summaries",
+                "files under core/, research/, decisions/, campaigns/, log/, and documents/",
+            ],
+            "operational_progress": [
+                "checklist state, missing input labels, persona/team-size routing, and next action",
+                "safe setup metadata that lets a later agent resume without a transcript",
+            ],
+            "never_store_here": [
+                "credentials, secrets, raw customer/member exports, or full finances",
+                "chat transcripts or large pasted source dumps",
+            ],
+        },
+        "boundaries": BOUNDARIES,
+        "notes": [],
+        "source": "mb onboard",
+    }
+
+
+def _merge_state(existing: dict[str, Any] | None, updates: dict[str, Any]) -> dict[str, Any]:
+    state = existing.copy() if existing else {}
+    if not state:
+        state = updates
+    else:
+        state["schema_version"] = ONBOARDING_STATE_VERSION
+        state["kind"] = "mainbranch.onboarding"
+        state.setdefault("created_at", updates.get("created_at", _now()))
+        state["updated_at"] = _now()
+        state.setdefault("contract", updates["contract"])
+        state.setdefault("boundaries", BOUNDARIES)
+        state.setdefault("notes", [])
+        profile = dict(state.get("profile") or {})
+        for key, value in updates["profile"].items():
+            if value not in {"", "unknown"}:
+                profile[key] = value
+            else:
+                profile.setdefault(key, value)
+        state["profile"] = profile
+        state["source"] = updates.get("source", "mb onboard")
+    return state
+
+
+def write_plan(
+    repo: str | Path = ".",
+    *,
+    business_name: str = "",
+    team_size: str = "unknown",
+    business_type: str = "",
+    success_stage: str = "unknown",
+    desired_outcome: str = "",
+) -> dict[str, Any]:
+    """Create or update the lightweight onboarding progress plan."""
+    target = Path(repo).expanduser().resolve()
+    target.mkdir(parents=True, exist_ok=True)
+    existing = _load_state(target)
+    updates = _initial_state(
+        repo=target,
+        business_name=business_name,
+        team_size=team_size,
+        business_type=business_type,
+        success_stage=success_stage,
+        desired_outcome=desired_outcome,
+    )
+    state = _merge_state(existing, updates)
+    path = _state_path(target)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(state, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return onboarding_status(target)
 
 
 def _repo_markers(repo: Path) -> dict[str, bool]:
@@ -145,12 +318,196 @@ def _next_steps(repo: Path) -> list[str]:
     ]
 
 
+def _has_any_file(paths: list[Path]) -> bool:
+    for path in paths:
+        if path.is_file() and path.name != ".gitkeep" and path.stat().st_size > 0:
+            return True
+        if path.is_dir():
+            for child in path.rglob("*.md"):
+                if child.is_file() and child.stat().st_size > 0:
+                    return True
+    return False
+
+
+def _core_inputs(repo: Path) -> dict[str, bool]:
+    core = repo / "core"
+    reference_core = repo / "reference" / "core"
+    return {
+        "offer": _has_any_file(
+            [
+                core / "offer.md",
+                core / "offers",
+                reference_core / "offer.md",
+                repo / "reference" / "offers",
+            ]
+        ),
+        "audience": _has_any_file([core / "audience.md", reference_core / "audience.md"]),
+        "voice": _has_any_file([core / "voice.md", reference_core / "voice.md"]),
+        "soul": _has_any_file([core / "soul.md", reference_core / "soul.md"]),
+        "proof": _has_any_file(
+            [
+                core / "proof.md",
+                core / "testimonials.md",
+                repo / "reference" / "proof",
+            ]
+        ),
+    }
+
+
+def _profile_missing(profile: dict[str, Any]) -> list[str]:
+    missing: list[str] = []
+    for key in ("business_type", "success_stage", "desired_outcome"):
+        if not str(profile.get(key) or "").strip() or profile.get(key) == "unknown":
+            missing.append(key)
+    if profile.get("team_size") in {"", "unknown", None}:
+        missing.append("team_size")
+    return missing
+
+
+def _team_step(profile: dict[str, Any], repo: Path) -> dict[str, Any]:
+    team_size = str(profile.get("team_size") or "unknown")
+    if team_size == "solo":
+        return {
+            "id": "team_layer",
+            "title": "Solo operating loop",
+            "status": "complete",
+            "owner": "agent",
+            "missing_inputs": [],
+            "next_action": (
+                "Use GitHub issues as your personal task list when work starts to sprawl."
+            ),
+            "required": False,
+        }
+
+    missing = []
+    if not (repo / ".github" / "CODEOWNERS").exists():
+        missing.append(".github/CODEOWNERS")
+    if not _has_any_file([repo / "decisions", repo / "documents" / "team-workflow.md"]):
+        missing.append("team workflow or decision note")
+    label = "Small-team GitHub loop" if team_size == "small_team" else "Larger-team GitHub loop"
+    return {
+        "id": "team_layer",
+        "title": label,
+        "status": "complete" if not missing else "pending",
+        "owner": "agent",
+        "missing_inputs": missing,
+        "next_action": (
+            "Document owners, review expectations, and where team tasks/proposals live."
+        ),
+        "required": team_size in {"small_team", "larger_team"},
+    }
+
+
+def _step(
+    *,
+    step_id: str,
+    title: str,
+    complete: bool,
+    missing_inputs: list[str],
+    next_action: str,
+    owner: str = "agent",
+    required: bool = True,
+) -> dict[str, Any]:
+    return {
+        "id": step_id,
+        "title": title,
+        "status": "complete" if complete else "pending",
+        "owner": owner,
+        "required": required,
+        "missing_inputs": missing_inputs,
+        "next_action": next_action,
+    }
+
+
+def _checklist(repo: Path, state: dict[str, Any], markers: dict[str, bool]) -> list[dict[str, Any]]:
+    profile = dict(state.get("profile") or {})
+    core_inputs = _core_inputs(repo)
+    missing_core = [key for key, ok in core_inputs.items() if not ok]
+    return [
+        _step(
+            step_id="repo_scaffold",
+            title="Business repo scaffold",
+            complete=_looks_initialized(markers),
+            missing_inputs=[]
+            if _looks_initialized(markers)
+            else ["CLAUDE.md", "core/", "research/", "decisions/"],
+            next_action="Run `mb onboard --mode new --path <repo> --name <business>`.",
+            owner="mb",
+        ),
+        _step(
+            step_id="business_profile",
+            title="Business profile and success direction",
+            complete=not _profile_missing(profile),
+            missing_inputs=_profile_missing(profile),
+            next_action=(
+                "Ask only for business type, team size, current success stage, "
+                "and desired outcome; do not collect full operations detail yet."
+            ),
+        ),
+        _step(
+            step_id="core_reference",
+            title="Core reference",
+            complete=not missing_core,
+            missing_inputs=missing_core,
+            next_action=(
+                "Collect just enough to draft core offer, audience, voice, soul, and proof files."
+            ),
+        ),
+        _team_step(profile, repo),
+        _step(
+            step_id="runtime_handoff",
+            title="Runtime handoff",
+            complete=bool(link_status(repo)["ok"]),
+            missing_inputs=[] if link_status(repo)["ok"] else ["Claude Code skill wiring"],
+            next_action="Run `mb skill link --repo .`, then `mb start --json`.",
+            owner="mb",
+        ),
+    ]
+
+
+def onboarding_status(repo: str | Path = ".") -> dict[str, Any]:
+    """Return the deterministic onboarding progress envelope for a business repo."""
+    target = Path(repo).expanduser().resolve()
+    loaded = _load_state(target)
+    state = loaded or _initial_state(repo=target)
+    markers = _repo_markers(target)
+    checklist = _checklist(target, state, markers)
+    required = [step for step in checklist if step.get("required", True)]
+    complete = [step for step in required if step["status"] == "complete"]
+    next_step = next((step for step in checklist if step["status"] != "complete"), None)
+    return {
+        "ok": _looks_initialized(markers),
+        "repo": str(target),
+        "state_path": str(_state_path(target)),
+        "state_exists": loaded is not None,
+        "state_valid": loaded is not None or not _state_path(target).exists(),
+        "profile": state.get("profile") or {},
+        "contract": state.get("contract") or {},
+        "boundaries": state.get("boundaries") or BOUNDARIES,
+        "checklist": checklist,
+        "summary": {
+            "status": "ready" if len(complete) == len(required) else "in_progress",
+            "completed_required": len(complete),
+            "total_required": len(required),
+            "missing_inputs": [
+                item for step in required for item in step.get("missing_inputs", [])
+            ],
+            "next_step": next_step["id"] if next_step else "",
+            "next_recommended_action": next_step["next_action"] if next_step else "Run `mb start`.",
+        },
+    }
+
+
 def run(
     *,
     path: str,
     name: str = "",
     mode: str = "auto",
     level: str = "auto",
+    team_size: str = "unknown",
+    business_type: str = "",
+    success_stage: str = "unknown",
+    desired_outcome: str = "",
 ) -> dict[str, Any]:
     """Create or connect a business repo and verify the Claude Code handoff."""
     target = Path(path).expanduser().resolve()
@@ -207,6 +564,18 @@ def run(
         warnings.append("Claude Code skill discovery is not wired. Run `mb doctor` for details.")
 
     ok = not errors and wiring["ok"] and after["claude_md"]
+    progress = (
+        write_plan(
+            target,
+            business_name=result_business_name,
+            team_size=team_size,
+            business_type=business_type,
+            success_stage=success_stage,
+            desired_outcome=desired_outcome,
+        )
+        if target.exists()
+        else onboarding_status(target)
+    )
     return {
         "ok": ok,
         "status": "ok" if ok else "error",
@@ -226,6 +595,7 @@ def run(
         "warnings": [warning for warning in warnings if warning],
         "errors": errors,
         "doctor_command": f"mb doctor {target}",
+        "onboarding": progress,
         "next_steps": _next_steps(target),
         "init": init_result,
         "link": link_result,

--- a/mb/mb/onboard.py
+++ b/mb/mb/onboard.py
@@ -36,6 +36,8 @@ BOUNDARIES = {
     ],
 }
 
+ONBOARDING_GITIGNORE_ENTRY = ".mb/onboarding.json"
+
 
 def _which(name: str) -> str:
     return shutil.which(name) or ""
@@ -75,6 +77,20 @@ def _now() -> str:
 
 def _state_path(repo: Path) -> Path:
     return repo / ONBOARDING_STATE_RELATIVE_PATH
+
+
+def _ensure_onboarding_gitignore(repo: Path) -> bool:
+    gitignore = repo / ".gitignore"
+    existing_text = gitignore.read_text(encoding="utf-8") if gitignore.exists() else ""
+    entries = {line.strip() for line in existing_text.splitlines()}
+    if ONBOARDING_GITIGNORE_ENTRY in entries or ".mb/" in entries:
+        return False
+    prefix = "" if not existing_text or existing_text.endswith("\n") else "\n"
+    gitignore.write_text(
+        existing_text + prefix + ONBOARDING_GITIGNORE_ENTRY + "\n",
+        encoding="utf-8",
+    )
+    return True
 
 
 def _normalize_team_size(value: str) -> str:
@@ -218,6 +234,7 @@ def write_plan(
     path = _state_path(target)
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(state, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    _ensure_onboarding_gitignore(target)
     return onboarding_status(target)
 
 
@@ -366,6 +383,16 @@ def _profile_missing(profile: dict[str, Any]) -> list[str]:
 
 def _team_step(profile: dict[str, Any], repo: Path) -> dict[str, Any]:
     team_size = str(profile.get("team_size") or "unknown")
+    if team_size == "unknown":
+        return {
+            "id": "team_layer",
+            "title": "Team operating loop",
+            "status": "pending",
+            "owner": "agent",
+            "missing_inputs": ["team_size"],
+            "next_action": "Ask whether this is a solo operator, small team, or larger team.",
+            "required": False,
+        }
     if team_size == "solo":
         return {
             "id": "team_layer",
@@ -423,6 +450,7 @@ def _checklist(repo: Path, state: dict[str, Any], markers: dict[str, bool]) -> l
     profile = dict(state.get("profile") or {})
     core_inputs = _core_inputs(repo)
     missing_core = [key for key, ok in core_inputs.items() if not ok]
+    wiring = link_status(repo)
     return [
         _step(
             step_id="repo_scaffold",
@@ -457,8 +485,8 @@ def _checklist(repo: Path, state: dict[str, Any], markers: dict[str, bool]) -> l
         _step(
             step_id="runtime_handoff",
             title="Runtime handoff",
-            complete=bool(link_status(repo)["ok"]),
-            missing_inputs=[] if link_status(repo)["ok"] else ["Claude Code skill wiring"],
+            complete=bool(wiring["ok"]),
+            missing_inputs=[] if wiring["ok"] else ["Claude Code skill wiring"],
             next_action="Run `mb skill link --repo .`, then `mb start --json`.",
             owner="mb",
         ),
@@ -573,7 +601,7 @@ def run(
             success_stage=success_stage,
             desired_outcome=desired_outcome,
         )
-        if target.exists()
+        if target.exists() and not errors
         else onboarding_status(target)
     )
     return {

--- a/mb/mb/status.py
+++ b/mb/mb/status.py
@@ -14,6 +14,7 @@ import yaml
 
 from mb import __version__, github_activity
 from mb import connect as connect_mod
+from mb import onboard as onboard_mod
 from mb.engine import install_mode, link_status
 from mb.freshness import format_update_alert, package_update_status
 
@@ -371,6 +372,14 @@ def _readiness(report: dict[str, Any]) -> dict[str, Any]:
         )
     if report["brain"]["stale_decisions"]:
         next_actions.append("Review stale proposed/running decisions in `decisions/`.")
+    onboarding_summary = (report.get("onboarding") or {}).get("summary") or {}
+    if onboarding_summary.get("status") == "in_progress":
+        next_actions.append(
+            str(
+                onboarding_summary.get("next_recommended_action")
+                or "Run `mb onboard status` to resume onboarding."
+            )
+        )
     if not report["github"]["authenticated"]:
         next_actions.append("Run `gh auth login` to include assigned issues and shipped PRs.")
     if not next_actions:
@@ -406,6 +415,7 @@ def run(path: str = ".") -> dict[str, Any]:
         "git": git,
         "git_activity": _git_recent_activity(repo_path, git),
         "brain": _brain(repo_path),
+        "onboarding": onboard_mod.onboarding_status(repo_path),
         "integrations": connect_mod.status_all(repo_path),
         "github": _github(repo_path, git),
     }
@@ -423,6 +433,7 @@ def render_human(report: dict[str, Any]) -> None:
     git = report["git"]
     runtime = report["runtime"]
     brain = report["brain"]
+    onboarding = report.get("onboarding") or {}
     integrations = report.get(
         "integrations",
         {"summary": {"configured": 0, "healthy": 0, "needs_repair": 0}, "providers": []},
@@ -488,6 +499,19 @@ def render_human(report: dict[str, Any]) -> None:
         console.print("\n[bold]Recent research[/bold]")
         for item in brain["recent_research"][:3]:
             console.print(f"  - {item['date'] or item['updated_at'][:10]}  {item['title']}")
+
+    onboarding_summary = onboarding.get("summary") or {}
+    if onboarding_summary.get("status") == "in_progress":
+        console.print("\n[bold]Onboarding[/bold]")
+        console.print(
+            "  "
+            f"{onboarding_summary.get('completed_required', 0)}/"
+            f"{onboarding_summary.get('total_required', 0)} required steps complete"
+        )
+        missing = onboarding_summary.get("missing_inputs") or []
+        if missing:
+            console.print(f"  missing: {', '.join(missing[:5])}")
+        console.print(f"  next: {onboarding_summary.get('next_recommended_action')}")
 
     if report["git_activity"]["items"]:
         console.print("\n[bold]Recent git activity[/bold]")

--- a/mb/tests/test_init.py
+++ b/mb/tests/test_init.py
@@ -35,6 +35,7 @@ def test_init_scaffolds_folders(tmp_path: Path) -> None:
     assert ".claude/settings.local.json" in gitignore
     assert ".claude/skills/start" in gitignore
     assert ".mb/backups/" in gitignore
+    assert ".mb/onboarding.json" in gitignore
     claude_md = (target / "CLAUDE.md").read_text()
     assert "Acme Brewing" in claude_md
     assert "## Connected accounts" in claude_md

--- a/mb/tests/test_onboard.py
+++ b/mb/tests/test_onboard.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typer.testing import CliRunner
 
 from mb import onboard as onboard_mod
+from mb import status as status_mod
 from mb.cli import app
 
 runner = CliRunner()
@@ -61,7 +62,16 @@ def test_onboard_rerun_is_idempotent(tmp_path: Path, monkeypatch) -> None:
 def test_onboard_connect_repairs_existing_initialized_repo(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(onboard_mod, "_which", _tool_path)
     repo = tmp_path / "acme"
-    onboard_mod.run(path=str(repo), name="Acme", mode="new", level="power")
+    onboard_mod.run(
+        path=str(repo),
+        name="Acme",
+        mode="new",
+        level="power",
+        team_size="solo",
+        business_type="coaching",
+        success_stage="working",
+        desired_outcome="usable core reference",
+    )
     settings = repo / ".claude" / "settings.local.json"
     settings.unlink()
 
@@ -132,6 +142,92 @@ def test_onboard_cli_yes_json_smoke(tmp_path: Path, monkeypatch) -> None:
     assert payload["ok"] is True
     assert payload["path"] == str(repo.resolve())
     assert payload["next_steps"][-1] == "/start"
+    assert (repo / ".mb" / "onboarding.json").exists()
+    assert payload["onboarding"]["summary"]["status"] == "in_progress"
+
+
+def test_onboard_status_reports_partial_small_team_progress(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(onboard_mod, "_which", _tool_path)
+    repo = tmp_path / "acme"
+    onboard_mod.run(
+        path=str(repo),
+        name="Acme",
+        mode="new",
+        level="power",
+        team_size="small-team",
+        business_type="agency",
+        success_stage="working",
+        desired_outcome="usable core reference",
+    )
+    (repo / "core" / "offer.md").write_text("# Offer\n", encoding="utf-8")
+
+    result = runner.invoke(app, ["onboard", "status", "--repo", str(repo), "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["state_exists"] is True
+    assert payload["profile"]["team_size"] == "small_team"
+    assert payload["summary"]["status"] == "in_progress"
+    assert payload["summary"]["next_step"] == "core_reference"
+    assert "audience" in payload["summary"]["missing_inputs"]
+    team_step = next(step for step in payload["checklist"] if step["id"] == "team_layer")
+    assert team_step["title"] == "Small-team GitHub loop"
+    assert team_step["required"] is True
+
+
+def test_onboard_plan_updates_profile_without_raw_business_state(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(onboard_mod, "_which", _tool_path)
+    repo = tmp_path / "solo"
+    onboard_mod.run(path=str(repo), name="Solo Co", mode="new", level="power")
+
+    result = runner.invoke(
+        app,
+        [
+            "onboard",
+            "plan",
+            "--repo",
+            str(repo),
+            "--team-size",
+            "solo",
+            "--business-type",
+            "coaching",
+            "--success-stage",
+            "successful",
+            "--desired-outcome",
+            "document the core reference",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["profile"]["success_stage"] == "successful"
+    state = json.loads((repo / ".mb" / "onboarding.json").read_text(encoding="utf-8"))
+    assert "never_store_here" in state["contract"]
+    assert "chat transcripts" in " ".join(state["contract"]["never_store_here"])
+
+
+def test_status_includes_onboarding_progress(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(onboard_mod, "_which", _tool_path)
+    monkeypatch.setattr(status_mod, "_which", _tool_path)
+    repo = tmp_path / "acme"
+    onboard_mod.run(
+        path=str(repo),
+        name="Acme",
+        mode="new",
+        level="power",
+        team_size="solo",
+        business_type="coaching",
+        success_stage="working",
+        desired_outcome="usable core reference",
+    )
+
+    report = status_mod.run(path=str(repo))
+
+    assert report["onboarding"]["summary"]["status"] == "in_progress"
+    assert any("Collect just enough" in action for action in report["readiness"]["next_actions"])
 
 
 def test_onboard_cli_interactive_path_renders_clear_labels(tmp_path: Path, monkeypatch) -> None:

--- a/mb/tests/test_onboard.py
+++ b/mb/tests/test_onboard.py
@@ -144,6 +144,7 @@ def test_onboard_cli_yes_json_smoke(tmp_path: Path, monkeypatch) -> None:
     assert payload["next_steps"][-1] == "/start"
     assert (repo / ".mb" / "onboarding.json").exists()
     assert payload["onboarding"]["summary"]["status"] == "in_progress"
+    assert ".mb/onboarding.json" in (repo / ".gitignore").read_text(encoding="utf-8")
 
 
 def test_onboard_status_reports_partial_small_team_progress(tmp_path: Path, monkeypatch) -> None:
@@ -173,6 +174,27 @@ def test_onboard_status_reports_partial_small_team_progress(tmp_path: Path, monk
     team_step = next(step for step in payload["checklist"] if step["id"] == "team_layer")
     assert team_step["title"] == "Small-team GitHub loop"
     assert team_step["required"] is True
+
+
+def test_onboard_status_unknown_team_size_is_not_larger_team(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(onboard_mod, "_which", _tool_path)
+    repo = tmp_path / "unknown-team"
+    onboard_mod.run(
+        path=str(repo),
+        name="Unknown Team",
+        mode="new",
+        level="power",
+        business_type="agency",
+        success_stage="working",
+        desired_outcome="usable core reference",
+    )
+
+    payload = onboard_mod.onboarding_status(repo)
+
+    team_step = next(step for step in payload["checklist"] if step["id"] == "team_layer")
+    assert team_step["title"] == "Team operating loop"
+    assert team_step["required"] is False
+    assert team_step["missing_inputs"] == ["team_size"]
 
 
 def test_onboard_plan_updates_profile_without_raw_business_state(
@@ -207,6 +229,35 @@ def test_onboard_plan_updates_profile_without_raw_business_state(
     state = json.loads((repo / ".mb" / "onboarding.json").read_text(encoding="utf-8"))
     assert "never_store_here" in state["contract"]
     assert "chat transcripts" in " ".join(state["contract"]["never_store_here"])
+
+
+def test_onboard_yes_does_not_overwrite_existing_team_size(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(onboard_mod, "_which", _tool_path)
+    monkeypatch.setattr(onboard_mod, "is_interactive", lambda: False)
+    repo = tmp_path / "team"
+    onboard_mod.run(path=str(repo), name="Team Co", mode="new", level="power")
+    plan = runner.invoke(
+        app,
+        [
+            "onboard",
+            "plan",
+            "--repo",
+            str(repo),
+            "--team-size",
+            "small-team",
+            "--json",
+        ],
+    )
+    assert plan.exit_code == 0
+
+    rerun = runner.invoke(
+        app,
+        ["onboard", "--yes", "--mode", "connect", "--path", str(repo), "--json"],
+    )
+
+    assert rerun.exit_code == 0
+    payload = json.loads(rerun.stdout)
+    assert payload["onboarding"]["profile"]["team_size"] == "small_team"
 
 
 def test_status_includes_onboarding_progress(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- Adds durable onboarding progress state under `.mb/onboarding.json` so a later agent/runtime session can resume without the prior transcript.
- Adds `mb onboard status` and `mb onboard plan` with human and JSON output, plus onboarding visibility in `mb status` and `mb doctor`.
- Updates `/start` and `/setup` to use the CLI progress contract and keep first-pass data collection bounded.
- Keeps onboarding progress local by gitignoring `.mb/onboarding.json` in new and repaired business repos.

## Scope
- In: onboarding progress contract, CLI status/plan surfaces, solo vs team checklist behavior, status/doctor integration, docs, bundled skill routing instructions, tests.
- Out: model calls, chat/transcript storage, dashboard/server/index work, and deeper team workflow automation beyond the progress contract.

## Commits
- `7ec690a` — `[add] MAIN-196 onboarding progress state`.
- `b10d3a8` — `[fix] MAIN-196 onboarding state review fixes`.

## Release / Issues
- Release: Candidate v0.2.3.
- Linear ID(s): MAIN-196.
- Closes: #225.
- Refs: MAIN-191, MAIN-121, MAIN-193.
- Follow-ups: richer team onboarding automation can follow after this contract lands.

## Success Metric
- A partially onboarded business repo can be resumed in a new session by running `mb onboard status --json`, with missing core inputs and next action visible without reading a previous conversation.

## Validation
- Level 0 docs/decision: `docs/onboarding-progress.md`, README, CHANGELOG, `/start`, and `/setup` updated; no private data added.
- Level 1 static: `scripts/check.sh` passed, including Ruff, mypy, coverage, and bundled skill validation.
- Level 2 CLI: focused onboarding/init/status tests passed; full suite passed with 132 tests.
- Level 3 package/install: fresh venv wheel smoke passed, including `mb onboard plan`, `mb onboard status`, rerun preservation of `small_team`, `mb start --json`, and gitignore coverage.
- Level 4 fixture repo: installed-wheel fixture smoke passed with `mb onboard`, `mb doctor`, `mb status`, `mb onboard status --json`, `mb start --json`, and `mb validate`.
- Level 5 runtime smoke: not run interactively; Claude Code is installed locally, and the manual `/start` smoke plan is documented in `docs/onboarding-progress.md`.

## Public / Private Boundary
- The progress file stores lightweight operational checklist/profile state only and explicitly excludes secrets, credentials, raw customer/member exports, full finances, chat transcripts, and large source dumps.
- `.context/` remained local scratch; no Conductor/private workflow details were committed as product truth.
