### PR TITLE
[update] Prepare 0.2.5 release

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mainbranch",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Main Branch Claude Code skills for running a business from markdown files in git.",
   "author": {
     "name": "Noontide"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+## [0.2.5] - 2026-05-04
+
+v0.2.5 finishes the noob-safe migration loop for past users with broken
+personal Claude Code skill symlinks from older Main Branch setups.
+
+### What this means for you (plain English)
+
+- **Old broken `/start`-style symlinks are cleaned up automatically.** Running
+  `mb skill link --repo .` now backs up broken personal symlinks with Main
+  Branch skill names before wiring the current `/mb-start` skill set.
+- **Real personal or third-party skills are still protected.** Main Branch only
+  moves stale Main Branch links and broken symlinks with Main Branch current or
+  legacy names; directories, real files, and live third-party links are
+  reported but not moved.
+
 ### Fixed
 
 - `mb skill link --repo .` and `mb skill repair --repo . --apply` now move

--- a/mb/mb/__init__.py
+++ b/mb/mb/__init__.py
@@ -7,6 +7,6 @@ file stays a thin dispatcher.
 
 from __future__ import annotations
 
-__version__ = "0.2.4"
+__version__ = "0.2.5"
 
 __all__ = ["__version__"]

--- a/mb/pyproject.toml
+++ b/mb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mainbranch"
-version = "0.2.4"
+version = "0.2.5"
 description = "Main Branch engine umbrella - scaffolds, validates, and graphs business-as-files repos. Claude Code first, runtime-agnostic by design."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- Cuts `mainbranch` to `0.2.5` for the broken legacy personal skill symlink repair.
- Adds plain-English release notes for old-user cleanup after v0.2.4 migration.
- Keeps package version, runtime version, and Claude plugin manifest version aligned.

## Scope
- In: package version, runtime `__version__`, plugin manifest version, and `CHANGELOG.md` release notes.
- Out: new product behavior beyond #253, release publication/tag creation.

## Commits
- `71ec9e0` — `[update] Prepare 0.2.5 release`.

## Release / Issues
- Release: `oe-v0.2.5` after merge.
- Linear ID(s): GitHub-origin release prep.
- Closes: none.
- Refs: #253, #252.
- Follow-ups: setuptools license metadata deprecation is still non-blocking packaging hygiene.

## Success Metric
- A fresh installed wheel reports `mb 0.2.5`, packages the plugin manifest at `0.2.5`, and `mb skill link --repo .` from that wheel backs up broken legacy personal `start` symlinks while linking `mb-start` into the repo.

## Validation
- Level 0 docs/decision: checked changelog release copy and version alignment.
- Level 1 static: `scripts/check.sh` passed: ruff, mypy, 163 tests, 14/14 bundled skills validate.
- Level 2 CLI: #253 added and passed focused engine tests for stale/broken personal symlink repair.
- Level 3 package/install: built wheel/sdist, installed wheel into `/tmp/mainbranch-smoke-025`, verified `mb --version`, `mb skill list`, packaged plugin manifest version, packaged `mb-start`, and absence of legacy packaged `start`.
- Level 4 fixture repo: with the built wheel, created a fake HOME containing a broken personal `start` symlink, ran `mb skill link --repo <repo>`, and verified the broken symlink moved to `.mainbranch-backups` while project-local `mb-start` was linked.
- Level 5 runtime smoke: not rerun in this branch; Claude Code discovery behavior is unchanged from #250/#253, only release metadata changes here.

## Public / Private Boundary
- No private paths, member data, or local logs committed. Release notes are public-safe.
