### PR TITLE
[update] Prepare 0.2.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,26 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+## [0.2.3] - 2026-05-03
+
+v0.2.3 makes Main Branch easier to resume after an interrupted first run and
+turns `mb graph` into a useful deterministic index for future dashboard,
+status, and agent-workflow work.
+
+### What this means for you (plain English)
+
+- **Onboarding can survive multiple sessions.** `mb onboard` now writes a
+  lightweight local progress file so agents can tell what setup inputs are
+  still missing without relying on the previous chat transcript.
+- **`mb status` and `mb doctor` know about onboarding gaps.** They can point a
+  beginner or agent back to the next setup step instead of silently treating an
+  empty repo as ready.
+- **`mb graph --json` now exposes real structure.** Files, frontmatter links,
+  wikilinks, and business entities become a machine-readable graph index.
+- **The public operating contract is clearer.** Contributors and agents now
+  have a public checklist for release readiness, runtime claims, issue/PR
+  discipline, and public/private boundaries.
+
 ### Added
 
 - Added `.mb/onboarding.json` as the lightweight onboarding progress contract,
@@ -24,6 +44,8 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   Main Branch product-boundary, release-readiness, runtime-claim,
   public/private, state-model, and issue/PR discipline, and linked it from
   agent and contributor docs.
+- Added a public-safe `mb connect` dogfood report documenting credential storage
+  behavior, beginner-facing repair gaps, and follow-up integration issues.
 
 ### Changed
 

--- a/mb/mb/__init__.py
+++ b/mb/mb/__init__.py
@@ -7,6 +7,6 @@ file stays a thin dispatcher.
 
 from __future__ import annotations
 
-__version__ = "0.2.2"
+__version__ = "0.2.3"
 
 __all__ = ["__version__"]

--- a/mb/pyproject.toml
+++ b/mb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mainbranch"
-version = "0.2.2"
+version = "0.2.3"
 description = "Main Branch engine umbrella - scaffolds, validates, and graphs business-as-files repos. Claude Code first, runtime-agnostic by design."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- Bumps `mainbranch` from `0.2.2` to `0.2.3`.
- Moves the merged onboarding-progress, graph-index, OSS checklist, and connect-dogfood work out of `[Unreleased]` into a dated `0.2.3` changelog section.
- Frames the release around resumable onboarding, `mb graph --json`, and clearer public operating guidance.

## Scope
In:
- `mb/pyproject.toml` version bump
- `mb/mb/__init__.py` version bump
- `CHANGELOG.md` 0.2.3 release notes

Out:
- no feature/code changes beyond version metadata
- no GitHub Release or PyPI publish in this PR
- no global-skill-shadow fix; tracked separately in #234

## Commits
- `9f3280d` — `[update] Prepare 0.2.3 release`

## Release / Issues
- Release: `oe-v0.2.3`
- Linear ID(s): none; release-prep branch
- Closes: none
- Refs: #121, #224, #225, #226, #234
- Follow-ups: #227, #228, #229, #234

## Success Metric
After merge, creating GitHub Release `oe-v0.2.3` publishes PyPI package `mainbranch==0.2.3` with changelog text that accurately describes the merged user-visible changes.

## Validation
- Level 0 docs/decision: changelog section reviewed for stale claims and public/private boundary.
- Level 1 static: `scripts/check.sh` passed after the version/changelog bump: Ruff, mypy, 137 tests, 83.09% coverage, 14/14 bundled skills valid.
- Level 2 CLI: covered by merged main and full gate; no command implementation changed in this PR.
- Level 3 package/install: installed-wheel smoke passed before the release bump on merged main for the exact feature set; should rerun after this PR merges before tagging.
- Level 4 fixture repo: fixture smoke passed before the release bump on merged main: `mb onboard`, `mb doctor`, `mb status`, `mb graph --json`, `mb onboard status --json`, `mb start --json`, `mb validate`.
- Level 5 runtime smoke: Claude Code `/start` project-local discovery passed from fresh fixture repo after temporarily moving the global `~/.claude/skills/start` symlink outside the skills directory and restoring it.

## Public / Private Boundary
No private Devon/Conductor details were added. The global-skill-shadow finding was turned into public issue #234 without including machine-private paths in committed files.
