### PR TITLE
[add] mb site paid readiness

### DIFF
--- a/.claude/skills/mb-ads/SKILL.md
+++ b/.claude/skills/mb-ads/SKILL.md
@@ -68,6 +68,29 @@ source ~/.config/vip/env.sh 2>/dev/null; echo "GOOGLE_API_KEY=${GOOGLE_API_KEY:+
 
 If set, note it for Batch 4 image generation after copy is saved.
 
+### 0e. Paid-Traffic Measurement Gate
+
+If this ad work is for Google Ads, paid traffic to a site/minisite/lander, retargeting, or any request that asks whether a campaign is ready to launch, check measurement readiness before saying "launch."
+
+1. Load `docs/google-ads-gtm-conversion-rubric.md`.
+2. Run `mb connect plan` or `mb connect status --all --json` from the business repo when provider readiness matters.
+3. If a site repo is known, run:
+
+```bash
+mb site check "$SITE_REPO" --business-repo "$BUSINESS_REPO" --json
+```
+
+Use the returned `state`:
+
+- `blocked`: do not recommend launch; list the blocked checks and exact next command/manual step.
+- `ready_for_preview`: ads can be drafted, but traffic should not launch; tell the operator to run GTM Preview/Tag Assistant and finish provider metadata/approvals.
+- `ready_for_operator_review`: ads can be prepared for review, but launch still needs explicit operator approval for GTM publication, conversion actions, consent posture, budget, billing, and spend.
+- `ready`: local readiness checks passed, but do not mutate accounts or launch campaigns.
+
+Do not invent `ready_for_launch` or treat `ready` as campaign launch permission. Main Branch can prepare and review; the operator launches manually.
+
+Never ask the operator to paste Google Ads/GTM tokens, OAuth secrets, conversion uploads, or customer data into chat. Quote `mb connect` repair commands instead.
+
 ---
 
 ## Pipeboard Detection (Lazy)

--- a/.claude/skills/mb-help/SKILL.md
+++ b/.claude/skills/mb-help/SKILL.md
@@ -23,7 +23,7 @@ Answer questions, troubleshoot issues, explain philosophy, suggest next steps.
 
 | Keywords | Reference |
 |----------|-----------|
-| Terminal, drag files, cd, folder | [terminal-basics.md](references/terminal-basics.md) |
+| Terminal, drag files, cd, folder, business repo vs site repo | [terminal-basics.md](references/terminal-basics.md) |
 | Two repos, engine, data model, data model | [two-repos.md](references/two-repos.md) |
 | Philosophy, why, compound, passive memory | [philosophy.md](references/philosophy.md) |
 | /mb-think, research, decide, codify | [the-think-cycle.md](references/the-think-cycle.md) |
@@ -64,6 +64,7 @@ Answer questions, troubleshoot issues, explain philosophy, suggest next steps.
 | Question | Answer |
 |----------|--------|
 | Start Claude in a folder? | `cd ~/Documents/GitHub/[your-business] && claude` — Claude sees files in that folder. Main Branch is linked via `settings.local.json`, with bridge links as a compatibility fallback for skill discovery. |
