### PR TITLE
[add] mb connect provider plan

### DIFF
--- a/.claude/educational/provider-readiness.md
+++ b/.claude/educational/provider-readiness.md
@@ -1,0 +1,76 @@
+---
+type: educational
+topic: provider-readiness
+status: draft
+last-updated: 2026-05-04
+---
+
+# Provider readiness: connect tools when the business job needs them
+
+Main Branch does not ask you to connect every account on day one. Setup should
+answer a business question:
+
+1. What are you trying to do next?
+2. Which outside account is needed for that job?
+3. Does `mb` say that account is ready, missing, or optional?
+4. What exact command fixes the next missing step?
+
+Run this from your business repo:
+
+```bash
+mb connect plan
+```
+
+For machine-readable status, use:
+
+```bash
+mb status --json --peek
+mb connect status --all --json
+mb connect doctor --json
+```
+
+## The default order
+
+1. **GitHub** - tasks, proposals, reviews, and shipped history.
+   - Check: `mb connect doctor --json`
+   - Common fix: `gh auth login`
+   - You can start local setup without it, but team/task loops are limited.
+
+2. **Cloudflare** - sites, DNS, Pages, and future Workers.
+   - Check: `mb connect status --all --json`
+   - Common setup: `printf '%s' "$CLOUDFLARE_API_TOKEN" | mb connect cloudflare --token-stdin --metadata account_id=...`
+   - Connect it when you are ready to publish or attach a domain.
+
+3. **Google / Workspace** - Drive, Docs, Sheets, Slides, and workspace source material.
+   - Check: `mb connect status --all --json`
+   - Common setup: `mb connect google --from-env`
+   - Connect it when a workflow needs existing Google files. Do not connect it just because you have a Google account.
+
+4. **Meta Ads** - ad accounts, campaigns, pixels, and future performance context.
+   - Check: `mb connect status --all --json`
+   - Common setup: `printf '%s' "$META_ACCESS_TOKEN" | mb connect meta --token-stdin --metadata ad_account_id=...`
+   - Connect it when paid-ad work needs account facts.
+
+5. **Apify** - research sidecar for scraping, YouTube, Instagram, and web mining.
+   - Check: `mb connect status --all --json`
+   - Common setup: `printf '%s' "$APIFY_TOKEN" | mb connect apify --token-stdin`
+   - Connect it when research or organic workflows need structured external data.
+
+## Readiness states
+
+- `not_connected` means no repo-safe provider metadata exists yet.
+- `missing_secret` means metadata exists but the local secret is missing.
+- `unvalidated` means a credential is stored, but it has not been tested.
+- `invalid` means validation failed and the credential should be replaced.
+- `ready` means the safest available check passed.
+
+Secrets stay outside the business repo. `.mb/connect.yaml` stores only safe
+metadata, labels, secret references, and last-check facts. Do not paste tokens
+into markdown files, GitHub issues, screenshots, or committed config.
+
+## Why this is business onboarding
+
+Providers are not developer config. They are permissions for business actions:
+publishing a site, reading source documents, learning from ads, or collecting
+research. Connect the rail when the next business action needs it, then let
+`mb status` and `mb connect` explain what is ready.

--- a/.claude/skills/mb-help/SKILL.md
+++ b/.claude/skills/mb-help/SKILL.md
@@ -30,6 +30,7 @@ Answer questions, troubleshoot issues, explain philosophy, suggest next steps.
 | /mb-bet, bet, hypothesis, deadline, public narration | [skills-guide.md](references/skills-guide.md) |
 | Task tracking, where left off, focus | [task-tracking-options.md](references/task-tracking-options.md) |
 | Error, command not found, MCP, Apify setup, GitHub issue | [troubleshooting.md](references/troubleshooting.md) |
+| Provider readiness, GitHub setup, Cloudflare, Google Workspace, Meta Ads, Apify | [provider-readiness.md](references/provider-readiness.md) |
 | Getting started, setup | Route to `/mb-setup` or `/mb-start` |
 | Which skill, when to use | [skills-guide.md](references/skills-guide.md) |
 | Create skill, Notion export, custom | [skills-guide.md](references/skills-guide.md) |
@@ -83,5 +84,6 @@ Answer questions, troubleshoot issues, explain philosophy, suggest next steps.
 | How do I recover after compaction? | Point Claude at recent files: "look at my last 3 decisions" or "read the commits from today." Or just run /mb-start — it scans your folders and rebuilds context automatically. You can also open files yourself in Cursor, Warp, VS Code, or any text editor. |
 | Is this system finished? | Still new and actively being tuned. We're building around Claude Code, minimizing commands you need to learn while giving you real power. There's progressive discovery in /mb-think — the more you use it, the more it reveals. You might find workflows we haven't documented yet. Post them in Skool. |
 | Where can I see my files? | Open your business repo folder in Finder, Cursor, Warp, VS Code, or any text editor. They're regular .md files on your hard drive. GitHub Desktop also shows them with version history. |
