### PR TITLE
[docs] clarify migration state and release truth

### DIFF
--- a/.claude/skills/mb-help/SKILL.md
+++ b/.claude/skills/mb-help/SKILL.md
@@ -64,6 +64,7 @@ Answer questions, troubleshoot issues, explain philosophy, suggest next steps.
 | Question | Answer |
 |----------|--------|
 | Start Claude in a folder? | `cd ~/Documents/GitHub/[your-business] && claude` — Claude sees files in that folder. Main Branch is linked via `settings.local.json`, with bridge links as a compatibility fallback for skill discovery. |
+| I see `.mb/`, not `.mb-vip/`. Is that wrong? | You're good. `.mb/` is the current repo-local Main Branch state folder. `.mb-vip/` was old clone-based setup language and is not required. If slash commands are missing, run `mb update --repo .`, `mb skill link --repo .`, `mb skill repair --repo .`, then restart Claude. |
 | Do I start Claude in the business repo or site repo? | Start in the business repo for planning and creating a site. Switch to the site repo after it exists for edits, review, deploy, and `mb site check`; the site repo should have `.mainbranch/source.json` pointing back to the business repo. |
 | When use skill prompts? | For structured tasks: `/mb-start`, `/mb-think`, `/mb-ads`, `/mb-vsl` |
 | Drag files in? | Drag from Finder into Terminal, path appears |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -382,6 +382,19 @@ PR bodies should give reviewers product scope and validation evidence:
 Update `CHANGELOG.md` for user-visible CLI, skill, packaging, compatibility, or
 workflow changes. Skip it only for invisible maintenance.
 
+## Release Truth
+
+Do not describe a version as shipped until the release surfaces agree:
+
+- `CHANGELOG.md` has the version section;
+- the matching `oe-vX.Y.Z` GitHub Release exists;
+- PyPI shows `mainbranch X.Y.Z` when the change is package-visible;
+- release notes, README copy, and roadmap language match those facts.
+
+`CHANGELOG.md` may describe unreleased work only under `[Unreleased]`. If a
+draft PR, planning doc, or local branch mentions a version that has not been
+released, use "planned", "target", or "next" rather than "shipped".
+
 ## Review Focus
 
 When reviewing, lead with findings:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,15 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   `/mb-end`, and `/mb-think` toward `mb checkpoint` so checkpointing can happen
   throughout long agent sessions instead of only at end-of-day. Refs #292.
 
+### Changed
+
+- Clarified beginner, migration, and `/mb-help` docs that `.mb/` is the current
+  repo-local Main Branch state folder and `.mb-vip/` is not required. Refs
+  #296.
+- Added release-truth rules to the agent contract and OSS checklist so docs do
+  not describe a version as shipped until CHANGELOG, GitHub Release, and PyPI
+  state agree. Closes #295.
+
 ## [0.3.0] - 2026-05-04
 
 v0.3.0 makes Main Branch better at telling a user what matters next. It adds

--- a/docs/BEGINNER-SETUP.md
+++ b/docs/BEGINNER-SETUP.md
@@ -82,6 +82,11 @@ files, git, and GitHub, scaffolds the business folder taxonomy (`core/`,
 `research/`, `decisions/`, `bets/`, `log/`, `campaigns/`, `documents/`), and wires the
 bridge files Claude Code needs to find Main Branch's skills.
 
+You may also see a `.mb/` folder. That is normal. It stores Main Branch's local
+operational state for that business repo, such as onboarding progress, safe
+provider metadata, backups, and issue drafts. You do not need a `.mb-vip/`
+folder; that name comes from the old clone-based setup.
+
 ---
 
 ## Step 3: First Session
@@ -243,6 +248,9 @@ mb skill repair --repo .
 
 Then restart Claude. This re-wires skill discovery in your business repo and
 checks whether an old personal skill is taking precedence.
+
+**I only see `.mb/`, not `.mb-vip/`:** good. `.mb/` is the current folder.
+`.mb-vip/` was old setup language and is not required.
 
 **`mb` not found after install:** run `pipx ensurepath`, close your terminal completely, reopen it.
 

--- a/docs/MIGRATING.md
+++ b/docs/MIGRATING.md
@@ -12,6 +12,29 @@ Existing repos do not need an urgent file move. The safe path is to update the
 engine first, repair skill discovery, and only migrate file layout on a clean
 branch when you need the new shape.
 
+## `.mb` Is The Current Folder
+
+If you see a `.mb/` folder in your business repo, that is expected. `.mb/` is
+Main Branch's repo-local operational state: onboarding progress, provider
+metadata, backups, issue drafts, schema markers, and other rebuildable helper
+files.
+
+You do **not** need a `.mb-vip/` folder. That name belongs to old clone-based
+setup language and the former internal repo name. The current pipx setup does
+not require a local engine clone inside your business repo.
+
+Open Claude Code in the business repo folder, not in an engine clone. If
+slash commands are missing, repair the skill wiring instead of creating a
+`.mb-vip/` folder:
+
+```bash
+mb update --repo .
+mb skill link --repo .
+mb skill repair --repo .
+mb doctor
+mb status
+```
+
 ## Recommended: Let Claude Walk You Through It
 
 If you are already using Main Branch and do not want to reason about old

--- a/docs/OSS-OPERATING-CHECKLIST.md
+++ b/docs/OSS-OPERATING-CHECKLIST.md
@@ -112,6 +112,10 @@ that keep Main Branch usable as public infrastructure while it evolves quickly.
 - [ ] Deprecated CLI surfaces, schemas, JSON contracts, or runtime adapters are
   marked with the deprecation date, the release that will remove them, and a
   migration command or fallback so users are not stranded.
+- [ ] Public docs describe a version as shipped only when `CHANGELOG.md`, the
+  matching `oe-vX.Y.Z` GitHub Release, and PyPI package state agree.
+- [ ] Planned release copy uses "planned", "target", or "next" until release
+  verification proves users can install it.
 
 ## 8. Issue / PR Discipline
 


### PR DESCRIPTION
## Summary
- Clarifies that `.mb/` is the current repo-local Main Branch state folder and `.mb-vip/` is not required.
- Adds the same answer to beginner setup, migration docs, and `/mb-help` so confused existing users get one consistent reply.
- Adds release-truth rules to AGENTS and the OSS checklist so agents do not call a version shipped until CHANGELOG, GitHub Release, and PyPI agree.

## Scope
- In: beginner/migration/help docs, public agent rules, OSS checklist, changelog.
- Out: CLI behavior, migration implementation, JSON envelope normalization.

## Commits
- `67e73d1` — `[docs] Clarify migration state and release truth`.

## Release / Issues
- Release: v0.3.x
- Linear ID(s): none
- Closes: #295, #296
- Refs: #297
- Follow-ups: #297

## Success Metric
A user who sees `.mb/` but not `.mb-vip/` can tell they are set up correctly, and future agents have a written release-truth rule before updating public docs.

## Validation
- Level 0 docs/decision: links and wording checked while editing.
- Level 1 static: `scripts/check.sh` passed from repo root (`226 passed`, skill validation clean).
- Level 2 CLI: not needed; docs/help-only change.
- Level 3 package/install: not needed; no packaging changes.
- Level 4 fixture repo: not needed; no CLI behavior changes.
- Level 5 runtime smoke: not needed; `/mb-help` text changed, discovery did not.

## Public / Private Boundary
Public-safe. The docs avoid private paths and tell users not to create/delete legacy folders; repair stays through Main Branch commands.