+| Do I start Claude in the business repo or site repo? | Start in the business repo for planning and creating a site. Switch to the site repo after it exists for edits, review, deploy, and `mb site check`; the site repo should have `.mainbranch/source.json` pointing back to the business repo. |
 | When use skill prompts? | For structured tasks: `/mb-start`, `/mb-think`, `/mb-ads`, `/mb-vsl` |
 | Drag files in? | Drag from Finder into Terminal, path appears |
 | Voice input? | [Wispr Flow](https://ref.wisprflow.ai/main) (affiliate link) |

--- a/.claude/skills/mb-help/references/terminal-basics.md
+++ b/.claude/skills/mb-help/references/terminal-basics.md
@@ -109,6 +109,36 @@ You can drag things from Finder (Mac) or Explorer (Windows) directly into Termin
 
 ---
 
+## Site Work: Business Repo or Site Repo?
+
+For `/mb-site`, use two stages:
+
+**1. Start in the business repo for planning.**
+
+```bash
+cd ~/Documents/GitHub/my-business
+claude
+/mb-site
+```
+
+This is where Claude reads your offer, audience, voice, research, decisions,
+and campaign context. `/mb-site` will create or select a separate site repo.
+
+**2. Switch to the site repo for implementation once it exists.**
+
+```bash
+cd ~/Documents/GitHub/my-offer-site
+claude
+/mb-site
+```
+
+This is where Claude edits pages, reviews the site, deploys, and runs
+measurement checks. The site repo should have `.mainbranch/source.json` pointing
+back to the business repo so Claude can still read the offer and campaign
+context.
+
+---
+
 ## Voice Input
 
 Don't want to type? Use dictation.

--- a/.claude/skills/mb-setup/references/cwd-detection.md
+++ b/.claude/skills/mb-setup/references/cwd-detection.md
@@ -112,7 +112,7 @@ to:
 
 ```bash
 mb skill link --repo "$REPO_PATH"
-mb doctor --repo "$REPO_PATH"
+mb doctor "$REPO_PATH"
 ```
 
 Never overwrite `~/.config/vip/local.yaml` with `cat >`. If you edit it, read

--- a/.claude/skills/mb-site/SKILL.md
+++ b/.claude/skills/mb-site/SKILL.md
@@ -108,6 +108,12 @@ claude
 /mb-site
 ```
 
+When creating or selecting the site repo, make sure Main Branch skills are linked there too:
+
+```bash
+mb skill link --repo ~/Documents/GitHub/my-offer-site
+```
+
 ---
 
 ## Prerequisites
@@ -139,7 +145,7 @@ Prefer repo-local links over global config.
 
 - In site repo mode, read `.mainbranch/source.json` first.
 - In business repo mode, inspect the active campaign or offer note for the site repo path/URL and launch status.
-- If neither exists, route to setup mode and create the link files as part of the site creation flow.
+- If neither exists, route to setup mode and create the link files plus project skill links as part of the site creation flow.
 - Treat `~/.mainbranch/sites.json` as a legacy fallback only when no repo-local link exists.
 
 ---

--- a/.claude/skills/mb-site/SKILL.md
+++ b/.claude/skills/mb-site/SKILL.md
@@ -47,21 +47,66 @@ When research subagents record findings, they follow the `/mb-think` research pa
 ## Where Files Go
 
 ```
-your-business-repo/          <- Reference files READ from here
-├── reference/core/           (offer.md, audience.md, voice.md, soul.md)
-├── reference/proof/          (testimonials.md, angles/)
-└── reference/domain/         (content-strategy.md)
+your-business-repo/              <- Business context READ here
+├── core/                         (offer.md, audience.md, voice.md, soul.md)
+├── core/offers/<offer>/          (optional offer-specific context)
+├── campaigns/                    (site/campaign records and measurement state)
+├── decisions/                    (briefs and launch decisions)
+└── research/                     (research used by the brief)
 
-your-site-repo/              <- Site code WRITTEN here
-                             (shape-specific layout — see per-shape build refs)
-
-~/.mainbranch/sites.json     <- Config pointing to repos
+your-site-repo/                  <- Site code WRITTEN here
+├── .mainbranch/source.json       (local link back to business repo context)
+├── .mainbranch/conversion.json   (conversion endpoint and measurement plan)
+└── index.html / app/ / src/ ...  (shape-specific layout)
 
 mainbranch/ (engine)         <- Never modified by /mb-site
 └── .claude/skills/mb-site/
 ```
 
-The skill reads from the business repo and writes to the site repo. These are separate repos.
+The skill reads from the business repo and writes to the site repo. These are separate repos with explicit links in both directions.
+
+---
+
+## Invocation Mode
+
+Detect mode at the start of every invocation.
+
+**Business repo mode = plan/create/link.** If CWD has `core/` or `reference/core/`, say:
+> "I'm reading business context here and will create or select a site repo."
+
+Use this mode for planning, research, the site brief, offer selection, campaign records, and first site creation.
+
+**Site repo mode = edit/review/deploy/check.** If CWD has `.mainbranch/source.json`, read it and say:
+> "I'm editing the site here and reading business context from the linked business repo."
+
+Use this mode for implementation, review, preview, deploy, and `mb site check`. The local source link should look like:
+
+```json
+{
+  "business_repo": "/absolute/path/to/my-business",
+  "offer_path": "core/offers/flagship/offer.md",
+  "campaign_path": "campaigns/2026-05-paid-minisite.md",
+  "safe_to_share": true
+}
+```
+
+The business repo should keep the reverse site record in `campaigns/` or the relevant offer/campaign note: site repo path or URL, domain, Cloudflare project, environment, measurement state, launch status, and the next manual approval step. Keep account IDs placeholder-safe when the repo is public.
+
+Typical workflow:
+
+```bash
+cd ~/Documents/GitHub/my-business
+claude
+/mb-site
+```
+
+Then after the site repo exists:
+
+```bash
+cd ~/Documents/GitHub/my-offer-site
+claude
+/mb-site
+```
 
 ---
 
@@ -88,17 +133,14 @@ Netlify is supported as a legacy fallback for pre-V1 Next.js templates only — 
 
 ---
 
-## Config Discovery
+## Site Link Discovery
 
-On every invocation, check for existing config:
+Prefer repo-local links over global config.
 
-```bash
-cat ~/.mainbranch/sites.json 2>/dev/null || echo "NO_CONFIG"
-```
-
-- **Config found, one site:** Confirm with user, load site repo path
-- **Config found, multiple sites:** Ask which site to work on (numbered list)
-- **No config:** Route to setup mode
+- In site repo mode, read `.mainbranch/source.json` first.
+- In business repo mode, inspect the active campaign or offer note for the site repo path/URL and launch status.
+- If neither exists, route to setup mode and create the link files as part of the site creation flow.
+- Treat `~/.mainbranch/sites.json` as a legacy fallback only when no repo-local link exists.
 
 ---
 
@@ -107,27 +149,13 @@ cat ~/.mainbranch/sites.json 2>/dev/null || echo "NO_CONFIG"
 Before loading reference files, resolve the active offer:
 
 1. Check `.vip/local.yaml` for `current_offer`
-2. If set: load `reference/offers/[current_offer]/offer.md` as the active offer
-3. If not set AND `reference/offers/` exists: ask which offer this site is for
-4. If no `offers/` folder: use `reference/core/offer.md` (single-offer, backward compatible)
+2. If set: load `core/offers/[current_offer]/offer.md` as the active offer
+3. If not set AND `core/offers/` exists: ask which offer this site is for
+4. If no `core/offers/` folder: use `core/offer.md` (single-offer, backward compatible)
 
 **Always-core files** (never per-offer): `soul.md`, `voice.md`, `content-strategy.md`
 **Offer-aware files** (check offers/ first, fall back to core/): `offer.md`, `audience.md`
 **Accumulate files** (load both): `testimonials.md` (offer-specific + brand-level)
-
-`~/.mainbranch/sites.json` can include an `offer` field that overrides `.vip/local.yaml`:
-
-```json
-{
-  "name": "thelastbill",
-  "offer": "the-last-bill",
-  "site_repo": "/absolute/path/to/site-repo",
-  "business_repo": "/absolute/path/to/business-repo",
-  "shape": "minisite",
-  "hosting": "cloudflare",
-  "domain": "thelastbill.com"
-}
-```
 
 ---
 
@@ -135,10 +163,10 @@ Before loading reference files, resolve the active offer:
 
 | File | Path | Required |
 |---|---|---|
-| Offer | `offers/[active]/offer.md` or `core/offer.md` (resolved) | **Yes** |
-| Audience | `offers/[active]/audience.md` or `core/audience.md` (resolved) | **Yes** |
-| Voice | `reference/core/voice.md` | Recommended |
-| Soul | `reference/core/soul.md` | Optional |
+| Offer | `core/offers/[active]/offer.md` or `core/offer.md` (resolved) | **Yes** |
+| Audience | `core/offers/[active]/audience.md` or `core/audience.md` (resolved) | **Yes** |
+| Voice | `core/voice.md` | Recommended |
+| Soul | `core/soul.md` | Optional |
 | Testimonials | `reference/proof/testimonials.md` (+ offer-specific if exists) | Recommended |
 | Angles | `reference/proof/angles/*.md` | Optional |
 | Content Strategy | `reference/domain/content-strategy.md` | Optional |
@@ -238,15 +266,41 @@ When reference files change significantly (new offer, new pricing), consider re-
 
 ---
 
+## Paid-Traffic Measurement Readiness
+
+When the operator says paid traffic, Google Ads, GTM, conversion tracking, retargeting, or launch readiness, load `docs/google-ads-gtm-conversion-rubric.md` before generating or approving the site. Use the rubric's `mb_*` event vocabulary and do not recommend launch from prose alone.
+
+After the site repo has `.mainbranch/conversion.json` and built HTML, run:
+
+```bash
+mb site check "$SITE_REPO" --business-repo "$BUSINESS_REPO" --json
+```
+
+If running from a site repo with `.mainbranch/source.json`, `mb site check . --json` can infer the linked business repo.
+
+Use that JSON as the readiness source of truth:
+
+- `blocked` means stop and give the exact failed checks plus the next command/manual step.
+- `ready_for_preview` means static instrumentation can be previewed, but provider metadata or approvals are still missing.
+- `ready_for_operator_review` means the operator must review GTM Preview/Tag Assistant, conversion actions, consent posture, and publication before any launch.
+- `ready` still does not launch anything; it only means local checks and recorded approvals passed.
+
+Do not invent `ready_for_launch` or say Main Branch can launch the campaign. The readiness states are exactly `missing`, `blocked`, `ready_for_preview`, `ready_for_operator_review`, and `ready`.
+
+Never ask the operator to paste Google Ads, GTM, OAuth, or API tokens into chat. Use `mb connect plan`, `mb connect status --all --json`, or `mb connect doctor --json` for provider readiness and quote the CLI's `next_command` / `repair_command`.
+
+---
+
 ## Recovery from Compaction
 
 If conversation compacted or context was lost:
 
 1. **Re-invoke `/mb-site`** to reload skill context
-2. **Check config:** `cat ~/.mainbranch/sites.json 2>/dev/null`
-3. **Identify the site shape** from the config's `shape` field; load the corresponding build ref
-4. **Check site repo status:** `cd <site_repo> && git status && git log --oneline -5`
-5. **Resume from last completed step** based on git history + sites.json state
+2. **Check invocation mode:** business repo mode (`core/`) or site repo mode (`.mainbranch/source.json`)
+3. **Load links:** read `.mainbranch/source.json` in the site repo, or the campaign/site record in the business repo
+4. **Identify the site shape** from the campaign/site record or existing files; load the corresponding build ref
+5. **Check site repo status:** `cd <site_repo> && git status && git log --oneline -5`
+6. **Resume from last completed step** based on git history, source links, and campaign launch status
 
 ---
 
@@ -288,6 +342,7 @@ Site shapes `/mb-site` covers: **lander** (1 page), **minisite** (~4–6 pages),
 - [references/lander-build.md](references/lander-build.md) — 1-page shape (V1 stub)
 - [references/minisite-build.md](references/minisite-build.md) — ~4–6 page shape (V1 target)
 - [references/website-build.md](references/website-build.md) — full-site shape (Next.js + future per-offer generation)
+- [references/site-repo-workflow.md](references/site-repo-workflow.md) — business repo mode vs site repo mode
 - [references/graduation.md](references/graduation.md) — paths between shapes + CMS bolt-on (Sanity, Contentful, Notion, etc.)
 
 **Generation + design (used by per-shape flows):**

--- a/.claude/skills/mb-site/references/minisite.md
+++ b/.claude/skills/mb-site/references/minisite.md
@@ -252,6 +252,8 @@ For operators with their own form endpoint or advanced flow. The operator suppli
 
 Pixels and analytics are **opt-in per offer** via `offer.md` frontmatter. The generation subagent injects them into all pages when declared; skips injection entirely when not.
 
+For paid-traffic, Google Ads, GTM, conversion tracking, retargeting, or launch-readiness work, the canonical contract is `docs/google-ads-gtm-conversion-rubric.md`. Load that rubric and run `mb site check "$SITE_REPO" --business-repo "$BUSINESS_REPO" --json` before saying the site is ready for paid launch. The check is local/read-only; it does not publish GTM or mutate Google Ads.
+
 ### Supported tracking providers (V1)
 
 | Provider | offer.md field | Where it goes |
@@ -264,20 +266,23 @@ If multiple are declared, all install. If GTM is declared, GA4 and Meta Pixel ty
 
 ### Conversion events
 
-The generation subagent fires standard conversion events when the corresponding tracking is installed. The conversion event name matches the conversion endpoint's kind:
+Generated sites push Main Branch events to `window.dataLayer`; GTM maps those events to Google Ads, GA4, Meta, or other provider tags. Use the rubric's event vocabulary exactly:
 
-| Event | When | Pixels | Conversion kind |
-|---|---|---|---|
-| `PageView` | Every page load | All declared | (always) |
-| `InitiateCheckout` | Click on a Stripe CTA (home hero, secondary, pricing) | All declared | Stripe payment page |
-| `Purchase` | Page load on `/start/thanks/` (after Stripe success) | All declared | Stripe payment page |
-| `Lead` | Form submit success / page load on `/start/thanks/` | All declared | Lead form |
-| `Schedule` | Page load on `/start/thanks/` (after appointment booked, if redirect supported by provider) | All declared | Appointment booking |
-| (operator-defined) | Operator's webhook flow decides; default fires `Lead` on home-CTA click | All declared | Custom webhook |
+| Event | When | Default Ads role |
+|---|---|---|
+| `mb_cta_click` | User clicks a meaningful CTA. | Secondary |
+| `mb_form_start` | User starts a lead/signup form. | Secondary |
+| `mb_lead_submit` | Lead form succeeds. | Primary for lead-gen |
+| `mb_calendar_click` | User clicks an outbound calendar/booking URL. | Secondary unless no booking confirmation exists |
+| `mb_booked_call` | Booking is confirmed by provider callback or thank-you page. | Primary for call funnels |
+| `mb_email_signup` | Email/newsletter signup is confirmed. | Primary for signup funnels |
+| `mb_purchase` | Purchase is confirmed. | Primary for checkout funnels |
+| `mb_deposit` | Deposit/application fee is confirmed. | Primary for deposit funnels |
+| `mb_offline_conversion_ready` | Offline conversion record is staged for operator review. | Diagnostic only |
 
-For Stripe: `Purchase` payload includes `value: <amount_usd>`, `currency: usd`. The subagent reads the amount from `offer.md` at build time (Stripe doesn't pass it through the redirect).
+For Stripe: confirmed purchase/deposit events may include `value` and `currency` only when the operator has chosen value-based reporting and the value is not sensitive in the repo or browser context.
 
-For lead/appointment: standard pixel taxonomy events. The subagent uses the conversion-endpoint kind to pick which event(s) to fire.
+Do not push email, phone, full name, address, CRM notes, booking notes, raw customer IDs, or hashed user identifiers by default.
 
 ### What's NOT in the tracking architecture (V1)
 
@@ -300,6 +305,7 @@ For lead/appointment: standard pixel taxonomy events. The subagent uses the conv
 | Cloudflare creds + GitHub App | All tool calls | `verify_live.py` returns 3/3 (Cloudflare scopes + zone lookup + domain-check) |
 | Domain decision | Setup | Operator confirms own-or-buy |
 | Tracking IDs (if declared) | Generation | offer.md frontmatter parse — if any tracking field present, validate format |
+| Paid-traffic measurement readiness | Paid launch recommendation | `mb site check "$SITE_REPO" --business-repo "$BUSINESS_REPO" --json` |
 
 ### Conversion-endpoint gates (only the chosen kind's gates apply)
 

--- a/.claude/skills/mb-site/references/site-repo-workflow.md
+++ b/.claude/skills/mb-site/references/site-repo-workflow.md
@@ -1,0 +1,63 @@
+# Site Repo Workflow
+
+`/mb-site` has two modes.
+
+## Business Repo Mode
+
+Start here when planning or creating a site:
+
+```bash
+cd ~/Documents/GitHub/my-business
+claude
+/mb-site
+```
+
+Use this mode to read business context, pick the offer, draft the site brief,
+create or select the site repo, and record campaign/site state.
+
+The business repo keeps durable truth: offer, audience, voice, research,
+briefs, campaign records, measurement state, launch status, and manual approval
+notes.
+
+## Site Repo Mode
+
+Switch here once a site repo exists:
+
+```bash
+cd ~/Documents/GitHub/my-offer-site
+claude
+/mb-site
+```
+
+Use this mode to edit site code, review pages, preview, deploy, and run
+readiness checks while reading linked business context.
+
+The site repo must include `.mainbranch/source.json`:
+
+```json
+{
+  "business_repo": "/absolute/path/to/my-business",
+  "offer_path": "core/offers/flagship/offer.md",
+  "campaign_path": "campaigns/2026-05-paid-minisite.md",
+  "safe_to_share": true
+}
+```
+
+The site repo also stores `.mainbranch/conversion.json` for the conversion
+endpoint and local measurement plan. `mb site check` reads these files and can
+infer the business repo from `source.json` when `--business-repo` is omitted.
+
+## Reverse Link
+
+The business repo should keep a reverse site record in `campaigns/` or the
+relevant offer/campaign note:
+
+- site repo path or GitHub URL;
+- deployed URL and domain;
+- Cloudflare project and environment;
+- offer path and campaign path;
+- measurement state from `mb site check`;
+- launch status and next manual approval step.
+
+Keep secrets, tokens, raw provider exports, customer rows, and private browser
+traces out of both repos.

--- a/.claude/skills/mb-site/references/site-repo-workflow.md
+++ b/.claude/skills/mb-site/references/site-repo-workflow.md
@@ -32,6 +32,13 @@ claude
 Use this mode to edit site code, review pages, preview, deploy, and run
 readiness checks while reading linked business context.
 
+When `/mb-site` creates or selects a site repo, it should also link Main Branch
+skills into that repo so Claude can discover `/mb-site` there:
+
+```bash
+mb skill link --repo ~/Documents/GitHub/my-offer-site
+```
+
 The site repo must include `.mainbranch/source.json`:
 
 ```json

--- a/.claude/skills/mb-start/SKILL.md
+++ b/.claude/skills/mb-start/SKILL.md
@@ -23,6 +23,17 @@ first. If the operator needs a provider choice or repair explanation, run
 `next_command` / `repair_command`. Do not ask for tokens or provider setup in
 prose before the CLI has named the missing step.
 
+**Paid-traffic facts first:** When routing a paid-traffic minisite, Google Ads,
+GTM, retargeting, or "ready to launch" request, load
+`docs/google-ads-gtm-conversion-rubric.md`. If a site repo is known, run
+`mb site check "$SITE_REPO" --business-repo "$REPO_PATH" --json` before routing
+to `/mb-site` or `/mb-ads` launch advice. Treat `blocked` as stop, `ready_for_preview`
+as preview-only, and `ready_for_operator_review` as manual review before
+launch. Do not publish GTM, mutate Google Ads, upload conversions, or ask for
+tokens in prose. Do not invent `ready_for_launch`; the valid readiness states
+are `missing`, `blocked`, `ready_for_preview`, `ready_for_operator_review`, and
+`ready`.
+
 ---
 
 ## CRITICAL: Repo Selection Rules
@@ -154,8 +165,8 @@ Use this report before asking additional questions:
 - `onboarding.summary` and `onboarding.checklist` replace separate onboarding
   probes unless the status report is unavailable.
 - `integrations.github`, `integrations.providers`, `github.sections`,
-  `brain.bets`, and `since_last_check` supply the continuity facts for routing
-  and triage.
+  `measurement`, `brain.bets`, and `since_last_check` supply the continuity
+  facts for routing and triage.
 
 Only run a narrower fallback command such as `mb onboard status --json`,
 `mb doctor`, `mb validate --cross-refs`, or `mb connect doctor --json` when status

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,10 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   landers/sites, including event naming, conversion action naming, consent
   guardrails, Cloudflare Pages instrumentation, verification gates, and future
   provider-readiness states. Refs #279.
+- Added `mb site check` for local paid-traffic measurement readiness checks
+  covering GTM installation, `mb_*` dataLayer events, consent/privacy posture,
+  Google Ads plan metadata, provider readiness summary, and manual operator
+  approval gates. Refs #283.
 
 ### Changed
 
@@ -69,6 +73,13 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 - Updated beginner setup and provider docs to teach GitHub, Cloudflare,
   Google/Workspace, Meta Ads, and Apify readiness without claiming unsupported
   provider workflows. Refs #273 and #144.
+- Updated `/mb-site`, `/mb-ads`, and `/mb-start` guidance to route
+  paid-traffic launch advice through the Google Ads/GTM rubric and
+  deterministic `mb site check` facts before recommending any launch step. Refs
+  #283.
+- Clarified `/mb-site` business-repo mode versus site-repo mode, including
+  `.mainbranch/source.json` source links and a progressive `/mb-help` answer
+  for where to start Claude during site work. Refs #283.
 
 ## [0.2.6] - 2026-05-04
 

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ The CLI surface for the engine. Built for Claude Code first; runtime-agnostic by
 | `mb status` | Show a local-first daily briefing: ranked next actions, since-last-check changes, drift, repo health, runtime wiring, recent decisions/research/bets/git activity, and GitHub tasks when `gh` is authenticated. Use `--json` for the v1 status schema, `--verbose` for detail, and `--peek` for non-mutating reads. |
 | `mb doctor` | Check the environment — repo shape, frontmatter sanity, settings on disk. Walks you through fixes. |
 | `mb connect` | Register provider credentials, test provider health, and inspect repair-safe integration status without committing secrets. |
+| `mb site check` | Check local paid-traffic measurement readiness for a site repo: GTM installation, Main Branch dataLayer events, consent posture, Google Ads plan metadata, and operator-review gates. |
 | `mb issue draft` | Create a local, privacy-scrubbed GitHub issue draft under `.mb/issue-drafts/` for bugs, feature gaps, or questions. |
 | `mb issue open` | Submit a reviewed issue draft with `gh issue create`, or print a browser/manual fallback when GitHub CLI is unavailable. |
 | `mb validate` | Frontmatter shape check across `core/`, `research/`, `decisions/`, `bets/`, `log/`, `campaigns/`, `documents/`. Pass/fail per file. |

--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -26,6 +26,7 @@ from mb import migrate as migrate_mod
 from mb import onboard as onboard_mod
 from mb import resolve as resolve_mod
 from mb import similar_bets as similar_bets_mod
+from mb import site as site_mod
 from mb import skill_validate as skill_validate_mod
 from mb import start as start_mod
 from mb import status as status_mod
@@ -74,6 +75,13 @@ issue_app = typer.Typer(
     no_args_is_help=True,
 )
 app.add_typer(issue_app, name="issue")
+
+site_app = typer.Typer(
+    name="site",
+    help="Inspect site readiness for launch-adjacent workflows.",
+    no_args_is_help=True,
+)
+app.add_typer(site_app, name="site")
 
 CONNECT_METADATA_OPTION = typer.Option(
     [],
@@ -758,6 +766,26 @@ def start_cmd(
     else:
         start_mod.render_human(report)
     raise typer.Exit(0 if report["ok"] else 1)
+
+
+@site_app.command("check")
+def site_check_cmd(
+    site_repo: str = typer.Argument(".", help="Site repo or built static site to inspect."),
+    business_repo: str = typer.Option(
+        "",
+        "--business-repo",
+        "--repo",
+        help="Business repo with offer and provider metadata.",
+    ),
+    json_out: bool = typer.Option(False, "--json", help="Machine-readable output."),
+) -> None:
+    """Check paid-traffic measurement readiness without mutating provider accounts."""
+    result = site_mod.check(site_repo, business_repo=business_repo or None)
+    if json_out:
+        typer.echo(json.dumps(result, indent=2))
+    else:
+        site_mod.render_check(result)
+    raise typer.Exit(0 if result["ok"] else 1)
 
 
 @app.command("validate")

--- a/mb/mb/site.py
+++ b/mb/mb/site.py
@@ -19,7 +19,6 @@ HTML_EXCLUDED_DIRS = {
     ".mainbranch",
     ".mb",
     ".next",
-    "dist",
     "node_modules",
 }
 REUSABLE_SOURCE_DIRS = {

--- a/mb/mb/site.py
+++ b/mb/mb/site.py
@@ -1,0 +1,656 @@
+"""Paid-traffic site readiness checks for ``mb site``."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from mb import connect as connect_mod
+
+CONVERSION_RELATIVE_PATH = Path(".mainbranch") / "conversion.json"
+SOURCE_RELATIVE_PATH = Path(".mainbranch") / "source.json"
+HTML_EXCLUDED_DIRS = {
+    ".git",
+    ".hg",
+    ".mainbranch",
+    ".mb",
+    ".next",
+    "dist",
+    "node_modules",
+}
+REUSABLE_SOURCE_DIRS = {
+    "app",
+    "components",
+    "layouts",
+    "pages",
+    "src",
+    "templates",
+}
+PLACEHOLDER_GTM_IDS = {"GTM-XXXXXXX", "GTM-XXXXXX", "GTM-PLACEHOLDER"}
+GTM_ID_RE = re.compile(r"\bGTM-[A-Z0-9]{5,}\b")
+GA4_ID_RE = re.compile(r"\bG-[A-Z0-9]{6,}\b")
+META_PIXEL_RE = re.compile(r"\b\d{10,20}\b")
+
+EVENTS_BY_KIND: dict[str, list[str]] = {
+    "stripe_payment_page": ["mb_cta_click", "mb_purchase"],
+    "payment_page": ["mb_cta_click", "mb_purchase"],
+    "deposit": ["mb_cta_click", "mb_deposit"],
+    "lead_form": ["mb_cta_click", "mb_form_start", "mb_lead_submit"],
+    "appointment_booking": ["mb_calendar_click", "mb_booked_call"],
+    "booking": ["mb_calendar_click", "mb_booked_call"],
+    "email_signup": ["mb_cta_click", "mb_email_signup"],
+    "custom_webhook": ["mb_cta_click", "mb_lead_submit"],
+}
+
+
+def _read_json(path: Path) -> tuple[dict[str, Any], str]:
+    if not path.exists():
+        return {}, "missing"
+    try:
+        parsed = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return {}, f"invalid JSON: {exc}"
+    return (parsed, "") if isinstance(parsed, dict) else ({}, "not a JSON object")
+
+
+def _resolve_source_path(site_repo: Path, value: Any) -> str:
+    if not isinstance(value, str) or not value.strip():
+        return ""
+    candidate = Path(value).expanduser()
+    if not candidate.is_absolute():
+        candidate = (site_repo / candidate).resolve()
+    return str(candidate)
+
+
+def _site_source(site_repo: Path) -> tuple[dict[str, Any], str]:
+    source, error = _read_json(site_repo / SOURCE_RELATIVE_PATH)
+    if error:
+        return {}, error
+    business_repo = _resolve_source_path(site_repo, source.get("business_repo"))
+    return {
+        "business_repo": business_repo,
+        "offer_path": str(source.get("offer_path") or ""),
+        "campaign_path": str(source.get("campaign_path") or ""),
+        "safe_to_share": True,
+    }, ""
+
+
+def _read_frontmatter(path: Path) -> dict[str, Any]:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return {}
+    if not text.startswith("---"):
+        return {}
+    end = text.find("\n---", 3)
+    if end == -1:
+        return {}
+    try:
+        parsed = yaml.safe_load(text[3:end].strip()) or {}
+    except yaml.YAMLError:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _offer_paths(repo: Path) -> list[Path]:
+    candidates = [
+        repo / "core" / "offer.md",
+        repo / "reference" / "core" / "offer.md",
+    ]
+    for root in (repo / "core" / "offers", repo / "reference" / "offers"):
+        if root.exists():
+            candidates.extend(sorted(root.glob("*/offer.md")))
+    return [path for path in candidates if path.is_file()]
+
+
+def _merged_offer_metadata(repo: Path | None) -> dict[str, Any]:
+    if repo is None:
+        return {}
+    metadata: dict[str, Any] = {}
+    for path in _offer_paths(repo):
+        metadata.update(_read_frontmatter(path))
+    return metadata
+
+
+def _string_value(*values: Any) -> str:
+    for value in values:
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            return str(value)
+    return ""
+
+
+def _list_value(value: Any) -> list[str]:
+    if isinstance(value, list):
+        return [str(item).strip() for item in value if str(item).strip()]
+    if isinstance(value, str) and value.strip():
+        return [part.strip() for part in value.split(",") if part.strip()]
+    return []
+
+
+def _metadata_sources(
+    conversion: dict[str, Any],
+    offer: dict[str, Any],
+    providers: list[dict[str, Any]],
+) -> dict[str, Any]:
+    raw_conversion_meta = conversion.get("metadata")
+    conversion_meta: dict[str, Any] = (
+        raw_conversion_meta if isinstance(raw_conversion_meta, dict) else {}
+    )
+    provider_metadata: dict[str, Any] = {}
+    for item in providers:
+        raw_metadata = item.get("metadata")
+        metadata: dict[str, Any] = raw_metadata if isinstance(raw_metadata, dict) else {}
+        for key, value in metadata.items():
+            provider_metadata.setdefault(key, value)
+    return {
+        "gtm_container_id": _string_value(
+            conversion.get("gtm_container_id"),
+            conversion_meta.get("gtm_container_id"),
+            offer.get("gtm_container_id"),
+            provider_metadata.get("gtm_container_id"),
+        ),
+        "ga4_measurement_id": _string_value(
+            conversion.get("ga4_measurement_id"),
+            conversion_meta.get("ga4_measurement_id"),
+            offer.get("ga4_measurement_id"),
+            provider_metadata.get("ga4_measurement_id"),
+        ),
+        "meta_pixel_id": _string_value(
+            conversion.get("meta_pixel_id"),
+            conversion_meta.get("meta_pixel_id"),
+            offer.get("meta_pixel_id"),
+            provider_metadata.get("meta_pixel_id"),
+        ),
+        "google_ads_customer_id": _string_value(
+            conversion.get("google_ads_customer_id"),
+            conversion_meta.get("google_ads_customer_id"),
+            conversion_meta.get("ads_customer_id"),
+            offer.get("google_ads_customer_id"),
+            offer.get("ads_customer_id"),
+            provider_metadata.get("google_ads_customer_id"),
+            provider_metadata.get("ads_customer_id"),
+        ),
+        "consent_posture": _string_value(
+            conversion.get("consent_posture"),
+            conversion_meta.get("consent_posture"),
+            offer.get("consent_posture"),
+        ),
+        "privacy_policy_url": _string_value(
+            conversion.get("privacy_policy_url"),
+            conversion_meta.get("privacy_policy_url"),
+            offer.get("privacy_policy_url"),
+        ),
+        "primary_conversions": _list_value(
+            conversion.get("primary_conversions") or conversion_meta.get("primary_conversions")
+        ),
+        "secondary_conversions": _list_value(
+            conversion.get("secondary_conversions") or conversion_meta.get("secondary_conversions")
+        ),
+        "operator_approvals": conversion.get("operator_approvals")
+        if isinstance(conversion.get("operator_approvals"), dict)
+        else {},
+    }
+
+
+def _is_placeholder_gtm(value: str) -> bool:
+    return value.upper() in PLACEHOLDER_GTM_IDS or bool(re.fullmatch(r"GTM-X+", value.upper()))
+
+
+def _html_files(site_repo: Path) -> list[Path]:
+    files: list[Path] = []
+    for path in site_repo.rglob("*.html"):
+        if any(part in HTML_EXCLUDED_DIRS for part in path.relative_to(site_repo).parts):
+            continue
+        if path.is_file():
+            files.append(path)
+    return sorted(files)
+
+
+def _relative(site_repo: Path, path: Path) -> str:
+    try:
+        return path.relative_to(site_repo).as_posix()
+    except ValueError:
+        return str(path)
+
+
+def _read_many(paths: list[Path]) -> list[tuple[Path, str]]:
+    items: list[tuple[Path, str]] = []
+    for path in paths:
+        try:
+            items.append((path, path.read_text(encoding="utf-8", errors="ignore")))
+        except OSError:
+            continue
+    return items
+
+
+def _check_html(
+    site_repo: Path,
+    *,
+    gtm_container_id: str,
+    expected_events: list[str],
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    html_files = _html_files(site_repo)
+    html_items = _read_many(html_files)
+    combined = "\n".join(text for _, text in html_items)
+    evidence: list[dict[str, Any]] = []
+    details: dict[str, Any] = {
+        "html_files": [_relative(site_repo, path) for path in html_files[:25]],
+        "html_file_count": len(html_files),
+        "missing_events": [],
+        "reusable_template_live_gtm_ids": [],
+    }
+
+    if not html_files:
+        evidence.append(
+            {
+                "kind": "static_html",
+                "state": "blocked",
+                "summary": "No built HTML files were found to inspect.",
+            }
+        )
+        return evidence, details
+
+    has_gtm_script = "googletagmanager.com/gtm.js" in combined
+    has_gtm_noscript = "googletagmanager.com/ns.html" in combined
+    has_sri = bool(
+        re.search(
+            r"<script[^>]+(?:googletagmanager\.com/(?:gtm|gtag)\.js)[^>]+integrity=",
+            combined,
+            flags=re.IGNORECASE,
+        )
+    )
+    placeholder_ids = sorted(
+        {
+            match.group(0)
+            for match in GTM_ID_RE.finditer(combined)
+            if _is_placeholder_gtm(match.group(0))
+        }
+    )
+
+    if gtm_container_id:
+        if has_gtm_script and has_gtm_noscript:
+            state = "passed"
+            summary = "GTM loader and noscript fallback found in built HTML."
+        else:
+            state = "blocked"
+            missing = []
+            if not has_gtm_script:
+                missing.append("head script")
+            if not has_gtm_noscript:
+                missing.append("body noscript")
+            summary = f"GTM is declared, but built HTML is missing {', '.join(missing)}."
+    else:
+        state = "missing"
+        summary = "No GTM container ID is declared for this paid-traffic check."
+    evidence.append({"kind": "static_html", "state": state, "summary": summary})
+
+    if placeholder_ids:
+        evidence.append(
+            {
+                "kind": "static_html_placeholders",
+                "state": "blocked",
+                "summary": "Built HTML still contains placeholder GTM IDs.",
+                "evidence": placeholder_ids[:5],
+            }
+        )
+    if has_sri:
+        evidence.append(
+            {
+                "kind": "gtm_loader_sri",
+                "state": "blocked",
+                "summary": "GTM or Google tag loader has an SRI integrity attribute.",
+            }
+        )
+
+    missing_events = [event for event in expected_events if event not in combined]
+    details["missing_events"] = missing_events
+    if expected_events and not missing_events:
+        evidence.append(
+            {
+                "kind": "data_layer_events",
+                "state": "passed",
+                "summary": "Expected Main Branch dataLayer events were found.",
+                "events": expected_events,
+            }
+        )
+    elif expected_events:
+        evidence.append(
+            {
+                "kind": "data_layer_events",
+                "state": "blocked",
+                "summary": "Expected Main Branch dataLayer events are missing from built HTML.",
+                "events": expected_events,
+                "missing": missing_events,
+            }
+        )
+
+    template_live_ids: list[str] = []
+    for source_dir in REUSABLE_SOURCE_DIRS:
+        root = site_repo / source_dir
+        if not root.exists():
+            continue
+        for source_path in root.rglob("*"):
+            if not source_path.is_file():
+                continue
+            try:
+                text = source_path.read_text(encoding="utf-8", errors="ignore")
+            except OSError:
+                continue
+            for match in GTM_ID_RE.finditer(text):
+                value = match.group(0)
+                if value == gtm_container_id and not _is_placeholder_gtm(value):
+                    template_live_ids.append(_relative(site_repo, source_path))
+                    break
+    details["reusable_template_live_gtm_ids"] = sorted(set(template_live_ids))
+    if template_live_ids:
+        evidence.append(
+            {
+                "kind": "template_gtm_config",
+                "state": "blocked",
+                "summary": "Reusable source/template files hardcode a live GTM ID.",
+                "evidence": sorted(set(template_live_ids))[:10],
+            }
+        )
+    else:
+        evidence.append(
+            {
+                "kind": "template_gtm_config",
+                "state": "passed",
+                "summary": "No live GTM ID was found in reusable source/template directories.",
+            }
+        )
+    return evidence, details
+
+
+def _provider_summary(providers: list[dict[str, Any]]) -> dict[str, Any]:
+    by_id = {item.get("provider"): item for item in providers}
+    wanted = ["google", "cloudflare", "meta"]
+    return {
+        provider_id: {
+            "state": str((by_id.get(provider_id) or {}).get("state") or "not_connected"),
+            "connected": bool((by_id.get(provider_id) or {}).get("connected")),
+            "ok": bool((by_id.get(provider_id) or {}).get("ok")),
+            "summary": str((by_id.get(provider_id) or {}).get("summary") or ""),
+            "repair_command": str((by_id.get(provider_id) or {}).get("repair_command") or ""),
+        }
+        for provider_id in wanted
+    }
+
+
+def _state(evidence: list[dict[str, Any]], facts: dict[str, Any]) -> str:
+    if any(item["state"] == "blocked" for item in evidence):
+        return "blocked"
+    if not facts["gtm_container_id"] and not facts["conversion_kind"]:
+        return "missing"
+    ads_ready = bool(facts["google_ads_customer_id"] and facts["primary_conversions"])
+    approvals = facts["operator_approvals"]
+    required_approval_keys = [
+        "gtm_container_reviewed",
+        "conversion_actions_reviewed",
+        "consent_posture_reviewed",
+    ]
+    approvals_ready = all(bool(approvals.get(key)) for key in required_approval_keys)
+    if ads_ready and approvals_ready:
+        return "ready"
+    if ads_ready:
+        return "ready_for_operator_review"
+    return "ready_for_preview"
+
+
+def check(
+    site_repo: str | Path = ".",
+    *,
+    business_repo: str | Path | None = None,
+) -> dict[str, Any]:
+    """Check static paid-traffic measurement readiness without mutating providers."""
+
+    site = Path(site_repo).resolve()
+    source, source_error = _site_source(site)
+    raw_source_business = source.get("business_repo") if source else ""
+    source_business = raw_source_business if isinstance(raw_source_business, str) else ""
+    business_value = business_repo or source_business
+    business = Path(business_value).resolve() if business_value else None
+    conversion, conversion_error = _read_json(site / CONVERSION_RELATIVE_PATH)
+    offer = _merged_offer_metadata(business)
+    provider_status = connect_mod.status_all(business or site, include_all=True)
+    providers = provider_status.get("providers") or []
+    facts = _metadata_sources(conversion, offer, providers)
+    conversion_kind = _string_value(conversion.get("kind"))
+    if conversion_kind == "stripe_payment_page":
+        payment_kind = _string_value((conversion.get("metadata") or {}).get("payment_kind"))
+        if payment_kind == "deposit":
+            conversion_kind = "deposit"
+    expected_events = EVENTS_BY_KIND.get(
+        conversion_kind, ["mb_cta_click"] if conversion_kind else []
+    )
+    facts.update(
+        {
+            "conversion_kind": conversion_kind,
+            "expected_events": expected_events,
+            "conversion_path": CONVERSION_RELATIVE_PATH.as_posix(),
+            "provider_state": _provider_summary(providers),
+        }
+    )
+
+    evidence: list[dict[str, Any]] = []
+    if conversion_error:
+        state = "missing" if conversion_error == "missing" else "blocked"
+        evidence.append(
+            {
+                "kind": "conversion_plan",
+                "state": state,
+                "summary": f"{CONVERSION_RELATIVE_PATH.as_posix()} is {conversion_error}.",
+            }
+        )
+    if source_error and source_error != "missing":
+        evidence.append(
+            {
+                "kind": "site_source_link",
+                "state": "blocked",
+                "summary": f"{SOURCE_RELATIVE_PATH.as_posix()} is {source_error}.",
+            }
+        )
+    elif source:
+        source_state = "passed" if source.get("business_repo") else "blocked"
+        evidence.append(
+            {
+                "kind": "site_source_link",
+                "state": source_state,
+                "summary": "Site repo links back to business context."
+                if source_state == "passed"
+                else "Site source link is missing business_repo.",
+            }
+        )
+    else:
+        evidence.append(
+            {
+                "kind": "conversion_plan",
+                "state": "passed",
+                "summary": f"Conversion endpoint kind is {conversion_kind or 'unspecified'}.",
+            }
+        )
+
+    gtm_id = str(facts["gtm_container_id"])
+    if gtm_id and _is_placeholder_gtm(gtm_id):
+        evidence.append(
+            {
+                "kind": "gtm_container",
+                "state": "blocked",
+                "summary": "GTM container ID is still a placeholder.",
+            }
+        )
+    elif gtm_id:
+        evidence.append(
+            {
+                "kind": "gtm_container",
+                "state": "passed",
+                "summary": "GTM container ID is declared in repo-safe metadata.",
+            }
+        )
+    else:
+        evidence.append(
+            {
+                "kind": "gtm_container",
+                "state": "missing",
+                "summary": "GTM container ID is not declared.",
+            }
+        )
+
+    html_evidence, html_details = _check_html(
+        site,
+        gtm_container_id=gtm_id,
+        expected_events=expected_events,
+    )
+    evidence.extend(html_evidence)
+
+    if facts["consent_posture"] and facts["privacy_policy_url"]:
+        evidence.append(
+            {
+                "kind": "consent_privacy",
+                "state": "passed",
+                "summary": "Consent posture and privacy policy URL are declared.",
+            }
+        )
+    else:
+        missing = []
+        if not facts["consent_posture"]:
+            missing.append("consent posture")
+        if not facts["privacy_policy_url"]:
+            missing.append("privacy policy URL")
+        evidence.append(
+            {
+                "kind": "consent_privacy",
+                "state": "blocked",
+                "summary": f"Missing {', '.join(missing)} for paid-traffic review.",
+            }
+        )
+
+    ads_missing = []
+    if not facts["google_ads_customer_id"]:
+        ads_missing.append("Google Ads customer ID")
+    if not facts["primary_conversions"]:
+        ads_missing.append("primary conversion plan")
+    if ads_missing:
+        evidence.append(
+            {
+                "kind": "google_ads_plan",
+                "state": "manual",
+                "summary": f"Missing {', '.join(ads_missing)} before launch review.",
+            }
+        )
+    else:
+        evidence.append(
+            {
+                "kind": "google_ads_plan",
+                "state": "passed",
+                "summary": "Google Ads customer and primary conversion plan are declared.",
+            }
+        )
+
+    approval_keys = [
+        "gtm_container_reviewed",
+        "conversion_actions_reviewed",
+        "consent_posture_reviewed",
+    ]
+    missing_approvals = [key for key in approval_keys if not facts["operator_approvals"].get(key)]
+    if missing_approvals:
+        evidence.append(
+            {
+                "kind": "operator_approval",
+                "state": "manual",
+                "summary": "Operator review approvals are not fully recorded.",
+                "missing": missing_approvals,
+            }
+        )
+    else:
+        evidence.append(
+            {
+                "kind": "operator_approval",
+                "state": "passed",
+                "summary": "Required operator review approvals are recorded.",
+            }
+        )
+
+    state = _state(evidence, facts)
+    blocked = [item for item in evidence if item["state"] == "blocked"]
+    manual = [item for item in evidence if item["state"] in {"manual", "missing"}]
+    if state == "blocked":
+        summary = "Paid-traffic measurement readiness is blocked by local setup gaps."
+        repair = "Fix the blocked evidence items, then rerun `mb site check`."
+    elif state == "ready_for_preview":
+        summary = "Static instrumentation is ready for preview; provider plan or approvals remain."
+        repair = (
+            "Run GTM Preview/Tag Assistant, record Google Ads conversion metadata, "
+            "then rerun `mb site check`."
+        )
+    elif state == "ready_for_operator_review":
+        summary = "Measurement plan is ready for operator review before any launch."
+        repair = (
+            "Review GTM publication, conversion actions, consent posture, and "
+            "campaign launch manually."
+        )
+    elif state == "ready":
+        summary = "Local readiness checks passed; launch still requires explicit operator action."
+        repair = ""
+    else:
+        summary = "No paid-traffic measurement plan was found."
+        repair = "Run `/mb-site` for a paid-traffic minisite and record conversion metadata."
+
+    return {
+        "ok": state in {"ready_for_preview", "ready_for_operator_review", "ready"},
+        "schema": {
+            "name": "mainbranch.site_readiness",
+            "version": "1.0",
+        },
+        "site_repo": str(site),
+        "business_repo": str(business) if business else "",
+        "source": source,
+        "state": state,
+        "safe_to_share": True,
+        "summary": summary,
+        "facts": facts,
+        "html": html_details,
+        "evidence": evidence,
+        "blocked": blocked,
+        "manual": manual,
+        "repair": repair,
+        "repair_command": "mb site check",
+        "provider_status": {
+            "summary": provider_status.get("summary") or {},
+            "safe_to_share": True,
+        },
+    }
+
+
+def render_check(result: dict[str, Any]) -> None:
+    """Render a concise human paid-traffic readiness report."""
+
+    print(f"mb site check  {result['site_repo']}")
+    print(f"state: {result['state']}")
+    print(result["summary"])
+    print("")
+    print("facts:")
+    facts = result["facts"]
+    for key in [
+        "conversion_kind",
+        "gtm_container_id",
+        "google_ads_customer_id",
+        "primary_conversions",
+        "consent_posture",
+        "privacy_policy_url",
+    ]:
+        value = facts.get(key)
+        print(f"  {key}: {value if value else '-'}")
+    print("")
+    print("evidence:")
+    for item in result["evidence"]:
+        print(f"  {item['state']:<8} {item['kind']}: {item['summary']}")
+    if result.get("repair"):
+        print("")
+        print(f"next: {result['repair']}")

--- a/mb/mb/site.py
+++ b/mb/mb/site.py
@@ -229,6 +229,16 @@ def _read_many(paths: list[Path]) -> list[tuple[Path, str]]:
     return items
 
 
+def _has_google_manager_url(text: str, *, script_name: str, gtm_container_id: str) -> bool:
+    if not gtm_container_id:
+        return False
+    pattern = (
+        rf"googletagmanager\.com/{re.escape(script_name)}"
+        rf"\?[^\"'<>\s]*\bid={re.escape(gtm_container_id)}(?:[&#\"'<>\s]|$)"
+    )
+    return bool(re.search(pattern, text, flags=re.IGNORECASE))
+
+
 def _check_html(
     site_repo: Path,
     *,
@@ -256,8 +266,12 @@ def _check_html(
         )
         return evidence, details
 
-    has_gtm_script = "googletagmanager.com/gtm.js" in combined
-    has_gtm_noscript = "googletagmanager.com/ns.html" in combined
+    has_gtm_script = _has_google_manager_url(
+        combined, script_name="gtm.js", gtm_container_id=gtm_container_id
+    )
+    has_gtm_noscript = _has_google_manager_url(
+        combined, script_name="ns.html", gtm_container_id=gtm_container_id
+    )
     has_sri = bool(
         re.search(
             r"<script[^>]+(?:googletagmanager\.com/(?:gtm|gtag)\.js)[^>]+integrity=",
@@ -348,7 +362,9 @@ def _check_html(
                     template_live_ids.append(_relative(site_repo, source_path))
                     break
     details["reusable_template_live_gtm_ids"] = sorted(set(template_live_ids))
-    if template_live_ids:
+    if not gtm_container_id:
+        pass
+    elif template_live_ids:
         evidence.append(
             {
                 "kind": "template_gtm_config",
@@ -448,6 +464,14 @@ def check(
                 "summary": f"{CONVERSION_RELATIVE_PATH.as_posix()} is {conversion_error}.",
             }
         )
+    else:
+        evidence.append(
+            {
+                "kind": "conversion_plan",
+                "state": "passed",
+                "summary": f"Conversion endpoint kind is {conversion_kind or 'unspecified'}.",
+            }
+        )
     if source_error and source_error != "missing":
         evidence.append(
             {
@@ -470,9 +494,9 @@ def check(
     else:
         evidence.append(
             {
-                "kind": "conversion_plan",
-                "state": "passed",
-                "summary": f"Conversion endpoint kind is {conversion_kind or 'unspecified'}.",
+                "kind": "site_source_link",
+                "state": "missing",
+                "summary": f"{SOURCE_RELATIVE_PATH.as_posix()} is missing.",
             }
         )
 

--- a/mb/mb/status.py
+++ b/mb/mb/status.py
@@ -16,6 +16,7 @@ from mb import __version__, github_activity
 from mb import connect as connect_mod
 from mb import onboard as onboard_mod
 from mb import ranker as ranker_mod
+from mb import site as site_mod
 from mb.engine import install_mode, link_status
 from mb.freshness import format_update_alert, package_update_status
 
@@ -553,6 +554,42 @@ def _schema() -> dict[str, Any]:
     }
 
 
+def _measurement(repo: Path) -> dict[str, Any]:
+    """Return a compact paid-traffic measurement summary for status consumers."""
+
+    conversion_path = repo / site_mod.CONVERSION_RELATIVE_PATH
+    if not conversion_path.exists():
+        return {
+            "available": False,
+            "state": "missing",
+            "summary": "No paid-traffic site conversion plan found.",
+            "repair": (
+                "Run `/mb-site` for a paid-traffic minisite before checking launch readiness."
+            ),
+            "repair_command": "mb site check",
+            "safe_to_share": True,
+        }
+    result = site_mod.check(repo, business_repo=repo)
+    return {
+        "available": True,
+        "state": result["state"],
+        "ok": result["ok"],
+        "summary": result["summary"],
+        "repair": result["repair"],
+        "repair_command": "mb site check",
+        "facts": {
+            "conversion_kind": result["facts"].get("conversion_kind"),
+            "expected_events": result["facts"].get("expected_events"),
+            "gtm_container_id_present": bool(result["facts"].get("gtm_container_id")),
+            "google_ads_customer_id_present": bool(result["facts"].get("google_ads_customer_id")),
+            "primary_conversions": result["facts"].get("primary_conversions") or [],
+        },
+        "blocked_count": len(result.get("blocked") or []),
+        "manual_count": len(result.get("manual") or []),
+        "safe_to_share": True,
+    }
+
+
 def _marker_path(repo: Path) -> Path:
     return repo / LAST_STATUS_SEEN_RELATIVE_PATH
 
@@ -944,6 +981,7 @@ def run(
         "brain": brain,
         "onboarding": onboard_mod.onboarding_status(repo_path),
         "integrations": connect_mod.status_all(repo_path, github=github.get("context")),
+        "measurement": _measurement(repo_path),
         "github": github,
     }
     report["since_last_check"] = _since_last_check(
@@ -1068,6 +1106,14 @@ def render_human(
                 console.print(
                     f"  - {item['provider']}: {item['state']}  next: {item['repair_command']}"
                 )
+
+    measurement = report.get("measurement") or {}
+    if measurement.get("available"):
+        console.print(
+            f"[bold]Measurement[/bold] {measurement.get('state')}  {measurement.get('summary')}"
+        )
+        if verbose and measurement.get("repair"):
+            console.print(f"  next: {measurement['repair']}")
 
     counts = brain["counts"]
     console.print(

--- a/mb/mb/status.py
+++ b/mb/mb/status.py
@@ -554,29 +554,82 @@ def _schema() -> dict[str, Any]:
     }
 
 
-def _measurement(repo: Path) -> dict[str, Any]:
-    """Return a compact paid-traffic measurement summary for status consumers."""
+SITE_REPO_PATH_FIELDS = (
+    "site_repo_path",
+    "site_repo",
+    "site_path",
+    "site_repository_path",
+)
 
-    conversion_path = repo / site_mod.CONVERSION_RELATIVE_PATH
-    if not conversion_path.exists():
-        return {
-            "available": False,
-            "state": "missing",
-            "summary": "No paid-traffic site conversion plan found.",
-            "repair": (
-                "Run `/mb-site` for a paid-traffic minisite before checking launch readiness."
-            ),
-            "repair_command": "mb site check",
-            "safe_to_share": True,
-        }
-    result = site_mod.check(repo, business_repo=repo)
+
+def _site_repo_path_values(value: Any) -> list[Any]:
+    if isinstance(value, dict):
+        items: list[Any] = []
+        for key in SITE_REPO_PATH_FIELDS:
+            if key in value:
+                items.append(value[key])
+        return items
+    if isinstance(value, list):
+        return [item for entry in value for item in _site_repo_path_values(entry)]
+    return [value]
+
+
+def _resolve_site_repo_path(repo: Path, value: Any) -> Path | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    raw = value.strip()
+    if re.match(r"^[a-z][a-z0-9+.-]*://", raw, flags=re.IGNORECASE):
+        return None
+    candidate = Path(raw).expanduser()
+    if not candidate.is_absolute():
+        candidate = repo / candidate
+    return candidate.resolve()
+
+
+def _candidate_site_repo_records(repo: Path) -> list[dict[str, Any]]:
+    paths = _relative_markdown_files(repo, "campaigns")
+    paths.extend(path for path in _relative_markdown_files(repo, "core") if path.name == "offer.md")
+    paths.extend(
+        path for path in _relative_markdown_files(repo, "reference/core") if path.name == "offer.md"
+    )
+
+    records: list[dict[str, Any]] = []
+    seen: set[Path] = set()
+    for path in paths:
+        meta = _read_frontmatter(path)
+        candidate_values: list[Any] = []
+        for key in SITE_REPO_PATH_FIELDS:
+            if key in meta:
+                candidate_values.append(meta[key])
+        for nested_key in ("site", "site_record", "measurement", "launch"):
+            if nested_key in meta:
+                candidate_values.extend(_site_repo_path_values(meta[nested_key]))
+
+        for value in candidate_values:
+            site_repo = _resolve_site_repo_path(repo, value)
+            if site_repo is None or site_repo in seen:
+                continue
+            if not (site_repo / site_mod.CONVERSION_RELATIVE_PATH).exists():
+                continue
+            try:
+                source = path.relative_to(repo).as_posix()
+            except ValueError:
+                source = str(path)
+            records.append({"path": site_repo, "source": source})
+            seen.add(site_repo)
+    return records
+
+
+def _measurement_payload(result: dict[str, Any], *, repair_command: str) -> dict[str, Any]:
     return {
         "available": True,
         "state": result["state"],
         "ok": result["ok"],
         "summary": result["summary"],
         "repair": result["repair"],
-        "repair_command": "mb site check",
+        "repair_command": repair_command,
+        "site_repo": result.get("site_repo", ""),
+        "business_repo": result.get("business_repo", ""),
         "facts": {
             "conversion_kind": result["facts"].get("conversion_kind"),
             "expected_events": result["facts"].get("expected_events"),
@@ -586,6 +639,35 @@ def _measurement(repo: Path) -> dict[str, Any]:
         },
         "blocked_count": len(result.get("blocked") or []),
         "manual_count": len(result.get("manual") or []),
+        "safe_to_share": True,
+    }
+
+
+def _measurement(repo: Path) -> dict[str, Any]:
+    """Return a compact paid-traffic measurement summary for status consumers."""
+
+    conversion_path = repo / site_mod.CONVERSION_RELATIVE_PATH
+    if conversion_path.exists():
+        result = site_mod.check(repo, business_repo=repo)
+        return _measurement_payload(result, repair_command="mb site check")
+
+    site_records = _candidate_site_repo_records(repo)
+    if site_records:
+        site_repo = site_records[0]["path"]
+        result = site_mod.check(site_repo, business_repo=repo)
+        payload = _measurement_payload(
+            result,
+            repair_command=f'mb site check "{site_repo}" --business-repo .',
+        )
+        payload["source_record"] = site_records[0]["source"]
+        return payload
+
+    return {
+        "available": False,
+        "state": "missing",
+        "summary": "No paid-traffic site conversion plan found.",
+        "repair": "Run `/mb-site` for a paid-traffic minisite before checking launch readiness.",
+        "repair_command": "mb site check",
         "safe_to_share": True,
     }
 

--- a/mb/tests/fixtures/status/schema-v1-basic.json
+++ b/mb/tests/fixtures/status/schema-v1-basic.json
@@ -11,6 +11,7 @@
     "install",
     "integrations",
     "marker_update",
+    "measurement",
     "ok",
     "onboarding",
     "ranked_actions",
@@ -92,6 +93,14 @@
       "repo",
       "repo_id",
       "safe_to_share",
+      "summary"
+    ],
+    "measurement": [
+      "available",
+      "repair",
+      "repair_command",
+      "safe_to_share",
+      "state",
       "summary"
     ],
     "github": [

--- a/mb/tests/test_site.py
+++ b/mb/tests/test_site.py
@@ -177,6 +177,84 @@ def test_site_check_blocks_missing_gtm_noscript_event_and_consent(tmp_path: Path
     assert "consent_privacy" in blocked_kinds
 
 
+def test_site_check_keeps_conversion_and_source_link_evidence_distinct(tmp_path: Path) -> None:
+    site = tmp_path / "site"
+    site.mkdir()
+
+    result = runner.invoke(app, ["site", "check", str(site), "--json"])
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    evidence_by_kind: dict[str, list[dict[str, object]]] = {}
+    for item in payload["evidence"]:
+        evidence_by_kind.setdefault(item["kind"], []).append(item)
+    assert evidence_by_kind["conversion_plan"] == [
+        {
+            "kind": "conversion_plan",
+            "state": "missing",
+            "summary": ".mainbranch/conversion.json is missing.",
+        }
+    ]
+    assert evidence_by_kind["site_source_link"] == [
+        {
+            "kind": "site_source_link",
+            "state": "missing",
+            "summary": ".mainbranch/source.json is missing.",
+        }
+    ]
+
+
+def test_site_check_blocks_wrong_gtm_loader_id(tmp_path: Path) -> None:
+    business = tmp_path / "business"
+    site = tmp_path / "site"
+    init_run(path=str(business), name="Acme")
+    site.mkdir()
+    (business / "core" / "offer.md").write_text(
+        (
+            "---\n"
+            "gtm_container_id: GTM-ABC1234\n"
+            "consent_posture: standard_tag_consent_reviewed\n"
+            "privacy_policy_url: https://example.com/privacy\n"
+            "---\n\n"
+            "# Offer\n"
+        ),
+        encoding="utf-8",
+    )
+    _write_conversion(
+        site,
+        {"kind": "lead_form", "url": "https://tally.so/r/example", "render": "link_out"},
+    )
+    _write_html(site, gtm_id="GTM-OTHER1", events=["mb_cta_click", "mb_form_start"])
+
+    result = runner.invoke(
+        app,
+        ["site", "check", str(site), "--business-repo", str(business), "--json"],
+    )
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    static_html = next(item for item in payload["evidence"] if item["kind"] == "static_html")
+    assert static_html["state"] == "blocked"
+    assert "head script" in static_html["summary"]
+    assert "body noscript" in static_html["summary"]
+
+
+def test_site_check_skips_template_gtm_config_when_no_container_is_declared(tmp_path: Path) -> None:
+    site = tmp_path / "site"
+    site.mkdir()
+    _write_conversion(
+        site,
+        {"kind": "lead_form", "url": "https://tally.so/r/example", "render": "link_out"},
+    )
+    _write_html(site, events=["mb_cta_click", "mb_form_start"])
+
+    result = runner.invoke(app, ["site", "check", str(site), "--json"])
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert not any(item["kind"] == "template_gtm_config" for item in payload["evidence"])
+
+
 def test_status_includes_measurement_summary_when_conversion_plan_exists(
     tmp_path: Path, monkeypatch
 ) -> None:
@@ -213,3 +291,48 @@ def test_status_includes_measurement_summary_when_conversion_plan_exists(
     assert payload["measurement"]["available"] is True
     assert payload["measurement"]["state"] == "ready_for_operator_review"
     assert payload["measurement"]["facts"]["primary_conversions"] == ["mb_lead_submit"]
+
+
+def test_status_follows_business_repo_site_record_for_measurement(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr("mb.status._which", lambda name: "")
+    business = tmp_path / "business"
+    site = tmp_path / "site"
+    init_run(path=str(business), name="Acme")
+    site.mkdir()
+    (business / "core" / "offer.md").write_text(
+        (
+            "---\n"
+            "gtm_container_id: GTM-ABC1234\n"
+            "google_ads_customer_id: '0000000000'\n"
+            "consent_posture: standard_tag_consent_reviewed\n"
+            "privacy_policy_url: https://example.com/privacy\n"
+            "---\n\n"
+            "# Offer\n"
+        ),
+        encoding="utf-8",
+    )
+    (business / "campaigns" / "paid-site.md").write_text(
+        f"---\nsite_repo_path: {site}\n---\n\n# Paid Site\n",
+        encoding="utf-8",
+    )
+    _write_conversion(
+        site,
+        {
+            "kind": "lead_form",
+            "url": "https://tally.so/r/example",
+            "render": "link_out",
+            "primary_conversions": ["mb_lead_submit"],
+        },
+    )
+    _write_html(site, events=["mb_cta_click", "mb_form_start", "mb_lead_submit"])
+
+    result = runner.invoke(app, ["status", str(business), "--json", "--peek"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["measurement"]["available"] is True
+    assert payload["measurement"]["site_repo"] == str(site.resolve())
+    assert payload["measurement"]["business_repo"] == str(business.resolve())
+    assert payload["measurement"]["source_record"] == "campaigns/paid-site.md"

--- a/mb/tests/test_site.py
+++ b/mb/tests/test_site.py
@@ -1,0 +1,215 @@
+"""``mb site`` paid-traffic readiness checks."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from mb.cli import app
+from mb.init import run as init_run
+
+runner = CliRunner()
+
+
+def _write_conversion(site: Path, payload: dict[str, object]) -> None:
+    target = site / ".mainbranch" / "conversion.json"
+    target.parent.mkdir(parents=True)
+    target.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def _write_html(
+    site: Path, *, gtm_id: str = "GTM-ABC1234", events: list[str] | None = None
+) -> None:
+    event_lines = "\n".join(
+        f'window.dataLayer.push({{event: "{event}", mb_event_id: "test"}});'
+        for event in (events or [])
+    )
+    (site / "index.html").write_text(
+        f"""<!doctype html>
+<html>
+<head>
+<script>window.dataLayer = window.dataLayer || [];</script>
+<script src="https://www.googletagmanager.com/gtm.js?id={gtm_id}"></script>
+<script>{event_lines}</script>
+</head>
+<body>
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id={gtm_id}"></iframe></noscript>
+</body>
+</html>
+""",
+        encoding="utf-8",
+    )
+
+
+def test_site_check_reports_ready_for_operator_review(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("MB_CONNECT_SECRET_BACKEND", "local-file")
+    monkeypatch.setenv("MAINBRANCH_HOME", str(tmp_path / "home"))
+    business = tmp_path / "business"
+    site = tmp_path / "site"
+    init_run(path=str(business), name="Acme")
+    site.mkdir()
+    (business / "core" / "offer.md").write_text(
+        (
+            "---\n"
+            "gtm_container_id: GTM-ABC1234\n"
+            "google_ads_customer_id: '0000000000'\n"
+            "consent_posture: standard_tag_consent_reviewed\n"
+            "privacy_policy_url: https://example.com/privacy\n"
+            "---\n\n"
+            "# Offer\n"
+        ),
+        encoding="utf-8",
+    )
+    _write_conversion(
+        site,
+        {
+            "kind": "lead_form",
+            "url": "https://tally.so/r/example",
+            "render": "link_out",
+            "primary_conversions": ["mb_lead_submit"],
+            "secondary_conversions": ["mb_cta_click", "mb_form_start"],
+            "metadata": {"provider": "tally"},
+        },
+    )
+    _write_html(site, events=["mb_cta_click", "mb_form_start", "mb_lead_submit"])
+
+    result = runner.invoke(
+        app,
+        ["site", "check", str(site), "--business-repo", str(business), "--json"],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["state"] == "ready_for_operator_review"
+    assert payload["facts"]["expected_events"] == [
+        "mb_cta_click",
+        "mb_form_start",
+        "mb_lead_submit",
+    ]
+    assert payload["facts"]["provider_state"]["google"]["state"] == "not_connected"
+    assert not payload["blocked"]
+    assert any(item["kind"] == "operator_approval" for item in payload["manual"])
+
+
+def test_site_check_uses_source_link_when_business_repo_is_omitted(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setenv("MB_CONNECT_SECRET_BACKEND", "local-file")
+    monkeypatch.setenv("MAINBRANCH_HOME", str(tmp_path / "home"))
+    business = tmp_path / "business"
+    site = tmp_path / "site"
+    init_run(path=str(business), name="Acme")
+    site.mkdir()
+    (business / "core" / "offer.md").write_text(
+        (
+            "---\n"
+            "gtm_container_id: GTM-ABC1234\n"
+            "google_ads_customer_id: '0000000000'\n"
+            "consent_posture: standard_tag_consent_reviewed\n"
+            "privacy_policy_url: https://example.com/privacy\n"
+            "---\n\n"
+            "# Offer\n"
+        ),
+        encoding="utf-8",
+    )
+    _write_conversion(
+        site,
+        {
+            "kind": "lead_form",
+            "url": "https://tally.so/r/example",
+            "render": "link_out",
+            "primary_conversions": ["mb_lead_submit"],
+        },
+    )
+    (site / ".mainbranch" / "source.json").write_text(
+        json.dumps(
+            {
+                "business_repo": str(business),
+                "offer_path": "core/offer.md",
+                "campaign_path": "campaigns/smoke.md",
+            }
+        ),
+        encoding="utf-8",
+    )
+    _write_html(site, events=["mb_cta_click", "mb_form_start", "mb_lead_submit"])
+
+    result = runner.invoke(app, ["site", "check", str(site), "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["business_repo"] == str(business.resolve())
+    assert payload["source"]["offer_path"] == "core/offer.md"
+    assert any(item["kind"] == "site_source_link" for item in payload["evidence"])
+
+
+def test_site_check_blocks_missing_gtm_noscript_event_and_consent(tmp_path: Path) -> None:
+    business = tmp_path / "business"
+    site = tmp_path / "site"
+    init_run(path=str(business), name="Acme")
+    site.mkdir()
+    (business / "core" / "offer.md").write_text(
+        "---\ngtm_container_id: GTM-XXXXXXX\n---\n\n# Offer\n",
+        encoding="utf-8",
+    )
+    _write_conversion(
+        site,
+        {"kind": "appointment_booking", "url": "https://cal.com/example", "render": "link_out"},
+    )
+    (site / "index.html").write_text(
+        '<script src="https://www.googletagmanager.com/gtm.js?id=GTM-XXXXXXX"></script>',
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(
+        app,
+        ["site", "check", str(site), "--business-repo", str(business), "--json"],
+    )
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["state"] == "blocked"
+    blocked_kinds = {item["kind"] for item in payload["blocked"]}
+    assert "gtm_container" in blocked_kinds
+    assert "static_html" in blocked_kinds
+    assert "data_layer_events" in blocked_kinds
+    assert "consent_privacy" in blocked_kinds
+
+
+def test_status_includes_measurement_summary_when_conversion_plan_exists(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr("mb.status._which", lambda name: "")
+    repo = tmp_path / "business"
+    init_run(path=str(repo), name="Acme")
+    (repo / "core" / "offer.md").write_text(
+        (
+            "---\n"
+            "gtm_container_id: GTM-ABC1234\n"
+            "google_ads_customer_id: '0000000000'\n"
+            "consent_posture: standard_tag_consent_reviewed\n"
+            "privacy_policy_url: https://example.com/privacy\n"
+            "---\n\n"
+            "# Offer\n"
+        ),
+        encoding="utf-8",
+    )
+    _write_conversion(
+        repo,
+        {
+            "kind": "lead_form",
+            "url": "https://tally.so/r/example",
+            "render": "link_out",
+            "primary_conversions": ["mb_lead_submit"],
+        },
+    )
+    _write_html(repo, events=["mb_cta_click", "mb_form_start", "mb_lead_submit"])
+
+    result = runner.invoke(app, ["status", str(repo), "--json", "--peek"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["measurement"]["available"] is True
+    assert payload["measurement"]["state"] == "ready_for_operator_review"
+    assert payload["measurement"]["facts"]["primary_conversions"] == ["mb_lead_submit"]

--- a/mb/tests/test_site.py
+++ b/mb/tests/test_site.py
@@ -43,6 +43,15 @@ def _write_html(
     )
 
 
+def _write_dist_html(
+    site: Path, *, gtm_id: str = "GTM-ABC1234", events: list[str] | None = None
+) -> None:
+    (site / "dist").mkdir()
+    original = site / "index.html"
+    _write_html(site, gtm_id=gtm_id, events=events)
+    original.replace(site / "dist" / "index.html")
+
+
 def test_site_check_reports_ready_for_operator_review(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setenv("MB_CONNECT_SECRET_BACKEND", "local-file")
     monkeypatch.setenv("MAINBRANCH_HOME", str(tmp_path / "home"))
@@ -91,6 +100,47 @@ def test_site_check_reports_ready_for_operator_review(tmp_path: Path, monkeypatc
     assert payload["facts"]["provider_state"]["google"]["state"] == "not_connected"
     assert not payload["blocked"]
     assert any(item["kind"] == "operator_approval" for item in payload["manual"])
+
+
+def test_site_check_inspects_dist_build_output(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("MB_CONNECT_SECRET_BACKEND", "local-file")
+    monkeypatch.setenv("MAINBRANCH_HOME", str(tmp_path / "home"))
+    business = tmp_path / "business"
+    site = tmp_path / "site"
+    init_run(path=str(business), name="Acme")
+    site.mkdir()
+    (business / "core" / "offer.md").write_text(
+        (
+            "---\n"
+            "gtm_container_id: GTM-ABC1234\n"
+            "google_ads_customer_id: '0000000000'\n"
+            "consent_posture: standard_tag_consent_reviewed\n"
+            "privacy_policy_url: https://example.com/privacy\n"
+            "---\n\n"
+            "# Offer\n"
+        ),
+        encoding="utf-8",
+    )
+    _write_conversion(
+        site,
+        {
+            "kind": "lead_form",
+            "url": "https://tally.so/r/example",
+            "render": "link_out",
+            "primary_conversions": ["mb_lead_submit"],
+        },
+    )
+    _write_dist_html(site, events=["mb_cta_click", "mb_form_start", "mb_lead_submit"])
+
+    result = runner.invoke(
+        app,
+        ["site", "check", str(site), "--business-repo", str(business), "--json"],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["state"] == "ready_for_operator_review"
+    assert payload["html"]["html_files"] == ["dist/index.html"]
 
 
 def test_site_check_uses_source_link_when_business_repo_is_omitted(

--- a/mb/tests/test_status.py
+++ b/mb/tests/test_status.py
@@ -90,6 +90,7 @@ def test_status_schema_v1_matches_golden_fixture(tmp_path: Path, monkeypatch) ->
                 "brain",
                 "onboarding",
                 "integrations",
+                "measurement",
                 "github",
                 "since_last_check",
                 "drift",


### PR DESCRIPTION
## Summary
- Adds `mb site check` as a deterministic local paid-traffic measurement readiness check for site repos.
- Routes `/mb-site`, `/mb-ads`, `/mb-start`, and `/mb-help` through the Google Ads/GTM rubric, provider readiness, and noob-safe next steps.
- Documents the two-stage `/mb-site` business-repo/site-repo workflow with `.mainbranch/source.json`, reverse site records, and project-local skill links.
- Surfaces measurement readiness in `mb status`, including linked site repos recorded in business repo campaign/offer notes.

## Scope
- In: local GTM/script/dataLayer/consent/provider-readiness checks, readiness states, status integration, skill guidance, docs, changelog, and stale `mb doctor "$REPO_PATH"` cleanup.
- Out: Google Ads mutation, GTM publish, conversion upload, campaign/budget/keyword/creative/billing changes, hosted dashboard UI, and live campaign launch automation.

## Commits
- `132519b` — `[add] Paid traffic site readiness check`.
- `6d7c922` — `[update] Route paid traffic skills through readiness`.
- `df5e8fa` — `[fix] Update stale doctor invocation`.
- `36ace27` — `[fix] Tighten paid readiness evidence`.

## Release / Issues
- Release: current pre-release implementation slice.
- Linear ID(s): MAIN-227.
- Closes: #283.
- Refs: none.
- Follow-ups: live Google Ads/GTM mutation, GTM publish, conversion uploads, and launch automation remain intentionally deferred.

## Success Metric
A paid-traffic site can be checked locally from either the site repo or linked business repo, and Claude guidance reports ready/missing/blocked/manual next steps without asking for provider tokens or claiming launch automation.

## Validation
- Level 0 docs/decision: updated README, CHANGELOG, and skill/reference prose; skill validation passed.
- Level 1 static: `scripts/check.sh` passed.
- Level 2 CLI: focused tests passed, including readiness states, duplicate-evidence regression, GTM ID pinning, and business-repo linked site lookup.
- Level 3 package/install: built wheel, installed into fresh venv, verified `mb --version`, `mb skill list`, and `mb site check --help`.
- Level 4 fixture repo: fresh business repo plus linked site repo showed `mb site check` and business-repo `mb status` at `ready_for_operator_review` via `campaigns/paid-site.md`.
- Level 5 runtime smoke: Claude Code `/mb-site` smoke passed with built wheel on `PATH` and project skills linked into the site repo; Claude detected site-repo mode, referenced `mb site check`, avoided token requests/provider mutation, and did not emit `ready_for_launch`.

## Public / Private Boundary
- Public-safe product truth landed in code, tests, docs, and bundled skills.
- Local fixture paths and Claude smoke logs stayed in `.context/` or `/tmp`; no secrets, tokens, raw provider data, or private account details were committed.
