### PR TITLE
[docs] Spec agent checkpoints as Git memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+### Added
+
+- Added planning-only `mb checkpoint --plan --json` so agents can inspect
+  dirty business repos, classify changed files, run safety gates, and propose
+  readable checkpoint messages before commit execution ships. Refs #290.
+- Added guarded `mb checkpoint --message ... --yes` execution so approved
+  checkpoint plans can become readable git commits without exposing raw git
+  mechanics to beginners. Refs #291.
+
 ## [0.3.0] - 2026-05-04
 
 v0.3.0 makes Main Branch better at telling a user what matters next. It adds

--- a/docs/ETHOS.md
+++ b/docs/ETHOS.md
@@ -12,6 +12,7 @@ operating substrate:
 - GitHub issues are tasks and requests;
 - pull requests are proposals and review conversations;
 - git history is the evolution story.
+- checkpoints make long agent runs durable before chat context is lost.
 
 The promise is simple: own the work, rent only the rails.
 
@@ -109,6 +110,18 @@ when the behavior depends on a real runtime.
 
 The product should feel alive, but the substrate should stay boring enough to
 debug.
+
+### 9. Git Is The Hidden App
+
+Main Branch should use git as the invisible save system for business work.
+Operators should not need to understand branches, diffs, or commits to benefit
+from them. Agents should checkpoint meaningful work throughout a run so future
+sessions can reconstruct what changed, what was decided, and what remains open
+from repo history.
+
+Checkpointing is not noisy autosave. It is durable business memory: readable
+commits at meaningful boundaries, with privacy and secret-safety gates before
+anything is recorded.
 
 ## What We Are Not Building Yet
 

--- a/docs/OPERATOR-LOOPS.md
+++ b/docs/OPERATOR-LOOPS.md
@@ -111,6 +111,8 @@ Next improvements:
 - optional provider and sidecar contracts;
 - noob-safe connector flows for GitHub, Cloudflare, Google, Meta, and Apify;
 - richer site, ads, organic, bookkeeping, and fulfillment loops.
+- agent checkpoints that save meaningful execution progress before context is
+  lost.
 
 ## 5. Narrate
 
@@ -124,6 +126,7 @@ Current surfaces:
 - `CHANGELOG.md`
 - decisions and retros;
 - `/mb-end`;
+- git checkpoint commits;
 - `bets/` and `/mb-bet`;
 - GitHub releases;
 - public site workflows through `/mb-site`
@@ -132,6 +135,7 @@ Next improvements:
 
 - bet-to-offer graduation rules;
 - status and dashboard visibility for active bets, deadlines, and outcomes;
+- `/mb-start` reconstruction from checkpoint commits;
 - public bets pages generated from repo truth.
 
 ## Applying The Loops

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -22,6 +22,7 @@ Main Branch already ships:
 - accepted workspace/repo/sensitive-data boundary guidance and
   GitHub/Obsidian-compatible markdown/link conventions for future dashboard,
   team daily log, bookkeeping, and multi-repo work.
+- initial paid-traffic site readiness checks through `mb site check`.
 
 Claude Code is the supported runtime today. Other runtimes are compatibility
 targets until adapter code and smoke evidence exist.
