### PR TITLE
[update] Release 0.3.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mainbranch",
-  "version": "0.2.6",
+  "version": "0.3.0",
   "description": "Main Branch Claude Code skills for running a business from markdown files in git.",
   "author": {
     "name": "Noontide"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,27 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-05-04
+
+v0.3.0 makes Main Branch better at telling a user what matters next. It adds
+the first public product frame, status/ranker improvements, bets, issue
+drafting, provider setup planning, and paid-traffic site readiness checks.
+
+### What this means for you (plain English)
+
+- **`mb status` is more useful.** It can now show deterministic drift signals,
+  recent changes, ranked next actions, active bets, and paid-traffic measurement
+  readiness.
+- **Main Branch can capture friction.** If something is confusing or broken,
+  `mb issue draft` can create a privacy-scrubbed local GitHub issue draft before
+  you decide to submit it.
+- **Paid site launch checks are safer.** `/mb-site`, `/mb-ads`, and
+  `mb site check` now route Google Ads/GTM advice through a local readiness
+  checklist instead of pretending to launch or mutate provider accounts.
+- **The product direction is public.** The ethos, operator loops, roadmap,
+  markdown conventions, and runtime boundary are now documented for agents and
+  contributors.
+
 ### Added
 
 - Added an accepted workspace/repo/sensitive-data boundary decision covering

--- a/mb/mb/__init__.py
+++ b/mb/mb/__init__.py
@@ -7,6 +7,6 @@ file stays a thin dispatcher.
 
 from __future__ import annotations
 
-__version__ = "0.2.6"
+__version__ = "0.3.0"
 
 __all__ = ["__version__"]

--- a/mb/pyproject.toml
+++ b/mb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mainbranch"
-version = "0.2.6"
+version = "0.3.0"
 description = "Main Branch engine umbrella - scaffolds, validates, and graphs business-as-files repos. Claude Code first, runtime-agnostic by design."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- Bumps `mainbranch` from 0.2.6 to 0.3.0.
- Moves the accumulated Unreleased changelog into `0.3.0` with plain-English release notes.
- Keeps the Claude plugin manifest version aligned with the package version.

## Scope
- In: package version, runtime `__version__`, plugin manifest version, changelog release heading.
- Out: feature changes after #285.

## Commits
- `8475002` — `[update] Release 0.3.0`.

## Release / Issues
- Release: `oe-v0.3.0`.
- Linear ID(s): release-only.
- Closes: none.
- Refs: #283, #286.
- Follow-ups: #284 legacy reference/path migration sweep; #286 live Google Ads/GTM provider automation.

## Success Metric
- A fresh install reports `mb 0.3.0`, bundled skills are discoverable, and the GitHub release can publish the matching PyPI package.

## Validation
- Level 0 docs/decision: CHANGELOG release notes updated.
- Level 1 static: `scripts/check.sh` passed: 212 tests, ruff, mypy, coverage, and skill validation.
- Level 2 CLI: version smoke via installed wheel.
- Level 3 package/install: built wheel, installed into fresh venv, verified `mb --version`, `mb skill list`, and `mb site check --help`.
- Level 4 fixture repo: covered by prior feature PR #285; no new fixture behavior in release bump.
- Level 5 runtime smoke: covered by prior feature PR #285; no new runtime behavior in release bump.

## Public / Private Boundary
- Public release metadata only; no private paths, secrets, account data, or local smoke logs committed.
