### PR TITLE
[docs] Triage operator note into roadmap

### DIFF
--- a/docs/OPERATOR-LOOPS.md
+++ b/docs/OPERATOR-LOOPS.md
@@ -26,9 +26,10 @@ Current surfaces:
 
 Next improvements:
 
-- resumable onboarding that can span multiple sessions;
+- beginner-safe GitHub/provider onboarding with persistent readiness checks;
 - domain and public-context enrichment through optional sidecars;
-- better detection of missing or stale reference files.
+- clearer rules for when one business should become multiple repos or
+  workspaces.
 
 ## 2. See
 
@@ -47,10 +48,12 @@ Current surfaces:
 
 Next improvements:
 
-- `mb status` v1 with "since last check";
-- drift detection for stale context and broken wiring;
-- stable `--json` schemas for agents and dashboards;
-- a thin local dashboard once the JSON substrate is useful.
+- richer drift detection for stale context, stale links, and broken wiring;
+- provider-readiness signals for GitHub, Cloudflare, Google, Meta, Apify, and
+  other optional tools;
+- an Obsidian-compatible link/readability pass for markdown repos;
+- a local dashboard that visualizes existing repo/GitHub/provider truth without
+  becoming the source of truth.
 
 ## 3. Decide
 
@@ -71,7 +74,9 @@ Next improvements:
 - a deterministic next-action ranker;
 - top-three recommendations in `mb status` and `/mb-start`;
 - explicit pin, skip, and defer controls;
-- privacy-safe prompts to open GitHub issues when the user hits friction.
+- noob-safe prompts to open GitHub issues when the user hits friction;
+- decision trees for provider choices, paid-SaaS exceptions, sensitive data, and
+  workspace/repo boundaries.
 
 ## 4. Execute
 
@@ -104,6 +109,7 @@ Next improvements:
 
 - skills leaning more heavily on CLI facts instead of duplicate checks;
 - optional provider and sidecar contracts;
+- noob-safe connector flows for GitHub, Cloudflare, Google, Meta, and Apify;
 - richer site, ads, organic, bookkeeping, and fulfillment loops.
 
 ## 5. Narrate
@@ -118,14 +124,14 @@ Current surfaces:
 - `CHANGELOG.md`
 - decisions and retros;
 - `/mb-end`;
+- `bets/` and `/mb-bet`;
 - GitHub releases;
 - public site workflows through `/mb-site`
 
 Next improvements:
 
-- a `bets/` primitive for public operating bets;
-- `/mb-bet` with `new`, `update`, `close`, `list`, and `narrate` modes;
-- status integration for active bets and deadlines;
+- bet-to-offer graduation rules;
+- status and dashboard visibility for active bets, deadlines, and outcomes;
 - public bets pages generated from repo truth.
 
 ## Applying The Loops

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -16,6 +16,8 @@ Main Branch already ships:
 - beginner setup, migration, repair, and update paths;
 - local-first provider metadata and secret-safe connection checks;
 - graph and status primitives for future dashboard and agent workflows;
+- privacy-safe GitHub issue drafting for user friction;
+- `bets/` and `/mb-bet` as the first narration primitive;
 - public contribution, support, security, compatibility, and agent guidance.
 
 Claude Code is the supported runtime today. Other runtimes are compatibility
@@ -26,17 +28,26 @@ targets until adapter code and smoke evidence exist.
 The next major product step is turning `mb status` and `/mb-start` into a
 useful daily decision surface.
 
