### PR TITLE
[add] mb status ranked next actions

### DIFF
--- a/.claude/skills/mb-start/SKILL.md
+++ b/.claude/skills/mb-start/SKILL.md
@@ -9,6 +9,13 @@ Single entry point for Main Branch. Detect user state, context level, experience
 
 **Recommended workflow:** Start Claude in your business repo, run `/mb-start`. It handles everything. Main Branch is loaded through `additionalDirectories`, with bridge links as a compatibility fallback for skill discovery.
 
+**Status facts first:** Once the business repo path is known, run
+`mb status --json --peek` before asking setup or routing questions. Treat that
+JSON as the source of truth for update severity, readiness, drift, onboarding,
+integrations, GitHub tasks/proposals, bets, dirty git, since-last-check, and
+`ranked_actions`. Do not duplicate those checks with ad hoc shell probes unless
+the status report says a section is unavailable.
+
 ---
 
 ## CRITICAL: Repo Selection Rules
@@ -64,14 +71,19 @@ Apply to: business repo selection, skill routing, any multiple choice.
 │   ├── CWD has .claude/skills/? ─────→ User is in the engine repo (old workflow). Trigger migration.
 │   └── Neither? ────────────────────→ Check config, then ask user.
 │
-├── Check engine updates ──────────────→ Use mb update for the active install
+├── Read status facts ────────────────→ `mb status --json --peek`
+│   ├── ranked_actions? ──────────────→ show top recommendation before menu
+│   ├── readiness/drift blockers? ────→ use cited status repair commands
+│   └── unavailable section? ─────────→ use only the documented fallback for that section
+│
+├── Check engine updates ──────────────→ Use status update severity and `mb update`
 │
 ├── Load config ──────────────────────→ See [config-system.md](references/config-system.md)
 │   ├── ~/.config/vip/local.yaml ─────→ legacy engine path + default_repo + user identity
 │   └── [repo]/.vip/config.yaml ──────→ Team settings, MCP requirements
 │
-├── Verify Main Branch loaded ────────────────→ Check additionalDirectories has Main Branch
-│   └── Missing? ────────────────────→ Run `mb skill link --repo .`, or route to /mb-setup if setup is incomplete
+├── Verify Main Branch loaded ────────→ Use status runtime.skill_wiring facts
+│   └── Missing? ────────────────────→ Run the repair command cited by status
 │
 ├── MCP pre-flight ───────────────────→ See [mcp-preflight.md](references/mcp-preflight.md)
 │   └── Missing required MCP? ────────→ Offer setup or skip
@@ -80,7 +92,7 @@ Apply to: business repo selection, skill routing, any multiple choice.
 │
 ├── Pull business repo updates ───────→ (your repo, silently)
 │
-├── Onboarding progress check ────────→ `mb onboard status --json`
+├── Onboarding progress check ────────→ Use status onboarding facts
 │   ├── missing core reference? ──────→ collect only current missing inputs
 │   └── complete? ───────────────────→ continue to readiness/menu
 │
@@ -91,7 +103,7 @@ Apply to: business repo selection, skill routing, any multiple choice.
 ├── Has repo but thin? ───────────────→ /mb-think codify
 │   (reference files exist but incomplete)
 │
-├── Present menu ────────────────────→ Readiness gates which options show
+├── Present menu ────────────────────→ status readiness gates which options show
 │   (option 1 = triage, recommended)
 │
 ├── User picks option 1? ───────────→ Spawn triage agents (see triage-agent.md)
@@ -117,11 +129,38 @@ Apply to: business repo selection, skill routing, any multiple choice.
 
 ---
 
+## Step 0: Read Status Facts
+
+After repo selection, run:
+
+```bash
+mb status --json --peek
+```
+
+Use this report before asking additional questions:
+
+- `ranked_actions` is the deterministic top-three next-action list. Surface
+  the first action as the recommendation, including its reason and cited signal
+  summaries.
+- `readiness` gates whether setup/repair work must happen before output skills.
+- `drift.items` names stale or broken status signals and repair commands.
+- `onboarding.summary` and `onboarding.checklist` replace separate onboarding
+  probes unless the status report is unavailable.
+- `github.sections`, `brain.bets`, and `since_last_check` supply the continuity
+  facts for routing and triage.
+
+Only run a narrower fallback command such as `mb onboard status --json`,
+`mb doctor`, `mb validate --cross-refs`, or `mb connect doctor` when status
+points at that section as unavailable, degraded, or needing repair.
+
 ## Step 1: Pull Engine Updates
 
-Check Main Branch updates from the business repo. **Do NOT silently swallow failures.** Users on stale code get broken features.
+Use the `update` section from `mb status --json --peek`. **Do NOT silently
+swallow required updates.** Users on stale code get broken features.
 
-See **[references/pull-engine-updates.md](references/pull-engine-updates.md)** for the canonical pull script, result handling table, the failure warning to surface, and the matching Step 3 business-repo pull logic.
+If `update.severity` is `required` or the top ranked action is an update action,
+run the cited command (`mb update` or the package-manager command from status),
+then run `mb status --json --peek` again before routing.
 
 ---
 
@@ -149,7 +188,8 @@ Once business repo is confirmed, pull its latest updates from `REPO_PATH`. See *
 
 ## Step 3a: Resume Onboarding Progress
 
