### PR TITLE
[add] mb connect provider trust loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,10 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 - Added `mb connect test <provider>` and `mb connect doctor` so users and
   onboarding agents can distinguish missing, unvalidated, invalid, and ready
   provider credentials without printing secret values or raw provider
-  responses. The JSON output now includes safe repair fields such as `state`,
-  `summary`, `repair`, `repair_command`, and `safe_to_share`.
+  responses. Providers without a safe API probe can complete the test with an
+  explicit "no automated probe yet" summary instead of looping forever. The
+  JSON output now includes safe repair fields such as `state`, `summary`,
+  `repair`, `repair_command`, and `safe_to_share`.
 - Decision doc `decisions/2026-05-03-skill-distribution-and-migration.md`
   records the proposed skill distribution and migration model: keep
   project-local symlink wiring as the v0.2 supported adapter, ship stale
@@ -37,6 +39,9 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   stored secret ref as provider health. Stored credentials report
   `unvalidated` until `mb connect test <provider>` succeeds, and repair output
   names the affected provider plus the next command.
+- Transient provider validation failures, such as rate limits, network errors,
+  and 5xx responses, remain `unvalidated` instead of being reported as invalid
+  credentials that need rotation.
 - GitHub integration health now distinguishes missing `gh`, unauthenticated
   `gh`, missing GitHub remotes, non-git folders, and ready GitHub repo context
   in secret-safe status and doctor output.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ### Added
 
+- Added `mb connect test <provider>` and `mb connect doctor` so users and
+  onboarding agents can distinguish missing, unvalidated, invalid, and ready
+  provider credentials without printing secret values or raw provider
+  responses. The JSON output now includes safe repair fields such as `state`,
+  `summary`, `repair`, `repair_command`, and `safe_to_share`.
 - Decision doc `decisions/2026-05-03-skill-distribution-and-migration.md`
   records the proposed skill distribution and migration model: keep
   project-local symlink wiring as the v0.2 supported adapter, ship stale
@@ -25,6 +30,16 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   collide with bundled Main Branch skill names today). Adds a follow-up
   to decide whether to rename bundled skills to a `mb-` prefix before
   the plugin spike lands. Refs #236 and #234.
+
+### Changed
+
+- `mb connect status --json`, `mb doctor`, and `mb status` no longer treat a
+  stored secret ref as provider health. Stored credentials report
+  `unvalidated` until `mb connect test <provider>` succeeds, and repair output
+  names the affected provider plus the next command.
+- GitHub integration health now distinguishes missing `gh`, unauthenticated
+  `gh`, missing GitHub remotes, non-git folders, and ready GitHub repo context
+  in secret-safe status and doctor output.
 
 ## [0.2.3] - 2026-05-03
 

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ The CLI surface for the engine. Built for Claude Code first; runtime-agnostic by
 | `mb init` | Set up a fresh business repo (six folders, CLAUDE.md, git init). |
 | `mb status` | Show a local-first daily briefing: repo health, runtime wiring, recent decisions/research/git activity, and GitHub tasks when `gh` is authenticated. |
 | `mb doctor` | Check the environment — repo shape, frontmatter sanity, settings on disk. Walks you through fixes. |
-| `mb connect` | Register provider credentials and integration metadata without committing secrets. |
+| `mb connect` | Register provider credentials, test provider health, and inspect repair-safe integration status without committing secrets. |
 | `mb validate` | Frontmatter shape check across `core/`, `research/`, `decisions/`, `log/`, `campaigns/`, `documents/`. Pass/fail per file. |
 | `mb graph` | Build a repo graph index from frontmatter links, wikilinks, and entity tags. Emits Graphviz DOT by default, `--json` for agents/dashboards, and `--open` to render a PNG view. |
 | `mb think <topic>` | Print the `/think` invocation hint. Run inside Claude Code for the full flow. |
@@ -170,6 +170,8 @@ Meta, Cloudflare, Postiz, Apify, Beancount, and transcription providers.
 ```bash
 mb connect list
 printf '%s' "$CLOUDFLARE_API_TOKEN" | mb connect cloudflare --token-stdin --metadata account_id=...
+mb connect test cloudflare
+mb connect doctor
 mb connect meta --from-env
 mb connect status --json
 ```
@@ -178,8 +180,13 @@ Secrets are stored outside the business repo, using the macOS Keychain when
 available and a local `~/.mainbranch/secrets/connect.json` fallback otherwise.
 The business repo only receives non-sensitive metadata in `.mb/connect.yaml`,
 such as the provider id, account label, credential backend, and last check time.
-Skills and future dashboards should read `mb connect status --json` or
-`.mb/connect.yaml`; they should never ask users to commit tokens.
+Stored credentials start as `unvalidated` until `mb connect test <provider>`
+proves the credential works, so a secret ref alone is never reported as healthy.
+`mb connect status --json` and `mb connect doctor --json` include safe repair
+fields such as `state`, `summary`, `repair`, `repair_command`, and
+`safe_to_share` for onboarding agents. Skills and future dashboards should read
+those JSON commands or `.mb/connect.yaml`; they should never ask users to commit
+tokens.
 `--from-env` is explicit: `mb connect` does not silently import general-purpose
 environment variables.
 

--- a/README.md
+++ b/README.md
@@ -181,7 +181,10 @@ available and a local `~/.mainbranch/secrets/connect.json` fallback otherwise.
 The business repo only receives non-sensitive metadata in `.mb/connect.yaml`,
 such as the provider id, account label, credential backend, and last check time.
 Stored credentials start as `unvalidated` until `mb connect test <provider>`
-proves the credential works, so a secret ref alone is never reported as healthy.
+runs the safest available check. Providers with a safe API probe validate
+against the provider; providers without one record that local credential
+presence was confirmed and that no automated probe exists yet. A secret ref
+alone is never reported as healthy.
 `mb connect status --json` and `mb connect doctor --json` include safe repair
 fields such as `state`, `summary`, `repair`, `repair_command`, and
 `safe_to_share` for onboarding agents. Skills and future dashboards should read

