### PR TITLE
[add] workspace data boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ### Added
 
+- Added an accepted workspace/repo/sensitive-data boundary decision covering
+  business repos, workspaces, repo/workspace/private dashboards, team daily
+  logs, finance/legal data, future `mb books` behavior, and why editable files
+  cannot be admin authority. Closes #274; refs #120 and #128.
+- Added GitHub/Obsidian-compatible markdown and link conventions for
+  frontmatter paths, body links, wikilinks, entity tags, cross-repo references,
+  and optional Obsidian usage. Closes #275.
 - Added `bets/` as a first-class business-repo primitive with validation,
   graph links, `mb status` active-deadline reporting, and the new `/mb-bet`
   Claude Code workflow for `new`, `update`, `close`, `list`, and `narrate`.
@@ -49,6 +56,9 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   until each has a documented adapter and fresh-repo smoke evidence.
 - Updated `/mb-start` to read deterministic status/ranker facts before asking
   setup or routing questions. Refs #263.
+- Extended `mb validate --cross-refs` to warn on missing or ambiguous
+  Obsidian-style wikilinks while keeping wikilink checks out of default
+  validation.
 
 ## [0.2.6] - 2026-05-04
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ Main Branch is the `mb` CLI plus MIT-licensed agent workflows for running busine
 Read the product frame in [docs/ETHOS.md](docs/ETHOS.md), the user loop in
 [docs/OPERATOR-LOOPS.md](docs/OPERATOR-LOOPS.md), and the release direction in
 [docs/ROADMAP.md](docs/ROADMAP.md).
+Workspace, repo, dashboard, finance/legal, and team-log boundaries are defined
+in
+[decisions/2026-05-04-workspace-repo-sensitive-data-boundaries.md](decisions/2026-05-04-workspace-repo-sensitive-data-boundaries.md).
+Markdown/link conventions for GitHub and Obsidian live in
+[docs/markdown-link-conventions.md](docs/markdown-link-conventions.md).
 
 ---
 
@@ -294,13 +299,19 @@ surfaces as a banner the next time you run `/mb-start`.
 No. You invoke skills with slash prompts and answer questions.
 
 **What if I have multiple products under one brand?**
-Use one repo with an `offers/` folder. Each offer gets its own `offer.md`. Soul and voice stay shared in `core/`. Run `/mb-setup` or `/mb-think` to add offers.
+Use one repo with an `offers/` folder when the products share the same brand,
+team, voice, and access boundary. Each offer gets its own `offer.md`. If an
+offer graduates into its own team, provider accounts, site, finance boundary,
+or operating history, move it into its own repo and keep the company repo as a
+hub.
 
 **What's a bet vs. an offer?**
 A bet is a time-boxed operating hypothesis: what you'll try, why, by when, and how you'll know if it worked. An offer is a durable thing you sell. A good bet can graduate into an offer, campaign, workflow, content pillar, or decision; a bad bet gets closed with learning.
 
 **What if I have multiple separate businesses?**
-Create a separate repo for each brand. If they share the same soul and voice, they can share a repo. If not, separate repos.
+Create a separate repo for each brand, legal entity, provider-account boundary,
+or team-access boundary. If businesses truly share the same voice, team, and
+access rules, they can share a repo. If not, separate repos.
 
 **How do I update when new skills come out?**
 `mb update --repo .`, or run `/mb-update` inside Claude Code.

