### PR TITLE
[add] Google Ads GTM conversion rubric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,10 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 - Added `mb connect plan` and `mb educational provider-readiness` so provider
   setup is presented as numbered business choices with readiness states and
   exact next commands. Refs #273.
+- Added the Google Ads, GTM, and conversion tracking rubric for paid-traffic
+  landers/sites, including event naming, conversion action naming, consent
+  guardrails, Cloudflare Pages instrumentation, verification gates, and future
+  provider-readiness states. Refs #279.
 
 ### Changed
 

--- a/decisions/2026-05-04-google-ads-gtm-conversion-rubric.md
+++ b/decisions/2026-05-04-google-ads-gtm-conversion-rubric.md
@@ -1,0 +1,255 @@
+---
+type: decision
+date: 2026-05-04
+status: accepted
+topic: Google Ads, Google Tag Manager, and conversion tracking rubric
+linked_decisions:
+  - decisions/2026-05-01-mb-cli-vs-agent-workflows-boundary.md
+  - decisions/2026-05-04-sidecar-enrichment-cli-contract.md
+linked_issues:
+  - https://github.com/noontide-co/mainbranch/issues/279
+  - https://github.com/noontide-co/mainbranch/issues/273
+  - https://github.com/noontide-co/mainbranch/issues/89
+participants: [Devon, Codex]
+tags: [v0-4, google-ads, gtm, conversion-tracking, integrations, sites]
+---
+
+# Google Ads, GTM, and Conversion Tracking Rubric
+
+## Decision
+
+Main Branch-generated landers and sites that are intended for paid traffic
+must use one canonical measurement shape:
+
+- a Google Tag Manager web container as the default tag surface;
+- Google Ads conversion actions mapped from a small, stable Main Branch event
+  vocabulary;
+- a Conversion Linker or equivalent Google tag behavior configured in GTM;
+- explicit consent/privacy posture before paid launch;
+- verification evidence before an agent recommends that traffic is ready.
+
+GTM is not mandatory for every generated site. It is mandatory for a
+Main Branch offer launch path once the operator selects paid traffic,
+analytics-driven iteration, retargeting, enhanced conversions, or more than one
+marketing tag. A content-only site can ship without GTM and add it later.
+
+The full rubric lives in
+[docs/google-ads-gtm-conversion-rubric.md](../docs/google-ads-gtm-conversion-rubric.md).
+
+## Why This Exists
+
+The v0.4 offer launch loop needs trustworthy measurement before it can launch
+ads, interpret results, or recommend iteration. Without a shared rubric, each
+site or ads agent would invent its own event names, conversion actions, consent
+posture, and verification checklist.
+
+This decision keeps the boundary clear:
+
+- `mb` owns deterministic readiness facts, local/provider metadata, validation,
+  and repair hints.
+- `/mb-site`, `/mb-ads`, and `/mb-start` own judgment, handoff, and operator
+  approval prompts.
+- Google Ads, GTM, Cloudflare, and consent tools remain external provider
+  state unless and until a future connector proves safe API behavior.
+
+## Canonical Shape
+
+For paid-traffic landers and sites:
+
+1. One business repo maps to one business/account boundary. Do not reuse a
+   GTM container or Google Ads conversion customer across unrelated businesses.
+2. Use one GTM web container per site and environment. A production site and a
+   preview/staging site should not share live conversion actions.
+3. Use GTM to load the Google tag, Google Ads conversion tags, GA4 tags if
+   selected, Conversion Linker, consent defaults/updates, and any future
+   third-party tags.
+4. Generated site code pushes Main Branch events to `window.dataLayer`.
+   Provider-specific conversion labels live in GTM/Ads/provider metadata, not
+   inside ad or site copy.
+5. Cloudflare Pages/static sites inject GTM through build-time configuration
+   or environment substitution, not by committing live IDs into public examples
+   or reusable templates.
+6. Cloudflare Google Tag Gateway is the preferred first-party transport when
+   the domain is already on Cloudflare and the operator explicitly enables it.
+   Server-side GTM is a later upgrade for higher spend, material EEA/UK volume,
+   or multi-platform server event needs.
+7. Google Ads conversion action settings should keep one primary optimization
+   goal per new campaign when possible, use data-driven attribution when
+   available, count leads/calls once, count purchases every time, and treat
+   click identifiers such as `gclid`, `gbraid`, and `wbraid` as private
+   operational data rather than durable public repo content.
+
+## State Boundary
+
+Committed business repos may contain non-secret identifiers and plans when they
+are useful for agents and operators:
+
+- GTM container ID, GA4 measurement ID, Google Ads customer ID, and conversion
+  action resource names or labels;
+- selected site/domain/environment;
+- expected conversion events and primary/secondary status;
+- consent posture and policy links;
+- sanitized conversion import schemas and summaries.
+
+Committed public templates, docs, fixtures, and examples must use placeholders.
+They must not include real account IDs, conversion labels, customer data,
+conversion values, upload rows, API tokens, OAuth refresh tokens, service
+account JSON, customer lists, or hashed personally identifiable information.
+
+Local/provider state belongs outside git:
+
+- OAuth tokens, API keys, service-account JSON, developer tokens, and refresh
+  tokens;
+- raw leads, CRM exports, booking records, customer lists, uploaded conversion
+  rows, and enhanced-conversion user identifiers;
+- GTM draft workspaces, unpublished container versions, account permissions,
+  and Google Ads billing/campaign state;
+- local verification captures that include account IDs, user data, or private
+  URLs.
+
+## Event Vocabulary
+
+Generated sites should push these event names exactly when the matching user
+action exists:
+
+| Main Branch event | Use |
+|---|---|
+| `mb_cta_click` | CTA clicked, before an outcome is known. |
+| `mb_form_start` | Lead/signup form interaction began. |
+| `mb_lead_submit` | Lead form submitted successfully. |
+| `mb_calendar_click` | User clicked an outbound booking/calendar URL. |
+| `mb_booked_call` | Booking provider or thank-you page confirms a call. |
+| `mb_email_signup` | Email/newsletter signup confirmed. |
+| `mb_purchase` | Purchase confirmed. |
+| `mb_deposit` | Deposit or paid application fee confirmed. |
+| `mb_offline_conversion_ready` | A local offline conversion record is staged for operator review. |
+
+Events must use lower snake case. Event payloads must avoid PII by default and
+should use stable non-secret keys such as `mb_site_id`, `mb_offer_id`,
+`mb_event_id`, `mb_conversion_kind`, `mb_destination`, `currency`, and
+`value_basis`. Do not push email, phone, full name, address, raw order notes, or
+hashed customer identifiers unless the operator has explicitly approved
+enhanced conversions and accepted the required Google terms.
+
+## Conversion Action Naming
+
+Google Ads conversion actions should be named:
+
+```text
+MB - <Offer> - <Action> - <Environment>
+```
+
+Examples:
+
+- `MB - Diagnostic Call - Lead Submit - Prod`
+- `MB - Diagnostic Call - Booked Call - Prod`
+- `MB - Workshop - Purchase - Prod`
+
+Primary conversions are the actions the campaign should optimize toward.
+Secondary conversions are diagnostics. For common lander shapes:
+
+| Lander goal | Primary conversions | Secondary conversions |
+|---|---|---|
+| Lead form | `mb_lead_submit` | `mb_form_start`, `mb_cta_click` |
+| Booked call | `mb_booked_call` | `mb_calendar_click`, `mb_lead_submit` |
+| Purchase/deposit | `mb_purchase` or `mb_deposit` | `mb_cta_click`, `mb_form_start` |
+| Newsletter/signup | `mb_email_signup` | `mb_cta_click` |
+| Offline sales | imported offline conversion action | `mb_lead_submit`, `mb_booked_call`, `mb_offline_conversion_ready` |
+
+## Consent and Privacy Guardrails
+
+Main Branch does not provide legal advice. The rubric must still force an
+operator decision before paid launch:
+
+- Sites with EEA/UK users or remarketing/personalization must implement Consent
+  Mode with `ad_storage`, `analytics_storage`, `ad_user_data`, and
+  `ad_personalization` signals through a consent banner or consent management
+  platform.
+- Enhanced conversions require explicit operator approval and acceptance of
+  Google's customer data terms before any user-provided data is collected or
+  uploaded.
+- Offline conversion imports must preserve user consent status and must be
+  reviewed by the operator before upload.
+- A US-only informational banner and privacy policy can be enough for simple
+  non-personalized measurement, but the site must not imply that Main Branch
+  decided legal compliance for the operator.
+
+## Verification Gate
+
+Before `/mb-site`, `/mb-ads`, or `/mb-start` treats a paid-traffic launch as
+measurement-ready, a future implementation must be able to report:
+
+1. the business repo declares which GTM container, site, environment, and
+   Google Ads conversion customer are in scope;
+2. the built site includes the GTM script in `<head>` and the noscript fallback
+   immediately after `<body>` when GTM is enabled;
+3. the GTM container URL resolves;
+4. the built page pushes the expected `mb_*` dataLayer events during a browser
+   smoke;
+5. GTM Preview/Tag Assistant or a provider API check confirms the expected tags
+   fire for those events;
+6. Google Ads conversion actions exist, are primary/secondary as planned, and
+   point at the expected event triggers;
+7. consent posture is explicit and compatible with the selected market;
+8. the operator has approved any account mutation, GTM publication, enhanced
+   conversion data use, offline upload, or paid campaign launch.
+
+Static and browser checks can prove site instrumentation. They do not prove
+that Google Ads attributed conversions. Provider diagnostics and delayed Ads
+reporting remain separate evidence.
+
+## Future CLI Contract
+
+Future `mb connect`, `mb status`, and `mb doctor` work should report Google
+measurement readiness without pretending a stored secret reference is health.
+Core `mb connect` should prove Google credential and metadata readiness when
+safe probes exist. A future Google Ads/GTM sidecar should own domain-specific
+provider checks such as container contents, conversion action listing, GTM
+workspace state, and Ads diagnostics. `/mb-site` should own static and browser
+instrumentation checks against generated pages.
+The desired states are:
+
+- `missing` - no Google/GTM metadata or credential path is configured;
+- `declared` - safe metadata exists, but credentials/provider state have not
+  been checked;
+- `unvalidated` - local credentials exist, but provider checks are unavailable
+  or inconclusive;
+- `ready_for_preview` - site instrumentation and GTM container resolution pass;
+- `ready_for_operator_review` - conversion plan and provider state are present,
+  but operator approval is still required;
+- `ready` - all deterministic checks pass and operator approvals are recorded;
+- `blocked` - an account, consent, publication, or verification issue prevents
+  launch.
+
+The CLI should expose `safe_to_share`, `summary`, `repair`,
+`repair_command`, and `evidence` fields so skills can explain next actions
+without leaking account details.
+
+## What Main Branch Must Not Automate Yet
+
+Main Branch must not automatically:
+
+- create Google Ads accounts;
+- accept Google customer data terms;
+- publish GTM containers to Live;
+- enable enhanced conversions;
+- upload offline conversions or customer lists;
+- mutate billing, budgets, keywords, ads, or campaigns;
+- claim Google Ads/GTM automation is supported before API and runtime smoke
+  evidence exists.
+
+Agents may draft plans, config, naming, checklists, and operator-reviewed
+artifacts. Mutating accounts and spending money require explicit operator
+approval every time until a later decision changes that boundary.
+
+## Review Triggers
+
+Revisit this decision if:
+
+- Google changes Consent Mode, customer data, or offline conversion
+  requirements materially;
+- Cloudflare Tag Gateway is no longer the preferred light first-party transport
+  for Cloudflare-hosted sites;
+- Main Branch adds a Google Ads/GTM connector that can safely inspect or mutate
+  provider state;
+- v0.4 offer launch needs a more specific campaign/ad-group naming standard.

