### PR TITLE
[add] bets primitive and mb-bet workflow

### DIFF
--- a/.claude/skills/mb-bet/SKILL.md
+++ b/.claude/skills/mb-bet/SKILL.md
@@ -1,0 +1,206 @@
+---
+name: mb-bet
+description: "Open, update, close, list, and narrate Main Branch business bets from repo truth. Use when the operator wants to frame an operating bet, track progress, capture a verdict, or draft public-safe narration."
+---
+
+# Bet
+
+Business bets are hub nodes in `bets/`. They connect decisions, research,
+campaigns, logs, documents, and outcomes without replacing any of them.
+
+Use `/mb-bet` for five modes:
+
+- `new` - open a bet with hypothesis, appetite, metric, target, deadline, and links.
+- `update` - add progress and link new evidence.
+- `close` - record result, verdict, learning, and follow-up links.
+- `list` - summarize active bets and deadlines.
+- `narrate` - draft public-safe site, community, or social copy from repo truth.
+
+Do not publish automatically. Narration drafts are files or message drafts only.
+
+## Repo Rules
+
+Work from the business repo. If unsure, confirm that `core/`, `research/`,
+`decisions/`, or `bets/` exists in the current directory. If not, ask the
+operator to start Claude from the business repo or run `/mb-start`.
+
+Before writing, run:
+
+```bash
+mb status --json
+```
+
+Use the result to spot active bets and repo readiness. After writing or editing
+bet files, run:
+
+```bash
+mb validate --cross-refs
+```
+
+If validation warns about missing bidirectional bet links, repair the linked
+file frontmatter when it is clearly in scope.
+
+## Bet Frontmatter
+
+Every bet file lives at `bets/YYYY-MM-DD-slug.md` and uses this frontmatter:
+
+```yaml
+---
+status: open
+opened: YYYY-MM-DD
+deadline: YYYY-MM-DD
+appetite: "2 weeks"
+hypothesis: "If we do X for Y, Z will happen because..."
+metric: "qualified calls booked"
+target: "10 qualified calls by deadline"
+result: ""
+linked_decisions: []
+linked_research: []
+linked_campaigns: []
+linked_outcomes: []
+public: false
+channels: []
+tags: []
+---
+```
+
+Allowed statuses: `open`, `paused`, `closed`, `canceled`.
+
+Use repo-relative paths in link fields:
+
+- `linked_decisions`: `decisions/*.md`
+- `linked_research`: `research/*.md`
+- `linked_campaigns`: `campaigns/*/campaign.md` or campaign artifacts
+- `linked_outcomes`: `log/*.md`, `documents/*.md`, or outcome artifacts
+
+When linking an existing file to a bet, add the reverse link too:
+
+```yaml
+linked_bets:
+  - bets/YYYY-MM-DD-slug.md
+```
+
+## Mode: new
+
+Use when the operator says they want to try, launch, test, prove, or make a bet.
+
+1. Ask only for missing essentials: hypothesis, appetite, deadline, metric,
+   target, public/private posture, channels, and any known linked files.
+2. Create `bets/YYYY-MM-DD-slug.md`.
+3. Add reverse `linked_bets` frontmatter to linked decisions, research,
+   campaigns, and outcome files when those files already exist and the edit is
+   clearly safe.
+4. End with the file path, deadline, target, and next action.
+
+Body template:
+
+```markdown
+# Bet Title
+
+## Why This Bet
+
+[The operating tension or opportunity.]
+
+## Hypothesis
+
+[Same claim as frontmatter, with context.]
+
+## Work Plan
+
+- [ ] [Concrete action]
+
+## Evidence Log
+
+- YYYY-MM-DD - Bet opened.
+
+## Result
+
+Open.
+
+## Narration Notes
+
+[Public-safe angles, claims to avoid, proof needed before sharing.]
+```
+
+## Mode: update
+
+Use when work happened but the bet is not finished.
+
+1. Read the bet and linked files.
+2. Append a dated `Evidence Log` entry.
+3. Update `linked_decisions`, `linked_research`, `linked_campaigns`, or
+   `linked_outcomes` if new files now matter.
+4. Keep `result` blank unless there is a real result.
+5. Repair reverse `linked_bets` fields on newly linked files.
+
+## Mode: close
+
+Use when the deadline passed, the target is hit, or the operator decides to stop.
+
+1. Ask for the actual result if repo evidence is not enough.
+2. Set `status: closed` or `status: canceled`.
+3. Fill `result` with the measured outcome and verdict.
+4. Add a `## Learning` section or update it if present.
+5. Link outcome files and add reverse `linked_bets` fields.
+6. Suggest follow-up decisions or issues only when the next step is concrete.
+
+## Mode: list
+
+Summarize active bets from `mb status --json` and direct file reads:
+
+- deadline
+- status
+- target
+- metric
+- public/private posture
+- blocked or overdue signals
+
+Keep it short. End with the next bet that needs attention.
+
+## Mode: narrate
+
+Draft public-safe narration from the bet and linked repo truth. Do not invent
+results, metrics, claims, testimonials, or publishing channels.
+
+Ask the operator which surface if unclear:
+
+1. site
+2. community
+3. social
+
+Draft format:
+
+```markdown
+# Narration Draft
+
+Surface: [site/community/social]
+Source bet: bets/YYYY-MM-DD-slug.md
+
+## Public Angle
+
+[What can be shared safely.]
+
+## Draft
+
+[Post or page copy.]
+
+## Claims To Verify
+
+- [Any metric, result, or proof that needs source confirmation.]
+
+## Source Links
+
+- [repo-relative paths read]
+```
+
+If the bet has `public: false`, ask before drafting public copy. Offer a private
+internal retrospective instead.
+
+## Exit
+
+Tell the operator what changed, which files were linked, whether validation
+passed, and the exact next command:
+
+```bash
+mb status
+```

--- a/.claude/skills/mb-help/SKILL.md
+++ b/.claude/skills/mb-help/SKILL.md
@@ -27,6 +27,7 @@ Answer questions, troubleshoot issues, explain philosophy, suggest next steps.
 | Two repos, engine, data model, data model | [two-repos.md](references/two-repos.md) |
 | Philosophy, why, compound, passive memory | [philosophy.md](references/philosophy.md) |
 | /mb-think, research, decide, codify | [the-think-cycle.md](references/the-think-cycle.md) |
+| /mb-bet, bet, hypothesis, deadline, public narration | [skills-guide.md](references/skills-guide.md) |
 | Task tracking, where left off, focus | [task-tracking-options.md](references/task-tracking-options.md) |
 | Error, command not found, MCP, Apify setup | [troubleshooting.md](references/troubleshooting.md) |
 | Getting started, setup | Route to `/mb-setup` or `/mb-start` |

--- a/.claude/skills/mb-help/references/skills-guide.md
+++ b/.claude/skills/mb-help/references/skills-guide.md
@@ -55,6 +55,24 @@ See [the-think-cycle.md](the-think-cycle.md) for deep dive.
 
 ---
 
+### /mb-bet - Business Bets
+**Use when:** Opening, updating, closing, listing, or narrating an operating bet.
+
+**What it does:**
+- Creates `bets/YYYY-MM-DD-slug.md` with hypothesis, appetite, metric, target, and deadline
+- Links bets to decisions, research, campaigns, and outcomes
+- Captures verdicts and learning when a bet closes
+- Drafts public-safe narration without publishing automatically
+
+**Modes:**
+- `/mb-bet new` - Open a bet
+- `/mb-bet update` - Add progress and evidence
+- `/mb-bet close` - Record result and learning
+- `/mb-bet list` - Summarize active bets and deadlines
+- `/mb-bet narrate` - Draft site, community, or social narration from repo truth
+
+---
+
 ### /mb-ads - Ad Generation and Review
 **Use when:** Need copy for static ads, video ad scripts, or compliance review.
 

--- a/.claude/skills/mb-setup/SKILL.md
+++ b/.claude/skills/mb-setup/SKILL.md
@@ -167,7 +167,7 @@ See **[references/context-gathering.md](references/context-gathering.md)** for:
 # Always create:
 mkdir -p .vip
 mkdir -p reference/core reference/visual-identity reference/proof/angles reference/domain
