### PR TITLE
[add] privacy-safe issue drafting

### DIFF
--- a/.claude/skills/mb-help/SKILL.md
+++ b/.claude/skills/mb-help/SKILL.md
@@ -28,7 +28,7 @@ Answer questions, troubleshoot issues, explain philosophy, suggest next steps.
 | Philosophy, why, compound, passive memory | [philosophy.md](references/philosophy.md) |
 | /mb-think, research, decide, codify | [the-think-cycle.md](references/the-think-cycle.md) |
 | Task tracking, where left off, focus | [task-tracking-options.md](references/task-tracking-options.md) |
-| Error, command not found, MCP, Apify setup | [troubleshooting.md](references/troubleshooting.md) |
+| Error, command not found, MCP, Apify setup, GitHub issue | [troubleshooting.md](references/troubleshooting.md) |
 | Getting started, setup | Route to `/mb-setup` or `/mb-start` |
 | Which skill, when to use | [skills-guide.md](references/skills-guide.md) |
 | Create skill, Notion export, custom | [skills-guide.md](references/skills-guide.md) |
@@ -53,6 +53,7 @@ Answer questions, troubleshoot issues, explain philosophy, suggest next steps.
 - **End with action** — Suggest next skill (`/mb-think`, `/mb-setup`, `/mb-ads`, `/mb-vsl`)
 - **Beginner-friendly** — Many never used Terminal
 - **Honest about gaps** — The system is new and evolving. Acknowledge what's still being built rather than presenting everything as polished.
+- **Public issue safety** — Suggest `mb issue draft` for reproducible Main Branch friction, but never submit issues for the operator.
 
 ---
 

--- a/.claude/skills/mb-help/references/troubleshooting.md
+++ b/.claude/skills/mb-help/references/troubleshooting.md
@@ -180,6 +180,41 @@ Good commands for refreshing context:
 
 ---
 
+## Turn Friction Into a GitHub Issue
+
+If a Main Branch command, skill, setup step, or doc gap is reproducibly confusing
+after the repair path above, help the operator create a privacy-safe public issue
+draft. Do not submit it for them.
+
+**Bug:**
+```bash
+mb issue draft bug --command "mb doctor" --what-happened "..." --expected "..."
+```
+
+**Feature gap:**
+```bash
+mb issue draft feature --problem "..." --proposal "..."
+```
+
+**Question:**
+```bash
+mb issue draft question --question "..." --context "..." --tried "..."
+```
+
+Drafts go under `.mb/issue-drafts/` and are gitignored. Tell the operator to
+review the draft for private business data, customer/member details, secrets,
+account IDs, screenshots, and local-only paths before running:
+
+```bash
+mb issue open .mb/issue-drafts/[draft].md --yes
+```
+
+Use this only for Main Branch product friction that belongs in the public issue
+tracker. Operator-specific business strategy belongs in the community or their
+private repo, not public GitHub.
+
+---
+
 ## MCP Not Working (Apify, etc.)
 
 ### "apify not found" in /mcp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ### Added
 
+- Added `mb issue draft` and `mb issue open` so users can turn confusing
+  Main Branch friction into privacy-scrubbed local GitHub issue drafts before
+  explicitly submitting with `gh issue create`.
+- Added issue-drafting docs and `/mb-help` troubleshooting guidance for when
+  skills should suggest a bug, feature, or question draft without submitting on
+  the operator's behalf.
 - Added public ethos, operator-loop, and roadmap docs so future product work can
   anchor to the Know -> See -> Decide -> Execute -> Narrate loop and the
   current v0.3/v0.4 release direction.

--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ The CLI surface for the engine. Built for Claude Code first; runtime-agnostic by
 | `mb status` | Show a local-first daily briefing: repo health, runtime wiring, recent decisions/research/git activity, and GitHub tasks when `gh` is authenticated. |
 | `mb doctor` | Check the environment — repo shape, frontmatter sanity, settings on disk. Walks you through fixes. |
 | `mb connect` | Register provider credentials, test provider health, and inspect repair-safe integration status without committing secrets. |
+| `mb issue draft` | Create a local, privacy-scrubbed GitHub issue draft under `.mb/issue-drafts/` for bugs, feature gaps, or questions. |
+| `mb issue open` | Submit a reviewed issue draft with `gh issue create`, or print a browser/manual fallback when GitHub CLI is unavailable. |
 | `mb validate` | Frontmatter shape check across `core/`, `research/`, `decisions/`, `log/`, `campaigns/`, `documents/`. Pass/fail per file. |
 | `mb graph` | Build a repo graph index from frontmatter links, wikilinks, and entity tags. Emits Graphviz DOT by default, `--json` for agents/dashboards, and `--open` to render a PNG view. |
 | `mb think <topic>` | Print the `/mb-think` invocation hint. Run inside Claude Code for the full flow. |
