### PR TITLE
[add] /mb-update skill alias

### DIFF
--- a/.claude/educational/upgrading-mainbranch.md
+++ b/.claude/educational/upgrading-mainbranch.md
@@ -17,7 +17,7 @@ mb --version
 ```
 
 `mb update` was added after the earliest public package, so old installs cannot
-run it yet. After the pipx upgrade, `mb update` and `/mb-pull` become the normal
+run it yet. After the pipx upgrade, `mb update` and `/mb-update` become the normal
 path.
 
 ## If you already have a business repo
@@ -64,4 +64,5 @@ the example path with your actual engine checkout:
 git -C ~/Documents/GitHub/mainbranch pull origin main
 ```
 
-`/mb-pull` detects the install mode and chooses the right update path.
+`/mb-update` detects the install mode and chooses the right update path.
+`/mb-pull` still works as a legacy alias.

--- a/.claude/reference/vip-path-resolution.md
+++ b/.claude/reference/vip-path-resolution.md
@@ -1,6 +1,6 @@
 # Engine Path Resolution
 
-Canonical resolver for locating the Main Branch engine from a Claude Code session running inside a business repo. Used by `/mb-start`, `/mb-pull`, `/mb-setup`, `/mb-help` (troubleshooting), and any reference file that needs to read or pull engine-side files.
+Canonical resolver for locating the Main Branch engine from a Claude Code session running inside a business repo. Used by `/mb-start`, `/mb-update`, legacy `/mb-pull`, `/mb-setup`, `/mb-help` (troubleshooting), and any reference file that needs to read or pull engine-side files.
 
 **Single source of truth.** Other reference files MUST link here rather than inline the snippet — the resolver semantics (and the order of fallbacks) need to stay in lockstep across the engine, and inline copies drift.
 
@@ -87,7 +87,8 @@ A reference file that inlines the resolver and *also* customises it should comme
 
 ## Callers that link to this file
 
-- `.claude/skills/mb-pull/SKILL.md`
+- `.claude/skills/mb-update/SKILL.md`
+- `.claude/skills/mb-pull/SKILL.md` (legacy alias)
 - `.claude/skills/mb-setup/references/cwd-detection.md`
 - `.claude/skills/mb-help/references/troubleshooting.md` (skills-not-working + git-conflicts sections)
 - `.claude/reference/pull-engine-updates.md`