--- a/decisions/2026-05-04-workspace-repo-sensitive-data-boundaries.md
+++ b/decisions/2026-05-04-workspace-repo-sensitive-data-boundaries.md
@@ -1,0 +1,274 @@
+---
+type: decision
+date: 2026-05-04
+status: accepted
+topic: Workspace, repo, and sensitive-data boundaries
+linked_decisions:
+  - decisions/2026-05-01-mb-cli-vs-agent-workflows-boundary.md
+  - decisions/2026-05-02-github-native-business-os.md
+  - decisions/2026-05-04-sidecar-enrichment-cli-contract.md
+linked_issues:
+  - https://github.com/noontide-co/mainbranch/issues/274
+  - https://github.com/noontide-co/mainbranch/issues/275
+  - https://github.com/noontide-co/mainbranch/issues/120
+  - https://github.com/noontide-co/mainbranch/issues/128
+participants: [Devon, Codex]
+tags: [v0-3, state-model, workspace, dashboard, privacy, markdown]
+---
+
+# Workspace, Repo, and Sensitive-Data Boundaries
+
+## Decision
+
+Main Branch should model business state through three explicit boundaries:
+
+1. A **business repo** is the default durable brain for one coherent business
+   context.
+2. A **workspace** is an operator-chosen grouping of one or more business repos
+   and local-only operational state.
+3. A **private operator dashboard** is a local or self-hosted control surface
+   over repos, GitHub, indexes, sidecars, credentials, and provider data. It is
+   not canonical memory.
+
+The default remains simple: one business repo per business, with canonical
+truth in git. Main Branch should add workspace and dashboard concepts only to
+make multi-repo, team, finance, legal, and provider boundaries explicit. It
+must not make editable repo files the authority for access control, admin
+rights, spending authority, legal authority, or provider permissions.
+
+## Boundary Map
+
+| Surface | Owns | Does not own |
+|---|---|---|
+| Business repo | Reference files, research, decisions, campaigns, bets, team-visible logs, durable summaries, proposals | Secrets, raw customer/member exports, broad ledgers, provider tokens, admin authority |
+| Workspace | Local grouping of repos, recent repo list, dashboard instance metadata, local indexes, cache locations, operator preferences | Canonical business truth, team-visible policy, provider permissions |
+| Repo dashboard | Read/write view for one repo through `mb`, GitHub, and files | Cross-repo authority, private finance/legal access, hosted auth |
+| Workspace dashboard | Aggregated view across selected repos and GitHub contexts | Source of truth, replacement for git history, override for repo permissions |
+| Private operator dashboard | Local or self-hosted view that may show private metrics, P&L, legal checklists, and personal notes | Public team memory, admin authority, account mutation without explicit operator action |
+| Provider account | Spending, publishing, emailing, billing, customer data, and platform permissions | Main Branch repo permissions or frontmatter claims |
+
+Dashboards are views and control surfaces. They may write proposed changes back
+to repos, create GitHub issues, or call `mb` commands, but the durable record is
+still the repo, GitHub, provider account, or git history that actually changed.
+
+## Repo Model
+
+Use one business repo when:
+
+- the offer, audience, voice, proof, team, and access boundary are shared;
+- multiple offers operate under the same brand or company brain;
+- the same teammates should generally see the same operating memory;
+- finance/legal details can stay summarized or excluded.
+
+Use multiple business repos when:
+
+- businesses have different legal entities, teams, brands, audiences, or
+  provider accounts;
+- one repo would force teammates to see finance, legal, customer, member, or
+  partner data they should not see;
+- a graduated offer becomes large enough to need its own site, tasks,
+  campaigns, fulfillment, or provider accounts;
+- private personal exploration should not become team-visible memory.
+
+Use a hub repo when a team needs shared cross-repo coordination:
+
+- company-level decisions;
+- team daily logs;
+- shared operating principles;
+- cross-offer priorities;
+- links to product or offer repos.
+
+Use graduated offer or product repos when an offer becomes its own operating
+surface. Keep the parent company repo as the hub and link to the child repo
+from decisions, roadmap notes, and team daily logs. Do not solve this by adding
+more folder aliases inside one repo.
+
+Path configuration is narrower than workspace modeling. A future path-config
+feature may let one repo rename canonical folders, but it must not decide which
+repos exist, which teammates can see them, or where sensitive data belongs.
+
+## Team Daily Logs
+
+The phrase is **team daily log**, not chat. A team daily log is a durable work
+record, not an opaque message database.
+
+Default placement:
+
+- single-repo team: `log/YYYY-MM-DD.md` in the business repo;
+- multi-repo team: `log/YYYY-MM-DD.md` in the hub repo, with repo-relative or
+  GitHub links to offer/product repos;
+- repo-specific daily details: `log/YYYY-MM-DD.md` in the repo where the work
+  happened, linked from the hub log when useful;
+- private operator notes: a private repo or local operator state, not the
+  team-visible business repo.
+
+Team daily logs may mention finance, legal, provider, or customer matters only
+at the level appropriate for the repo audience. A log can say "May close
+blocked on bank reconciliation" without committing transaction rows, statements,
+customer names, or legal advice.
+
+## Finance, Legal, and `mb books`
+
+`mb books` must not quietly turn a shared business repo into a finance database.
+Bookkeeping is an Execute loop, but its data boundary is stricter than normal
+campaign or decision work.
+
+Safe for a team-visible business repo:
+
+- high-level finance decisions;
+- sanitized P&L summaries approved for that team;
+- chart-of-accounts templates;
+- bookkeeping workflow docs;
+- non-secret provider identifiers needed for repair;
+- links to private finance repos or provider dashboards when the audience is
+  authorized to know they exist.
+
+Not safe by default for a team-visible business repo:
+
+- raw ledger rows;
+- bank, credit-card, payroll, tax, legal, invoice, or statement exports;
+- account numbers;
+- customer/member payment records;
+- legal advice, contracts, disputes, or entity documents;
+- anything that would be harmful if every repo collaborator, fork, checkout,
+  backup, or future agent could read it.
+
+For solo operators, real ledger files may live in a private business repo only
+after an explicit operator decision. For teams, real finance/legal records
+should usually live in a private finance/legal repo, a provider account, or
+local encrypted storage with narrow access. `mb books` should read those sources
+through explicit paths, sidecar contracts, or provider exports, then write only
+approved summaries back to team-visible repos.
+
+Future dashboard P&L views must inherit this boundary. A dashboard may show P&L
+only when the current local operator or hosting environment already has access
+to the private finance source. A repo file saying `role: admin` or
+`can_view_finance: true` is not enough.
+
+## Editable Files Are Not Admin Authority
+
+Business repos are editable by collaborators and agents. That is a feature for
+business memory and proposals, but it makes repo files unsuitable as the final
+authority for privileged actions.
+
+Main Branch must not trust tracked markdown, frontmatter, `.mb/` files, or
+workspace config as the sole proof that someone can:
+
+- spend money;
+- publish or deploy;
+- email customers;
+- access finance or legal records;
+- change provider credentials;
+- change teammate roles;
+- approve invoices, payroll, taxes, or contracts;
+- override safety gates.
+
+Authority must come from the system that enforces it:
+
+- GitHub permissions for repo read/write/admin rights;
+- provider permissions for ads, billing, email, banking, analytics, and deploys;
+- local OS user/session and secret-store access for private operator state;
+- explicit human approval at the command or workflow boundary;
+- future hosted access control only after a separate accepted decision.
+
+Repo files can declare intent, desired roles, policy, or proposals. They can
+help a dashboard render controls. They cannot bypass the actual permission
+check before a privileged action runs.
+
+## GitHub, Self-Hosted Git, and Backups
+
+GitHub private repos are the default durable substrate because they give Main
+Branch portable git history, issues, pull requests, permissions, and a familiar
+team layer. That default is not a promise that all data belongs on GitHub.
+
+Use self-hosted git, Forgejo, encrypted local storage, or provider-native
+systems when legal, finance, privacy, jurisdiction, customer, or company policy
+requires a narrower boundary. Main Branch should preserve portability by using
+plain git, markdown, JSON contracts, and explicit local state paths. GitHub is a
+strong default collaboration layer, not the only possible place to keep private
+records.
+
+## Markdown and Link Compatibility
+
+Business repos should stay pleasant in GitHub, local editors, and Obsidian.
+The durable conventions live in
+[docs/markdown-link-conventions.md](../docs/markdown-link-conventions.md).
+
+The short version:
+
+- frontmatter links use repo-relative paths with `.md` extensions;
+- body links prefer standard Markdown links when GitHub clickability matters;
+- Obsidian wikilinks are allowed for graph navigation when targets resolve
+  uniquely;
+- filenames should be lowercase, hyphenated, and stable;
+- entity tags use the existing graph style such as `#company/example-co`;
+- `mb validate --cross-refs` should warn on broken frontmatter links and broken
+  or ambiguous wikilinks.
+
+## Implementation Guidance
+
+Future dashboard work should:
+
+- start as local-first and optional;
+- read through `mb status --json`, `mb graph --json`, `mb connect status
+  --json`, GitHub, and repo files;
+- keep local indexes and caches rebuildable;
+- store credentials outside tracked repos;
+- show which repo, workspace, provider, and operator boundary each fact came
+  from;
+- refuse privileged actions unless the enforcing system grants permission.
+
+Future `mb books` work should:
+
+- accept that bookkeeping can read private finance sources without committing
+  them to a team repo;
+- keep real ledgers and statement exports out of public examples and fixtures;
+- warn before writing finance/legal data into a repo with collaborators;
+- produce approved summaries separately from raw ledgers;
+- support provider inputs such as bank exports without making any one bank a
+  hard dependency;
+- coordinate with sidecar/provider contracts for private account data.
+
+Future path-config work should:
+
+- stay limited to folder-name/path overrides inside one repo;
+- avoid implying that a renamed folder changes access boundaries;
+- leave workspace grouping, multi-repo strategy, and sensitive-data placement
+  to this decision.
+
+## Validation Contract
+
+For this decision slice:
+
+- Level 0 docs/decision review is required for public/private boundary,
+  frontmatter, and links.
+- `scripts/check.sh` must pass before pushing.
+- Focused `mb validate` tests are required only for the wikilink validation
+  change.
+- Package/install, fixture repo, and runtime smoke are not required because
+  this does not change packaging, repo scaffolding, first-run behavior, or
+  runtime discovery.
+
+## Consequences
+
+- Future dashboard, bookkeeping, legal, team-log, and multi-repo work has one
+  public boundary decision to cite.
+- Main Branch can add dashboards without making them canonical memory.
+- `mb books` can become important without turning shared repos into finance
+  databases.
+- Path-config stays a local layout feature, not a workspace or permissions
+  model.
+- Markdown remains useful in GitHub and Obsidian without adding an Obsidian
+  dependency.
+
+## Review Trigger
+
+Revisit this decision before Main Branch ships any of these:
+
+- hosted dashboard accounts;
+- team roles inside a Main Branch service;
+- `mb books` writing ledger data;
+- dashboard P&L or legal views;
+- background sync across multiple repos;
+- a workspace config file that claims to grant permissions;
+- provider mutations initiated from dashboard controls.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -19,6 +19,9 @@ Main Branch already ships:
 - privacy-safe GitHub issue drafting for user friction;
 - `bets/` and `/mb-bet` as the first narration primitive;
 - public contribution, support, security, compatibility, and agent guidance.