-Planned scope:
+Shipped scope:
 
 - `mb status` v1 with "since last check", drift detection, and a stable JSON
   schema ([#261](https://github.com/noontide-co/mainbranch/issues/261));
+- privacy-safe issue drafting for bugs, missing workflows, confusing errors,
+  and feature ideas ([#264](https://github.com/noontide-co/mainbranch/issues/264));
+- `bets/` and `/mb-bet` as the first primitive for tracking and narrating
+  operator bets ([#266](https://github.com/noontide-co/mainbranch/issues/266)).
+
+Remaining planned scope:
+
 - a deterministic next-action ranker with top-three recommendations and cited
   signals ([#262](https://github.com/noontide-co/mainbranch/issues/262));
 - `/mb-start` using the same status and ranker substrate
   ([#262](https://github.com/noontide-co/mainbranch/issues/262));
 - shared readiness checks so skills call `mb` instead of duplicating probes
   ([#263](https://github.com/noontide-co/mainbranch/issues/263));
-- docs that make the product ethos and operator loops explicit.
+- cleaner beginner/provider onboarding that explains the tool philosophy and
+  proves GitHub/provider readiness before noob users get stuck
+  ([#273](https://github.com/noontide-co/mainbranch/issues/273)).
 
 Anti-scope for v0.3.0:
 
@@ -44,7 +55,7 @@ Anti-scope for v0.3.0:
 - no broad multi-runtime support claims;
 - no marketplace;
 - no automatic model invocation from `mb`;
-- no issue-submission automation until the privacy layer is ready.
+- no provider setup that stores secrets in repo files.
 
 ## Soon: v0.3.x - Improves Itself In Public
 
@@ -53,29 +64,33 @@ friction easier to turn into public improvement.
 
 Planned scope:
 
-- privacy-safe issue drafting for bugs, missing workflows, confusing errors,
-  and feature ideas ([#264](https://github.com/noontide-co/mainbranch/issues/264));
 - `/mb-status` as a thin runtime wrapper over `mb status`;
 - a small read-only local dashboard spike over existing JSON outputs
   ([#189](https://github.com/noontide-co/mainbranch/issues/189));
 - sidecar enrichment contract for optional tools such as public company
   context, analytics, bookkeeping, transcription, or deployment helpers
   ([#265](https://github.com/noontide-co/mainbranch/issues/265)).
+- Obsidian-compatible markdown/link conventions so business repos remain useful
+  in existing markdown tools
+  ([#275](https://github.com/noontide-co/mainbranch/issues/275));
+- a workspace/repo boundary decision for multi-repo businesses, private operator
+  dashboards, finance/legal access, and team daily logs
+  ([#274](https://github.com/noontide-co/mainbranch/issues/274)).
 
-## Later: v0.4 - Launches Bets
+## Later: v0.4 - Launches Offers From Bets
 
-The next proof point after the daily decision loop is launching and narrating
-real business bets from the repo.
+The next proof point after the daily decision loop is graduating real business
+bets into offers, pages, ads, fulfillment, and public narration.
 
 Planned scope:
 
-- `bets/` as a first-class business-repo primitive;
-- `/mb-bet` with `new`, `update`, `close`, `list`, and `narrate` modes;
 - links between bets, decisions, research, campaigns, and outcomes;
 - public bets feed generated through site workflows;
-- `mb status` showing active bets, deadlines, and outcomes;
-- core bets work tracked in [#266](https://github.com/noontide-co/mainbranch/issues/266);
-- decisions on fulfillment and bookkeeping workflows.
+- offer launch workflow: keyword gate, lander, ads, and `/mb-start`
+  orchestration ([#89](https://github.com/noontide-co/mainbranch/issues/89));
+- decisions on fulfillment and bookkeeping workflows;
+- bookkeeping/P&L primitives that respect finance-data privacy boundaries
+  ([#128](https://github.com/noontide-co/mainbranch/issues/128)).
 
 ## Longer Range
 
@@ -88,7 +103,8 @@ Likely directions:
   orchestration, and local runtimes;
 - dashboard/server mode as an optional local or self-hosted view over repo
   truth, graph output, GitHub, and connected tools;
-- structured data layer for metrics, ads, analytics, P&L, and ledgers;
+- structured data layer for metrics, ads, analytics, P&L, and ledgers, with
+  explicit access boundaries before sensitive financial/legal data is surfaced;
 - richer sidecar ecosystem behind narrow JSON contracts;
 - deeper pages, paid ads, organic, fulfillment, and bookkeeping workflows.
 


### PR DESCRIPTION
## Summary
- Updates the public roadmap after status v1, privacy-safe issue drafting, and bets landed.
- Captures the 2026-05-04 operator-note implications as public-safe roadmap direction: provider onboarding, Obsidian compatibility, workspace boundaries, and finance-data guardrails.
- Keeps dashboard and bookkeeping direction tied to deterministic repo/GitHub/provider contracts instead of hidden app state.

## Scope
- In: `docs/ROADMAP.md`, `docs/OPERATOR-LOOPS.md`, and GitHub issue triage comments.
- Out: CLI behavior, skill behavior, package versioning, release automation, private Monologue transcript content.

## Commits
- `8571698` — `[docs] Triage operator note into roadmap`

## Release / Issues
- Release: none; roadmap/docs only.
- Linear ID(s): none.
- Closes: none.
- Refs: #89, #120, #128, #144, #189, #262, #263, #273, #274, #275.
- Follow-ups: implement or prioritize #273, #274, and #275 in Linear/GitHub planning.

## Success Metric
- The 12:47 PM operator-note ideas are no longer private-only memory: each major product implication now has either a public roadmap mention, a GitHub issue, or a comment on the relevant implementation thread.

## Validation
- Level 0 docs/decision: updated public docs only; avoided private transcript details.
- Level 1 static: `scripts/check.sh` passed.
- Level 2 CLI: not needed; no CLI behavior changed.
- Level 3 package/install: not needed; no package behavior changed.
- Level 4 fixture repo: not needed; docs-only.
- Level 5 runtime smoke: not needed; docs-only.

## Public / Private Boundary
- The Monologue note stayed private source material. Public docs/issues use distilled product implications only: no raw transcript, local private context, account details, or personal planning specifics.