### PR TITLE
[fix] Auto-repair broken legacy skill links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+### Fixed
+
+- `mb skill link --repo .` and `mb skill repair --repo . --apply` now move
+  broken personal Claude Code symlinks with Main Branch current or legacy skill
+  names to timestamped backups instead of leaving old `/start`, `/think`, and
+  similar traps in place. User-authored directories, real files, and live
+  third-party skill links remain report-only.
+
 ## [0.2.4] - 2026-05-04
 
 v0.2.4 is the noob-safe migration and provider-trust release. It moves bundled

--- a/README.md
+++ b/README.md
@@ -158,8 +158,8 @@ The CLI surface for the engine. Built for Claude Code first; runtime-agnostic by
 | `mb skill list` | List the skills bundled with this engine. |
 | `mb skill path <name>` | Print the on-disk path to a bundled skill. |
 | `mb skill validate <name>` | Validate one bundled skill's frontmatter, local references, and 500-line gate. Use `--all --json` for CI. |
-| `mb skill link --repo .` | Repair Claude Code skill discovery in a business repo. |
-| `mb skill repair --repo .` | Detect personal Claude Code skills that shadow Main Branch and explain safe repair. Use `--apply` only for stale Main Branch symlinks. |
+| `mb skill link --repo .` | Repair Claude Code skill discovery in a business repo and back up stale or broken Main Branch personal symlinks. |
+| `mb skill repair --repo .` | Detect personal Claude Code skills that shadow Main Branch and explain safe repair. Use `--apply` only for stale Main Branch symlinks or broken links with Main Branch skill names. |
 
 Full list: `mb --help`.
 

--- a/docs/MIGRATING.md
+++ b/docs/MIGRATING.md
@@ -50,20 +50,23 @@ mb start
 `/mb-think`, `/mb-ads`, and the other bundled skills point at the installed
 Main Branch package instead of an old clone path. It also removes stale
 Main Branch engine paths from `.claude/settings.local.json` so Claude Code does
-not keep access to two engine copies after a clone-to-pipx migration.
+not keep access to two engine copies after a clone-to-pipx migration. During
+that link step, Main Branch also moves provably stale or broken personal
+symlinks with Main Branch skill names into a timestamped backup.
 
 `mb skill repair --repo .` checks your personal `~/.claude/skills/` directory
 for entries that can beat the project-local Main Branch skills in Claude Code.
 It reports the resolved target for each finding. If the entry is a provably
-stale Main Branch symlink, run:
+stale Main Branch symlink or a broken symlink using one of Main Branch's current
+or legacy skill names, run:
 
 ```bash
 mb skill repair --repo . --apply
 ```
 
-That moves the symlink to a timestamped backup under
+That moves the symlink itself to a timestamped backup under
 `~/.claude/skills/.mainbranch-backups/`. It does not delete or move
-user-authored or third-party skills.
+user-authored directories, real files, or live third-party skill links.
 
 ## Do Not Start By Moving Files
 

--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -912,7 +912,7 @@ def skill_repair_cmd(
     apply_changes: bool = typer.Option(
         False,
         "--apply",
-        help="Move provably stale Main Branch personal skill links to a timestamped backup.",
+        help="Move stale or broken Main Branch personal skill links to a timestamped backup.",
     ),
     json_out: bool = typer.Option(False, "--json", help="Machine-readable output."),
 ) -> None:
@@ -945,10 +945,12 @@ def skill_repair_cmd(
                     else:
                         typer.echo("  safe repair: run `mb skill repair --repo . --apply`")
                 else:
-                    typer.echo("  not changed: this is not provably a stale Main Branch link")
+                    typer.echo(
+                        "  not changed: this is not a stale or broken Main Branch skill link"
+                    )
         if not apply_changes and summary["repairable"]:
             typer.echo("")
-            typer.echo("To move stale Main Branch symlinks to backup:")
+            typer.echo("To move stale or broken Main Branch symlinks to backup:")
             typer.echo("  mb skill repair --repo . --apply")
     raise typer.Exit(0 if result["ok"] else 1)
 

--- a/mb/mb/engine.py
+++ b/mb/mb/engine.py
@@ -336,7 +336,7 @@ def _conflict_finding(
 ) -> dict[str, Any]:
     entry = global_dir / name
     classification, target = _classify_personal_skill(entry, name)
-    safe_to_repair = classification == "stale-mainbranch-link"
+    safe_to_repair = classification in {"stale-mainbranch-link", "broken-symlink"}
     backup_path = ""
     repaired = False
     error = ""
@@ -379,8 +379,9 @@ def inspect_personal_skill_conflicts(
 ) -> dict[str, Any]:
     """Inspect or repair personal Claude Code skills that can shadow Main Branch.
 
-    ``apply`` only moves entries that are provably stale Main Branch symlinks.
-    User-authored or third-party skills are reported but never changed.
+    ``apply`` only moves stale Main Branch symlinks and broken symlinks matching
+    Main Branch's current or legacy skill names. User-authored or third-party
+    skills are reported but never changed.
     """
     target = Path(repo).expanduser().resolve()
     global_dir = personal_skills_dir or _personal_skills_dir()
@@ -512,7 +513,7 @@ def link_skills(repo: str | Path) -> dict[str, Any]:
         "removed_legacy": removed_legacy,
         "removed_stale_engine_paths": removed_stale_engine_paths,
         "errors": [],
-        "shadow_report": inspect_personal_skill_conflicts(target, apply=False),
+        "shadow_report": inspect_personal_skill_conflicts(target, apply=True),
     }
 
 