@@ -73,6 +74,9 @@ Planned scope:
 - sidecar enrichment contract for optional tools such as public company
   context, analytics, bookkeeping, transcription, or deployment helpers
   ([#265](https://github.com/noontide-co/mainbranch/issues/265)).
+- agent checkpoints as hidden Git memory so long Claude Code runs can be saved
+  throughout execution and resumed by `/mb-start`
+  ([#288](https://github.com/noontide-co/mainbranch/issues/288)).
 - follow-up implementation work from the workspace/repo boundary decision and
   markdown/link conventions, including dashboard spikes, team daily log
   surfaces, finance/legal warnings, and broader link repair where issues prove

--- a/docs/prd/v0-3-agent-checkpoints.md
+++ b/docs/prd/v0-3-agent-checkpoints.md
@@ -1,0 +1,367 @@
+---
+title: "PRD: v0.3 Agent Checkpoints + Git Memory"
+status: draft
+date: 2026-05-04
+release: v0.3.x
+linked_issue: https://github.com/noontide-co/mainbranch/issues/288
+---
+
+# PRD: v0.3 Agent Checkpoints + Git Memory
+
+## Summary
+
+Main Branch should make git feel like an invisible save system for business
+work. The operator should be able to work with an agent for hours, survive
+context compaction or a new runtime session, and have the next session
+reconstruct what happened from repo history instead of asking the operator to
+re-explain the whole conversation.
+
+The current product has the right ingredients:
+
+- the business repo is durable memory;
+- `mb status` can summarize repo state;
+- `/mb-start` can reorient from repo facts;
+- `/mb-end` can close a session and commit work.
+
+The gap is timing. `/mb-end` is too late for long runs. Checkpointing needs to
+be woven through execution.
+
+## Problem
+
+Agents lose conversation context. Users pause, resume, compact, start fresh
+sessions, or switch repos. When important work only lives in chat, the next
+agent has to reconstruct it from memory or ask the user to explain again.
+
+That creates a visible failure mode:
+
+- "We already talked about this."
+- "Claude forgot what we built Friday."
+- "I have to remind it of the plan before it can continue."
+- "ChatGPT history feels more continuous than Claude Code."
+
+Main Branch should not try to make chat history the source of truth. It should
+make the repo and git history strong enough that chat history matters less.
+
+## Product Stance
+
+Users should not need to understand git to benefit from git.
+
+Git history is:
+
+- the session memory;
+- the undo stack;
+- the work log;
+- the audit trail;
+- the source for `/mb-start`, `mb status`, future dashboards, and team daily
+  logs.
+
+The agent should create readable checkpoints throughout meaningful work. Those
+checkpoints should feel like "saved progress," not developer ceremony.
+
+## Goals
+
+- Make meaningful work durable before context is lost.
+- Let `/mb-start` reconstruct recent work from commits, diffs, status, and
+  repo files.
+- Let `/mb-end` use the same checkpoint substrate instead of owning all
+  checkpoint behavior itself.
+- Give agents deterministic rules for when to checkpoint.
+- Keep commit history readable and business-shaped.
+- Protect users from accidental secret, private-data, or broken-work commits.
+- Keep power-user git control available.
+
+## Non-Goals
+
+- No background daemon or file watcher in this slice.
+- No commits after every small edit.
+- No fully automatic commits when the agent is uncertain about privacy, scope,
+  or correctness.
+- No model invocation from `mb`.
+- No hosted sync layer.
+- No replacing GitHub issues, PRs, or git history with an app database.
+
+## Target Users
+
+### Beginner Operator
+
+They do not know git. They should experience checkpoints as safe progress
+saves:
+
+> "I saved this work as a checkpoint so we can pick it up later."
+
+They should see plain-English summaries and exact next commands. They should
+not be asked to choose between obscure git strategies.
+
+### Power User
+
+They understand commits and branches. They should be able to inspect the plan,
+choose concern-based commits, disable automatic prompts, or run a scriptable
+`mb checkpoint --plan --json`.
+
+### Agent Runtime
+
+Claude Code is the reference runtime today. Future runtimes should get the
+same deterministic checkpoint contract through `mb`, not runtime-specific prose
+rewrites.
+
+## Checkpoint Triggers
+
+An agent should consider a checkpoint when any of these happen:
+
+| Trigger | Example | Default behavior |
+|---|---|---|
+| Meaningful file write | `core/offer.md` updated, site files generated | Propose checkpoint |
+| Decision locked | decision created or accepted | Propose checkpoint |
+| Research batch complete | research files saved from a deep work loop | Propose checkpoint |
+| Task boundary | moving from research to ads, site to deploy, setup to execution | Propose checkpoint |
+| Context threshold | long agent run, compaction risk, or >30K token block completed | Propose checkpoint |
+| Before risky action | deploy, provider mutation, migration apply, broad rewrite | Require checkpoint prompt |
+| Before repo switch | business repo -> site repo, one workspace -> another | Propose checkpoint |
+| Before session end | `/mb-end`, "pause", "done", "wrap" | Checkpoint or explain no changes |
+
+The key is not "commit every write." It is "commit before the useful shape can
+be lost."
+
+## Commit Grouping
+
+The system should support two modes.
+
+### Beginner Mode: One Checkpoint
+
+Use one commit per meaningful run segment:
+
+```text
+[checkpoint] Draft paid traffic site plan
+[checkpoint] Update flagship offer and audience
+[checkpoint] Research competitor positioning
+```
+
+The commit body can carry the detail:
+
+```text
+Changed:
+- core/offer.md
+- campaigns/2026-05-paid-site.md
+- decisions/2026-05-04-paid-site-plan.md
+
+Why:
+- Captures the campaign plan before site generation starts.
+
+Next:
+- Run /mb-site from the business repo.
+```
+
+### Power Mode: Concern Commits
+
+When the agent can separate concerns cleanly:
+
+```text
+[update] Offer: clarify guarantee
+[add] Campaign: paid site measurement plan
+[docs] Decision: accept GTM conversion rubric
+```
+
+Power mode is useful for contributors and technical operators, but it should
+not be the beginner default.
+
+## Privacy and Safety Gates
+
+Before checkpointing, the agent or future `mb checkpoint` command must check:
+
+- no obvious secrets, tokens, service-account JSON, bearer tokens, or `.env`
+  files are staged;
+- no machine-local bridge files such as `.claude/settings.local.json` or skill
+  symlinks are staged;
+- no customer/member/account data is being committed accidentally;
+- generated files are in the intended business or site repo, not the engine;
+- repo state is not already in merge/rebase conflict;
+- changes fit the current user task.
+
+If risk is detected, do not commit. Explain the issue and give the next safe
+command.
+
+## Proposed CLI Surface
+
+### `mb checkpoint`
+
+Create or preview a business-repo checkpoint.
+
+Candidate options:
+
+```bash
+mb checkpoint --plan
+mb checkpoint --json
+mb checkpoint --message "[checkpoint] Draft paid traffic site plan"
+mb checkpoint --yes
+mb checkpoint --mode beginner
+mb checkpoint --mode concern
+mb checkpoint --repo .
+```
+
+Expected behavior:
+
+- inspect git status;
+- classify changed files by business section;
+- run privacy/safety gates;
+- propose one or more commit messages;
+- produce machine-readable JSON for skills;
+- commit only when explicitly approved or `--yes` is passed in a context where
+  safety gates pass.
+
+### `mb checkpoint status`
+
+Optional follow-up surface for agents:
+
+```bash
+mb checkpoint status --json
+```
+
+Returns recent checkpoint facts:
+
+- last checkpoint commit;
+- changed files since last checkpoint;
+- whether work is dirty;
+- suggested checkpoint urgency.
+
+## Skill Integration
+
+### `/mb-start`
+
+At start:
+
+- read recent checkpoint commits;
+- summarize what changed since last session;
+- show dirty work if present;
+- recommend continuing, checkpointing, or repairing before new work.
+
+### `/mb-end`
+
+At close:
+
+- call the same checkpoint planner;
+- commit any remaining meaningful work after user confirmation;
+- save crystallize output as repo memory;
+- close with a summary.
+
+`/mb-end` remains valuable, but it is no longer the only checkpoint moment.
+
+### Execution Skills
+
+Skills that write meaningful files should call the checkpoint planner at
+natural boundaries:
+
+- `/mb-think` after a research batch or decision;
+- `/mb-site` after site brief, first generated site, and before deploy;
+- `/mb-ads` after generated ad batch and after compliance review;
+- `/mb-bet` after bet creation, update, close, or narration;
+- migration/setup flows before and after applying broad changes.
+
+## User-Facing Copy
+
+Beginner language:
+
+> "I saved a checkpoint. That means the work is in your repo history, so a
+> future Claude session can pick it back up."
+
+Before commit:
+
+> "I changed 4 files. Want me to save a checkpoint before we move on?"
+
+When refusing:
+
+> "I found something that looks like a secret or local machine file, so I did
+> not checkpoint this yet."
+
+At next start:
+
+> "Last checkpoint: paid site plan. Since then, 2 files changed and nothing is
+> committed yet."
+
+## State Model
+
+Canonical checkpoint truth is normal git history. Main Branch should not create
+a second source of truth for commits.
+
+Optional local state may live under `.mb/` only for rebuildable helper data,
+such as:
+
+- last checkpoint prompt seen;
+- checkpoint preference mode;
+- ignored temporary files;
+- cached classification from the latest plan.
+
+Any `.mb/` checkpoint state must be rebuildable from git and safe to delete.
+
+## Validation
+
+Implementation should include:
+
+- unit tests for dirty/clean repos;
+- tests for staged secret-like files refusing to commit;
+- tests for noob one-commit and concern-commit planning;
+- JSON contract tests;
+- fixture business repo smoke:
+
+```bash
+tmpdir="$(mktemp -d)"
+mb onboard --yes --name "Test Business" --path "$tmpdir/test-business"
+cd "$tmpdir/test-business"
+# modify core/offer.md
+mb checkpoint --plan --json
+mb checkpoint --message "[checkpoint] Update test offer" --yes
+mb status --json --peek
+```
+
+- runtime smoke for a skill writing files, asking for checkpoint, and then
+  `/mb-start` reconstructing the checkpoint in a fresh session.
+
+## Implementation Slices
+
+### Slice 1: Spec and Docs
+
+This PRD plus small updates to ethos, roadmap, and operator loops.
+
+### Slice 2: Deterministic Planner
+
+Build `mb checkpoint --plan --json` with file classification and safety gates.
+No committing yet.
+
+### Slice 3: Commit Execution
+
+Add `mb checkpoint --yes` and human rendering. Keep approval and safety gates
+strict.
+
+### Slice 4: Skill Wiring
+
+Update `/mb-start`, `/mb-end`, and one high-write skill such as `/mb-think` or
+`/mb-site` to use the checkpoint contract.
+
+### Slice 5: Dashboard and Team Daily Log
+
+Future dashboard surfaces can read checkpoint history as the "what happened"
+timeline. Team daily logs should build from checkpoint commits and explicit log
+files, not chat transcripts.
+
+## Open Questions
+
+- Should beginner mode default to one checkpoint per task boundary or one per
+  context threshold?
+- What is the right prompt threshold: 10K tokens, 30K tokens, or runtime-
+  reported context percentage?
+- Should `mb checkpoint` ever stage untracked generated output automatically,
+  or should untracked files require explicit mention?
+- Should checkpoint preferences live in `.mb/` or runtime-local config?
+- How should multi-repo work checkpoint when a business repo drives a separate
+  site repo?
+
+## Acceptance Criteria
+
+The first implementation is successful when:
+
+- a user can ask an agent to checkpoint mid-run;
+- the agent can preview exactly what will be committed;
+- sensitive/local files are blocked;
+- the commit message is readable to a non-technical operator;
+- `/mb-start` can summarize recent checkpoint history;
+- a new Claude Code session can continue without the user re-explaining the
+  last work block.

--- a/mb/mb/checkpoint.py
+++ b/mb/mb/checkpoint.py
@@ -1,0 +1,555 @@
+"""Plan git-backed agent checkpoints for business repos."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from mb.freshness import looks_like_business_repo
+
+SURFACE_ORDER = [
+    "core",
+    "campaigns",
+    "decisions",
+    "research",
+    "bets",
+    "outputs",
+    "log",
+    "documents",
+    "site",
+    "config",
+    "unknown",
+]
+
+SECRET_RE = re.compile(
+    r"(?i)("
+    r"(api[_-]?key|access[_-]?token|secret|client[_-]?secret)\s*[:=]\s*['\"]?[A-Za-z0-9_./+=-]{8,}"
+    r"|authorization:\s*bearer\s+\S+"
+    r"|-----BEGIN [A-Z ]*PRIVATE KEY-----"
+    r")"
+)
+
+
+def _run_git(repo: Path, args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=str(repo),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def _git_error(label: str, result: subprocess.CompletedProcess[str]) -> str:
+    details = (result.stderr or result.stdout).strip()
+    return f"{label} failed with exit code {result.returncode}: {details or 'no output'}"
+
+
+def _git_root(repo: Path) -> tuple[Path | None, str | None]:
+    result = _run_git(repo, ["rev-parse", "--show-toplevel"])
+    if result.returncode != 0:
+        return None, _git_error("git rev-parse --show-toplevel", result)
+    return Path(result.stdout.strip()).resolve(), None
+
+
+def _git_dir(repo: Path) -> Path | None:
+    result = _run_git(repo, ["rev-parse", "--git-dir"])
+    if result.returncode != 0:
+        return None
+    raw = result.stdout.strip()
+    path = Path(raw)
+    if not path.is_absolute():
+        path = repo / path
+    return path.resolve()
+
+
+def _is_engine_repo(repo: Path) -> bool:
+    pyproject = repo / "mb" / "pyproject.toml"
+    cli = repo / "mb" / "mb" / "cli.py"
+    return pyproject.is_file() and cli.is_file()
+
+
+def _status_records(repo: Path) -> tuple[list[dict[str, Any]], str | None]:
+    result = _run_git(repo, ["status", "--porcelain=v1", "-z", "--untracked-files=all"])
+    if result.returncode != 0:
+        return [], _git_error("git status --porcelain", result)
+
+    records: list[dict[str, Any]] = []
+    parts = result.stdout.split("\0")
+    index = 0
+    while index < len(parts):
+        item = parts[index]
+        index += 1
+        if not item:
+            continue
+        raw = item[:2]
+        path = item[3:] if len(item) > 3 else ""
+        old_path = ""
+        if (raw[0] in {"R", "C"} or raw[1] in {"R", "C"}) and index < len(parts):
+            old_path = parts[index]
+            index += 1
+        records.append(
+            {
+                "path": path,
+                "old_path": old_path,
+                "git_status": raw,
+                "staged": raw[0] not in {" ", "?"},
+                "unstaged": raw[1] not in {" ", "?"},
+                "untracked": raw == "??",
+                "deleted": "D" in raw,
+                "conflict": _is_conflict_status(raw),
+            }
+        )
+    return records, None
+
+
+def _is_conflict_status(raw: str) -> bool:
+    return raw in {"DD", "AU", "UD", "UA", "DU", "AA", "UU"} or "U" in raw
+
+
+def _surface(path: str) -> str:
+    if path.startswith("core/") or path == "core":
+        return "core"
+    if path.startswith("campaigns/") or path == "campaigns":
+        return "campaigns"
+    if path.startswith("decisions/") or path == "decisions":
+        return "decisions"
+    if path.startswith("research/") or path == "research":
+        return "research"
+    if path.startswith("bets/") or path == "bets":
+        return "bets"
+    if path.startswith("outputs/") or path == "outputs":
+        return "outputs"
+    if path.startswith("log/") or path == "log":
+        return "log"
+    if path.startswith("documents/") or path == "documents":
+        return "documents"
+    if path.startswith(("src/", "app/", "pages/", "components/", "public/", "dist/")):
+        return "site"
+    if path in {"package.json", "astro.config.mjs", "vite.config.ts", "vite.config.js"}:
+        return "site"
+    if path.startswith((".github/", ".claude/", ".mainbranch/", ".mb/")):
+        return "config"
+    if path in {"CLAUDE.md", ".gitignore", "README.md"}:
+        return "config"
+    return "unknown"
+
+
+def _safe_read(path: Path, limit: int = 262_144) -> str:
+    try:
+        data = path.read_bytes()[:limit]
+    except OSError:
+        return ""
+    if b"\x00" in data:
+        return ""
+    return data.decode("utf-8", errors="ignore")
+
+
+def _is_env_file(path: str) -> bool:
+    name = Path(path).name
+    return name == ".env" or name.startswith(".env.")
+
+
+def _is_local_bridge(path: str) -> bool:
+    return (
+        path == ".claude/settings.local.json"
+        or path.startswith(".claude/skills/")
+        or path.startswith(".mb/backups/")
+        or path.startswith(".mb/issue-drafts/")
+    )
+
+
+def _service_account_json(path: str, text: str) -> bool:
+    if not path.endswith(".json"):
+        return False
+    lowered = text.lower()
+    return '"type"' in lowered and "service_account" in lowered and "private_key" in lowered
+
+
+def _safety_blocks(repo: Path, changes: list[dict[str, Any]]) -> list[dict[str, str]]:
+    blocks: list[dict[str, str]] = []
+    if _is_engine_repo(repo):
+        blocks.append(
+            {
+                "code": "engine_repo",
+                "path": ".",
+                "message": "checkpoint planning is for business repos, not the engine repo",
+            }
+        )
+
+    git_dir = _git_dir(repo)
+    if git_dir is not None:
+        for marker in ("MERGE_HEAD", "rebase-merge", "rebase-apply"):
+            if (git_dir / marker).exists():
+                blocks.append(
+                    {
+                        "code": "git_operation_in_progress",
+                        "path": ".git",
+                        "message": f"git operation in progress: {marker}",
+                    }
+                )
+
+    for change in changes:
+        path = str(change["path"])
+        abs_path = repo / path
+        if change.get("conflict"):
+            blocks.append(
+                {
+                    "code": "merge_conflict",
+                    "path": path,
+                    "message": "file has an unresolved merge conflict status",
+                }
+            )
+        if _is_local_bridge(path):
+            blocks.append(
+                {
+                    "code": "local_bridge_file",
+                    "path": path,
+                    "message": "local Claude/Main Branch bridge files must not be checkpointed",
+                }
+            )
+        if _is_env_file(path):
+            blocks.append(
+                {
+                    "code": "env_file",
+                    "path": path,
+                    "message": "environment files may contain secrets",
+                }
+            )
+        if abs_path.is_symlink() and path.startswith(".claude/"):
+            blocks.append(
+                {
+                    "code": "local_symlink",
+                    "path": path,
+                    "message": "local Claude symlinks are machine-specific",
+                }
+            )
+        if change.get("deleted") or not abs_path.is_file() or abs_path.is_symlink():
+            continue
+        text = _safe_read(abs_path)
+        if _service_account_json(path, text):
+            blocks.append(
+                {
+                    "code": "service_account_json",
+                    "path": path,
+                    "message": "service-account JSON contains private credentials",
+                }
+            )
+        elif SECRET_RE.search(text):
+            blocks.append(
+                {
+                    "code": "secret_like_content",
+                    "path": path,
+                    "message": "file content looks like it may contain a secret",
+                }
+            )
+    return blocks
+
+
+def _surface_counts(changes: list[dict[str, Any]]) -> dict[str, int]:
+    counts = {surface: 0 for surface in SURFACE_ORDER}
+    for change in changes:
+        counts[str(change["surface"])] += 1
+    return {surface: count for surface, count in counts.items() if count}
+
+
+def _surface_phrase(surfaces: list[str]) -> str:
+    if not surfaces:
+        return "work"
+    labels = {
+        "core": "core",
+        "campaigns": "campaigns",
+        "decisions": "decisions",
+        "research": "research",
+        "bets": "bets",
+        "outputs": "outputs",
+        "log": "log",
+        "documents": "documents",
+        "site": "site",
+        "config": "setup",
+        "unknown": "repo files",
+    }
+    named = [labels.get(surface, surface) for surface in surfaces]
+    if len(named) == 1:
+        return named[0]
+    if len(named) == 2:
+        return f"{named[0]} and {named[1]}"
+    return ", ".join(named[:-1]) + f", and {named[-1]}"
+
+
+def _proposal(changes: list[dict[str, Any]], blocks: list[dict[str, str]]) -> dict[str, Any] | None:
+    if not changes or blocks:
+        return None
+    counts = _surface_counts(changes)
+    surfaces = [surface for surface in SURFACE_ORDER if surface in counts]
+    phrase = _surface_phrase(surfaces)
+    changed_paths = [str(change["path"]) for change in changes]
+    return {
+        "mode": "beginner",
+        "message": f"[checkpoint] Update {phrase}",
+        "body": {
+            "changed": changed_paths,
+            "why": "Save meaningful business progress before moving on.",
+            "next": "Run mb status or /mb-start to continue from repo truth.",
+        },
+    }
+
+
+def _commit_body(proposal: dict[str, Any]) -> str:
+    body = proposal.get("body", {})
+    changed = body.get("changed", []) if isinstance(body, dict) else []
+    why = str(body.get("why", "") if isinstance(body, dict) else "")
+    next_step = str(body.get("next", "") if isinstance(body, dict) else "")
+    lines = ["Changed:"]
+    if isinstance(changed, list) and changed:
+        lines.extend(f"- {path}" for path in changed)
+    else:
+        lines.append("- repo files")
+    if why:
+        lines.extend(["", "Why:", f"- {why}"])
+    if next_step:
+        lines.extend(["", "Next:", f"- {next_step}"])
+    return "\n".join(lines)
+
+
+def _head_sha(repo: Path) -> str:
+    result = _run_git(repo, ["rev-parse", "HEAD"])
+    return result.stdout.strip() if result.returncode == 0 else ""
+
+
+def plan(repo: str | Path = ".", *, mode: str = "beginner") -> dict[str, Any]:
+    """Plan a checkpoint without staging or committing changes."""
+    target = Path(repo).resolve()
+    if mode not in {"beginner", "concern"}:
+        return {
+            "ok": False,
+            "status": "error",
+            "repo": str(target),
+            "mode": mode,
+            "errors": ["mode must be beginner or concern"],
+        }
+    if not target.exists():
+        return {
+            "ok": False,
+            "status": "error",
+            "repo": str(target),
+            "mode": mode,
+            "errors": ["repo not found"],
+        }
+
+    root, root_error = _git_root(target)
+    if root is None:
+        return {
+            "ok": False,
+            "status": "error",
+            "repo": str(target),
+            "mode": mode,
+            "errors": [root_error or "not a git repo"],
+        }
+
+    records, status_error = _status_records(root)
+    if status_error is not None:
+        return {
+            "ok": False,
+            "status": "error",
+            "repo": str(root),
+            "mode": mode,
+            "errors": [status_error],
+        }
+
+    changes = [
+        {
+            **record,
+            "surface": _surface(str(record["path"])),
+        }
+        for record in records
+    ]
+    blocks = _safety_blocks(root, changes)
+    warnings: list[dict[str, str]] = []
+    if not looks_like_business_repo(root) and not _is_engine_repo(root):
+        warnings.append(
+            {
+                "code": "not_business_repo",
+                "path": ".",
+                "message": "repo does not look like a Main Branch business repo",
+            }
+        )
+
+    status = "clean"
+    if changes:
+        status = "blocked" if blocks else "ready"
+    proposal = _proposal(changes, blocks)
+    counts = _surface_counts(changes)
+    return {
+        "ok": not blocks,
+        "status": status,
+        "repo": str(root),
+        "mode": mode,
+        "has_changes": bool(changes),
+        "summary": {
+            "changed_files": len(changes),
+            "staged_files": sum(1 for change in changes if change["staged"]),
+            "unstaged_files": sum(1 for change in changes if change["unstaged"]),
+            "untracked_files": sum(1 for change in changes if change["untracked"]),
+            "surfaces": counts,
+        },
+        "changes": changes,
+        "safety": {
+            "ok": not blocks,
+            "blocks": blocks,
+            "warnings": warnings,
+        },
+        "proposal": proposal,
+        "errors": [],
+    }
+
+
+def commit(
+    repo: str | Path = ".",
+    *,
+    message: str = "",
+    mode: str = "beginner",
+    yes: bool = False,
+) -> dict[str, Any]:
+    """Commit an approved checkpoint plan."""
+    planned = plan(repo=repo, mode=mode)
+    if planned.get("status") == "clean":
+        return {
+            "ok": True,
+            "status": "clean",
+            "repo": planned.get("repo"),
+            "committed": False,
+            "plan": planned,
+            "errors": [],
+        }
+    if not planned.get("ok"):
+        return {
+            "ok": False,
+            "status": "blocked",
+            "repo": planned.get("repo"),
+            "committed": False,
+            "plan": planned,
+            "errors": ["checkpoint plan is blocked"],
+        }
+    if not yes:
+        return {
+            "ok": False,
+            "status": "approval_required",
+            "repo": planned.get("repo"),
+            "committed": False,
+            "plan": planned,
+            "errors": ["pass --yes after reviewing the checkpoint plan"],
+        }
+
+    proposal = planned.get("proposal")
+    if not isinstance(proposal, dict):
+        return {
+            "ok": False,
+            "status": "error",
+            "repo": planned.get("repo"),
+            "committed": False,
+            "plan": planned,
+            "errors": ["checkpoint plan did not include a proposal"],
+        }
+
+    repo_path = Path(str(planned["repo"]))
+    commit_message = message.strip() or str(proposal["message"])
+    paths = [str(change["path"]) for change in planned.get("changes", [])]
+    if not paths:
+        return {
+            "ok": True,
+            "status": "clean",
+            "repo": str(repo_path),
+            "committed": False,
+            "plan": planned,
+            "errors": [],
+        }
+
+    add = _run_git(repo_path, ["add", "--", *paths])
+    if add.returncode != 0:
+        return {
+            "ok": False,
+            "status": "error",
+            "repo": str(repo_path),
+            "committed": False,
+            "plan": planned,
+            "errors": [_git_error("git add", add)],
+        }
+    body = _commit_body({**proposal, "message": commit_message})
+    commit_result = _run_git(repo_path, ["commit", "-m", commit_message, "-m", body])
+    if commit_result.returncode != 0:
+        return {
+            "ok": False,
+            "status": "error",
+            "repo": str(repo_path),
+            "committed": False,
+            "plan": planned,
+            "errors": [_git_error("git commit", commit_result)],
+        }
+
+    return {
+        "ok": True,
+        "status": "committed",
+        "repo": str(repo_path),
+        "committed": True,
+        "commit": {
+            "sha": _head_sha(repo_path),
+            "message": commit_message,
+            "body": body,
+        },
+        "plan": planned,
+        "errors": [],
+    }
+
+
+def render_human(result: dict[str, Any]) -> None:
+    """Render a checkpoint plan for operators."""
+    status = result.get("status")
+    print("mb checkpoint")
+    print(f"repo: {result.get('repo')}")
+    if status == "committed":
+        commit_info = result.get("commit", {})
+        sha = commit_info.get("sha", "") if isinstance(commit_info, dict) else ""
+        message = commit_info.get("message", "") if isinstance(commit_info, dict) else ""
+        print(f"saved checkpoint: {message}")
+        if sha:
+            print(f"commit: {sha[:12]}")
+        return
+    if status == "approval_required":
+        print("approval required.")
+        print("review the plan, then rerun with --yes to save the checkpoint.")
+        return
+    if status == "clean":
+        print("nothing to checkpoint.")
+        return
+    if status == "error":
+        for error in result.get("errors", []):
+            print(f"error: {error}")
+        return
+
+    summary = result.get("summary", {})
+    changed_files = summary.get("changed_files", 0)
+    print(f"changed files: {changed_files}")
+    surfaces = summary.get("surfaces", {})
+    if isinstance(surfaces, dict) and surfaces:
+        rendered = ", ".join(f"{key}={value}" for key, value in surfaces.items())
+        print(f"surfaces: {rendered}")
+
+    safety = result.get("safety", {})
+    blocks = safety.get("blocks", []) if isinstance(safety, dict) else []
+    if blocks:
+        print("")
+        print("checkpoint blocked:")
+        for block in blocks:
+            print(f"  - {block['path']}: {block['message']}")
+        return
+
+    proposal = result.get("proposal")
+    if isinstance(proposal, dict):
+        print("")
+        print("suggested checkpoint:")
+        print(f"  {proposal['message']}")
+        print("")
+        print("This is a plan only. Commit execution ships in the next slice.")

--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -16,6 +16,7 @@ from typing import Any
 import typer
 
 from mb import __version__
+from mb import checkpoint as checkpoint_mod
 from mb import connect as connect_mod
 from mb import doctor as doctor_mod
 from mb import educational as educational_mod
@@ -900,6 +901,36 @@ def update_cmd(
         typer.echo(json.dumps(result, indent=2))
     else:
         update_mod.render_human(result)
+    raise typer.Exit(0 if result["ok"] else 1)
+
+
+@app.command("checkpoint")
+def checkpoint_cmd(
+    repo: str = typer.Option(".", "--repo", help="Business repo to inspect."),
+    plan: bool = typer.Option(
+        False,
+        "--plan",
+        help="Preview checkpointable changes without committing.",
+    ),
+    message: str = typer.Option("", "--message", "-m", help="Commit message for --yes."),
+    yes: bool = typer.Option(False, "--yes", help="Save the checkpoint after safety gates pass."),
+    mode: str = typer.Option(
+        "beginner",
+        "--mode",
+        help="Checkpoint grouping mode: beginner or concern.",
+    ),
+    json_out: bool = typer.Option(False, "--json", help="Machine-readable output."),
+) -> None:
+    """Plan or save a git checkpoint."""
+    if yes or message:
+        result = checkpoint_mod.commit(repo=repo, message=message, mode=mode, yes=yes)
+    else:
+        _ = plan
+        result = checkpoint_mod.plan(repo=repo, mode=mode)
+    if json_out:
+        typer.echo(json.dumps(result, indent=2))
+    else:
+        checkpoint_mod.render_human(result)
     raise typer.Exit(0 if result["ok"] else 1)
 
 

--- a/mb/tests/test_checkpoint.py
+++ b/mb/tests/test_checkpoint.py
@@ -1,0 +1,255 @@
+"""``mb checkpoint`` planning contract tests."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from mb import checkpoint as checkpoint_mod
+from mb.cli import app
+from mb.init import run as init_run
+
+runner = CliRunner()
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def _business_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test User")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "initial")
+    return repo
+
+
+def test_checkpoint_plan_clean_repo_returns_clean(tmp_path: Path) -> None:
+    repo = _business_repo(tmp_path)
+
+    report = checkpoint_mod.plan(repo)
+
+    assert report["ok"] is True
+    assert report["status"] == "clean"
+    assert report["has_changes"] is False
+    assert report["changes"] == []
+    assert report["proposal"] is None
+
+
+def test_checkpoint_plan_classifies_dirty_business_files(tmp_path: Path) -> None:
+    repo = _business_repo(tmp_path)
+    (repo / "core" / "offer.md").write_text("# Offer\n", encoding="utf-8")
+    (repo / "decisions" / "2026-05-05-test.md").write_text("# Decision\n", encoding="utf-8")
+    (repo / "campaigns" / "paid.md").write_text("# Campaign\n", encoding="utf-8")
+
+    report = checkpoint_mod.plan(repo)
+
+    assert report["ok"] is True
+    assert report["status"] == "ready"
+    assert report["summary"]["changed_files"] == 3
+    assert report["summary"]["surfaces"] == {
+        "core": 1,
+        "campaigns": 1,
+        "decisions": 1,
+    }
+    assert report["proposal"]["message"] == "[checkpoint] Update core, campaigns, and decisions"
+    paths = {change["path"] for change in report["changes"]}
+    assert paths == {
+        "core/offer.md",
+        "decisions/2026-05-05-test.md",
+        "campaigns/paid.md",
+    }
+
+
+def test_checkpoint_cli_json_contract(tmp_path: Path) -> None:
+    repo = _business_repo(tmp_path)
+    (repo / "research" / "market.md").write_text("# Market\n", encoding="utf-8")
+
+    result = runner.invoke(app, ["checkpoint", "--repo", str(repo), "--plan", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "ready"
+    assert payload["mode"] == "beginner"
+    assert payload["summary"]["surfaces"] == {"research": 1}
+    assert payload["proposal"]["message"] == "[checkpoint] Update research"
+
+
+def test_checkpoint_blocks_env_and_secret_like_content(tmp_path: Path) -> None:
+    repo = _business_repo(tmp_path)
+    (repo / ".env").write_text("API_KEY=super-secret\n", encoding="utf-8")
+    (repo / "core" / "credentials.md").write_text(
+        "Authorization: Bearer abcdefghijklmnop\n",
+        encoding="utf-8",
+    )
+    _git(repo, "add", "-f", ".env")
+
+    report = checkpoint_mod.plan(repo)
+
+    assert report["ok"] is False
+    assert report["status"] == "blocked"
+    codes = {block["code"] for block in report["safety"]["blocks"]}
+    assert "env_file" in codes
+    assert "secret_like_content" in codes
+    assert report["proposal"] is None
+
+
+def test_checkpoint_blocks_service_account_json(tmp_path: Path) -> None:
+    repo = _business_repo(tmp_path)
+    (repo / "core" / "service-account.json").write_text(
+        '{"type":"service_account","private_key":"-----BEGIN PRIVATE KEY-----"}',
+        encoding="utf-8",
+    )
+
+    report = checkpoint_mod.plan(repo)
+
+    assert report["ok"] is False
+    assert report["safety"]["blocks"][0]["code"] == "service_account_json"
+
+
+def test_checkpoint_blocks_forced_local_bridge_files(tmp_path: Path) -> None:
+    repo = _business_repo(tmp_path)
+    _git(repo, "add", "-f", ".claude/settings.local.json")
+
+    report = checkpoint_mod.plan(repo)
+
+    assert report["ok"] is False
+    assert report["status"] == "blocked"
+    assert report["safety"]["blocks"][0]["code"] == "local_bridge_file"
+
+
+def test_checkpoint_blocks_engine_repo(tmp_path: Path) -> None:
+    repo = tmp_path / "engine"
+    (repo / "mb" / "mb").mkdir(parents=True)
+    (repo / "mb" / "pyproject.toml").write_text("[project]\nname='mainbranch'\n")
+    (repo / "mb" / "mb" / "cli.py").write_text("# cli\n")
+    _git(repo, "init", "-q", "-b", "main")
+    (repo / "README.md").write_text("dirty\n", encoding="utf-8")
+
+    report = checkpoint_mod.plan(repo)
+
+    assert report["ok"] is False
+    assert report["status"] == "blocked"
+    assert report["safety"]["blocks"][0]["code"] == "engine_repo"
+
+
+def test_checkpoint_rejects_invalid_mode(tmp_path: Path) -> None:
+    repo = _business_repo(tmp_path)
+
+    result = runner.invoke(app, ["checkpoint", "--repo", str(repo), "--mode", "auto", "--json"])
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "error"
+    assert "mode must be beginner or concern" in payload["errors"][0]
+
+
+def test_checkpoint_commit_requires_yes_after_plan_review(tmp_path: Path) -> None:
+    repo = _business_repo(tmp_path)
+    (repo / "core" / "offer.md").write_text("# Offer\n", encoding="utf-8")
+
+    result = runner.invoke(
+        app,
+        [
+            "checkpoint",
+            "--repo",
+            str(repo),
+            "--message",
+            "[checkpoint] Update offer",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "approval_required"
+    assert payload["committed"] is False
+    assert "pass --yes" in payload["errors"][0]
+
+
+def test_checkpoint_commit_saves_readable_checkpoint(tmp_path: Path) -> None:
+    repo = _business_repo(tmp_path)
+    (repo / "core" / "offer.md").write_text("# Offer\nUpdated\n", encoding="utf-8")
+
+    result = runner.invoke(
+        app,
+        [
+            "checkpoint",
+            "--repo",
+            str(repo),
+            "--message",
+            "[checkpoint] Update offer",
+            "--yes",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "committed"
+    assert payload["committed"] is True
+    assert payload["commit"]["message"] == "[checkpoint] Update offer"
+    assert "core/offer.md" in payload["commit"]["body"]
+    assert payload["commit"]["sha"]
+    assert _git(repo, "status", "--porcelain").stdout == ""
+    log = _git(repo, "log", "-1", "--pretty=%B").stdout
+    assert "[checkpoint] Update offer" in log
+    assert "Changed:\n- core/offer.md" in log
+
+
+def test_checkpoint_commit_refuses_blocked_plan_without_commit(tmp_path: Path) -> None:
+    repo = _business_repo(tmp_path)
+    (repo / ".env").write_text("API_KEY=super-secret\n", encoding="utf-8")
+    _git(repo, "add", "-f", ".env")
+
+    result = runner.invoke(
+        app,
+        [
+            "checkpoint",
+            "--repo",
+            str(repo),
+            "--message",
+            "[checkpoint] Unsafe",
+            "--yes",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "blocked"
+    assert payload["committed"] is False
+    assert _git(repo, "log", "--oneline").stdout.count("\n") == 1
+
+
+def test_checkpoint_commit_clean_repo_is_noop(tmp_path: Path) -> None:
+    repo = _business_repo(tmp_path)
+
+    result = runner.invoke(
+        app,
+        [
+            "checkpoint",
+            "--repo",
+            str(repo),
+            "--message",
+            "[checkpoint] Nothing",
+            "--yes",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "clean"
+    assert payload["committed"] is False


### PR DESCRIPTION
## Summary
- Defines agent checkpoints as the hidden Git memory layer for long business work runs.
- Adds a v0.3.x PRD for `mb checkpoint`, safety gates, commit grouping, and `/mb-start`/`/mb-end` integration.
- Updates the ethos, operator loops, and roadmap so checkpointing is part of the public product frame.

## Scope
- In: checkpoint PRD, hidden-Git-app product stance, operator loop references, roadmap pointer to #288.
- Out: CLI implementation, skill wiring, package changes, runtime smoke, dashboard/team daily log implementation.

## Commits
- `4aea9c1` — `[docs] Spec agent checkpoints as Git memory`

## Release / Issues
- Release: v0.3.x
- Linear ID(s): MAIN-230
- Closes: #288
- Refs: none
- Follow-ups: implement `mb checkpoint --plan --json`, add commit execution with safety gates, and wire the planner into `/mb-start`, `/mb-end`, and one high-write skill.

## Success Metric
A future implementation branch has a clear public spec for making long agent runs durable through readable checkpoint commits, so `/mb-start` can reconstruct recent work without the user re-explaining the previous session.

## Validation
- Level 0 docs/decision: PRD added with frontmatter; public roadmap/ethos/operator-loop links updated; no private Devon or local machine details committed.
- Level 1 static: `scripts/check.sh` passed.
- Level 2 CLI: not applicable; docs/spec only.
- Level 3 package/install: not applicable; no package or bundled-data changes.
- Level 4 fixture repo: not applicable; no runtime behavior changed.
- Level 5 runtime smoke: not applicable; implementation will need fresh runtime smoke when skills are wired.

## Public / Private Boundary
Committed content is public-safe product/spec language. Branch-specific planning stayed in `.context/cold-start.md` and was not committed.