--- a/docs/google-ads-gtm-conversion-rubric.md
+++ b/docs/google-ads-gtm-conversion-rubric.md
@@ -1,0 +1,555 @@
+# Google Ads, GTM, and Conversion Tracking Rubric
+
+This is the implementation rubric for Main Branch-generated landers and sites
+that are meant to run paid traffic. It answers which GTM container to use,
+which conversion actions exist, which events fire, where config belongs, how to
+verify the setup, and what the operator must approve before launch.
+
+Linked decision:
+[decisions/2026-05-04-google-ads-gtm-conversion-rubric.md](../decisions/2026-05-04-google-ads-gtm-conversion-rubric.md).
+
+## Product Boundary
+
+Main Branch recommends and verifies measurement readiness. It does not seize
+control of Google accounts.
+
+`mb` owns deterministic facts:
+
+- repo-safe connection metadata;
+- local credential presence and provider probes when implemented;
+- static site instrumentation checks;
+- browser smoke results;
+- safe repair commands and JSON readiness states.
+
+Skills own judgment:
+
+- explaining setup to the operator;
+- deciding whether paid traffic is blocked;
+- drafting GTM/Ads naming and conversion plans;
+- asking for explicit approval before publishing, uploading, or spending.
+
+Google Ads, GTM, Cloudflare, consent tools, booking tools, Stripe, and CRMs own
+provider state. Main Branch records the durable plan and evidence, but it does
+not become the provider.
+
+## Default Stack
+
+| Layer | Default | When to choose another path |
+|---|---|---|
+| Tag manager | GTM web container | gtag-only is acceptable for a content-only or analytics-only site with no paid traffic and no near-term third-party tags. |
+| Ads conversion tags | Google Ads conversion tags in GTM | GA4-imported conversions can be secondary diagnostics, but paid campaigns should have explicit Google Ads conversion actions for primary goals. |
+| Click attribution | Conversion Linker or equivalent Google tag behavior in GTM | Do not omit click attribution on paid landers. |
+| First-party transport | Cloudflare Google Tag Gateway when the domain is already on Cloudflare | Standard GTM is acceptable when Cloudflare is not in use. Server-side GTM is a later upgrade. |
+| Consent | Consent Mode-compatible banner/CMP when EEA/UK or personalization is in scope | A simple US-only informational banner can be acceptable for non-personalized measurement, but the operator owns legal compliance. |
+
+GTM is required once the operator chooses paid traffic, retargeting, enhanced
+conversions, analytics-driven iteration, or multiple tags. It is optional for a
+plain content site.
+
+## Beginner Setup Path
+
+For a first paid lander, the beginner-safe setup path is:
+
+1. Create or choose the Google account that owns this business.
+2. Create the Google Ads account for this business, or choose the existing
+   account. Use a manager account only when the operator manages more than one
+   Ads account.
+3. Create a GTM web container for the production site.
+4. Install the GTM container on the generated site through `/mb-site`
+   instrumentation.
+5. In GTM, add the Google tag, Conversion Linker when needed, consent defaults
+   and updates, and event triggers for the selected `mb_*` events.
+6. In Google Ads, create conversion actions using the naming and goal rules in
+   this rubric.
+7. In GTM, map `mb_*` dataLayer events to Google Ads conversion tags.
+8. Use GTM Preview/Tag Assistant and a browser smoke to verify that tags fire.
+9. Publish the GTM container only after the operator reviews it.
+10. Launch paid traffic only after the operator approves consent/privacy,
+    conversion actions, billing, budgets, and campaign launch.
+
+Agents may draft the checklist and configuration plan. The operator creates
+accounts, accepts terms, publishes GTM, and launches campaigns.
+
+## Business and Account Granularity
+
+Use these boundaries:
+
+- one business repo per business/account boundary;
+- one Google Ads conversion customer per business unless the operator has a
+  manager-account structure;
+- one GTM account per business when possible;
+- one GTM web container per site and environment;
+- one production conversion action set per offer goal.
+
+Do not share a GTM container or Google Ads conversion action across unrelated
+business repos. Do not send preview/staging traffic into production conversion
+actions.
+
+Suggested GTM container name:
+
+```text
+<business>-<site>-<environment>
+```
+
+Example:
+
+```text
+acme-diagnostic-prod
+```
+
+## State and Storage Rules
+
+### Safe in an Access-Controlled Business Repo
+
+These values are not credentials. They can be stored in a private or
+access-controlled business repo when they help operators and agents inspect the
+launch plan. If a business repo is public, use placeholders or local/provider
+metadata instead.
+
+- GTM container ID, such as `GTM-XXXXXXX`;
+- GA4 measurement ID, such as `G-XXXXXXXXXX`;
+- Google Ads customer ID;
+- Google Ads conversion action resource names or human labels;
+- Cloudflare zone/site/project names;
+- site domain and environment;
+- selected conversion events;
+- consent posture and policy links;
+- sanitized offline import schema;
+- verification checklist results that do not expose customer data.
+
+Today `/mb-site` can read opt-in tracking fields from resolved `offer.md`
+frontmatter, such as:
+
+```yaml
+gtm_container_id: GTM-XXXXXXX
+ga4_measurement_id: G-XXXXXXXXXX
+meta_pixel_id: "000000000000000"
+```
+
+Those fields are acceptable in a private business repo when the operator wants
+agents to inspect the plan. They are not sufficient proof of readiness. Future
+provider work should prefer `.mb/connect.yaml` for repo-safe connection
+metadata and build-time environment variables for site deployment values.
+
+### Public Examples Must Use Placeholders
+
+Committed public docs, templates, and fixtures must never contain real account
+IDs, conversion labels, customer data, conversion values, API responses, or
+private URLs. Use placeholder IDs such as `GTM-XXXXXXX`, `AW-XXXXXXXXX`, and
+`customers/0000000000/conversionActions/111111111`.
+
+### Never Commit
+
+Never commit:
+
+- API tokens, OAuth refresh tokens, service-account JSON, client secrets, or
+  Google Ads developer tokens;
+- raw leads, CRM exports, customer lists, booking records, conversion uploads,
+  or enhanced-conversion user identifiers;
+- email, phone, name, address, or hashed PII;
+- conversion values tied to individual customers;
+- unpublished GTM export files if they expose private account details;
+- local browser traces, HAR files, or screenshots with account/customer data.
+
+Use the OS keychain, runtime-specific secret storage, environment variables,
+1Password, `.env.local`, `.claude/settings.local.json`, or
+`~/.mainbranch/secrets/` for local-only secrets and raw provider data.
+
+## Site Instrumentation
+
+When GTM is enabled, generated static HTML must include:
+
+- the GTM script as high in `<head>` as the generator can place it;
+- the GTM noscript iframe immediately after the opening `<body>` tag;
+- the dataLayer initialization before the GTM loader when page-level metadata
+  is needed by initial tags;
+- no Subresource Integrity attribute on Google tag/GTM loaders;
+- CSP support through nonces when the site uses a strict CSP.
+
+The committed site source should not hardcode a live GTM ID in reusable
+templates. Prefer build-time configuration:
+
+```env
+PUBLIC_GTM_CONTAINER_ID=GTM-XXXXXXX
+PUBLIC_GA4_MEASUREMENT_ID=G-XXXXXXXXXX
+```
+
+For pure static sites, use a build step that replaces placeholders with
+environment variables before deploy. For framework sites, use the framework's
+public environment-variable convention.
+
+Cloudflare Pages production and preview environments must use separate
+measurement values when preview traffic should not count as production
+conversions.
+
+If a generated one-off private site repo inlines the GTM ID during early
+implementation, that is a compatibility bridge, not the long-term template
+contract. Public templates and reusable examples must keep placeholders or env
+variables.
+
+## DataLayer Contract
+
+Generated sites should push Main Branch events to `window.dataLayer`.
+
+Base payload:
+
+```js
+window.dataLayer = window.dataLayer || [];
+window.dataLayer.push({
+  event: "mb_lead_submit",
+  mb_site_id: "diagnostic-lander",
+  mb_offer_id: "diagnostic-call",
+  mb_event_id: "01J00000000000000000000000",
+  mb_conversion_kind: "lead_submit",
+  mb_destination: "lead_form",
+  value_basis: "configured_in_ads"
+});
+```
+
+Payload rules:
+
+- `event` is required.
+- `mb_event_id` should be unique per event occurrence when the site can
+  generate one.
+- `mb_offer_id` should match the offer slug used by the business repo.
+- `mb_site_id` should be stable for the site/environment.
+- `mb_conversion_kind` should mirror the event family.
+- `mb_destination` should describe the destination without exposing private
+  data.
+- `currency` is allowed only for confirmed purchase/deposit events.
+- `value` is allowed only when the operator has chosen value-based reporting
+  and the value is not sensitive in the repo or browser context.
+
+Do not push email, phone, full name, address, raw CRM notes, booking notes,
+customer IDs, or hashed user identifiers by default.
+
+## Event Vocabulary
+
+Use these event names exactly:
+
+| Event | Trigger | Default Ads role |
+|---|---|---|
+| `mb_cta_click` | User clicks a meaningful CTA. | Secondary |
+| `mb_form_start` | User starts a lead/signup form. | Secondary |
+| `mb_lead_submit` | Lead form succeeds. | Primary for lead-gen |
+| `mb_calendar_click` | User clicks an outbound calendar/booking URL. | Secondary unless no booking confirmation exists |
+| `mb_booked_call` | Booking is confirmed by provider callback or thank-you page. | Primary for call funnels |
+| `mb_email_signup` | Email/newsletter signup is confirmed. | Primary for signup funnels |
+| `mb_purchase` | Purchase is confirmed. | Primary for checkout funnels |
+| `mb_deposit` | Deposit/application fee is confirmed. | Primary for deposit funnels |
+| `mb_offline_conversion_ready` | Offline conversion record is staged for operator review. | Diagnostic; uploaded offline action is primary when used |
+
+Events are intentionally generic enough for `/mb-site`, `/mb-ads`, and future
+sidecars to share. GTM maps these events to provider-specific tags, triggers,
+and conversion labels.
+
+## Google Ads Conversion Actions
+
+Name conversion actions:
+
+```text
+MB - <Offer> - <Action> - <Environment>
+```
+
+Use title case for the human-facing action:
+
+- `Lead Submit`
+- `Calendar Click`
+- `Booked Call`
+- `Email Signup`
+- `Purchase`
+- `Deposit`
+- `Offline Qualified Lead`
+- `Offline Sale`
+
+Recommended mapping:
+
+| Site goal | Primary conversion action | Secondary conversion actions |
+|---|---|---|
+| Lead form | `MB - <Offer> - Lead Submit - Prod` | Form Start, CTA Click |
+| Booked call | `MB - <Offer> - Booked Call - Prod` | Calendar Click, Lead Submit |
+| Purchase | `MB - <Offer> - Purchase - Prod` | CTA Click, Form Start |
+| Deposit/application | `MB - <Offer> - Deposit - Prod` | CTA Click, Form Start |
+| Email signup | `MB - <Offer> - Email Signup - Prod` | CTA Click |
+| Offline sale | `MB - <Offer> - Offline Sale - Prod` | Lead Submit, Booked Call, Offline Conversion Ready |
+
+Use production conversion actions for production traffic only. Preview and
+staging environments should either use separate conversion actions or block
+Google Ads conversion tags entirely.
+
+Recommended Google Ads settings:
+
+| Setting | Lead/call funnels | Purchase/deposit funnels |
+|---|---|---|
+| Optimization role | Exactly one primary conversion when possible | Exactly one primary conversion when possible |
+| Count | One | Every |
+| Attribution | Data-driven when available | Data-driven when available |
+| Click-through window | 30 days by default; 60-90 only for longer sales cycles | 7-30 days depending on buying cycle |
+| View-through window | Conservative; document if changed | Conservative; document if changed |
+| Value | Use configured static value only when meaningful | Use actual value only when privacy-safe and approved |
+
+Secondary events are diagnostics, not optimization goals. Do not optimize a new
+campaign against every micro-event just because the site can fire them.
+
+## Click Identifiers
+
+Google Ads auto-tagging appends click identifiers such as `gclid`, `gbraid`,
+and `wbraid`. Paid landers should preserve attribution through the Google tag
+or Conversion Linker. If a future site implementation captures click
+identifiers for offline conversion staging, it must:
+
+- store them only in local/browser or gitignored operational state;
+- preserve the landing-page timestamp and consent status;
+- avoid committing raw click identifiers to public docs, templates, fixtures, or
+  durable markdown;
+- include `gclid` when available for offline imports, with `gbraid`/`wbraid`
+  support where Google Ads requires it;
+- avoid custom conversion variables when the selected identifier type does not
+  support them.
+
+Click IDs are not API secrets, but they are user/session attribution data and
+should be treated as private operational data.
+
+## Offline Conversions
+
+Offline conversion support starts as staging and review, not automatic upload.
+
+Durable committed files can describe:
+
+- the conversion action name/resource placeholder;
+- required columns;
+- consent requirements;
+- source system;
+- review checklist;
+- upload history summary without customer rows.
+
+Raw rows belong outside git. A future local path such as
+`.mb/offline-conversions/` should be gitignored and should contain only
+operator-reviewed staging files.
+
+Minimum staged fields for a future importer:
+
+| Field | Required | Notes |
+|---|---|---|
+| `conversion_action` | Yes | Google Ads conversion action resource or configured alias. |
+| `conversion_date_time` | Yes | Include timezone. |
+| `order_id` | Strongly recommended | Helps deduplicate and adjust conversions. |
+| `gclid`, `gbraid`, or `wbraid` | Recommended when present | Captured from click URLs or session storage. |
+| `user_identifiers` | Optional, approval-gated | Must be normalized/hashed per Google rules and consent-gated. |
+| `conversion_value` | Optional | Do not commit customer-level values. |
+| `currency_code` | Required when value is present | ISO currency code. |
+| `ad_user_data_consent` | Required for EEA/UK user data uploads | Preserve consent status. |
+
+An agent may draft the schema and remind the operator how to upload. It must
+not upload offline conversions until a future connector has explicit approval
+and smoke evidence.
+
+## Consent and Enhanced Conversions
+
+Consent posture is a launch gate, not an afterthought.
+
+Minimum decisions before paid traffic:
+
+- target geography: US-only, EEA/UK, mixed, or unknown;
+- whether remarketing or ad personalization is used;
+- whether enhanced conversions are used;
+- whether offline conversions or customer lists are uploaded;
+- which privacy policy and cookie/consent UI apply.
+
+For EEA/UK or mixed traffic, the setup must support Google Consent Mode signals:
+
+- `ad_storage`
+- `analytics_storage`
+- `ad_user_data`
+- `ad_personalization`
+
+Enhanced conversions require:
+
+- explicit operator approval;
+- customer data terms accepted in Google Ads;
+- first-party data collected directly from the user;
+- consent status preserved when required;
+- no committed raw or hashed PII.
+
+If those requirements are not met, enhanced conversions are blocked. The site
+can still use standard tag-based conversion tracking where lawful and approved.
+
+## Cloudflare Pages and Tag Gateway
+
+Cloudflare Pages remains the default deploy target for `/mb-site`.
+
+For Cloudflare-hosted paid landers:
+
+1. inject GTM through build-time environment configuration;
+2. use Cloudflare Pages environment separation for production vs preview;
+3. enable Cloudflare Google Tag Gateway only after the operator approves
+   Cloudflare/Google account linking or API configuration;
+4. record the endpoint path and measurement ID as local/provider metadata;
+5. verify that the deployed page still loads tags and pushes `mb_*` events.
+
+Cloudflare Google Tag Gateway is the preferred lightweight first-party
+transport when available. Server-side GTM should wait until one of these is
+true:
+
+- monthly paid spend is high enough that signal recovery is economically
+  meaningful;
+- EEA/UK traffic share makes consent and first-party measurement quality a
+  central constraint;
+- the operator needs server-side deduplication for Meta CAPI, TikTok Events
+  API, or another non-Google server event system;
+- an analyst or technical operator can maintain the server container.
+
+## Verification Checklist
+
+A future implementation should produce evidence at these levels.
+
+### Level 0: Repo Plan
+
+- Business repo declares site, offer, environment, GTM container, Google Ads
+  conversion customer, and conversion action plan.
+- Privacy/consent posture is explicit.
+- No secrets or customer rows are committed.
+
+### Level 1: Static Build
+
+- Built HTML includes GTM head script and body noscript when GTM is enabled.
+- Built HTML does not include placeholder IDs.
+- Reusable templates do not commit live IDs.
+- CSP is absent, compatible, or nonce-aware.
+- No SRI attribute is attached to GTM/gtag loaders.
+
+### Level 2: Network Probe
+
+- `https://www.googletagmanager.com/gtm.js?id=<GTM_ID>` returns a successful
+  response.
+- If Cloudflare Google Tag Gateway is enabled, the configured first-party
+  endpoint responds for the deployed domain.
+
+### Level 3: Browser Smoke
+
+- A Playwright or equivalent browser run triggers the expected user actions.
+- `window.dataLayer` receives the expected `mb_*` events.
+- Network logs show GTM/Google tag requests after consent state allows them.
+- Preview/staging does not fire production conversion actions.
+
+### Level 4: Provider Preview
+
+- GTM Preview/Tag Assistant confirms expected triggers and tags fire.
+- GTM workspace/container version is reviewed before publication.
+- Google Ads conversion actions exist and match the primary/secondary plan.
+
+### Level 5: Post-Launch Diagnostics
+
+- Google Ads diagnostics do not report missing tags or consent blockers.
+- Delayed conversion reporting is checked after the provider's normal latency.
+- Any discrepancy becomes a GitHub issue or campaign decision with sanitized
+  evidence.
+
+There is no reliable provider-independent CLI today that proves a deployed page
+fires a Google Ads conversion and that Google Ads attributes it immediately.
+Static, browser, Tag Assistant, and delayed provider diagnostics are separate
+evidence types.
+
+## Future `mb connect` Readiness Shape
+
+Future Google/GTM readiness should follow the existing provider-readiness
+contract: a secret reference alone is never healthy.
+
+Core `mb connect` should validate only generic provider connectivity and
+repo-safe metadata: a Google credential exists, the account can be reached when
+safe probes exist, and the declared metadata is parseable. A future Google Ads
+or GTM sidecar should own deeper domain probes such as container contents,
+conversion action listing, GTM workspace state, Tag Assistant-adjacent checks,
+and Ads diagnostics. `/mb-site` owns local static/browser instrumentation
+checks against generated pages.
+
+Sketch JSON:
+
+```json
+{
+  "provider": "google_ads",
+  "state": "ready_for_operator_review",
+  "safe_to_share": true,
+  "summary": "Google Ads metadata and GTM site instrumentation are present; operator must review GTM publication and consent before launch.",
+  "metadata": {
+    "ads_customer_id_present": true,
+    "gtm_container_id_present": true,
+    "site_environment": "prod",
+    "primary_conversions": ["mb_booked_call"],
+    "secondary_conversions": ["mb_calendar_click", "mb_lead_submit"]
+  },
+  "evidence": [
+    {
+      "kind": "static_html",
+      "state": "passed",
+      "summary": "GTM loader and noscript fallback found in built HTML."
+    },
+    {
+      "kind": "browser_data_layer",
+      "state": "passed",
+      "summary": "Expected mb_calendar_click and mb_lead_submit events observed."
+    },
+    {
+      "kind": "operator_approval",
+      "state": "blocked",
+      "summary": "GTM publish and enhanced conversions approval not recorded."
+    }
+  ],
+  "repair": "Review GTM Preview, publish the container if correct, record consent/enhanced-conversion approvals, then rerun the readiness check.",
+  "repair_command": "mb connect test google-ads"
+}
+```
+
+Recommended states:
+
+| State | Meaning |
+|---|---|
+| `missing` | No relevant metadata or credential path. |
+| `declared` | Repo-safe metadata exists, but no provider/local checks have run. |
+| `unvalidated` | Credentials or metadata exist, but provider checks are unavailable or inconclusive. |
+| `ready_for_preview` | Site instrumentation and container resolution pass. |
+| `ready_for_operator_review` | Provider state and conversion plan are present; approval remains. |
+| `ready` | Deterministic checks pass and required approvals are recorded. |
+| `blocked` | A missing account, consent, publication, or verification issue prevents launch. |
+
+`mb status --json` should summarize this readiness. `mb doctor --json` should
+provide the next repair command. Skills should read the JSON instead of
+duplicating provider probes.
+
+## Operator Approval Checklist
+
+Before an agent recommends paid launch, the operator must explicitly approve:
+
+- GTM container selection;
+- GTM workspace publication to Live;
+- Google Ads conversion action selection and primary/secondary status;
+- Consent banner/CMP and privacy policy posture;
+- Cloudflare Google Tag Gateway or server-side routing if used;
+- enhanced conversions if used;
+- offline conversion upload if used;
+- campaign launch, budget, billing, and spend.
+
+No approval, no launch recommendation.
+
+## Official References
+
+- Google Tag Manager installation:
+  <https://support.google.com/tagmanager/answer/14847097>
+- Google Tag Manager data layer:
+  <https://developers.google.com/tag-platform/tag-manager/datalayer>
+- Google Tag Manager with CSP:
+  <https://developers.google.com/tag-platform/security/guides/csp>
+- Google Consent Mode:
+  <https://support.google.com/google-ads/answer/10000067>
+- Google Consent Mode reference:
+  <https://support.google.com/google-ads/answer/13802165>
+- Google enhanced conversions:
+  <https://support.google.com/google-ads/answer/9888656>
+- Google customer data policies:
+  <https://support.google.com/google-ads/answer/7475709>
+- Google Ads API offline conversions:
+  <https://developers.google.com/google-ads/api/docs/conversions/upload-offline>
+- Cloudflare Google Tag Gateway:
+  <https://developers.cloudflare.com/google-tag-gateway/>
+- Cloudflare Google Tag Gateway API:
+  <https://developers.cloudflare.com/api/go/resources/google_tag_gateway/>


