### PR TITLE
[add] mb checkpoint commit execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 - Added planning-only `mb checkpoint --plan --json` so agents can inspect
   dirty business repos, classify changed files, run safety gates, and propose
   readable checkpoint messages before commit execution ships. Refs #290.
+- Added guarded `mb checkpoint --message ... --yes` execution so approved
+  checkpoint plans can become readable git commits without exposing raw git
+  mechanics to beginners. Refs #291.
 
 ## [0.3.0] - 2026-05-04
 

--- a/mb/mb/checkpoint.py
+++ b/mb/mb/checkpoint.py
@@ -297,6 +297,28 @@ def _proposal(changes: list[dict[str, Any]], blocks: list[dict[str, str]]) -> di
     }
 
 
+def _commit_body(proposal: dict[str, Any]) -> str:
+    body = proposal.get("body", {})
+    changed = body.get("changed", []) if isinstance(body, dict) else []
+    why = str(body.get("why", "") if isinstance(body, dict) else "")
+    next_step = str(body.get("next", "") if isinstance(body, dict) else "")
+    lines = ["Changed:"]
+    if isinstance(changed, list) and changed:
+        lines.extend(f"- {path}" for path in changed)
+    else:
+        lines.append("- repo files")
+    if why:
+        lines.extend(["", "Why:", f"- {why}"])
+    if next_step:
+        lines.extend(["", "Next:", f"- {next_step}"])
+    return "\n".join(lines)
+
+
+def _head_sha(repo: Path) -> str:
+    result = _run_git(repo, ["rev-parse", "HEAD"])
+    return result.stdout.strip() if result.returncode == 0 else ""
+
+
 def plan(repo: str | Path = ".", *, mode: str = "beginner") -> dict[str, Any]:
     """Plan a checkpoint without staging or committing changes."""
     target = Path(repo).resolve()
@@ -384,11 +406,121 @@ def plan(repo: str | Path = ".", *, mode: str = "beginner") -> dict[str, Any]:
     }
 
 
+def commit(
+    repo: str | Path = ".",
+    *,
+    message: str = "",
+    mode: str = "beginner",
+    yes: bool = False,
+) -> dict[str, Any]:
+    """Commit an approved checkpoint plan."""
+    planned = plan(repo=repo, mode=mode)
+    if planned.get("status") == "clean":
+        return {
+            "ok": True,
+            "status": "clean",
+            "repo": planned.get("repo"),
+            "committed": False,
+            "plan": planned,
+            "errors": [],
+        }
+    if not planned.get("ok"):
+        return {
+            "ok": False,
+            "status": "blocked",
+            "repo": planned.get("repo"),
+            "committed": False,
+            "plan": planned,
+            "errors": ["checkpoint plan is blocked"],
+        }
+    if not yes:
+        return {
+            "ok": False,
+            "status": "approval_required",
+            "repo": planned.get("repo"),
+            "committed": False,
+            "plan": planned,
+            "errors": ["pass --yes after reviewing the checkpoint plan"],
+        }
+
+    proposal = planned.get("proposal")
+    if not isinstance(proposal, dict):
+        return {
+            "ok": False,
+            "status": "error",
+            "repo": planned.get("repo"),
+            "committed": False,
+            "plan": planned,
+            "errors": ["checkpoint plan did not include a proposal"],
+        }
+
+    repo_path = Path(str(planned["repo"]))
+    commit_message = message.strip() or str(proposal["message"])
+    paths = [str(change["path"]) for change in planned.get("changes", [])]
+    if not paths:
+        return {
+            "ok": True,
+            "status": "clean",
+            "repo": str(repo_path),
+            "committed": False,
+            "plan": planned,
+            "errors": [],
+        }
+
+    add = _run_git(repo_path, ["add", "--", *paths])
+    if add.returncode != 0:
+        return {
+            "ok": False,
+            "status": "error",
+            "repo": str(repo_path),
+            "committed": False,
+            "plan": planned,
+            "errors": [_git_error("git add", add)],
+        }
+    body = _commit_body({**proposal, "message": commit_message})
+    commit_result = _run_git(repo_path, ["commit", "-m", commit_message, "-m", body])
+    if commit_result.returncode != 0:
+        return {
+            "ok": False,
+            "status": "error",
+            "repo": str(repo_path),
+            "committed": False,
+            "plan": planned,
+            "errors": [_git_error("git commit", commit_result)],
+        }
+
+    return {
+        "ok": True,
+        "status": "committed",
+        "repo": str(repo_path),
+        "committed": True,
+        "commit": {
+            "sha": _head_sha(repo_path),
+            "message": commit_message,
+            "body": body,
+        },
+        "plan": planned,
+        "errors": [],
+    }
+
+
 def render_human(result: dict[str, Any]) -> None:
     """Render a checkpoint plan for operators."""
     status = result.get("status")
     print("mb checkpoint")
     print(f"repo: {result.get('repo')}")
