### PR TITLE
[update] Claude-led migration guidance

### DIFF
--- a/.claude/skills/mb-pull/SKILL.md
+++ b/.claude/skills/mb-pull/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mb-pull
-description: Quick update Main Branch. Use when user wants to update the engine without running /mb-start, says "pull", "update", or "get latest", wants to see what changed, or after Devon announces features in Skool. Note that /mb-start updates automatically, so skip /mb-pull if running /mb-start next.
+description: Quick update Main Branch. Use when user wants to update the engine without running /mb-start, says "pull", "update", or "get latest", wants to see what changed, or after Devon announces features in Skool. /mb-start runs the same update check at session start, so skip /mb-pull if running /mb-start next.
 ---
 
 # Pull

--- a/README.md
+++ b/README.md
@@ -261,10 +261,12 @@ Main Branch is fully usable on its own. The paid community is the live narration
 
 ## Updating
 
-- **pipx users (most people)**: `pipx upgrade mainbranch`. Or just run `/mb-pull` inside Claude Code — it figures out which install you have and runs the right thing.
+- **pipx users (most people)**: `mb update --repo .` from your business repo. Or just run `/mb-pull` inside Claude Code — it figures out which install you have and runs the right thing.
 - **Clone (developer mode)**: `git pull origin main` from the engine repo.
 
-The CHANGELOG entry for the new version surfaces as a banner the next time you run `/mb-start`.
+`/mb-start` checks for important updates at the beginning of a session and will
+tell you when updating matters. The CHANGELOG entry for the new version
+surfaces as a banner the next time you run `/mb-start`.
 
 ---
 
@@ -280,7 +282,7 @@ Use one repo with an `offers/` folder. Each offer gets its own `offer.md`. Soul 
 Create a separate repo for each brand. If they share the same soul and voice, they can share a repo. If not, separate repos.
 
 **How do I update when new skills come out?**
-`pipx upgrade mainbranch`, or run `/mb-pull` inside Claude Code.
+`mb update --repo .`, or run `/mb-pull` inside Claude Code.
 
 If `mb --version` still says `0.1.x`, run `pipx upgrade mainbranch` once before
 using `mb update`; old installs now surface this as an in-product
@@ -288,6 +290,12 @@ using `mb update`; old installs now surface this as an in-product
 surfaces. Existing business repos should then run `mb skill link --repo .` and
 `mb skill repair --repo .`, then `mb doctor` from the repo root. See
 [docs/MIGRATING.md](docs/MIGRATING.md) for the old-repo path.