@@ -336,6 +338,8 @@ For platform support and security reporting, see [SUPPORT.md](SUPPORT.md), [SECU
 - "Skills aren't working" — run `mb skill link --repo .` from your business repo to repair bridge symlinks, then restart Claude. If still broken, run `/mb-setup`.
 - "Output sounds generic" — add more detail to your reference files, especially `core/voice.md`.
 - "I edited Main Branch but can't push" — that's expected for most users. Main Branch is the shared engine. Your business data goes in YOUR repo.
+
+**Turn friction into a public issue:** run `mb issue draft bug --command "mb doctor" --what-happened "..."` from your business repo. Review the local draft under `.mb/issue-drafts/`, then run `mb issue open <draft> --yes` when it is safe to submit. See [docs/issue-drafting.md](docs/issue-drafting.md).
 
 ---
 

--- a/docs/issue-drafting.md
+++ b/docs/issue-drafting.md
@@ -1,0 +1,58 @@
+# Privacy-Safe Issue Drafting
+
+Main Branch improves through public friction reports, but business repos can
+contain private context. Use `mb issue` when an error, confusing step, missing
+workflow, or question should become a GitHub issue.
+
+## Commands
+
+```bash
+mb issue draft bug --command "mb status" --what-happened "..." --expected "..."
+mb issue draft feature --problem "..." --proposal "..."
+mb issue draft question --question "..." --context "..." --tried "..."
+```
+
+Drafts are written under `.mb/issue-drafts/` in the active business repo. That
+directory is local operational state and should stay gitignored.
+
+Bug drafts include scrubbed `mb doctor --json` output by default. Use
+`--no-doctor` when you only want the fields you supplied.
+
+After reviewing the draft:
+
+```bash
+mb issue open .mb/issue-drafts/<draft>.md --yes
+```
+
+`mb issue open` uses `gh issue create` when GitHub CLI is installed and
+authenticated. If `gh` is missing, unauthenticated, or `--yes` is omitted, it
+prints a browser/manual fallback instead of submitting.
+
+## Privacy Defaults
+
+The scrubber redacts common hazards:
+
+- local absolute paths such as home, temp, volume, and Windows drive paths;
+- token-shaped values and bearer tokens;
+- sensitive environment lines such as `API_TOKEN=...`;
+- URL query secrets such as `?token=...`;
+- email addresses.
+
+The scrubber is a guardrail, not a guarantee. Before submitting, review the
+draft and remove private business data, customer/member data, account details,
+raw files, screenshots with private information, and secrets.
+
+## Skill Convention
+
+Skills should suggest `mb issue draft` only when the operator hits reproducible
+friction that would help future users:
+
+- command or setup errors that persist after the documented repair command;
+- missing Main Branch workflow surfaces;
+- confusing docs or runtime handoff steps;
+- questions whose answer belongs in public docs or the issue tracker.
+
+Skills should not file or open issues on their own. They should summarize the
+public-safe problem, recommend the matching shape (`bug`, `feature`, or
+`question`), and let the operator run `mb issue open ... --yes` after reviewing
+the draft.

--- a/mb/mb/_data/templates/.gitignore.tmpl
+++ b/mb/mb/_data/templates/.gitignore.tmpl
@@ -11,3 +11,4 @@ node_modules/
 .venv/
 .mb/backups/
 .mb/onboarding.json
+.mb/issue-drafts/

--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -21,6 +21,7 @@ from mb import doctor as doctor_mod
 from mb import educational as educational_mod
 from mb import graph as graph_mod
 from mb import init as init_mod
+from mb import issue as issue_mod
 from mb import migrate as migrate_mod
 from mb import onboard as onboard_mod
 from mb import resolve as resolve_mod
@@ -65,6 +66,13 @@ onboard_app = typer.Typer(
     invoke_without_command=True,
 )
 app.add_typer(onboard_app, name="onboard")
+
+issue_app = typer.Typer(
+    name="issue",
+    help="Draft and open privacy-safe GitHub issues.",
+    no_args_is_help=True,
+)
+app.add_typer(issue_app, name="issue")
 
 CONNECT_METADATA_OPTION = typer.Option(
     [],
@@ -428,7 +436,125 @@ def doctor_cmd(
         typer.echo(json.dumps(report, indent=2))
     else:
         doctor_mod.render_human(report)
+        if not report["ok"]:
+            typer.echo(
+                "\nIf this should become a public task, run "
+                "`mb issue draft bug --command 'mb doctor' --what-happened '<summary>'` "
+                "after removing private details."
+            )
     raise typer.Exit(0 if report["ok"] else 1)
+
+
+@issue_app.command("draft")
+def issue_draft_cmd(
+    kind: str = typer.Argument("bug", help="Issue shape: bug, feature, or question."),
+    repo: str = typer.Option(".", "--repo", help="Business repo where the draft is stored."),
+    title: str = typer.Option("", "--title", help="Issue title. Prefix is added by template."),
+    command: str = typer.Option("", "--command", help="Command or skill that failed."),
+    what_happened: str = typer.Option(
+        "",
+        "--what-happened",
+        "--happened",
+        help="Actual behavior or error output.",
+    ),
+    expected: str = typer.Option("", "--expected", help="Expected behavior."),
+    diagnostics: str = typer.Option("", "--diagnostics", help="Extra diagnostic text to scrub."),
+    diagnostics_file: str = typer.Option(
+        "",
+        "--diagnostics-file",
+        help="Read extra diagnostics from a local file, then scrub them.",
+    ),
+    problem: str = typer.Option("", "--problem", help="Feature request problem statement."),
+    surface: str = typer.Option(
+        "Other / not sure",
+        "--surface",
+        help="Feature surface: CLI subcommand, Skill, Both, or Other / not sure.",
+    ),
+    proposal: str = typer.Option("", "--proposal", help="Feature request proposal."),
+    alternatives: str = typer.Option("", "--alternatives", help="Alternatives considered."),
+    related: str = typer.Option("", "--related", help="Related issues or PRs."),
+    question: str = typer.Option("", "--question", help="Question to ask."),
+    context: str = typer.Option("", "--context", help="Context for a question."),
+    tried: str = typer.Option("", "--tried", help="What you have tried."),
+    include_doctor: bool = typer.Option(
+        True,
+        "--doctor/--no-doctor",
+        help="For bug drafts, include scrubbed `mb doctor --json` output.",
+    ),
+    json_out: bool = typer.Option(False, "--json", help="Machine-readable output."),
+) -> None:
+    """Create a local, scrubbed issue draft under .mb/issue-drafts/."""
+    diagnostics_text = diagnostics
+    if diagnostics_file:
+        try:
+            diagnostics_text = Path(diagnostics_file).read_text(encoding="utf-8")
+        except OSError as exc:
+            typer.echo(f"mb issue draft: could not read diagnostics file: {exc}", err=True)
+            raise typer.Exit(2) from exc
+    fields = {
+        "command": command,
+        "happened": what_happened,
+        "expected": expected,
+        "diagnostics": diagnostics_text,
+        "problem": problem,
+        "surface": surface,
+        "proposal": proposal,
+        "alternatives": alternatives,
+        "related": related,
+        "question": question,
+        "context": context,
+        "tried": tried,
+    }
+    try:
+        result = issue_mod.create_draft(
+            repo=repo,
+            kind=kind,
+            title=title,
+            fields=fields,
+            include_doctor=include_doctor,
+        )
+    except ValueError as exc:
+        typer.echo(f"mb issue draft: {exc}", err=True)
+        raise typer.Exit(2) from exc
+    if json_out:
+        typer.echo(json.dumps(result, indent=2))
+    else:
+        typer.echo(f"drafted {result['kind']} issue: {result['relative_path']}")
+        typer.echo("review it before submitting; drafts are local and gitignored by default.")
+        if result["redactions"]:
+            summary = ", ".join(f"{key}={value}" for key, value in result["redactions"].items())
+            typer.echo(f"redactions: {summary}")
+        typer.echo("next:")
+        typer.echo(f"  {result['next_command']} --yes")
+
+
+@issue_app.command("open")
+def issue_open_cmd(
+    draft: str = typer.Argument(..., help="Draft markdown file from `mb issue draft`."),
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        help="Submit with gh after you have reviewed the draft.",
+    ),
+    json_out: bool = typer.Option(False, "--json", help="Machine-readable output."),
+) -> None:
+    """Open a reviewed issue draft through gh, or print a manual fallback."""
+    try:
+        result = issue_mod.open_draft(draft, yes=yes)
+    except ValueError as exc:
+        typer.echo(f"mb issue open: {exc}", err=True)
+        raise typer.Exit(2) from exc
+    if json_out:
+        typer.echo(json.dumps(result, indent=2))
+    elif result.get("submitted"):
+        typer.echo(f"opened issue: {result['url']}")
+    else:
+        typer.echo("issue not submitted.")
+        typer.echo(result["reason"])
+        typer.echo("manual fallback:")
+        for step in result["manual_steps"]:
+            typer.echo(f"  - {step}")
+    raise typer.Exit(0 if result["ok"] else 1)
 
 
 @app.command("connect")

--- a/mb/mb/init.py
+++ b/mb/mb/init.py
@@ -43,6 +43,7 @@ node_modules/
 .venv/
 .mb/backups/
 .mb/onboarding.json
+.mb/issue-drafts/
 """
 
 

--- a/mb/mb/issue.py
+++ b/mb/mb/issue.py
@@ -24,11 +24,11 @@ ISSUE_DRAFTS_GITIGNORE_ENTRY = ".mb/issue-drafts/"
 ISSUE_KINDS = {"bug", "feature", "question"}
 
 SENSITIVE_ENV_RE = re.compile(
-    r"(?im)^([A-Z_][A-Z0-9_]*(?:TOKEN|KEY|SECRET|PASSWORD|PASS|PWD|"
+    r"(?im)^([A-Z0-9_]*(?:TOKEN|KEY|SECRET|PASSWORD|PASS|PWD|"
     r"CREDENTIAL|AUTH|BEARER)[A-Z0-9_]*\s*=\s*).+$"
 )
 INLINE_SECRET_RE = re.compile(
-    r"(?i)\b([A-Z_][A-Z0-9_]*(?:TOKEN|KEY|SECRET|PASSWORD|PASS|PWD|"
+    r"(?i)(?<![?&])\b([A-Z0-9_]*(?:TOKEN|KEY|SECRET|PASSWORD|PASS|PWD|"
     r"CREDENTIAL|AUTH|BEARER)[A-Z0-9_]*\s*=\s*)(?!\[REDACTED\])[^\s`'\",;]+"
 )
 BEARER_RE = re.compile(r"(?i)\b(bearer\s+)[A-Za-z0-9._~+/=-]{10,}")
@@ -182,7 +182,22 @@ def _scrub_field(value: str) -> tuple[str, dict[str, int]]:
 
 
 def _safe_doctor_json(repo: Path) -> tuple[str, dict[str, int]]:
-    report = doctor_mod.run(path=str(repo))
+    try:
+        report = doctor_mod.run(path=str(repo))
+    except Exception as exc:
+        scrubbed = scrub_text(str(exc))
+        return (
+            json.dumps(
+                {
+                    "ok": False,
+                    "error": "mb doctor --json could not run while drafting this issue.",
+                    "detail": scrubbed.text,
+                    "fallback": "Re-run with `mb issue draft bug --no-doctor` if needed.",
+                },
+                indent=2,
+            ),
+            scrubbed.redactions,
+        )
     scrubbed, redactions = scrub_value(report)
     return json.dumps(scrubbed, indent=2), redactions
 
@@ -369,7 +384,6 @@ def create_draft(
     created_at = _now().isoformat(timespec="seconds")
     slug = _slug(scrubbed_title.text)
     filename = f"{created_at.replace(':', '').replace('+0000', 'Z')}-{normalized_kind}-{slug}.md"
-    filename = filename.replace("+00:00", "Z")
     path = draft_dir / filename
     counter = 2
     while path.exists():
@@ -395,6 +409,7 @@ removing private business context before submitting a public issue.
 
 {body}
 """
+    relative_path = str(path.relative_to(repo_path))
     path.write_text(content, encoding="utf-8")
     return {
         "ok": True,
@@ -402,7 +417,7 @@ removing private business context before submitting a public issue.
         "title": scrubbed_title.text,
         "labels": labels,
         "path": str(path),
-        "relative_path": str(path.relative_to(repo_path)),
+        "relative_path": relative_path,
         "repo": str(repo_path),
         "gitignore_updated": gitignore_updated,
         "redactions": redactions,
@@ -411,7 +426,7 @@ removing private business context before submitting a public issue.
             "requires_operator_review": True,
             "submitted": False,
         },
-        "next_command": f"mb issue open {path}",
+        "next_command": f"mb issue open {relative_path}",
     }
 
 

--- a/mb/mb/issue.py
+++ b/mb/mb/issue.py
@@ -1,0 +1,525 @@
+"""Privacy-safe GitHub issue drafting for Main Branch friction."""
+
+from __future__ import annotations
+
+import json
+import platform
+import re
+import shutil
+import subprocess
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote
+
+from mb import __version__
+from mb import doctor as doctor_mod
+from mb.engine import install_mode
+
+PUBLIC_REPO = "noontide-co/mainbranch"
+ISSUE_DRAFTS_RELATIVE_PATH = Path(".mb") / "issue-drafts"
+ISSUE_DRAFTS_GITIGNORE_ENTRY = ".mb/issue-drafts/"
+ISSUE_KINDS = {"bug", "feature", "question"}
+
+SENSITIVE_ENV_RE = re.compile(
+    r"(?im)^([A-Z_][A-Z0-9_]*(?:TOKEN|KEY|SECRET|PASSWORD|PASS|PWD|"
+    r"CREDENTIAL|AUTH|BEARER)[A-Z0-9_]*\s*=\s*).+$"
+)
+INLINE_SECRET_RE = re.compile(
+    r"(?i)\b([A-Z_][A-Z0-9_]*(?:TOKEN|KEY|SECRET|PASSWORD|PASS|PWD|"
+    r"CREDENTIAL|AUTH|BEARER)[A-Z0-9_]*\s*=\s*)(?!\[REDACTED\])[^\s`'\",;]+"
+)
+BEARER_RE = re.compile(r"(?i)\b(bearer\s+)[A-Za-z0-9._~+/=-]{10,}")
+TOKEN_RE = re.compile(
+    r"\b(?:ghp|gho|ghu|ghs|ghr|github_pat|sk|xoxb|xoxp|xapp)-[A-Za-z0-9_./=-]{8,}\b"
+)
+QUERY_SECRET_RE = re.compile(r"(?i)([?&](?:token|key|secret|auth|password)=)[^&\s]+")
+ABSOLUTE_PATH_RE = re.compile(
+    r"(?<![A-Za-z0-9:])(?:"
+    r"/(?:Users|home|private|tmp|var|Volumes|opt|usr/local)/[^\s\"'`<>),;]+"
+    r"|[A-Za-z]:\\[^\s\"'`<>),;]+"
+    r")"
+)
+HOME_PATH_RE = re.compile(r"(?<![\w])~/[^\s\"'`<>),;]+")
+EMAIL_RE = re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b")
+
+
+@dataclass(frozen=True)
+class ScrubbedText:
+    text: str
+    redactions: dict[str, int]
+
+
+def _bump(redactions: dict[str, int], key: str) -> None:
+    redactions[key] = redactions.get(key, 0) + 1
+
+
+def _replace_pattern(
+    text: str,
+    pattern: re.Pattern[str],
+    replacement: str | Callable[[re.Match[str]], str],
+    redactions: dict[str, int],
+    key: str,
+) -> str:
+    def repl(match: re.Match[str]) -> str:
+        _bump(redactions, key)
+        if callable(replacement):
+            return replacement(match)
+        return replacement
+
+    return pattern.sub(repl, text)
+
+
+def merge_redactions(*items: dict[str, int]) -> dict[str, int]:
+    merged: dict[str, int] = {}
+    for item in items:
+        for key, value in item.items():
+            merged[key] = merged.get(key, 0) + value
+    return merged
+
+
+def scrub_text(text: str) -> ScrubbedText:
+    """Redact common public-issue hazards while preserving useful shape."""
+    redactions: dict[str, int] = {}
+    scrubbed = text
+    scrubbed = _replace_pattern(
+        scrubbed,
+        SENSITIVE_ENV_RE,
+        lambda match: f"{match.group(1)}[REDACTED]",
+        redactions,
+        "sensitive_env",
+    )
+    scrubbed = _replace_pattern(
+        scrubbed,
+        INLINE_SECRET_RE,
+        lambda match: f"{match.group(1)}[REDACTED]",
+        redactions,
+        "sensitive_env",
+    )
+    scrubbed = _replace_pattern(
+        scrubbed,
+        BEARER_RE,
+        lambda match: f"{match.group(1)}[REDACTED]",
+        redactions,
+        "token",
+    )
+    scrubbed = _replace_pattern(scrubbed, TOKEN_RE, "[REDACTED_TOKEN]", redactions, "token")
+    scrubbed = _replace_pattern(
+        scrubbed,
+        QUERY_SECRET_RE,
+        lambda match: f"{match.group(1)}[REDACTED]",
+        redactions,
+        "url_secret",
+    )
+    scrubbed = _replace_pattern(
+        scrubbed, ABSOLUTE_PATH_RE, "<local-path>", redactions, "local_path"
+    )
+    scrubbed = _replace_pattern(scrubbed, HOME_PATH_RE, "<home-path>", redactions, "local_path")
+    scrubbed = _replace_pattern(scrubbed, EMAIL_RE, "<email>", redactions, "email")
+    return ScrubbedText(text=scrubbed, redactions=redactions)
+
+
+def scrub_value(value: Any) -> tuple[Any, dict[str, int]]:
+    """Recursively scrub strings inside JSON-like structures."""
+    if isinstance(value, str):
+        scrubbed = scrub_text(value)
+        return scrubbed.text, scrubbed.redactions
+    if isinstance(value, list):
+        redactions: list[dict[str, int]] = []
+        scrubbed_items = []
+        for item in value:
+            scrubbed, item_redactions = scrub_value(item)
+            scrubbed_items.append(scrubbed)
+            redactions.append(item_redactions)
+        return scrubbed_items, merge_redactions(*redactions)
+    if isinstance(value, dict):
+        redactions = []
+        scrubbed_dict: dict[str, Any] = {}
+        for key, item in value.items():
+            scrubbed, item_redactions = scrub_value(item)
+            scrubbed_dict[str(key)] = scrubbed
+            redactions.append(item_redactions)
+        return scrubbed_dict, merge_redactions(*redactions)
+    return value, {}
+
+
+def _slug(text: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", text.lower()).strip("-")
+    return slug[:48].strip("-") or "issue"
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _default_title(kind: str, fields: dict[str, str]) -> str:
+    if kind == "bug":
+        command = fields.get("command", "").strip()
+        suffix = command or "Main Branch friction"
+        return f"bug: {suffix}"
+    if kind == "feature":
+        problem = fields.get("problem", "").strip()
+        suffix = problem.splitlines()[0][:80] if problem else "Main Branch workflow gap"
+        return f"feat: {suffix}"
+    question = fields.get("question", "").strip()
+    suffix = question.splitlines()[0][:80] if question else "Main Branch question"
+    return f"question: {suffix}"
+
+
+def _labels_for_kind(kind: str) -> list[str]:
+    if kind == "bug":
+        return ["bug", "triage"]
+    if kind == "feature":
+        return ["enhancement", "triage"]
+    return ["question", "triage"]
+
+
+def _scrub_field(value: str) -> tuple[str, dict[str, int]]:
+    scrubbed = scrub_text(value.strip() or "_Not provided yet._")
+    return scrubbed.text, scrubbed.redactions
+
+
+def _safe_doctor_json(repo: Path) -> tuple[str, dict[str, int]]:
+    report = doctor_mod.run(path=str(repo))
+    scrubbed, redactions = scrub_value(report)
+    return json.dumps(scrubbed, indent=2), redactions
+
+
+def _bug_body(
+    repo: Path,
+    fields: dict[str, str],
+    include_doctor: bool,
+) -> tuple[str, dict[str, int]]:
+    redactions: list[dict[str, int]] = []
+    command, item_redactions = _scrub_field(fields.get("command", ""))
+    redactions.append(item_redactions)
+    happened, item_redactions = _scrub_field(fields.get("happened", ""))
+    redactions.append(item_redactions)
+    expected, item_redactions = _scrub_field(fields.get("expected", ""))
+    redactions.append(item_redactions)
+    diagnostics, item_redactions = _scrub_field(fields.get("diagnostics", ""))
+    redactions.append(item_redactions)
+    doctor_json = ""
+    if include_doctor:
+        doctor_json, item_redactions = _safe_doctor_json(repo)
+        redactions.append(item_redactions)
+    doctor_block = (
+        "\n## `mb doctor --json` output\n\n"
+        "<details>\n<summary>mb doctor --json</summary>\n\n"
+        "```json\n"
+        f"{doctor_json}\n"
+        "```\n\n"
+        "</details>\n"
+        if doctor_json
+        else ""
+    )
+    body = f"""## `mb --version` output
+
+```text
+mb {__version__}
+```
+
+## Operating system
+
+{platform.system() or "Unknown"}
+
+## Install mode
+
+{install_mode()}
+
+## Command or skill that failed
+
+```text
+{command}
+```
+
+## What happened
+
+{happened}
+
+## What you expected
+
+{expected}
+
+## Extra diagnostics
+
+```text
+{diagnostics}
+```
+{doctor_block}
+## Privacy review
+
+- [ ] I reviewed this draft and removed private business data, customer data, secrets,
+      account details, and local-only paths.
+"""
+    return body, merge_redactions(*redactions)
+
+
+def _feature_body(fields: dict[str, str]) -> tuple[str, dict[str, int]]:
+    redactions: list[dict[str, int]] = []
+    problem, item_redactions = _scrub_field(fields.get("problem", ""))
+    redactions.append(item_redactions)
+    surface, item_redactions = _scrub_field(fields.get("surface", "Other / not sure"))
+    redactions.append(item_redactions)
+    proposal, item_redactions = _scrub_field(fields.get("proposal", ""))
+    redactions.append(item_redactions)
+    alternatives, item_redactions = _scrub_field(fields.get("alternatives", ""))
+    redactions.append(item_redactions)
+    related, item_redactions = _scrub_field(fields.get("related", ""))
+    redactions.append(item_redactions)
+    body = f"""## Problem statement
+
+{problem}
+
+## Proposed surface
+
+{surface}
+
+## Proposed change
+
+{proposal}
+
+## Alternatives considered
+
+{alternatives}
+
+## Related issues or PRs
+
+{related}
+
+## Privacy review
+
+- [ ] I reviewed this draft and removed private business data, customer data, secrets,
+      account details, and local-only paths.
+"""
+    return body, merge_redactions(*redactions)
+
+
+def _question_body(fields: dict[str, str]) -> tuple[str, dict[str, int]]:
+    redactions: list[dict[str, int]] = []
+    question, item_redactions = _scrub_field(fields.get("question", ""))
+    redactions.append(item_redactions)
+    context, item_redactions = _scrub_field(fields.get("context", ""))
+    redactions.append(item_redactions)
+    tried, item_redactions = _scrub_field(fields.get("tried", ""))
+    redactions.append(item_redactions)
+    body = f"""## Question
+
+{question}
+
+## Context
+
+{context}
+
+## What you've tried
+
+{tried}
+
+## Privacy review
+
+- [ ] I reviewed this draft and removed private business data, customer data, secrets,
+      account details, and local-only paths.
+"""
+    return body, merge_redactions(*redactions)
+
+
+def ensure_issue_gitignore(repo: Path) -> bool:
+    gitignore = repo / ".gitignore"
+    existing = gitignore.read_text(encoding="utf-8") if gitignore.exists() else ""
+    entries = {line.strip() for line in existing.splitlines()}
+    if ISSUE_DRAFTS_GITIGNORE_ENTRY in entries or ".mb/" in entries:
+        return False
+    prefix = "" if not existing or existing.endswith("\n") else "\n"
+    gitignore.write_text(existing + prefix + ISSUE_DRAFTS_GITIGNORE_ENTRY + "\n", encoding="utf-8")
+    return True
+
+
+def create_draft(
+    *,
+    repo: str,
+    kind: str,
+    title: str,
+    fields: dict[str, str],
+    include_doctor: bool = True,
+) -> dict[str, Any]:
+    normalized_kind = kind.strip().lower()
+    if normalized_kind not in ISSUE_KINDS:
+        supported = ", ".join(sorted(ISSUE_KINDS))
+        raise ValueError(f"unknown issue kind {kind!r}; expected one of: {supported}")
+
+    repo_path = Path(repo).resolve()
+    if not repo_path.exists():
+        raise ValueError(f"repo not found: {repo}")
+    draft_dir = repo_path / ISSUE_DRAFTS_RELATIVE_PATH
+    draft_dir.mkdir(parents=True, exist_ok=True)
+    gitignore_updated = ensure_issue_gitignore(repo_path)
+
+    raw_title = title.strip() or _default_title(normalized_kind, fields)
+    scrubbed_title = scrub_text(raw_title)
+    if normalized_kind == "bug":
+        body, body_redactions = _bug_body(repo_path, fields, include_doctor=include_doctor)
+    elif normalized_kind == "feature":
+        body, body_redactions = _feature_body(fields)
+    else:
+        body, body_redactions = _question_body(fields)
+    redactions = merge_redactions(scrubbed_title.redactions, body_redactions)
+    labels = _labels_for_kind(normalized_kind)
+    created_at = _now().isoformat(timespec="seconds")
+    slug = _slug(scrubbed_title.text)
+    filename = f"{created_at.replace(':', '').replace('+0000', 'Z')}-{normalized_kind}-{slug}.md"
+    filename = filename.replace("+00:00", "Z")
+    path = draft_dir / filename
+    counter = 2
+    while path.exists():
+        path = draft_dir / f"{path.stem}-{counter}{path.suffix}"
+        counter += 1
+
+    label_lines = "\n".join(f"  - {label}" for label in labels)
+    content = f"""---
+mb_issue_draft: 1
+kind: {normalized_kind}
+title: {json.dumps(scrubbed_title.text)}
+labels:
+{label_lines}
+created_at: {created_at}
+privacy_review: required
+---
+
+<!-- mb:internal
+Review before opening. Main Branch scrubbed common secrets, local paths, email
+addresses, and token-shaped values, but the operator is still responsible for
+removing private business context before submitting a public issue.
+-->
+
+{body}
+"""
+    path.write_text(content, encoding="utf-8")
+    return {
+        "ok": True,
+        "kind": normalized_kind,
+        "title": scrubbed_title.text,
+        "labels": labels,
+        "path": str(path),
+        "relative_path": str(path.relative_to(repo_path)),
+        "repo": str(repo_path),
+        "gitignore_updated": gitignore_updated,
+        "redactions": redactions,
+        "privacy": {
+            "safe_by_default": True,
+            "requires_operator_review": True,
+            "submitted": False,
+        },
+        "next_command": f"mb issue open {path}",
+    }
+
+
+def _parse_frontmatter(text: str) -> tuple[dict[str, Any], str]:
+    if not text.startswith("---\n"):
+        return {}, text
+    end = text.find("\n---\n", 4)
+    if end == -1:
+        return {}, text
+    metadata_text = text[4:end]
+    body = text[end + 5 :].lstrip()
+    metadata: dict[str, Any] = {}
+    labels: list[str] = []
+    in_labels = False
+    for line in metadata_text.splitlines():
+        if line.startswith("labels:"):
+            in_labels = True
+            continue
+        if in_labels and line.startswith("  - "):
+            labels.append(line[4:].strip())
+            continue
+        in_labels = False
+        if ": " not in line:
+            continue
+        key, value = line.split(": ", 1)
+        if key == "title":
+            try:
+                metadata[key] = json.loads(value)
+            except json.JSONDecodeError:
+                metadata[key] = value.strip('"')
+        else:
+            metadata[key] = value
+    if labels:
+        metadata["labels"] = labels
+    return metadata, body
+
+
+def _public_body(body: str) -> str:
+    return re.sub(r"<!-- mb:internal.*?-->\n\n?", "", body, flags=re.DOTALL).strip() + "\n"
+
+
+def _run(args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(args, capture_output=True, text=True, timeout=30, check=False)
+
+
+def _fallback(title: str, reason: str, draft_path: Path) -> dict[str, Any]:
+    title_query = quote(title)
+    return {
+        "ok": True,
+        "submitted": False,
+        "fallback": True,
+        "reason": reason,
+        "draft_path": str(draft_path),
+        "manual_url": f"https://github.com/{PUBLIC_REPO}/issues/new?title={title_query}",
+        "manual_steps": [
+            f"Open https://github.com/{PUBLIC_REPO}/issues/new/choose",
+            f"Use the draft body from {draft_path}",
+            "Review the privacy checklist before submitting.",
+        ],
+    }
+
+
+def open_draft(
+    draft: str,
+    *,
+    yes: bool = False,
+    runner: Callable[[list[str]], subprocess.CompletedProcess[str]] = _run,
+) -> dict[str, Any]:
+    draft_path = Path(draft).resolve()
+    if not draft_path.exists():
+        raise ValueError(f"issue draft not found: {draft}")
+    metadata, body = _parse_frontmatter(draft_path.read_text(encoding="utf-8"))
+    title = str(metadata.get("title") or draft_path.stem)
+    labels = [str(label) for label in metadata.get("labels", [])]
+    public_body = _public_body(body)
+
+    if not yes:
+        return _fallback(
+            title,
+            "pass --yes after reviewing the draft to submit with gh",
+            draft_path,
+        )
+    if not shutil.which("gh"):
+        return _fallback(title, "GitHub CLI `gh` is not on PATH", draft_path)
+
+    auth = runner(["gh", "auth", "status"])
+    if auth.returncode != 0:
+        return _fallback(title, "GitHub CLI is not authenticated", draft_path)
+
+    args = ["gh", "issue", "create", "--repo", PUBLIC_REPO, "--title", title, "--body", public_body]
+    for label in labels:
+        args.extend(["--label", label])
+    result = runner(args)
+    if result.returncode != 0:
+        return {
+            "ok": False,
+            "submitted": False,
+            "fallback": True,
+            "reason": result.stderr.strip() or result.stdout.strip() or "gh issue create failed",
+            "draft_path": str(draft_path),
+            "manual_url": f"https://github.com/{PUBLIC_REPO}/issues/new/choose",
+        }
+    return {
+        "ok": True,
+        "submitted": True,
+        "fallback": False,
+        "url": result.stdout.strip(),
+        "draft_path": str(draft_path),
+        "title": title,
+        "labels": labels,
+    }

--- a/mb/mb/issue.py
+++ b/mb/mb/issue.py
@@ -521,14 +521,13 @@ def open_draft(
         args.extend(["--label", label])
     result = runner(args)
     if result.returncode != 0:
-        return {
-            "ok": False,
-            "submitted": False,
-            "fallback": True,
-            "reason": result.stderr.strip() or result.stdout.strip() or "gh issue create failed",
-            "draft_path": str(draft_path),
-            "manual_url": f"https://github.com/{PUBLIC_REPO}/issues/new/choose",
-        }
+        fallback = _fallback(
+            title,
+            result.stderr.strip() or result.stdout.strip() or "gh issue create failed",
+            draft_path,
+        )
+        fallback["ok"] = False
+        return fallback
     return {
         "ok": True,
         "submitted": True,

--- a/mb/tests/test_init.py
+++ b/mb/tests/test_init.py
@@ -36,6 +36,7 @@ def test_init_scaffolds_folders(tmp_path: Path) -> None:
     assert ".claude/skills/mb-start" in gitignore
     assert ".mb/backups/" in gitignore
     assert ".mb/onboarding.json" in gitignore
+    assert ".mb/issue-drafts/" in gitignore
     claude_md = (target / "CLAUDE.md").read_text()
     assert "Acme Brewing" in claude_md
     assert "## Connected accounts" in claude_md

--- a/mb/tests/test_issue.py
+++ b/mb/tests/test_issue.py
@@ -210,3 +210,30 @@ def test_issue_open_submits_with_gh_when_reviewed(tmp_path: Path, monkeypatch) -
     assert create_call[:3] == ["gh", "issue", "create"]
     assert "--label" in create_call
     assert "question" in create_call
+
+
+def test_issue_open_gh_create_failure_keeps_manual_fallback(tmp_path: Path, monkeypatch) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    draft = issue_mod.create_draft(
+        repo=str(repo),
+        kind="bug",
+        title="bug: submit failure",
+        fields={"command": "mb doctor", "happened": "failed", "expected": "pass"},
+        include_doctor=False,
+    )
+
+    def fake_runner(args: list[str]) -> subprocess.CompletedProcess[str]:
+        if args[:3] == ["gh", "auth", "status"]:
+            return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+        return subprocess.CompletedProcess(args, 1, stdout="", stderr="label not found")
+
+    monkeypatch.setattr(issue_mod.shutil, "which", lambda name: "/usr/bin/gh")
+
+    result = issue_mod.open_draft(draft["path"], yes=True, runner=fake_runner)
+
+    assert result["ok"] is False
+    assert result["submitted"] is False
+    assert result["fallback"] is True
+    assert result["reason"] == "label not found"
+    assert result["manual_steps"]

--- a/mb/tests/test_issue.py
+++ b/mb/tests/test_issue.py
@@ -22,6 +22,7 @@ Traceback File "/Users/alex/business/core/offer.md", line 4
 Authorization: Bearer abcdefghijklmnop
 https://example.com/callback?token=abc123
 customer@example.com
+--token=plain-secret
 """
 
     scrubbed = issue_mod.scrub_text(raw)
@@ -31,7 +32,8 @@ customer@example.com
     assert "abcdefghijklmnop" not in scrubbed.text
     assert "abc123" not in scrubbed.text
     assert "customer@example.com" not in scrubbed.text
-    assert scrubbed.redactions["sensitive_env"] == 1
+    assert "plain-secret" not in scrubbed.text
+    assert scrubbed.redactions["sensitive_env"] == 2
     assert scrubbed.redactions["local_path"] == 1
     assert scrubbed.redactions["token"] == 1
     assert scrubbed.redactions["url_secret"] == 1
@@ -80,6 +82,7 @@ def test_issue_draft_bug_creates_local_gitignored_scrubbed_draft(tmp_path: Path)
     assert payload["privacy"]["requires_operator_review"] is True
     assert payload["redactions"]["email"] == 1
     assert payload["redactions"]["local_path"] >= 1
+    assert payload["next_command"].startswith("mb issue open .mb/issue-drafts/")
 
 
 def test_issue_draft_supports_feature_and_question_shapes(tmp_path: Path) -> None:
@@ -129,6 +132,30 @@ def test_issue_draft_requires_existing_repo(tmp_path: Path) -> None:
             fields={"command": "mb status"},
             include_doctor=False,
         )
+
+
+def test_issue_draft_degrades_when_doctor_fails(tmp_path: Path, monkeypatch) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    def fail_doctor(path: str) -> dict[str, object]:
+        raise RuntimeError("failed at /Users/alex/business with token=secret")
+
+    monkeypatch.setattr(issue_mod.doctor_mod, "run", fail_doctor)
+
+    result = issue_mod.create_draft(
+        repo=str(repo),
+        kind="bug",
+        title="bug: doctor failure",
+        fields={"command": "mb doctor", "happened": "doctor crashed"},
+    )
+
+    body = Path(result["path"]).read_text(encoding="utf-8")
+    assert result["ok"] is True
+    assert "mb doctor --json could not run" in body
+    assert "/Users/alex" not in body
+    assert "token=secret" not in body
+    assert "`mb issue draft bug --no-doctor`" in body
 
 
 def test_issue_open_requires_yes_and_returns_manual_fallback(tmp_path: Path) -> None:

--- a/mb/tests/test_issue.py
+++ b/mb/tests/test_issue.py
@@ -1,0 +1,185 @@
+"""Privacy-safe GitHub issue draft tests."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from mb import issue as issue_mod
+from mb.cli import app
+
+runner = CliRunner()
+
+
+def test_scrub_text_redacts_paths_tokens_env_and_email() -> None:
+    raw = """
+API_TOKEN=super-secret
+Traceback File "/Users/alex/business/core/offer.md", line 4
+Authorization: Bearer abcdefghijklmnop
+https://example.com/callback?token=abc123
+customer@example.com
+"""
+
+    scrubbed = issue_mod.scrub_text(raw)
+
+    assert "super-secret" not in scrubbed.text
+    assert "/Users/alex" not in scrubbed.text
+    assert "abcdefghijklmnop" not in scrubbed.text
+    assert "abc123" not in scrubbed.text
+    assert "customer@example.com" not in scrubbed.text
+    assert scrubbed.redactions["sensitive_env"] == 1
+    assert scrubbed.redactions["local_path"] == 1
+    assert scrubbed.redactions["token"] == 1
+    assert scrubbed.redactions["url_secret"] == 1
+    assert scrubbed.redactions["email"] == 1
+
+
+def test_issue_draft_bug_creates_local_gitignored_scrubbed_draft(tmp_path: Path) -> None:
+    repo = tmp_path / "biz"
+    (repo / "core" / "finance").mkdir(parents=True)
+    secret_path = tmp_path / "biz" / "core" / "offer.md"
+
+    result = runner.invoke(
+        app,
+        [
+            "issue",
+            "draft",
+            "bug",
+            "--repo",
+            str(repo),
+            "--title",
+            "bug: checkout failure for customer@example.com",
+            "--command",
+            "mb status",
+            "--what-happened",
+            f"failed at {secret_path} with API_KEY=abc123",
+            "--expected",
+            "status should render",
+            "--diagnostics",
+            "Bearer abcdefghijklmnop",
+            "--no-doctor",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    draft = Path(payload["path"])
+    body = draft.read_text(encoding="utf-8")
+    assert draft.exists()
+    assert ".mb/issue-drafts/" in (repo / ".gitignore").read_text(encoding="utf-8")
+    assert "customer@example.com" not in body
+    assert str(secret_path) not in body
+    assert "API_KEY=abc123" not in body
+    assert "abcdefghijklmnop" not in body
+    assert "<local-path>" in body
+    assert payload["privacy"]["requires_operator_review"] is True
+    assert payload["redactions"]["email"] == 1
+    assert payload["redactions"]["local_path"] >= 1
+
+
+def test_issue_draft_supports_feature_and_question_shapes(tmp_path: Path) -> None:
+    feature_repo = tmp_path / "feature-repo"
+    question_repo = tmp_path / "question-repo"
+    feature_repo.mkdir()
+    question_repo.mkdir()
+
+    feature = issue_mod.create_draft(
+        repo=str(feature_repo),
+        kind="feature",
+        title="feat: make update clearer",
+        fields={
+            "problem": "I cannot tell what changed.",
+            "surface": "CLI subcommand",
+            "proposal": "Add a summary.",
+            "alternatives": "Read the changelog manually.",
+        },
+        include_doctor=False,
+    )
+    question = issue_mod.create_draft(
+        repo=str(question_repo),
+        kind="question",
+        title="question: when should I use status?",
+        fields={
+            "question": "When should I run mb status?",
+            "context": "I am starting the day.",
+            "tried": "I read the README.",
+        },
+        include_doctor=False,
+    )
+
+    assert feature["kind"] == "feature"
+    assert feature["labels"] == ["enhancement", "triage"]
+    assert "## Problem statement" in Path(feature["path"]).read_text(encoding="utf-8")
+    assert question["kind"] == "question"
+    assert question["labels"] == ["question", "triage"]
+    assert "## What you've tried" in Path(question["path"]).read_text(encoding="utf-8")
+
+
+def test_issue_draft_requires_existing_repo(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="repo not found"):
+        issue_mod.create_draft(
+            repo=str(tmp_path / "missing"),
+            kind="bug",
+            title="bug: missing repo",
+            fields={"command": "mb status"},
+            include_doctor=False,
+        )
+
+
+def test_issue_open_requires_yes_and_returns_manual_fallback(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    draft = issue_mod.create_draft(
+        repo=str(repo),
+        kind="bug",
+        title="bug: fallback",
+        fields={"command": "mb doctor", "happened": "failed", "expected": "pass"},
+        include_doctor=False,
+    )
+
+    result = issue_mod.open_draft(draft["path"], yes=False)
+
+    assert result["ok"] is True
+    assert result["submitted"] is False
+    assert "pass --yes" in result["reason"]
+    assert "manual_url" in result
+
+
+def test_issue_open_submits_with_gh_when_reviewed(tmp_path: Path, monkeypatch) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    draft = issue_mod.create_draft(
+        repo=str(repo),
+        kind="question",
+        title="question: submit",
+        fields={"question": "How?", "context": "Testing.", "tried": "A draft."},
+        include_doctor=False,
+    )
+    calls: list[list[str]] = []
+
+    def fake_runner(args: list[str]) -> subprocess.CompletedProcess[str]:
+        calls.append(args)
+        if args[:3] == ["gh", "auth", "status"]:
+            return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+        return subprocess.CompletedProcess(
+            args,
+            0,
+            stdout="https://github.com/noontide-co/mainbranch/issues/999\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr(issue_mod.shutil, "which", lambda name: "/usr/bin/gh")
+
+    result = issue_mod.open_draft(draft["path"], yes=True, runner=fake_runner)
+
+    assert result["submitted"] is True
+    assert result["url"].endswith("/999")
+    create_call = calls[-1]
+    assert create_call[:3] == ["gh", "issue", "create"]
+    assert "--label" in create_call
+    assert "question" in create_call


### PR DESCRIPTION
## Summary
- Adds `mb issue draft` and `mb issue open` so users can turn confusing Main Branch friction into local, privacy-scrubbed GitHub issue drafts.
- Supports bug, feature, and question shapes that match the public issue templates while keeping drafts under gitignored `.mb/issue-drafts/`.
- Keeps submission explicit through reviewed `mb issue open ... --yes`, with a browser/manual fallback when `gh` is missing, unauthenticated, or not confirmed.
- Documents the workflow in README, CHANGELOG, `docs/issue-drafting.md`, and `/mb-help` troubleshooting guidance.

## Scope
In:
- Privacy scrubber for paths, token-shaped values, bearer tokens, sensitive env values, URL secrets, and emails.
- Local draft creation plus opt-in `gh issue create` submission edge.
- Tests and package template updates for the new `.mb/issue-drafts/` local state.

Out:
- Automatic issue submission.
- Hosted telemetry.
- Raw business files, customer data, secrets, account details, or local paths in drafts by default.

## Commits
- `c4707fd` — `[add] MAIN-219 privacy-safe issue drafts`.
- `9b62fdf` — `[fix] MAIN-219 tighten issue draft edges`.

## Release / Issues
Release: v0.3.x - Improves itself in public
Linear ID(s): MAIN-219
Closes: #264
Refs: none
Follow-ups: none identified

## Success Metric
A beginner can turn a confusing Main Branch failure into a useful public GitHub issue draft in under two minutes, while the default draft is safe to review before sharing publicly.

## Validation
Level 0 docs/decision: README, CHANGELOG, `docs/issue-drafting.md`, and `/mb-help` guidance updated and public-safe.
Level 1 static: `scripts/check.sh` passed; Ruff, mypy, coverage gate, and skill validation passed.
Level 2 CLI: `pytest tests/test_issue.py -q` passed 7 tests; full suite in `scripts/check.sh` passed 170 tests with 81.03% coverage.
Level 3 package/install: `python3 -m build`; installed wheel into `/tmp/mainbranch-smoke`; verified `mb --version`, installed `mb init`, `mb issue draft`, and `mb issue open` fallback.
Level 4 fixture repo: fresh business repo smoke verified `.mb/issue-drafts/` is gitignored, local path and token text are redacted, and `mb issue open` does not submit without review.
Level 5 runtime smoke: not run; no runtime discovery or invocation behavior changed.

## Public / Private Boundary
The implementation keeps drafts local and gitignored, targets the public `noontide-co/mainbranch` repository only at explicit submission time, and keeps Devon/Conductor workflow details in `.context/` rather than durable public docs.