+| What should I connect first? | Run `mb connect plan` from your business repo. It shows GitHub, Cloudflare, Google/Workspace, Meta Ads, and Apify as numbered choices with readiness and exact next commands. |
 | Skills not showing in Conductor? | Conductor workspaces are isolated — they don't know where Main Branch is. You need a Pre-Agent (PA) config script that creates bridge symlinks and `settings.local.json` before Claude starts. See [conductor-setup.md](references/conductor-setup.md) for the script and setup steps. |
 | What's a PA config? | Pre-Agent config — a script Conductor runs before Claude starts in a workspace. Used to set up Main Branch bridge links so skills appear. One-time setup per workspace. |

--- a/.claude/skills/mb-help/references/provider-readiness.md
+++ b/.claude/skills/mb-help/references/provider-readiness.md
@@ -1,0 +1,61 @@
+# Provider Readiness
+
+Provider setup should feel like business onboarding, not developer config. Start
+with the job the operator is trying to do, then use `mb` facts to name what is
+ready or missing.
+
+## First Commands
+
+Run from the business repo:
+
+```bash
+mb status --json --peek
+mb connect plan
+mb connect doctor --json
+```
+
+Use `mb status --json --peek` first when the operator asks "what should I do
+next?" Use `mb connect plan` when the question is "what should I connect?" Use
+`mb connect doctor --json` when something looks broken.
+
+## Numbered Choice Pattern
+
+When a provider is missing, give exactly two or three numbered choices:
+
+> "This action needs [business capability].
+>
+> 1. Set up [provider] now — `[exact command from mb]`
+> 2. Skip for this session — [specific limitation]
+> 3. Tell me why — `mb educational provider-readiness`"
+
+Do not ask for tokens in prose unless the CLI repair command already says which
+provider is missing. Never ask the operator to commit tokens or paste them into
+GitHub.
+
+## Decision Tree
+
+1. **GitHub** - tasks, proposals, reviews, and shipped history.
+   - Use when: issue drafts, PRs, review, team visibility, daily task tracking.
+   - Check/fix: `mb connect doctor --json`.
+
+2. **Cloudflare** - sites, DNS, Pages, and future Workers.
+   - Use when: publish a landing page, attach a domain, or deploy a site.
+   - Check/fix: `mb connect status --all --json`.
+
+3. **Google / Workspace** - Drive, Docs, Sheets, Slides, and source material.
+   - Use when: a workflow needs existing Google files.
+   - Check/fix: `mb connect status --all --json`.
+
+4. **Meta Ads** - ad accounts, campaigns, pixels, and future performance facts.
+   - Use when: paid-ad generation, review, or learning needs account context.
+   - Check/fix: `mb connect status --all --json`.
+
+5. **Apify** - optional research sidecar for scraping, YouTube, Instagram, and web mining.
+   - Use when: research or organic workflows need structured external data.
+   - Check/fix: `mb connect status --all --json`.
+
+## Support Boundary
+
+Readiness means `mb` can see local metadata and the safest available credential
+check has the reported state. It does not mean every future provider workflow is
+implemented. Claude Code is still the only supported runtime today.

--- a/.claude/skills/mb-setup/SKILL.md
+++ b/.claude/skills/mb-setup/SKILL.md
@@ -9,6 +9,11 @@ Get a new user fully configured with Claude Code and their business repo. Use
 `mb onboard status --json` and `mb onboard plan` as the durable progress
 contract; do not keep onboarding state only in chat prose.
 
+For provider setup, use `mb connect plan`, `mb connect status --all --json`,
+and `mb connect doctor --json` as the durable readiness contract. Explain
+providers as business capabilities, not developer config, and end with exact
+commands.
+
 ---
 
 ## Before We Begin

--- a/.claude/skills/mb-start/SKILL.md
+++ b/.claude/skills/mb-start/SKILL.md
@@ -16,6 +16,13 @@ integrations, GitHub tasks/proposals, bets, dirty git, since-last-check, and
 `ranked_actions`. Do not duplicate those checks with ad hoc shell probes unless
 the status report says a section is unavailable.
 
+**Provider facts first:** When setup or routing depends on GitHub, Cloudflare,
+Google/Workspace, Meta Ads, or Apify, read the status `integrations` facts
+first. If the operator needs a provider choice or repair explanation, run
+`mb connect plan` or `mb connect doctor --json` and use the cited
+`next_command` / `repair_command`. Do not ask for tokens or provider setup in
+prose before the CLI has named the missing step.
+
 ---
 
 ## CRITICAL: Repo Selection Rules
@@ -86,7 +93,7 @@ Apply to: business repo selection, skill routing, any multiple choice.
 │   └── Missing? ────────────────────→ Run the repair command cited by status
 │
 ├── MCP pre-flight ───────────────────→ See [mcp-preflight.md](references/mcp-preflight.md)
-│   └── Missing required MCP? ────────→ Offer setup or skip
+│   └── Provider/tool missing? ───────→ Use `mb connect plan` / status repair facts
 │
 ├── No business repo found? ──────────→ /mb-setup (creates repo, saves path)
 │
@@ -146,11 +153,12 @@ Use this report before asking additional questions:
 - `drift.items` names stale or broken status signals and repair commands.
 - `onboarding.summary` and `onboarding.checklist` replace separate onboarding
   probes unless the status report is unavailable.
