### PR TITLE
[docs] Add product ethos and roadmap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,10 @@ Paperclip-adjacent orchestration, and local runtimes are compatibility targets
 only when tested. Do not claim support before there is an adapter or smoke
 evidence.
 
+The public product frame lives in `docs/ETHOS.md`, the operator loop taxonomy
+lives in `docs/OPERATOR-LOOPS.md`, and release direction lives in
+`docs/ROADMAP.md`.
+
 ## Quick Start
 
 For normal repo validation:
@@ -115,20 +119,25 @@ Before editing:
 
 1. Read this file.
 2. Read `README.md`.
-3. Read the assigned GitHub/Linear issue and all comments.
-4. If the work touches public product shape, release discipline, runtime claims,
+3. Read `docs/ETHOS.md`.
+4. Read the assigned GitHub/Linear issue and all comments.
+5. If the work touches public product shape, release discipline, runtime claims,
    contributor workflow, or public/private boundaries, apply
    `docs/OSS-OPERATING-CHECKLIST.md`.
-5. If the work touches v0.2 product direction, read:
+6. If the work touches roadmap, priorities, workflow shape, or product framing,
+   read:
+   - `docs/OPERATOR-LOOPS.md`
+   - `docs/ROADMAP.md`
+7. If the work touches v0.2 product direction, read:
    - `decisions/2026-05-02-github-native-business-os.md`
    - `docs/prd/v0-2-first-run-daily-briefing.md`
    - `docs/prd/v0-2-agent-workflow-and-evals.md`
-6. If the work touches the CLI/runtime boundary, read:
+8. If the work touches the CLI/runtime boundary, read:
    - `decisions/2026-05-01-mb-cli-vs-agent-workflows-boundary.md`
    - `docs/compatibility.md`
-7. If the work touches skills, inspect the relevant
+9. If the work touches skills, inspect the relevant
    `.claude/skills/<name>/SKILL.md` and nearby tests or fixtures.
-8. Check open PRs for overlapping files before making broad edits.
+10. Check open PRs for overlapping files before making broad edits.
 
 For substantial branches, write `.context/cold-start.md` before editing:
 
@@ -166,12 +175,17 @@ Prefer one coherent user loop per branch. Do not broaden scope silently. If you
 find adjacent work, open or comment on a follow-up issue instead of burying it in
 the current PR.
 
+Name which operator loop the branch improves: Know, See, Decide, Execute, or
+Narrate. Use `docs/OPERATOR-LOOPS.md` when the fit is unclear.
+
 Good issue slices look like:
 
 - one command surface, such as `mb status`;
 - one repair loop, such as `mb update`;
 - one validator, such as cross-reference validation;
 - one runtime proof, such as Claude Code `/start` discovery from a fresh repo.
+- one product loop, such as "turn user friction into a GitHub issue draft" or
+  "surface the next three actions from status signals."
 
 Avoid tiny PRs that cost more in cold start, review, CI, and merge overhead than
 they return. Large PRs are fine when they have one success metric and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+### Added
+
+- Added public ethos, operator-loop, and roadmap docs so future product work can
+  anchor to the Know -> See -> Decide -> Execute -> Narrate loop and the
+  current v0.3/v0.4 release direction.
+
+### Changed
+
+- Updated the README and agent instructions to point contributors and agents at
+  the public product frame before making roadmap, runtime, or workflow changes.
+
 ## [0.2.6] - 2026-05-04
 
 v0.2.6 adds `/mb-update` as the beginner-facing Claude Code update command

--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ Own the work. Rent only the rails.
 
 Main Branch is the `mb` CLI plus MIT-licensed agent workflows for running business-as-files systems. Today the workflows ship for Claude Code; Codex, Cursor, OpenClaw, Hermes, and local runtimes are next. Your offer, audience, voice, research, decisions, and campaigns live in six folders inside your own git repo — versioned, portable, agent-readable.
 