-mkdir -p research decisions campaigns documents
+mkdir -p research decisions bets log campaigns documents
 ```
 
 **Multi-offer only (if user has multiple offers from Step 2.5):**
@@ -216,6 +216,11 @@ Full structure (single-offer):
 │
 ├── decisions/             # Dated choices with rationale
 │   └── YYYY-MM-DD-topic.md
+│
+├── bets/                  # Operating bets with target, deadline, and result
+│   └── YYYY-MM-DD-topic.md
+│
+├── log/                   # Running activity log
 │
 └── outputs/               # All generated content (lifecycle via frontmatter status)
     └── YYYY-MM-DD-batch-name/

--- a/.claude/skills/mb-start/SKILL.md
+++ b/.claude/skills/mb-start/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mb-start
-description: "Main entry point for Main Branch. Detects state and routes to the right skill. Use when: user says start/help/begin, is new/returning/lost, opens Main Branch without a task, or needs triage. Routes to /mb-setup, /mb-think, /mb-ads, /mb-vsl, /mb-organic, /mb-wiki, /mb-help."
+description: "Main entry point for Main Branch. Detects state and routes to the right skill. Use when: user says start/help/begin, is new/returning/lost, opens Main Branch without a task, or needs triage. Routes to /mb-setup, /mb-think, /mb-bet, /mb-ads, /mb-vsl, /mb-organic, /mb-wiki, /mb-help."
 ---
 
 # Start
@@ -99,6 +99,7 @@ Apply to: business repo selection, skill routing, any multiple choice.
 ├── Ready to work? ───────────────────→ Route by intent:
 │   │
 │   ├── "research" / "decide" ────────→ /mb-think
+│   ├── "bet" / "launch test" ─────────→ /mb-bet (new/update/close/list/narrate)
 │   ├── "ads" / "copy" ───────────────→ /mb-ads (triages to static/video/review)
 │   ├── "vsl" / "sales video" ────────→ /mb-vsl (triages to skool/b2b)
 │   ├── "content" / "organic" ────────→ /mb-organic

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ### Added
 
+- Added `bets/` as a first-class business-repo primitive with validation,
+  graph links, `mb status` active-deadline reporting, and the new `/mb-bet`
+  Claude Code workflow for `new`, `update`, `close`, `list`, and `narrate`.
 - Added public ethos, operator-loop, and roadmap docs so future product work can
   anchor to the Know -> See -> Decide -> Execute -> Narrate loop and the
   current v0.3/v0.4 release direction.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You're renting your business. Not just the dashboards — the operational memory
 
 The open-source gap closed in 2025. The tools to own your stack exist now. Almost nobody has carved time to migrate, because there's no coherent environment that ties it together.
 
-Main Branch is that environment. Your offer, audience, voice, decisions, research, and campaigns live as markdown files in a git repo you own. The `mb` CLI scaffolds it. The bundled skills read those files and produce work that sounds like you — without re-prompting.
+Main Branch is that environment. Your offer, audience, voice, decisions, research, bets, and campaigns live as markdown files in a git repo you own. The `mb` CLI scaffolds it. The bundled skills read those files and produce work that sounds like you — without re-prompting.
 
 The end state isn't sitting at a terminal all day. It's the opposite — eventually you dump thoughts from your phone, drafts get made, you approve, it executes. We're not all the way there. The work is still real. But the substrate is the right one to build on.
 
@@ -30,7 +30,7 @@ Own the work. Rent only the rails.
 
 ## What it is
 
-Main Branch is the `mb` CLI plus MIT-licensed agent workflows for running business-as-files systems. Today the workflows ship for Claude Code; Codex, Cursor, OpenClaw, Hermes, and local runtimes are next. Your offer, audience, voice, research, decisions, and campaigns live in six folders inside your own git repo — versioned, portable, agent-readable.
+Main Branch is the `mb` CLI plus MIT-licensed agent workflows for running business-as-files systems. Today the workflows ship for Claude Code; Codex, Cursor, OpenClaw, Hermes, and local runtimes are next. Your offer, audience, voice, research, decisions, bets, and campaigns live in your own git repo — versioned, portable, agent-readable.
 
 Read the product frame in [docs/ETHOS.md](docs/ETHOS.md), the user loop in
 [docs/OPERATOR-LOOPS.md](docs/OPERATOR-LOOPS.md), and the release direction in
@@ -78,6 +78,7 @@ git clone https://github.com/noontide-co/mainbranch.git
 Once set up, you can:
 
 - Research topics and document decisions
+- Open, update, close, and narrate business bets
 - Generate batches of ad copy in your voice
 - Create video scripts for Meta ads
 - Generate organic content — Reels, TikTok, carousels — from your reference files and research
@@ -116,6 +117,7 @@ my-business/
 │   └── finance/
 ├── research/
 ├── decisions/
+├── bets/
 ├── log/
 ├── campaigns/
 └── documents/
@@ -150,11 +152,11 @@ The CLI surface for the engine. Built for Claude Code first; runtime-agnostic by
 |---|---|
 | `mb onboard` | Human setup flow: create or connect a business repo, explain the substrate, wire Claude Code skills, and show the next `/mb-start` step. |
 | `mb onboard status` | Show durable onboarding progress from `.mb/onboarding.json`, including missing core-reference inputs and the next recommended action. |
-| `mb init` | Set up a fresh business repo (six folders, CLAUDE.md, git init). |
-| `mb status` | Show a local-first daily briefing: repo health, runtime wiring, recent decisions/research/git activity, and GitHub tasks when `gh` is authenticated. |
+| `mb init` | Set up a fresh business repo (business folders, CLAUDE.md, git init). |
+| `mb status` | Show a local-first daily briefing: repo health, runtime wiring, recent decisions/research/bets/git activity, and GitHub tasks when `gh` is authenticated. |
 | `mb doctor` | Check the environment — repo shape, frontmatter sanity, settings on disk. Walks you through fixes. |
 | `mb connect` | Register provider credentials, test provider health, and inspect repair-safe integration status without committing secrets. |
-| `mb validate` | Frontmatter shape check across `core/`, `research/`, `decisions/`, `log/`, `campaigns/`, `documents/`. Pass/fail per file. |
+| `mb validate` | Frontmatter shape check across `core/`, `research/`, `decisions/`, `bets/`, `log/`, `campaigns/`, `documents/`. Pass/fail per file. |
 | `mb graph` | Build a repo graph index from frontmatter links, wikilinks, and entity tags. Emits Graphviz DOT by default, `--json` for agents/dashboards, and `--open` to render a PNG view. |
 | `mb think <topic>` | Print the `/mb-think` invocation hint. Run inside Claude Code for the full flow. |
 | `mb resolve <key>` | Resolve a reference path (checks free first, then paid). |
@@ -209,6 +211,7 @@ Skills are pre-built workflows you invoke with slash prompts. Instead of figurin
 | `/mb-start` | Main entry point — figures out what you need and routes you there |
 | `/mb-setup` | Set up your business repo (run this first if you're new) |
 | `/mb-think` | Research, make decisions, add context, transcribe local recordings, update reference files |
+| `/mb-bet` | Open, update, close, list, and narrate business bets |
 | `/mb-ads` | Create ad copy (static or video) and review for compliance |
 | `/mb-vsl` | Write video sales letter scripts (Skool or B2B) |
 | `/mb-organic` | Generate organic content — Reels, TikTok, carousels |
@@ -314,7 +317,7 @@ repairs or layout migrations.
 You can, but you don't need to. They're designed to work out of the box.
 
 **What makes this different from ChatGPT?**
-ChatGPT is a chat surface that resets between sessions. Main Branch is a CLI plus a skill set that reads files Claude can re-read every session — your offer, audience, voice, decisions, research — so outputs stay consistent with your business instead of restarting from zero.
+ChatGPT is a chat surface that resets between sessions. Main Branch is a CLI plus a skill set that reads files Claude can re-read every session — your offer, audience, voice, decisions, research, and bets — so outputs stay consistent with your business instead of restarting from zero.
 
 **I'm stuck. What do I do?**
 Type `/mb-start` again. It picks up where you left off.

--- a/decisions/2026-05-04-sidecar-enrichment-cli-contract.md
+++ b/decisions/2026-05-04-sidecar-enrichment-cli-contract.md
@@ -1,0 +1,434 @@
+---
+type: decision
+date: 2026-05-04
+status: accepted
+topic: Sidecar enrichment CLI contract
+linked_decisions:
+  - decisions/2026-05-01-mb-cli-vs-agent-workflows-boundary.md
+  - decisions/2026-05-02-github-native-business-os.md
+  - decisions/2026-05-04-skill-cli-runtime-adapter-contract.md
+linked_issues:
+  - https://github.com/noontide-co/mainbranch/issues/265
+participants: [Devon, Codex]
+tags: [v0-3, sidecars, integrations, cli, context, product-boundary]
+---
+
+# Sidecar Enrichment CLI Contract
+
+## Decision
+
+Main Branch should support optional context-enrichment sidecars through a
+narrow, one-shot CLI contract. A sidecar is an external provider tool that does
+one specialized job, returns a stable JSON envelope, and exits. `mb` may
+discover, connect, health-check, invoke, cache, and summarize sidecar output,
+but the sidecar must not become a hard dependency of the core engine.
+
+The first reference sidecar is `companyctx` for public company context. It is a
+reference implementation, not a required install. Main Branch must continue to
+work when `companyctx` is missing, unauthenticated, degraded, or replaced by a
+different provider.
+
+Sidecars enrich the Know, See, and Execute loops:
+
+- Know: fetch public or external context that helps a business repo understand
+  offers, markets, customers, competitors, and constraints.
+- See: report whether connected context providers are configured, healthy,
+  stale, or degraded.
+- Execute: give skills and future dashboards structured facts without making
+  each workflow invent a new integration style.
+
+The core rule is simple: sidecars return evidence; Main Branch decides how to
+surface it; humans and skills decide which durable business truth to write back
+to the repo.
+
+## Product Boundary
+
+`mb` remains deterministic and scriptable. It may:
+
+- list available sidecar providers;
+- register safe provider metadata through `mb connect`;
+- store or reference credentials outside the business repo;
+- run a provider health check;
+- invoke a sidecar once and read JSON from stdout;
+- cache rebuildable sidecar responses outside tracked business truth;
+- expose sidecar status in `mb status --json`, `mb connect status --json`, and
+  future dashboard JSON;
+- print exact repair commands when a sidecar is missing, unhealthy, or stale.
+
+`mb` must not:
+
+- import a sidecar package as a required dependency;
+- run background sync by default;
+- turn sidecar output into canonical business truth automatically;
+- commit raw third-party exports, account data, credentials, or bearer tokens;
+- hide external account mutations behind a context-fetch command;
+- become a provider marketplace.
+
+Sidecars must be optional. A missing provider is a degraded enrichment path, not
+a broken Main Branch install.
+
+## Provider Discovery
+
+Provider discovery has two layers.
+
+The Main Branch provider registry defines provider ids that `mb` knows how to
+reason about. Each sidecar provider entry must include:
+
+- `id`, such as `companyctx`;
+- display name;
+- provider kind, such as `context`, `analytics`, `bookkeeping`,
+  `transcription`, or `deployment`;
+- executable or command name;
+- minimum supported sidecar contract version;
+- supported context subjects, such as company, domain, website, account,
+  ledger, recording, or deployment target;
+- whether auth is required;
+- safe health-check command;
+- default cache policy and TTL;
+- safe repair command;
+- whether the provider may read local repo files;
+- whether the provider may call external networks.
+
+The local business repo records only safe connection metadata in
+`.mb/connect.yaml`, following the existing `mb connect` boundary. This file may
+record provider id, account label, non-secret account identifiers, credential
+backend, last health-check time, contract version, and cache policy. It must not
+contain API keys, OAuth refresh tokens, service-account JSON, bearer tokens,
+raw exports, or customer/member data.
+
+Discovery should be boring:
+
+1. `mb connect list` shows known providers and whether the sidecar executable is
+   available.
+2. `mb connect status --json` shows configured providers, missing executables,
+   missing credentials, stale checks, and repair commands.
+3. `mb connect test <provider>` runs the provider's safest available health
+   check without fetching broad account data.
+4. `mb context fetch <provider> ...` refuses to run when required health checks
+   have not passed, unless the user explicitly asks for best-effort behavior.
+
+## Minimal CLI Surface
+
+Sidecar setup stays under the existing provider boundary:
+
+```bash
+mb connect <provider>
+mb connect test <provider>
+mb connect status --json
+mb connect doctor
+```
+
+`mb connect status --json` is the read contract for configured providers.
+`mb connect doctor` is the repair-oriented view over the same provider state:
+it may include broader environment checks and should prioritize exact commands
+that get the operator back to a healthy connection.
+
+Context retrieval uses one new command family:
+
+```bash
+mb context fetch <provider> --subject <value> --json
+```
+
+The first implementation should keep the surface intentionally small:
+
+- `<provider>` is a registered provider id, such as `companyctx`.
+- `--subject <value>` is the human-provided lookup target. For `companyctx`,
+  this can be a company name or domain.
+- `--kind <kind>` may disambiguate the subject when a provider supports more
+  than one subject kind.
+- `--refresh` ignores any cached entry and fetches again, replacing the cache on
+  success.
+- `--offline` reads only cache and fails clearly when no cache exists.
+- `--no-cache` avoids writing a local cache for sensitive or throwaway lookups.
+- `--json` emits the sidecar envelope plus Main Branch wrapper metadata.
+
+The first implementation may reject unsupported combinations rather than
+guess. For example, if `companyctx` only supports public company/domain context,
+`mb context fetch companyctx --kind ledger ...` should fail with an exact repair
+or "unsupported kind" message.
+
+Future command families such as `mb context list`, `mb context cache clear`, or
+provider-specific aliases can be added after `fetch` proves useful. They should
+not be added up front.
+
+## Sidecar Invocation Contract
+
+A sidecar is invoked as a one-shot command. It receives explicit arguments and
+returns JSON on stdout. Diagnostic logs go to stderr. Exit codes are part of the
+contract:
+
+| Exit code | Meaning | `mb` behavior |
+|---|---|---|
+| 0 | Usable response | Accept envelope when schema is valid and status is `ok`, `empty`, `partial`, or `degraded`. |
+| 1 | Provider-reported error | Accept envelope only if status is `error`; surface safe errors and repair commands. |
+| 2 | User/config/auth problem | Treat as provider not ready; print repair command. |
+| 3 | Unsupported request | Treat as deterministic failure; do not retry. |
+| 4 | Transient upstream problem | Surface retry guidance; may use stale cache. |
+| 5+ | Provider bug or invalid output | Treat as failed provider; include safe diagnostic summary. |
+
+`mb` validates the envelope before exposing it to skills or dashboards. Invalid
+JSON, a missing `schema_version`, or an unsupported schema version is a provider
+failure even when the process exits successfully.
+
+Status and exit code must agree. `ok`, `empty`, `partial`, and `degraded`
+should exit 0 with a valid envelope because they are usable responses.
+`error` should exit 1 with a valid envelope because the provider understood the
+request but returned no usable data. Exit codes 2 and higher are reserved for
+failures where the request could not be completed as a valid sidecar response.
+
+Sidecars must not prompt interactively during `mb context fetch`. A provider
+that needs setup should fail with a repair command that points back to
+`mb connect <provider>` or provider-specific setup docs.
+
+## JSON Envelope
+
+Every sidecar response must use this top-level shape:
+
+```json
+{
+  "schema_version": "mb.sidecar.context.v1",
+  "status": "ok",
+  "provider": {
+    "id": "companyctx",
+    "name": "Company Context",
+    "version": "0.4.0",
+    "contract_version": "mb.sidecar.context.v1"
+  },
+  "request": {
+    "id": "01HXAMPLE000000000000000000",
+    "subject": {
+      "kind": "company",
+      "value": "Example Co",
+      "domain": "example.com"
+    },
+    "mode": "fetch",
+    "requested_at": "2026-05-04T18:00:00Z"
+  },
+  "data": {
+    "summary": "Public context summary for Example Co.",
+    "facts": [],
+    "links": [],
+    "metrics": []
+  },
+  "provenance": [
+    {
+      "source": "https://example.com/about",
+      "source_type": "public_web",
+      "retrieved_at": "2026-05-04T18:00:00Z",
+      "license": "unknown",
+      "confidence": "medium"
+    }
+  ],
+  "warnings": [],
+  "errors": [],
+  "cache": {
+    "key": "companyctx/company/example.com",
+    "policy": "use",
+    "hit": false,
+    "ttl_seconds": 604800,
+    "expires_at": "2026-05-11T18:00:00Z"
+  }
+}
+```
+
+Required fields:
+
+- `schema_version`: semantic contract string. The first accepted contract is
+  `mb.sidecar.context.v1`.
+- `status`: one of `ok`, `partial`, `degraded`, `empty`, or `error`.
+- `provider`: provider identity, version, and sidecar contract version.
+- `request`: request id, subject, mode, and timestamp.
+- `data`: provider-specific structured payload. It may be empty.
+- `provenance`: source records for externally derived facts.
+- `warnings`: non-fatal issues.
+- `errors`: fatal or request-scoped issues.
+
+Optional but recommended fields:
+
+- `cache`: cache key, cache policy, freshness, and expiry.
+- `limits`: provider rate-limit or quota hints safe to share.
+- `redactions`: fields removed because they were secrets, raw account data, or
+  unsafe for durable repo storage.
+- `next_actions`: provider-suggested repair or refinement actions.
+
+Warnings and errors use this shape:
+
+```json
+{
+  "code": "auth.unvalidated",
+  "message": "Run `mb connect test companyctx` before fetching context.",
+  "retryable": false,
+  "safe_to_share": true,
+  "repair_command": "mb connect test companyctx"
+}
+```
+
+`safe_to_share` is required for warnings and errors. It lets skills and future
+issue-drafting flows avoid leaking local paths, credentials, account details, or
+private business data.
+
+## Status Semantics
+
+`status` is about the requested enrichment, not the operator's whole business
+repo.
+
+- `ok`: the provider completed the request and returned usable data.
+- `partial`: some data is usable, but at least one source, field, account, or
+  upstream service was missing.
+- `degraded`: the provider could answer only from stale cache, limited auth, or
+  a reduced mode.
+- `empty`: the provider found no matching context and this is a valid result.
+- `error`: no usable data is available for this request.
+
+`mb context fetch` should exit 0 for `ok`, `partial`, `degraded`, and `empty`
+when the envelope is valid. It should exit non-zero for `error`, invalid
+envelopes, unsupported schemas, missing provider executables, missing required
+auth, unsupported requests, or failed health checks.
+
+## Provenance
+
+Every externally derived fact that may influence business judgment needs
+provenance. Sidecars do not need to cite every low-level API field, but they
+must provide enough evidence for a skill or human to inspect where the context
+came from.
+
+Provenance records should include:
+
+- source identifier, URL, file path, account id, or provider object id when safe;
+- source type;
+- retrieval timestamp;
+- provider confidence when available;
+- terms/license hints when available;
+- whether the source is public, private, user-supplied, or cached.
+
+Private account ids may appear only when they are already safe connection
+metadata for the business repo. Raw third-party account data, customer data,
+ledger rows, transcripts, ad account exports, or analytics event streams must
+not be committed to tracked business files by default.
+
+## Caching
+
+Sidecar caches are rebuildable local operational state. They are not canonical
+business truth.
+
+Default cache location should be outside tracked repo files, under the Main
+Branch local state home. A future implementation may use a repo-local
+`.mb/cache/` directory only if it is gitignored, repairable, and documented.
+Cache entries must include the provider id, subject, schema version, fetched
+time, expiry, and enough metadata to explain stale reads.
+
+`mb context fetch` should support three cache modes:
+
+- default: use fresh cache when available, otherwise fetch;
+- `--refresh`: fetch again and replace cache when successful;
+- `--offline`: read cache only and fail clearly when no cache exists.
+
+Stale cache may be used only when the output status is `degraded` and the
+envelope includes a warning. Skills must not treat stale sidecar data as fresh
+business truth.
+
+## Auth Boundary
+
+`mb connect` owns the connection boundary. Sidecars may use credentials provided
+through a documented secret backend, environment variable, OS keychain, runtime
+config, or provider-native auth flow, but secrets must stay outside tracked
+business files.
+
+Provider health has three separate states:
+
+- executable discovery: can `mb` find the sidecar command?
+- credential presence: can the provider find required credentials?
+- safe validation: can the provider prove those credentials work without
+  fetching broad or sensitive data?
+
+A secret reference alone is never healthy. A provider that cannot safely probe
+the upstream API should report that limitation explicitly and stay below
+`ready` until a documented manual validation path exists.
+
+Sidecars must not mutate external accounts during health checks or context
+fetches. Spending money, publishing, emailing, deploying, or changing third
+party account state belongs behind an explicit Execute command and human
+approval gate, not behind enrichment.
+
+## Failure Behavior
+
+Sidecars are allowed to fail. Main Branch must fail soft:
+
+- `mb status` may say context enrichment is unavailable, degraded, or stale.
+- `mb start` and skills may continue with repo-local context.
+- `mb context fetch` should explain the provider failure and exact next command.
+- Future dashboards should show missing sidecars as optional integrations, not
+  core engine breakage.
+- Cached stale data may be offered only when clearly marked degraded.
+
+Failure messages must avoid leaking secrets, raw account data, customer/member
+data, or private local paths. When a low-level provider error is unsafe to share,
+the sidecar should return a safe summary plus a local log pointer outside the
+business repo.
+
+## Reference and Future Sidecars
+
+`companyctx` is the first reference sidecar because public company/domain
+context is useful across Know, See, and Execute workflows and can stay optional.
+It should prove:
+
+- command discovery;
+- connection and health status;
+- public company/domain lookup;
+- stable `mb.sidecar.context.v1` envelope output;
+- provenance for public sources;
+- graceful degradation when unavailable.
+
+Next plausible sidecars:
+
+- public-site context: sitemap, page inventory, headings, metadata, and broken
+  link summaries;
+- ads metrics: spend, impressions, CTR, CPA, creative ids, and campaign health
+  summaries;
+- bookkeeping: ledger/P&L summaries, open invoices, cash movement, and account
+  reconciliation hints;
+- transcription: local recording or provider transcript summaries with source
+  file provenance;
+- analytics: site traffic, events, conversions, and attribution summaries;
+- deployment helpers: build status, deployment health, DNS checks, and rollback
+  metadata.
+
+Each future sidecar should add provider-specific `data` schemas, but it must
+reuse the same envelope, provenance, auth, cache, and failure contract.
+
+## Validation Contract
+
+For this decision, Level 0 docs/decision validation is enough: frontmatter is
+valid, links resolve, the public/private boundary is preserved, and the decision
+does not claim implemented sidecar support before CLI work lands.
+
+Future implementation work must add:
+
+- focused CLI tests for `mb context fetch`, exit codes, cache modes, invalid
+  envelopes, missing providers, and `--json` behavior;
+- `mb connect` tests for sidecar provider discovery, health checks, repair
+  commands, and safe metadata;
+- fixture repo smoke when new `.mb/` files or cache paths are introduced;
+- package/install smoke when provider registry data or bundled sidecar adapters
+  ship in the wheel;
+- runtime/manual notes when skills start consuming sidecar context.
+
+## Consequences
+
+- Main Branch gets one integration style for optional enrichment instead of a
+  bespoke tool contract per workflow.
+- `mb connect` remains the credential and health boundary.
+- `mb context fetch` becomes the deterministic retrieval surface for skills,
+  scripts, and dashboards.
+- Sidecar data is useful evidence, not automatically canonical business truth.
+- `companyctx` can become the reference implementation without becoming a core
+  dependency.
+
+## Review Trigger
+
+Revisit this decision when either of these becomes true:
+
+- more than two sidecars need provider-specific lifecycle behavior that does
+  not fit the envelope; or
+- a proposed sidecar wants background sync, account mutation, hosted auth, or a
+  marketplace surface inside Main Branch.

--- a/docs/BEGINNER-SETUP.md
+++ b/docs/BEGINNER-SETUP.md
@@ -78,8 +78,8 @@ cd my-business
 ```
 
 `mb onboard` walks you through the setup, explains why Main Branch uses local