-- `github.sections`, `brain.bets`, and `since_last_check` supply the continuity
-  facts for routing and triage.
+- `integrations.github`, `integrations.providers`, `github.sections`,
+  `brain.bets`, and `since_last_check` supply the continuity facts for routing
+  and triage.
 
 Only run a narrower fallback command such as `mb onboard status --json`,
-`mb doctor`, `mb validate --cross-refs`, or `mb connect doctor` when status
+`mb doctor`, `mb validate --cross-refs`, or `mb connect doctor --json` when status
 points at that section as unavailable, degraded, or needing repair.
 
 ## Step 1: Pull Engine Updates
@@ -215,14 +223,32 @@ mb onboard plan --repo "$REPO_PATH" --team-size solo --success-stage working
 
 ---
 
-## Step 4: MCP Pre-Flight (Not Full Research Detection)
+## Step 4: Provider And Tool Pre-Flight (Not Full Research Detection)
 
-Check for MCPs required by skills user might invoke. See [mcp-preflight.md](references/mcp-preflight.md).
+Check provider and MCP readiness only for skills the user might invoke. See
+[mcp-preflight.md](references/mcp-preflight.md).
+
+Start from CLI facts:
+
+```bash
+mb status --json --peek
+mb connect plan
+mb connect doctor --json
+```
+
+Use the status and connect JSON before checking runtime tool presence. The
+operator-facing pattern is:
+
+> "This action needs [business capability].
+>
+> 1. Set up [provider] now — `[exact command]`
+> 2. Skip for this session — [specific limitation]"
 
 **Full research tool detection still happens in /mb-think** — deferred to when user actually needs research. This keeps /mb-start fast and avoids checking tools user might not use this session.
 
 **What /mb-start DOES check:**
-- MCPs that skills depend on (Apify for /mb-organic, etc.)
+- Provider readiness from `mb status --json --peek` and `mb connect plan`
+- MCPs that a selected skill depends on when provider status says runtime tools are still unknown
 - Critical blockers (missing config, broken paths)
 
 **What /mb-start DOES NOT do here:**

--- a/.claude/skills/mb-start/references/mcp-preflight.md
+++ b/.claude/skills/mb-start/references/mcp-preflight.md
@@ -1,18 +1,56 @@
-# MCP Pre-Flight Check
+# Provider And MCP Pre-Flight Check
 
-Verify required MCPs are installed before routing to skills that need them.
+Verify provider readiness and required runtime tools before routing to skills
+that need them.
 
 ---
 
 ## Why This Matters
 
-MCPs install to USER'S machine (`~/.claude.json`), not the repo. When someone clones their business repo on a new machine, MCPs won't be there.
+Provider metadata belongs to the business repo through `.mb/connect.yaml`, while
+secrets and MCP installs live on the user's machine. When someone clones their
+business repo on a new machine, provider metadata may be visible but local
+secrets and MCP tools may still be missing.
+
+Start with deterministic CLI facts:
+
+```bash
+mb status --json --peek
+mb connect plan
+mb connect doctor --json
+```
+
+Use the CLI's `state`, `summary`, `next_command`, and `repair_command` before
+probing runtime tools manually.
 
 ---
 
 ## Check Flow
 
-### 1. Read expected MCPs from config
+### 1. Read provider readiness from mb
+
+Use `mb status --json --peek` for the daily route. If the operator asks which
+account to connect or a selected workflow needs outside access, run:
+
+```bash
+mb connect plan
+mb connect status --all --json
+```
+
+Required provider choices for the setup/provider loop:
+
+| Provider | Business job | Check |
+|---|---|---|
+| GitHub | tasks, proposals, reviews, shipped history | `mb connect doctor --json` |
+| Cloudflare | sites, DNS, Pages, Workers | `mb connect status --all --json` |
+| Google / Workspace | Drive, Docs, Sheets, Slides | `mb connect status --all --json` |
+| Meta Ads | ad accounts, campaigns, pixels | `mb connect status --all --json` |
+| Apify | scraping, YouTube, Instagram, research sidecars | `mb connect status --all --json` |
+
+Only continue to MCP/tool presence checks when the selected skill needs runtime
+tools that `mb connect` cannot inspect directly.
+
+### 2. Read expected MCPs from config
 
 ```yaml
 # From .vip/config.yaml
@@ -22,20 +60,20 @@ mcps:
     setup_guide: ".claude/skills/mb-organic/references/apify-setup.md"
 ```
 
-### 2. Check if MCP tools are available
+### 3. Check if MCP tools are available
 
 Look for tool presence:
 - `mcp__apify__*` tools → Apify loaded (handles web scraping + YouTube transcripts)
 - `mcp__whisper__*` tools → whisper-mcp loaded (local video/audio transcription)
 
-### 3. Prompt if missing
+### 4. Prompt if missing
 
 If routing to skill that needs missing MCP:
 
-> "The organic skill works best with Apify. Not set up on this machine.
+> "This action needs Apify research access. `mb connect plan` says Apify is [state].
 >
-> 1. Set up now (5 min, one-time)
-> 2. Skip for now (some features limited)"
+> 1. Set up now — `[exact command from mb]`
+> 2. Skip for now — YouTube and Instagram mining will be limited"
 
 If user picks 1 → Show setup guide path, walk through it.
 