+    if status == "committed":
+        commit_info = result.get("commit", {})
+        sha = commit_info.get("sha", "") if isinstance(commit_info, dict) else ""
+        message = commit_info.get("message", "") if isinstance(commit_info, dict) else ""
+        print(f"saved checkpoint: {message}")
+        if sha:
+            print(f"commit: {sha[:12]}")
+        return
+    if status == "approval_required":
+        print("approval required.")
+        print("review the plan, then rerun with --yes to save the checkpoint.")
+        return
     if status == "clean":
         print("nothing to checkpoint.")
         return

--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -910,8 +910,10 @@ def checkpoint_cmd(
     plan: bool = typer.Option(
         False,
         "--plan",
-        help="Preview checkpointable changes. Commit execution is not shipped yet.",
+        help="Preview checkpointable changes without committing.",
     ),
+    message: str = typer.Option("", "--message", "-m", help="Commit message for --yes."),
+    yes: bool = typer.Option(False, "--yes", help="Save the checkpoint after safety gates pass."),
     mode: str = typer.Option(
         "beginner",
         "--mode",
@@ -919,9 +921,12 @@ def checkpoint_cmd(
     ),
     json_out: bool = typer.Option(False, "--json", help="Machine-readable output."),
 ) -> None:
-    """Plan a git checkpoint without staging or committing changes."""
-    _ = plan
-    result = checkpoint_mod.plan(repo=repo, mode=mode)
+    """Plan or save a git checkpoint."""
+    if yes or message:
+        result = checkpoint_mod.commit(repo=repo, message=message, mode=mode, yes=yes)
+    else:
+        _ = plan
+        result = checkpoint_mod.plan(repo=repo, mode=mode)
     if json_out:
         typer.echo(json.dumps(result, indent=2))
     else:

--- a/mb/tests/test_checkpoint.py
+++ b/mb/tests/test_checkpoint.py
@@ -153,3 +153,103 @@ def test_checkpoint_rejects_invalid_mode(tmp_path: Path) -> None:
     payload = json.loads(result.stdout)
     assert payload["status"] == "error"
     assert "mode must be beginner or concern" in payload["errors"][0]
+
+
+def test_checkpoint_commit_requires_yes_after_plan_review(tmp_path: Path) -> None:
+    repo = _business_repo(tmp_path)
+    (repo / "core" / "offer.md").write_text("# Offer\n", encoding="utf-8")
+
+    result = runner.invoke(
+        app,
+        [
+            "checkpoint",
+            "--repo",
+            str(repo),
+            "--message",
+            "[checkpoint] Update offer",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "approval_required"
+    assert payload["committed"] is False
+    assert "pass --yes" in payload["errors"][0]
+
+
+def test_checkpoint_commit_saves_readable_checkpoint(tmp_path: Path) -> None:
+    repo = _business_repo(tmp_path)
+    (repo / "core" / "offer.md").write_text("# Offer\nUpdated\n", encoding="utf-8")
+
+    result = runner.invoke(
+        app,
+        [
+            "checkpoint",
+            "--repo",
+            str(repo),
+            "--message",
+            "[checkpoint] Update offer",
+            "--yes",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "committed"
+    assert payload["committed"] is True
+    assert payload["commit"]["message"] == "[checkpoint] Update offer"
+    assert "core/offer.md" in payload["commit"]["body"]
+    assert payload["commit"]["sha"]
+    assert _git(repo, "status", "--porcelain").stdout == ""
+    log = _git(repo, "log", "-1", "--pretty=%B").stdout
+    assert "[checkpoint] Update offer" in log
+    assert "Changed:\n- core/offer.md" in log
+
+
+def test_checkpoint_commit_refuses_blocked_plan_without_commit(tmp_path: Path) -> None:
+    repo = _business_repo(tmp_path)
+    (repo / ".env").write_text("API_KEY=super-secret\n", encoding="utf-8")
+    _git(repo, "add", "-f", ".env")
+
+    result = runner.invoke(
+        app,
+        [
+            "checkpoint",
+            "--repo",
+            str(repo),
+            "--message",
+            "[checkpoint] Unsafe",
+            "--yes",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "blocked"
+    assert payload["committed"] is False
+    assert _git(repo, "log", "--oneline").stdout.count("\n") == 1
+
+
+def test_checkpoint_commit_clean_repo_is_noop(tmp_path: Path) -> None:
+    repo = _business_repo(tmp_path)
+
+    result = runner.invoke(
+        app,
+        [
+            "checkpoint",
+            "--repo",
+            str(repo),
+            "--message",
+            "[checkpoint] Nothing",
+            "--yes",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "clean"
+    assert payload["committed"] is False


### PR DESCRIPTION
## Summary
- Adds guarded `mb checkpoint --message ... --yes` execution on top of the checkpoint planner.
- Stages planner-approved paths, refuses blocked plans, and writes readable checkpoint commit bodies.
- Keeps `--message` without `--yes` as an approval-required state so agents can show the plan before saving.

## Scope
- In: commit execution, approval-required state, human/JSON committed output, execution tests, changelog.
- Out: skill wiring, background watcher/daemon, concern-splitting UI beyond the current planner metadata.

## Commits
- `4d436e8` — `[add] MAIN-232 checkpoint commit execution`

## Release / Issues
- Release: v0.3.x
- Linear ID(s): MAIN-232
- Closes: #291
- Refs: #288, #289, #290, #293
- Follow-ups: #292 wires this into `/mb-start`, `/mb-end`, and one writer skill.

## Success Metric
A beginner user can ask an agent to save a checkpoint mid-run, review what will be saved, and get a readable commit without learning git commands.

## Validation
- Level 0 docs/decision: CHANGELOG updated; PRD lives in #289.
- Level 1 static: `scripts/check.sh` passed.
- Level 2 CLI: `cd mb && pytest tests/test_checkpoint.py -q` passed; commit, refusal, no-op, and approval-required JSON paths covered.
- Level 3 package/install: not run; no packaging metadata changed.
- Level 4 fixture repo: fresh `mb onboard`, initial commit, dirty `core/offer.md`, `mb checkpoint --plan --json`, then `mb checkpoint --message "[checkpoint] Update smoke offer" --yes --json`; git log showed the readable checkpoint body and status was clean.
- Level 5 runtime smoke: not applicable; no skill/runtime wiring in this slice.

## Public / Private Boundary
Execution inherits the planner safety gates for `.env`, service-account JSON, secret-like content, local Claude/Main Branch bridge files, conflict states, and engine-repo writes. Smoke output stayed in `/tmp`.

## Stacking Note
This PR targets #293 because it depends on the checkpoint planner. Merge order: #289 -> #293 -> this PR.