### PR DESCRIPTION
## Summary

- Adds the accepted Google Ads, GTM, and conversion tracking decision for paid-traffic landers/sites.
- Adds a reusable rubric covering GTM setup, event vocabulary, conversion action naming, consent guardrails, offline conversion staging, Cloudflare Pages/Tag Gateway instrumentation, and verification levels.
- Defines future `mb connect` / `mb status` / `mb doctor` readiness states without claiming Google Ads/GTM automation works today.
- Updates `CHANGELOG.md` under Unreleased for the user-visible workflow contract.

## Scope

- In: public-safe measurement rubric for Main Branch-generated landers/sites, repo vs provider/local state boundaries, operator approval gates, and future readiness JSON shape.
- Out: live campaign launch, Google account mutation, GTM publication, offline conversion upload, provider connector implementation, package changes, and runtime behavior changes.

## Commits

- `69b1e60` — `[add] MAIN-226 Google Ads GTM conversion rubric`.

## Release / Issues

- Release: v0.4 prerequisite / Unreleased
- Linear ID(s): MAIN-226
- Closes: #279
- Refs: #273, #89
- Follow-ups: implementation work remains in the provider onboarding and offer launch surfaces.

## Success Metric

- Given a Main Branch lander and connected Google account, a future implementation agent can consistently answer which GTM container to use, which conversion actions exist, which events fire, where config is stored, how to verify the setup, and what the operator must approve before launch.

## Validation

- Level 0 docs/decision: new accepted decision, rubric doc, and changelog entry reviewed for issue fit, linked docs, public/private boundary, and stale runtime claims.
- Level 1 static: `scripts/check.sh` passed; `python3 -m mb validate .. --strict` passed from `mb/`.
- Level 2 CLI: N/A — no command behavior changed.
- Level 3 package/install: N/A — no packaging, entrypoint, or bundled data changed.
- Level 4 fixture repo: N/A — no repo-shape or first-run behavior changed.
- Level 5 runtime smoke: N/A — no skill discovery, runtime invocation, or generated site code changed.

## Public / Private Boundary

- Examples use placeholders only; no real account IDs, secrets, customer rows, Conductor details, or private operator context were committed.