-files, git, and GitHub, scaffolds the six-folder taxonomy (`core/`,
-`research/`, `decisions/`, `log/`, `campaigns/`, `documents/`), and wires the
+files, git, and GitHub, scaffolds the business folder taxonomy (`core/`,
+`research/`, `decisions/`, `bets/`, `log/`, `campaigns/`, `documents/`), and wires the
 bridge files Claude Code needs to find Main Branch's skills.
 
 ---

--- a/docs/MIGRATING.md
+++ b/docs/MIGRATING.md
@@ -4,8 +4,8 @@ Main Branch has two repo shapes in the wild:
 
 - **Legacy shape:** `reference/core/`, `reference/domain/`, `reference/proof/`,
   and `outputs/`.
-- **Current shape:** `core/`, `research/`, `decisions/`, `log/`, `campaigns/`,
-  and `documents/`, with `reference/` kept as a compatibility layer for
+- **Current shape:** `core/`, `research/`, `decisions/`, `bets/`, `log/`,
+  `campaigns/`, and `documents/`, with `reference/` kept as a compatibility layer for
   agent-runtime skills.
 
 Existing repos do not need an urgent file move. The safe path is to update the
@@ -233,8 +233,8 @@ ln -s ../core/offers reference/offers
 Then add the current empty working folders:
 
 ```bash
-mkdir -p log campaigns documents core/finance
-touch log/.gitkeep campaigns/.gitkeep documents/.gitkeep core/finance/.gitkeep
+mkdir -p bets log campaigns documents core/finance
+touch bets/.gitkeep log/.gitkeep campaigns/.gitkeep documents/.gitkeep core/finance/.gitkeep
 ```
 
 Validate before merging the branch:

