### PR TITLE
[add] mb status v1 daily briefing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,8 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   support levels, runtime-aware invocation hints, workflow launcher gates, and
   onboarding resume state. Refs #220.
 - Added `mb status` schema v1.0 with repo-local since-last-check state,
-  deterministic drift signals, `--verbose` detail output, and `--no-color`
-  human output. Refs #261.
+  deterministic drift signals, `--peek` non-mutating reads, `--verbose` detail
+  output, and `--no-color` human output. Refs #261.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   and production skill boundaries, Claude Code as the reference adapter,
   support levels, runtime-aware invocation hints, workflow launcher gates, and
   onboarding resume state. Refs #220.
+- Added `mb status` schema v1.0 with repo-local since-last-check state,
+  deterministic drift signals, `--verbose` detail output, and `--no-color`
+  human output. Refs #261.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ The CLI surface for the engine. Built for Claude Code first; runtime-agnostic by
 | `mb onboard` | Human setup flow: create or connect a business repo, explain the substrate, wire Claude Code skills, and show the next `/mb-start` step. |
 | `mb onboard status` | Show durable onboarding progress from `.mb/onboarding.json`, including missing core-reference inputs and the next recommended action. |
 | `mb init` | Set up a fresh business repo (six folders, CLAUDE.md, git init). |
-| `mb status` | Show a local-first daily briefing: repo health, runtime wiring, recent decisions/research/git activity, and GitHub tasks when `gh` is authenticated. |
+| `mb status` | Show a local-first daily briefing: since-last-check changes, drift, repo health, runtime wiring, recent decisions/research/git activity, and GitHub tasks when `gh` is authenticated. Use `--json` for the v1 status schema and `--verbose` for detail. |
 | `mb doctor` | Check the environment — repo shape, frontmatter sanity, settings on disk. Walks you through fixes. |
 | `mb connect` | Register provider credentials, test provider health, and inspect repair-safe integration status without committing secrets. |
 | `mb validate` | Frontmatter shape check across `core/`, `research/`, `decisions/`, `log/`, `campaigns/`, `documents/`. Pass/fail per file. |

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ The CLI surface for the engine. Built for Claude Code first; runtime-agnostic by
 | `mb onboard` | Human setup flow: create or connect a business repo, explain the substrate, wire Claude Code skills, and show the next `/mb-start` step. |
 | `mb onboard status` | Show durable onboarding progress from `.mb/onboarding.json`, including missing core-reference inputs and the next recommended action. |
 | `mb init` | Set up a fresh business repo (six folders, CLAUDE.md, git init). |
-| `mb status` | Show a local-first daily briefing: since-last-check changes, drift, repo health, runtime wiring, recent decisions/research/git activity, and GitHub tasks when `gh` is authenticated. Use `--json` for the v1 status schema and `--verbose` for detail. |
+| `mb status` | Show a local-first daily briefing: since-last-check changes, drift, repo health, runtime wiring, recent decisions/research/git activity, and GitHub tasks when `gh` is authenticated. Use `--json` for the v1 status schema, `--verbose` for detail, and `--peek` for non-mutating reads. |
 | `mb doctor` | Check the environment — repo shape, frontmatter sanity, settings on disk. Walks you through fixes. |
 | `mb connect` | Register provider credentials, test provider health, and inspect repair-safe integration status without committing secrets. |
 | `mb validate` | Frontmatter shape check across `core/`, `research/`, `decisions/`, `log/`, `campaigns/`, `documents/`. Pass/fail per file. |

--- a/mb/mb/_data/templates/.gitignore.tmpl
+++ b/mb/mb/_data/templates/.gitignore.tmpl
@@ -11,3 +11,4 @@ node_modules/
 .venv/
 .mb/backups/
 .mb/onboarding.json
+.mb/last-status-seen.json