--- a/.claude/skills/mb-help/references/conductor-setup.md
+++ b/.claude/skills/mb-help/references/conductor-setup.md
@@ -25,7 +25,7 @@ Conductor has a **Pre-Agent config** — a script that runs before Claude starts
 
 ```bash
 ENGINE_PATH="/absolute/path/to/mainbranch"
-for skill in mb-ads mb-end mb-help mb-organic mb-pull mb-setup mb-site mb-start mb-think mb-vsl mb-wiki; do
+for skill in mb-ads mb-end mb-help mb-organic mb-update mb-pull mb-setup mb-site mb-start mb-think mb-vsl mb-wiki; do
   target="$ENGINE_PATH/.claude/skills/$skill"
   link=".claude/skills/$skill"
   [ -d "$target" ] && [ ! -e "$link" ] && ln -s "$target" "$link" || true

--- a/.claude/skills/mb-help/references/vip-path-resolution.md
+++ b/.claude/skills/mb-help/references/vip-path-resolution.md
@@ -1,6 +1,6 @@
 # Engine Path Resolution
 
-Canonical resolver for locating the Main Branch engine repo from a Claude Code session running inside a business repo. Used by `/mb-start`, `/mb-pull`, `/mb-setup`, `/mb-help` (troubleshooting), and any reference file that needs to read or pull engine-side files.
+Canonical resolver for locating the Main Branch engine repo from a Claude Code session running inside a business repo. Used by `/mb-start`, `/mb-update`, legacy `/mb-pull`, `/mb-setup`, `/mb-help` (troubleshooting), and any reference file that needs to read or pull engine-side files.
 
 **Single source of truth.** Other reference files MUST link here rather than inline the snippet — the resolver semantics (and the order of fallbacks) need to stay in lockstep across the engine, and inline copies drift.
 
@@ -87,7 +87,8 @@ A reference file that inlines the resolver and *also* customises it should comme
 
 ## Callers that link to this file
 
-- `.claude/skills/mb-pull/SKILL.md`
+- `.claude/skills/mb-update/SKILL.md`
+- `.claude/skills/mb-pull/SKILL.md` (legacy alias)
 - `.claude/skills/mb-setup/references/cwd-detection.md`
 - `.claude/skills/mb-help/references/troubleshooting.md` (skills-not-working + git-conflicts sections)
 - `.claude/reference/pull-engine-updates.md`

--- a/.claude/skills/mb-pull/SKILL.md
+++ b/.claude/skills/mb-pull/SKILL.md
@@ -1,130 +1,19 @@
 ---
 name: mb-pull
-description: Quick update Main Branch. Use when user wants to update the engine without running /mb-start, says "pull", "update", or "get latest", wants to see what changed, or after Devon announces features in Skool. /mb-start runs the same update check at session start, so skip /mb-pull if running /mb-start next.
+description: Legacy alias for /mb-update. Use only when the user explicitly types /mb-pull or says pull latest using old Main Branch language.
 ---
 
 # Pull
 
-Update the Main Branch engine.
+`/mb-pull` is kept for existing users. The preferred command is now
+`/mb-update`, matching the CLI command `mb update`.
 
----
-
-## What It Does
-
-Runs `mb update` for the mechanical engine refresh. The CLI detects whether Main Branch was installed with pipx or from a clone, updates that install, and refreshes skill links for the current business repo. This skill keeps ownership of the "what's new" narrative after the CLI step completes.
-
-### Step 1: Resolve Engine Path
-
-For the canonical bash + python3 resolver (settings.local.json first, ~/.config/vip/local.yaml fallback), see **[references/vip-path-resolution.md](references/vip-path-resolution.md)**.
-
-### Step 2: Update Main Branch
+Run the same update command:
 
 ```bash
 mb update --repo "${REPO_PATH:-.}" --json 2>&1
 ```
 
-### Step 3: Pull Business Repo (if it has a remote)
+Then follow the result handling in `/mb-update`.
 
-```bash
-git pull origin main 2>&1
-```
-
-### Handling Results
-
-**Main Branch updated:** If the JSON result has `"ok": true`, say "Updated Main Branch and refreshed skill links." — then read the CHANGELOG and surface unread entries (see "What's New from CHANGELOG" below).
-
-**Main Branch current:** If old_version and new_version match, "Engine already up to date." — still surface unread CHANGELOG entries (the user might not have run /mb-start since the last release landed).
-
-**Main Branch path not found:** If the JSON result is not valid or reports an engine-root error, say "Couldn't find Main Branch. Run `mb skill link --repo .`, then restart Claude."
-
-**Business repo updated:** "Also pulled updates for [repo-name]."
-
-**Business repo current or local-only:** Say nothing.
-
-**Error:** "Couldn't update: [error]. Try `mb update --check --repo .` to see which install path Main Branch detects."
-
----
-
-## What's New from CHANGELOG
-
-After a successful pull, surface unread CHANGELOG entries so the user knows what landed.
-
-### Read the current engine version
-
-```bash
-ENGINE_VERSION=$(python3 -c "
-import re, sys
-try:
-    body = open('$ENGINE_PATH/CHANGELOG.md').read()
-    # First versioned heading after the [Unreleased] block
-    m = re.search(r'^## \[(\d+\.\d+\.\d+[^\]]*)\]', body, re.M)
-    print(m.group(1) if m else '')
-except Exception:
-    print('')
-" 2>/dev/null)
-```
-
-### Read the user's last seen version
-
-```bash
-LAST_SEEN=$(python3 -c "
-import os
-try:
-    import yaml
-    with open(os.path.expanduser('~/.config/vip/local.yaml')) as f:
-        cfg = yaml.safe_load(f) or {}
-    print(cfg.get('last_seen_version', '') or '')
-except Exception:
-    print('')
-" 2>/dev/null)
-```
-
-### Compare and surface unread entries
-
-If `ENGINE_VERSION` is set and `LAST_SEEN != ENGINE_VERSION`, extract the matching CHANGELOG section (and any newer ones between `LAST_SEEN` and `ENGINE_VERSION`) and render as a banner:
-
-```
-Pulled latest engine updates.
-
-─── What's new in <ENGINE_VERSION> ───
-<First 4-6 lines of the matching section's most prominent bullets,
-trimmed for screen. Skip "Notes / follow-ups" sub-sections.>
-──────────────────────────────────────
-
-(Run /mb-start to begin, or run a named skill directly.)
-```
-
-If no unread entries (`LAST_SEEN == ENGINE_VERSION` or both empty): just print "Pulled latest engine updates." with nothing after.
-
-### Mark as seen
-
-After display, update `~/.config/vip/local.yaml`:
-
-```bash
-python3 -c "
-import os, yaml
-path = os.path.expanduser('~/.config/vip/local.yaml')
-os.makedirs(os.path.dirname(path), exist_ok=True)
-try:
-    with open(path) as f:
-        cfg = yaml.safe_load(f) or {}
-except FileNotFoundError:
-    cfg = {}
-cfg['last_seen_version'] = '$ENGINE_VERSION'
-with open(path, 'w') as f:
-    yaml.safe_dump(cfg, f)
-"
-```
-
-The user's `last_seen_version` is also bumped automatically when `/mb-start` surfaces the same banner — only one of the two needs to fire per pull.
-
-### Honour user dismiss
-
-If the user types "dismiss" / "seen" / "got it" after the banner appears, also bump `last_seen_version` to the current engine version. The banner stops surfacing on subsequent runs until a new release lands.
-
----
-
-## References
-
-- [references/vip-path-resolution.md](references/vip-path-resolution.md) — canonical vip-path resolver
-- Root `CHANGELOG.md` — release notes (the source surfaced as "what's new")
+If the user asks which command to remember, teach `/mb-update`.

--- a/.claude/skills/mb-pull/references/vip-path-resolution.md
+++ b/.claude/skills/mb-pull/references/vip-path-resolution.md
@@ -1,6 +1,6 @@
 # Engine Path Resolution
 
-Canonical resolver for locating the Main Branch engine repo from a Claude Code session running inside a business repo. Used by `/mb-start`, `/mb-pull`, `/mb-setup`, `/mb-help` (troubleshooting), and any reference file that needs to read or pull engine-side files.
+Canonical resolver for locating the Main Branch engine repo from a Claude Code session running inside a business repo. Used by `/mb-start`, `/mb-update`, legacy `/mb-pull`, `/mb-setup`, `/mb-help` (troubleshooting), and any reference file that needs to read or pull engine-side files.
 
 **Single source of truth.** Other reference files MUST link here rather than inline the snippet — the resolver semantics (and the order of fallbacks) need to stay in lockstep across the engine, and inline copies drift.
 
@@ -87,7 +87,8 @@ A reference file that inlines the resolver and *also* customises it should comme
 
 ## Callers that link to this file
 
-- `.claude/skills/mb-pull/SKILL.md`
+- `.claude/skills/mb-update/SKILL.md`
+- `.claude/skills/mb-pull/SKILL.md` (legacy alias)
 - `.claude/skills/mb-setup/references/cwd-detection.md`
 - `.claude/skills/mb-help/references/troubleshooting.md` (skills-not-working + git-conflicts sections)
 - `.claude/reference/pull-engine-updates.md`

--- a/.claude/skills/mb-setup/references/vip-path-resolution.md
+++ b/.claude/skills/mb-setup/references/vip-path-resolution.md
@@ -1,6 +1,6 @@
 # Engine Path Resolution
 
-Canonical resolver for locating the Main Branch engine repo from a Claude Code session running inside a business repo. Used by `/mb-start`, `/mb-pull`, `/mb-setup`, `/mb-help` (troubleshooting), and any reference file that needs to read or pull engine-side files.
+Canonical resolver for locating the Main Branch engine repo from a Claude Code session running inside a business repo. Used by `/mb-start`, `/mb-update`, legacy `/mb-pull`, `/mb-setup`, `/mb-help` (troubleshooting), and any reference file that needs to read or pull engine-side files.
 
 **Single source of truth.** Other reference files MUST link here rather than inline the snippet — the resolver semantics (and the order of fallbacks) need to stay in lockstep across the engine, and inline copies drift.
 
@@ -87,7 +87,8 @@ A reference file that inlines the resolver and *also* customises it should comme
 
 ## Callers that link to this file
 
-- `.claude/skills/mb-pull/SKILL.md`
+- `.claude/skills/mb-update/SKILL.md`
+- `.claude/skills/mb-pull/SKILL.md` (legacy alias)
 - `.claude/skills/mb-setup/references/cwd-detection.md`
 - `.claude/skills/mb-help/references/troubleshooting.md` (skills-not-working + git-conflicts sections)
 - `.claude/reference/pull-engine-updates.md`

--- a/.claude/skills/mb-start/SKILL.md
+++ b/.claude/skills/mb-start/SKILL.md
@@ -340,7 +340,7 @@ Read `user.experience` from `~/.config/vip/local.yaml` (defaults to `beginner` i
 
 ## Intent Keywords
 
-Auto-detect user intent and route. Skills: `/mb-pull`, `/mb-help`, `/mb-setup`, `/mb-think`, `/mb-ads`, `/mb-vsl`, `/mb-organic`, `/newsletter`, `/mb-site`, `/mb-wiki`, `/mb-end`. Some skills spawn parallel subagents automatically.
+Auto-detect user intent and route. Skills: `/mb-update`, `/mb-help`, `/mb-setup`, `/mb-think`, `/mb-ads`, `/mb-vsl`, `/mb-organic`, `/mb-site`, `/mb-wiki`, `/mb-end`. Some skills spawn parallel subagents automatically.
 
 | Keywords | Route To |
 |----------|----------|
@@ -357,7 +357,7 @@ Auto-detect user intent and route. Skills: `/mb-pull`, `/mb-help`, `/mb-setup`, 
 | "content", "reels", "tiktok", "organic", "carousel" | `/mb-organic` |
 | "site", "landing page", "lander", "minisite", "website", "one-pager", "spin up a site", "deploy site", "put this online", "I need a site", "publish site", "graduate my site", "add a CMS to my site", "/mb-start launch" | `/mb-site` (or `/mb-start launch <offer>` for the speedrun orchestration) |
 | "wiki", "notes", "atomic", "wikilinks", "publish wiki" | `/mb-wiki` |
-| "pull", "update Main Branch", "get latest" | `/mb-pull` |
+| "pull", "update Main Branch", "get latest" | `/mb-update` |
 | "done", "wrapping up", "end my day", "closing out", "call it a day", "that's it" | `/mb-end` |
 
 ---

--- a/.claude/skills/mb-start/references/config-system.md
+++ b/.claude/skills/mb-start/references/config-system.md
@@ -138,7 +138,7 @@ media:
 # OK spending more tokens for more variation.
 default_concepts: 2
 
-# CHANGELOG version tracking (managed by /mb-start and /mb-pull)
+# CHANGELOG version tracking (managed by /mb-start and /mb-update)
 # Last engine version the user has seen the "what's new" banner for.
 # Diff'd against the most recent versioned heading in
 # the active engine's `CHANGELOG.md` to decide whether to surface unread entries.

--- a/.claude/skills/mb-update/SKILL.md
+++ b/.claude/skills/mb-update/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: mb-update
+description: Update Main Branch. Use when the user says update, upgrade, pull latest, get latest Main Branch, asks whether they are current, or after Devon announces a new release. Preferred over legacy /mb-pull.
+---
+
+# Update
+
+Update the Main Branch engine and refresh this business repo's skill links.
+
+Use this instead of asking the user to remember whether they installed with
+pipx or an old clone. The CLI owns the mechanics.
+
+---
+
+## Step 1: Update Main Branch
+
+Run from the business repo:
+
+```bash
+mb update --repo . --json 2>&1
+```
+
+Handle the JSON result:
+
+| Result | What to say |
+|---|---|
+| `"ok": true`, `old_version != new_version` | "Updated Main Branch and refreshed skill links." |
+| `"ok": true`, `old_version == new_version` | "Main Branch is already up to date." |
+| `"ok": false` | Show the first error and the repair copy below. |
+| Invalid JSON | "I couldn't read the update result. Run `mb update --check --repo .` and send me the output." |
+
+If the result includes warnings, show them after the main status.
+
+---
+
+## Step 2: If Update Fails
+
+Tell the user:
+
+> "I wasn't able to update Main Branch. This can leave you on old skills or old
+> migration behavior.
+>
+> Try these from your business repo:
+>
+> ```bash
+> mb update --check --repo .
+> mb doctor
+> ```
+>
+> If `mb --version` says `0.1.x`, run this once first:
+>
+> ```bash
+> pipx upgrade mainbranch
+> ```"
+
+Do not continue as if the update worked.
+
+---
+
+## Step 3: Restart If Skill Links Changed
+
+If `skills_relinked_count` is greater than zero, tell the user:
+
+> "Skill links were refreshed. If a slash command does not appear in Claude
+> Code, restart Claude from this repo and run `/mb-start`."
+
+Claude Code loads slash commands at session start, so a restart can be required
+after repairing links.
+
+---
+
+## Step 4: What Changed
+
+After a successful update, read `CHANGELOG.md` from the active Main Branch
+engine if available and summarize only the most recent "What this means for
+you" section. Keep it short: 3-5 bullets max.
+
+If no changelog is available, do not guess. Say:
+
+> "Update complete. I couldn't find the local changelog, so run `mb --version`
+> to confirm the installed version."
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,8 @@ jobs:
             || { echo "::error::py.typed missing from wheel"; exit 1; }
           python -m zipfile -l "$wheel" | grep -E '(^|/)mb/_engine/\.claude/skills/mb-start/SKILL\.md([[:space:]]|$)' \
             || { echo "::error::bundled skills missing from wheel"; exit 1; }
+          python -m zipfile -l "$wheel" | grep -E '(^|/)mb/_engine/\.claude/skills/mb-update/SKILL\.md([[:space:]]|$)' \
+            || { echo "::error::bundled mb-update skill missing from wheel"; exit 1; }
           python -m zipfile -l "$wheel" | grep -E '(^|/)mb/_engine/\.claude/playbooks/ship-bet/SKILL\.md([[:space:]]|$)' \
             || { echo "::error::bundled playbooks missing from wheel"; exit 1; }
           python -m zipfile -l "$wheel" | grep -E '(^|/)mb/_engine/\.claude/reference/vip-path-resolution\.md([[:space:]]|$)' \
@@ -245,6 +247,8 @@ jobs:
             || { echo "::error::mb skill list missing bundled mb-start skill"; exit 1; }
           grep -qx "mb-think" skills.txt \
             || { echo "::error::mb skill list missing bundled mb-think skill"; exit 1; }
+          grep -qx "mb-update" skills.txt \
+            || { echo "::error::mb skill list missing bundled mb-update skill"; exit 1; }
 
       - name: Smoke — packaged bundled skills validate
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+### Added
+
+- Added `/mb-update` as the preferred Claude Code update skill so the slash
+  command matches the CLI command `mb update`.
+
+### Changed
+
+- Kept `/mb-pull` as a legacy alias for existing users while public docs now
+  teach `/mb-update`.
+
 ## [0.2.5] - 2026-05-04
 
 v0.2.5 finishes the noob-safe migration loop for past users with broken

--- a/README.md
+++ b/README.md
@@ -212,7 +212,8 @@ Skills are pre-built workflows you invoke with slash prompts. Instead of figurin
 | `/mb-wiki` | Personal wiki with atomic notes |
 | `/mb-end` | Close session — summary, crystallize, commit |
 | `/mb-help` | Get answers, troubleshoot, learn the system |
-| `/mb-pull` | Quick update — delegates install-mode refresh to `mb update` and summarizes what's new |
+| `/mb-update` | Update Main Branch — delegates install-mode refresh to `mb update` and summarizes what's new |
+| `/mb-pull` | Legacy alias for `/mb-update` |
 
 ---
 
@@ -261,7 +262,7 @@ Main Branch is fully usable on its own. The paid community is the live narration
 
 ## Updating
 
-- **pipx users (most people)**: `mb update --repo .` from your business repo. Or just run `/mb-pull` inside Claude Code — it figures out which install you have and runs the right thing.
+- **pipx users (most people)**: `mb update --repo .` from your business repo. Or run `/mb-update` inside Claude Code — it figures out which install you have and runs the right thing.
 - **Clone (developer mode)**: `git pull origin main` from the engine repo.
 
 `/mb-start` checks for important updates at the beginning of a session and will
@@ -282,7 +283,7 @@ Use one repo with an `offers/` folder. Each offer gets its own `offer.md`. Soul 
 Create a separate repo for each brand. If they share the same soul and voice, they can share a repo. If not, separate repos.
 
 **How do I update when new skills come out?**
-`mb update --repo .`, or run `/mb-pull` inside Claude Code.
+`mb update --repo .`, or run `/mb-update` inside Claude Code.
 
 If `mb --version` still says `0.1.x`, run `pipx upgrade mainbranch` once before
 using `mb update`; old installs now surface this as an in-product
@@ -290,6 +291,7 @@ using `mb update`; old installs now surface this as an in-product
 surfaces. Existing business repos should then run `mb skill link --repo .` and
 `mb skill repair --repo .`, then `mb doctor` from the repo root. See
 [docs/MIGRATING.md](docs/MIGRATING.md) for the old-repo path.
+`/mb-pull` still works as a legacy alias, but new docs teach `/mb-update`.
 
 **Can Claude migrate an old setup for me?**
 Yes. Start Claude Code anywhere and paste the prompt in

--- a/docs/BEGINNER-SETUP.md
+++ b/docs/BEGINNER-SETUP.md
@@ -118,7 +118,7 @@ When new versions drop:
 mb update --repo .
 ```
 
-Or run `/mb-pull` inside Claude Code — it figures out which install you have
+Or run `/mb-update` inside Claude Code — it figures out which install you have
 and runs the right thing. `/mb-start` also checks for important updates at the
 beginning of a session and will tell you when an update matters. The CHANGELOG
 entry for the new version surfaces as a banner the next time you run
@@ -168,7 +168,8 @@ starts, so repaired `/mb-start` links usually appear after restart.
 | `/mb-wiki` | Personal wiki with atomic notes. |
 | `/mb-end` | Close session intentionally — summary, crystallize, commit. |
 | `/mb-help` | Get answers, troubleshoot. |
-| `/mb-pull` | Update Main Branch (figures out pipx vs clone). |
+| `/mb-update` | Update Main Branch (figures out pipx vs clone). |
+| `/mb-pull` | Old name for `/mb-update`; still works for existing users. |
 
 ---
 

--- a/docs/MIGRATING.md
+++ b/docs/MIGRATING.md
@@ -83,8 +83,10 @@ mb update --repo /path/to/your-business
 or, from inside Claude Code:
 
 ```text
-/mb-pull
+/mb-update
 ```
+
+`/mb-pull` still works as a legacy alias for existing users.
 
 ## Repair An Existing Business Repo
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -67,7 +67,7 @@ mb update
 `mb update` detects whether the engine is a `pipx` install or clone checkout,
 runs the appropriate update path, and refreshes skill links. Use
 `mb update --check` for a dry-run and `mb update --json` for automation.
-Inside Claude Code, `/mb-pull` calls `mb update` for this mechanical step and keeps
+Inside Claude Code, `/mb-update` calls `mb update` for this mechanical step and keeps
 ownership of the human-readable "what's new" summary.
 
 Early `0.1.x` installs do not have `mb update` yet. If `mb`, `mb doctor`,

--- a/docs/prd/v0-2-agent-workflow-and-evals.md
+++ b/docs/prd/v0-2-agent-workflow-and-evals.md
@@ -359,7 +359,7 @@ Expected evidence:
 
 ### Level 5: Agent Runtime Smoke
 
-Use when first-run, skill discovery, `/mb-start`, `/mb-pull`, `/mb-think`, or runtime
+Use when first-run, skill discovery, `/mb-start`, `/mb-update`, `/mb-think`, or runtime
 handoff behavior changes.
 
 This is manual or semi-automated in v0.2.0. Do not pretend it is covered by

--- a/docs/prd/v0-2-first-run-daily-briefing.md
+++ b/docs/prd/v0-2-first-run-daily-briefing.md
@@ -281,7 +281,7 @@ Acceptance:
 
 Linked issue: #174
 
-`mb update` should own the install-mode-aware refresh mechanism that `/mb-pull`
+`mb update` should own the install-mode-aware refresh mechanism that `/mb-update`
 can later call or explain.
 
 Required behavior:

--- a/mb/mb/_data/educational/upgrading-mainbranch.md
+++ b/mb/mb/_data/educational/upgrading-mainbranch.md
@@ -15,7 +15,7 @@ mb --version
 ```
 
 `mb update` was added after the earliest public package, so old installs cannot
-run it yet. After the pipx upgrade, `mb update` and `/mb-pull` become the normal
+run it yet. After the pipx upgrade, `mb update` and `/mb-update` become the normal
 path.
 
 If you already have a business repo, repair Claude Code skill discovery from

--- a/mb/tests/test_cli.py
+++ b/mb/tests/test_cli.py
@@ -95,6 +95,7 @@ def test_skill_list_runs() -> None:
     result = runner.invoke(app, ["skill", "list"])
     assert result.exit_code == 0
     assert "mb-start" in result.stdout.splitlines()
+    assert "mb-update" in result.stdout.splitlines()
 
 
 def test_skill_link_wires_repo(tmp_path) -> None:

--- a/mb/tests/test_smoke_coverage.py
+++ b/mb/tests/test_smoke_coverage.py
@@ -173,6 +173,7 @@ def test_skill_list_command_runs() -> None:
     result = runner.invoke(app, ["skill", "list"])
     assert result.exit_code == 0
     assert "mb-start" in result.stdout.splitlines()
+    assert "mb-update" in result.stdout.splitlines()
 
 
 def test_claude_plugin_manifest_points_at_prefixed_skills() -> None:


### PR DESCRIPTION
## Summary
- Adds `/mb-update` as the preferred Claude Code update skill, matching the CLI command `mb update`.
- Keeps `/mb-pull` as a small legacy alias so existing users do not break.
- Updates public docs, PRDs, educational copy, and startup routing to teach `/mb-update`.
- Extends CI/package smoke checks so the built wheel must include `mb-update`.

## Scope
- In: bundled skill, legacy alias, docs copy, changelog, CI wheel/skill-list assertions.
- Out: removing `/mb-pull`, changing `mb update` mechanics, publishing a release.

## Commits
- c688889 — [add] MAIN-215 prefer mb-update skill

## Release / Issues
- Release: next patch release
- Linear ID(s): MAIN-215
- Closes: #257
- Refs: none
- Follow-ups: remove or hide `/mb-pull` only after at least one compatibility window and user comms.

## Success Metric
A beginner sees one update verb across surfaces: `mb update` in terminal and `/mb-update` in Claude Code. Existing users who type `/mb-pull` still get a working update path.

## Validation
- Level 0 docs/decision: swept public docs and skill references for preferred `/mb-update` language while preserving legacy alias notes.
- Level 1 static: `scripts/check.sh` passed.
- Level 2 CLI: `mb skill list` tests now assert `mb-update` is bundled.
- Level 3 package/install: built wheel, installed into `/tmp/mainbranch-update-smoke`, verified `mb --version`, `mb skill list`, and `mb-update` in installed skill list.
- Level 4 fixture repo: not run; update mechanics unchanged.
- Level 5 runtime smoke: not run; this adds/renames skill guidance but does not change Claude Code discovery mechanics.

## Public / Private Boundary
No private Devon/Conductor settings were committed. One unrelated local `.gitignore` modification remains unstaged in this workspace and is intentionally excluded from the PR.