--- a/.claude/skills/mb-status/SKILL.md
+++ b/.claude/skills/mb-status/SKILL.md
@@ -28,6 +28,18 @@ mb status --json --peek
    - cited signal summaries
 5. Then summarize only the sections that matter for the operator's question.
    Do not re-run shell probes that duplicate status facts.
+6. If provider readiness is the question, use `integrations.github` and
+   `integrations.providers` from status first. If the operator needs choices or
+   repair commands, run:
+
+```bash
+mb connect plan
+mb connect doctor --json
+```
+
+Summarize GitHub, Cloudflare, Google/Workspace, Meta Ads, and Apify as numbered
+business choices. Use the CLI's `next_command` or `repair_command`; do not ask
+the operator to paste tokens into files or public issue text.
 
 ## Mutating The Last-Check Marker
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 - Added `mb similar-bets <thesis>` for deterministic bets memory over
   `bets/*.md` plus graduated/dead offer context, with JSON shaped for agent,
   ranker, and future consumers. Refs #143.
+- Added `mb connect plan` and `mb educational provider-readiness` so provider
+  setup is presented as numbered business choices with readiness states and
+  exact next commands. Refs #273.
 
 ### Changed
 
@@ -59,6 +62,9 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 - Extended `mb validate --cross-refs` to warn on missing or ambiguous
   Obsidian-style wikilinks while keeping wikilink checks out of default
   validation.
+- Updated beginner setup and provider docs to teach GitHub, Cloudflare,
+  Google/Workspace, Meta Ads, and Apify readiness without claiming unsupported
+  provider workflows. Refs #273 and #144.
 
 ## [0.2.6] - 2026-05-04
 

--- a/README.md
+++ b/README.md
@@ -180,14 +180,19 @@ Full list: `mb --help`.
 
 `mb connect` is the local-first foundation for integrations such as Google,
 Meta, Cloudflare, Postiz, Apify, Beancount, and transcription providers.
+Use `mb connect plan` when you are not sure what to connect first; it explains
+GitHub, Cloudflare, Google/Workspace, Meta Ads, and Apify as numbered business
+choices with the current readiness state and exact next command.
 
 ```bash
+mb connect plan
 mb connect list
 printf '%s' "$CLOUDFLARE_API_TOKEN" | mb connect cloudflare --token-stdin --metadata account_id=...
 mb connect test cloudflare
 mb connect doctor
 mb connect meta --from-env
 mb connect status --json
+mb educational provider-readiness
 ```
 
 Secrets are stored outside the business repo, using the macOS Keychain when

--- a/docs/BEGINNER-SETUP.md
+++ b/docs/BEGINNER-SETUP.md
@@ -110,6 +110,44 @@ Three lines. That's the daily flow.
 
 ---
 
+## Provider Readiness
+
+Providers are outside accounts Main Branch can use when a business workflow
+needs them. You do not need to connect everything during first setup.
+
+Use the plan command from your business repo:
+
+```bash
+mb connect plan
+```
+
+It shows numbered choices:
+
+1. **GitHub** — tasks, proposals, reviews, and shipped history.
+2. **Cloudflare** — sites, DNS, Pages, and future Workers.
+3. **Google / Workspace** — existing Docs, Drive, Sheets, and Slides.
+4. **Meta Ads** — ad accounts, campaigns, and pixels.
+5. **Apify** — research sidecar for scraping, YouTube, Instagram, and web mining.
+
+If a provider is missing, Main Branch prints the next command. Examples:
+
+```bash
+gh auth login
+printf '%s' "$CLOUDFLARE_API_TOKEN" | mb connect cloudflare --token-stdin --metadata account_id=...
+mb connect status --all --json
+mb connect doctor --json
+```
+
+Secrets stay outside your repo. Main Branch stores only safe metadata in
+`.mb/connect.yaml`, such as provider name, account label, and last check time.
+For the longer plain-English explanation, run:
+
+```bash
+mb educational provider-readiness
+```
+
+---
+
 ## Updating Main Branch
 
 When new versions drop:
@@ -181,6 +219,7 @@ starts, so repaired `/mb-start` links usually appear after restart.
 | `mb init` | Scaffold a fresh business repo. |
 | `mb status` | Show a daily repo/runtime/GitHub briefing. |
 | `mb start` | Check runtime handoff readiness and print or launch Claude Code. |
+| `mb connect plan` | Show numbered provider setup choices with readiness and exact next commands. |
 | `mb update` | Update Main Branch based on pipx vs clone install mode. |
 | `mb doctor` | Check that everything is set up correctly. Walks you through fixes. |
 | `mb skill link --repo .` | Repair Claude Code skill discovery if `/mb-start` doesn't show up. |