+- accepted workspace/repo/sensitive-data boundary guidance and
+  GitHub/Obsidian-compatible markdown/link conventions for future dashboard,
+  team daily log, bookkeeping, and multi-repo work.
 
 Claude Code is the supported runtime today. Other runtimes are compatibility
 targets until adapter code and smoke evidence exist.
@@ -70,12 +73,11 @@ Planned scope:
 - sidecar enrichment contract for optional tools such as public company
   context, analytics, bookkeeping, transcription, or deployment helpers
   ([#265](https://github.com/noontide-co/mainbranch/issues/265)).
-- Obsidian-compatible markdown/link conventions so business repos remain useful
-  in existing markdown tools
-  ([#275](https://github.com/noontide-co/mainbranch/issues/275));
-- a workspace/repo boundary decision for multi-repo businesses, private operator
-  dashboards, finance/legal access, and team daily logs
-  ([#274](https://github.com/noontide-co/mainbranch/issues/274)).
+- follow-up implementation work from the workspace/repo boundary decision and
+  markdown/link conventions, including dashboard spikes, team daily log
+  surfaces, finance/legal warnings, and broader link repair where issues prove
+  the need ([#274](https://github.com/noontide-co/mainbranch/issues/274),
+  [#275](https://github.com/noontide-co/mainbranch/issues/275)).
 
 ## Later: v0.4 - Launches Offers From Bets
 

--- a/docs/markdown-link-conventions.md
+++ b/docs/markdown-link-conventions.md
@@ -1,0 +1,156 @@
+# Markdown and Link Conventions
+
+Main Branch business repos should be readable in GitHub, local editors, and
+Obsidian without becoming dependent on any markdown app.
+
+The repo is the durable source of truth. Markdown tools are views over that
+truth.
+
+## Goals
+
+- GitHub links work in pull requests, issues, and the browser.
+- Obsidian can browse the same repo as a vault.
+- `mb graph` can build useful file and entity relationships.
+- `mb validate --cross-refs` can catch broken important links.
+- Agents can follow links without guessing.
+
+## Filenames
+
+Use stable, lowercase, hyphenated filenames:
+
+```text
+decisions/2026-05-04-pricing-model.md
+research/2026-05-04-audience-notes.md
+bets/2026-05-04-trial-offer.md
+campaigns/spring-launch/campaign.md
+core/offers/main-branch/offer.md
+```
+
+Avoid spaces, case-only distinctions, punctuation-heavy names, and repeated
+stems in different folders when you expect to use wikilinks. Obsidian can
+resolve `[[pricing-model]]` by filename stem only when the stem is unique.
+
+## Frontmatter Links
+
+Frontmatter links are machine-readable. Use repo-relative paths with `.md`
+extensions:
+
+```yaml
+linked_decisions:
+  - decisions/2026-05-04-pricing-model.md
+linked_research:
+  - research/2026-05-04-audience-notes.md
+linked_campaigns:
+  - campaigns/spring-launch/campaign.md
+```
+
+Do not use Obsidian wikilink syntax in frontmatter. Do not omit the extension.
+Do not use absolute local paths.
+
+Allowed external references:
+
+```yaml
+linked_issues:
+  - https://github.com/noontide-co/mainbranch/issues/274
+```
+
+Use external URLs for public issue, PR, release, or source links. Use local
+paths for files inside the same repo.
+
+## Body Links
+
+Use standard Markdown links when GitHub clickability matters:
+
+```markdown
+See [the pricing decision](../decisions/2026-05-04-pricing-model.md).
+```
+
+Use Obsidian wikilinks when graph browsing is the main reason and the target is
+unambiguous:
+
+```markdown
+See [[decisions/2026-05-04-pricing-model|pricing decision]].
+See [[pricing-model]] only when that filename stem is unique.
+```
+
+For durable docs, prefer the path form over bare stems. It is clearer to
+GitHub readers, agents, and future validation.
+
+Heading anchors are less stable than file links because GitHub and Obsidian do
+not generate anchors the same way in every case. Prefer linking to the file and
+using a clear heading near the target.
+
+## Entity Tags
+
+`mb graph` recognizes typed entity tags in markdown bodies:
+
+```markdown
+#company/example-co
+#person/jane-doe
+#offer/main-branch
+#channel/github
+#competitor/status-quo
+#metric/activation-rate
+```
+
+Use these for durable entities that should appear in graph output. Keep values
+lowercase and hyphenated. Do not use entity tags for secrets, private customer
+names, account numbers, or legal/finance identifiers that should not be visible
+to the repo audience.
+
+## Cross-Repo Links
+
+A business repo may link to another repo, but a cross-repo link is not the same
+as access.
+
+Use public URLs when the target is public:
+
+```markdown
+See [Main Branch issue #274](https://github.com/noontide-co/mainbranch/issues/274).
+```
+
+Use a plain-text repo/path reference when the target may be private and the
+link should not imply broad access:
+
+```markdown
+Private finance source: finance-repo/core/finance/ledger/
+```
+
+Do not commit private local machine paths. If a local-only path is needed for
+an operator, keep it in local config, a private repo, or `.context/` rather
+than public docs.
+
+## Obsidian Setup
+
+Opening a business repo as an Obsidian vault should be optional:
+
+1. Open the repo root as the vault.
+2. Keep attachments and exports in existing repo folders only when they are
+   safe for the repo audience.
+3. Do not rely on an Obsidian plugin for Main Branch correctness.
+4. Keep `.obsidian/` local unless a team intentionally agrees to commit shared
+   vault settings.
+
+Main Branch should not require Obsidian, replace Obsidian, or add Obsidian as a
+runtime dependency.
+
+## Validation
+
+Run:
+
+```bash
+mb validate --cross-refs
+```
+
+This checks known frontmatter link fields and warns when important links are
+missing. It also warns when wikilinks point to missing markdown files or match
+multiple files by stem.
+
+Use strict mode in CI or branch cleanup when warnings should fail:
+
+```bash
+mb validate --cross-refs --strict
+```
+
+Validation does not prove a user can access a private cross-repo target. It only
+checks the current repo and safe external references.

--- a/docs/markdown-link-conventions.md
+++ b/docs/markdown-link-conventions.md
@@ -26,6 +26,11 @@ campaigns/spring-launch/campaign.md
 core/offers/main-branch/offer.md
 ```
 
+These examples use the current v0.x canonical folders. If future user research
+shows that folder names should change, that change should land through
+path-config and migration work, not ad hoc docs or skill examples that teach a
+different repo shape.
+
 Avoid spaces, case-only distinctions, punctuation-heavy names, and repeated
 stems in different folders when you expect to use wikilinks. Obsidian can
 resolve `[[pricing-model]]` by filename stem only when the stem is unique.

--- a/mb/mb/validate.py
+++ b/mb/mb/validate.py
@@ -278,7 +278,7 @@ def _resolve_wikilink(
             repo_direct.relative_to(repo)
         except ValueError:
             continue
-        if repo_direct.exists():
+        if repo_direct.is_file() and repo_direct.suffix == ".md":
             return repo_direct, False
     matches = files_by_stem.get(Path(clean).stem, [])
     if len(matches) == 1:

--- a/mb/mb/validate.py
+++ b/mb/mb/validate.py
@@ -9,6 +9,7 @@ The schemas tolerate extras; only listed required keys are checked.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
@@ -41,6 +42,9 @@ LINK_FIELDS = (
     "related_prds",
     "supersedes",
 )
+
+WIKILINK_RE = re.compile(r"(?<!!)\[\[([^\]\n]+)\]\]")
+INLINE_CODE_RE = re.compile(r"`[^`\n]*`")
 
 LOCAL_REF_ROOTS = {
     "bets",
@@ -213,6 +217,73 @@ def _is_external_ref(ref: str) -> bool:
 def _clean_ref(ref: str) -> str:
     without_anchor = ref.split("#", 1)[0]
     return without_anchor.split("?", 1)[0].strip()
+
+
+def _read_markdown_body(path: Path) -> str | None:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    if not text.startswith("---"):
+        return text
+    try:
+        end = text.index("\n---", 3)
+    except ValueError:
+        return text
+    return text[end + len("\n---") :]
+
+
+def _strip_fenced_code_blocks(markdown: str) -> str:
+    lines: list[str] = []
+    in_fence = False
+    for line in markdown.splitlines(keepends=True):
+        if line.lstrip().startswith("```"):
+            in_fence = not in_fence
+            lines.append("\n")
+            continue
+        if not in_fence:
+            lines.append(line)
+    return "".join(lines)
+
+
+def _strip_markdown_code(markdown: str) -> str:
+    return INLINE_CODE_RE.sub("", _strip_fenced_code_blocks(markdown))
+
+
+def _wikilink_target(raw_target: str) -> str:
+    target = raw_target.split("|", 1)[0].strip()
+    target = target.split("#", 1)[0].strip()
+    return target
+
+
+def _resolve_wikilink(
+    *,
+    repo: Path,
+    target: str,
+    files_by_stem: dict[str, list[Path]],
+    files_by_rel: dict[str, Path],
+) -> tuple[Path | None, bool]:
+    clean = _wikilink_target(target)
+    if not clean:
+        return None, False
+    candidates = [clean]
+    if not clean.endswith(".md"):
+        candidates.append(f"{clean}.md")
+    for candidate in candidates:
+        direct = files_by_rel.get(candidate)
+        if direct is not None:
+            return direct, False
+        repo_direct = (repo / candidate).resolve()
+        try:
+            repo_direct.relative_to(repo)
+        except ValueError:
+            continue
+        if repo_direct.exists():
+            return repo_direct, False
+    matches = files_by_stem.get(Path(clean).stem, [])
+    if len(matches) == 1:
+        return matches[0], False
+    return None, len(matches) > 1
 
 
 def _status_order_for(path: Path) -> dict[str, int] | None:
@@ -389,8 +460,16 @@ def _check_cross_refs(
 ) -> dict[str, Any]:
     findings: list[dict[str, str]] = []
     orphan_offers: list[dict[str, str]] = []
+    markdown_files = _iter_frontmatter_files(repo)
+    files_by_stem: dict[str, list[Path]] = {}
+    files_by_rel: dict[str, Path] = {}
 
-    for source in _iter_frontmatter_files(repo):
+    for file_path in markdown_files:
+        rel = file_path.relative_to(repo).as_posix()
+        files_by_rel[rel] = file_path
+        files_by_stem.setdefault(file_path.stem, []).append(file_path)
+
+    for source in markdown_files:
         fm, err = _read_frontmatter(source)
         if err is not None or fm is None:
             continue
@@ -463,6 +542,40 @@ def _check_cross_refs(
                         target_fm=target_fm,
                         findings=findings,
                     )
+
+    for source in markdown_files:
+        body = _read_markdown_body(source)
+        if body is None:
+            continue
+        for match in WIKILINK_RE.finditer(_strip_markdown_code(body)):
+            raw_target = match.group(1)
+            clean_target = _wikilink_target(raw_target)
+            if not clean_target:
+                continue
+            resolved, ambiguous = _resolve_wikilink(
+                repo=repo,
+                target=raw_target,
+                files_by_stem=files_by_stem,
+                files_by_rel=files_by_rel,
+            )
+            if resolved is not None:
+                continue
+            code = "ambiguous-wikilink" if ambiguous else "missing-wikilink-target"
+            message = (
+                f"wikilink target {raw_target!r} matches multiple markdown files"
+                if ambiguous
+                else f"wikilink target {raw_target!r} does not resolve to a markdown file"
+            )
+            findings.append(
+                _finding(
+                    code=code,
+                    source=source,
+                    repo=repo,
+                    field="wikilink",
+                    target=raw_target,
+                    message=message,
+                )
+            )
 
     offers_root = repo / "core" / "offers"
     if offers_root.exists():

--- a/mb/mb/validate.py
+++ b/mb/mb/validate.py
@@ -266,6 +266,7 @@ def _resolve_wikilink(
     clean = _wikilink_target(target)
     if not clean:
         return None, False
+    is_bare_wikilink = len(Path(clean).parts) == 1
     candidates = [clean]
     if not clean.endswith(".md"):
         candidates.append(f"{clean}.md")
@@ -280,6 +281,8 @@ def _resolve_wikilink(
             continue
         if repo_direct.is_file() and repo_direct.suffix == ".md":
             return repo_direct, False
+    if not is_bare_wikilink:
+        return None, False
     matches = files_by_stem.get(Path(clean).stem, [])
     if len(matches) == 1:
         return matches[0], False

--- a/mb/tests/test_validate.py
+++ b/mb/tests/test_validate.py
@@ -208,6 +208,84 @@ def test_cross_refs_skip_bundled_package_data(tmp_path: Path) -> None:
     assert report["summary"]["warnings"] == 0
 
 
+def test_cross_refs_warn_on_missing_wikilink_target(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "decisions" / "2026-05-04-link.md",
+        "---\ndate: 2026-05-04\nstatus: accepted\n---\nSee [[missing-note]].\n",
+    )
+
+    report = run(path=str(tmp_path), cross_refs=True)
+
+    assert report["ok"] is True
+    assert report["summary"]["warnings"] == 1
+    finding = report["cross_refs"]["warnings"][0]
+    assert finding["code"] == "missing-wikilink-target"
+    assert finding["field"] == "wikilink"
+    assert finding["target"] == "missing-note"
+
+
+def test_cross_refs_warn_on_ambiguous_wikilink_target(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "research" / "note.md",
+        "---\ndate: 2026-05-04\ntopic: one\nsource: manual\n---\n# Note\n",
+    )
+    _write(
+        tmp_path / "documents" / "note.md",
+        "---\ntitle: Other note\n---\n# Other\n",
+    )
+    _write(
+        tmp_path / "decisions" / "2026-05-04-link.md",
+        "---\ndate: 2026-05-04\nstatus: accepted\n---\nSee [[note]].\n",
+    )
+
+    report = run(path=str(tmp_path), cross_refs=True)
+
+    assert report["summary"]["warnings"] == 1
+    finding = report["cross_refs"]["warnings"][0]
+    assert finding["code"] == "ambiguous-wikilink"
+    assert finding["target"] == "note"
+
+
+def test_cross_refs_accept_resolved_wikilink_target_without_extension(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "research" / "audience.md",
+        "---\ndate: 2026-05-04\ntopic: audience\nsource: manual\n---\n# Audience\n",
+    )
+    _write(
+        tmp_path / "decisions" / "2026-05-04-link.md",
+        "---\ndate: 2026-05-04\nstatus: accepted\n---\nSee [[research/audience|audience]].\n",
+    )
+
+    report = run(path=str(tmp_path), cross_refs=True, strict=True)
+
+    assert report["ok"] is True
+    assert report["summary"]["warnings"] == 0
+
+
+def test_cross_refs_ignore_wikilink_like_syntax_inside_fenced_code(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "documents" / "netlify.md",
+        '---\ntitle: Netlify\n---\n```toml\n[[redirects]]\nfrom = "/"\n```\n',
+    )
+
+    report = run(path=str(tmp_path), cross_refs=True, strict=True)
+
+    assert report["ok"] is True
+    assert report["summary"]["warnings"] == 0
+
+
+def test_cross_refs_ignore_wikilink_like_syntax_inside_inline_code(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "documents" / "obsidian.md",
+        "---\ntitle: Obsidian\n---\nUse `[[example]]` only when the target exists.\n",
+    )
+
+    report = run(path=str(tmp_path), cross_refs=True, strict=True)
+
+    assert report["ok"] is True
+    assert report["summary"]["warnings"] == 0
+
+
 def test_cross_refs_flag_status_transition_regressions(tmp_path: Path) -> None:
     _write(
         tmp_path / "decisions" / "2026-04-28-old.md",

--- a/mb/tests/test_validate.py
+++ b/mb/tests/test_validate.py
@@ -262,6 +262,54 @@ def test_cross_refs_accept_resolved_wikilink_target_without_extension(tmp_path: 
     assert report["summary"]["warnings"] == 0
 
 
+def test_cross_refs_accept_resolved_wikilink_target_with_heading_anchor(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "research" / "audience.md",
+        "---\ndate: 2026-05-04\ntopic: audience\nsource: manual\n---\n# Details\n",
+    )
+    _write(
+        tmp_path / "decisions" / "2026-05-04-link.md",
+        "---\ndate: 2026-05-04\nstatus: accepted\n---\nSee [[research/audience#details]].\n",
+    )
+
+    report = run(path=str(tmp_path), cross_refs=True, strict=True)
+
+    assert report["ok"] is True
+    assert report["summary"]["warnings"] == 0
+
+
+def test_cross_refs_warn_when_wikilink_resolves_only_to_directory(tmp_path: Path) -> None:
+    (tmp_path / "campaigns" / "spring-launch").mkdir(parents=True)
+    _write(
+        tmp_path / "decisions" / "2026-05-04-link.md",
+        "---\ndate: 2026-05-04\nstatus: accepted\n---\nSee [[campaigns/spring-launch]].\n",
+    )
+
+    report = run(path=str(tmp_path), cross_refs=True)
+
+    assert report["summary"]["warnings"] == 1
+    finding = report["cross_refs"]["warnings"][0]
+    assert finding["code"] == "missing-wikilink-target"
+    assert finding["target"] == "campaigns/spring-launch"
+
+
+def test_cross_refs_warn_when_wikilink_resolves_only_to_non_markdown_file(
+    tmp_path: Path,
+) -> None:
+    _write(tmp_path / "documents" / "diagram.png", "fake image\n")
+    _write(
+        tmp_path / "decisions" / "2026-05-04-link.md",
+        "---\ndate: 2026-05-04\nstatus: accepted\n---\nSee [[documents/diagram.png]].\n",
+    )
+
+    report = run(path=str(tmp_path), cross_refs=True)
+
+    assert report["summary"]["warnings"] == 1
+    finding = report["cross_refs"]["warnings"][0]
+    assert finding["code"] == "missing-wikilink-target"
+    assert finding["target"] == "documents/diagram.png"
+
+
 def test_cross_refs_ignore_wikilink_like_syntax_inside_fenced_code(tmp_path: Path) -> None:
     _write(
         tmp_path / "documents" / "netlify.md",

--- a/mb/tests/test_validate.py
+++ b/mb/tests/test_validate.py
@@ -278,6 +278,24 @@ def test_cross_refs_accept_resolved_wikilink_target_with_heading_anchor(tmp_path
     assert report["summary"]["warnings"] == 0
 
 
+def test_cross_refs_do_not_stem_fallback_for_path_like_wikilinks(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "documents" / "audience.md",
+        "---\ntitle: Audience\n---\n# Audience\n",
+    )
+    _write(
+        tmp_path / "decisions" / "2026-05-04-link.md",
+        "---\ndate: 2026-05-04\nstatus: accepted\n---\nSee [[research/audience]].\n",
+    )
+
+    report = run(path=str(tmp_path), cross_refs=True)
+
+    assert report["summary"]["warnings"] == 1
+    finding = report["cross_refs"]["warnings"][0]
+    assert finding["code"] == "missing-wikilink-target"
+    assert finding["target"] == "research/audience"
+
+
 def test_cross_refs_warn_when_wikilink_resolves_only_to_directory(tmp_path: Path) -> None:
     (tmp_path / "campaigns" / "spring-launch").mkdir(parents=True)
     _write(


### PR DESCRIPTION
## Summary
- Defines the public workspace/repo/sensitive-data boundary for future dashboard, team daily log, bookkeeping, legal, and multi-repo work.
- Adds GitHub/Obsidian-compatible markdown and link conventions for business repos, including the caveat that current folder examples are v0.x conventions and future naming changes belong in path-config/migration work.
- Extends `mb validate --cross-refs` so Obsidian-style wikilinks warn when they point to missing, ambiguous, directory-only, non-markdown, or path-form targets that do not exist at that exact path.
- Updates README, roadmap, and changelog so future agents can find the new product truth.

## Scope
- In: boundary decision, markdown/link guidance, README/roadmap/changelog pointers, and narrow wikilink validation.
- Out: `mb books` implementation, dashboard UI, auth/admin systems, path-config workspace modeling, package/install changes, fixture scaffolding, and runtime behavior.

## Commits
- `4a0e7f7` — `[add] MAIN-224 workspace data boundaries`.
- `394e5f7` — `[fix] MAIN-225 require markdown wikilink targets`.
- `1a0a134` — `[fix] MAIN-225 keep path wikilinks exact`.

## Release / Issues
- Release: v0.3.x planning / Unreleased.
- Linear ID(s): MAIN-224, MAIN-225.
- Closes: #274, #275.
- Refs: #120, #128.
- Follow-ups: finance/legal write warnings for future `mb books`, dashboard permission enforcement, and broader link repair only where future issues prove the need.

## Success Metric
- A future agent building dashboard, books, legal, team daily log, or multi-repo features can read one public decision/doc and know what state belongs in git, what stays local/private, what needs separate access boundaries, and which markdown/link conventions must hold in GitHub and Obsidian.

## Validation
- Level 0 docs/decision: public/private boundary reviewed; no private Devon, Conductor, customer, member, or local-machine details committed.
- Level 1 static: `scripts/check.sh` passed from repo root; ruff format/check and mypy clean.
- Level 2 CLI: `pytest mb/tests/test_validate.py -q` passed with 24 tests; `pytest tests/test_graph.py -q` passed with 8 tests earlier in the branch; `python3 -m mb validate .. --cross-refs --strict --json` passed with 0 warnings earlier in the branch; full suite in `scripts/check.sh` passed with 200 tests.
- Level 3 package/install: not required; no packaging, bundled data, entrypoint, or install behavior changed.
- Level 4 fixture repo: not required; no repo scaffolding or first-run behavior changed.
- Level 5 runtime smoke: not required; no runtime discovery, skill invocation, or adapter behavior changed.

## Public / Private Boundary
- The decision and conventions use generic public examples and keep private operator details, raw finance/legal/customer/member data, secrets, and local paths out of durable docs.