--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -435,7 +435,11 @@ def doctor_cmd(
 def connect_cmd(
     target: str = typer.Argument(
         "",
-        help="Provider to connect, or `list` / `status`.",
+        help="Provider to connect, or `list` / `status` / `doctor` / `test`.",
+    ),
+    provider: str = typer.Argument(
+        "",
+        help="Provider for subcommands such as `mb connect test <provider>`.",
     ),
     repo: str = typer.Option(".", "--repo", help="Business repo whose metadata is updated."),
     account_label: str = typer.Option("", "--account", "--label", help="Human account label."),
@@ -484,6 +488,30 @@ def connect_cmd(
         else:
             connect_mod.render_status(result)
         raise typer.Exit(0 if result["ok"] else 1)
+    if target == "doctor":
+        result = connect_mod.doctor(repo)
+        if json_out:
+            typer.echo(json.dumps(result, indent=2))
+        else:
+            connect_mod.render_doctor(result)
+        raise typer.Exit(0 if result["ok"] else 1)
+    if target == "test":
+        if not provider:
+            typer.echo("mb connect test: provider required", err=True)
+            raise typer.Exit(2)
+        try:
+            result = connect_mod.test_provider(provider, repo)
+        except ValueError as exc:
+            typer.echo(f"mb connect test: {exc}", err=True)
+            raise typer.Exit(2) from exc
+        if json_out:
+            typer.echo(json.dumps(result, indent=2))
+        else:
+            connect_mod.render_test_result(result)
+        raise typer.Exit(0 if result["ok"] else 1)
+    if provider:
+        typer.echo(f"mb connect: unexpected extra argument {provider!r}", err=True)
+        raise typer.Exit(2)
 
     try:
         provider_info = connect_mod.normalize_provider(target)

--- a/mb/mb/connect.py
+++ b/mb/mb/connect.py
@@ -10,7 +10,10 @@ import platform
 import shutil
 import subprocess
 import sys
+import urllib.error
+import urllib.request
 import uuid
+from collections.abc import Callable
 from contextlib import suppress
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -22,6 +25,9 @@ import yaml
 CONFIG_RELATIVE_PATH = Path(".mb") / "connect.yaml"
 SERVICE_NAME = "mainbranch"
 SENSITIVE_KEY_PARTS = ("token", "secret", "password", "credential", "api_key", "apikey", "key")
+VALIDATION_TIMEOUT_SECONDS = 8
+CommandRunner = Callable[[list[str], Path | None, float], dict[str, Any]]
+Which = Callable[[str], str | None]
 
 
 @dataclass(frozen=True)
@@ -207,6 +213,51 @@ def _write_config(repo: Path, config: dict[str, Any]) -> Path:
 def _secret_ref(repo_id: str, provider_id: str, field: str) -> str:
     digest = hashlib.sha256(f"{repo_id}:{provider_id}:{field}".encode()).hexdigest()[:24]
     return f"mainbranch://{digest}/{provider_id}/{field}"
+
+
+def _repair(provider: Provider, state: str, missing: list[str] | None = None) -> dict[str, str]:
+    missing_fields = ", ".join(missing or provider.required_secrets)
+    connect_command = f"mb connect {provider.id} --token-stdin"
+    if state == "not_connected":
+        if provider.required_secrets:
+            return {
+                "summary": f"{provider.name} is not connected.",
+                "repair": f"Run `{connect_command}` to store the credential outside the repo.",
+                "repair_command": connect_command,
+            }
+        return {
+            "summary": f"{provider.name} metadata is not connected.",
+            "repair": f"Run `mb connect {provider.id}` with the needed metadata.",
+            "repair_command": f"mb connect {provider.id}",
+        }
+    if state == "missing_secret":
+        return {
+            "summary": f"{provider.name} metadata exists, but local secret material is missing.",
+            "repair": (
+                f"Run `{connect_command}` to replace the missing credential ({missing_fields})."
+            ),
+            "repair_command": connect_command,
+        }
+    if state == "unvalidated":
+        return {
+            "summary": f"{provider.name} has stored credentials, but they have not been validated.",
+            "repair": f"Run `mb connect test {provider.id}`.",
+            "repair_command": f"mb connect test {provider.id}",
+        }
+    if state == "invalid":
+        return {
+            "summary": f"{provider.name} validation failed without exposing the provider response.",
+            "repair": (
+                f"Run `{connect_command}` to replace the credential, then "
+                f"`mb connect test {provider.id}`."
+            ),
+            "repair_command": connect_command,
+        }
+    return {
+        "summary": f"{provider.name} is ready.",
+        "repair": "",
+        "repair_command": "",
+    }
 
 
 class SecretStore:
@@ -409,7 +460,8 @@ def connect_provider(
     path = _write_config(target, config)
     status = status_provider(provider.id, target)
     return {
-        "ok": bool(status["ok"]),
+        "ok": status["state"] != "missing_secret",
+        "ready": bool(status["ok"]),
         "provider": provider.id,
         "config_path": str(path),
         "credential_backend": store.backend,
@@ -424,16 +476,22 @@ def status_provider(provider_id: str, repo: str | Path = ".") -> dict[str, Any]:
     config = _read_config(target)
     entry = config["providers"].get(provider.id)
     if not isinstance(entry, dict):
+        repair = _repair(provider, "not_connected")
         return {
             "provider": provider.id,
             "name": provider.name,
             "connected": False,
             "ok": False,
             "state": "not_connected",
+            "summary": repair["summary"],
+            "repair": repair["repair"],
+            "repair_command": repair["repair_command"],
+            "safe_to_share": True,
             "account_label": "",
             "metadata": {},
             "secrets": {},
             "last_checked_at": "",
+            "validation": {"state": "not_connected", "checked_at": "", "summary": ""},
         }
 
     secrets: dict[str, dict[str, Any]] = {}
@@ -449,19 +507,161 @@ def status_provider(provider_id: str, repo: str | Path = ".") -> dict[str, Any]:
             missing.append(field)
         secrets[field] = {"present": present, "ref": ref, "backend": backend}
 
-    metadata = entry.get("metadata") if isinstance(entry.get("metadata"), dict) else {}
-    ok = not missing
-    state = "connected" if ok else "missing_secret"
+    raw_metadata = entry.get("metadata")
+    metadata: dict[str, Any] = raw_metadata if isinstance(raw_metadata, dict) else {}
+    raw_validation = entry.get("validation")
+    validation: dict[str, Any] = raw_validation if isinstance(raw_validation, dict) else {}
+    if missing:
+        state = "missing_secret"
+        ok = False
+    elif not provider.required_secrets:
+        state = "ready"
+        ok = True
+    else:
+        validation_state = str(validation.get("state") or "unvalidated")
+        if validation_state == "ready":
+            state = "ready"
+            ok = True
+        elif validation_state == "invalid":
+            state = "invalid"
+            ok = False
+        else:
+            state = "unvalidated"
+            ok = False
+    repair = _repair(provider, state, missing)
     return {
         "provider": provider.id,
         "name": provider.name,
         "connected": bool(entry.get("connected", False)),
         "ok": ok,
         "state": state,
+        "summary": repair["summary"],
+        "repair": repair["repair"],
+        "repair_command": repair["repair_command"],
+        "safe_to_share": True,
         "account_label": str(entry.get("account_label") or ""),
         "metadata": metadata,
         "secrets": secrets,
         "last_checked_at": str(entry.get("last_checked_at") or ""),
+        "validation": {
+            "state": str(validation.get("state") or state),
+            "checked_at": str(validation.get("checked_at") or ""),
+            "summary": str(validation.get("summary") or ""),
+            "safe_to_share": True,
+        },
+    }
+
+
+def _stored_secret(provider: Provider, entry: dict[str, Any]) -> str:
+    stored_secrets = entry.get("secrets") if isinstance(entry.get("secrets"), dict) else {}
+    if not provider.required_secrets:
+        return ""
+    primary = provider.required_secrets[0]
+    raw = stored_secrets.get(primary) if isinstance(stored_secrets, dict) else None
+    raw = raw if isinstance(raw, dict) else {}
+    ref = str(raw.get("ref") or "")
+    backend = str(raw.get("backend") or "local-file")
+    return SecretStore(backend).get(ref) if ref else ""
+
+
+def _http_get_json(url: str, headers: dict[str, str] | None = None) -> tuple[bool, str]:
+    request = urllib.request.Request(url, headers=headers or {})
+    try:
+        with urllib.request.urlopen(request, timeout=VALIDATION_TIMEOUT_SECONDS) as response:
+            status = int(getattr(response, "status", 0) or 0)
+            body = response.read(8192)
+    except urllib.error.HTTPError as exc:
+        if exc.code in {400, 401, 403}:
+            return False, "provider rejected the credential"
+        return False, f"provider validation returned HTTP {exc.code}"
+    except (urllib.error.URLError, TimeoutError, OSError):
+        return False, "provider validation could not reach the service"
+    if status < 200 or status >= 300:
+        return False, f"provider validation returned HTTP {status}"
+    if body:
+        with suppress(json.JSONDecodeError, UnicodeDecodeError):
+            json.loads(body.decode("utf-8"))
+    return True, "credential validated with provider"
+
+
+def _validate_with_provider(provider: Provider, secret: str) -> dict[str, Any]:
+    checked_at = _now()
+    if provider.id == "cloudflare":
+        ok, summary = _http_get_json(
+            "https://api.cloudflare.com/client/v4/user/tokens/verify",
+            {"Authorization": f"Bearer {secret}"},
+        )
+    elif provider.id == "meta":
+        ok, summary = _http_get_json(
+            "https://graph.facebook.com/v19.0/me?fields=id",
+            {"Authorization": f"Bearer {secret}"},
+        )
+    elif provider.id == "apify":
+        ok, summary = _http_get_json(
+            "https://api.apify.com/v2/users/me",
+            {"Authorization": f"Bearer {secret}"},
+        )
+    else:
+        return {
+            "ok": False,
+            "state": "unvalidated",
+            "checked_at": checked_at,
+            "summary": (f"{provider.name} does not have an automated safe validation probe yet."),
+            "safe_to_share": True,
+        }
+    return {
+        "ok": ok,
+        "state": "ready" if ok else "invalid",
+        "checked_at": checked_at,
+        "summary": summary,
+        "safe_to_share": True,
+    }
+
+
+def test_provider(provider_id: str, repo: str | Path = ".") -> dict[str, Any]:
+    provider = normalize_provider(provider_id)
+    target = Path(repo).resolve()
+    config = _read_config(target)
+    entry = config["providers"].get(provider.id)
+    status = status_provider(provider.id, target)
+    if not isinstance(entry, dict) or status["state"] in {"not_connected", "missing_secret"}:
+        return {"ok": False, "provider": provider.id, "status": status, "safe_to_share": True}
+
+    if not provider.required_secrets:
+        validation = {
+            "ok": True,
+            "state": "ready",
+            "checked_at": _now(),
+            "summary": f"{provider.name} uses repo-local metadata and has no secret to validate.",
+            "safe_to_share": True,
+        }
+    else:
+        secret = _stored_secret(provider, entry)
+        if not secret:
+            return {
+                "ok": False,
+                "provider": provider.id,
+                "status": status_provider(provider.id, target),
+                "safe_to_share": True,
+            }
+        validation = _validate_with_provider(provider, secret)
+
+    entry["validation"] = {
+        "state": validation["state"],
+        "checked_at": validation["checked_at"],
+        "summary": validation["summary"],
+        "safe_to_share": True,
+    }
+    entry["last_checked_at"] = validation["checked_at"]
+    config["providers"][provider.id] = entry
+    _write_config(target, config)
+    status = status_provider(provider.id, target)
+    return {
+        "ok": bool(validation["ok"]),
+        "provider": provider.id,
+        "validation": entry["validation"],
+        "status": status,
+        "safe_to_share": True,
     }
 
 
@@ -475,17 +675,107 @@ def status_all(repo: str | Path = ".", *, include_all: bool = False) -> dict[str
             providers.append(status_provider(provider.id, target))
     connected = [item for item in providers if item["connected"]]
     broken = [item for item in connected if not item["ok"]]
+    unvalidated = [item for item in connected if item["state"] == "unvalidated"]
     return {
         "ok": not broken,
         "repo": str(target),
         "config_path": str(_config_path(target)),
         "repo_id": str(config.get("repo_id") or ""),
         "providers": providers,
+        "github": github_context(target),
+        "safe_to_share": True,
         "summary": {
             "configured": len(connected),
             "healthy": len([item for item in connected if item["ok"]]),
             "needs_repair": len(broken),
+            "unvalidated": len(unvalidated),
         },
+    }
+
+
+def _run_command(args: list[str], cwd: Path | None = None, timeout: float = 5.0) -> dict[str, Any]:
+    try:
+        result = subprocess.run(
+            args,
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except FileNotFoundError:
+        return {"ok": False, "returncode": 127, "stdout": "", "stderr": f"{args[0]} not found"}
+    except subprocess.TimeoutExpired:
+        return {"ok": False, "returncode": 124, "stdout": "", "stderr": "command timed out"}
+    except subprocess.SubprocessError:
+        return {"ok": False, "returncode": 1, "stdout": "", "stderr": "command failed"}
+    return {
+        "ok": result.returncode == 0,
+        "returncode": result.returncode,
+        "stdout": result.stdout,
+        "stderr": result.stderr,
+    }
+
+
+def github_context(
+    repo: str | Path = ".",
+    *,
+    which_func: Which | None = None,
+    command_runner: CommandRunner | None = None,
+) -> dict[str, Any]:
+    target = Path(repo).resolve()
+    which = which_func or shutil.which
+    run = command_runner or _run_command
+    if not which("gh"):
+        return {
+            "ok": False,
+            "state": "missing_cli",
+            "summary": "GitHub CLI is not installed.",
+            "repair": "Install GitHub CLI, then run `gh auth login`.",
+            "repair_command": "gh auth login",
+            "safe_to_share": True,
+        }
+
+    auth = run(["gh", "auth", "status"], target, 5.0)
+    if not auth["ok"]:
+        return {
+            "ok": False,
+            "state": "unauthenticated",
+            "summary": "GitHub CLI is installed but not authenticated.",
+            "repair": "Run `gh auth login`.",
+            "repair_command": "gh auth login",
+            "safe_to_share": True,
+        }
+
+    git = run(["git", "rev-parse", "--is-inside-work-tree"], target, 3.0)
+    if not git["ok"] or git["stdout"].strip() != "true":
+        return {
+            "ok": False,
+            "state": "not_git_repo",
+            "summary": "This folder is not a git repo.",
+            "repair": "Run `git init` if this should be a business repo.",
+            "repair_command": "git init",
+            "safe_to_share": True,
+        }
+
+    remote = run(["git", "config", "--get", "remote.origin.url"], target, 3.0)
+    remote_value = remote["stdout"].strip() if remote["ok"] else ""
+    if "github.com" not in remote_value:
+        return {
+            "ok": False,
+            "state": "missing_github_remote",
+            "summary": "This repo does not have a GitHub origin remote.",
+            "repair": "Add a GitHub origin remote before relying on GitHub tasks or proposals.",
+            "repair_command": "gh repo create --source . --remote origin --push",
+            "safe_to_share": True,
+        }
+
+    return {
+        "ok": True,
+        "state": "ready",
+        "summary": "GitHub CLI auth and repo remote are ready.",
+        "repair": "",
+        "repair_command": "",
+        "safe_to_share": True,
     }
 
 
@@ -508,22 +798,70 @@ def doctor_check(repo: str | Path = ".") -> dict[str, Any]:
             "ok": True,
             "detail": "no providers connected",
             "severity": "info",
+            "repair": "",
+            "repair_command": "",
+            "safe_to_share": True,
         }
     if summary["needs_repair"]:
+        repairs = [item for item in status["providers"] if not item["ok"]]
+        first = repairs[0] if repairs else {}
+        names = ", ".join(item["provider"] for item in repairs[:3])
         return {
             "name": "integration-credentials",
             "ok": False,
             "detail": (
                 f"{summary['needs_repair']} of {summary['configured']} connected provider(s) "
-                "need credential repair; run `mb connect status`."
+                f"need repair ({names}); run `mb connect doctor`."
             ),
             "severity": "warn",
+            "repair": str(first.get("repair") or "Run `mb connect doctor`."),
+            "repair_command": str(first.get("repair_command") or "mb connect doctor"),
+            "safe_to_share": True,
         }
     return {
         "name": "integration-credentials",
         "ok": True,
         "detail": f"{summary['healthy']} connected provider(s) ready",
         "severity": "ok",
+        "repair": "",
+        "repair_command": "",
+        "safe_to_share": True,
+    }
+
+
+def doctor(repo: str | Path = ".") -> dict[str, Any]:
+    status = status_all(repo)
+    github = status["github"]
+    checks = [
+        {
+            "name": "github-context",
+            "ok": bool(github["ok"]),
+            "state": github["state"],
+            "summary": github["summary"],
+            "repair": github["repair"],
+            "repair_command": github["repair_command"],
+            "safe_to_share": True,
+        },
+        *[
+            {
+                "name": f"provider:{item['provider']}",
+                "provider": item["provider"],
+                "ok": bool(item["ok"]),
+                "state": item["state"],
+                "summary": item["summary"],
+                "repair": item["repair"],
+                "repair_command": item["repair_command"],
+                "safe_to_share": True,
+            }
+            for item in status["providers"]
+        ],
+    ]
+    return {
+        "ok": all(check["ok"] for check in checks),
+        "repo": status["repo"],
+        "checks": checks,
+        "integrations": status,
+        "safe_to_share": True,
     }
 
 
@@ -542,6 +880,12 @@ def render_status(result: dict[str, Any]) -> None:
         f"configured: {summary['configured']}  "
         f"healthy: {summary['healthy']}  needs repair: {summary['needs_repair']}"
     )
+    github = result.get("github") or {}
+    if github:
+        state = "ok" if github.get("ok") else "warn"
+        print(f"  {state}  github: {github.get('state')}")
+        if github.get("repair_command"):
+            print(f"       next: {github['repair_command']}")
     if not result["providers"]:
         print("no providers connected")
         return
@@ -549,21 +893,47 @@ def render_status(result: dict[str, Any]) -> None:
         state = "ok" if item["ok"] else "warn"
         label = f" ({item['account_label']})" if item["account_label"] else ""
         print(f"  {state}  {item['provider']}{label}: {item['state']}")
+        if item["repair_command"]:
+            print(f"       next: {item['repair_command']}")
+
+
+def render_doctor(result: dict[str, Any]) -> None:
+    print(f"mb connect doctor  {result['repo']}")
+    for check in result["checks"]:
+        state = "ok" if check["ok"] else "warn"
+        print(f"  {state}  {check['name']}: {check['state']}")
+        if check["repair_command"]:
+            print(f"       next: {check['repair_command']}")
+
+
+def render_test_result(result: dict[str, Any]) -> None:
+    status = result["status"]
+    state = "ok" if result["ok"] else "warn"
+    print(f"mb connect test {result['provider']}: {state} ({status['state']})")
+    summary = (result.get("validation") or status.get("validation") or {}).get("summary")
+    if summary:
+        print(f"summary: {summary}")
+    if status.get("repair_command"):
+        print(f"next: {status['repair_command']}")
 
 
 def render_connect_result(result: dict[str, Any]) -> None:
     status = result["status"]
-    if result["ok"]:
-        print(f"connected {result['provider']}")
-    else:
+    if status["state"] == "ready":
+        print(f"connected {result['provider']} and ready")
+    elif status["state"] == "unvalidated":
+        print(f"stored {result['provider']} credential; validation still needed")
+    elif not result["ok"]:
         print(f"connected {result['provider']} metadata; credential still needs repair")
+    else:
+        print(f"connected {result['provider']} metadata")
     print(f"metadata: {result['config_path']}")
     print(f"secrets: {result['credential_boundary']}")
     source = result.get("credential_source") or {}
     if source.get("type") == "env" and source.get("env_var"):
         print(f"credential source: env {source['env_var']}")
-    if status["state"] != "connected":
-        print("next: rerun with --token-stdin or --token to store the required credential")
+    if status["repair_command"]:
+        print(f"next: {status['repair_command']}")
 
 
 def read_stdin_token() -> str:

--- a/mb/mb/connect.py
+++ b/mb/mb/connect.py
@@ -564,7 +564,7 @@ def _stored_secret(provider: Provider, entry: dict[str, Any]) -> str:
     return SecretStore(backend).get(ref) if ref else ""
 
 
-def _http_get_json(url: str, headers: dict[str, str] | None = None) -> tuple[bool, str]:
+def _http_get_json(url: str, headers: dict[str, str] | None = None) -> tuple[str, str]:
     request = urllib.request.Request(url, headers=headers or {})
     try:
         with urllib.request.urlopen(request, timeout=VALIDATION_TIMEOUT_SECONDS) as response:
@@ -572,46 +572,53 @@ def _http_get_json(url: str, headers: dict[str, str] | None = None) -> tuple[boo
             body = response.read(8192)
     except urllib.error.HTTPError as exc:
         if exc.code in {400, 401, 403}:
-            return False, "provider rejected the credential"
-        return False, f"provider validation returned HTTP {exc.code}"
+            return "invalid", "provider rejected the credential"
+        if exc.code in {408, 429} or exc.code >= 500:
+            return "unvalidated", f"provider validation returned HTTP {exc.code}"
+        return "unvalidated", f"provider validation returned HTTP {exc.code}"
     except (urllib.error.URLError, TimeoutError, OSError):
-        return False, "provider validation could not reach the service"
+        return "unvalidated", "provider validation could not reach the service"
     if status < 200 or status >= 300:
-        return False, f"provider validation returned HTTP {status}"
+        if status in {400, 401, 403}:
+            return "invalid", "provider rejected the credential"
+        return "unvalidated", f"provider validation returned HTTP {status}"
     if body:
         with suppress(json.JSONDecodeError, UnicodeDecodeError):
             json.loads(body.decode("utf-8"))
-    return True, "credential validated with provider"
+    return "ready", "credential validated with provider"
 
 
 def _validate_with_provider(provider: Provider, secret: str) -> dict[str, Any]:
     checked_at = _now()
     if provider.id == "cloudflare":
-        ok, summary = _http_get_json(
+        state, summary = _http_get_json(
             "https://api.cloudflare.com/client/v4/user/tokens/verify",
             {"Authorization": f"Bearer {secret}"},
         )
     elif provider.id == "meta":
-        ok, summary = _http_get_json(
+        state, summary = _http_get_json(
             "https://graph.facebook.com/v19.0/me?fields=id",
             {"Authorization": f"Bearer {secret}"},
         )
     elif provider.id == "apify":
-        ok, summary = _http_get_json(
+        state, summary = _http_get_json(
             "https://api.apify.com/v2/users/me",
             {"Authorization": f"Bearer {secret}"},
         )
     else:
         return {
-            "ok": False,
-            "state": "unvalidated",
+            "ok": True,
+            "state": "ready",
             "checked_at": checked_at,
-            "summary": (f"{provider.name} does not have an automated safe validation probe yet."),
+            "summary": (
+                f"{provider.name} has no automated safe validation probe yet; "
+                "local credential presence was confirmed."
+            ),
             "safe_to_share": True,
         }
     return {
-        "ok": ok,
-        "state": "ready" if ok else "invalid",
+        "ok": state == "ready",
+        "state": state,
         "checked_at": checked_at,
         "summary": summary,
         "safe_to_share": True,
@@ -665,7 +672,12 @@ def test_provider(provider_id: str, repo: str | Path = ".") -> dict[str, Any]:
     }
 
 
-def status_all(repo: str | Path = ".", *, include_all: bool = False) -> dict[str, Any]:
+def status_all(
+    repo: str | Path = ".",
+    *,
+    include_all: bool = False,
+    github: dict[str, Any] | None = None,
+) -> dict[str, Any]:
     target = Path(repo).resolve()
     config = _read_config(target)
     configured = set(config["providers"].keys())
@@ -682,7 +694,7 @@ def status_all(repo: str | Path = ".", *, include_all: bool = False) -> dict[str
         "config_path": str(_config_path(target)),
         "repo_id": str(config.get("repo_id") or ""),
         "providers": providers,
-        "github": github_context(target),
+        "github": github or github_context(target),
         "safe_to_share": True,
         "summary": {
             "configured": len(connected),
@@ -789,8 +801,8 @@ def list_providers(repo: str | Path = ".") -> dict[str, Any]:
     return {"ok": True, "providers": providers, "config_path": status["config_path"]}
 
 
-def doctor_check(repo: str | Path = ".") -> dict[str, Any]:
-    status = status_all(repo)
+def doctor_check(repo: str | Path = ".", *, status: dict[str, Any] | None = None) -> dict[str, Any]:
+    status = status or status_all(repo)
     summary = status["summary"]
     if summary["configured"] == 0:
         return {
@@ -830,7 +842,8 @@ def doctor_check(repo: str | Path = ".") -> dict[str, Any]:
 
 
 def doctor(repo: str | Path = ".") -> dict[str, Any]:
-    status = status_all(repo)
+    github = github_context(repo)
+    status = status_all(repo, github=github)
     github = status["github"]
     checks = [
         {

--- a/mb/mb/doctor.py
+++ b/mb/mb/doctor.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 import os
 import shutil
 import socket
-import subprocess
 import sys
 from pathlib import Path
 from typing import Any
@@ -40,20 +39,10 @@ def _which(name: str) -> str:
 
 
 def _gh_status() -> tuple[bool, str]:
-    if not _which("gh"):
-        return False, "gh not on PATH"
-    try:
-        out = subprocess.run(
-            ["gh", "auth", "status"],
-            capture_output=True,
-            text=True,
-            timeout=5,
-        )
-        if out.returncode == 0:
-            return True, "authenticated"
-        return False, "not authenticated"
-    except subprocess.SubprocessError:
-        return False, "gh probe failed"
+    context = connect_mod.github_context(".")
+    if context["ok"]:
+        return True, "authenticated and GitHub repo context ready"
+    return False, str(context["summary"])
 
 
 def _net() -> tuple[bool, str]:
@@ -227,8 +216,19 @@ def run(path: str) -> dict[str, Any]:
         }
     )
 
-    gh_ok, gh_detail = _gh_status()
-    checks.append({"name": "gh-auth", "ok": gh_ok, "detail": gh_detail})
+    gh_context = connect_mod.github_context(repo)
+    checks.append(
+        {
+            "name": "github-context",
+            "ok": bool(gh_context["ok"]),
+            "detail": gh_context["summary"],
+            "severity": "warn",
+            "state": gh_context["state"],
+            "repair": gh_context["repair"],
+            "repair_command": gh_context["repair_command"],
+            "safe_to_share": True,
+        }
+    )
 
     net_ok, net_detail = _net()
     checks.append({"name": "network", "ok": net_ok, "detail": net_detail})

--- a/mb/mb/doctor.py
+++ b/mb/mb/doctor.py
@@ -38,13 +38,6 @@ def _which(name: str) -> str:
     return shutil.which(name) or ""
 
 
-def _gh_status() -> tuple[bool, str]:
-    context = connect_mod.github_context(".")
-    if context["ok"]:
-        return True, "authenticated and GitHub repo context ready"
-    return False, str(context["summary"])
-
-
 def _net() -> tuple[bool, str]:
     """Best-effort: open a TCP connection to api.github.com:443."""
     try:
@@ -217,6 +210,7 @@ def run(path: str) -> dict[str, Any]:
     )
 
     gh_context = connect_mod.github_context(repo)
+    integration_status = connect_mod.status_all(repo, github=gh_context)
     checks.append(
         {
             "name": "github-context",
@@ -289,7 +283,7 @@ def run(path: str) -> dict[str, Any]:
     )
     checks.append(_repo_layout_check(repo))
     checks.append(_schema_version_check(repo))
-    checks.append(connect_mod.doctor_check(repo))
+    checks.append(connect_mod.doctor_check(repo, status=integration_status))
     onboarding = onboard_mod.onboarding_status(repo)
     onboarding_summary = onboarding["summary"]
     checks.append(
@@ -344,7 +338,7 @@ def run(path: str) -> dict[str, Any]:
         "ok": overall and not hard_fail,
         "checks": checks,
         "repo": str(repo),
-        "integrations": connect_mod.status_all(repo),
+        "integrations": integration_status,
         "onboarding": onboarding,
         "update": update,
         "python": sys.version.split()[0],

--- a/mb/mb/status.py
+++ b/mb/mb/status.py
@@ -449,6 +449,7 @@ def run(path: str = ".") -> dict[str, Any]:
     repo_shape = _looks_like_mainbranch_repo(repo_path)
     git = _git_info(repo_path)
     update = package_update_status(repo_path)
+    github = _github(repo_path, git)
     report: dict[str, Any] = {
         "ok": True,
         "repo": {"path": str(repo_path), **repo_shape},
@@ -459,8 +460,8 @@ def run(path: str = ".") -> dict[str, Any]:
         "git_activity": _git_recent_activity(repo_path, git),
         "brain": _brain(repo_path),
         "onboarding": onboard_mod.onboarding_status(repo_path),
-        "integrations": connect_mod.status_all(repo_path),
-        "github": _github(repo_path, git),
+        "integrations": connect_mod.status_all(repo_path, github=github.get("context")),
+        "github": github,
     }
     report["readiness"] = _readiness(report)
     report["ok"] = report["readiness"]["level"] != "not_ready"

--- a/mb/mb/status.py
+++ b/mb/mb/status.py
@@ -282,13 +282,46 @@ def _gh_json(args: list[str], repo: Path) -> tuple[bool, Any, str]:
 
 
 def _github(repo: Path, git: dict[str, Any]) -> dict[str, Any]:
-    return github_activity.collect(
+    context = connect_mod.github_context(repo, which_func=_which, command_runner=_run_command)
+    if not context["ok"]:
+        sections: dict[str, list[dict[str, Any]]] = {
+            "assigned_tasks": [],
+            "attention_requests": [],
+            "open_proposals": [],
+            "shipped_this_week": [],
+            "recently_closed_tasks": [],
+            "blocked_or_stale_tasks": [],
+        }
+        return {
+            "available": context["state"] != "missing_cli",
+            "authenticated": context["state"] not in {"missing_cli", "unauthenticated"},
+            "degraded": True,
+            "source": "gh",
+            "repo": "",
+            "summary": {
+                "assigned_tasks": 0,
+                "attention_requests": 0,
+                "open_proposals": 0,
+                "shipped_this_week": 0,
+                "recently_closed_tasks": 0,
+                "blocked_or_stale_tasks": 0,
+            },
+            "sections": sections,
+            "errors": [str(context["summary"])],
+            "assigned_issues": [],
+            "review_requests": [],
+            "recent_merged_prs": [],
+            "context": context,
+        }
+    report = github_activity.collect(
         repo,
         remote=str(git.get("remote", "")),
         which_func=_which,
         command_runner=_run_command,
         json_runner=_gh_json,
     )
+    report["context"] = context
+    return report
 
 
 def _recent_merged_prs(prs: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -380,7 +413,17 @@ def _readiness(report: dict[str, Any]) -> dict[str, Any]:
                 or "Run `mb onboard status` to resume onboarding."
             )
         )
-    if not report["github"]["authenticated"]:
+    integration_repairs = [
+        item for item in (report.get("integrations") or {}).get("providers", []) if not item["ok"]
+    ]
+    for item in integration_repairs[:3]:
+        command = str(item.get("repair_command") or "mb connect doctor")
+        next_actions.append(f"Repair {item['provider']} integration: `{command}`.")
+    github_context = report["github"].get("context") or {}
+    if github_context and not github_context.get("ok"):
+        command = str(github_context.get("repair_command") or "gh auth login")
+        next_actions.append(f"Repair GitHub context: `{command}`.")
+    elif not report["github"]["authenticated"]:
         next_actions.append("Run `gh auth login` to include assigned issues and shipped PRs.")
     if not next_actions:
         next_actions.append("Run `claude` in this repo, then `/start`.")
@@ -477,6 +520,11 @@ def render_human(report: dict[str, Any]) -> None:
             f"healthy {integration_summary['healthy']}  "
             f"needs repair {integration_summary['needs_repair']}"
         )
+        for item in integrations.get("providers", []):
+            if not item["ok"]:
+                console.print(
+                    f"  - {item['provider']}: {item['state']}  next: {item['repair_command']}"
+                )
 
     counts = brain["counts"]
     console.print(
@@ -522,7 +570,12 @@ def render_human(report: dict[str, Any]) -> None:
             console.print(f"  - {item['date']} {item['commit']}  {item['subject']}  {files}")
 
     console.print("\n[bold]GitHub[/bold]")
-    if not github["available"]:
+    github_context = github.get("context") or {}
+    if github_context and not github_context.get("ok"):
+        console.print(f"  {github_context.get('summary')}")
+        if github_context.get("repair_command"):
+            console.print(f"  next: {github_context['repair_command']}")
+    elif not github["available"]:
         console.print("  gh unavailable; skipping issues and PRs.")
     elif not github["authenticated"]:
         console.print("  gh not authenticated; run `gh auth login` to include business tasks.")

--- a/mb/tests/test_connect.py
+++ b/mb/tests/test_connect.py
@@ -204,7 +204,7 @@ def test_connect_test_records_invalid_provider_without_leaking_secret(
     monkeypatch.setattr(
         connect_mod,
         "_http_get_json",
-        lambda url, headers=None: (False, "provider rejected the credential"),
+        lambda url, headers=None: ("invalid", "provider rejected the credential"),
     )
 
     result = runner.invoke(app, ["connect", "test", "cloudflare", "--repo", str(repo), "--json"])
@@ -215,6 +215,56 @@ def test_connect_test_records_invalid_provider_without_leaking_secret(
     assert payload["status"]["state"] == "invalid"
     assert payload["status"]["repair_command"] == "mb connect cloudflare --token-stdin"
     assert payload["status"]["validation"]["summary"] == "provider rejected the credential"
+    assert "cf-secret-token" not in result.stdout
+
+
+def test_connect_test_no_probe_provider_reaches_ready_without_loop(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _local_secret_env(monkeypatch, tmp_path)
+    repo = tmp_path / "biz"
+    repo.mkdir()
+    runner.invoke(app, ["connect", "google", "--repo", str(repo), "--token", "google-token"])
+
+    result = runner.invoke(app, ["connect", "test", "google", "--repo", str(repo), "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["status"]["state"] == "ready"
+    assert payload["status"]["repair_command"] == ""
+    assert "no automated safe validation probe" in payload["validation"]["summary"]
+    assert "google-token" not in result.stdout
+
+    status = runner.invoke(app, ["connect", "status", "--repo", str(repo), "--json"])
+    assert status.exit_code == 0
+    status_payload = json.loads(status.stdout)
+    assert status_payload["summary"]["healthy"] == 1
+    assert status_payload["summary"]["needs_repair"] == 0
+    assert status_payload["providers"][0]["state"] == "ready"
+
+
+def test_connect_test_transient_provider_failure_stays_unvalidated(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _local_secret_env(monkeypatch, tmp_path)
+    repo = tmp_path / "biz"
+    repo.mkdir()
+    runner.invoke(app, ["connect", "cloudflare", "--repo", str(repo), "--token", "cf-secret-token"])
+    monkeypatch.setattr(
+        connect_mod,
+        "_http_get_json",
+        lambda url, headers=None: ("unvalidated", "provider validation returned HTTP 503"),
+    )
+
+    result = runner.invoke(app, ["connect", "test", "cloudflare", "--repo", str(repo), "--json"])
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False
+    assert payload["status"]["state"] == "unvalidated"
+    assert payload["status"]["repair_command"] == "mb connect test cloudflare"
+    assert payload["status"]["validation"]["summary"] == "provider validation returned HTTP 503"
     assert "cf-secret-token" not in result.stdout
 
 
@@ -259,6 +309,26 @@ def test_github_context_distinguishes_missing_remote(monkeypatch, tmp_path: Path
     assert context["ok"] is False
     assert context["state"] == "missing_github_remote"
     assert context["repair_command"] == "gh repo create --source . --remote origin --push"
+
+
+def test_status_all_reuses_supplied_github_context(monkeypatch, tmp_path: Path) -> None:
+    context = {
+        "ok": True,
+        "state": "ready",
+        "summary": "cached GitHub context",
+        "repair": "",
+        "repair_command": "",
+        "safe_to_share": True,
+    }
+
+    def fail_context(repo: Path) -> dict[str, Any]:
+        raise AssertionError("github_context should not be recomputed")
+
+    monkeypatch.setattr(connect_mod, "github_context", fail_context)
+
+    status = connect_mod.status_all(tmp_path, github=context)
+
+    assert status["github"] == context
 
 
 def test_connect_status_tolerates_malformed_config_version(tmp_path: Path, monkeypatch) -> None:

--- a/mb/tests/test_connect.py
+++ b/mb/tests/test_connect.py
@@ -77,7 +77,10 @@ def test_connect_provider_stores_secret_outside_repo(tmp_path: Path, monkeypatch
     assert result.exit_code == 0
     payload = json.loads(result.stdout)
     assert payload["ok"] is True
+    assert payload["ready"] is False
     assert payload["credential_backend"] == "local-file"
+    assert payload["status"]["state"] == "unvalidated"
+    assert payload["status"]["repair_command"] == "mb connect test cloudflare"
 
     config_path = repo / ".mb" / "connect.yaml"
     config_text = config_path.read_text(encoding="utf-8")
@@ -116,6 +119,7 @@ def test_connect_provider_only_reads_env_when_explicit(tmp_path: Path, monkeypat
         "type": "env",
         "env_var": "META_ACCESS_TOKEN",
     }
+    assert explicit_payload["status"]["state"] == "unvalidated"
     assert "meta-test-token" not in (repo / ".mb" / "connect.yaml").read_text(encoding="utf-8")
 
 
@@ -137,6 +141,124 @@ def test_connect_status_reports_missing_secret_as_repair_not_hard_crash(
     status_payload = json.loads(status.stdout)
     assert status_payload["summary"]["needs_repair"] == 1
     assert status_payload["providers"][0]["secrets"]["access_token"]["present"] is False
+    assert status_payload["providers"][0]["state"] == "missing_secret"
+    assert status_payload["providers"][0]["repair_command"] == "mb connect meta --token-stdin"
+    assert status_payload["providers"][0]["safe_to_share"] is True
+
+
+def test_connect_status_reports_unvalidated_secret_without_claiming_health(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _local_secret_env(monkeypatch, tmp_path)
+    repo = tmp_path / "biz"
+    repo.mkdir()
+
+    result = runner.invoke(
+        app,
+        ["connect", "cloudflare", "--repo", str(repo), "--token", "cf-test-token", "--json"],
+    )
+
+    assert result.exit_code == 0
+    status = runner.invoke(app, ["connect", "status", "--repo", str(repo), "--json"])
+    assert status.exit_code == 1
+    payload = json.loads(status.stdout)
+    provider = payload["providers"][0]
+    assert payload["summary"]["configured"] == 1
+    assert payload["summary"]["healthy"] == 0
+    assert payload["summary"]["unvalidated"] == 1
+    assert provider["state"] == "unvalidated"
+    assert provider["summary"]
+    assert provider["repair"] == "Run `mb connect test cloudflare`."
+    assert provider["repair_command"] == "mb connect test cloudflare"
+    assert provider["safe_to_share"] is True
+    assert "cf-test-token" not in status.stdout
+
+
+def test_connect_test_marks_metadata_only_provider_ready(tmp_path: Path, monkeypatch) -> None:
+    _local_secret_env(monkeypatch, tmp_path)
+    repo = tmp_path / "biz"
+    repo.mkdir()
+    connect_mod.connect_provider(
+        "beancount", repo=repo, metadata_pairs=["ledger_path=core/finance/main.bean"]
+    )
+
+    result = runner.invoke(app, ["connect", "test", "beancount", "--repo", str(repo), "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["status"]["state"] == "ready"
+    assert payload["status"]["repair_command"] == ""
+
+
+def test_connect_test_records_invalid_provider_without_leaking_secret(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _local_secret_env(monkeypatch, tmp_path)
+    repo = tmp_path / "biz"
+    repo.mkdir()
+    runner.invoke(
+        app,
+        ["connect", "cloudflare", "--repo", str(repo), "--token", "cf-secret-token", "--json"],
+    )
+    monkeypatch.setattr(
+        connect_mod,
+        "_http_get_json",
+        lambda url, headers=None: (False, "provider rejected the credential"),
+    )
+
+    result = runner.invoke(app, ["connect", "test", "cloudflare", "--repo", str(repo), "--json"])
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False
+    assert payload["status"]["state"] == "invalid"
+    assert payload["status"]["repair_command"] == "mb connect cloudflare --token-stdin"
+    assert payload["status"]["validation"]["summary"] == "provider rejected the credential"
+    assert "cf-secret-token" not in result.stdout
+
+
+def test_connect_doctor_includes_github_context_and_provider_repairs(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _local_secret_env(monkeypatch, tmp_path)
+    repo = tmp_path / "biz"
+    repo.mkdir()
+    runner.invoke(app, ["connect", "meta", "--repo", str(repo), "--json"])
+    monkeypatch.setattr(connect_mod.shutil, "which", lambda name: "")
+
+    result = runner.invoke(app, ["connect", "doctor", "--repo", str(repo), "--json"])
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    checks = {check["name"]: check for check in payload["checks"]}
+    assert checks["github-context"]["state"] == "missing_cli"
+    assert checks["provider:meta"]["state"] == "missing_secret"
+    assert checks["provider:meta"]["repair_command"] == "mb connect meta --token-stdin"
+    assert payload["safe_to_share"] is True
+
+
+def test_github_context_distinguishes_missing_remote(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(
+        connect_mod.shutil, "which", lambda name: "/usr/bin/gh" if name == "gh" else ""
+    )
+
+    def fake_run(args: list[str], cwd: Path | None = None, timeout: float = 5.0) -> dict[str, Any]:
+        if args[:3] == ["gh", "auth", "status"]:
+            return {"ok": True, "returncode": 0, "stdout": "", "stderr": ""}
+        if args[:3] == ["git", "rev-parse", "--is-inside-work-tree"]:
+            return {"ok": True, "returncode": 0, "stdout": "true\n", "stderr": ""}
+        if args[:4] == ["git", "config", "--get", "remote.origin.url"]:
+            return {"ok": False, "returncode": 1, "stdout": "", "stderr": ""}
+        raise AssertionError(args)
+
+    monkeypatch.setattr(connect_mod, "_run_command", fake_run)
+
+    context = connect_mod.github_context(tmp_path)
+
+    assert context["ok"] is False
+    assert context["state"] == "missing_github_remote"
+    assert context["repair_command"] == "gh repo create --source . --remote origin --push"
 
 
 def test_connect_status_tolerates_malformed_config_version(tmp_path: Path, monkeypatch) -> None:

--- a/mb/tests/test_doctor.py
+++ b/mb/tests/test_doctor.py
@@ -21,6 +21,29 @@ def test_doctor_runs_on_empty_dir(tmp_path: Path) -> None:
     assert "update" in report
 
 
+def test_doctor_reuses_github_context_for_integrations(tmp_path: Path, monkeypatch) -> None:
+    calls = 0
+
+    def fake_context(repo: Path) -> dict[str, object]:
+        nonlocal calls
+        calls += 1
+        return {
+            "ok": False,
+            "state": "missing_github_remote",
+            "summary": "This repo does not have a GitHub origin remote.",
+            "repair": "Add a GitHub origin remote before relying on GitHub tasks or proposals.",
+            "repair_command": "gh repo create --source . --remote origin --push",
+            "safe_to_share": True,
+        }
+
+    monkeypatch.setattr(doctor_mod.connect_mod, "github_context", fake_context)
+
+    report = run(path=str(tmp_path))
+
+    assert calls == 1
+    assert report["integrations"]["github"]["state"] == "missing_github_remote"
+
+
 def test_cloud_path_detection_via_symlink(tmp_path: Path, monkeypatch) -> None:
     # Build a fake repo whose core/finance/ is a symlink pointing at a path
     # whose realpath includes "Dropbox".

--- a/mb/tests/test_doctor.py
+++ b/mb/tests/test_doctor.py
@@ -13,7 +13,7 @@ def test_doctor_runs_on_empty_dir(tmp_path: Path) -> None:
     report = run(path=str(tmp_path))
     assert "checks" in report
     names = {c["name"] for c in report["checks"]}
-    assert {"claude-code", "gh-auth", "network", "anti-cloud-backup"}.issubset(names)
+    assert {"claude-code", "github-context", "network", "anti-cloud-backup"}.issubset(names)
     assert "skill-wiring" in names
     assert "mainbranch-version" in names
     assert "repo-layout" in names

--- a/mb/tests/test_status.py
+++ b/mb/tests/test_status.py
@@ -459,6 +459,32 @@ def test_status_github_context_stops_before_low_level_remote_errors(
     assert "no git remotes found" not in json.dumps(github)
 
 
+def test_status_reuses_github_context_for_integrations(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+    calls = 0
+
+    def fake_context(repo: Path, **kwargs: Any) -> dict[str, Any]:
+        nonlocal calls
+        calls += 1
+        return {
+            "ok": False,
+            "state": "missing_cli",
+            "summary": "GitHub CLI is not installed.",
+            "repair": "Install GitHub CLI, then run `gh auth login`.",
+            "repair_command": "gh auth login",
+            "safe_to_share": True,
+        }
+
+    monkeypatch.setattr(connect_mod, "github_context", fake_context)
+
+    report = status_mod.run(path=str(repo))
+
+    assert calls == 1
+    assert report["integrations"]["github"] == report["github"]["context"]
+
+
 def test_status_renderer_prints_optional_sections(capsys) -> None:
     report: dict[str, Any] = {
         "repo": {"path": "/tmp/biz", "looks_like_mainbranch_repo": True},

--- a/mb/tests/test_status.py
+++ b/mb/tests/test_status.py
@@ -11,6 +11,7 @@ from typing import Any
 
 from typer.testing import CliRunner
 
+from mb import connect as connect_mod
 from mb import status as status_mod
 from mb.cli import app
 from mb.init import run as init_run
@@ -103,6 +104,30 @@ def test_status_required_update_json_and_human_copy(tmp_path: Path, monkeypatch)
     assert "Update required." in human_result.stdout
     assert "pipx upgrade mainbranch" in human_result.stdout
     assert "mb skill link --repo ." in human_result.stdout
+
+
+def test_status_names_integration_repairs(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
+    monkeypatch.setenv("MB_CONNECT_SECRET_BACKEND", "local-file")
+    monkeypatch.setenv("MAINBRANCH_HOME", str(tmp_path / "home"))
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+    connect_mod.connect_provider("meta", repo=repo)
+
+    json_result = runner.invoke(app, ["status", str(repo), "--json"])
+
+    assert json_result.exit_code == 0
+    payload = json.loads(json_result.stdout)
+    assert payload["integrations"]["providers"][0]["state"] == "missing_secret"
+    assert any(
+        "mb connect meta --token-stdin" in action for action in payload["readiness"]["next_actions"]
+    )
+
+    human_result = runner.invoke(app, ["status", str(repo)])
+
+    assert human_result.exit_code == 0
+    assert "meta: missing_secret" in human_result.stdout
+    assert "mb connect meta --token-stdin" in human_result.stdout
 
 
 def test_status_detects_non_business_repo(tmp_path: Path, monkeypatch) -> None:
@@ -233,6 +258,18 @@ def test_status_brain_marks_stale_decisions(tmp_path: Path, monkeypatch) -> None
 
 
 def test_status_github_authenticated_branches(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(
+        connect_mod,
+        "github_context",
+        lambda repo, **kwargs: {
+            "ok": True,
+            "state": "ready",
+            "summary": "GitHub ready",
+            "repair": "",
+            "repair_command": "",
+            "safe_to_share": True,
+        },
+    )
     monkeypatch.setattr(status_mod, "_which", lambda name: "/usr/bin/gh" if name == "gh" else "")
     monkeypatch.setattr(
         status_mod,
@@ -306,6 +343,18 @@ def test_status_github_authenticated_branches(tmp_path: Path, monkeypatch) -> No
 
 
 def test_status_github_activity_business_sections(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(
+        connect_mod,
+        "github_context",
+        lambda repo, **kwargs: {
+            "ok": True,
+            "state": "ready",
+            "summary": "GitHub ready",
+            "repair": "",
+            "repair_command": "",
+            "safe_to_share": True,
+        },
+    )
     monkeypatch.setattr(status_mod, "_which", lambda name: "/usr/bin/gh" if name == "gh" else "")
     monkeypatch.setattr(
         status_mod,
@@ -382,6 +431,32 @@ def test_status_github_activity_business_sections(tmp_path: Path, monkeypatch) -
     assert sections["shipped_this_week"][0]["what_shipped"] == "Launched 7"
     assert sections["recently_closed_tasks"][0]["business_status"] == "closed"
     assert sections["blocked_or_stale_tasks"][0]["labels"] == ["blocked"]
+
+
+def test_status_github_context_stops_before_low_level_remote_errors(
+    tmp_path: Path, monkeypatch
+) -> None:
+    context = {
+        "ok": False,
+        "state": "missing_github_remote",
+        "summary": "This repo does not have a GitHub origin remote.",
+        "repair": "Add a GitHub origin remote before relying on GitHub tasks or proposals.",
+        "repair_command": "gh repo create --source . --remote origin --push",
+        "safe_to_share": True,
+    }
+    monkeypatch.setattr(connect_mod, "github_context", lambda repo, **kwargs: context)
+
+    def fail_gh_json(args: list[str], repo: Path) -> tuple[bool, Any, str]:
+        raise AssertionError(args)
+
+    monkeypatch.setattr(status_mod, "_gh_json", fail_gh_json)
+
+    github = status_mod._github(tmp_path, {"remote": ""})
+
+    assert github["authenticated"] is True
+    assert github["context"]["state"] == "missing_github_remote"
+    assert github["errors"] == ["This repo does not have a GitHub origin remote."]
+    assert "no git remotes found" not in json.dumps(github)
 
 
 def test_status_renderer_prints_optional_sections(capsys) -> None:


### PR DESCRIPTION
## Summary
- Adds a trustworthy `mb connect` repair loop with `mb connect test <provider>` and `mb connect doctor`.
- Changes provider health so stored secret refs are not treated as healthy until validation runs, with explicit `missing_secret`, `unvalidated`, `invalid`, and `ready` states.
- Adds GitHub context health for missing `gh`, unauthenticated `gh`, non-git folders, missing GitHub remotes, and ready repo context.
- Threads safe repair fields through `mb connect status --json`, `mb doctor`, and `mb status` so onboarding/runtime agents can show exact next commands.

## Scope
- In: provider validation and repair JSON, GitHub context checks, status/doctor repair output, docs/changelog, and focused CLI tests.
- Out: full OAuth flows, background sync, dashboard UI, raw provider responses, and account-private output.

## Commits
- `00d9975` — `[add] MAIN-198 mb connect trust loop`.
- `8e04f0b` — `[fix] MAIN-198 connect audit findings`.

## Release / Issues
- Release: not assigned in Linear.
- Linear ID(s): MAIN-198.
- Closes: #227.
- Refs: #228, #229.
- Follow-ups: none identified.

## Success Metric
- A noob user or onboarding agent can run `mb connect status`, `mb connect doctor`, `mb doctor`, or `mb status` and see whether GitHub and configured providers are missing, unvalidated, invalid, or ready, with safe next commands and no secret leakage.

## Validation
- Level 0 docs/decision: README and CHANGELOG updated for the new command surface and health semantics.
- Level 1 static: `scripts/check.sh` passed from repo root, including ruff and mypy.
- Level 2 CLI: `scripts/check.sh` passed with 149 tests; focused connect/doctor/status coverage includes exit codes, JSON repair fields, no-probe providers, transient validation failures, token redaction, and GitHub context caching.
- Level 3 package/install: not run; packaging, entrypoints, bundled data, and install/update paths were not changed.
- Level 4 fixture repo: local fixture smoke passed for `mb onboard`, `mb doctor`, `mb status`, `mb start --json`, `mb validate`, plus `mb connect google`, `mb connect test google`, `mb connect status --json`, and `mb connect doctor --json`.
- Level 5 runtime smoke: not run; skill discovery and runtime invocation were not changed.

## Public / Private Boundary
- Secret values, credential file contents, raw provider responses, account-private details, and Devon/Conductor-only workflow notes stayed out of committed files and CLI output.