--- a/mb/mb/_data/educational/provider-readiness.md
+++ b/mb/mb/_data/educational/provider-readiness.md
@@ -1,0 +1,76 @@
+---
+type: educational
+topic: provider-readiness
+status: draft
+last-updated: 2026-05-04
+---
+
+# Provider readiness: connect tools when the business job needs them
+
+Main Branch does not ask you to connect every account on day one. Setup should
+answer a business question:
+
+1. What are you trying to do next?
+2. Which outside account is needed for that job?
+3. Does `mb` say that account is ready, missing, or optional?
+4. What exact command fixes the next missing step?
+
+Run this from your business repo:
+
+```bash
+mb connect plan
+```
+
+For machine-readable status, use:
+
+```bash
+mb status --json --peek
+mb connect status --all --json
+mb connect doctor --json
+```
+
+## The default order
+
+1. **GitHub** - tasks, proposals, reviews, and shipped history.
+   - Check: `mb connect doctor --json`
+   - Common fix: `gh auth login`
+   - You can start local setup without it, but team/task loops are limited.
+
+2. **Cloudflare** - sites, DNS, Pages, and future Workers.
+   - Check: `mb connect status --all --json`
+   - Common setup: `printf '%s' "$CLOUDFLARE_API_TOKEN" | mb connect cloudflare --token-stdin --metadata account_id=...`
+   - Connect it when you are ready to publish or attach a domain.
+
+3. **Google / Workspace** - Drive, Docs, Sheets, Slides, and workspace source material.
+   - Check: `mb connect status --all --json`
+   - Common setup: `mb connect google --from-env`
+   - Connect it when a workflow needs existing Google files. Do not connect it just because you have a Google account.
+
+4. **Meta Ads** - ad accounts, campaigns, pixels, and future performance context.
+   - Check: `mb connect status --all --json`
+   - Common setup: `printf '%s' "$META_ACCESS_TOKEN" | mb connect meta --token-stdin --metadata ad_account_id=...`
+   - Connect it when paid-ad work needs account facts.
+
+5. **Apify** - research sidecar for scraping, YouTube, Instagram, and web mining.
+   - Check: `mb connect status --all --json`
+   - Common setup: `printf '%s' "$APIFY_TOKEN" | mb connect apify --token-stdin`
+   - Connect it when research or organic workflows need structured external data.
+
+## Readiness states
+
+- `not_connected` means no repo-safe provider metadata exists yet.
+- `missing_secret` means metadata exists but the local secret is missing.
+- `unvalidated` means a credential is stored, but it has not been tested.
+- `invalid` means validation failed and the credential should be replaced.
+- `ready` means the safest available check passed.
+
+Secrets stay outside the business repo. `.mb/connect.yaml` stores only safe
+metadata, labels, secret references, and last-check facts. Do not paste tokens
+into markdown files, GitHub issues, screenshots, or committed config.
+
+## Why this is business onboarding
+
+Providers are not developer config. They are permissions for business actions:
+publishing a site, reading source documents, learning from ads, or collecting
+research. Connect the rail when the next business action needs it, then let
+`mb status` and `mb connect` explain what is ready.

