### PR TITLE
[update] checkpoint resume loop

### DIFF
--- a/.claude/skills/mb-end/SKILL.md
+++ b/.claude/skills/mb-end/SKILL.md
@@ -272,33 +272,36 @@ If an insight was substantial enough to update reference directly (soul.md, offe
 
 ---
 
-## Step 6: Commit & Close
+## Step 6: Checkpoint & Close
 
-### Check for uncommitted work
+Use the checkpoint CLI. Do not hand-roll staging logic unless `mb checkpoint`
+is unavailable.
 
 ```bash
-git status --short 2>/dev/null
+mb checkpoint --plan --json
 ```
 
-**If there are uncommitted changes:**
+**If `status == "ready"`:**
 
-> "You have uncommitted changes:
+> "You have unsaved work:
 >
-> - [list modified/new files, brief]
+> - [summarize changed surfaces/files from the plan]
 >
-> Want me to commit these?"
+> Want me to save a checkpoint before we close?"
 
 If yes:
-- Stage the changed files (prefer specific files over `git add -A`)
-- Write a descriptive commit message following the `[type] Brief description` convention
-- If work was offer-specific, suggest commit message like: `[update] community offer: added pricing tiers and guarantee`
-- If the user shared final thoughts in Step 4, incorporate them into the commit message
-- Include the crystallize research file in the commit
-- Commit
+- Run `mb checkpoint --message "[checkpoint] <plain business summary>" --yes`.
+- Use beginner-safe language: "saved checkpoint," not "ran git commit."
+- Include the crystallize research file in the checkpoint if one was created.
 
-If no: Leave them. Some people prefer to commit at start of next session.
+If no: Leave the work unchanged. Some people prefer to checkpoint at the start
+of next session.
 
-**If no uncommitted changes:** Skip this.
+**If `status == "blocked"`:** Explain the safety block from JSON. Do not commit
+around it with raw git. Tell the user the checkpoint was not saved because Main
+Branch found something that may be local, private, conflicted, or unsafe.
+
+**If `status == "clean"`:** Skip this.
 
 ### The Close
 

--- a/.claude/skills/mb-start/SKILL.md
+++ b/.claude/skills/mb-start/SKILL.md
@@ -16,6 +16,12 @@ integrations, GitHub tasks/proposals, bets, dirty git, since-last-check, and
 `ranked_actions`. Do not duplicate those checks with ad hoc shell probes unless
 the status report says a section is unavailable.
 
+**Checkpoint facts first:** Also run `mb checkpoint --status --json` from the
+business repo. If `recent[]` has entries, summarize the latest checkpoint as
+"where we left off." If `pending.status` is `ready`, say there is unsaved work
+and offer to save a checkpoint before starting new work. If `pending.status` is
+`blocked`, explain the safety block and do not commit around it.
+
 **Provider facts first:** When setup or routing depends on GitHub, Cloudflare,
 Google/Workspace, Meta Ads, or Apify, read the status `integrations` facts
 first. If the operator needs a provider choice or repair explanation, run
@@ -94,6 +100,11 @@ Apply to: business repo selection, skill routing, any multiple choice.
 │   ├── readiness/drift blockers? ────→ use cited status repair commands
 │   └── unavailable section? ─────────→ use only the documented fallback for that section
 │
+├── Read checkpoint facts ────────────→ `mb checkpoint --status --json`
+│   ├── recent checkpoint? ───────────→ summarize "where we left off"
+│   ├── pending ready? ───────────────→ offer to save before new work
+│   └── pending blocked? ─────────────→ explain safety block; do not commit
+│
 ├── Check engine updates ──────────────→ Use status update severity and `mb update`
 │
 ├── Load config ──────────────────────→ See [config-system.md](references/config-system.md)
@@ -171,6 +182,27 @@ Use this report before asking additional questions:
 Only run a narrower fallback command such as `mb onboard status --json`,
 `mb doctor`, `mb validate --cross-refs`, or `mb connect doctor --json` when status
 points at that section as unavailable, degraded, or needing repair.
+
+## Step 0b: Read Checkpoint Facts
+
+Then run:
+
+```bash
+mb checkpoint --status --json
+```
+
+Use this report for session continuity:
+
+- `recent[0]` is the latest checkpoint commit. Summarize it in plain English
+  before asking the user to choose work.
+- `pending.status == "ready"` means the repo has unsaved meaningful work. Ask:
+  "Want me to save a checkpoint before we start something new?"
+- If the user says yes, run:
+  `mb checkpoint --message "[checkpoint] <plain summary>" --yes`
+- `pending.status == "blocked"` means safety gates found a local bridge file,
+  secret-like content, conflict, or engine-repo write. Explain the block and do
+  not work around it with raw git commands.
+- `pending.status == "clean"` means there is no unsaved checkpoint work.
 
 ## Step 1: Pull Engine Updates
 

--- a/.claude/skills/mb-think/SKILL.md
+++ b/.claude/skills/mb-think/SKILL.md
@@ -21,6 +21,14 @@ Something came your way — a video, a voice memo, a vague feeling, a problem to
 - Switching focus
 - Anytime you feel lost
 
+**Save checkpoints at natural boundaries.** After a research batch, accepted
+decision, codify pass, or major reference-file update, run
+`mb checkpoint --plan --json`. If the plan is ready, ask whether to save a
+checkpoint before moving to the next phase. If approved, run
+`mb checkpoint --message "[checkpoint] <plain business summary>" --yes`. If the
+plan is blocked, explain the safety block and do not work around it with raw
+git.
+
 ---
 
 ## Two Modes of Work

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 - Added guarded `mb checkpoint --message ... --yes` execution so approved
   checkpoint plans can become readable git commits without exposing raw git
   mechanics to beginners. Refs #291.
+- Added checkpoint resume facts to `mb start --json` and wired `/mb-start`,
+  `/mb-end`, and `/mb-think` toward `mb checkpoint` so checkpointing can happen
+  throughout long agent sessions instead of only at end-of-day. Refs #292.
 
 ## [0.3.0] - 2026-05-04
 

--- a/mb/mb/checkpoint.py
+++ b/mb/mb/checkpoint.py
@@ -319,6 +319,71 @@ def _head_sha(repo: Path) -> str:
     return result.stdout.strip() if result.returncode == 0 else ""
 
 
+def recent(repo: str | Path = ".", *, limit: int = 5) -> dict[str, Any]:
+    """Return recent checkpoint commits for resume surfaces."""
+    target = Path(repo).resolve()
+    root, root_error = _git_root(target)
+    if root is None:
+        return {
+            "ok": False,
+            "repo": str(target),
+            "commits": [],
+            "errors": [root_error or "not a git repo"],
+        }
+    result = _run_git(
+        root,
+        [
+            "log",
+            f"--max-count={limit}",
+            "--grep=^\\[checkpoint\\]",
+            "--extended-regexp",
+            "--format=%H%x1f%ct%x1f%s",
+        ],
+    )
+    if result.returncode != 0:
+        return {
+            "ok": False,
+            "repo": str(root),
+            "commits": [],
+            "errors": [_git_error("git log checkpoint history", result)],
+        }
+    commits = []
+    for line in result.stdout.splitlines():
+        parts = line.split("\x1f", 2)
+        if len(parts) != 3:
+            continue
+        sha, timestamp, subject = parts
+        commits.append(
+            {
+                "sha": sha,
+                "timestamp": int(timestamp) if timestamp.isdigit() else 0,
+                "subject": subject,
+            }
+        )
+    return {"ok": True, "repo": str(root), "commits": commits, "errors": []}
+
+
+def status(repo: str | Path = ".", *, mode: str = "beginner") -> dict[str, Any]:
+    """Return checkpoint resume facts: recent checkpoints plus pending plan."""
+    planned = plan(repo=repo, mode=mode)
+    history = recent(repo=planned.get("repo", repo))
+    pending = {
+        "status": planned.get("status"),
+        "has_changes": planned.get("has_changes", False),
+        "summary": planned.get("summary", {}),
+        "proposal": planned.get("proposal"),
+        "safety": planned.get("safety", {}),
+        "errors": planned.get("errors", []),
+    }
+    return {
+        "ok": bool(planned.get("status") != "error" and history.get("ok")),
+        "repo": planned.get("repo") or history.get("repo") or str(Path(repo).resolve()),
+        "recent": history.get("commits", []),
+        "pending": pending,
+        "errors": [*planned.get("errors", []), *history.get("errors", [])],
+    }
+
+
 def plan(repo: str | Path = ".", *, mode: str = "beginner") -> dict[str, Any]:
     """Plan a checkpoint without staging or committing changes."""
     target = Path(repo).resolve()
@@ -552,4 +617,4 @@ def render_human(result: dict[str, Any]) -> None:
         print("suggested checkpoint:")
         print(f"  {proposal['message']}")
         print("")
-        print("This is a plan only. Commit execution ships in the next slice.")
+        print("This is a plan only. Rerun with --message and --yes to save it.")

--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -912,6 +912,11 @@ def checkpoint_cmd(
         "--plan",
         help="Preview checkpointable changes without committing.",
     ),
+    status_check: bool = typer.Option(
+        False,
+        "--status",
+        help="Show recent checkpoint commits plus pending checkpoint state.",
+    ),
     message: str = typer.Option("", "--message", "-m", help="Commit message for --yes."),
     yes: bool = typer.Option(False, "--yes", help="Save the checkpoint after safety gates pass."),
     mode: str = typer.Option(
@@ -924,6 +929,8 @@ def checkpoint_cmd(
     """Plan or save a git checkpoint."""
     if yes or message:
         result = checkpoint_mod.commit(repo=repo, message=message, mode=mode, yes=yes)
+    elif status_check:
+        result = checkpoint_mod.status(repo=repo, mode=mode)
     else:
         _ = plan
         result = checkpoint_mod.plan(repo=repo, mode=mode)

--- a/mb/mb/start.py
+++ b/mb/mb/start.py
@@ -10,6 +10,7 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from mb import checkpoint as checkpoint_mod
 from mb.engine import install_mode, link_status
 from mb.freshness import format_update_alert, package_update_status
 from mb.status import _looks_like_mainbranch_repo
@@ -233,6 +234,7 @@ def run(repo: str = ".", launch: bool = False) -> dict[str, Any]:
     claude_path = _which("claude")
     wiring = link_status(repo_path)
     update = package_update_status(repo_path)
+    checkpoint = checkpoint_mod.status(repo_path)
     checks = _build_checks(repo_shape, git, claude_path, wiring, update)
     hard_failures = _hard_failures(checks)
     handoff_ready = not hard_failures
@@ -263,6 +265,7 @@ def run(repo: str = ".", launch: bool = False) -> dict[str, Any]:
         "handoff_ready": handoff_ready,
         "repo": {"path": str(repo_path), **repo_shape},
         "update": update,
+        "checkpoint": checkpoint,
         "git": git,
         "runtime": {
             "name": "claude-code",
@@ -294,6 +297,7 @@ def render_human(report: dict[str, Any]) -> None:
     wiring = runtime["skill_wiring"]
     command = report["command"]
     launch = report["launch"]
+    checkpoint = report.get("checkpoint", {})
 
     console.print(f"\n[bold]mb start[/bold]  {repo['path']}\n")
     alert = format_update_alert(report.get("update", {}))
@@ -320,6 +324,12 @@ def render_human(report: dict[str, Any]) -> None:
         "[bold]Skills[/bold]  /mb-start "
         + ("[green]wired[/green]" if wiring["ok"] else "[red]missing[/red]")
     )
+    if isinstance(checkpoint, dict):
+        pending = checkpoint.get("pending", {})
+        recent = checkpoint.get("recent", [])
+        pending_status = pending.get("status") if isinstance(pending, dict) else "unknown"
+        recent_label = recent[0]["subject"] if isinstance(recent, list) and recent else "none yet"
+        console.print(f"[bold]Checkpoint[/bold]  pending={pending_status}  last={recent_label}")
 
     console.print("\n[bold]Command[/bold]")
     console.print(f"  {command['display']}")

--- a/mb/tests/test_checkpoint.py
+++ b/mb/tests/test_checkpoint.py
@@ -253,3 +253,23 @@ def test_checkpoint_commit_clean_repo_is_noop(tmp_path: Path) -> None:
     payload = json.loads(result.stdout)
     assert payload["status"] == "clean"
     assert payload["committed"] is False
+
+
+def test_checkpoint_status_reports_recent_checkpoint_and_pending_work(tmp_path: Path) -> None:
+    repo = _business_repo(tmp_path)
+    (repo / "core" / "offer.md").write_text("# Offer\nUpdated\n", encoding="utf-8")
+    checkpoint_mod.commit(
+        repo,
+        message="[checkpoint] Update offer",
+        yes=True,
+    )
+    (repo / "research" / "next.md").write_text("# Next\n", encoding="utf-8")
+
+    result = runner.invoke(app, ["checkpoint", "--repo", str(repo), "--status", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["recent"][0]["subject"] == "[checkpoint] Update offer"
+    assert payload["pending"]["status"] == "ready"
+    assert payload["pending"]["summary"]["surfaces"] == {"research": 1}

--- a/mb/tests/test_start.py
+++ b/mb/tests/test_start.py
@@ -46,6 +46,7 @@ def test_start_json_prints_ready_handoff(tmp_path: Path, monkeypatch) -> None:
     assert report["command"]["display"].endswith(" && claude")
     assert report["command"]["follow_up"] == "/mb-start"
     assert report["launch"]["requested"] is False
+    assert report["checkpoint"]["pending"]["status"] == "ready"
     assert "update" in report
     assert "ranked_actions" not in report
     assert "status" not in report
@@ -145,6 +146,47 @@ def test_start_does_not_run_full_status_pipeline(tmp_path: Path, monkeypatch) ->
     result = runner.invoke(app, ["start", "--repo", str(repo), "--json"])
 
     assert result.exit_code == 0
+
+
+def test_start_surfaces_recent_checkpoint_history(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(start_mod, "_which", _with_claude)
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+    subprocess_result = start_mod._run_command(
+        ["git", "config", "user.email", "test@example.com"],
+        cwd=repo,
+    )
+    assert subprocess_result["ok"] is True
+    subprocess_result = start_mod._run_command(
+        ["git", "config", "user.name", "Test User"], cwd=repo
+    )
+    assert subprocess_result["ok"] is True
+    subprocess_result = start_mod._run_command(["git", "add", "."], cwd=repo)
+    assert subprocess_result["ok"] is True
+    subprocess_result = start_mod._run_command(["git", "commit", "-m", "initial"], cwd=repo)
+    assert subprocess_result["ok"] is True
+    (repo / "core" / "offer.md").write_text("# Offer\n", encoding="utf-8")
+    commit = runner.invoke(
+        app,
+        [
+            "checkpoint",
+            "--repo",
+            str(repo),
+            "--message",
+            "[checkpoint] Update offer",
+            "--yes",
+            "--json",
+        ],
+    )
+    assert commit.exit_code == 0
+    (repo / "research" / "next.md").write_text("# Next\n", encoding="utf-8")
+
+    result = runner.invoke(app, ["start", "--repo", str(repo), "--json"])
+
+    assert result.exit_code == 0
+    report = json.loads(result.stdout)
+    assert report["checkpoint"]["recent"][0]["subject"] == "[checkpoint] Update offer"
+    assert report["checkpoint"]["pending"]["status"] == "ready"
 
 
 def test_start_asks_for_repo_when_path_is_not_business_repo(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- Adds `mb checkpoint --status --json` so agents can see recent checkpoints and pending unsaved work before starting a session.
- Adds checkpoint resume facts to `mb start --json` and the human `mb start` handoff.
- Routes `/mb-start`, `/mb-end`, and `/mb-think` through the checkpoint contract instead of ad hoc git staging.

## Scope
- In: checkpoint history/status API, start handoff facts, skill guidance for natural checkpoint boundaries, tests, changelog.
- Out: background autosave, dashboard UI, runtime-specific checkpoint buttons, raw git automation outside `mb checkpoint`.

## Commits
- `1ae8d81` — `[update] MAIN-233 wire checkpoint resume loop`.

## Release / Issues
- Release: v0.3.x
- Linear ID(s): MAIN-233
- Closes: #292
- Refs: #288, #290, #291
- Follow-ups: #295, #296, #297

## Success Metric
A fresh session can tell the user where they left off, detect unsaved meaningful work, and guide the agent to save a safe checkpoint through `mb checkpoint` at start/end/think boundaries.

## Validation
- Level 0 docs/decision: updated skill prose validates through the skill line/reference gate.
- Level 1 static: `scripts/check.sh` passed from repo root.
- Level 2 CLI: `cd mb && pytest tests/test_checkpoint.py tests/test_start.py -q` passed (`24 passed`).
- Level 3 package/install: covered by `scripts/check.sh` wheel-install smoke.
- Level 4 fixture repo: fresh `mb onboard`, initial git commit, `mb checkpoint --message "[checkpoint] Update runtime offer" --yes --json`, dirty follow-up, then `mb start --repo . --json`; latest checkpoint and pending work surfaced correctly.
- Level 5 runtime smoke: not run; this changes deterministic CLI facts and skill instructions, not runtime discovery. The skill bundle validation ran in `scripts/check.sh`.

## Public / Private Boundary
Committed content is public-safe. Safety remains inside `mb checkpoint`: local bridges, secret-like files, conflicts, and engine-repo writes stay blocked instead of being staged by skills with raw git commands.