--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -575,13 +575,15 @@ def connect_cmd(
 def status_cmd(
     path: str = typer.Argument(".", help="Business repo to brief."),
     json_out: bool = typer.Option(False, "--json", help="Machine-readable output."),
+    verbose: bool = typer.Option(False, "--verbose", "-v", help="Show detailed briefing sections."),
+    no_color: bool = typer.Option(False, "--no-color", help="Disable ANSI color in human output."),
 ) -> None:
     """Show a cheap daily briefing for a Main Branch repo."""
     report = status_mod.run(path=path)
     if json_out:
         typer.echo(json.dumps(report, indent=2))
     else:
-        status_mod.render_human(report)
+        status_mod.render_human(report, verbose=verbose, no_color=no_color)
 
 
 @app.command("start")

--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -577,9 +577,14 @@ def status_cmd(
     json_out: bool = typer.Option(False, "--json", help="Machine-readable output."),
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Show detailed briefing sections."),
     no_color: bool = typer.Option(False, "--no-color", help="Disable ANSI color in human output."),
+    peek: bool = typer.Option(
+        False,
+        "--peek",
+        help="Read status without updating the last-status-seen marker.",
+    ),
 ) -> None:
     """Show a cheap daily briefing for a Main Branch repo."""
-    report = status_mod.run(path=path)
+    report = status_mod.run(path=path, update_marker=not peek)
     if json_out:
         typer.echo(json.dumps(report, indent=2))
     else:

--- a/mb/mb/init.py
+++ b/mb/mb/init.py
@@ -43,6 +43,7 @@ node_modules/
 .venv/
 .mb/backups/
 .mb/onboarding.json
+.mb/last-status-seen.json
 """
 
 

--- a/mb/mb/status.py
+++ b/mb/mb/status.py
@@ -478,23 +478,33 @@ def _marker_path(repo: Path) -> Path:
 
 def _marker_gitignore_state(repo: Path) -> dict[str, Any]:
     gitignore = repo / ".gitignore"
+    entry = LAST_STATUS_SEEN_GITIGNORE_ENTRY
+    if _which("git"):
+        check = _run_command(["git", "check-ignore", entry], cwd=repo)
+        if check["ok"]:
+            return {
+                "ok": True,
+                "path": ".gitignore",
+                "entry": entry,
+                "repair": "",
+            }
     if not gitignore.exists():
         return {
             "ok": False,
             "path": ".gitignore",
-            "entry": LAST_STATUS_SEEN_GITIGNORE_ENTRY,
-            "repair": f"Add `{LAST_STATUS_SEEN_GITIGNORE_ENTRY}` to `.gitignore`.",
+            "entry": entry,
+            "repair": f"Add `{entry}` to `.gitignore`.",
         }
     try:
         lines = gitignore.read_text(encoding="utf-8").splitlines()
     except OSError:
         lines = []
-    ignored = LAST_STATUS_SEEN_GITIGNORE_ENTRY in {line.strip() for line in lines}
+    ignored = entry in {line.strip() for line in lines}
     return {
         "ok": ignored,
         "path": ".gitignore",
-        "entry": LAST_STATUS_SEEN_GITIGNORE_ENTRY,
-        "repair": "" if ignored else f"Add `{LAST_STATUS_SEEN_GITIGNORE_ENTRY}` to `.gitignore`.",
+        "entry": entry,
+        "repair": "" if ignored else f"Add `{entry}` to `.gitignore`.",
     }
 
 
@@ -693,7 +703,7 @@ def _drift(report: dict[str, Any]) -> dict[str, Any]:
     broken_integrations = [
         item
         for item in (report.get("integrations") or {}).get("providers", [])
-        if item.get("connected") and not item.get("ok")
+        if not item.get("ok")
     ]
     if broken_integrations:
         items.append(

--- a/mb/mb/status.py
+++ b/mb/mb/status.py
@@ -6,7 +6,7 @@ import json
 import re
 import shutil
 import subprocess
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -27,7 +27,34 @@ IMPORTANT_DIRS = (
     "log",
     "documents",
 )
+STATUS_SCHEMA_VERSION = "1.0"
+LAST_STATUS_SEEN_RELATIVE_PATH = Path(".mb") / "last-status-seen.json"
+LAST_STATUS_SEEN_GITIGNORE_ENTRY = ".mb/last-status-seen.json"
 STALE_DECISION_DAYS = 14
+STALE_RESEARCH_DAYS = 45
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc).replace(microsecond=0)
+
+
+def _format_timestamp(value: datetime) -> str:
+    return value.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _parse_timestamp(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    raw = value.strip()
+    if raw.endswith("Z"):
+        raw = raw[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
 
 
 def _which(name: str) -> str:
@@ -152,6 +179,71 @@ def _git_recent_activity(repo: Path, git: dict[str, Any]) -> dict[str, Any]:
     return {"available": True, "items": items[:8], "error": ""}
 
 
+def _parse_git_log_with_files(output: str, *, limit: int = 8) -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+    current: dict[str, Any] | None = None
+    for raw_line in output.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        parts = line.split("\t", 2)
+        if len(parts) == 3 and re.fullmatch(r"[0-9a-f]{4,}", parts[0]):
+            if current is not None:
+                items.append(current)
+            current = {"commit": parts[0], "date": parts[1], "subject": parts[2], "files": []}
+            continue
+        if current is not None:
+            current["files"].append(line)
+    if current is not None:
+        items.append(current)
+    return items[:limit]
+
+
+def _git_since_last_seen(
+    repo: Path,
+    git: dict[str, Any],
+    marker: dict[str, Any],
+) -> dict[str, Any]:
+    if not git.get("inside_work_tree"):
+        return {
+            "available": False,
+            "commits": [],
+            "changed_files": [],
+            "error": git.get("error") or "git unavailable",
+        }
+
+    marker_git_raw = marker.get("git")
+    marker_git: dict[str, Any] = marker_git_raw if isinstance(marker_git_raw, dict) else {}
+    previous_commit = str(marker_git.get("commit") or "")
+    current_commit = str(git.get("commit") or "")
+    args = [
+        "git",
+        "log",
+        "--date=short",
+        "--pretty=format:%h%x09%ad%x09%s",
+        "--name-only",
+    ]
+    if previous_commit and current_commit and previous_commit != current_commit:
+        args.append(f"{previous_commit}..HEAD")
+    else:
+        previous_seen_at = _parse_timestamp(marker.get("seen_at"))
+        if previous_seen_at is None:
+            return {"available": True, "commits": [], "changed_files": [], "error": ""}
+        args.append(f"--since={previous_seen_at.isoformat()}")
+    result = _run_command(args, cwd=repo)
+    if not result["ok"]:
+        return {"available": False, "commits": [], "changed_files": [], "error": result["stderr"]}
+
+    commits = _parse_git_log_with_files(result["stdout"])
+    changed_files = sorted({file for item in commits for file in item["files"]})
+    return {
+        "available": True,
+        "commits": commits,
+        "changed_files": changed_files[:20],
+        "error": "",
+    }
+
+
 def _read_frontmatter(path: Path) -> dict[str, Any]:
     try:
         text = path.read_text(encoding="utf-8")
@@ -255,15 +347,27 @@ def _brain(repo: Path) -> dict[str, Any]:
                 stale_item["age_days"] = age_days
                 stale.append(stale_item)
 
-    research = [
-        _file_summary(repo, path) for path in _relative_markdown_files(repo, "research")[:5]
-    ]
+    research_files = _relative_markdown_files(repo, "research")
+    research: list[dict[str, Any]] = []
+    stale_research: list[dict[str, Any]] = []
+    for path in research_files:
+        meta = _read_frontmatter(path)
+        item = _file_summary(repo, path, meta)
+        research.append(item)
+        research_date = _parse_date(meta.get("date"), path)
+        if research_date is not None:
+            age_days = (today - research_date).days
+            if age_days > STALE_RESEARCH_DAYS:
+                stale_item = dict(item)
+                stale_item["age_days"] = age_days
+                stale_research.append(stale_item)
 
     return {
         "counts": counts,
         "recent_decisions": decisions[:5],
         "stale_decisions": stale[:5],
-        "recent_research": research,
+        "recent_research": research[:5],
+        "stale_research": stale_research[:5],
     }
 
 
@@ -360,6 +464,273 @@ def _install() -> dict[str, Any]:
     }
 
 
+def _schema() -> dict[str, Any]:
+    return {
+        "name": "mainbranch.status",
+        "version": STATUS_SCHEMA_VERSION,
+        "compatibility": "v1 additions are additive; existing v1 keys must not change meaning.",
+    }
+
+
+def _marker_path(repo: Path) -> Path:
+    return repo / LAST_STATUS_SEEN_RELATIVE_PATH
+
+
+def _marker_gitignore_state(repo: Path) -> dict[str, Any]:
+    gitignore = repo / ".gitignore"
+    if not gitignore.exists():
+        return {
+            "ok": False,
+            "path": ".gitignore",
+            "entry": LAST_STATUS_SEEN_GITIGNORE_ENTRY,
+            "repair": f"Add `{LAST_STATUS_SEEN_GITIGNORE_ENTRY}` to `.gitignore`.",
+        }
+    try:
+        lines = gitignore.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        lines = []
+    ignored = LAST_STATUS_SEEN_GITIGNORE_ENTRY in {line.strip() for line in lines}
+    return {
+        "ok": ignored,
+        "path": ".gitignore",
+        "entry": LAST_STATUS_SEEN_GITIGNORE_ENTRY,
+        "repair": "" if ignored else f"Add `{LAST_STATUS_SEEN_GITIGNORE_ENTRY}` to `.gitignore`.",
+    }
+
+
+def _read_last_seen_marker(repo: Path) -> dict[str, Any]:
+    path = _marker_path(repo)
+    if not path.exists():
+        return {
+            "exists": False,
+            "path": LAST_STATUS_SEEN_RELATIVE_PATH.as_posix(),
+            "error": "",
+        }
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return {
+            "exists": True,
+            "path": LAST_STATUS_SEEN_RELATIVE_PATH.as_posix(),
+            "error": f"could not read last status marker: {exc}",
+        }
+    return data if isinstance(data, dict) else {"exists": True, "error": "invalid marker shape"}
+
+
+def _brain_count_changes(
+    current_counts: dict[str, int],
+    previous_counts: dict[str, Any],
+) -> list[dict[str, Any]]:
+    changes: list[dict[str, Any]] = []
+    for folder, current in sorted(current_counts.items()):
+        try:
+            previous = int(previous_counts.get(folder, 0))
+        except (TypeError, ValueError):
+            previous = 0
+        delta = current - previous
+        if delta:
+            changes.append({"folder": folder, "before": previous, "after": current, "delta": delta})
+    return changes
+
+
+def _since_last_check(
+    repo: Path,
+    *,
+    marker: dict[str, Any],
+    git: dict[str, Any],
+    brain: dict[str, Any],
+    generated_at: str,
+) -> dict[str, Any]:
+    marker_exists = bool(marker.get("exists", True)) and not marker.get("error")
+    previous_seen_at = str(marker.get("seen_at") or "") if marker_exists else ""
+    previous_brain_raw = marker.get("brain")
+    previous_brain: dict[str, Any] = (
+        previous_brain_raw if isinstance(previous_brain_raw, dict) else {}
+    )
+    previous_counts_raw = previous_brain.get("counts")
+    previous_counts: dict[str, Any] = (
+        previous_counts_raw if isinstance(previous_counts_raw, dict) else {}
+    )
+    git_since: dict[str, Any] = (
+        _git_since_last_seen(repo, git, marker)
+        if marker_exists
+        else {
+            "available": bool(git.get("inside_work_tree")),
+            "commits": [],
+            "changed_files": [],
+            "error": "",
+        }
+    )
+    count_changes = _brain_count_changes(brain.get("counts") or {}, previous_counts)
+    dirty_count = int(git.get("dirty_count") or 0)
+    commits = git_since.get("commits") or []
+    changed_files = git_since.get("changed_files") or []
+    summary = {
+        "commits": len(commits) if isinstance(commits, list) else 0,
+        "files_changed": len(changed_files) if isinstance(changed_files, list) else 0,
+        "dirty_files": dirty_count,
+        "brain_count_changes": len(count_changes),
+    }
+    first_run = not marker_exists
+    return {
+        "ok": not bool(marker.get("error")),
+        "marker_path": LAST_STATUS_SEEN_RELATIVE_PATH.as_posix(),
+        "marker_gitignore": _marker_gitignore_state(repo),
+        "previous_seen_at": previous_seen_at,
+        "current_seen_at": generated_at,
+        "first_run": first_run,
+        "summary": summary,
+        "git": git_since,
+        "brain_count_changes": count_changes,
+        "error": str(marker.get("error") or ""),
+        "safe_to_share": True,
+    }
+
+
+def _write_last_seen_marker(repo: Path, report: dict[str, Any]) -> dict[str, Any]:
+    if not report["repo"].get("looks_like_mainbranch_repo"):
+        return {
+            "attempted": False,
+            "ok": False,
+            "reason": "not a Main Branch repo",
+            "path": LAST_STATUS_SEEN_RELATIVE_PATH.as_posix(),
+        }
+    marker = {
+        "kind": "mainbranch.status.last_seen",
+        "schema_version": STATUS_SCHEMA_VERSION,
+        "seen_at": report["generated_at"],
+        "repo": str(repo),
+        "git": {
+            "branch": str(report["git"].get("branch") or ""),
+            "commit": str(report["git"].get("commit") or ""),
+        },
+        "brain": {"counts": report["brain"].get("counts") or {}},
+        "readiness": {
+            "level": str(report["readiness"].get("level") or ""),
+            "score": int(report["readiness"].get("score") or 0),
+        },
+        "safe_to_share": True,
+    }
+    path = _marker_path(repo)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(marker, indent=2) + "\n", encoding="utf-8")
+    except OSError as exc:
+        return {
+            "attempted": True,
+            "ok": False,
+            "reason": str(exc),
+            "path": LAST_STATUS_SEEN_RELATIVE_PATH.as_posix(),
+        }
+    return {
+        "attempted": True,
+        "ok": True,
+        "reason": "",
+        "path": LAST_STATUS_SEEN_RELATIVE_PATH.as_posix(),
+    }
+
+
+def _drift(report: dict[str, Any]) -> dict[str, Any]:
+    items: list[dict[str, Any]] = []
+    stale_decisions = report["brain"].get("stale_decisions") or []
+    if stale_decisions:
+        items.append(
+            {
+                "id": "stale_decisions",
+                "severity": "warn",
+                "summary": f"{len(stale_decisions)} proposed/running decision(s) are stale.",
+                "evidence": [item["path"] for item in stale_decisions[:5]],
+                "repair": "Review stale proposed/running decisions in `decisions/`.",
+                "safe_to_share": True,
+            }
+        )
+    stale_research = report["brain"].get("stale_research") or []
+    if stale_research:
+        items.append(
+            {
+                "id": "stale_research",
+                "severity": "info",
+                "summary": (
+                    f"{len(stale_research)} research note(s) are older than "
+                    "current freshness rules."
+                ),
+                "evidence": [item["path"] for item in stale_research[:5]],
+                "repair": "Refresh or supersede stale research before using it for decisions.",
+                "safe_to_share": True,
+            }
+        )
+    onboarding_summary = (report.get("onboarding") or {}).get("summary") or {}
+    if onboarding_summary.get("status") == "in_progress":
+        items.append(
+            {
+                "id": "incomplete_onboarding",
+                "severity": "warn",
+                "summary": (
+                    f"{onboarding_summary.get('completed_required', 0)}/"
+                    f"{onboarding_summary.get('total_required', 0)} required onboarding "
+                    "steps complete."
+                ),
+                "evidence": list(onboarding_summary.get("missing_inputs") or [])[:5],
+                "repair": str(
+                    onboarding_summary.get("next_recommended_action")
+                    or "Run `mb onboard status` to resume onboarding."
+                ),
+                "safe_to_share": True,
+            }
+        )
+    skill_wiring = report["runtime"].get("skill_wiring") or {}
+    if not skill_wiring.get("ok"):
+        items.append(
+            {
+                "id": "broken_skill_wiring",
+                "severity": "error",
+                "summary": "Claude Code skill wiring is missing or unhealthy.",
+                "evidence": list(skill_wiring.get("missing") or [])[:5],
+                "repair": str(skill_wiring.get("repair") or "Run `mb skill link --repo .`."),
+                "safe_to_share": True,
+            }
+        )
+    broken_integrations = [
+        item
+        for item in (report.get("integrations") or {}).get("providers", [])
+        if item.get("connected") and not item.get("ok")
+    ]
+    if broken_integrations:
+        items.append(
+            {
+                "id": "unhealthy_integrations",
+                "severity": "warn",
+                "summary": f"{len(broken_integrations)} declared integration(s) need repair.",
+                "evidence": [
+                    f"{item['provider']}:{item['state']}" for item in broken_integrations[:5]
+                ],
+                "repair": str(broken_integrations[0].get("repair_command") or "mb connect doctor"),
+                "safe_to_share": True,
+            }
+        )
+    if not report["since_last_check"]["marker_gitignore"]["ok"]:
+        items.append(
+            {
+                "id": "status_marker_not_gitignored",
+                "severity": "info",
+                "summary": "The local status marker is not ignored by git yet.",
+                "evidence": [LAST_STATUS_SEEN_GITIGNORE_ENTRY],
+                "repair": report["since_last_check"]["marker_gitignore"]["repair"],
+                "safe_to_share": True,
+            }
+        )
+    return {
+        "ok": not any(item["severity"] == "error" for item in items),
+        "summary": {
+            "total": len(items),
+            "errors": len([item for item in items if item["severity"] == "error"]),
+            "warnings": len([item for item in items if item["severity"] == "warn"]),
+            "info": len([item for item in items if item["severity"] == "info"]),
+        },
+        "items": items,
+    }
+
+
 def _readiness(report: dict[str, Any]) -> dict[str, Any]:
     checks = [
         {
@@ -405,6 +776,8 @@ def _readiness(report: dict[str, Any]) -> dict[str, Any]:
         )
     if report["brain"]["stale_decisions"]:
         next_actions.append("Review stale proposed/running decisions in `decisions/`.")
+    if report["brain"].get("stale_research"):
+        next_actions.append("Refresh or supersede stale research before relying on it.")
     onboarding_summary = (report.get("onboarding") or {}).get("summary") or {}
     if onboarding_summary.get("status") == "in_progress":
         next_actions.append(
@@ -419,6 +792,9 @@ def _readiness(report: dict[str, Any]) -> dict[str, Any]:
     for item in integration_repairs[:3]:
         command = str(item.get("repair_command") or "mb connect doctor")
         next_actions.append(f"Repair {item['provider']} integration: `{command}`.")
+    marker_gitignore = (report.get("since_last_check") or {}).get("marker_gitignore") or {}
+    if marker_gitignore and not marker_gitignore.get("ok") and marker_gitignore.get("repair"):
+        next_actions.append(str(marker_gitignore["repair"]))
     github_context = report["github"].get("context") or {}
     if github_context and not github_context.get("ok"):
         command = str(github_context.get("repair_command") or "gh auth login")
@@ -443,14 +819,25 @@ def _readiness(report: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def run(path: str = ".") -> dict[str, Any]:
+def run(
+    path: str = ".",
+    *,
+    update_marker: bool = True,
+    now: datetime | None = None,
+) -> dict[str, Any]:
     """Build a deterministic daily briefing report."""
     repo_path = Path(path).resolve()
+    generated_at = _format_timestamp(now or _utc_now())
     repo_shape = _looks_like_mainbranch_repo(repo_path)
     git = _git_info(repo_path)
     update = package_update_status(repo_path)
     github = _github(repo_path, git)
+    brain = _brain(repo_path)
+    marker = _read_last_seen_marker(repo_path)
     report: dict[str, Any] = {
+        "schema_version": STATUS_SCHEMA_VERSION,
+        "schema": _schema(),
+        "generated_at": generated_at,
         "ok": True,
         "repo": {"path": str(repo_path), **repo_shape},
         "install": _install(),
@@ -458,21 +845,44 @@ def run(path: str = ".") -> dict[str, Any]:
         "runtime": _runtime(repo_path),
         "git": git,
         "git_activity": _git_recent_activity(repo_path, git),
-        "brain": _brain(repo_path),
+        "brain": brain,
         "onboarding": onboard_mod.onboarding_status(repo_path),
         "integrations": connect_mod.status_all(repo_path, github=github.get("context")),
         "github": github,
     }
+    report["since_last_check"] = _since_last_check(
+        repo_path,
+        marker=marker,
+        git=git,
+        brain=brain,
+        generated_at=generated_at,
+    )
+    report["drift"] = _drift(report)
     report["readiness"] = _readiness(report)
     report["ok"] = report["readiness"]["level"] != "not_ready"
+    report["marker_update"] = (
+        _write_last_seen_marker(repo_path, report)
+        if update_marker
+        else {
+            "attempted": False,
+            "ok": False,
+            "reason": "disabled",
+            "path": LAST_STATUS_SEEN_RELATIVE_PATH.as_posix(),
+        }
+    )
     return report
 
 
-def render_human(report: dict[str, Any]) -> None:
+def render_human(
+    report: dict[str, Any],
+    *,
+    verbose: bool = False,
+    no_color: bool = False,
+) -> None:
     """Print a concise terminal briefing."""
     from rich.console import Console
 
-    console = Console()
+    console = Console(no_color=no_color)
     repo = report["repo"]
     git = report["git"]
     runtime = report["runtime"]
@@ -484,6 +894,8 @@ def render_human(report: dict[str, Any]) -> None:
     )
     github = report["github"]
     readiness = report["readiness"]
+    since = report.get("since_last_check") or {}
+    drift = report.get("drift") or {"summary": {"total": 0}, "items": []}
 
     console.print(f"\n[bold]mb status[/bold]  {repo['path']}")
     alert = format_update_alert(report.get("update", {}))
@@ -493,6 +905,39 @@ def render_human(report: dict[str, Any]) -> None:
     console.print(
         f"[bold]{readiness['level'].replace('_', ' ')}[/bold]  {readiness['score']}/100\n"
     )
+
+    since_summary = since.get("summary") or {}
+    if since.get("first_run"):
+        console.print(
+            f"[bold]Since last check[/bold] first run; recording {since.get('marker_path')}."
+        )
+    else:
+        previous_seen = str(since.get("previous_seen_at") or "unknown")
+        console.print(
+            "[bold]Since last check[/bold] "
+            f"{since_summary.get('commits', 0)} commit(s), "
+            f"{since_summary.get('files_changed', 0)} tracked file change(s), "
+            f"{since_summary.get('dirty_files', 0)} dirty file(s), "
+            f"{since_summary.get('brain_count_changes', 0)} brain count change(s) "
+            f"since {previous_seen}"
+        )
+    if since.get("error"):
+        console.print(f"  [yellow]degraded:[/yellow] {since['error']}")
+
+    drift_summary = drift.get("summary") or {}
+    if drift_summary.get("total", 0):
+        console.print(
+            "[bold]Drift[/bold] "
+            f"{drift_summary.get('errors', 0)} error(s), "
+            f"{drift_summary.get('warnings', 0)} warning(s), "
+            f"{drift_summary.get('info', 0)} info"
+        )
+        for item in (drift.get("items") or [])[:5]:
+            console.print(f"  - {item['severity']}: {item['summary']}")
+            if verbose and item.get("repair"):
+                console.print(f"    next: {item['repair']}")
+    else:
+        console.print("[bold]Drift[/bold] no stale or broken status signals detected")
 
     repo_mark = (
         "[green]yes[/green]" if repo["looks_like_mainbranch_repo"] else "[yellow]no[/yellow]"
@@ -522,7 +967,7 @@ def render_human(report: dict[str, Any]) -> None:
             f"needs repair {integration_summary['needs_repair']}"
         )
         for item in integrations.get("providers", []):
-            if not item["ok"]:
+            if not item["ok"] and verbose:
                 console.print(
                     f"  - {item['provider']}: {item['state']}  next: {item['repair_command']}"
                 )
@@ -535,22 +980,26 @@ def render_human(report: dict[str, Any]) -> None:
         f"campaigns {counts['campaigns']}  log {counts['log']}  documents {counts['documents']}"
     )
 
-    if brain["recent_decisions"]:
+    if verbose and brain["recent_decisions"]:
         console.print("\n[bold]Recent decisions[/bold]")
         for item in brain["recent_decisions"][:3]:
             suffix = f" [{item['status']}]" if item["status"] else ""
             console.print(f"  - {item['date'] or item['updated_at'][:10]}  {item['title']}{suffix}")
-    if brain["stale_decisions"]:
+    if verbose and brain["stale_decisions"]:
         console.print("[yellow]Stale proposed/running decisions[/yellow]")
         for item in brain["stale_decisions"][:3]:
             console.print(f"  - {item['path']} ({item['age_days']} days)")
-    if brain["recent_research"]:
+    if verbose and brain.get("stale_research"):
+        console.print("[yellow]Stale research[/yellow]")
+        for item in brain["stale_research"][:3]:
+            console.print(f"  - {item['path']} ({item['age_days']} days)")
+    if verbose and brain["recent_research"]:
         console.print("\n[bold]Recent research[/bold]")
         for item in brain["recent_research"][:3]:
             console.print(f"  - {item['date'] or item['updated_at'][:10]}  {item['title']}")
 
     onboarding_summary = onboarding.get("summary") or {}
-    if onboarding_summary.get("status") == "in_progress":
+    if verbose and onboarding_summary.get("status") == "in_progress":
         console.print("\n[bold]Onboarding[/bold]")
         console.print(
             "  "
@@ -562,7 +1011,7 @@ def render_human(report: dict[str, Any]) -> None:
             console.print(f"  missing: {', '.join(missing[:5])}")
         console.print(f"  next: {onboarding_summary.get('next_recommended_action')}")
 
-    if report["git_activity"]["items"]:
+    if verbose and report["git_activity"]["items"]:
         console.print("\n[bold]Recent git activity[/bold]")
         for item in report["git_activity"]["items"][:3]:
             files = ", ".join(item["files"][:2])
@@ -583,29 +1032,35 @@ def render_human(report: dict[str, Any]) -> None:
     else:
         summary = github.get("summary") or {}
         sections = github.get("sections") or {}
-        console.print(
-            f"  tasks assigned: {summary.get('assigned_tasks', len(github['assigned_issues']))}  "
-            f"attention: {summary.get('attention_requests', len(github['review_requests']))}  "
-            f"open proposals: {summary.get('open_proposals', 0)}  "
-            "shipped this week: "
-            f"{summary.get('shipped_this_week', len(github['recent_merged_prs']))}"
+        assigned_count = summary.get("assigned_tasks", len(github.get("assigned_issues", [])))
+        attention_count = summary.get(
+            "attention_requests",
+            len(github.get("review_requests", [])),
         )
-        assigned_tasks = sections.get("assigned_tasks") or github["assigned_issues"]
-        attention_requests = sections.get("attention_requests") or github["review_requests"]
+        shipped_count = summary.get("shipped_this_week", len(github.get("recent_merged_prs", [])))
+        console.print(
+            f"  tasks assigned: {assigned_count}  "
+            f"attention: {attention_count}  "
+            f"open proposals: {summary.get('open_proposals', 0)}  "
+            f"shipped this week: {shipped_count}"
+        )
+        assigned_tasks = sections.get("assigned_tasks") or github.get("assigned_issues", [])
+        attention_requests = sections.get("attention_requests") or github.get("review_requests", [])
         open_proposals = sections.get("open_proposals") or []
-        shipped = sections.get("shipped_this_week") or github["recent_merged_prs"]
+        shipped = sections.get("shipped_this_week") or github.get("recent_merged_prs", [])
         blocked_or_stale = sections.get("blocked_or_stale_tasks") or []
-        for issue in assigned_tasks[:3]:
-            console.print(f"  - task #{issue['number']}: {issue['title']}")
-        for item in attention_requests[:3]:
-            reason = item.get("reason", "Needs attention")
-            console.print(f"  - attention #{item['number']}: {item['title']} ({reason})")
-        for pr in open_proposals[:3]:
-            console.print(f"  - proposal #{pr['number']}: {pr['title']}")
-        for pr in shipped[:3]:
-            console.print(f"  - shipped #{pr['number']}: {pr['what_shipped']}")
-        for issue in blocked_or_stale[:3]:
-            console.print(f"  - blocked/stale #{issue['number']}: {issue['title']}")
+        if verbose:
+            for issue in assigned_tasks[:3]:
+                console.print(f"  - task #{issue['number']}: {issue['title']}")
+            for item in attention_requests[:3]:
+                reason = item.get("reason", "Needs attention")
+                console.print(f"  - attention #{item['number']}: {item['title']} ({reason})")
+            for pr in open_proposals[:3]:
+                console.print(f"  - proposal #{pr['number']}: {pr['title']}")
+            for pr in shipped[:3]:
+                console.print(f"  - shipped #{pr['number']}: {pr['what_shipped']}")
+            for issue in blocked_or_stale[:3]:
+                console.print(f"  - blocked/stale #{issue['number']}: {issue['title']}")
         for error in github["errors"][:2]:
             console.print(f"  [yellow]degraded:[/yellow] {error}")
 

--- a/mb/tests/fixtures/status/schema-v1-basic.json
+++ b/mb/tests/fixtures/status/schema-v1-basic.json
@@ -1,0 +1,140 @@
+{
+  "schema_version": "1.0",
+  "schema_name": "mainbranch.status",
+  "top_level_keys": [
+    "brain",
+    "drift",
+    "generated_at",
+    "git",
+    "git_activity",
+    "github",
+    "install",
+    "integrations",
+    "marker_update",
+    "ok",
+    "onboarding",
+    "readiness",
+    "repo",
+    "runtime",
+    "schema",
+    "schema_version",
+    "since_last_check",
+    "update"
+  ],
+  "section_keys": {
+    "repo": [
+      "looks_like_mainbranch_repo",
+      "markers",
+      "missing_markers",
+      "path"
+    ],
+    "install": [
+      "detail",
+      "mode",
+      "ok",
+      "version"
+    ],
+    "update": [
+      "command",
+      "installed",
+      "latest",
+      "minimum_supported",
+      "post_update_commands",
+      "reason",
+      "severity"
+    ],
+    "runtime": [
+      "claude_code",
+      "skill_wiring"
+    ],
+    "git": [
+      "available",
+      "branch",
+      "commit",
+      "dirty",
+      "dirty_count",
+      "dirty_files",
+      "error",
+      "inside_work_tree",
+      "remote"
+    ],
+    "git_activity": [
+      "available",
+      "error",
+      "items"
+    ],
+    "brain": [
+      "counts",
+      "recent_decisions",
+      "recent_research",
+      "stale_decisions",
+      "stale_research"
+    ],
+    "onboarding": [
+      "boundaries",
+      "checklist",
+      "contract",
+      "ok",
+      "profile",
+      "repo",
+      "state_exists",
+      "state_path",
+      "state_valid",
+      "summary"
+    ],
+    "integrations": [
+      "config_path",
+      "github",
+      "ok",
+      "providers",
+      "repo",
+      "repo_id",
+      "safe_to_share",
+      "summary"
+    ],
+    "github": [
+      "assigned_issues",
+      "authenticated",
+      "available",
+      "context",
+      "degraded",
+      "errors",
+      "recent_merged_prs",
+      "repo",
+      "review_requests",
+      "sections",
+      "source",
+      "summary"
+    ],
+    "since_last_check": [
+      "brain_count_changes",
+      "current_seen_at",
+      "error",
+      "first_run",
+      "git",
+      "marker_gitignore",
+      "marker_path",
+      "ok",
+      "previous_seen_at",
+      "safe_to_share",
+      "summary"
+    ],
+    "drift": [
+      "items",
+      "ok",
+      "summary"
+    ],
+    "readiness": [
+      "checks",
+      "level",
+      "next_actions",
+      "score"
+    ],
+    "marker_update": [
+      "attempted",
+      "ok",
+      "path",
+      "reason"
+    ]
+  }
+}

--- a/mb/tests/test_status.py
+++ b/mb/tests/test_status.py
@@ -143,6 +143,37 @@ def test_status_since_last_check_uses_repo_marker(tmp_path: Path, monkeypatch) -
     } in second_payload["since_last_check"]["brain_count_changes"]
 
 
+def test_status_peek_does_not_update_seen_marker(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+
+    first = runner.invoke(app, ["status", str(repo), "--json"])
+    marker_before = (repo / ".mb" / "last-status-seen.json").read_text(encoding="utf-8")
+    peek = runner.invoke(app, ["status", str(repo), "--json", "--peek"])
+    marker_after = (repo / ".mb" / "last-status-seen.json").read_text(encoding="utf-8")
+
+    assert first.exit_code == 0
+    assert peek.exit_code == 0
+    payload = json.loads(peek.stdout)
+    assert payload["marker_update"]["reason"] == "disabled"
+    assert marker_after == marker_before
+
+
+def test_marker_gitignore_state_honors_broader_gitignore_patterns(
+    tmp_path: Path, monkeypatch
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    runner.invoke(app, ["init", str(repo), "--name", "Acme"])
+    (repo / ".gitignore").write_text(".mb/\n", encoding="utf-8")
+
+    state = status_mod._marker_gitignore_state(repo)
+
+    assert state["ok"] is True
+    assert state["repair"] == ""
+
+
 def test_status_no_color_and_verbose_output(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
     repo = tmp_path / "acme"
@@ -223,6 +254,35 @@ def test_status_names_integration_repairs(tmp_path: Path, monkeypatch) -> None:
     assert human_result.exit_code == 0
     assert "meta: missing_secret" in human_result.stdout
     assert "mb connect meta --token-stdin" in human_result.stdout
+
+
+def test_status_drift_aligns_unhealthy_integrations_with_readiness(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+    provider = {
+        "provider": "meta",
+        "ok": False,
+        "connected": False,
+        "state": "unvalidated",
+        "repair_command": "mb connect test meta",
+    }
+    report = status_mod.run(path=str(repo), update_marker=False)
+    report["integrations"]["providers"] = [provider]
+    report["integrations"]["summary"] = {
+        "configured": 1,
+        "healthy": 0,
+        "needs_repair": 1,
+        "unvalidated": 1,
+    }
+
+    drift = status_mod._drift(report)
+    readiness = status_mod._readiness(report)
+
+    assert any(item["id"] == "unhealthy_integrations" for item in drift["items"])
+    assert any("mb connect test meta" in action for action in readiness["next_actions"])
 
 
 def test_status_detects_non_business_repo(tmp_path: Path, monkeypatch) -> None:

--- a/mb/tests/test_status.py
+++ b/mb/tests/test_status.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import shutil
 import subprocess
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -17,6 +17,7 @@ from mb.cli import app
 from mb.init import run as init_run
 
 runner = CliRunner()
+FIXTURES = Path(__file__).parent / "fixtures"
 
 
 def _without_github_or_claude(name: str) -> str:
@@ -42,6 +43,9 @@ def test_status_json_degrades_without_github(tmp_path: Path, monkeypatch) -> Non
 
     assert result.exit_code == 0
     report = json.loads(result.stdout)
+    assert report["schema_version"] == "1.0"
+    assert report["schema"]["name"] == "mainbranch.status"
+    assert report["generated_at"]
     assert report["repo"]["looks_like_mainbranch_repo"] is True
     assert report["runtime"]["skill_wiring"]["ok"] is True
     assert report["github"]["authenticated"] is False
@@ -49,8 +53,52 @@ def test_status_json_degrades_without_github(tmp_path: Path, monkeypatch) -> Non
     assert "assigned_tasks" in report["github"]["sections"]
     assert report["brain"]["counts"]["decisions"] == 1
     assert report["brain"]["recent_research"][0]["title"] == "Market"
+    assert report["since_last_check"]["first_run"] is True
+    assert report["marker_update"]["ok"] is True
+    assert (repo / ".mb" / "last-status-seen.json").is_file()
     assert "readiness" in report
     assert "update" in report
+
+
+def test_status_schema_v1_matches_golden_fixture(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+
+    payload = status_mod.run(
+        path=str(repo),
+        now=datetime(2026, 5, 4, 12, 0, tzinfo=timezone.utc),
+        update_marker=False,
+    )
+    actual = {
+        "schema_version": payload["schema_version"],
+        "schema_name": payload["schema"]["name"],
+        "top_level_keys": sorted(payload.keys()),
+        "section_keys": {
+            key: sorted(payload[key].keys())
+            for key in [
+                "repo",
+                "install",
+                "update",
+                "runtime",
+                "git",
+                "git_activity",
+                "brain",
+                "onboarding",
+                "integrations",
+                "github",
+                "since_last_check",
+                "drift",
+                "readiness",
+                "marker_update",
+            ]
+        },
+    }
+    expected = json.loads(
+        (FIXTURES / "status" / "schema-v1-basic.json").read_text(encoding="utf-8")
+    )
+
+    assert actual == expected
 
 
 def test_status_human_output_mentions_core_sections(tmp_path: Path, monkeypatch) -> None:
@@ -63,9 +111,55 @@ def test_status_human_output_mentions_core_sections(tmp_path: Path, monkeypatch)
     assert result.exit_code == 0
     assert "mb status" in result.stdout
     assert "Repo" in result.stdout
+    assert "Since last check" in result.stdout
+    assert "Drift" in result.stdout
     assert "Runtime" in result.stdout
     assert "GitHub" in result.stdout
     assert "Next" in result.stdout
+
+
+def test_status_since_last_check_uses_repo_marker(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+
+    first = runner.invoke(app, ["status", str(repo), "--json"])
+    assert first.exit_code == 0
+    first_payload = json.loads(first.stdout)
+    assert first_payload["since_last_check"]["first_run"] is True
+
+    (repo / "research" / "2026-05-02-market.md").write_text("# Market\n", encoding="utf-8")
+    second = runner.invoke(app, ["status", str(repo), "--json"])
+
+    assert second.exit_code == 0
+    second_payload = json.loads(second.stdout)
+    assert second_payload["since_last_check"]["first_run"] is False
+    assert second_payload["since_last_check"]["previous_seen_at"] == first_payload["generated_at"]
+    assert {
+        "folder": "research",
+        "before": 0,
+        "after": 1,
+        "delta": 1,
+    } in second_payload["since_last_check"]["brain_count_changes"]
+
+
+def test_status_no_color_and_verbose_output(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+    (repo / "decisions" / "2026-05-01-pricing.md").write_text(
+        "---\ndate: 2026-05-01\nstatus: accepted\n---\n\n# Pricing\n",
+        encoding="utf-8",
+    )
+
+    terse = runner.invoke(app, ["status", str(repo), "--no-color"])
+    verbose = runner.invoke(app, ["status", str(repo), "--verbose", "--no-color"])
+
+    assert terse.exit_code == 0
+    assert "\x1b[" not in terse.stdout
+    assert "Recent decisions" not in terse.stdout
+    assert verbose.exit_code == 0
+    assert "Recent decisions" in verbose.stdout
 
 
 def test_status_required_update_json_and_human_copy(tmp_path: Path, monkeypatch) -> None:
@@ -98,7 +192,7 @@ def test_status_required_update_json_and_human_copy(tmp_path: Path, monkeypatch)
         "pipx upgrade mainbranch" in action for action in payload["readiness"]["next_actions"]
     )
 
-    human_result = runner.invoke(app, ["status", str(repo)])
+    human_result = runner.invoke(app, ["status", str(repo), "--verbose"])
 
     assert human_result.exit_code == 0
     assert "Update required." in human_result.stdout
@@ -119,11 +213,12 @@ def test_status_names_integration_repairs(tmp_path: Path, monkeypatch) -> None:
     assert json_result.exit_code == 0
     payload = json.loads(json_result.stdout)
     assert payload["integrations"]["providers"][0]["state"] == "missing_secret"
+    assert any(item["id"] == "unhealthy_integrations" for item in payload["drift"]["items"])
     assert any(
         "mb connect meta --token-stdin" in action for action in payload["readiness"]["next_actions"]
     )
 
-    human_result = runner.invoke(app, ["status", str(repo)])
+    human_result = runner.invoke(app, ["status", str(repo), "--verbose"])
 
     assert human_result.exit_code == 0
     assert "meta: missing_secret" in human_result.stdout
@@ -248,13 +343,18 @@ def test_status_brain_marks_stale_decisions(tmp_path: Path, monkeypatch) -> None
         encoding="utf-8",
     )
     (repo / "research").mkdir()
-    (repo / "research" / "2026-05-01-market.md").write_text("# Market\n", encoding="utf-8")
+    old_research_date = date.today().replace(year=date.today().year - 1)
+    (repo / "research" / f"{old_research_date.isoformat()}-market.md").write_text(
+        f"---\ndate: {old_research_date.isoformat()}\n---\n\n# Market\n",
+        encoding="utf-8",
+    )
 
     brain = status_mod._brain(repo)
 
     assert brain["recent_decisions"][0]["title"] == "Old proposal"
     assert brain["stale_decisions"][0]["age_days"] > status_mod.STALE_DECISION_DAYS
     assert brain["recent_research"][0]["title"] == "Market"
+    assert brain["stale_research"][0]["age_days"] > status_mod.STALE_RESEARCH_DAYS
 
 
 def test_status_github_authenticated_branches(tmp_path: Path, monkeypatch) -> None:
@@ -535,7 +635,7 @@ def test_status_renderer_prints_optional_sections(capsys) -> None:
         "readiness": {"level": "ready", "score": 100, "next_actions": ["Run `claude`."]},
     }
 
-    status_mod.render_human(report)
+    status_mod.render_human(report, verbose=True, no_color=True)
 
     output = capsys.readouterr().out
     assert "Recent decisions" in output


### PR DESCRIPTION
## Summary
- Makes `mb status` the v1 See/Decide briefing surface with since-last-check state, deterministic drift signals, and schema metadata for agents and future dashboard consumers.
- Adds `.mb/last-status-seen.json` as repo-local operational state, with non-mutating `--peek` reads and broad `.gitignore` pattern detection.
- Keeps default human output tight while preserving detail through `--verbose`, `--no-color`, and the additive `--json` schema v1.0.
- Adds golden fixture and focused tests for schema shape, marker behavior, drift, no-color, verbose output, and integration/readiness alignment.

## Scope
- In: `mb status` schema v1.0, since-last-check marker, deterministic drift detection, `--verbose`, `--no-color`, `--peek`, template gitignore coverage, docs/changelog updates, and status tests.
- Out: dashboard UI, LLM ranking, background process state, new runtime support claims, and `/mb-start` skill changes.

## Commits
- `94debe7` — `[add] MAIN-216 status v1 daily briefing`
- `bcf57bf` — `[fix] MAIN-216 refine status marker reads`

## Release / Issues
- Release: v0.3.0 - Knows what to do next
- Linear ID(s): MAIN-216
- Closes: #261
- Refs: #262, #263
- Follow-ups: existing next-action ranker and skill reconciliation issues remain out of scope.

## Success Metric
- A user can run `mb status` from a business repo and understand what changed since their last check, what is stale or broken, and what evidence-backed status data an agent should use next.

## Validation
- Level 0 docs/decision: README and CHANGELOG updated; public/private boundary checked.
- Level 1 static: `scripts/check.sh` passed, including ruff, mypy, coverage, and skill validation.
- Level 2 CLI: `scripts/check.sh` passed 169 tests; focused `tests/test_status.py` passed 19 tests.
- Level 3 package/install: wheel build, venv install, `mb --version`, `mb skill list`, onboard, status schema v1, `status --peek`, repeated marker behavior, and `start --json` passed.
- Level 4 fixture repo: onboard, doctor, status, `status --peek`, repeated marker behavior, `start --json`, and validate passed.
- Level 5 runtime smoke: not run; this PR changes deterministic CLI/status reads only, not skill discovery or runtime invocation.

## Public / Private Boundary
- No secrets, customer/member data, private local paths, or Conductor workflow notes were committed; `.context/` stayed local scratch only.
