### PR TITLE
[update] Prepare 0.2.4 release

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mainbranch",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Main Branch Claude Code skills for running a business from markdown files in git.",
   "author": {
     "name": "Noontide"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,28 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+## [0.2.4] - 2026-05-04
+
+v0.2.4 is the noob-safe migration and provider-trust release. It moves bundled
+Claude Code skills to collision-resistant `mb-` names, adds repair tools for
+legacy global skill wiring, makes legacy migration checks privacy-safe by
+default, and stops treating stored provider credentials as healthy until they
+are validated.
+
+### What this means for you (plain English)
+
+- **Skill commands are now prefixed.** New and repaired repos use `/mb-start`,
+  `/mb-think`, `/mb-ads`, and the rest of the `mb-` skill set so Main Branch is
+  less likely to collide with personal or third-party Claude Code skills.
+- **Old installs have a safer repair path.** `mb skill repair --repo .`,
+  `mb skill link --repo .`, `mb doctor`, and `mb start --json` can explain and
+  repair stale wiring without deleting unrelated user-authored skills.
+- **Migration checks are private by default.** Legacy repo migration plans show
+  path/action summaries unless you explicitly ask for full diffs.
+- **Connected accounts must prove they work.** `mb connect test <provider>` and
+  `mb connect doctor` distinguish missing, unvalidated, invalid, and ready
+  credentials without printing secrets.
+
 ### Added
 
 - `mb skill repair --repo .` detects personal Claude Code skills that shadow

--- a/mb/mb/__init__.py
+++ b/mb/mb/__init__.py
@@ -7,6 +7,6 @@ file stays a thin dispatcher.
 
 from __future__ import annotations
 
-__version__ = "0.2.3"
+__version__ = "0.2.4"
 
 __all__ = ["__version__"]

--- a/mb/pyproject.toml
+++ b/mb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mainbranch"
-version = "0.2.3"
+version = "0.2.4"
 description = "Main Branch engine umbrella - scaffolds, validates, and graphs business-as-files repos. Claude Code first, runtime-agnostic by design."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- Cuts `mainbranch` to `0.2.4` for the merged noob-safe migration and provider-trust work.
- Adds a plain-English changelog section for prefixed skills, safe legacy repair, privacy-safe migration checks, and provider validation.
- Keeps the Claude Code plugin prototype manifest version aligned with the package version.

## Scope
- In: package version, runtime `__version__`, plugin manifest version, and `CHANGELOG.md` release notes.
- Out: new product behavior, new migration logic, release publication/tag creation.

## Commits
- `c6d4360` — `[update] Prepare 0.2.4 release`.

## Release / Issues
- Release: `oe-v0.2.4` after merge.
- Linear ID(s): release prep only.
- Closes: none.
- Refs: #249, #250.
- Follow-ups: plugin distribution remains behind a separate runtime proof.

## Success Metric
- A fresh installed wheel reports `mb 0.2.4`, packages `mb-start` and the plugin manifest at `0.2.4`, and does not package legacy unprefixed `start`.

## Validation
- Level 0 docs/decision: checked changelog release copy and version alignment.
- Level 1 static: `scripts/check.sh` passed: ruff, mypy, 161 tests, 14/14 bundled skills validate.
- Level 2 CLI: covered by full test suite and fixture smoke.
- Level 3 package/install: built wheel/sdist, installed wheel into `/tmp/mainbranch-smoke-024`, verified `mb --version`, `mb skill list`, packaged plugin manifest version, packaged `mb-start`, and absence of legacy packaged `start`.
- Level 4 fixture repo: fresh wheel install ran `mb onboard`, `mb doctor`, `mb status`, `mb start --json`, and `mb validate`; verified project-local `mb-start` wiring and `/mb-start` follow-up.
- Level 5 runtime smoke: not rerun in this branch; #250 already supplied Claude Code runtime smoke for the behavior being released. This branch only aligns release metadata.

## Public / Private Boundary
- No private machine paths or member/customer data committed. Release notes are public-safe.