--- a/mb/README.md
+++ b/mb/README.md
@@ -23,11 +23,11 @@ mb --version
 | Command | What it does |
 |---|---|
 | `mb onboard` | Human setup flow. Creates or connects a business repo, explains the local files/git/GitHub substrate, wires Claude Code skills, verifies discovery, and prints the next `/mb-start` step. Supports `--yes` and `--json` for smoke tests. |
-| `mb init` | Scaffold a new business repo (six folders, CLAUDE.md, CODEOWNERS, `git init`) and wire the bundled Claude Code skill adapter. One question only: business name. |
+| `mb init` | Scaffold a new business repo (business folders, CLAUDE.md, CODEOWNERS, `git init`) and wire the bundled Claude Code skill adapter. One question only: business name. |
 | `mb doctor` | Diagnostic. Checks Claude Code, gh auth, network, librsvg, runtime wiring, and package freshness. Warns on cloud-backed finance paths and offers educational triage. |
 | `mb status` | Daily briefing. Summarizes repo shape, install/runtime readiness, recent brain files, recent git activity, and GitHub tasks when `gh` is authenticated. Supports `--json`. |
 | `mb start` | Runtime handoff. Verifies the current business repo, git, Claude Code, and `/mb-start` skill wiring, then prints the exact `claude` command or launches it with `--launch`. Supports `--json`. |
-| `mb validate` | Frontmatter shape check across `decisions/`, `core/offers/`, `research/`, `log/`, `campaigns/`, `documents/`. Exit 1 on any fail. |
+| `mb validate` | Frontmatter shape check across `decisions/`, `core/offers/`, `research/`, `bets/`, `log/`, `campaigns/`, `documents/`. Exit 1 on any fail. |
 | `mb graph` | Walk linked_research / linked_decisions / supersedes; emit Graphviz DOT to stdout. `--open` shells to `dot` + `open`. |
 | `mb update` | Refresh the Main Branch engine according to install mode (`pipx` upgrade or clone `git pull`) and repair skill links. `--check` dry-runs; `--json` emits an envelope. |
 | `mb migrate` | Inspect and apply numbered repo schema migrations. `status`, `--check`, and `--apply` support `--json`; `--check` prints privacy-safe summaries by default, with full diffs behind `--diff`. |

--- a/mb/mb/_data/educational/github-vs-gdocs.md
+++ b/mb/mb/_data/educational/github-vs-gdocs.md
@@ -23,7 +23,7 @@ Google Docs is the default place businesses put their thinking — meeting notes
 
 ## What we recommend instead
 