--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -614,7 +614,7 @@ def connect_cmd(
             typer.echo(json.dumps(result, indent=2))
         else:
             connect_mod.render_plan(result)
-        raise typer.Exit(0 if result["ok"] else 1)
+        raise typer.Exit(0)
     if target == "status":
         result = connect_mod.status_all(repo, include_all=all_providers)
         if json_out:

--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -562,7 +562,7 @@ def issue_open_cmd(
 def connect_cmd(
     target: str = typer.Argument(
         "",
-        help="Provider to connect, or `list` / `status` / `doctor` / `test`.",
+        help="Provider to connect, or `list` / `plan` / `status` / `doctor` / `test`.",
     ),
     provider: str = typer.Argument(
         "",
@@ -608,6 +608,13 @@ def connect_cmd(
         else:
             connect_mod.render_list(result)
         raise typer.Exit(0)
+    if target == "plan":
+        result = connect_mod.provider_plan(repo)
+        if json_out:
+            typer.echo(json.dumps(result, indent=2))
+        else:
+            connect_mod.render_plan(result)
+        raise typer.Exit(0 if result["ok"] else 1)
     if target == "status":
         result = connect_mod.status_all(repo, include_all=all_providers)
         if json_out:

--- a/mb/mb/connect.py
+++ b/mb/mb/connect.py
@@ -894,8 +894,14 @@ def provider_plan(repo: str | Path = ".") -> dict[str, Any]:
             "safe_to_share": bool(github.get("safe_to_share", True)),
         }
     ]
-    for provider_id in ("cloudflare", "google", "meta", "apify"):
-        item = by_id[provider_id]
+    provider_ids = sorted(
+        (provider_id for provider_id in PROVIDER_GUIDANCE if provider_id != "github"),
+        key=lambda provider_id: int(PROVIDER_GUIDANCE[provider_id]["priority"]),
+    )
+    for provider_id in provider_ids:
+        item = by_id.get(provider_id)
+        if item is None:
+            continue
         guidance = PROVIDER_GUIDANCE[provider_id]
         steps.append(
             {

--- a/mb/mb/connect.py
+++ b/mb/mb/connect.py
@@ -121,6 +121,75 @@ PROVIDERS: tuple[Provider, ...] = (
     ),
 )
 
+PROVIDER_GUIDANCE: dict[str, dict[str, Any]] = {
+    "github": {
+        "priority": 1,
+        "why": (
+            "GitHub is the task, proposal, review, and shipped-work layer for the business repo."
+        ),
+        "use_when": (
+            "Use for daily task tracking, public issue drafts, pull requests, reviews, "
+            "and team visibility."
+        ),
+        "defer_when": (
+            "You can start solo local setup without it, but issue, proposal, and team "
+            "loops will be limited."
+        ),
+        "status_command": "mb connect doctor --json",
+    },
+    "cloudflare": {
+        "priority": 2,
+        "why": (
+            "Cloudflare is the default low-lock-in rail for sites, DNS, Pages, and future Workers."
+        ),
+        "use_when": (
+            "Use when the business needs a landing page, custom domain, deploy, or DNS check."
+        ),
+        "defer_when": "Defer until you are ready to publish or connect a domain.",
+        "status_command": "mb connect status --all --json",
+    },
+    "google": {
+        "priority": 3,
+        "why": (
+            "Google/Workspace is the bridge for existing Docs, Sheets, Drive, and workspace assets."
+        ),
+        "use_when": (
+            "Use when the business has source material in Google Drive or needs "
+            "spreadsheet/docs context."
+        ),
+        "defer_when": (
+            "Do not connect it just because a Google account exists; connect it when "
+            "a workflow needs it."
+        ),
+        "status_command": "mb connect status --all --json",
+    },
+    "meta": {
+        "priority": 4,
+        "why": (
+            "Meta Ads readiness lets ad workflows reason about ad accounts, campaigns, and pixels."
+        ),
+        "use_when": (
+            "Use when the business is generating, reviewing, or learning from Meta/Facebook ads."
+        ),
+        "defer_when": (
+            "Defer for organic, research, or site work that does not need ad-account facts."
+        ),
+        "status_command": "mb connect status --all --json",
+    },
+    "apify": {
+        "priority": 5,
+        "why": (
+            "Apify is the optional research sidecar for scraping, YouTube, Instagram, "
+            "and web mining."
+        ),
+        "use_when": (
+            "Use when research or organic workflows need structured external data collection."
+        ),
+        "defer_when": "Defer for first-pass reference setup or local-only thinking.",
+        "status_command": "mb connect status --all --json",
+    },
+}
+
 
 def provider_map() -> dict[str, Provider]:
     return {provider.id: provider for provider in PROVIDERS}
@@ -797,8 +866,67 @@ def list_providers(repo: str | Path = ".") -> dict[str, Any]:
     providers = []
     for provider in provider_registry():
         state = by_id[provider["id"]]["state"]
-        providers.append({**provider, "state": state})
+        guidance = PROVIDER_GUIDANCE.get(provider["id"], {})
+        providers.append({**provider, **guidance, "state": state})
     return {"ok": True, "providers": providers, "config_path": status["config_path"]}
+
+
+def provider_plan(repo: str | Path = ".") -> dict[str, Any]:
+    """Return noob-safe provider setup choices backed by readiness facts."""
+
+    status = status_all(repo, include_all=True)
+    by_id = {item["provider"]: item for item in status["providers"]}
+    github = status["github"]
+    steps: list[dict[str, Any]] = [
+        {
+            "id": "github",
+            "name": "GitHub",
+            "category": "work",
+            "priority": PROVIDER_GUIDANCE["github"]["priority"],
+            "ready": bool(github["ok"]),
+            "state": github["state"],
+            "summary": github["summary"],
+            "why": PROVIDER_GUIDANCE["github"]["why"],
+            "use_when": PROVIDER_GUIDANCE["github"]["use_when"],
+            "defer_when": PROVIDER_GUIDANCE["github"]["defer_when"],
+            "status_command": PROVIDER_GUIDANCE["github"]["status_command"],
+            "next_command": github["repair_command"] or "gh auth status",
+            "safe_to_share": bool(github.get("safe_to_share", True)),
+        }
+    ]
+    for provider_id in ("cloudflare", "google", "meta", "apify"):
+        item = by_id[provider_id]
+        guidance = PROVIDER_GUIDANCE[provider_id]
+        steps.append(
+            {
+                "id": provider_id,
+                "name": item["name"],
+                "category": normalize_provider(provider_id).category,
+                "priority": guidance["priority"],
+                "ready": bool(item["ok"]),
+                "state": item["state"],
+                "summary": item["summary"],
+                "why": guidance["why"],
+                "use_when": guidance["use_when"],
+                "defer_when": guidance["defer_when"],
+                "status_command": guidance["status_command"],
+                "next_command": item["repair_command"] or f"mb connect test {provider_id}",
+                "safe_to_share": bool(item.get("safe_to_share", True)),
+            }
+        )
+    ready = len([step for step in steps if step["ready"]])
+    return {
+        "ok": True,
+        "readiness_ok": status["ok"],
+        "repo": status["repo"],
+        "steps": sorted(steps, key=lambda step: int(step["priority"])),
+        "summary": {
+            "total": len(steps),
+            "ready": ready,
+            "needs_setup": len(steps) - ready,
+        },
+        "safe_to_share": True,
+    }
 
 
 def doctor_check(repo: str | Path = ".", *, status: dict[str, Any] | None = None) -> dict[str, Any]:
@@ -884,6 +1012,18 @@ def render_list(result: dict[str, Any]) -> None:
             f"{provider['id']:<14} {provider['state']:<14} "
             f"{provider['auth']:<22} {provider['description']}"
         )
+
+
+def render_plan(result: dict[str, Any]) -> None:
+    print(f"mb connect plan  {result['repo']}")
+    print("Choose the provider that matches the business job in front of you:")
+    for index, step in enumerate(result["steps"], start=1):
+        state = "ready" if step["ready"] else step["state"]
+        print(f"{index}. {step['name']} ({state})")
+        print(f"   why: {step['why']}")
+        print(f"   use when: {step['use_when']}")
+        if not step["ready"]:
+            print(f"   next: {step['next_command']}")
 
 
 def render_status(result: dict[str, Any]) -> None:

--- a/mb/mb/educational.py
+++ b/mb/mb/educational.py
@@ -44,14 +44,32 @@ def load(topic: str) -> str | None:
     return None
 
 
+def topics() -> list[str]:
+    """Return known educational topics from active engine and bundled data."""
+
+    names: set[str] = set()
+    engine = _engine_path()
+    if engine is not None:
+        names.update(path.stem for path in engine.glob("*.md"))
+    try:
+        ref = resources.files("mb").joinpath("_data").joinpath("educational")
+        names.update(
+            path.name.removesuffix(".md") for path in ref.iterdir() if path.name.endswith(".md")
+        )
+    except (FileNotFoundError, ModuleNotFoundError, AttributeError):
+        pass
+    return sorted(names)
+
+
 def run(topic: str) -> None:
     """Print the educational file or an honest error."""
     body = load(topic)
     if body is None:
+        available = ", ".join(topics()) or (
+            "anti-cloud-backup, cloudflare-vs-vercel, github-vs-gdocs, upgrading-mainbranch"
+        )
         print(
-            f"educational topic not found: {topic}\n"
-            "Try one of: anti-cloud-backup, cloudflare-vs-vercel, "
-            "github-vs-gdocs, upgrading-mainbranch",
+            f"educational topic not found: {topic}\nTry one of: {available}",
             file=sys.stderr,
         )
         sys.exit(1)

--- a/mb/tests/test_connect.py
+++ b/mb/tests/test_connect.py
@@ -49,7 +49,58 @@ def test_connect_list_json_does_not_create_repo_metadata(tmp_path: Path) -> None
     assert result.exit_code == 0
     payload = json.loads(result.stdout)
     assert any(provider["id"] == "cloudflare" for provider in payload["providers"])
+    cloudflare = next(
+        provider for provider in payload["providers"] if provider["id"] == "cloudflare"
+    )
+    assert "low-lock-in rail" in cloudflare["why"]
+    assert cloudflare["status_command"] == "mb connect status --all --json"
     assert not (repo / ".mb" / "connect.yaml").exists()
+
+
+def test_connect_plan_returns_numbered_provider_choices(tmp_path: Path, monkeypatch) -> None:
+    repo = tmp_path / "biz"
+    repo.mkdir()
+    github_context = {
+        "ok": False,
+        "state": "unauthenticated",
+        "summary": "GitHub CLI is installed but not authenticated.",
+        "repair": "Run `gh auth login`.",
+        "repair_command": "gh auth login",
+        "safe_to_share": True,
+    }
+    monkeypatch.setattr(connect_mod, "github_context", lambda repo: github_context)
+
+    result = runner.invoke(app, ["connect", "plan", "--repo", str(repo), "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    steps = {step["id"]: step for step in payload["steps"]}
+    assert list(steps) == ["github", "cloudflare", "google", "meta", "apify"]
+    assert steps["github"]["next_command"] == "gh auth login"
+    assert steps["github"]["safe_to_share"] is True
+    assert steps["meta"]["next_command"] == "mb connect meta --token-stdin"
+    assert payload["summary"]["total"] == 5
+
+
+def test_connect_plan_human_output_uses_numbered_choices(tmp_path: Path, monkeypatch) -> None:
+    repo = tmp_path / "biz"
+    repo.mkdir()
+    github_context = {
+        "ok": True,
+        "state": "ready",
+        "summary": "GitHub CLI auth and repo remote are ready.",
+        "repair": "",
+        "repair_command": "",
+        "safe_to_share": True,
+    }
+    monkeypatch.setattr(connect_mod, "github_context", lambda repo: github_context)
+
+    result = runner.invoke(app, ["connect", "plan", "--repo", str(repo)])
+
+    assert result.exit_code == 0
+    assert "1. GitHub (ready)" in result.stdout
+    assert "2. Cloudflare (not_connected)" in result.stdout
+    assert "next: mb connect cloudflare --token-stdin" in result.stdout
 
 
 def test_connect_provider_stores_secret_outside_repo(tmp_path: Path, monkeypatch) -> None:

--- a/mb/tests/test_connect.py
+++ b/mb/tests/test_connect.py
@@ -80,6 +80,7 @@ def test_connect_plan_returns_numbered_provider_choices(tmp_path: Path, monkeypa
     assert steps["github"]["safe_to_share"] is True
     assert steps["meta"]["next_command"] == "mb connect meta --token-stdin"
     assert payload["summary"]["total"] == 5
+    assert not (repo / ".mb" / "connect.yaml").exists()
 
 
 def test_connect_plan_human_output_uses_numbered_choices(tmp_path: Path, monkeypatch) -> None:
@@ -101,6 +102,7 @@ def test_connect_plan_human_output_uses_numbered_choices(tmp_path: Path, monkeyp
     assert "1. GitHub (ready)" in result.stdout
     assert "2. Cloudflare (not_connected)" in result.stdout
     assert "next: mb connect cloudflare --token-stdin" in result.stdout
+    assert not (repo / ".mb" / "connect.yaml").exists()
 
 
 def test_connect_provider_stores_secret_outside_repo(tmp_path: Path, monkeypatch) -> None:

--- a/mb/tests/test_smoke_coverage.py
+++ b/mb/tests/test_smoke_coverage.py
@@ -52,6 +52,16 @@ def test_educational_upgrading_mainbranch_exists() -> None:
     assert "pipx upgrade mainbranch" in result
 
 
+def test_educational_provider_readiness_exists() -> None:
+    from mb.educational import load, topics
+
+    result = load("provider-readiness")
+
+    assert result is not None
+    assert "mb connect plan" in result
+    assert "provider-readiness" in topics()
+
+
 # ------------------------------------------------------------------------ think
 
 


### PR DESCRIPTION
## Summary

Adds a provider-readiness loop for first-run and daily-run routing:

- adds `mb connect plan` as a read-only provider decision tree with numbered next actions;
- adds beginner-facing provider readiness education for GitHub, Cloudflare, Google/Workspace, Meta Ads, and Apify;
- updates `/mb-start`, `/mb-status`, `/mb-setup`, and `/mb-help` so skills route from `mb status --json --peek`, `mb connect plan`, and `mb connect doctor --json` facts instead of prose probes;
- updates README, beginner setup docs, changelog, and focused tests around the new contract.

## Scope

In scope:

- Provider decision tree and readiness language for GitHub, Cloudflare, Google/Workspace, Meta Ads, and Apify.
- Exact command-first setup guidance through `mb connect plan`, `mb connect status --all --json`, and `mb connect doctor --json`.
- Skill guidance that treats provider setup as business onboarding and keeps Claude Code as the only claimed runtime.
- Focused CLI, educational topic, and smoke coverage for the new loop.

Out of scope:

- Implementing every provider integration.
- Building dashboard UI.
- Starting bookkeeping.
- Claiming non-Claude runtimes are supported.
- Adding private Devon/community details.
- Defining the deeper Google Ads / GTM / conversion-tracking rubric, which is tracked separately in #279.

## Commits

- `c9ae69f` - `[add] MAIN-223 provider readiness plan`
- `4b17ea6` - `[fix] MAIN-223 tighten provider plan`

## Release / Issues

Release: v0.3.0 - Main Branch knows what to do next  
Linear ID: MAIN-223

Closes #273.  
Refs #263.  
Refs #144.  
Refs #279.

## Success Metric

A noob user can understand which setup/provider thing is missing, why Main Branch recommends the next step, and exactly what command or slash command to run, while the skill text relies on CLI facts instead of duplicating provider probes.

## Validation

Level 0, docs/decision:

- Reviewed README, `docs/BEGINNER-SETUP.md`, changelog, educational content, and skill references for stale claims, runtime overclaiming, and public/private boundary issues.

Level 1, static:

- `scripts/check.sh` passed.
- Full gate included formatting, ruff, mypy, pytest, and `mb skill validate --all --json`.
- Full test suite result from the gate: 194 passed.

Level 2, CLI contract:

- `python3 -m pytest mb/tests/test_connect.py mb/tests/test_smoke_coverage.py -q` passed: 34 passed.
- Covered `mb connect plan` JSON/human output, read-only behavior, provider guidance fields, and educational topic discovery.

Level 3, package/install smoke:

- Built the wheel with `python3 -m build` from `mb/`.
- Installed into `/tmp/mainbranch-smoke-columbia`.
- Verified `mb --version`, `mb skill list`, `mb educational provider-readiness`, `mb connect plan`, and `mb skill validate --all --json` from the installed wheel.

Level 4, fixture repo:

- Created `/tmp/mainbranch-smoke-business-columbia` with `mb onboard --yes --name "Smoke Business" --path ... --json`.
- Verified `mb start --repo ... --json`, `mb doctor`, `mb status --peek`, and `mb validate`.
- Observed expected warnings for missing GitHub remote and incomplete onboarding.

Level 5, runtime/manual:

- Ran Claude Code non-interactively from the fresh fixture repo with the smoke wheel first on `PATH`.
- `/mb-start` was discoverable as a Claude skill, read repo context, ran `mb status --json --peek`, and reported the CLI-derived `resume_onboarding` and GitHub repair facts.

## Public / Private Boundary

No secrets, customer/member data, private local automation, or private community details were added. Provider docs tell users not to commit or paste tokens. The PR keeps non-Claude runtimes as compatibility targets only and leaves deeper Google Ads / GTM / conversion-tracking support to #279.