+
+**Can Claude migrate an old setup for me?**
+Yes. Start Claude Code anywhere and paste the prompt in
+[docs/MIGRATING.md](docs/MIGRATING.md#recommended-let-claude-walk-you-through-it).
+Claude should inspect first, show you exact commands, and ask before applying
+repairs or layout migrations.
 
 **Can I edit the skills?**
 You can, but you don't need to. They're designed to work out of the box.

--- a/docs/BEGINNER-SETUP.md
+++ b/docs/BEGINNER-SETUP.md
@@ -115,10 +115,14 @@ Three lines. That's the daily flow.
 When new versions drop:
 
 ```bash
-pipx upgrade mainbranch
+mb update --repo .
 ```
 
-Or just run `/mb-pull` inside Claude Code — it figures out which install you have and runs the right thing. The CHANGELOG entry for the new version surfaces as a banner the next time you run `/mb-start`.
+Or run `/mb-pull` inside Claude Code — it figures out which install you have
+and runs the right thing. `/mb-start` also checks for important updates at the
+beginning of a session and will tell you when an update matters. The CHANGELOG
+entry for the new version surfaces as a banner the next time you run
+`/mb-start`.
 
 If you installed an early `0.1.x` version, upgrade once with
 `pipx upgrade mainbranch` before trying `mb update`. If you already had a
@@ -132,6 +136,22 @@ mb doctor
 
 For old `reference/core/` repos, read [MIGRATING.md](MIGRATING.md). You usually
 do not need to move files immediately.
+
+### Already Using The Old Setup?
+
+You can let Claude walk you through the migration. Start Claude Code anywhere
+and paste:
+
+```text
+I want to migrate my existing Main Branch setup to the current pipx + /mb-start
+workflow. Please run read-only checks first, find my likely business repos,
+show me the exact commands you recommend, and ask before running anything that
+writes files. Use docs/MIGRATING.md as the source of truth.
+```
+
+Claude may ask you to restart in a business repo after it repairs skill
+discovery. That is normal — Claude Code loads slash commands when a session
+starts, so repaired `/mb-start` links usually appear after restart.
 
 ---
 

--- a/docs/MIGRATING.md
+++ b/docs/MIGRATING.md
@@ -12,6 +12,59 @@ Existing repos do not need an urgent file move. The safe path is to update the
 engine first, repair skill discovery, and only migrate file layout on a clean
 branch when you need the new shape.
 
+## Recommended: Let Claude Walk You Through It
+
+If you are already using Main Branch and do not want to reason about old
+symlinks, clone paths, or repo shapes, start Claude Code anywhere and paste this
+prompt:
+
+```text
+I want to migrate my existing Main Branch setup to the current pipx + /mb-start
+workflow.
+
+Please go slowly and do this safely:
+
+1. First run read-only checks only:
+   - mb --version
+   - mb update --check --json
+   - mb skill list
+   - find likely business repos under ~/Documents/GitHub that have CLAUDE.md
+     plus core/ or reference/core/, research/, or decisions/
+2. For each likely business repo, inspect without changing files:
+   - mb doctor <repo>
+   - mb status <repo>
+   - mb skill repair --repo <repo>
+   - mb migrate --repo <repo> status
+3. Show me the exact commands you recommend before running anything that writes.
+4. Do not delete real files. Only use Main Branch repair/apply commands after I
+   confirm.
+5. If a command says I need to restart Claude, stop and tell me exactly which
+   folder to open next and which slash command to run.
+```
+
+Claude should end by getting each chosen business repo to this state:
+
+```bash
+cd /path/to/your-business
+mb update --repo .
+mb skill link --repo .
+mb skill repair --repo .
+mb doctor
+mb status
+mb start
+```
+
+Then restart Claude Code from that business repo and run:
+
+```text
+/mb-start
+```
+
+This flow is intentionally confirmation-gated. `mb skill link` and
+`mb skill repair --apply` only move stale Main Branch symlinks and broken links
+with Main Branch skill names into timestamped backups. They do not delete
+user-authored skill folders, real files, or live third-party skill links.
+
 ## If You Are On `mb 0.1.x`
 
 Old `mb` versions do not have `mb update` yet. Run the bootstrap upgrade once:
@@ -39,6 +92,7 @@ From the business repo:
 
 ```bash
 cd /path/to/your-business
+mb update --repo .
 mb skill link --repo .
 mb skill repair --repo .
 mb doctor
@@ -81,7 +135,7 @@ Current Main Branch commands understand that legacy shape:
 The only thing legacy users usually need immediately is:
 
 ```bash
-pipx upgrade mainbranch
+mb update --repo /path/to/your-business
 mb skill link --repo /path/to/your-business
 mb skill repair --repo /path/to/your-business
 ```
@@ -210,12 +264,14 @@ the old config files yet.
 
 For old business repos:
 
-1. Upgrade Main Branch with `pipx upgrade mainbranch`.
-2. Run `mb skill link --repo /path/to/repo`.
-3. Run `mb skill repair --repo /path/to/repo`; use `--apply` only when it says
+1. Start with the Claude-led migration prompt above if you want guidance.
+2. Upgrade Main Branch with `mb update --repo /path/to/repo`; if your install
+   is still on `0.1.x`, run `pipx upgrade mainbranch` first.
+3. Run `mb skill link --repo /path/to/repo`.
+4. Run `mb skill repair --repo /path/to/repo`; use `--apply` only when it says
    a stale Main Branch symlink is safe to move.
-4. Run `mb doctor` and `mb status`.
-5. Run `mb migrate --check`, read the diff, then run `mb migrate --apply` on a
+5. Run `mb doctor` and `mb status`.
+6. Run `mb migrate --check`, read the diff, then run `mb migrate --apply` on a
    clean branch when you are ready.
 
 For personal knowledge repos that do not have `reference/core/`, treat them as


### PR DESCRIPTION
## Summary
- Adds a paste-ready Claude Code migration prompt for existing Main Branch users.
- Makes the old-repo path beginner-safe: inspect first, show exact commands, ask before writes.
- Updates public setup/update docs to prefer `mb update --repo .`, `/mb-pull`, and `/mb-start` update alerts.
- Clarifies that repair commands protect user-authored and third-party skills.

## Scope
- In: README updating FAQ, BEGINNER-SETUP update/migration section, MIGRATING Claude-led flow, /mb-pull description wording.
- Out: New migration discovery CLI, layout migration behavior changes, release automation changes, community post committed to repo.

## Commits
- 462dc6c — [update] MAIN-214 add Claude-led migration guidance

## Release / Issues
- Release: next patch docs release
- Linear ID(s): MAIN-214
- Closes: #255
- Refs: none
- Follow-ups: consider a future `mb migrate discover` or `mb doctor --all` command if Claude-led discovery becomes common.

## Success Metric
An existing non-technical user can paste the migration prompt into Claude Code, get a safe audit, approve exact commands, and end in a business repo where `/mb-start` is discoverable without manually reasoning about old symlinks or clone paths.

## Validation
- Level 0 docs/decision: reviewed updated public docs for command shape and stale v0.1.1 language in the touched surfaces.
- Level 1 static: `scripts/check.sh` passed.
- Level 2 CLI: covered by existing `scripts/check.sh` CLI test suite; no CLI behavior changed.
- Level 3 package/install: not run; docs/skill description only.
- Level 4 fixture repo: not run; migration behavior was covered by existing tests during `scripts/check.sh`.
- Level 5 runtime smoke: not run; no runtime discovery behavior changed.

## Public / Private Boundary
No private Devon/Conductor paths or user repo logs were committed. The community post stays out of the repo; only durable public migration instructions were added.