-A private GitHub (or Forgejo) repo with a CLAUDE.md at the root and a six-primitive folder structure: `core/`, `research/`, `decisions/`, `log/`, `campaigns/`, `documents/`. Markdown for everything. Frontmatter for status. The repo is the company brain. Conductor or any AI agent reads it as the working substrate.
+A private GitHub (or Forgejo) repo with a CLAUDE.md at the root and a primitive folder structure: `core/`, `research/`, `decisions/`, `bets/`, `log/`, `campaigns/`, `documents/`. Markdown for everything. Frontmatter for status. The repo is the company brain. Conductor or any AI agent reads it as the working substrate.
 
 The pitch in one sentence: **your business is a tree of files**. Once it is, every agent that can read files becomes a coworker.
 
@@ -48,16 +48,17 @@ The pitch in one sentence: **your business is a tree of files**. Once it is, eve
    - core/ — soul, offer, audience, voice, visual identity, finance
    - research/ — dated investigations, never deleted
    - decisions/ — dated choices with rationale, frontmatter status field
+   - bets/ — operating bets with targets, deadlines, and outcomes
    - log/ — daily/weekly notes, inbox-style dumps
    - campaigns/ — outputs grouped by campaign
    - documents/ — long-form artifacts (briefs, SOPs, contracts)
    ```
 
-4. Set up the six-primitive folders:
+4. Set up the primitive folders:
    ```bash
    mkdir -p core/{soul,offer,audience,voice,visual-identity,finance} \