--- a/mb/tests/test_engine.py
+++ b/mb/tests/test_engine.py
@@ -52,6 +52,37 @@ def test_personal_legacy_mainbranch_symlink_is_reported_and_backed_up(
     assert Path(applied["findings"][0]["backup_path"]).is_symlink()
 
 
+def test_personal_legacy_broken_symlink_is_reported_and_backed_up(
+    tmp_path: Path, monkeypatch
+) -> None:
+    personal = tmp_path / "home" / ".claude" / "skills"
+    personal.mkdir(parents=True)
+    (personal / "start").symlink_to(tmp_path / "missing-engine" / "start")
+    repo = tmp_path / "biz"
+    _write_skill(repo, "mb-start")
+
+    monkeypatch.setattr(engine_mod, "bundled_skills", lambda: ["mb-start"])
+
+    dry = engine_mod.inspect_personal_skill_conflicts(repo, personal_skills_dir=personal)
+
+    assert dry["ok"] is True
+    assert dry["summary"]["legacy_globals"] == 1
+    assert dry["summary"]["repairable"] == 1
+    assert dry["findings"][0]["classification"] == "broken-symlink"
+    assert (personal / "start").is_symlink()
+
+    applied = engine_mod.inspect_personal_skill_conflicts(
+        repo,
+        apply=True,
+        personal_skills_dir=personal,
+    )
+
+    assert applied["summary"]["repaired"] == 1
+    assert not (personal / "start").exists()
+    assert not (personal / "start").is_symlink()
+    assert Path(applied["findings"][0]["backup_path"]).is_symlink()
+
+
 def test_personal_third_party_active_shadow_is_reported_but_not_repaired(
     tmp_path: Path, monkeypatch
 ) -> None:
@@ -73,6 +104,27 @@ def test_personal_third_party_active_shadow_is_reported_but_not_repaired(
     assert result["summary"]["repairable"] == 0
     assert result["findings"][0]["classification"] == "not-mainbranch-link"
     assert (personal / "mb-start" / "SKILL.md").exists()
+
+
+def test_link_skills_auto_repairs_broken_legacy_personal_symlink(
+    tmp_path: Path, monkeypatch
+) -> None:
+    personal = tmp_path / "home" / ".claude" / "skills"
+    personal.mkdir(parents=True)
+    (personal / "start").symlink_to(tmp_path / "missing-engine" / "start")
+    repo = tmp_path / "biz"
+
+    monkeypatch.setattr(engine_mod, "bundled_skills", lambda: ["mb-start"])
+    monkeypatch.setattr(engine_mod, "_personal_skills_dir", lambda: personal)
+
+    result = engine_mod.link_skills(repo)
+
+    assert result["ok"] is True
+    assert result["shadow_report"]["summary"]["repaired"] == 1
+    assert result["shadow_report"]["findings"][0]["classification"] == "broken-symlink"
+    assert not (personal / "start").exists()
+    assert not (personal / "start").is_symlink()
+    assert (repo / ".claude" / "skills" / "mb-start" / "SKILL.md").exists()
 
 
 def test_link_skills_removes_legacy_project_symlink(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Treats broken personal Claude Code symlinks with Main Branch current or legacy skill names as safe to repair.
- Makes `mb skill link --repo .` apply safe personal-skill repairs automatically during the normal post-upgrade flow.
- Keeps user-authored directories, real files, and live third-party skill links report-only.
- Updates migration docs and command copy so old users understand what gets moved to backup.

## Scope
- In: personal skill shadow/legacy trap classification, `mb skill link` safe repair behavior, tests, README/MIGRATING/CHANGELOG copy.
- Out: deleting real user-authored skills, changing Claude Code plugin distribution, changing v0.1-to-v0.2 path migration.

## Commits
- `52d7cd8` — `[fix] Auto-repair broken legacy skill links`.

## Release / Issues
- Release: next patch release.
- Linear ID(s): GitHub-origin issue; Linear should sync from #252.
- Closes: #252.
- Refs: #250.
- Follow-ups: none required unless runtime smoke exposes another legacy install shape.

## Success Metric
- A past user with broken personal `start`, `think`, `ads`, etc. symlinks can run `mb skill link --repo .` and end with project-local `mb-*` skills wired while the broken personal symlinks are moved to `~/.claude/skills/.mainbranch-backups/`, without touching real third-party skills.

## Validation
- Level 0 docs/decision: updated public README, MIGRATING, and CHANGELOG wording around safe repairs.
- Level 1 static: `scripts/check.sh` passed: ruff, mypy, 163 tests, and bundled skill validation.
- Level 2 CLI: focused `pytest tests/test_engine.py -q` passed; added coverage for broken legacy symlink backup and automatic repair during `link_skills`.
- Level 3 package/install: not run; packaging metadata and bundled data are unchanged.
- Level 4 fixture repo: covered by existing link/doctor/start tests in full suite; no path migration code changed.
- Level 5 runtime smoke: not run; Claude Code discovery behavior is unchanged, only stale personal symlink cleanup changes.

## Public / Private Boundary
- No private paths, member data, or local logs committed. The attached dogfood log informed the fix but stayed in `.context/attachments`.