-Run:
+Prefer the `onboarding` section from `mb status --json --peek`. If status is
+unavailable or the operator specifically asks for onboarding detail, run:
 
 ```bash
 mb onboard status --repo "$REPO_PATH" --json
@@ -209,7 +249,9 @@ See [tool-status-audit.md](references/tool-status-audit.md) for the full procedu
 
 ## Step 6: Readiness Assessment
 
-**Run AFTER MCP pre-flight and tool-status audit, BEFORE routing.** Scores reference files, checks session state, and gates routing so users don't jump into output skills with thin context.
+Use `readiness` and `ranked_actions` from `mb status --json --peek` before
+routing. The legacy scoring rubric below is fallback detail for gaps that status
+does not expose yet.
 
 See [readiness-assessment.md](references/readiness-assessment.md) for complete scoring rubric, session state checks, soul health check, skill-specific requirements, and display format.
 

--- a/.claude/skills/mb-status/SKILL.md
+++ b/.claude/skills/mb-status/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: mb-status
+description: "Thin Main Branch status wrapper. Use when the operator asks what changed, what is healthy, what is stale, what to do next, or wants a daily briefing inside Claude Code."
+---
+
+# Status
+
+Show the operator the deterministic Main Branch briefing without duplicating
+repo-health checks in prose.
+
+## Workflow
+
+1. Confirm you are in the business repo. If not, ask the operator to `cd` into
+   the business repo or pass the repo path.
+2. Run:
+
+```bash
+mb status --json --peek
+```
+
+3. Treat the JSON as the source of truth for setup, update, drift, GitHub,
+   onboarding, integrations, bets, since-last-check, readiness, and ranked
+   actions.
+4. Summarize the top `ranked_actions` first. For each one, include:
+   - title
+   - command or slash command
+   - reason
+   - cited signal summaries
+5. Then summarize only the sections that matter for the operator's question.
+   Do not re-run shell probes that duplicate status facts.
+
+## Mutating The Last-Check Marker
+
+`--peek` is the default inside this skill because a conversation may inspect
+status before the operator is ready to record a daily check.
+
+If the operator explicitly says this is the daily check-in and wants it
+recorded, run:
+
+```bash
+mb status --json
+```
+
+Use the new report for the answer.
+
+## Privacy
+
+Respect each action and signal's `safe_to_share` field. If `safe_to_share` is
+false, keep evidence local to the conversation and do not suggest pasting it
+into public GitHub without review.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,11 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 - Added `mb status` schema v1.0 with repo-local since-last-check state,
   deterministic drift signals, `--peek` non-mutating reads, `--verbose` detail
   output, and `--no-color` human output. Refs #261.
+- Added deterministic `mb status` ranked next actions with cited signals,
+  confidence, and `safe_to_share` fields, plus top-three human rendering. Refs
+  #262.
+- Added `/mb-status` as a thin Claude Code wrapper over
+  `mb status --json --peek`.
 
 ### Changed
 
@@ -39,6 +44,8 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   the public product frame before making roadmap, runtime, or workflow changes.
 - Clarified compatibility docs so non-Claude runtimes remain roadmap surfaces
   until each has a documented adapter and fresh-repo smoke evidence.
+- Updated `/mb-start` to read deterministic status/ranker facts before asking
+  setup or routing questions. Refs #263.
 
 ## [0.2.6] - 2026-05-04
 

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ The CLI surface for the engine. Built for Claude Code first; runtime-agnostic by
 | `mb onboard` | Human setup flow: create or connect a business repo, explain the substrate, wire Claude Code skills, and show the next `/mb-start` step. |
 | `mb onboard status` | Show durable onboarding progress from `.mb/onboarding.json`, including missing core-reference inputs and the next recommended action. |
 | `mb init` | Set up a fresh business repo (business folders, CLAUDE.md, git init). |
-| `mb status` | Show a local-first daily briefing: since-last-check changes, drift, repo health, runtime wiring, recent decisions/research/bets/git activity, and GitHub tasks when `gh` is authenticated. Use `--json` for the v1 status schema, `--verbose` for detail, and `--peek` for non-mutating reads. |
+| `mb status` | Show a local-first daily briefing: ranked next actions, since-last-check changes, drift, repo health, runtime wiring, recent decisions/research/bets/git activity, and GitHub tasks when `gh` is authenticated. Use `--json` for the v1 status schema, `--verbose` for detail, and `--peek` for non-mutating reads. |
 | `mb doctor` | Check the environment — repo shape, frontmatter sanity, settings on disk. Walks you through fixes. |
 | `mb connect` | Register provider credentials, test provider health, and inspect repair-safe integration status without committing secrets. |
 | `mb issue draft` | Create a local, privacy-scrubbed GitHub issue draft under `.mb/issue-drafts/` for bugs, feature gaps, or questions. |
@@ -211,6 +211,7 @@ Skills are pre-built workflows you invoke with slash prompts. Instead of figurin
 | Skill | What it does |
 |---|---|
 | `/mb-start` | Main entry point — figures out what you need and routes you there |
+| `/mb-status` | Thin Claude Code wrapper over `mb status --json --peek` for daily briefing facts and ranked next actions |
 | `/mb-setup` | Set up your business repo (run this first if you're new) |
 | `/mb-think` | Research, make decisions, add context, transcribe local recordings, update reference files |
 | `/mb-bet` | Open, update, close, list, and narrate business bets |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -43,6 +43,7 @@ Remaining planned scope:
   signals ([#262](https://github.com/noontide-co/mainbranch/issues/262));
 - `/mb-start` using the same status and ranker substrate
   ([#262](https://github.com/noontide-co/mainbranch/issues/262));
+- `/mb-status` as a thin runtime wrapper over deterministic status facts;
 - shared readiness checks so skills call `mb` instead of duplicating probes
   ([#263](https://github.com/noontide-co/mainbranch/issues/263));
 - cleaner beginner/provider onboarding that explains the tool philosophy and
@@ -64,7 +65,6 @@ friction easier to turn into public improvement.
 
 Planned scope:
 
-- `/mb-status` as a thin runtime wrapper over `mb status`;
 - a small read-only local dashboard spike over existing JSON outputs
   ([#189](https://github.com/noontide-co/mainbranch/issues/189));
 - sidecar enrichment contract for optional tools such as public company

--- a/mb/mb/ranker.py
+++ b/mb/mb/ranker.py
@@ -1,0 +1,565 @@
+"""Deterministic next-action ranking over ``mb status`` reports."""
+
+from __future__ import annotations
+
+from typing import Any
+
+RANKER_SCHEMA_VERSION = "1.0"
+MAX_ACTIONS = 3
+
+WEIGHTS: dict[str, int] = {
+    "update_required": 120,
+    "not_mainbranch_repo": 115,
+    "skill_wiring_broken": 110,
+    "git_repo_missing": 105,
+    "onboarding_incomplete": 95,
+    "overdue_bets": 90,
+    "unhealthy_integrations": 85,
+    "github_context_repair": 80,
+    "dirty_git": 75,
+    "attention_requests": 70,
+    "assigned_tasks": 65,
+    "blocked_or_stale_tasks": 60,
+    "due_bets": 58,
+    "stale_decisions": 50,
+    "stale_research": 35,
+    "since_last_check": 25,
+    "low_signal": 1,
+}
+
+SEVERITY_PRIORITY: dict[str, str] = {
+    "error": "urgent",
+    "warn": "high",
+    "info": "medium",
+}
+
+
+def rank_status_report(
+    report: dict[str, Any],
+    *,
+    limit: int = MAX_ACTIONS,
+) -> list[dict[str, Any]]:
+    """Return ranked next actions from a status v1 report.
+
+    This function is intentionally deterministic and local: it only inspects
+    the report passed in, uses static weights, and never calls a model or
+    external service.
+    """
+
+    actions: list[dict[str, Any]] = []
+    _add_readiness_actions(actions, report)
+    _add_drift_actions(actions, report)
+    _add_bet_actions(actions, report)
+    _add_github_actions(actions, report)
+    _add_since_last_check_action(actions, report)
+
+    ranked = sorted(actions, key=_action_sort_key)
+    if not ranked:
+        ranked = [_low_signal_action(report)]
+    return ranked[:limit]
+
+
+def _add_readiness_actions(actions: list[dict[str, Any]], report: dict[str, Any]) -> None:
+    update = _dict(report.get("update"))
+    update_severity = str(update.get("severity") or "")
+    if update_severity in {"required", "recommended"}:
+        severity = "error" if update_severity == "required" else "warn"
+        score = WEIGHTS["update_required"] if update_severity == "required" else 78
+        actions.append(
+            _action(
+                action_id=f"mainbranch_update_{update_severity}",
+                title="Update Main Branch",
+                command=str(update.get("command") or "mb update"),
+                severity=severity,
+                score=score,
+                reason=str(update.get("reason") or "The installed Main Branch package is stale."),
+                signals=[
+                    _signal(
+                        "update.severity",
+                        severity=severity,
+                        summary=f"update severity is {update_severity}",
+                        evidence=[
+                            str(update.get("installed") or ""),
+                            str(update.get("latest") or ""),
+                        ],
+                        weight=score,
+                    )
+                ],
+            )
+        )
+
+    repo = _dict(report.get("repo"))
+    if not bool(repo.get("looks_like_mainbranch_repo")):
+        missing = [str(item) for item in _list(repo.get("missing_markers"))]
+        actions.append(
+            _action(
+                action_id="initialize_or_switch_business_repo",
+                title="Open or initialize a Main Branch business repo",
+                command="mb init",
+                severity="error",
+                score=WEIGHTS["not_mainbranch_repo"],
+                reason="This folder does not have the required Main Branch repo markers.",
+                signals=[
+                    _signal(
+                        "repo.looks_like_mainbranch_repo",
+                        severity="error",
+                        summary="business repo shape is missing",
+                        evidence=missing[:5],
+                        weight=WEIGHTS["not_mainbranch_repo"],
+                    )
+                ],
+            )
+        )
+
+    git = _dict(report.get("git"))
+    if not bool(git.get("inside_work_tree")):
+        actions.append(
+            _action(
+                action_id="initialize_git_work_tree",
+                title="Repair git setup",
+                command="git init",
+                severity="error",
+                score=WEIGHTS["git_repo_missing"],
+                reason=str(git.get("error") or "This folder is not a git work tree."),
+                signals=[
+                    _signal(
+                        "git.inside_work_tree",
+                        severity="error",
+                        summary="git work tree is missing",
+                        evidence=[str(git.get("error") or "")],
+                        weight=WEIGHTS["git_repo_missing"],
+                    )
+                ],
+            )
+        )
+    elif bool(git.get("dirty")):
+        dirty_count = _as_int(git.get("dirty_count"))
+        dirty_files = [str(item) for item in _list(git.get("dirty_files"))]
+        actions.append(
+            _action(
+                action_id="review_local_git_changes",
+                title="Review local git changes",
+                command="git status --short",
+                severity="warn",
+                score=WEIGHTS["dirty_git"] + min(dirty_count, 10),
+                reason=f"{dirty_count} local file(s) changed since the last clean handoff.",
+                signals=[
+                    _signal(
+                        "git.dirty",
+                        severity="warn",
+                        summary=f"{dirty_count} dirty file(s)",
+                        evidence=dirty_files[:5],
+                        weight=WEIGHTS["dirty_git"],
+                        safe_to_share=False,
+                    )
+                ],
+            )
+        )
+
+    runtime = _dict(report.get("runtime"))
+    skill_wiring = _dict(runtime.get("skill_wiring"))
+    if skill_wiring and not bool(skill_wiring.get("ok")):
+        actions.append(
+            _action(
+                action_id="repair_skill_wiring",
+                title="Repair Claude Code skill wiring",
+                command=str(
+                    skill_wiring.get("repair")
+                    or "mb skill repair --repo . && mb skill link --repo ."
+                ),
+                severity="error",
+                score=WEIGHTS["skill_wiring_broken"],
+                reason="Claude Code cannot reliably discover the bundled Main Branch skills.",
+                signals=[
+                    _signal(
+                        "runtime.skill_wiring.ok",
+                        severity="error",
+                        summary="skill wiring is not healthy",
+                        evidence=[str(item) for item in _list(skill_wiring.get("missing"))[:5]],
+                        weight=WEIGHTS["skill_wiring_broken"],
+                    )
+                ],
+            )
+        )
+
+    onboarding = _dict(report.get("onboarding"))
+    onboarding_summary = _dict(onboarding.get("summary"))
+    if onboarding_summary.get("status") == "in_progress":
+        missing_inputs = [str(item) for item in _list(onboarding_summary.get("missing_inputs"))]
+        actions.append(
+            _action(
+                action_id="resume_onboarding",
+                title="Finish required onboarding inputs",
+                command=str(
+                    onboarding_summary.get("next_recommended_action") or "mb onboard status"
+                ),
+                severity="warn",
+                score=WEIGHTS["onboarding_incomplete"] + min(len(missing_inputs), 10),
+                reason=(
+                    f"{_as_int(onboarding_summary.get('completed_required'))}/"
+                    f"{_as_int(onboarding_summary.get('total_required'))} required onboarding "
+                    "steps are complete."
+                ),
+                signals=[
+                    _signal(
+                        "onboarding.summary.status",
+                        severity="warn",
+                        summary="onboarding is still in progress",
+                        evidence=missing_inputs[:5],
+                        weight=WEIGHTS["onboarding_incomplete"],
+                    )
+                ],
+            )
+        )
+
+
+def _add_drift_actions(actions: list[dict[str, Any]], report: dict[str, Any]) -> None:
+    drift = _dict(report.get("drift"))
+    for item in _list(drift.get("items")):
+        drift_item = _dict(item)
+        drift_id = str(drift_item.get("id") or "")
+        if drift_id == "unhealthy_integrations":
+            score = WEIGHTS["unhealthy_integrations"]
+            actions.append(
+                _action(
+                    action_id="repair_unhealthy_integrations",
+                    title="Repair unhealthy integrations",
+                    command=str(drift_item.get("repair") or "mb connect doctor"),
+                    severity="warn",
+                    score=score,
+                    reason=str(drift_item.get("summary") or "A declared integration needs repair."),
+                    signals=[_drift_signal(drift_item, weight=score)],
+                )
+            )
+        elif drift_id == "stale_decisions":
+            score = WEIGHTS["stale_decisions"]
+            actions.append(
+                _action(
+                    action_id="review_stale_decisions",
+                    title="Review stale decisions",
+                    command="/mb-think",
+                    severity="warn",
+                    score=score + len(_list(drift_item.get("evidence"))),
+                    reason=str(
+                        drift_item.get("summary")
+                        or "Proposed or running decisions have gone stale."
+                    ),
+                    signals=[_drift_signal(drift_item, weight=score, safe_to_share=False)],
+                )
+            )
+        elif drift_id == "stale_research":
+            score = WEIGHTS["stale_research"]
+            actions.append(
+                _action(
+                    action_id="refresh_stale_research",
+                    title="Refresh stale research",
+                    command="/mb-think",
+                    severity="info",
+                    score=score + len(_list(drift_item.get("evidence"))),
+                    reason=str(
+                        drift_item.get("summary") or "Research is older than freshness rules."
+                    ),
+                    signals=[_drift_signal(drift_item, weight=score, safe_to_share=False)],
+                )
+            )
+
+    github_context = _dict(_dict(report.get("github")).get("context"))
+    if github_context and not bool(github_context.get("ok")):
+        severity = "warn" if github_context.get("state") != "missing_cli" else "info"
+        score = WEIGHTS["github_context_repair"]
+        actions.append(
+            _action(
+                action_id="repair_github_context",
+                title="Repair GitHub task context",
+                command=str(github_context.get("repair_command") or "gh auth login"),
+                severity=severity,
+                score=score,
+                reason=str(
+                    github_context.get("summary")
+                    or "GitHub task and proposal facts are unavailable."
+                ),
+                signals=[
+                    _signal(
+                        "github.context.ok",
+                        severity=severity,
+                        summary=str(github_context.get("state") or "not_ready"),
+                        evidence=[str(github_context.get("summary") or "")],
+                        weight=score,
+                    )
+                ],
+            )
+        )
+
+
+def _add_bet_actions(actions: list[dict[str, Any]], report: dict[str, Any]) -> None:
+    bets = _dict(_dict(report.get("brain")).get("bets"))
+    overdue = [_dict(item) for item in _list(bets.get("overdue"))]
+    if overdue:
+        score = WEIGHTS["overdue_bets"] + min(len(overdue) * 3, 15)
+        actions.append(
+            _action(
+                action_id="update_overdue_bets",
+                title="Close or update overdue bets",
+                command="/mb-bet update",
+                severity="warn",
+                score=score,
+                reason=f"{len(overdue)} active bet(s) are past their deadline.",
+                signals=[
+                    _signal(
+                        "brain.bets.overdue",
+                        severity="warn",
+                        summary="active bet deadlines are overdue",
+                        evidence=[_bet_evidence(item) for item in overdue[:5]],
+                        weight=WEIGHTS["overdue_bets"],
+                        safe_to_share=False,
+                    )
+                ],
+            )
+        )
+        return
+
+    due_soon = [_dict(item) for item in _list(bets.get("due_soon"))]
+    if due_soon:
+        score = WEIGHTS["due_bets"] + min(len(due_soon) * 3, 15)
+        actions.append(
+            _action(
+                action_id="review_due_bets",
+                title="Review bets due this week",
+                command="/mb-bet update",
+                severity="info",
+                score=score,
+                reason=f"{len(due_soon)} active bet(s) have deadlines in the next 7 days.",
+                signals=[
+                    _signal(
+                        "brain.bets.due_soon",
+                        severity="info",
+                        summary="active bet deadlines are approaching",
+                        evidence=[_bet_evidence(item) for item in due_soon[:5]],
+                        weight=WEIGHTS["due_bets"],
+                        safe_to_share=False,
+                    )
+                ],
+            )
+        )
+
+
+def _add_github_actions(actions: list[dict[str, Any]], report: dict[str, Any]) -> None:
+    github = _dict(report.get("github"))
+    if not bool(github.get("authenticated")):
+        return
+    sections = _dict(github.get("sections"))
+    candidates = [
+        (
+            "review_github_attention",
+            "Review GitHub attention requests",
+            "gh pr list --search review-requested:@me",
+            "attention_requests",
+            "proposal or task needs review/response",
+            WEIGHTS["attention_requests"],
+        ),
+        (
+            "work_assigned_github_tasks",
+            "Work assigned GitHub tasks",
+            "gh issue list --assignee @me",
+            "assigned_tasks",
+            "task is assigned to you",
+            WEIGHTS["assigned_tasks"],
+        ),
+        (
+            "unstick_blocked_or_stale_tasks",
+            "Unstick blocked or stale tasks",
+            "gh issue list --search 'label:blocked label:stale'",
+            "blocked_or_stale_tasks",
+            "task is blocked or stale",
+            WEIGHTS["blocked_or_stale_tasks"],
+        ),
+    ]
+    for action_id, title, command, section, summary, weight in candidates:
+        items = [_dict(item) for item in _list(sections.get(section))]
+        if not items:
+            continue
+        actions.append(
+            _action(
+                action_id=action_id,
+                title=title,
+                command=command,
+                severity="info",
+                score=weight + min(len(items) * 2, 12),
+                reason=f"{len(items)} GitHub {section.replace('_', ' ')} item(s) surfaced.",
+                signals=[
+                    _signal(
+                        f"github.sections.{section}",
+                        severity="info",
+                        summary=summary,
+                        evidence=[_github_evidence(item) for item in items[:5]],
+                        weight=weight,
+                        safe_to_share=False,
+                    )
+                ],
+            )
+        )
+
+
+def _add_since_last_check_action(actions: list[dict[str, Any]], report: dict[str, Any]) -> None:
+    since = _dict(report.get("since_last_check"))
+    summary = _dict(since.get("summary"))
+    changed = (
+        _as_int(summary.get("commits"))
+        + _as_int(summary.get("files_changed"))
+        + _as_int(summary.get("brain_count_changes"))
+    )
+    if since.get("first_run") or changed <= 0:
+        return
+    actions.append(
+        _action(
+            action_id="review_since_last_check",
+            title="Review what changed since the last check",
+            command="mb status --verbose --peek",
+            severity="info",
+            score=WEIGHTS["since_last_check"] + min(changed, 20),
+            reason=(
+                f"{summary.get('commits', 0)} commit(s), "
+                f"{summary.get('files_changed', 0)} file change(s), and "
+                f"{summary.get('brain_count_changes', 0)} brain count change(s) since the "
+                "last recorded check."
+            ),
+            signals=[
+                _signal(
+                    "since_last_check.summary",
+                    severity="info",
+                    summary="repo changed since the last status check",
+                    evidence=[str(summary)],
+                    weight=WEIGHTS["since_last_check"],
+                    safe_to_share=False,
+                )
+            ],
+        )
+    )
+
+
+def _low_signal_action(report: dict[str, Any]) -> dict[str, Any]:
+    readiness = _dict(report.get("readiness"))
+    level = str(readiness.get("level") or "unknown")
+    return _action(
+        action_id="not_enough_signal",
+        title="Choose the next workflow manually",
+        command="claude",
+        severity="info",
+        score=WEIGHTS["low_signal"],
+        confidence="low",
+        reason=(
+            "Status did not find enough repair, deadline, GitHub, drift, or recent-change "
+            f"signal to rank work confidently. Readiness is {level}."
+        ),
+        signals=[
+            _signal(
+                "ranker.low_signal_floor",
+                severity="info",
+                summary="not enough deterministic signal to rank work",
+                evidence=[f"readiness={level}"],
+                weight=WEIGHTS["low_signal"],
+            )
+        ],
+    )
+
+
+def _action(
+    *,
+    action_id: str,
+    title: str,
+    command: str,
+    severity: str,
+    score: int,
+    reason: str,
+    signals: list[dict[str, Any]],
+    confidence: str | None = None,
+) -> dict[str, Any]:
+    action_confidence = confidence or _confidence(score, signals)
+    safe_to_share = all(bool(signal.get("safe_to_share")) for signal in signals)
+    return {
+        "id": action_id,
+        "title": title,
+        "command": command,
+        "priority": SEVERITY_PRIORITY.get(severity, "low"),
+        "severity": severity,
+        "score": score,
+        "confidence": action_confidence,
+        "reason": reason,
+        "signals": signals,
+        "safe_to_share": safe_to_share,
+    }
+
+
+def _signal(
+    signal_id: str,
+    *,
+    severity: str,
+    summary: str,
+    evidence: list[str],
+    weight: int,
+    safe_to_share: bool = True,
+) -> dict[str, Any]:
+    return {
+        "id": signal_id,
+        "severity": severity,
+        "summary": summary,
+        "evidence": [item for item in evidence if item][:5],
+        "weight": weight,
+        "safe_to_share": safe_to_share,
+    }
+
+
+def _drift_signal(
+    item: dict[str, Any],
+    *,
+    weight: int,
+    safe_to_share: bool = True,
+) -> dict[str, Any]:
+    severity = str(item.get("severity") or "info")
+    return _signal(
+        f"drift.{item.get('id') or 'item'}",
+        severity=severity,
+        summary=str(item.get("summary") or ""),
+        evidence=[str(value) for value in _list(item.get("evidence"))],
+        weight=weight,
+        safe_to_share=safe_to_share and bool(item.get("safe_to_share", True)),
+    )
+
+
+def _confidence(score: int, signals: list[dict[str, Any]]) -> str:
+    if score >= 80 and signals:
+        return "high"
+    if score >= 35 and signals:
+        return "medium"
+    return "low"
+
+
+def _action_sort_key(action: dict[str, Any]) -> tuple[int, str]:
+    return (-_as_int(action.get("score")), str(action.get("id") or ""))
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _as_int(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _bet_evidence(item: dict[str, Any]) -> str:
+    title = str(item.get("title") or item.get("path") or "untitled bet")
+    deadline = str(item.get("deadline") or "no deadline")
+    return f"{title} ({deadline})"
+
+
+def _github_evidence(item: dict[str, Any]) -> str:
+    number = item.get("number")
+    title = str(item.get("title") or "untitled")
+    return f"#{number}: {title}" if number else title

--- a/mb/mb/start.py
+++ b/mb/mb/start.py
@@ -10,9 +10,9 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from mb import status as status_mod
 from mb.engine import install_mode, link_status
 from mb.freshness import format_update_alert, package_update_status
-from mb.status import _looks_like_mainbranch_repo
 
 
 def _which(name: str) -> str:
@@ -106,6 +106,30 @@ def _launch_claude(repo: Path) -> int:
         return 127
     except subprocess.SubprocessError:
         return 1
+
+
+def _status_facts(repo: Path) -> dict[str, Any]:
+    """Return the non-mutating status facts that agent skills should consume."""
+    try:
+        report = status_mod.run(path=str(repo), update_marker=False)
+    except Exception as exc:  # pragma: no cover - defensive CLI degradation
+        return {
+            "available": False,
+            "error": str(exc),
+            "ranked_actions": [],
+            "readiness": {},
+            "drift": {},
+        }
+    return {
+        "available": True,
+        "error": "",
+        "schema_version": report.get("schema_version"),
+        "generated_at": report.get("generated_at"),
+        "ranked_actions": report.get("ranked_actions") or [],
+        "readiness": report.get("readiness") or {},
+        "drift": report.get("drift") or {},
+        "since_last_check": report.get("since_last_check") or {},
+    }
 
 
 def _build_checks(
@@ -228,11 +252,12 @@ def _next_actions(
 def run(repo: str = ".", launch: bool = False) -> dict[str, Any]:
     """Build a handoff report and optionally launch Claude Code."""
     repo_path = Path(repo).expanduser().resolve()
-    repo_shape = _looks_like_mainbranch_repo(repo_path)
+    repo_shape = status_mod._looks_like_mainbranch_repo(repo_path)
     git = _git_status(repo_path)
     claude_path = _which("claude")
     wiring = link_status(repo_path)
     update = package_update_status(repo_path)
+    status_facts = _status_facts(repo_path)
     checks = _build_checks(repo_shape, git, claude_path, wiring, update)
     hard_failures = _hard_failures(checks)
     handoff_ready = not hard_failures
@@ -271,6 +296,8 @@ def run(repo: str = ".", launch: bool = False) -> dict[str, Any]:
             "path": claude_path,
             "skill_wiring": wiring,
         },
+        "status": status_facts,
+        "ranked_actions": status_facts.get("ranked_actions", []),
         "checks": checks,
         "command": {
             "cwd": str(repo_path),
@@ -335,4 +362,9 @@ def render_human(report: dict[str, Any]) -> None:
         console.print("\n[bold]Next[/bold]")
         for action in report["next_actions"]:
             console.print(f"  - {action}")
+    ranked_actions = report.get("ranked_actions") or []
+    if ranked_actions:
+        console.print("\n[bold]Recommended from mb status[/bold]")
+        for action in ranked_actions[:3]:
+            console.print(f"  - {action.get('title')}: {action.get('reason')}")
     console.print()

--- a/mb/mb/start.py
+++ b/mb/mb/start.py
@@ -10,9 +10,9 @@ import sys
 from pathlib import Path
 from typing import Any
 
-from mb import status as status_mod
 from mb.engine import install_mode, link_status
 from mb.freshness import format_update_alert, package_update_status
+from mb.status import _looks_like_mainbranch_repo
 
 
 def _which(name: str) -> str:
@@ -106,30 +106,6 @@ def _launch_claude(repo: Path) -> int:
         return 127
     except subprocess.SubprocessError:
         return 1
-
-
-def _status_facts(repo: Path) -> dict[str, Any]:
-    """Return the non-mutating status facts that agent skills should consume."""
-    try:
-        report = status_mod.run(path=str(repo), update_marker=False)
-    except Exception as exc:  # pragma: no cover - defensive CLI degradation
-        return {
-            "available": False,
-            "error": str(exc),
-            "ranked_actions": [],
-            "readiness": {},
-            "drift": {},
-        }
-    return {
-        "available": True,
-        "error": "",
-        "schema_version": report.get("schema_version"),
-        "generated_at": report.get("generated_at"),
-        "ranked_actions": report.get("ranked_actions") or [],
-        "readiness": report.get("readiness") or {},
-        "drift": report.get("drift") or {},
-        "since_last_check": report.get("since_last_check") or {},
-    }
 
 
 def _build_checks(
@@ -252,12 +228,11 @@ def _next_actions(
 def run(repo: str = ".", launch: bool = False) -> dict[str, Any]:
     """Build a handoff report and optionally launch Claude Code."""
     repo_path = Path(repo).expanduser().resolve()
-    repo_shape = status_mod._looks_like_mainbranch_repo(repo_path)
+    repo_shape = _looks_like_mainbranch_repo(repo_path)
     git = _git_status(repo_path)
     claude_path = _which("claude")
     wiring = link_status(repo_path)
     update = package_update_status(repo_path)
-    status_facts = _status_facts(repo_path)
     checks = _build_checks(repo_shape, git, claude_path, wiring, update)
     hard_failures = _hard_failures(checks)
     handoff_ready = not hard_failures
@@ -296,8 +271,6 @@ def run(repo: str = ".", launch: bool = False) -> dict[str, Any]:
             "path": claude_path,
             "skill_wiring": wiring,
         },
-        "status": status_facts,
-        "ranked_actions": status_facts.get("ranked_actions", []),
         "checks": checks,
         "command": {
             "cwd": str(repo_path),
@@ -362,9 +335,4 @@ def render_human(report: dict[str, Any]) -> None:
         console.print("\n[bold]Next[/bold]")
         for action in report["next_actions"]:
             console.print(f"  - {action}")
-    ranked_actions = report.get("ranked_actions") or []
-    if ranked_actions:
-        console.print("\n[bold]Recommended from mb status[/bold]")
-        for action in ranked_actions[:3]:
-            console.print(f"  - {action.get('title')}: {action.get('reason')}")
     console.print()

--- a/mb/mb/status.py
+++ b/mb/mb/status.py
@@ -15,6 +15,7 @@ import yaml
 from mb import __version__, github_activity
 from mb import connect as connect_mod
 from mb import onboard as onboard_mod
+from mb import ranker as ranker_mod
 from mb.engine import install_mode, link_status
 from mb.freshness import format_update_alert, package_update_status
 
@@ -954,6 +955,7 @@ def run(
     )
     report["drift"] = _drift(report)
     report["readiness"] = _readiness(report)
+    report["ranked_actions"] = ranker_mod.rank_status_report(report)
     report["ok"] = report["readiness"]["level"] != "not_ready"
     report["marker_update"] = (
         _write_last_seen_marker(repo_path, report)
@@ -1174,6 +1176,18 @@ def render_human(
             console.print(f"  [yellow]degraded:[/yellow] {error}")
 
     console.print("\n[bold]Next[/bold]")
-    for action in readiness["next_actions"]:
-        console.print(f"  - {action}")
+    ranked_actions = report.get("ranked_actions") or []
+    if ranked_actions:
+        for index, action in enumerate(ranked_actions[:3], start=1):
+            title = str(action.get("title") or action.get("id") or "Next action")
+            reason = str(action.get("reason") or "")
+            command = str(action.get("command") or "")
+            console.print(f"  {index}. {title}")
+            if reason:
+                console.print(f"     why: {reason}")
+            if command:
+                console.print(f"     next: {command}")
+    else:
+        for action in readiness["next_actions"]:
+            console.print(f"  - {action}")
     console.print()

--- a/mb/tests/fixtures/status/schema-v1-basic.json
+++ b/mb/tests/fixtures/status/schema-v1-basic.json
@@ -13,6 +13,7 @@
     "marker_update",
     "ok",
     "onboarding",
+    "ranked_actions",
     "readiness",
     "repo",
     "runtime",

--- a/mb/tests/test_ranker.py
+++ b/mb/tests/test_ranker.py
@@ -1,0 +1,125 @@
+"""Deterministic next-action ranker."""
+
+from __future__ import annotations
+
+from mb import ranker
+
+
+def _base_report() -> dict[str, object]:
+    return {
+        "repo": {"looks_like_mainbranch_repo": True, "missing_markers": []},
+        "git": {"inside_work_tree": True, "dirty": False, "dirty_count": 0, "dirty_files": []},
+        "update": {
+            "severity": "current",
+            "command": "",
+            "reason": "",
+            "installed": "0.2.6",
+            "latest": "0.2.6",
+        },
+        "runtime": {
+            "skill_wiring": {"ok": True, "repair": "", "missing": []},
+            "claude_code": {"found": True, "repair": ""},
+        },
+        "onboarding": {"summary": {"status": "ready"}},
+        "integrations": {"providers": []},
+        "github": {
+            "authenticated": True,
+            "context": {"ok": True},
+            "sections": {
+                "attention_requests": [],
+                "assigned_tasks": [],
+                "blocked_or_stale_tasks": [],
+            },
+        },
+        "brain": {
+            "bets": {"overdue": [], "due_soon": []},
+        },
+        "drift": {"items": []},
+        "since_last_check": {
+            "first_run": False,
+            "summary": {"commits": 0, "files_changed": 0, "brain_count_changes": 0},
+        },
+        "readiness": {"level": "ready"},
+    }
+
+
+def test_ranker_prioritizes_repair_before_business_work() -> None:
+    report = _base_report()
+    report["update"] = {
+        "severity": "required",
+        "command": "pipx upgrade mainbranch",
+        "reason": "Installed version is below the supported floor.",
+        "installed": "0.1.0",
+        "latest": "0.2.6",
+    }
+    report["brain"] = {
+        "bets": {
+            "overdue": [
+                {
+                    "title": "Launch test",
+                    "deadline": "2026-05-01",
+                    "days_overdue": 3,
+                }
+            ],
+            "due_soon": [],
+        }
+    }
+
+    actions = ranker.rank_status_report(report)
+
+    assert actions[0]["id"] == "mainbranch_update_required"
+    assert actions[0]["priority"] == "urgent"
+    assert actions[0]["command"] == "pipx upgrade mainbranch"
+    assert actions[0]["signals"][0]["id"] == "update.severity"
+    assert actions[1]["id"] == "update_overdue_bets"
+    assert actions[1]["safe_to_share"] is False
+
+
+def test_ranker_surfaces_low_confidence_floor_when_no_signals() -> None:
+    actions = ranker.rank_status_report(_base_report())
+
+    assert actions == [
+        {
+            "id": "not_enough_signal",
+            "title": "Choose the next workflow manually",
+            "command": "claude",
+            "priority": "medium",
+            "severity": "info",
+            "score": 1,
+            "confidence": "low",
+            "reason": (
+                "Status did not find enough repair, deadline, GitHub, drift, or recent-change "
+                "signal to rank work confidently. Readiness is ready."
+            ),
+            "signals": [
+                {
+                    "id": "ranker.low_signal_floor",
+                    "severity": "info",
+                    "summary": "not enough deterministic signal to rank work",
+                    "evidence": ["readiness=ready"],
+                    "weight": 1,
+                    "safe_to_share": True,
+                }
+            ],
+            "safe_to_share": True,
+        }
+    ]
+
+
+def test_ranker_uses_github_status_sections() -> None:
+    report = _base_report()
+    report["github"] = {
+        "authenticated": True,
+        "context": {"ok": True},
+        "sections": {
+            "attention_requests": [{"number": 12, "title": "Review proposal"}],
+            "assigned_tasks": [{"number": 13, "title": "Write docs"}],
+            "blocked_or_stale_tasks": [],
+        },
+    }
+
+    actions = ranker.rank_status_report(report)
+
+    assert actions[0]["id"] == "review_github_attention"
+    assert actions[0]["signals"][0]["evidence"] == ["#12: Review proposal"]
+    assert actions[0]["safe_to_share"] is False

--- a/mb/tests/test_ranker.py
+++ b/mb/tests/test_ranker.py
@@ -78,32 +78,13 @@ def test_ranker_prioritizes_repair_before_business_work() -> None:
 def test_ranker_surfaces_low_confidence_floor_when_no_signals() -> None:
     actions = ranker.rank_status_report(_base_report())
 
-    assert actions == [
-        {
-            "id": "not_enough_signal",
-            "title": "Choose the next workflow manually",
-            "command": "claude",
-            "priority": "medium",
-            "severity": "info",
-            "score": 1,
-            "confidence": "low",
-            "reason": (
-                "Status did not find enough repair, deadline, GitHub, drift, or recent-change "
-                "signal to rank work confidently. Readiness is ready."
-            ),
-            "signals": [
-                {
-                    "id": "ranker.low_signal_floor",
-                    "severity": "info",
-                    "summary": "not enough deterministic signal to rank work",
-                    "evidence": ["readiness=ready"],
-                    "weight": 1,
-                    "safe_to_share": True,
-                }
-            ],
-            "safe_to_share": True,
-        }
-    ]
+    assert len(actions) == 1
+    action = actions[0]
+    assert action["id"] == "not_enough_signal"
+    assert action["confidence"] == "low"
+    assert action["safe_to_share"] is True
+    assert action["signals"][0]["id"] == "ranker.low_signal_floor"
+    assert action["signals"][0]["evidence"] == ["readiness=ready"]
 
 
 def test_ranker_uses_github_status_sections() -> None:

--- a/mb/tests/test_start.py
+++ b/mb/tests/test_start.py
@@ -46,6 +46,8 @@ def test_start_json_prints_ready_handoff(tmp_path: Path, monkeypatch) -> None:
     assert report["command"]["follow_up"] == "/mb-start"
     assert report["launch"]["requested"] is False
     assert "update" in report
+    assert "ranked_actions" in report
+    assert report["status"]["available"] is True
 
 
 def test_start_degrades_when_claude_is_missing(tmp_path: Path, monkeypatch) -> None:

--- a/mb/tests/test_start.py
+++ b/mb/tests/test_start.py
@@ -11,6 +11,7 @@ from typing import Any
 from typer.testing import CliRunner
 
 from mb import start as start_mod
+from mb import status as status_mod
 from mb.cli import app
 from mb.init import run as init_run
 
@@ -46,8 +47,8 @@ def test_start_json_prints_ready_handoff(tmp_path: Path, monkeypatch) -> None:
     assert report["command"]["follow_up"] == "/mb-start"
     assert report["launch"]["requested"] is False
     assert "update" in report
-    assert "ranked_actions" in report
-    assert report["status"]["available"] is True
+    assert "ranked_actions" not in report
+    assert "status" not in report
 
 
 def test_start_degrades_when_claude_is_missing(tmp_path: Path, monkeypatch) -> None:
@@ -129,6 +130,21 @@ def test_start_recommended_update_keeps_handoff_ready(tmp_path: Path, monkeypatc
     assert report["update"]["severity"] == "recommended"
     update_check = next(check for check in report["checks"] if check["name"] == "mainbranch_update")
     assert update_check["severity"] == "warn"
+
+
+def test_start_does_not_run_full_status_pipeline(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(start_mod, "_which", _with_claude)
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+
+    def fail_github(*args: object, **kwargs: object) -> object:
+        raise AssertionError("mb start should not collect full status facts")
+
+    monkeypatch.setattr(status_mod, "_github", fail_github)
+
+    result = runner.invoke(app, ["start", "--repo", str(repo), "--json"])
+
+    assert result.exit_code == 0
 
 
 def test_start_asks_for_repo_when_path_is_not_business_repo(tmp_path: Path, monkeypatch) -> None:

--- a/mb/tests/test_status.py
+++ b/mb/tests/test_status.py
@@ -59,6 +59,9 @@ def test_status_json_degrades_without_github(tmp_path: Path, monkeypatch) -> Non
     assert (repo / ".mb" / "last-status-seen.json").is_file()
     assert "readiness" in report
     assert "update" in report
+    assert report["ranked_actions"]
+    assert report["ranked_actions"][0]["signals"]
+    assert "safe_to_share" in report["ranked_actions"][0]
 
 
 def test_status_schema_v1_matches_golden_fixture(tmp_path: Path, monkeypatch) -> None:
@@ -91,8 +94,10 @@ def test_status_schema_v1_matches_golden_fixture(tmp_path: Path, monkeypatch) ->
                 "since_last_check",
                 "drift",
                 "readiness",
+                "ranked_actions",
                 "marker_update",
             ]
+            if isinstance(payload[key], dict)
         },
     }
     expected = json.loads(
@@ -117,6 +122,8 @@ def test_status_human_output_mentions_core_sections(tmp_path: Path, monkeypatch)
     assert "Runtime" in result.stdout
     assert "GitHub" in result.stdout
     assert "Next" in result.stdout
+    assert "why:" in result.stdout
+    assert "next:" in result.stdout
 
 
 def test_status_since_last_check_uses_repo_marker(tmp_path: Path, monkeypatch) -> None:
@@ -223,6 +230,7 @@ def test_status_required_update_json_and_human_copy(tmp_path: Path, monkeypatch)
     assert any(
         "pipx upgrade mainbranch" in action for action in payload["readiness"]["next_actions"]
     )
+    assert payload["ranked_actions"][0]["id"] == "mainbranch_update_required"
 
     human_result = runner.invoke(app, ["status", str(repo), "--verbose"])
 
@@ -248,6 +256,9 @@ def test_status_names_integration_repairs(tmp_path: Path, monkeypatch) -> None:
     assert any(item["id"] == "unhealthy_integrations" for item in payload["drift"]["items"])
     assert any(
         "mb connect meta --token-stdin" in action for action in payload["readiness"]["next_actions"]
+    )
+    assert any(
+        action["id"] == "repair_unhealthy_integrations" for action in payload["ranked_actions"]
     )
 
     human_result = runner.invoke(app, ["status", str(repo), "--verbose"])
@@ -386,6 +397,99 @@ def test_status_readiness_mentions_due_bets(tmp_path: Path) -> None:
     readiness = status_mod._readiness(report)
 
     assert any("active bets" in action for action in readiness["next_actions"])
+
+
+def test_status_ranker_mentions_due_bets(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(status_mod, "_which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setattr(
+        status_mod,
+        "_git_info",
+        lambda repo: {
+            "available": True,
+            "inside_work_tree": True,
+            "branch": "main",
+            "commit": "abc123",
+            "dirty": False,
+            "dirty_count": 0,
+            "dirty_files": [],
+            "remote": "https://github.com/example/acme.git",
+            "error": "",
+        },
+    )
+    monkeypatch.setattr(
+        status_mod,
+        "_git_recent_activity",
+        lambda repo, git: {"available": True, "items": [], "error": ""},
+    )
+    monkeypatch.setattr(
+        status_mod,
+        "_github",
+        lambda repo, git: {
+            "available": True,
+            "authenticated": True,
+            "degraded": False,
+            "source": "gh",
+            "repo": "example/acme",
+            "summary": {
+                "assigned_tasks": 0,
+                "attention_requests": 0,
+                "open_proposals": 0,
+                "shipped_this_week": 0,
+                "recently_closed_tasks": 0,
+                "blocked_or_stale_tasks": 0,
+            },
+            "sections": {
+                "assigned_tasks": [],
+                "attention_requests": [],
+                "open_proposals": [],
+                "shipped_this_week": [],
+                "recently_closed_tasks": [],
+                "blocked_or_stale_tasks": [],
+            },
+            "errors": [],
+            "assigned_issues": [],
+            "review_requests": [],
+            "recent_merged_prs": [],
+            "context": {"ok": True, "state": "ready"},
+        },
+    )
+    monkeypatch.setattr(
+        status_mod.onboard_mod,
+        "onboarding_status",
+        lambda repo: {"summary": {"status": "ready"}, "checklist": []},
+    )
+    repo = tmp_path / "repo"
+    init_run(path=str(repo), name="Acme")
+    today = date.today()
+    (repo / "bets" / f"{today.isoformat()}-due.md").write_text(
+        (
+            "---\n"
+            "status: open\n"
+            f"opened: {today.isoformat()}\n"
+            f"deadline: {today.isoformat()}\n"
+            "appetite: 1 day\n"
+            "hypothesis: Fast follow-up increases replies.\n"
+            "metric: replies\n"
+            "target: 3 replies\n"
+            "result: ''\n"
+            "linked_decisions: []\n"
+            "linked_research: []\n"
+            "linked_campaigns: []\n"
+            "linked_outcomes: []\n"
+            "public: false\n"
+            "channels: []\n"
+            "tags: []\n"
+            "---\n\n"
+            "# Due bet\n"
+        ),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["status", str(repo), "--json", "--peek"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert any(action["id"] == "review_due_bets" for action in payload["ranked_actions"])
 
 
 def test_status_empty_bet_deadline_does_not_fall_back_to_opened_filename(tmp_path: Path) -> None:
@@ -835,6 +939,14 @@ def test_status_renderer_prints_optional_sections(capsys) -> None:
             "errors": ["merged PRs: degraded"],
         },
         "readiness": {"level": "ready", "score": 100, "next_actions": ["Run `claude`."]},
+        "ranked_actions": [
+            {
+                "id": "review_due_bets",
+                "title": "Review bets due this week",
+                "command": "/mb-bet update",
+                "reason": "1 active bet has a deadline soon.",
+            }
+        ],
     }
 
     status_mod.render_human(report, verbose=True, no_color=True)
@@ -849,3 +961,4 @@ def test_status_renderer_prints_optional_sections(capsys) -> None:
     assert "shipped this week: 1" in output
     assert "task #173" in output
     assert "shipped #192" in output
+    assert "Review bets due this week" in output

--- a/mb/tests/test_status.py
+++ b/mb/tests/test_status.py
@@ -962,3 +962,48 @@ def test_status_renderer_prints_optional_sections(capsys) -> None:
     assert "task #173" in output
     assert "shipped #192" in output
     assert "Review bets due this week" in output
+
+
+def test_status_renderer_falls_back_to_readiness_actions_for_legacy_reports(capsys) -> None:
+    report: dict[str, Any] = {
+        "repo": {"path": "/tmp/biz", "looks_like_mainbranch_repo": True},
+        "install": {"detail": "mb 0.2.6 (wheel mode)"},
+        "runtime": {
+            "claude_code": {"found": True},
+            "skill_wiring": {"ok": True},
+        },
+        "git": {"inside_work_tree": True, "branch": "main", "dirty": False},
+        "brain": {
+            "counts": {
+                "core": 0,
+                "reference/core": 0,
+                "research": 0,
+                "decisions": 0,
+                "bets": 0,
+                "campaigns": 0,
+                "log": 0,
+                "documents": 0,
+            },
+            "recent_decisions": [],
+            "stale_decisions": [],
+            "stale_research": [],
+            "recent_research": [],
+            "bets": {"active": [], "due_soon": [], "overdue": [], "recent": []},
+        },
+        "git_activity": {"items": []},
+        "github": {
+            "available": False,
+            "authenticated": False,
+            "errors": [],
+        },
+        "readiness": {
+            "level": "ready",
+            "score": 100,
+            "next_actions": ["Run `claude` in this repo, then `/mb-start`."],
+        },
+    }
+
+    status_mod.render_human(report, no_color=True)
+
+    output = capsys.readouterr().out
+    assert "Run `claude` in this repo, then `/mb-start`." in output


### PR DESCRIPTION
## Summary
- Adds deterministic ranked next actions to `mb status` JSON and human output using status v1 facts only.
- Keeps `mb start` as the fast runtime handoff surface while `/mb-start` consumes `mb status --json --peek` for daily decision facts.
- Adds `/mb-status` as a thin Claude Code wrapper over status JSON and documents the new status/ranker surface.

## Scope
- In: deterministic ranker module, additive `ranked_actions`, top-three status rendering, `/mb-start` status-first guidance, `/mb-status`, docs/changelog/tests.
- Out: model calls, scheduler, autonomous execution, dashboard UI, broad runtime ports, and making `mb start` run full status by default.

## Commits
- `6b1b612` — `[add] MAIN-217 rank status next actions`.
- `0477397` — `[update] MAIN-218 route skills through status facts`.
- `e0f3a6b` — `[fix] MAIN-217 keep start handoff fast`.

## Release / Issues
- Release: v0.3.0 - Knows what to do next.
- Linear ID(s): MAIN-217, MAIN-218.
- Closes: #262.
- Refs: #263.
- Follow-ups: keep #263 open if broader lifecycle/output skill audit remains beyond the focused `/mb-start` and `/mb-status` reconciliation.

## Success Metric
- `mb status` can show three evidence-backed next actions from deterministic repo/GitHub/status facts, while `/mb-start` reads those facts before routing and `mb start` stays a handoff command.

## Validation
- Level 0 docs/decision: README, ROADMAP, CHANGELOG, `/mb-start`, and `/mb-status` updated; public/private boundary reviewed.
- Level 1 static: `scripts/check.sh` passed with ruff, mypy, coverage, and bundled skill validation before rebase.
- Level 2 CLI: focused ranker/status/start tests passed after rebase; full suite passed with 189 tests before rebase.
- Level 3 package/install: wheel built and installed before rebase; `mb-status` discoverable at installed `_engine/.claude/skills/mb-status/SKILL.md`.
- Level 4 fixture repo: fresh `mb onboard`, `mb status --json --peek`, `mb start --json`, and `mb validate` smoke passed before rebase; status returned ranked actions and start stayed handoff-only.
- Level 5 runtime smoke: Claude Code noninteractive `/mb-start` with the branch wheel on `PATH` ran `mb status --json --peek` and reported `ranked_actions`, first action `resume_onboarding`.
- Post-rebase CI: GitHub Actions passed for Python 3.10, 3.11, 3.12, SKILL.md line-count gate, and wheel-install-smoke.

## Public / Private Boundary
- No private Devon, Conductor, customer, credential, or local runtime details were committed; runtime and fixture evidence used temporary paths only.