+Read the product frame in [docs/ETHOS.md](docs/ETHOS.md), the user loop in
+[docs/OPERATOR-LOOPS.md](docs/OPERATOR-LOOPS.md), and the release direction in
+[docs/ROADMAP.md](docs/ROADMAP.md).
+
 ---
 
 ## Quick start
@@ -224,13 +228,22 @@ Skills are pre-built workflows you invoke with slash prompts. Instead of figurin
 - **Schema is v1; will evolve.** Frontmatter shapes covered by `mb validate` are stable for the current major; breaking changes bump the major.
 - **Runtime compatibility is still ahead.** Codex, Cursor, OpenClaw, Hermes, and local LLMs are roadmap targets, not supported adapters yet.
 
-The engine v0.1.0 decision lives at [`decisions/2026-04-29-mb-vip-v0-1-0-master.md`](decisions/2026-04-29-mb-vip-v0-1-0-master.md). The business-side master plan is tracked in [`noontide-co/projects#119`](https://github.com/noontide-co/projects/pull/119).
+| Runtime | Status | Notes |
+|---|---|---|
+| Claude Code | Supported today | First-class adapter with skill wiring, repair, and smoke-tested first-run flow. |
+| Codex | Roadmap | Target runtime; no public adapter support claim yet. |
+| Cursor | Roadmap | Target runtime; no public adapter support claim yet. |
+| OpenClaw | Roadmap | First-tier compatibility target because users operate there; no adapter support claim yet. |
+| Hermes / Paperclip-adjacent orchestration | Roadmap | Target orchestration layer; must consume stable repo and JSON contracts. |
+| Local runtimes | Roadmap | Long-range endpoint once adapter contracts are proven. |
+
+The engine v0.1.0 decision lives at [`decisions/2026-04-29-mb-vip-v0-1-0-master.md`](decisions/2026-04-29-mb-vip-v0-1-0-master.md). The business-side master plan amendment was merged in [`noontide-co/projects#119`](https://github.com/noontide-co/projects/pull/119).
 
 ---
 
 ## Roadmap
 
-The current package is the CLI + Claude Code first-run foundation. Next work deepens GitHub activity, credential/config foundations, graph/indexing, and runtime compatibility. Direction, not promises.
+The current package is the CLI + Claude Code first-run foundation. Next work makes Main Branch better at knowing what changed, what is stale, and what to do next. See [docs/ROADMAP.md](docs/ROADMAP.md) for the public roadmap. Direction, not promises.
 
 The proposed long-range product direction is captured in
 [`decisions/2026-05-02-github-native-business-os.md`](decisions/2026-05-02-github-native-business-os.md):
@@ -238,12 +251,10 @@ Main Branch as a GitHub-native business operating system, with `mb` as the
 control plane, GitHub as the team layer, graph/structured data as the
 intelligence layer, and agent runtimes as execution.
 
-- `mb books` — BeanCount integration for ledger workflows ([#128](https://github.com/noontide-co/mainbranch/issues/128))
-- `mb fulfillment` — agency-arm tooling for delivery ops
-- Runtime compatibility — Codex, Cursor, OpenClaw, Hermes, local LLMs
-- Deeper `/mb-site` workflows — lander → minisite → website graduation
-- Dashboard — visual operating loop for your bets and decisions, ships **free as part of `mb`** when the graph/sync substrate is ready
-- Skool → GitHub webhook automation
+- **v0.3.0: Knows what to do next.** `mb status` v1, drift detection, next-action ranking, and `/mb-start` using the same deterministic substrate.
+- **v0.3.x: Improves itself in public.** Privacy-safe issue drafting, `doctor --json`, `/mb-status`, a small dashboard spike, and optional sidecar contracts.
+- **v0.4: Launches bets.** `bets/`, `/mb-bet`, public narration, and status integration for active business bets.
+- **Longer range.** Runtime adapters, dashboard/server mode, structured data, bookkeeping, fulfillment, and deeper pages/ads/organic workflows.
 
 See [CHANGELOG.md](CHANGELOG.md) for what's in this release. Each release ships a "What this means for you" plain-English section above the technical detail.
 

--- a/docs/ETHOS.md
+++ b/docs/ETHOS.md
@@ -1,0 +1,120 @@
+# Main Branch Ethos
+
+Main Branch is public open-source infrastructure for running a business from
+markdown files in git.
+
+The product is not another place to paste prompts. The product is a durable
+operating substrate:
+
+- the business repo is the business brain;
+- `mb` is the deterministic control plane;
+- agent-runtime skills are the judgment-heavy execution layer;
+- GitHub issues are tasks and requests;
+- pull requests are proposals and review conversations;
+- git history is the evolution story.
+
+The promise is simple: own the work, rent only the rails.
+
+## What We Are Building
+
+Main Branch should help an operator move through five loops:
+
+1. **Know the business** - capture offers, audience, voice, proof, research,
+   decisions, and context in files the operator owns.
+2. **See what is happening** - summarize repo health, recent changes, stale
+   context, connected tools, GitHub tasks, and local setup state.
+3. **Decide what matters** - surface the next best actions with clear evidence,
+   while leaving the operator in charge.
+4. **Execute the work** - run focused workflows for pages, ads, organic
+   content, research, fulfillment, bookkeeping, and other business domains.
+5. **Narrate and learn** - turn bets, outcomes, changelogs, decisions, and
+   retros into public or private operating memory.
+
+Those loops are described in detail in [OPERATOR-LOOPS.md](OPERATOR-LOOPS.md).
+
+## Product Principles
+
+### 1. Files First
+
+Canonical business truth belongs in git: reference files, research, decisions,
+campaigns, plans, public artifacts, durable summaries, and proposal changes.
+Rebuildable indexes, local caches, credentials, runtime preferences, and live
+process state can exist outside git, but they must not replace the repo.
+
+### 2. Thin CLI, Fat Workflows
+
+`mb` should stay deterministic, inspectable, scriptable, and exit-coded. It
+owns repo shape, validation, migration, status, updates, graphing, integration
+metadata, skill wiring, and runtime adapter contracts.
+
+Agent-runtime skills own synthesis, writing, review, routing, and judgment. A
+skill may call `mb` for facts. It should not reimplement repo-health probes or
+structural invariants in prose.
+
+### 3. Operator Sovereignty
+
+Main Branch should recommend, not seize control. The system can tell the
+operator what looks stale, risky, blocked, or important. It should cite the
+signals behind that recommendation and make override paths explicit.
+
+Publishing, spending money, contacting customers, mutating accounts, and
+shipping public-facing work should remain intentional operator actions unless a
+future decision explicitly changes that boundary.
+
+### 4. Beginner-Safe, Power-User-Honest
+
+The product is for non-developers, but it should not hide the real primitives.
+GitHub issues can be described as tasks. Pull requests can be described as
+proposals. Git history can be described as shipped work. The underlying terms
+should remain available when the user needs them.
+
+Beginner flows should end with exact commands. Power users should always have a
+quiet, scriptable path.
+
+### 5. Runtime Honesty
+
+Claude Code is the first supported runtime today. Codex, Cursor, OpenClaw,
+Hermes, Paperclip-adjacent orchestration, and local runtimes are compatibility
+targets only when adapter code and smoke evidence exist.
+
+Main Branch should meet operators where they already work, but it should not
+claim support before support is proven.
+
+### 6. Improve Through Friction
+
+If a user hits an error, missing workflow, confusing step, or repeated manual
+repair, Main Branch should make it easy to turn that friction into a clean
+GitHub issue. That loop is part of the product. The public issue tracker is how
+operator usage becomes shared infrastructure.
+
+Issue drafting must be privacy-safe by default. Business context, customer
+data, tokens, local paths, and account details must not be sent without an
+explicit operator decision.
+
+### 7. Sidecars Are Optional
+
+Specialized tools can make Main Branch stronger when they do one narrow job
+well and return structured output. Examples include public company context,
+ads metrics, bookkeeping, transcription, analytics, or deployment helpers.
+
+Sidecars should be optional providers behind stable contracts, not hard
+dependencies of the core engine.
+
+### 8. Evidence Beats Vibes
+
+Do not ship runtime claims, migration paths, packaging changes, or first-run
+flows without evidence. Use the validation ladder in [AGENTS.md](../AGENTS.md):
+static checks, CLI tests, package smoke, fixture repo smoke, and runtime smoke
+when the behavior depends on a real runtime.
+
+The product should feel alive, but the substrate should stay boring enough to
+debug.
+
+## What We Are Not Building Yet
+
+Main Branch is not a hosted SaaS dashboard, chat client, background daemon,
+model host, vector database, scheduler, or marketplace today.
+
+Those may become useful surfaces later. They earn their way in by preserving
+the same source of truth: the business repo, GitHub, git history, deterministic
+CLI contracts, and explicit runtime adapters.

--- a/docs/OPERATOR-LOOPS.md
+++ b/docs/OPERATOR-LOOPS.md
@@ -1,0 +1,145 @@
+# Operator Loops
+
+Main Branch work should be understood through the operator's loop, not only the
+implementation surface. A command, skill, issue, or release should make at
+least one of these loops better.
+
+## 1. Know
+
+**Question:** What does this business know about itself?
+
+This loop captures the durable context an agent needs before doing serious
+work:
+
+- offers, audience, voice, proof, constraints, and pricing;
+- research, competitors, insights, and raw notes;
+- decisions and why they were made;
+- campaigns, logs, documents, and operating history.
+
+Current surfaces:
+
+- `mb onboard`
+- `mb init`
+- `/mb-start`
+- `/mb-think`
+- `core/`, `research/`, `decisions/`, `campaigns/`, `log/`, `documents/`
+
+Next improvements:
+
+- resumable onboarding that can span multiple sessions;
+- domain and public-context enrichment through optional sidecars;
+- better detection of missing or stale reference files.
+
+## 2. See
+
+**Question:** What changed, what is stale, and what is healthy?
+
+This loop turns the repo, local environment, GitHub activity, connected tools,
+and graph into a concise briefing.
+
+Current surfaces:
+
+- `mb status`
+- `mb doctor`
+- `mb graph`
+- `mb connect status`
+- GitHub issues, pull requests, and release history
+
+Next improvements:
+
+- `mb status` v1 with "since last check";
+- drift detection for stale context and broken wiring;
+- stable `--json` schemas for agents and dashboards;
+- a thin local dashboard once the JSON substrate is useful.
+
+## 3. Decide
+
+**Question:** What should I do next, and why?
+
+This loop ranks possible work without pretending the system owns the business.
+Main Branch should cite evidence and let the operator override it.
+
+Current surfaces:
+
+- `/mb-start`
+- `/mb-think`
+- GitHub issues and priorities
+- `mb status`
+
+Next improvements:
+
+- a deterministic next-action ranker;
+- top-three recommendations in `mb status` and `/mb-start`;
+- explicit pin, skip, and defer controls;
+- privacy-safe prompts to open GitHub issues when the user hits friction.
+
+## 4. Execute
+
+**Question:** What work are we shipping?
+
+This loop is where domain workflows live. The domains are not the whole
+product, but they are where the product proves itself.
+
+Current surfaces:
+
+- `/mb-ads`
+- `/mb-vsl`
+- `/mb-organic`
+- `/mb-site`
+- `/mb-wiki`
+- `/mb-end`
+- `mb connect`
+
+Execution domains:
+
+- pages and CMS;
+- paid ads and compliance;
+- organic content;
+- research and positioning;
+- fulfillment and delivery;
+- bookkeeping and P&L;
+- integrations and sidecar CLIs.
+
+Next improvements:
+
+- skills leaning more heavily on CLI facts instead of duplicate checks;
+- optional provider and sidecar contracts;
+- richer site, ads, organic, bookkeeping, and fulfillment loops.
+
+## 5. Narrate
+
+**Question:** What did we learn, and what should others see?
+
+This loop turns shipped work and business outcomes into durable internal memory
+and optional public narration.
+
+Current surfaces:
+
+- `CHANGELOG.md`
+- decisions and retros;
+- `/mb-end`;
+- GitHub releases;
+- public site workflows through `/mb-site`
+
+Next improvements:
+
+- a `bets/` primitive for public operating bets;
+- `/mb-bet` with `new`, `update`, `close`, `list`, and `narrate` modes;
+- status integration for active bets and deadlines;
+- public bets pages generated from repo truth.
+
+## Applying The Loops
+
+When opening or working an issue, name the loop it improves:
+
+- **Know** for onboarding, reference, research, decisions, and context capture.
+- **See** for status, doctor, graph, update, migrations, and integrations.
+- **Decide** for ranking, triage, recommendations, issue drafting, and
+  operator overrides.
+- **Execute** for domain workflows and sidecar tools.
+- **Narrate** for bets, retros, release notes, public pages, and community
+  updates.
+
+A large branch is acceptable when it improves one coherent loop with one
+observable success metric. A tiny branch is not automatically better if it
+costs more cold start, review, CI, and release overhead than it returns.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,103 @@
+# Roadmap
+
+This roadmap is direction, not a promise. GitHub issues and release notes are
+the detailed execution record. This file explains the product shape so users,
+contributors, and agents understand where Main Branch is going.
+
+## Shipped Foundation
+
+Main Branch already ships:
+
+- public PyPI package and MIT-licensed engine;
+- `mb onboard`, `mb init`, `mb status`, `mb start`, `mb update`, `mb doctor`,
+  `mb graph`, `mb validate`, `mb migrate`, `mb connect`, and skill management
+  commands;
+- Claude Code skill wiring with `mb-` prefixed bundled skills;
+- beginner setup, migration, repair, and update paths;
+- local-first provider metadata and secret-safe connection checks;
+- graph and status primitives for future dashboard and agent workflows;
+- public contribution, support, security, compatibility, and agent guidance.
+
+Claude Code is the supported runtime today. Other runtimes are compatibility
+targets until adapter code and smoke evidence exist.
+
+## Next: v0.3.0 - Knows What To Do Next
+
+The next major product step is turning `mb status` and `/mb-start` into a
+useful daily decision surface.
+
+Planned scope:
+
+- `mb status` v1 with "since last check", drift detection, and a stable JSON
+  schema ([#261](https://github.com/noontide-co/mainbranch/issues/261));
+- a deterministic next-action ranker with top-three recommendations and cited
+  signals ([#262](https://github.com/noontide-co/mainbranch/issues/262));
+- `/mb-start` using the same status and ranker substrate
+  ([#262](https://github.com/noontide-co/mainbranch/issues/262));
+- shared readiness checks so skills call `mb` instead of duplicating probes
+  ([#263](https://github.com/noontide-co/mainbranch/issues/263));
+- docs that make the product ethos and operator loops explicit.
+
+Anti-scope for v0.3.0:
+
+- no dashboard as source of truth;
+- no broad multi-runtime support claims;
+- no marketplace;
+- no automatic model invocation from `mb`;
+- no issue-submission automation until the privacy layer is ready.
+
+## Soon: v0.3.x - Improves Itself In Public
+
+Once Main Branch knows enough to surface next actions, the product should make
+friction easier to turn into public improvement.
+
+Planned scope:
+
+- privacy-safe issue drafting for bugs, missing workflows, confusing errors,
+  and feature ideas ([#264](https://github.com/noontide-co/mainbranch/issues/264));
+- `/mb-status` as a thin runtime wrapper over `mb status`;
+- a small read-only local dashboard spike over existing JSON outputs
+  ([#189](https://github.com/noontide-co/mainbranch/issues/189));
+- sidecar enrichment contract for optional tools such as public company
+  context, analytics, bookkeeping, transcription, or deployment helpers
+  ([#265](https://github.com/noontide-co/mainbranch/issues/265)).
+
+## Later: v0.4 - Launches Bets
+
+The next proof point after the daily decision loop is launching and narrating
+real business bets from the repo.
+
+Planned scope:
+
+- `bets/` as a first-class business-repo primitive;
+- `/mb-bet` with `new`, `update`, `close`, `list`, and `narrate` modes;
+- links between bets, decisions, research, campaigns, and outcomes;
+- public bets feed generated through site workflows;
+- `mb status` showing active bets, deadlines, and outcomes;
+- core bets work tracked in [#266](https://github.com/noontide-co/mainbranch/issues/266);
+- decisions on fulfillment and bookkeeping workflows.
+
+## Longer Range
+
+Longer-range work should preserve the same state model: canonical truth in git,
+local operational state outside git, and live process state only when explicit.
+
+Likely directions:
+
+- runtime adapters for Codex, Cursor, OpenClaw, Hermes, Paperclip-adjacent
+  orchestration, and local runtimes;
+- dashboard/server mode as an optional local or self-hosted view over repo
+  truth, graph output, GitHub, and connected tools;
+- structured data layer for metrics, ads, analytics, P&L, and ledgers;
+- richer sidecar ecosystem behind narrow JSON contracts;
+- deeper pages, paid ads, organic, fulfillment, and bookkeeping workflows.
+
+## Reading Order
+
+- [ETHOS.md](ETHOS.md) for the product principles.
+- [OPERATOR-LOOPS.md](OPERATOR-LOOPS.md) for the Know -> See -> Decide ->
+  Execute -> Narrate loop.
+- [compatibility.md](compatibility.md) for runtime support status.
+- [CHANGELOG.md](../CHANGELOG.md) for what actually shipped.
+- [GitHub issues](https://github.com/noontide-co/mainbranch/issues) for the
+  live task list.


### PR DESCRIPTION
## Summary

- Adds a public `docs/ETHOS.md` so contributors and agents share the same product principles.
- Adds `docs/OPERATOR-LOOPS.md` to frame work around Know -> See -> Decide -> Execute -> Narrate.
- Adds `docs/ROADMAP.md` with the current v0.3/v0.4 release direction and links to the consolidated GitHub issues.
- Updates README and AGENTS.md so future roadmap/runtime/workflow work starts from the public product frame.

## Scope

In:

- Public docs for ethos, operator loops, and roadmap.
- README runtime-honesty table and roadmap pointer updates.
- AGENTS.md cold-start alignment with the new public docs.
- CHANGELOG Unreleased note.

Out:

- No implementation of `mb status` v1, ranker, issue drafting, sidecars, dashboard, or bets.
- No release cut.
- No runtime support claims beyond Claude Code.
- No private `.context` roadmap research committed.

## Commits

- `25614b7` — `[docs] Add product ethos and roadmap`
- `a791952` — merge `origin/main` and keep both Unreleased changelog entries

## Release / Issues

- Release: next docs-bearing release
- Linear ID(s): none
- Closes: none
- Refs: #261, #262, #263, #264, #265, #266, #189
- Follow-ups: use #261 and #262 as the v0.3.0 engineering spine; #264/#265/#266 are later release tracks.

## Success Metric

A new contributor or agent can read README -> AGENTS.md -> ETHOS/OPERATOR-LOOPS/ROADMAP and understand the product direction, runtime honesty posture, and next release priorities without needing private `.context` research notes.

## Validation

- Level 0 docs/decision: reviewed public/private boundary, runtime support language, roadmap links, and stale `projects#119` wording.
- Level 1 static: `scripts/check.sh` passed from repo root after merging current `origin/main`.
- Level 2 CLI: not needed; docs-only product framing.
- Level 3 package/install: not needed; no package or bundled-data change.
- Level 4 fixture repo: not needed; no business-repo behavior change.
- Level 5 runtime smoke: not needed; no runtime discovery or skill behavior change.

## Public / Private Boundary

This PR turns private roadmap synthesis into generic public docs. It does not commit `.context` research files, private Monologue notes, private Conductor preferences, local paths, customer/member data, tokens, or untested runtime claims.