-            research decisions log campaigns documents
-   git add . && git commit -m "[init] six-primitive structure"
+            research decisions bets log campaigns documents
+   git add . && git commit -m "[init] business primitive structure"
    git push
    ```
 

--- a/mb/mb/_data/templates/CLAUDE.md.tmpl
+++ b/mb/mb/_data/templates/CLAUDE.md.tmpl
@@ -10,6 +10,7 @@ Your business as files. Claude reads these; you edit them; git remembers them.
   (run `mb educational anti-cloud-backup` for why this should not live in iCloud or Drive)
 - `research/` — dated notes from when you went looking
 - `decisions/` — dated choices, with rationale
+- `bets/` — operating bets with appetite, metric, target, and outcome
 - `log/` — running activity log
 - `campaigns/` — paid + organic campaign work
 - `documents/` — anything that doesn't belong above
@@ -18,7 +19,7 @@ Your business as files. Claude reads these; you edit them; git remembers them.
 
 ## Conventions
 
-- Decisions, research, offers, and campaigns carry a small block of metadata
+- Decisions, research, bets, offers, and campaigns carry a small block of metadata
   at the top (frontmatter). Run `mb validate` to check it.
 - Status field: `proposed | running | scaling | killed | graduated | died`
   (decisions also use `accepted | rejected | superseded`).

--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -141,7 +141,7 @@ def init_cmd(
     name: str = typer.Option("", "--name", help="Business name (skips prompt if given)."),
     json_out: bool = typer.Option(False, "--json", help="Machine-readable output."),
 ) -> None:
-    """Set up a fresh business repo (six folders, CLAUDE.md, git init)."""
+    """Set up a fresh business repo (business folders, CLAUDE.md, git init)."""
     result = init_mod.run(path=path, name=name)
     if json_out:
         typer.echo(json.dumps(result, indent=2))

--- a/mb/mb/doctor.py
+++ b/mb/mb/doctor.py
@@ -152,7 +152,7 @@ def _repo_layout_check(repo: Path) -> dict[str, Any]:
             "ok": False,
             "detail": (
                 "legacy reference/ layout detected without core/. Main Branch can "
-                "brief this repo, but current six-folder features may be limited. "
+                "brief this repo, but current schema features may be limited. "
                 "Read `docs/MIGRATING.md` before moving files."
             ),
             "severity": "warn",

--- a/mb/mb/graph.py
+++ b/mb/mb/graph.py
@@ -17,9 +17,12 @@ INDEX_VERSION = 1
 EdgeKey = tuple[str, str, str, tuple[tuple[str, str], ...]]
 
 LINK_FIELDS = (
+    "linked_bets",
     "linked_research",
     "linked_decision",
     "linked_decisions",
+    "linked_campaigns",
+    "linked_outcomes",
     "linked_prd",
     "linked_prds",
     "related_prds",
@@ -57,6 +60,7 @@ ENTITY_TAG_TYPES = {
 }
 
 LOCAL_REF_ROOTS = {
+    "bets",
     "campaigns",
     "core",
     "decisions",

--- a/mb/mb/init.py
+++ b/mb/mb/init.py
@@ -1,7 +1,7 @@
 """``mb init`` — non-interactive scaffold for a Main Branch business repo.
 
 Per master decision, v0.1 asks ONE question (business name). Path-config
-flexibility is locked; folder names are the canonical six. Re-running on
+flexibility is locked; folder names are canonical. Re-running on
 an existing repo returns ``status=already-initialized`` (idempotent).
 """
 
@@ -17,13 +17,14 @@ from typing import Any
 from mb.engine import link_skills
 from mb.migrate import LATEST_SCHEMA_VERSION, SCHEMA_MARKER
 
-# The canonical six. v0.1 lock; v0.2 unlocks via .vip/config.yaml paths block.
+# The canonical business folders. Keep these stable unless a schema migration lands.
 DATA_FOLDERS = [
     "core",
     "core/offers",
     "core/finance",
     "research",
     "decisions",
+    "bets",
     "log",
     "campaigns",
     "documents",
@@ -219,6 +220,7 @@ Your business as files. Claude reads these; you edit them; git remembers them.
 - `core/finance/` — ledger and tax artifacts
 - `research/` — dated notes from when you went looking
 - `decisions/` — dated choices, with rationale
+- `bets/` — operating bets with appetite, metric, target, and outcome
 - `log/` — running activity log
 - `campaigns/` — paid + organic campaign work
 - `documents/` — anything that doesn't belong above
@@ -227,7 +229,7 @@ Your business as files. Claude reads these; you edit them; git remembers them.
 
 ## Conventions
 
-- Decisions, research, and offers carry a small block of metadata at the top
+- Decisions, research, bets, and offers carry a small block of metadata at the top
   (frontmatter). Run `mb validate` to check it.
 - Status field: proposed | running | scaling | killed | graduated | died.
 - One owner per file (CODEOWNERS pattern).

--- a/mb/mb/onboard.py
+++ b/mb/mb/onboard.py
@@ -169,7 +169,7 @@ def _initial_state(
             "state_path": str(ONBOARDING_STATE_RELATIVE_PATH),
             "canonical_business_truth": [
                 "accepted offer, audience, voice, proof, decisions, and durable summaries",
-                "files under core/, research/, decisions/, campaigns/, log/, and documents/",
+                "files under core/, research/, decisions/, bets/, campaigns/, log/, and documents/",
             ],
             "operational_progress": [
                 "checklist state, missing input labels, persona/team-size routing, and next action",

--- a/mb/mb/resolve.py
+++ b/mb/mb/resolve.py
@@ -8,7 +8,7 @@ Resolution order for a key like ``voice``:
 If only the stub matches, ``is_stub=True`` and the caller knows to
 display the upgrade banner.
 
-``v0.1`` ships with the canonical six-folder names locked. Per the
+``v0.1`` shipped with canonical folder names locked. Per the
 master decision, path-config flexibility is a v0.2 unlock; this module
 reads ``.vip/config.yaml``'s ``paths:`` block defensively but defaults
 to the lock.
@@ -29,6 +29,7 @@ CANONICAL_PATHS = {
     "core": "core",
     "research": "research",
     "decisions": "decisions",
+    "bets": "bets",
     "log": "log",
     "campaigns": "campaigns",
     "documents": "documents",

--- a/mb/mb/status.py
+++ b/mb/mb/status.py
@@ -192,6 +192,19 @@ def _parse_date(value: Any, fallback_path: Path) -> date | None:
     return None
 
 
+def _parse_explicit_date(value: Any) -> date | None:
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    if isinstance(value, str) and value.strip():
+        try:
+            return date.fromisoformat(value[:10])
+        except ValueError:
+            return None
+    return None
+
+
 def _relative_markdown_files(repo: Path, folder: str) -> list[Path]:
     root = repo / folder
     if not root.exists():
@@ -275,7 +288,7 @@ def _brain(repo: Path) -> dict[str, Any]:
 def _bet_summary(repo: Path, path: Path) -> dict[str, Any]:
     meta = _read_frontmatter(path)
     opened = _parse_date(meta.get("opened"), path)
-    deadline = _parse_date(meta.get("deadline"), path)
+    deadline = _parse_explicit_date(meta.get("deadline"))
     try:
         rel = path.relative_to(repo).as_posix()
     except ValueError:
@@ -315,7 +328,7 @@ def _bets(repo: Path) -> dict[str, Any]:
     due_soon: list[dict[str, Any]] = []
     overdue: list[dict[str, Any]] = []
     for item in active:
-        deadline = _parse_date(str(item.get("deadline") or ""), Path(str(item.get("path") or "")))
+        deadline = _parse_explicit_date(item.get("deadline"))
         if deadline is None:
             continue
         days_until = (deadline - today).days

--- a/mb/mb/status.py
+++ b/mb/mb/status.py
@@ -23,11 +23,13 @@ IMPORTANT_DIRS = (
     "reference/core",
     "research",
     "decisions",
+    "bets",
     "campaigns",
     "log",
     "documents",
 )
 STALE_DECISION_DAYS = 14
+ACTIVE_BET_STATUSES = {"open", "paused"}
 
 
 def _which(name: str) -> str:
@@ -124,6 +126,7 @@ def _git_recent_activity(repo: Path, git: dict[str, Any]) -> dict[str, Any]:
         "reference/core",
         "research",
         "decisions",
+        "bets",
         "campaigns",
         "log",
         "documents",
@@ -258,12 +261,77 @@ def _brain(repo: Path) -> dict[str, Any]:
     research = [
         _file_summary(repo, path) for path in _relative_markdown_files(repo, "research")[:5]
     ]
+    bets = _bets(repo)
 
     return {
         "counts": counts,
         "recent_decisions": decisions[:5],
         "stale_decisions": stale[:5],
         "recent_research": research,
+        "bets": bets,
+    }
+
+
+def _bet_summary(repo: Path, path: Path) -> dict[str, Any]:
+    meta = _read_frontmatter(path)
+    opened = _parse_date(meta.get("opened"), path)
+    deadline = _parse_date(meta.get("deadline"), path)
+    try:
+        rel = path.relative_to(repo).as_posix()
+    except ValueError:
+        rel = str(path)
+    channels = meta.get("channels")
+    if not isinstance(channels, list):
+        channels = []
+    return {
+        "path": rel,
+        "title": _title_from_markdown(path),
+        "status": str(meta.get("status", "") or ""),
+        "opened": opened.isoformat() if opened else "",
+        "deadline": deadline.isoformat() if deadline else "",
+        "appetite": str(meta.get("appetite", "") or ""),
+        "hypothesis": str(meta.get("hypothesis", "") or ""),
+        "metric": str(meta.get("metric", "") or ""),
+        "target": str(meta.get("target", "") or ""),
+        "result": str(meta.get("result", "") or ""),
+        "public": bool(meta.get("public", False)),
+        "channels": [str(channel) for channel in channels if isinstance(channel, str)],
+        "updated_at": datetime.fromtimestamp(path.stat().st_mtime).isoformat(timespec="seconds"),
+    }
+
+
+def _bet_sort_key(item: dict[str, Any]) -> tuple[str, str]:
+    deadline = str(item.get("deadline") or "9999-12-31")
+    return (deadline, str(item.get("path") or ""))
+
+
+def _bets(repo: Path) -> dict[str, Any]:
+    bet_items = [_bet_summary(repo, path) for path in _relative_markdown_files(repo, "bets")]
+    active = [
+        item for item in bet_items if str(item.get("status", "")).lower() in ACTIVE_BET_STATUSES
+    ]
+    active.sort(key=_bet_sort_key)
+    today = date.today()
+    due_soon: list[dict[str, Any]] = []
+    overdue: list[dict[str, Any]] = []
+    for item in active:
+        deadline = _parse_date(str(item.get("deadline") or ""), Path(str(item.get("path") or "")))
+        if deadline is None:
+            continue
+        days_until = (deadline - today).days
+        if days_until < 0:
+            overdue_item = dict(item)
+            overdue_item["days_overdue"] = abs(days_until)
+            overdue.append(overdue_item)
+        elif days_until <= 7:
+            due_item = dict(item)
+            due_item["days_until_deadline"] = days_until
+            due_soon.append(due_item)
+    return {
+        "active": active[:5],
+        "due_soon": due_soon[:5],
+        "overdue": overdue[:5],
+        "recent": bet_items[:5],
     }
 
 
@@ -405,6 +473,11 @@ def _readiness(report: dict[str, Any]) -> dict[str, Any]:
         )
     if report["brain"]["stale_decisions"]:
         next_actions.append("Review stale proposed/running decisions in `decisions/`.")
+    bets = report["brain"].get("bets") or {}
+    if bets.get("overdue"):
+        next_actions.append("Close or update overdue active bets in `bets/`.")
+    elif bets.get("due_soon"):
+        next_actions.append("Review active bets with deadlines in the next 7 days.")
     onboarding_summary = (report.get("onboarding") or {}).get("summary") or {}
     if onboarding_summary.get("status") == "in_progress":
         next_actions.append(
@@ -532,6 +605,7 @@ def render_human(report: dict[str, Any]) -> None:
         "[bold]Brain[/bold] "
         f"core {counts['core'] + counts['reference/core']}  "
         f"research {counts['research']}  decisions {counts['decisions']}  "
+        f"bets {counts['bets']}  "
         f"campaigns {counts['campaigns']}  log {counts['log']}  documents {counts['documents']}"
     )
 
@@ -548,6 +622,19 @@ def render_human(report: dict[str, Any]) -> None:
         console.print("\n[bold]Recent research[/bold]")
         for item in brain["recent_research"][:3]:
             console.print(f"  - {item['date'] or item['updated_at'][:10]}  {item['title']}")
+
+    bets = brain.get("bets") or {}
+    active_bets = bets.get("active") or []
+    if active_bets:
+        console.print("\n[bold]Active bets[/bold]")
+        for item in active_bets[:3]:
+            deadline = item.get("deadline") or "no deadline"
+            console.print(f"  - {deadline}  {item['title']} [{item['status']}]")
+    overdue_bets = bets.get("overdue") or []
+    if overdue_bets:
+        console.print("[yellow]Overdue active bets[/yellow]")
+        for item in overdue_bets[:3]:
+            console.print(f"  - {item['path']} ({item['days_overdue']} days overdue)")
 
     onboarding_summary = onboarding.get("summary") or {}
     if onboarding_summary.get("status") == "in_progress":

--- a/mb/mb/validate.py
+++ b/mb/mb/validate.py
@@ -27,11 +27,15 @@ OFFER_STATUS = {
     "rejected",
 }
 RESEARCH_STATUS = {"complete", "in-progress", "stale"}
+BET_STATUS = {"open", "paused", "closed", "canceled"}
 
 LINK_FIELDS = (
+    "linked_bets",
     "linked_research",
     "linked_decision",
     "linked_decisions",
+    "linked_campaigns",
+    "linked_outcomes",
     "linked_prd",
     "linked_prds",
     "related_prds",
@@ -39,6 +43,7 @@ LINK_FIELDS = (
 )
 
 LOCAL_REF_ROOTS = {
+    "bets",
     "campaigns",
     "core",
     "decisions",
@@ -83,6 +88,27 @@ SCHEMAS: dict[str, dict[str, Any]] = {
         "glob": "research/*.md",
         "required": ["date", "topic", "source"],
         "enums": {},
+    },
+    "bets": {
+        "glob": "bets/*.md",
+        "required": [
+            "status",
+            "opened",
+            "deadline",
+            "appetite",
+            "hypothesis",
+            "metric",
+            "target",
+            "result",
+            "linked_decisions",
+            "linked_research",
+            "linked_campaigns",
+            "linked_outcomes",
+            "public",
+            "channels",
+            "tags",
+        ],
+        "enums": {"status": BET_STATUS},
     },
     "log": {
         "glob": "log/*.md",
@@ -276,6 +302,87 @@ def _check_status_transition(
         )
 
 
+def _relative_ref(path: Path, repo: Path) -> str:
+    return path.relative_to(repo).as_posix()
+
+
+def _ref_list_contains(value: Any, expected: str) -> bool:
+    refs, valid_type = _coerce_refs(value)
+    return valid_type and expected in {_clean_ref(ref) for ref in refs}
+
+
+def _reverse_bet_field(source: Path, repo: Path) -> str:
+    parts = source.relative_to(repo).parts
+    if not parts:
+        return ""
+    section = parts[0]
+    if section == "decisions":
+        return "linked_decisions"
+    if section == "research":
+        return "linked_research"
+    if section == "campaigns":
+        return "linked_campaigns"
+    if section in {"log", "documents"}:
+        return "linked_outcomes"
+    return ""
+
+
+def _check_bet_backlink(
+    *,
+    source: Path,
+    target: Path,
+    repo: Path,
+    field: str,
+    ref: str,
+    target_fm: dict[str, Any],
+    findings: list[dict[str, str]],
+) -> None:
+    source_rel = _relative_ref(source, repo)
+    target_rel = _relative_ref(target, repo)
+    source_is_bet = source_rel.startswith("bets/")
+    target_is_bet = target_rel.startswith("bets/")
+
+    if (
+        source_is_bet
+        and not target_is_bet
+        and field
+        in {
+            "linked_decisions",
+            "linked_research",
+            "linked_campaigns",
+            "linked_outcomes",
+        }
+    ):
+        if not _ref_list_contains(target_fm.get("linked_bets"), source_rel):
+            findings.append(
+                _finding(
+                    code="missing-bet-backlink",
+                    source=source,
+                    repo=repo,
+                    field=field,
+                    target=ref,
+                    message=(f"{field} target {ref!r} should include linked_bets: {source_rel}"),
+                )
+            )
+        return
+
+    if field == "linked_bets" and target_is_bet and not source_is_bet:
+        reverse_field = _reverse_bet_field(source, repo)
+        if reverse_field and not _ref_list_contains(target_fm.get(reverse_field), source_rel):
+            findings.append(
+                _finding(
+                    code="missing-bet-backlink",
+                    source=source,
+                    repo=repo,
+                    field=field,
+                    target=ref,
+                    message=(
+                        f"{field} target {ref!r} should include {reverse_field}: {source_rel}"
+                    ),
+                )
+            )
+
+
 def _check_cross_refs(
     repo: Path,
     files_by_path: dict[str, dict[str, Any]],
@@ -345,6 +452,17 @@ def _check_cross_refs(
                     source_fm=fm,
                     findings=findings,
                 )
+                target_fm, target_err = _read_frontmatter(target)
+                if target_err is None and target_fm is not None:
+                    _check_bet_backlink(
+                        source=source,
+                        target=target,
+                        repo=repo,
+                        field=field,
+                        ref=ref,
+                        target_fm=target_fm,
+                        findings=findings,
+                    )
 
     offers_root = repo / "core" / "offers"
     if offers_root.exists():

--- a/mb/tests/test_graph.py
+++ b/mb/tests/test_graph.py
@@ -36,6 +36,43 @@ def test_links_become_edges(tmp_path: Path) -> None:
     assert "->" in out
 
 
+def test_bet_links_become_edges(tmp_path: Path) -> None:
+    bets = tmp_path / "bets"
+    decisions = tmp_path / "decisions"
+    bets.mkdir()
+    decisions.mkdir()
+    (bets / "2026-05-04-demo.md").write_text(
+        "---\n"
+        "status: open\n"
+        "opened: 2026-05-04\n"
+        "deadline: 2026-05-11\n"
+        "appetite: 1 week\n"
+        "hypothesis: Demo creates qualified calls.\n"
+        "metric: calls\n"
+        "target: 5 calls\n"
+        "result: ''\n"
+        "linked_decisions:\n  - decisions/2026-05-04-demo.md\n"
+        "linked_research: []\n"
+        "linked_campaigns: []\n"
+        "linked_outcomes: []\n"
+        "public: true\n"
+        "channels: []\n"
+        "tags: []\n"
+        "---\n",
+        encoding="utf-8",
+    )
+    (decisions / "2026-05-04-demo.md").write_text(
+        "---\ndate: 2026-05-04\nstatus: accepted\nlinked_bets:\n  - bets/2026-05-04-demo.md\n---\n",
+        encoding="utf-8",
+    )
+
+    index = build_index(path=str(tmp_path))
+    edge_types = {edge["type"] for edge in index["edges"]}
+
+    assert "linked_decisions" in edge_types
+    assert "linked_bets" in edge_types
+
+
 def test_build_index_includes_frontmatter_links_wikilinks_and_entities(tmp_path: Path) -> None:
     decisions = tmp_path / "decisions"
     research = tmp_path / "research"

--- a/mb/tests/test_init.py
+++ b/mb/tests/test_init.py
@@ -19,6 +19,7 @@ def test_init_scaffolds_folders(tmp_path: Path) -> None:
     assert (target / "reference" / "proof" / "angles").is_dir()
     assert (target / "reference" / "domain").is_dir()
     assert (target / "reference" / "visual-identity").is_dir()
+    assert (target / "bets").is_dir()
     assert (target / "CLAUDE.md").exists()
     assert (target / ".github" / "CODEOWNERS").exists()
     assert (target / ".gitignore").exists()
@@ -44,6 +45,7 @@ def test_init_scaffolds_folders(tmp_path: Path) -> None:
     assert "MCP server names" in claude_md
     assert "MCP tokens" in claude_md
     assert "Never commit API keys" in claude_md
+    assert "`bets/`" in claude_md
 
 
 def test_init_idempotent(tmp_path: Path) -> None:

--- a/mb/tests/test_init.py
+++ b/mb/tests/test_init.py
@@ -1,4 +1,4 @@
-"""``mb init`` scaffolds the canonical six folders + CLAUDE.md."""
+"""``mb init`` scaffolds the canonical business folders + CLAUDE.md."""
 
 from __future__ import annotations
 

--- a/mb/tests/test_status.py
+++ b/mb/tests/test_status.py
@@ -169,6 +169,9 @@ def test_status_low_level_helpers_handle_edge_cases(tmp_path: Path, monkeypatch)
     assert status_mod._parse_date(date(2026, 5, 2), plain) == date(2026, 5, 2)
     assert status_mod._parse_date("not-a-date", tmp_path / "2026-05-01-note.md") == date(2026, 5, 1)
     assert status_mod._parse_date("not-a-date", tmp_path / "note.md") is None
+    assert status_mod._parse_explicit_date("2026-05-02") == date(2026, 5, 2)
+    assert status_mod._parse_explicit_date("") is None
+    assert status_mod._parse_explicit_date("not-a-date") is None
 
     external = tmp_path / "external.md"
     external.write_text("no heading\n", encoding="utf-8")
@@ -331,6 +334,41 @@ def test_status_readiness_mentions_due_bets(tmp_path: Path) -> None:
     readiness = status_mod._readiness(report)
 
     assert any("active bets" in action for action in readiness["next_actions"])
+
+
+def test_status_empty_bet_deadline_does_not_fall_back_to_opened_filename(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    (repo / "bets").mkdir(parents=True)
+    (repo / "bets" / "2020-01-01-no-deadline.md").write_text(
+        (
+            "---\n"
+            "status: open\n"
+            "opened: 2020-01-01\n"
+            "deadline: ''\n"
+            "appetite: 1 week\n"
+            "hypothesis: A no-deadline bet should stay active but not due.\n"
+            "metric: replies\n"
+            "target: 3 replies\n"
+            "result: ''\n"
+            "linked_decisions: []\n"
+            "linked_research: []\n"
+            "linked_campaigns: []\n"
+            "linked_outcomes: []\n"
+            "public: false\n"
+            "channels: []\n"
+            "tags: []\n"
+            "---\n\n"
+            "# No deadline\n"
+        ),
+        encoding="utf-8",
+    )
+
+    bets = status_mod._brain(repo)["bets"]
+
+    assert bets["active"][0]["title"] == "No deadline"
+    assert bets["active"][0]["deadline"] == ""
+    assert bets["due_soon"] == []
+    assert bets["overdue"] == []
 
 
 def test_status_github_authenticated_branches(tmp_path: Path, monkeypatch) -> None:

--- a/mb/tests/test_status.py
+++ b/mb/tests/test_status.py
@@ -48,6 +48,7 @@ def test_status_json_degrades_without_github(tmp_path: Path, monkeypatch) -> Non
     assert report["github"]["source"] == "gh"
     assert "assigned_tasks" in report["github"]["sections"]
     assert report["brain"]["counts"]["decisions"] == 1
+    assert report["brain"]["counts"]["bets"] == 0
     assert report["brain"]["recent_research"][0]["title"] == "Market"
     assert "readiness" in report
     assert "update" in report
@@ -249,12 +250,87 @@ def test_status_brain_marks_stale_decisions(tmp_path: Path, monkeypatch) -> None
     )
     (repo / "research").mkdir()
     (repo / "research" / "2026-05-01-market.md").write_text("# Market\n", encoding="utf-8")
+    deadline = date.today().replace(year=date.today().year + 1)
+    (repo / "bets").mkdir()
+    (repo / "bets" / "2026-05-01-launch.md").write_text(
+        (
+            "---\n"
+            "status: open\n"
+            "opened: 2026-05-01\n"
+            f"deadline: {deadline.isoformat()}\n"
+            "appetite: 2 weeks\n"
+            "hypothesis: Launching a demo will create calls.\n"
+            "metric: calls\n"
+            "target: 5 calls\n"
+            "result: ''\n"
+            "linked_decisions: []\n"
+            "linked_research: []\n"
+            "linked_campaigns: []\n"
+            "linked_outcomes: []\n"
+            "public: true\n"
+            "channels:\n"
+            "  - site\n"
+            "tags: []\n"
+            "---\n\n"
+            "# Launch bet\n"
+        ),
+        encoding="utf-8",
+    )
 
     brain = status_mod._brain(repo)
 
     assert brain["recent_decisions"][0]["title"] == "Old proposal"
     assert brain["stale_decisions"][0]["age_days"] > status_mod.STALE_DECISION_DAYS
     assert brain["recent_research"][0]["title"] == "Market"
+    assert brain["bets"]["active"][0]["title"] == "Launch bet"
+    assert brain["bets"]["active"][0]["deadline"] == deadline.isoformat()
+
+
+def test_status_readiness_mentions_due_bets(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    (repo / "bets").mkdir(parents=True)
+    today = date.today()
+    (repo / "bets" / f"{today.isoformat()}-due.md").write_text(
+        (
+            "---\n"
+            "status: open\n"
+            f"opened: {today.isoformat()}\n"
+            f"deadline: {today.isoformat()}\n"
+            "appetite: 1 day\n"
+            "hypothesis: Fast follow-up increases replies.\n"
+            "metric: replies\n"
+            "target: 3 replies\n"
+            "result: ''\n"
+            "linked_decisions: []\n"
+            "linked_research: []\n"
+            "linked_campaigns: []\n"
+            "linked_outcomes: []\n"
+            "public: false\n"
+            "channels: []\n"
+            "tags: []\n"
+            "---\n\n"
+            "# Due bet\n"
+        ),
+        encoding="utf-8",
+    )
+    report = {
+        "repo": {"looks_like_mainbranch_repo": True},
+        "git": {"inside_work_tree": True, "dirty": False},
+        "install": {"ok": True},
+        "update": {"severity": "current", "command": ""},
+        "runtime": {
+            "skill_wiring": {"ok": True, "repair": ""},
+            "claude_code": {"found": True, "repair": ""},
+        },
+        "brain": status_mod._brain(repo),
+        "onboarding": {"summary": {"status": "ready"}},
+        "integrations": {"providers": []},
+        "github": {"authenticated": True, "context": {"ok": True}},
+    }
+
+    readiness = status_mod._readiness(report)
+
+    assert any("active bets" in action for action in readiness["next_actions"])
 
 
 def test_status_github_authenticated_branches(tmp_path: Path, monkeypatch) -> None:
@@ -500,6 +576,7 @@ def test_status_renderer_prints_optional_sections(capsys) -> None:
                 "reference/core": 1,
                 "research": 1,
                 "decisions": 1,
+                "bets": 1,
                 "campaigns": 1,
                 "log": 1,
                 "documents": 1,
@@ -513,6 +590,18 @@ def test_status_renderer_prints_optional_sections(capsys) -> None:
             "recent_research": [
                 {"date": "2026-05-01", "updated_at": "", "title": "Market"},
             ],
+            "bets": {
+                "active": [
+                    {
+                        "deadline": "2026-05-08",
+                        "title": "Launch bet",
+                        "status": "open",
+                    }
+                ],
+                "due_soon": [],
+                "overdue": [],
+                "recent": [],
+            },
         },
         "git_activity": {
             "items": [
@@ -541,6 +630,7 @@ def test_status_renderer_prints_optional_sections(capsys) -> None:
     assert "Recent decisions" in output
     assert "Stale proposed/running decisions" in output
     assert "Recent research" in output
+    assert "Active bets" in output
     assert "Recent git activity" in output
     assert "tasks assigned: 1" in output
     assert "shipped this week: 1" in output

--- a/mb/tests/test_validate.py
+++ b/mb/tests/test_validate.py
@@ -27,6 +27,29 @@ def test_validate_passes_well_formed(tmp_path: Path) -> None:
         tmp_path / "research" / "2026-04-29-topic-claude-code.md",
         "---\ndate: 2026-04-29\ntopic: tau\nsource: claude-code\n---\n# r\n",
     )
+    _write(
+        tmp_path / "bets" / "2026-04-29-launch.md",
+        (
+            "---\n"
+            "status: open\n"
+            "opened: 2026-04-29\n"
+            "deadline: 2026-05-13\n"
+            "appetite: 2 weeks\n"
+            "hypothesis: If we launch, qualified calls will increase.\n"
+            "metric: qualified calls\n"
+            "target: 10 qualified calls\n"
+            "result: ''\n"
+            "linked_decisions: []\n"
+            "linked_research: []\n"
+            "linked_campaigns: []\n"
+            "linked_outcomes: []\n"
+            "public: false\n"
+            "channels: []\n"
+            "tags: []\n"
+            "---\n"
+            "# Launch bet\n"
+        ),
+    )
     report = run(path=str(tmp_path))
     assert report["ok"] is True
     assert all(f["ok"] for f in report["files"])
@@ -225,6 +248,92 @@ def test_cross_refs_flag_orphan_offer_dirs(tmp_path: Path) -> None:
             "message": "core/offers/alpha/ is missing offer.md",
         }
     ]
+
+
+def test_cross_refs_warn_when_bet_link_lacks_reverse_link(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "bets" / "2026-05-04-demo.md",
+        (
+            "---\n"
+            "status: open\n"
+            "opened: 2026-05-04\n"
+            "deadline: 2026-05-11\n"
+            "appetite: 1 week\n"
+            "hypothesis: If demo prospects see the workflow, calls increase.\n"
+            "metric: calls\n"
+            "target: 5 calls\n"
+            "result: ''\n"
+            "linked_decisions:\n"
+            "  - decisions/2026-05-04-demo.md\n"
+            "linked_research: []\n"
+            "linked_campaigns: []\n"
+            "linked_outcomes: []\n"
+            "public: true\n"
+            "channels:\n"
+            "  - site\n"
+            "tags:\n"
+            "  - channel:site\n"
+            "---\n"
+            "# Demo bet\n"
+        ),
+    )
+    _write(
+        tmp_path / "decisions" / "2026-05-04-demo.md",
+        "---\ndate: 2026-05-04\nstatus: accepted\n---\n# Demo\n",
+    )
+
+    report = run(path=str(tmp_path), cross_refs=True)
+
+    assert report["summary"]["warnings"] == 1
+    finding = report["cross_refs"]["warnings"][0]
+    assert finding["code"] == "missing-bet-backlink"
+    assert finding["field"] == "linked_decisions"
+    assert "linked_bets: bets/2026-05-04-demo.md" in finding["message"]
+
+
+def test_cross_refs_pass_when_bet_links_are_bidirectional(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "bets" / "2026-05-04-demo.md",
+        (
+            "---\n"
+            "status: open\n"
+            "opened: 2026-05-04\n"
+            "deadline: 2026-05-11\n"
+            "appetite: 1 week\n"
+            "hypothesis: If demo prospects see the workflow, calls increase.\n"
+            "metric: calls\n"
+            "target: 5 calls\n"
+            "result: ''\n"
+            "linked_decisions:\n"
+            "  - decisions/2026-05-04-demo.md\n"
+            "linked_research: []\n"
+            "linked_campaigns: []\n"
+            "linked_outcomes: []\n"
+            "public: true\n"
+            "channels:\n"
+            "  - site\n"
+            "tags: []\n"
+            "---\n"
+            "# Demo bet\n"
+        ),
+    )
+    _write(
+        tmp_path / "decisions" / "2026-05-04-demo.md",
+        (
+            "---\n"
+            "date: 2026-05-04\n"
+            "status: accepted\n"
+            "linked_bets:\n"
+            "  - bets/2026-05-04-demo.md\n"
+            "---\n"
+            "# Demo\n"
+        ),
+    )
+
+    report = run(path=str(tmp_path), cross_refs=True)
+
+    assert report["ok"] is True
+    assert report["summary"]["warnings"] == 0
 
 
 def test_validate_cli_cross_refs_default_warns_strict_fails(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Adds `bets/` as a first-class business-repo primitive for opening, tracking, closing, and narrating operating bets.
- Adds the `/mb-bet` Claude Code workflow with `new`, `update`, `close`, `list`, and `narrate` modes, plus `/mb-start` and `/mb-help` routing.
- Extends `mb validate`, `mb graph`, and `mb status` so bets have frontmatter schema checks, bidirectional links, graph edges, active/deadline reporting, and no filename fallback for empty deadlines.

## Scope
- In:
  - `bets/` scaffold, onboarding copy, docs, and changelog.
  - Bet frontmatter validation and bidirectional `linked_bets` warnings.
  - Status active/due/overdue bet reporting and graph/link support.
  - Packaged `/mb-bet` workflow and help/start routing.
- Out:
  - Automatic public publishing.
  - Dashboard dependency.
  - Replacing decisions or campaigns.
  - Interactive Claude Code runtime launch smoke.

## Commits
- `f4711cc` — `[add] MAIN-221 bets primitive and workflow`.
- `fd44558` — `[fix] MAIN-221 parse bet deadlines explicitly`.
- `7e8dba4` — `[add] MAIN-221 restore sidecar decision from main`.
- `31c3f6b` — merge `origin/main` to keep the PR review diff focused.

## Release / Issues
- Release: v0.4 - Launches bets.
- Linear ID(s): MAIN-221.
- Closes: #266.
- Refs: none.
- Follow-ups: none required.

## Success Metric
- A user can open a business bet, work against it, close it with a verdict, and produce a public-safe narration draft from repo truth.

## Validation
- Level 0 docs/decision: README, beginner setup, migration docs, educational copy, `CHANGELOG.md`, skill routing, and public/private boundaries reviewed; restored the sidecar decision file from `origin/main` so the PR does not delete unrelated main work.
- Level 1 static: `scripts/check.sh` passed, including ruff format/check, mypy, 168 tests with coverage, and bundled skill validation.
- Level 2 CLI: focused status/init/validate/graph tests cover bet schema, bidirectional links, graph edges, active/due/overdue status, and the empty-deadline regression.
- Level 3 package/install: `python3 -m build` passed; fresh wheel install smoke confirmed `mb-bet` in `mb skill list`, `bets/.gitkeep`, and `.claude/skills/mb-bet` in a new repo.
- Level 4 fixture repo: populated temp repo rendered `Active bets` and `Overdue active bets`; empty-deadline bet rendered as `no deadline` and was not overdue; fixture `mb validate --json` passed.
- Level 5 runtime smoke: interactive Claude Code launch not run; closest verified fallback is packaged skill discovery, project-local `.claude/skills/mb-bet/SKILL.md`, and `mb start --json` handoff readiness from a fresh repo.

## Public / Private Boundary
- No secrets, customer/member data, private runtime details, or local Conductor preferences were committed.
- Smoke artifacts and raw local paths stayed in `/tmp`/`.context`; durable product truth lives in code, tests, docs, skills, and changelog.
