### PR TITLE
[update] prepare 0.2.6 release

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mainbranch",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Main Branch Claude Code skills for running a business from markdown files in git.",
   "author": {
     "name": "Noontide"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+## [0.2.6] - 2026-05-04
+
+v0.2.6 adds `/mb-update` as the beginner-facing Claude Code update command
+while keeping `/mb-pull` as a compatibility alias for existing users.
+
+### What this means for you (plain English)
+
+- **Use `/mb-update` going forward.** It matches the terminal command
+  `mb update`, so new users only need to remember one word.
+- **Old `/mb-pull` still works.** Existing users can keep using it while docs
+  and onboarding copy move to `/mb-update`.
+
 ### Added
 
 - Added `/mb-update` as the preferred Claude Code update skill so the slash

--- a/mb/mb/__init__.py
+++ b/mb/mb/__init__.py
@@ -7,6 +7,6 @@ file stays a thin dispatcher.
 
 from __future__ import annotations
 
-__version__ = "0.2.5"
+__version__ = "0.2.6"
 
 __all__ = ["__version__"]

--- a/mb/pyproject.toml
+++ b/mb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mainbranch"
-version = "0.2.5"
+version = "0.2.6"
 description = "Main Branch engine umbrella - scaffolds, validates, and graphs business-as-files repos. Claude Code first, runtime-agnostic by design."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- Bumps the package and plugin manifest to `0.2.6`.
- Promotes the `/mb-update` changelog entry into a dated 0.2.6 section.
- Prepares the GitHub Release/PyPI publish path for the new preferred update skill.

## Scope
- In: version bump, plugin manifest version, changelog release section.
- Out: additional skill behavior, migration logic, docs beyond the already-merged `/mb-update` PR.

## Commits
- 327b8c3 — [update] MAIN-215 prepare 0.2.6 release

## Release / Issues
- Release: Main Branch 0.2.6 / `oe-v0.2.6`
- Linear ID(s): MAIN-215
- Closes: none
- Refs: #257
- Follow-ups: publish GitHub Release after merge and verify PyPI install.

## Success Metric
`mainbranch==0.2.6` publishes to PyPI and a clean install reports `mb 0.2.6` with `mb-update` in `mb skill list`.

## Validation
- Level 0 docs/decision: changelog has a dated 0.2.6 section and no unreleased release notes left behind.
- Level 1 static: `scripts/check.sh` passed.
- Level 2 CLI: existing CLI tests passed, including `mb skill list` coverage.
- Level 3 package/install: built `mainbranch-0.2.6` wheel, installed into `/tmp/mainbranch-026-smoke`, verified `mb --version`, `mb skill list`, `mb-update` in installed skills, and `mb/_engine/.claude/skills/mb-update/SKILL.md` inside the wheel.
- Level 4 fixture repo: not run; release metadata only.
- Level 5 runtime smoke: not run; release metadata only.

## Public / Private Boundary
No private local paths or user data were committed. Smoke-test paths are only noted in PR validation evidence.