### PR TITLE
[update] Reconcile bundled skills around CLI facts

### DIFF
--- a/.claude/skills/mb-ads/SKILL.md
+++ b/.claude/skills/mb-ads/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: mb-ads
 description: "Create and review Meta/Facebook/Instagram ads. Flexible entry points: full pipeline (copy + images), copy only, images only, creative variations (hook library), video scripts, video repurpose, compliance review, or ad account check (Pipeboard). Use when asked to create ads, ad copy, image prompts, video scripts, creative variations, or review ads. Say /mb-ads or describe what you need."
+loops: [ship, reflect]
 ---
 
 # Ads Skill

--- a/.claude/skills/mb-ads/SKILL.md
+++ b/.claude/skills/mb-ads/SKILL.md
@@ -9,7 +9,10 @@ Create ads, generate creative variations, review for compliance, and check ad ac
 
 ## Step 0: Pre-Flight Readiness
 
-**Before triage, find the business repo and score reference file depth.** This prevents generating generic ads from thin reference.
+**Before triage, find the business repo, read deterministic Main Branch facts,
+then score ad-specific reference depth only when needed.** This prevents
+generating generic ads from thin reference without duplicating repo-health or
+provider checks that `mb` already owns.
 
 ### 0a. Find Business Repo (REQUIRED — do this first)
 
@@ -19,16 +22,25 @@ Create ads, generate creative variations, review for compliance, and check ad ac
 
 If CWD is NOT a business repo:
 
+Run:
+
 ```bash
-cat ~/.config/vip/local.yaml 2>/dev/null
+mb status --json --peek
 ```
 
-- If `default_repo:` exists → **ask user to confirm:** "Found saved repo: [name]. Use this? (y/n)"
-- If no config or no default_repo → **ask the user:** "Which business repo should I use? Give me the path."
-- If the command returns nothing or errors → **that is fine. Just ask the user. Do NOT search for repos.**
-- If `/mb-ads` was invoked from `/mb-start`, the repo is already identified — use it without asking.
+- If status identifies a usable business repo, ask the user to confirm it.
+- If status cannot identify a repo, ask: "Which business repo should I use?
+  Give me the path."
+- If `/mb-ads` was invoked from `/mb-start`, the repo is already identified —
+  use it without asking.
 
 **Always confirm the repo before proceeding.** Never assume.
+
+After the repo is confirmed, run `mb status --json --peek` from that repo. Use
+`readiness`, `drift.items`, `integrations`, `measurement`, and `ranked_actions`
+as the source of truth for setup, stale context, GitHub, provider readiness, and
+repair commands. Only run the direct scoring below for ad-specific creative
+depth when status is unavailable or lacks the needed ad-specific detail.
 
 ### 0b. Score Reference Files (fast — direct Read only, NO agents)
 
@@ -60,20 +72,23 @@ Composite = sum of all 6 scores (max 18).
 
 Display the readiness report, then proceed. See [references/preflight-algorithm.md](references/preflight-algorithm.md) for gap guidance and smart mix recommendations.
 
-### 0d. Check Nano Banana
+### 0d. Check Image Generation Readiness
 
 ```bash
-source ~/.config/vip/env.sh 2>/dev/null; echo "GOOGLE_API_KEY=${GOOGLE_API_KEY:+set}"
+mb connect doctor --json
 ```
 
-If set, note it for Batch 4 image generation after copy is saved.
+Use status/connect facts first for Google/Workspace readiness. Only check local
+environment variables when image generation is actually selected and the CLI
+does not report that capability. Never ask the operator to paste API keys into
+chat or public issue text.
 
 ### 0e. Paid-Traffic Measurement Gate
 
 If this ad work is for Google Ads, paid traffic to a site/minisite/lander, retargeting, or any request that asks whether a campaign is ready to launch, check measurement readiness before saying "launch."
 
 1. Load `docs/google-ads-gtm-conversion-rubric.md`.
-2. Run `mb connect plan` or `mb connect status --all --json` from the business repo when provider readiness matters.
+2. Run `mb connect plan` or `mb connect doctor --json` from the business repo when provider readiness matters.
 3. If a site repo is known, run:
 
 ```bash
@@ -93,40 +108,25 @@ Never ask the operator to paste Google Ads/GTM tokens, OAuth secrets, conversion
 
 ---
 
-## Pipeboard Detection (Lazy)
+## Meta Ad Account Readiness (Lazy)
 
-Check for Meta ad account access on first /mb-ads invocation when topic is ads-related. Same pattern as Gemini/Grok/whisper detection -- config-first, probe unknowns, cache results.
+Check Meta ad account access only when the user's request needs live ad account
+context. Do not duplicate provider setup or health checks in prose.
 
-### Detection Flow
+### Readiness Flow
 
 ```
-1. Read .vip/config.yaml → tools.pipeboard
-2. If status: true → note available, skip detection
-3. If status: false AND last_checked is valid and <30 days old → skip
-4. If status: null OR missing OR stale false:
-   a. Check for mcp__pipeboard__* tools in session
-   b. If found: probe with get_ad_accounts (lightweight)
-   c. If probe succeeds: write status: true to config
-   d. If not found or probe fails: write status: false to config
-5. Never block on detection failure
+1. Read `mb status --json --peek` → integrations/providers/measurement facts.
+2. If the operator needs setup choices, run `mb connect plan`.
+3. If something looks broken, run `mb connect doctor --json`.
+4. Only after `mb` says Meta Ads account context is ready or repairable, check
+   whether the current Claude Code session exposes the required read-only MCP
+   tools.
+5. Never block generation on missing ad account access.
 ```
 
-`stale false` means: `status: false` and `last_checked` is missing, invalid, or >=30 days old.
-
-### Config Update (REQUIRED after detection)
-
-```yaml
-tools:
-  pipeboard:
-    status: true              # detection result
-    method: mcp
-    tier: free                # free | pro (self-reported)
-    notes: "meta-ads MCP configured via remote URL"
-    last_checked: 2026-02-10
-    weekly_calls_used: 0      # lightweight tracking (Phase 1.5)
-```
-
-**Graceful degradation:** If Pipeboard is not configured, skip all account-related features. The skill works fully without it. Pipeboard is additive, not required.
+**Graceful degradation:** If Meta Ads account context is not ready, skip all
+account-related features. The skill works fully from repo reference files.
 
 ### User-Facing Display
 
@@ -134,16 +134,16 @@ tools:
 
 **Pre-flight status line (add after Nano Banana check):**
 
-If configured:
+If ready:
 > `Ad account:   ✓ connected (I can check what's performing before we create)`
 
-If not configured:
+If not ready:
 > `Ad account:   — not connected (optional — lets me see your live Meta ad performance to inform new ads)`
 
 **Never say:** "Pipeboard: not configured (no account check — that's fine)" — this means nothing to a new user.
 
 **If user asks what this means:**
-> "You can optionally connect your Meta/Facebook ad account so I can pull live performance data — what's spending, what's winning, CPAs, creative that's working. This helps me create ads that fit your account structure and build on what's already performing. It uses a tool called Pipeboard (free tier: 30 calls/week). Want to set it up, or skip and work from your reference files?"
+> "You can optionally connect your Meta/Facebook ad account so I can pull live performance data — what's spending, what's winning, CPAs, creative that's working. This helps me create ads that fit your account structure and build on what's already performing. Want to run `mb connect plan`, or skip and work from your reference files?"
 
 ---
 
@@ -162,9 +162,9 @@ Detect what the user wants from natural language. Route internally to the right 
 | "video scripts", "ad scripts", "spoken word" | Video Scripts | Spoken-word script pipeline |
 | "I'm repurposing a video", "I shot a video" | Video Repurpose | Transcribe + extract hooks + copy variants |
 | "I want ideas for an ad", "brainstorm" | Ideation | Account check (if available) + concept generation |
-| "Check my ad performance", "what's working" | Account Check | Pipeboard read-only (requires Pipeboard) |
-| "Give me 5 variations of this winning ad" | Performance Iteration | Pull winner + generate variants (requires Pipeboard) |
-| "What's working before we create?" | Pre-Gen Account Check | Account overview + creative audit (requires Pipeboard) |
+| "Check my ad performance", "what's working" | Account Check | Read-only Meta Ads context if `mb connect` and runtime tools are ready |
+| "Give me 5 variations of this winning ad" | Performance Iteration | Pull winner + generate variants if account context is ready |
+| "What's working before we create?" | Pre-Gen Account Check | Account overview + creative audit if account context is ready |
 | "review", "audit", "compliance check" | Review | 6-lens compliance review |
 
 **Also accepts:** "static", "static ads", "video", "video scripts", "one-liners", "review" -- these route to the same pipelines.
@@ -173,7 +173,8 @@ Detect what the user wants from natural language. Route internally to the right 
 
 ### Proactive Account Awareness
 
-If Pipeboard is configured (tools.pipeboard.status: true in config):
+If `mb status --json --peek` / `mb connect doctor --json` reports Meta Ads
+ready and the current runtime exposes the read-only ad account tools:
 
 **Before generating:** Suggest checking the account first. Explain the value briefly — don't assume the user knows what this does:
 > "Your Meta ad account is connected. Want me to pull your live performance data first? I can see what's spending, which creative has the best CPA, and use that to inform what we create. (Takes ~30 seconds.)"
@@ -186,7 +187,7 @@ If user says yes, run Account Check component (see [references/pipeboard-integra
 
 If user says no, proceed to generation with reference files only.
 
-**After generating:** If Pipeboard is available, show account context:
+**After generating:** If Meta Ads account context is available, show account context:
 > "Here's what's currently live. Your new creative could fit as [suggested placement]."
 
 Account awareness is currently read-only. Write operations (duplicate + swap) are on the roadmap -- see [references/pipeboard-integration.md](references/pipeboard-integration.md).
@@ -252,7 +253,7 @@ Before creating ads, the business repo must have:
 | Visual Style | `reference/visual-identity/visual-style.md` | Optional (affects image gen) |
 | Content Strategy | `reference/domain/content-strategy.md` (always brand-level) | Optional (improves topic selection) |
 | Skool Surfaces | `reference/domain/funnel/skool-surfaces.md` | Optional (congruence check) |
-| Ad Account Access | `.vip/config.yaml` → `tools.pipeboard.status` | Optional (enables live performance data) |
+| Ad Account Access | `mb status --json --peek` + `mb connect doctor --json` | Optional (enables live performance data) |
 
 If required files are missing, Step 0 pre-flight catches this and routes appropriately.
 
@@ -354,7 +355,7 @@ If context was compacted mid-task, check:
 2. **What entry point?** Full pipeline, copy only, hook library, video scripts, review, account check
 3. **What stage?** Planning angles, writing hooks, generating prompts, reviewing, pulling account data
 4. **What's done?** Check outputs/ folder for partial work
-5. **Pipeboard status?** Read `.vip/config.yaml` for `tools.pipeboard.status`
+5. **Ad account status?** Re-run `mb status --json --peek`; if needed, run `mb connect doctor --json`
 6. **Resume:** Continue from the last completed step
 
 For full pipeline: Did we finish image prompts (Part 1) before copy (Part 2)?
@@ -370,4 +371,4 @@ For review: Which lenses completed?
 **Hook library (creative variations):** Flexible quantity (default 30), Andromeda-optimized
 **Video scripts:** 15-30 diverse scripts, spoken-word optimized
 **Review:** 6 lenses, P1/P2/P3 report, fix suggestions
-**Account check:** Pipeboard read-only -- campaigns, performance, creative audit (requires Pipeboard)
+**Account check:** read-only Meta Ads context -- campaigns, performance, creative audit when `mb connect` and runtime tools are ready

--- a/.claude/skills/mb-ads/references/image-generation-workflow.md
+++ b/.claude/skills/mb-ads/references/image-generation-workflow.md
@@ -37,8 +37,9 @@ python3 -c "from google import genai; print('OK')" 2>/dev/null
 **If unavailable:** Output text prompts only. Note: "Image prompts saved. Paste into Gemini or another image tool to generate."
 
 Use `mb status --json --peek` / `mb connect doctor --json` first for
-Google/Workspace readiness. Treat the local SDK import check above as a
-runtime-only fallback when the selected mode actually needs image generation.
+Google/Workspace readiness. Those commands do not prove the Gemini API key used
+by Nano Banana is present; use the local SDK/env check above when the selected
+mode actually needs image generation.
 
 ---
 

--- a/.claude/skills/mb-ads/references/image-generation-workflow.md
+++ b/.claude/skills/mb-ads/references/image-generation-workflow.md
@@ -36,7 +36,9 @@ python3 -c "from google import genai; print('OK')" 2>/dev/null
 **If available:** Offer Batch 4 (image generation) after copy + compliance.
 **If unavailable:** Output text prompts only. Note: "Image prompts saved. Paste into Gemini or another image tool to generate."
 
-Also check `.vip/config.yaml` → `tools.nano_banana.status` for cached detection result.
+Use `mb status --json --peek` / `mb connect doctor --json` first for
+Google/Workspace readiness. Treat the local SDK import check above as a
+runtime-only fallback when the selected mode actually needs image generation.
 
 ---
 

--- a/.claude/skills/mb-ads/references/pipeboard-integration.md
+++ b/.claude/skills/mb-ads/references/pipeboard-integration.md
@@ -1,14 +1,19 @@
 # Pipeboard Integration
 
-Meta ad account awareness via Pipeboard MCP. Read-only in Phase 1. Write operations in Phase 1.5.
+Meta ad account awareness via a read-only runtime MCP. `mb connect` owns
+provider readiness and repair facts; this reference only describes how account
+context is used once the provider and runtime tool are ready.
 
 ---
 
 ## What Pipeboard Provides
 
-Pipeboard exposes Meta's Marketing API as 29 MCP tools via remote MCP at `mcp.pipeboard.co/meta-ads-mcp`. OAuth handles auth -- no local install, no Meta Developer account needed.
+Pipeboard is the current MCP implementation for Meta account reads. OAuth
+handles auth -- no local install or committed secret is required.
 
-**Detection:** Lazy -- triggered at /mb-think or /mb-ads when ads-related, NOT at /mb-start. See detection flow in SKILL.md.
+**Readiness:** Lazy -- triggered at `/mb-think` or `/mb-ads` when ads-related,
+not at `/mb-start`. Start with `mb status --json --peek` and
+`mb connect doctor --json`; only then check runtime MCP tool presence.
 
 ---
 
@@ -148,7 +153,8 @@ Pro tier supports daily checks and multiple creative iterations per week with he
 
 ## Graceful Degradation
 
-Pipeboard is **additive, not required.** The entire /mb-ads skill works without it.
+Ad account context is **additive, not required.** The entire /mb-ads skill works
+without it.
 
 | With Ad Account Connected | Without Ad Account |
 |---------------------------|-------------------|
@@ -158,49 +164,47 @@ Pipeboard is **additive, not required.** The entire /mb-ads skill works without 
 | Suggest where new creative fits | User decides placement |
 | Duplicate + swap (Phase 1.5) | Manual upload in Ads Manager |
 
-**Never block on missing ad account connection.** If detection fails or tool is missing, proceed with standard generation flow. Mention the option once per session, then move on.
+**Never block on missing ad account connection.** If `mb connect` reports a
+missing provider or the runtime tool is unavailable, proceed with standard
+generation flow. Mention the option once per session, then move on.
 
 ---
 
-## Config Schema
+## Provider Facts
 
-```yaml
-# In .vip/config.yaml under tools:
-tools:
-  pipeboard:
-    status: true              # true | false | null
-    method: mcp               # always mcp for Pipeboard
-    tier: free                # free | pro (self-reported or detected)
-    notes: "meta-ads MCP configured via remote URL"
-    last_checked: 2026-02-10  # date of last detection
-    weekly_calls_used: 0      # lightweight tracking (Phase 1.5)
+Provider metadata and repair state come from the CLI:
+
+```bash
+mb status --json --peek
+mb connect plan
+mb connect doctor --json
 ```
+
+Use the CLI's `summary`, `next_command`, and `repair_command` fields. Do not
+write provider readiness into `.vip/config.yaml` from this skill.
 
 ---
 
-## Detection Flow
+## Readiness Flow
 
-Triggered lazily at /mb-think or /mb-ads when topic is ads-related:
+Triggered lazily at `/mb-think` or `/mb-ads` when topic is ads-related:
 
 ```
-1. Read .vip/config.yaml → tools.pipeboard
-2. If status: true → use it, skip detection
-3. If status: false AND last_checked is valid and <30 days old → skip
-4. If status: null OR missing OR stale false:
-   a. Check for mcp__pipeboard__* tools in session
-   b. If found: probe with get_ad_accounts (lightweight)
-   c. If probe succeeds: write status: true to config
-   d. If not found or probe fails: write status: false to config
-5. Never block on detection failure
+1. Read `mb status --json --peek`.
+2. If the operator needs setup choices, run `mb connect plan`.
+3. If the provider is degraded or missing, run `mb connect doctor --json` and
+   quote the repair command.
+4. If provider facts are ready, check for read-only ad account MCP tools in the
+   current runtime session.
+5. Never block generation on missing account access.
 ```
-
-`stale false` means: `status: false` and `last_checked` is missing, invalid, or >=30 days old.
 
 ---
 
 ## Proactive Suggestions
 
-When Pipeboard is configured, skills suggest account access at natural moments. **Always describe the capability, not the tool name.** Users may not know what "Pipeboard" is -- lead with what it DOES.
+When ad account context is ready, skills suggest account access at natural
+moments. **Always describe the capability, not the tool name.**
 
 | Context | Suggestion |
 |---------|-----------|
@@ -246,11 +250,15 @@ The user should never stare at a blank screen wondering what happened.
 
 ## Provider Abstraction
 
-The skill logic is **provider-agnostic.** Pipeboard is the current implementation, but the skill refers to "ad account access" not "Pipeboard" in user-facing messages. This means swapping to Composio, DIY Meta SDK, or another MCP server later requires only:
+The skill logic is **provider-agnostic.** Pipeboard is the current runtime
+implementation, but the skill refers to "ad account access" in user-facing
+messages. Swapping to Composio, DIY Meta SDK, or another MCP server later should
+only require:
 
-1. Update detection method in config
-2. Update tool name prefixes (e.g., `mcp__composio__*` instead of `mcp__pipeboard__*`)
-3. Skill logic and user experience stay the same
+1. Update the runtime tool prefix check (e.g., `mcp__composio__*` instead of
+   `mcp__pipeboard__*`)
+2. Keep provider readiness behind `mb connect`
+3. Keep skill logic and user experience the same
 
 ---
 

--- a/.claude/skills/mb-ads/references/preflight-algorithm.md
+++ b/.claude/skills/mb-ads/references/preflight-algorithm.md
@@ -1,17 +1,31 @@
 # Pre-Flight Readiness Algorithm
 
-Score reference file depth before generating ads. Prevents thin reference from producing generic output.
+Read deterministic status first, then score ad-specific reference depth before
+generating ads when status lacks the needed creative detail. This prevents thin
+reference from producing generic output without duplicating repo-health,
+provider, drift, or setup checks.
 
 ---
 
 ## When to Run
 
-- **`/mb-ads` Step 0** — Before triage menu appears
-- **`/mb-start`** — As part of global gap scan (surfaces priorities)
+- **`/mb-ads` Step 0** — After `mb status --json --peek`, before triage menu appears
+- **`/mb-start`** — Only as fallback/detail after status `readiness`
 
 ---
 
 ## Scoring Matrix
+
+First run:
+
+```bash
+mb status --json --peek
+```
+
+Use status `readiness`, `drift.items`, `ranked_actions`, `integrations`, and
+`measurement` as source of truth for setup, stale context, provider readiness,
+and repair commands. The scoring below is ad-specific creative depth, not repo
+health.
 
 Score each file 0-3 based on line count + section presence.
 

--- a/.claude/skills/mb-bet/SKILL.md
+++ b/.claude/skills/mb-bet/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: mb-bet
-description: "Open, update, close, list, and show Main Branch business bets from repo truth. Use when the operator wants to frame an operating bet, track progress, capture a verdict, or draft public-safe show copy."
+description: "Open, update, close, list, and narrate Main Branch business bets from repo truth. Use when the operator wants to frame an operating bet, track progress, capture a verdict, or draft public-safe narration."
+loops: [decide, reflect, ship]
 ---
 
 # Bet
@@ -19,9 +20,9 @@ Use `/mb-bet` for five modes:
 - `update` - add progress and link new evidence.
 - `close` - record result, verdict, learning, and follow-up links.
 - `list` - summarize active bets and deadlines.
-- `show` - draft public-safe site, community, or social copy from repo truth.
+- `narrate` - draft public-safe site, community, or social copy from repo truth.
 
-Do not publish automatically. Show drafts are files or message drafts only.
+Do not publish automatically. Narration drafts are files or message drafts only.
 
 ## Repo Rules
 
@@ -122,7 +123,7 @@ Body template:
 
 Open.
 
-## Show Notes
+## Narration Notes
 
 [Public-safe angles, claims to avoid, proof needed before sharing.]
 ```
@@ -162,9 +163,9 @@ Summarize active bets from `mb status --json --peek` and direct file reads:
 
 Keep it short. End with the next bet that needs attention.
 
-## Mode: show
+## Mode: narrate
 
-Draft public-safe show copy from the bet and linked repo truth. Do not invent
+Draft public-safe narration from the bet and linked repo truth. Do not invent
 results, metrics, claims, testimonials, or publishing channels.
 
 Ask the operator which surface if unclear:
@@ -176,7 +177,7 @@ Ask the operator which surface if unclear:
 Draft format:
 
 ```markdown
-# Show Draft
+# Narration Draft
 
 Surface: [site/community/social]
 Source bet: bets/YYYY-MM-DD-slug.md

--- a/.claude/skills/mb-bet/SKILL.md
+++ b/.claude/skills/mb-bet/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mb-bet
-description: "Open, update, close, list, and narrate Main Branch business bets from repo truth. Use when the operator wants to frame an operating bet, track progress, capture a verdict, or draft public-safe narration."
+description: "Open, update, close, list, and show Main Branch business bets from repo truth. Use when the operator wants to frame an operating bet, track progress, capture a verdict, or draft public-safe show copy."
 ---
 
 # Bet
@@ -19,9 +19,9 @@ Use `/mb-bet` for five modes:
 - `update` - add progress and link new evidence.
 - `close` - record result, verdict, learning, and follow-up links.
 - `list` - summarize active bets and deadlines.
-- `narrate` - draft public-safe site, community, or social copy from repo truth.
+- `show` - draft public-safe site, community, or social copy from repo truth.
 
-Do not publish automatically. Narration drafts are files or message drafts only.
+Do not publish automatically. Show drafts are files or message drafts only.
 
 ## Repo Rules
 
@@ -32,7 +32,7 @@ operator to start Claude from the business repo or run `/mb-start`.
 Before writing, run:
 
 ```bash
-mb status --json
+mb status --json --peek
 ```
 
 Use the result to spot active bets and repo readiness. After writing or editing
@@ -122,7 +122,7 @@ Body template:
 
 Open.
 
-## Narration Notes
+## Show Notes
 
 [Public-safe angles, claims to avoid, proof needed before sharing.]
 ```
@@ -151,7 +151,7 @@ Use when the deadline passed, the target is hit, or the operator decides to stop
 
 ## Mode: list
 
-Summarize active bets from `mb status --json` and direct file reads:
+Summarize active bets from `mb status --json --peek` and direct file reads:
 
 - deadline
 - status
@@ -162,9 +162,9 @@ Summarize active bets from `mb status --json` and direct file reads:
 
 Keep it short. End with the next bet that needs attention.
 
-## Mode: narrate
+## Mode: show
 
-Draft public-safe narration from the bet and linked repo truth. Do not invent
+Draft public-safe show copy from the bet and linked repo truth. Do not invent
 results, metrics, claims, testimonials, or publishing channels.
 
 Ask the operator which surface if unclear:
@@ -176,7 +176,7 @@ Ask the operator which surface if unclear:
 Draft format:
 
 ```markdown
-# Narration Draft
+# Show Draft
 
 Surface: [site/community/social]
 Source bet: bets/YYYY-MM-DD-slug.md

--- a/.claude/skills/mb-end/SKILL.md
+++ b/.claude/skills/mb-end/SKILL.md
@@ -64,6 +64,16 @@ A quick `/mb-end` (user says "just commit and close") can be steps 1-3 and 6. Bu
 
 ## Step 2: Scan Today's Activity
 
+First read checkpoint continuity:
+
+```bash
+mb checkpoint --status --json
+```
+
+Use `recent[]` to name where the last session left off and `pending.status` to
+explain whether meaningful unsaved work exists. Then scan today's activity for
+the reflective summary.
+
 Run these in the user's business repo:
 
 ```bash

--- a/.claude/skills/mb-end/SKILL.md
+++ b/.claude/skills/mb-end/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: mb-end
 description: "Session-closing skill that helps users wrap up intentionally. Use when: user says done, wrapping up, end my day, closing out, call it a day, goodnight, that's it for today, checkpoint, pause. Bookend to /mb-start. Scans git activity, surfaces what happened, spawns a crystallize agent for deep analysis, commits uncommitted work, and closes with a brief summary. Works for end-of-day, end-of-research-batch, end-of-decision-sprint, or mid-work checkpoints."
+loops: [reflect, ship]
 ---
 
 # End

--- a/.claude/skills/mb-end/SKILL.md
+++ b/.claude/skills/mb-end/SKILL.md
@@ -64,16 +64,6 @@ A quick `/mb-end` (user says "just commit and close") can be steps 1-3 and 6. Bu
 
 ## Step 2: Scan Today's Activity
 
-First read checkpoint continuity:
-
-```bash
-mb checkpoint --status --json
-```
-
-Use `recent[]` to name where the last session left off and `pending.status` to
-explain whether meaningful unsaved work exists. Then scan today's activity for
-the reflective summary.
-
 Run these in the user's business repo:
 
 ```bash
@@ -284,14 +274,10 @@ If an insight was substantial enough to update reference directly (soul.md, offe
 
 ## Step 6: Checkpoint & Close
 
-Use the checkpoint CLI. Do not hand-roll staging logic unless `mb checkpoint`
-is unavailable.
+Use the current repo git workflow with explicit operator approval. The
+checkpoint CLI is future v0.3.x work; do not ask current PyPI users to run it.
 
-```bash
-mb checkpoint --plan --json
-```
-
-**If `status == "ready"`:**
+**If there are unsaved changes:**
 
 > "You have unsaved work:
 >
@@ -300,18 +286,16 @@ mb checkpoint --plan --json
 > Want me to save a checkpoint before we close?"
 
 If yes:
-- Run `mb checkpoint --message "[checkpoint] <plain business summary>" --yes`.
+- Stage only the intended business-repo files.
+- Commit with a readable operator subject.
 - Use beginner-safe language: "saved checkpoint," not "ran git commit."
 - Include the crystallize research file in the checkpoint if one was created.
 
 If no: Leave the work unchanged. Some people prefer to checkpoint at the start
 of next session.
 
-**If `status == "blocked"`:** Explain the safety block from JSON. Do not commit
-around it with raw git. Tell the user the checkpoint was not saved because Main
-Branch found something that may be local, private, conflicted, or unsafe.
-
-**If `status == "clean"`:** Skip this.
+If safety is unclear, do not stage or commit. Explain the block and leave the
+work unchanged.
 
 ### The Close
 

--- a/.claude/skills/mb-help/SKILL.md
+++ b/.claude/skills/mb-help/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: mb-help
 description: "Answer questions about Main Branch and Claude Code. Use when: user asks how/what/why questions, is confused about two-repo model or skills, encounters errors, says help or stuck, asks about workflow, is a beginner, or wants to know what to do next."
+loops: [sense, decide]
 ---
 
 # Help
@@ -27,7 +28,7 @@ Answer questions, troubleshoot issues, explain philosophy, suggest next steps.
 | Two repos, engine, data model, data model | [two-repos.md](references/two-repos.md) |
 | Philosophy, why, compound, passive memory | [philosophy.md](references/philosophy.md) |
 | /mb-think, research, decide, codify | [the-think-cycle.md](references/the-think-cycle.md) |
-| /mb-bet, bet, hypothesis, deadline, public show | [skills-guide.md](references/skills-guide.md) |
+| /mb-bet, bet, hypothesis, deadline, public narration | [skills-guide.md](references/skills-guide.md) |
 | Task tracking, where left off, focus | [task-tracking-options.md](references/task-tracking-options.md) |
 | Error, command not found, MCP, Apify setup, GitHub issue | [troubleshooting.md](references/troubleshooting.md) |
 | Provider readiness, GitHub setup, Cloudflare, Google Workspace, Meta Ads, Apify | [provider-readiness.md](references/provider-readiness.md) |

--- a/.claude/skills/mb-help/SKILL.md
+++ b/.claude/skills/mb-help/SKILL.md
@@ -27,7 +27,7 @@ Answer questions, troubleshoot issues, explain philosophy, suggest next steps.
 | Two repos, engine, data model, data model | [two-repos.md](references/two-repos.md) |
 | Philosophy, why, compound, passive memory | [philosophy.md](references/philosophy.md) |
 | /mb-think, research, decide, codify | [the-think-cycle.md](references/the-think-cycle.md) |
-| /mb-bet, bet, hypothesis, deadline, public narration | [skills-guide.md](references/skills-guide.md) |
+| /mb-bet, bet, hypothesis, deadline, public show | [skills-guide.md](references/skills-guide.md) |
 | Task tracking, where left off, focus | [task-tracking-options.md](references/task-tracking-options.md) |
 | Error, command not found, MCP, Apify setup, GitHub issue | [troubleshooting.md](references/troubleshooting.md) |
 | Provider readiness, GitHub setup, Cloudflare, Google Workspace, Meta Ads, Apify | [provider-readiness.md](references/provider-readiness.md) |

--- a/.claude/skills/mb-help/references/provider-readiness.md
+++ b/.claude/skills/mb-help/references/provider-readiness.md
@@ -40,19 +40,19 @@ GitHub.
 
 2. **Cloudflare** - sites, DNS, Pages, and future Workers.
    - Use when: publish a landing page, attach a domain, or deploy a site.
-   - Check/fix: `mb connect status --all --json`.
+   - Check/fix: `mb connect doctor --json`.
 
 3. **Google / Workspace** - Drive, Docs, Sheets, Slides, and source material.
    - Use when: a workflow needs existing Google files.
-   - Check/fix: `mb connect status --all --json`.
+   - Check/fix: `mb connect doctor --json`.
 
 4. **Meta Ads** - ad accounts, campaigns, pixels, and future performance facts.
    - Use when: paid-ad generation, review, or learning needs account context.
-   - Check/fix: `mb connect status --all --json`.
+   - Check/fix: `mb connect doctor --json`.
 
 5. **Apify** - optional research sidecar for scraping, YouTube, Instagram, and web mining.
    - Use when: research or organic workflows need structured external data.
-   - Check/fix: `mb connect status --all --json`.
+   - Check/fix: `mb connect doctor --json`.
 
 ## Support Boundary
 

--- a/.claude/skills/mb-help/references/skills-guide.md
+++ b/.claude/skills/mb-help/references/skills-guide.md
@@ -56,20 +56,20 @@ See [the-think-cycle.md](the-think-cycle.md) for deep dive.
 ---
 
 ### /mb-bet - Business Bets
-**Use when:** Opening, updating, closing, listing, or narrating an operating bet.
+**Use when:** Opening, updating, closing, listing, or showing an operating bet.
 
 **What it does:**
 - Creates `bets/YYYY-MM-DD-slug.md` with hypothesis, appetite, metric, target, and deadline
 - Links bets to decisions, research, campaigns, and outcomes
 - Captures verdicts and learning when a bet closes
-- Drafts public-safe narration without publishing automatically
+- Drafts public-safe show copy without publishing automatically
 
 **Modes:**
 - `/mb-bet new` - Open a bet
 - `/mb-bet update` - Add progress and evidence
 - `/mb-bet close` - Record result and learning
 - `/mb-bet list` - Summarize active bets and deadlines
-- `/mb-bet narrate` - Draft site, community, or social narration from repo truth
+- `/mb-bet show` - Draft site, community, or social show copy from repo truth
 
 ---
 

--- a/.claude/skills/mb-help/references/skills-guide.md
+++ b/.claude/skills/mb-help/references/skills-guide.md
@@ -56,20 +56,20 @@ See [the-think-cycle.md](the-think-cycle.md) for deep dive.
 ---
 
 ### /mb-bet - Business Bets
-**Use when:** Opening, updating, closing, listing, or showing an operating bet.
+**Use when:** Opening, updating, closing, listing, or narrating an operating bet.
 
 **What it does:**
 - Creates `bets/YYYY-MM-DD-slug.md` with hypothesis, appetite, metric, target, and deadline
 - Links bets to decisions, research, campaigns, and outcomes
 - Captures verdicts and learning when a bet closes
-- Drafts public-safe show copy without publishing automatically
+- Drafts public-safe narration without publishing automatically
 
 **Modes:**
 - `/mb-bet new` - Open a bet
 - `/mb-bet update` - Add progress and evidence
 - `/mb-bet close` - Record result and learning
 - `/mb-bet list` - Summarize active bets and deadlines
-- `/mb-bet show` - Draft site, community, or social show copy from repo truth
+- `/mb-bet narrate` - Draft site, community, or social narration from repo truth
 
 ---
 

--- a/.claude/skills/mb-help/references/task-tracking-options.md
+++ b/.claude/skills/mb-help/references/task-tracking-options.md
@@ -76,8 +76,8 @@ Native task management in your repo. Claude can read/write via `gh` CLI.
 
 **Setup:**
 ```bash
-# Ensure gh is authenticated
-gh auth status
+# Check GitHub task readiness from the business repo
+mb connect doctor --json
 ```
 
 **Usage:**

--- a/.claude/skills/mb-organic/SKILL.md
+++ b/.claude/skills/mb-organic/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: mb-organic
 description: "CREATE organic content scripts (Reels, TikTok, carousels, static posts). Use when user wants to GENERATE new scripts from concepts. NOT for research/mining competitor content - that's /mb-think. NOT for paid ads - use /mb-ads instead. Modes: video, carousel, static. If user says \"mine\", \"scrape\", \"research competitors\" → route to /mb-think."
+loops: [ship]
 ---
 
 # Organic

--- a/.claude/skills/mb-organic/SKILL.md
+++ b/.claude/skills/mb-organic/SKILL.md
@@ -33,6 +33,11 @@ Detect if user is in the right place:
 
 For the canonical engine resolution + pull bash block (and the failure warning), see [`references/pull-engine-updates.md`](references/pull-engine-updates.md). Run it at the start of every invocation.
 
+Then run `mb status --json --peek` from the business repo and use its
+`readiness`, `drift.items`, and `ranked_actions` facts before asking setup or
+reference-health questions. Direct file checks below are content-specific, not
+repo-health probes.
+
 ---
 
 ## About Mining (Lives in /mb-think Now)
@@ -80,7 +85,7 @@ Requires `reference/core/voice.md` (always core), plus resolved `offer.md` and `
 
 **Congruence check:** If `reference/domain/funnel/skool-surfaces.md` exists, read it. Organic content should echo the same positioning and claims visible on the Skool about page and pricing cards. No contradictions between organic and the landing experience.
 
-**CWD-first:** If `reference/core/` exists in CWD, you're already in the business repo. Otherwise, resolve via `~/.config/vip/local.yaml` (`default_repo`). If missing, ask the user or run `/mb-setup`.
+**CWD-first:** If `reference/core/` exists in CWD, you're already in the business repo. Otherwise, run `mb status --json --peek` and use its repo/readiness facts if available. If status cannot identify a repo, ask the user or run `/mb-setup`.
 
 Missing files? See [references/first-time-setup.md](references/first-time-setup.md).
 

--- a/.claude/skills/mb-organic/references/pull-engine-updates.md
+++ b/.claude/skills/mb-organic/references/pull-engine-updates.md
@@ -5,7 +5,7 @@ Canonical command for pulling latest Main Branch updates at the start of any ski
 `mb update` owns the install-mode mechanics. It detects pipx vs clone installs, runs the correct update command, and refreshes skill links for the business repo.
 
 ```bash
-mb update --repo "${REPO_PATH:-.}" --json 2>&1
+mb update --repo . --json 2>&1
 ```
 
 ## Handle the Result

--- a/.claude/skills/mb-pull/SKILL.md
+++ b/.claude/skills/mb-pull/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: mb-pull
 description: Legacy alias for /mb-update. Use only when the user explicitly types /mb-pull or says pull latest using old Main Branch language.
+loops: [ship]
 ---
 
 # Pull

--- a/.claude/skills/mb-pull/SKILL.md
+++ b/.claude/skills/mb-pull/SKILL.md
@@ -11,7 +11,7 @@ description: Legacy alias for /mb-update. Use only when the user explicitly type
 Run the same update command:
 
 ```bash
-mb update --repo "${REPO_PATH:-.}" --json 2>&1
+mb update --repo . --json 2>&1
 ```
 
 Then follow the result handling in `/mb-update`.

--- a/.claude/skills/mb-setup/SKILL.md
+++ b/.claude/skills/mb-setup/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: mb-setup
 description: "Bootstrap a new business repo with Main Branch structure, or migrate an existing single-offer repo to multi-offer. Use when: (1) New user needs Claude Code environment configured (2) User says \"set up\", \"get started\", \"initialize\", \"bootstrap\", \"create my repo\", \"new business\" (3) User is new to Main Branch and needs full onboarding (4) Migrating existing business context into the Main Branch structure (5) User wants to add a second offer to an existing repo. Creates Chrome extension setup, two-repo model, business repo with full structure. Gathers context aggressively until complete. Applies domain rubrics by business type. Teaches concepts during setup."
+loops: [sense, decide, ship]
 ---
 
 # Repo Setup

--- a/.claude/skills/mb-setup/SKILL.md
+++ b/.claude/skills/mb-setup/SKILL.md
@@ -9,10 +9,9 @@ Get a new user fully configured with Claude Code and their business repo. Use
 `mb onboard status --json` and `mb onboard plan` as the durable progress
 contract; do not keep onboarding state only in chat prose.
 
-For provider setup, use `mb connect plan`, `mb connect status --all --json`,
-and `mb connect doctor --json` as the durable readiness contract. Explain
-providers as business capabilities, not developer config, and end with exact
-commands.
+For provider setup, use `mb connect plan` and `mb connect doctor --json` as the
+durable readiness contract. Explain providers as business capabilities, not
+developer config, and end with exact commands.
 
 ---
 

--- a/.claude/skills/mb-setup/references/git-workflow.md
+++ b/.claude/skills/mb-setup/references/git-workflow.md
@@ -212,8 +212,8 @@ EOF
 ## GitHub CLI Reference
 
 ```bash
-# Check authentication
-gh auth status
+# Check GitHub readiness from the business repo
+mb connect doctor --json
 
 # Create private repo and push
 gh repo create [name] --private --source=. --push

--- a/.claude/skills/mb-site/SKILL.md
+++ b/.claude/skills/mb-site/SKILL.md
@@ -309,7 +309,7 @@ If conversation compacted or context was lost:
 2. **Check invocation mode:** business repo mode (`core/`) or site repo mode (`.mainbranch/source.json`)
 3. **Load links:** read `.mainbranch/source.json` in the site repo, or the campaign/site record in the business repo
 4. **Identify the site shape** from the campaign/site record or existing files; load the corresponding build ref
-5. **Check continuity:** run `mb checkpoint --status --json` from the linked business repo, then use site-repo git history only for site-code changes
+5. **Check continuity:** use business-repo `mb status --json --peek` facts first, then site-repo git history only for site-code changes
 6. **Resume from last completed step** based on git history, source links, and campaign launch status
 
 ---

--- a/.claude/skills/mb-site/SKILL.md
+++ b/.claude/skills/mb-site/SKILL.md
@@ -26,6 +26,10 @@ Say `/mb-site` again after compaction, context loss, or switching focus. It relo
 
 For the canonical engine resolution + pull bash block (and the failure warning), see [`references/pull-engine-updates.md`](references/pull-engine-updates.md). Run it at the start of every invocation.
 
+When a business repo is known, run `mb status --json --peek` and use its
+`readiness`, `drift.items`, `integrations`, `measurement`, and `ranked_actions`
+facts before inventing setup, provider, or launch-readiness checks in prose.
+
 ---
 
 ## Operating principles
@@ -293,7 +297,7 @@ Use that JSON as the readiness source of truth:
 
 Do not invent `ready_for_launch` or say Main Branch can launch the campaign. The readiness states are exactly `missing`, `blocked`, `ready_for_preview`, `ready_for_operator_review`, and `ready`.
 
-Never ask the operator to paste Google Ads, GTM, OAuth, or API tokens into chat. Use `mb connect plan`, `mb connect status --all --json`, or `mb connect doctor --json` for provider readiness and quote the CLI's `next_command` / `repair_command`.
+Never ask the operator to paste Google Ads, GTM, OAuth, or API tokens into chat. Use `mb connect plan` or `mb connect doctor --json` for provider readiness and quote the CLI's `next_command` / `repair_command`.
 
 ---
 
@@ -305,7 +309,7 @@ If conversation compacted or context was lost:
 2. **Check invocation mode:** business repo mode (`core/`) or site repo mode (`.mainbranch/source.json`)
 3. **Load links:** read `.mainbranch/source.json` in the site repo, or the campaign/site record in the business repo
 4. **Identify the site shape** from the campaign/site record or existing files; load the corresponding build ref
-5. **Check site repo status:** `cd <site_repo> && git status && git log --oneline -5`
+5. **Check continuity:** run `mb checkpoint --status --json` from the linked business repo, then use site-repo git history only for site-code changes
 6. **Resume from last completed step** based on git history, source links, and campaign launch status
 
 ---

--- a/.claude/skills/mb-site/SKILL.md
+++ b/.claude/skills/mb-site/SKILL.md
@@ -8,6 +8,7 @@ description: "Triage and build any site shape — lander (1 page), minisite (~4 
   (5) Previewing or publishing changes
 
   Triggered by: /mb-site, 'build a site', 'landing page', 'lander', 'minisite', 'website', 'I need a site', 'spin up a site', 'put this online', 'publish site', 'deploy site', 'update my site', 'graduate my site', 'add a CMS to my site'"
+loops: [ship]
 ---
 
 # Site

--- a/.claude/skills/mb-site/references/pull-engine-updates.md
+++ b/.claude/skills/mb-site/references/pull-engine-updates.md
@@ -5,7 +5,7 @@ Canonical command for pulling latest Main Branch updates at the start of any ski
 `mb update` owns the install-mode mechanics. It detects pipx vs clone installs, runs the correct update command, and refreshes skill links for the business repo.
 
 ```bash
-mb update --repo "${REPO_PATH:-.}" --json 2>&1
+mb update --repo . --json 2>&1
 ```
 
 ## Handle the Result

--- a/.claude/skills/mb-site/references/website-build.md
+++ b/.claude/skills/mb-site/references/website-build.md
@@ -37,14 +37,14 @@ These are Devon-specific examples, not the broader Website tier. Future per-offe
 
 **3. Check prerequisites.**
 ```bash
-node --version    # Need 18+
-pnpm --version    # Package manager
-gh auth status    # GitHub CLI authenticated
+node --version          # Need 18+
+pnpm --version          # Package manager
+mb connect doctor --json # GitHub/provider readiness
 ```
 If anything missing, install before proceeding:
 - Wrong Node version → `nvm use 18`
 - pnpm not found → `npm install -g pnpm`
-- gh not authenticated → `gh auth login`
+- GitHub not ready → use the repair command from `mb connect doctor --json`
 
 **4. Create GitHub repo.**
 ```bash

--- a/.claude/skills/mb-skill-brief-draft/SKILL.md
+++ b/.claude/skills/mb-skill-brief-draft/SKILL.md
@@ -3,6 +3,7 @@ name: mb-skill-brief-draft
 tier: skill
 calls: []
 description: "Compose a site brief from offer.md + audience.md + voice.md + research files + the operator's dial / archetype picks. Used by /mb-site as the brief-drafting step. Loadable independently for /mb-vsl, /mb-ads, /mb-organic if they want to share the same brief shape."
+loops: [sense, ship]
 ---
 
 # skill-brief-draft

--- a/.claude/skills/mb-skill-concept/SKILL.md
+++ b/.claude/skills/mb-skill-concept/SKILL.md
@@ -3,6 +3,7 @@ name: mb-skill-concept
 tier: skill
 calls: []
 description: "Generate N concept variations of a site / asset on localhost in parallel, foreground subagents. Default 2. Operator picks one to publish. Used by /mb-site as the concept-generation step."
+loops: [ship]
 ---
 
 # skill-concept

--- a/.claude/skills/mb-skill-review/SKILL.md
+++ b/.claude/skills/mb-skill-review/SKILL.md
@@ -3,6 +3,7 @@ name: mb-skill-review
 tier: skill
 calls: []
 description: "Run dial-gated Seven Sweeps + auxiliary gates against a brief or copy draft. Returns synthesized findings to the operator. Used by /mb-site at pre-lock and pre-publish moments. Reusable by /mb-vsl, /mb-ads in v0.2."
+loops: [reflect]
 ---
 
 # skill-review

--- a/.claude/skills/mb-start/SKILL.md
+++ b/.claude/skills/mb-start/SKILL.md
@@ -185,7 +185,7 @@ If `update.severity` is `required` or the top ranked action is an update action,
 run the cited command. When status does not cite a narrower command, use:
 
 ```bash
-mb update --repo "$REPO_PATH" --json
+mb update --repo . --json
 ```
 
 Then run `mb status --json --peek` again before routing.

--- a/.claude/skills/mb-start/SKILL.md
+++ b/.claude/skills/mb-start/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: mb-start
 description: "Main entry point for Main Branch. Detects state and routes to the right skill. Use when: user says start/help/begin, is new/returning/lost, opens Main Branch without a task, or needs triage. Routes to /mb-setup, /mb-think, /mb-bet, /mb-ads, /mb-vsl, /mb-organic, /mb-wiki, /mb-help."
+loops: [sense, decide]
 ---
 
 # Start
@@ -133,7 +134,7 @@ Apply to: business repo selection, skill routing, any multiple choice.
 ├── Ready to work? ───────────────────→ Route by intent:
 │   │
 │   ├── "research" / "decide" ────────→ /mb-think
-│   ├── "bet" / "launch test" ─────────→ /mb-bet (new/update/close/list/show)
+│   ├── "bet" / "launch test" ─────────→ /mb-bet (new/update/close/list/narrate)
 │   ├── "ads" / "copy" ───────────────→ /mb-ads (triages to static/video/review)
 │   ├── "vsl" / "sales video" ────────→ /mb-vsl (triages to skool/b2b)
 │   ├── "content" / "organic" ────────→ /mb-organic

--- a/.claude/skills/mb-start/SKILL.md
+++ b/.claude/skills/mb-start/SKILL.md
@@ -210,8 +210,13 @@ Use the `update` section from `mb status --json --peek`. **Do NOT silently
 swallow required updates.** Users on stale code get broken features.
 
 If `update.severity` is `required` or the top ranked action is an update action,
-run the cited command (`mb update` or the package-manager command from status),
-then run `mb status --json --peek` again before routing.
+run the cited command. When status does not cite a narrower command, use:
+
+```bash
+mb update --repo "$REPO_PATH" --json
+```
+
+Then run `mb status --json --peek` again before routing.
 
 ---
 
@@ -300,17 +305,21 @@ operator-facing pattern is:
 
 **Why defer:** Most sessions don't use all tools. Checking everything upfront wastes time and clutters the greeting. /mb-think detects tools when user's intent requires them and surfaces setup options at the right moment.
 
-If user's stated intent involves research, route to /mb-think — it will handle tool detection with config-first logic (reads `.vip/config.yaml`, only probes unknowns, updates config with results).
+If user's stated intent involves research, route to /mb-think. It will use
+`mb` provider facts first, then detect only the runtime tools needed for the
+selected research path.
 
 ---
 
-## Step 5: Tool Status Audit (Lightweight Self-Heal)
+## Step 5: Tool Status Audit (Deterministic Facts First)
 
-Run a lightweight `.vip/config.yaml` audit before readiness to repair stale `status: false` entries and normalize missing `last_checked` values.
+Run a lightweight provider/readiness audit before routing:
 
-- Re-probe only stale false entries (missing/invalid/old `last_checked`)
-- Write updates immediately when status or metadata is repaired
-- Notify only when status changes (`false → true` or `true → false`)
+- Use `mb status --json --peek` facts already gathered.
+- Run `mb connect doctor --json` when a provider section is degraded, missing,
+  or selected by the operator.
+- Quote the CLI's `next_command` / `repair_command`.
+- Do not re-probe provider credentials from prose or mutate `.vip/config.yaml`.
 
 See [tool-status-audit.md](references/tool-status-audit.md) for the full procedure and messaging rules.
 
@@ -384,18 +393,18 @@ find "$REPO_PATH/reference/offers" -mindepth 2 -maxdepth 2 -name "offer.md" 2>/d
 
 ## Step 9: Detect State and Assess Completeness
 
-Check `reference/core/*.md`. No folder → `/mb-setup`. Exists → check completeness:
+Use `readiness`, `onboarding`, `drift.items`, and `ranked_actions` from
+`mb status --json --peek` first. If those sections are unavailable, use this
+fallback check.
 
-| File | Complete If |
-|------|------------|
-| soul.md | >30 lines or "Beliefs" section |
-| offer.md | >50 lines or "Price" section |
-| audience.md | >30 lines or "Pains" section |
-| voice.md | >20 lines or "Tone" section |
+Fallback: check `reference/core/*.md`. No folder → `/mb-setup`. If two or more
+core files are missing/thin, route to `/mb-think codify`; otherwise route by
+intent. Use [readiness-assessment.md](references/readiness-assessment.md) for
+the exact fallback thresholds.
 
-2+ empty/missing → `/mb-think codify`. Complete → route by intent.
-
-**Multi-offer completeness:** When `offers/` exists, also check the active offer's `offer.md` for substance. A thin offer file (< 20 lines) means `/mb-think` should be recommended to flesh it out. Don't count brand-level `core/offer.md` as a substitute for a missing offer-specific file.
+**Multi-offer completeness:** When status does not expose offer readiness, check
+the active offer's `offer.md`; a thin/missing offer-specific file should route
+to `/mb-think`.
 
 ---
 
@@ -421,26 +430,17 @@ Check `reference/core/*.md`. No folder → `/mb-setup`. Exists → check complet
 
 ## Context Awareness
 
-| Level | Action |
-|-------|--------|
-| Fresh (0-20%) | Full load, explain briefly |
-| Working (20-70%) | Route to task |
-| Heavy (70-85%) | Warn: "Finish this, then new session" |
-| Critical (85%+) | "Context nearly full. Wrap up." |
-
-Show percentage when relevant: "You're at ~60% — plenty of room."
+Fresh context gets a fuller load; working context routes directly; heavy context
+gets a brief warning; critical context routes to `/mb-end`. Show percentage only
+when relevant.
 
 ---
 
 ## Adapt to Experience
 
-Read `user.experience` from `~/.config/vip/local.yaml` (defaults to `beginner` if missing).
-
-| Experience | Behavior |
-|------------|----------|
-| `beginner` | Verbose explanations, show context tips, more hand-holding |
-| `intermediate` | Balanced — explain when relevant, skip basics |
-| `advanced` | Minimal — get out of the way, route fast |
+Read `user.experience` from `~/.config/vip/local.yaml` (defaults to `beginner`
+if missing): beginner = explain more, intermediate = balanced, advanced = route
+fast.
 
 **First-time** (no config, thin reference): Be verbose, route to /mb-setup
 **Returning** (config exists): Quick confirmation, route by intent
@@ -489,7 +489,7 @@ If re-invoked after compaction: re-read `~/.config/vip/local.yaml` for repo + id
 - [references/config-system.md](references/config-system.md) — Config loading and recovery
 - [references/mcp-preflight.md](references/mcp-preflight.md) — MCP pre-flight checks
 - [references/readiness-assessment.md](references/readiness-assessment.md) — Step 6 readiness scoring
-- [references/tool-status-audit.md](references/tool-status-audit.md) — Step 5 self-heal
+- [references/tool-status-audit.md](references/tool-status-audit.md) — Step 5 provider/readiness audit
 - [references/triage-agent.md](references/triage-agent.md) — Triage agent prompts and synthesis
 
 ---

--- a/.claude/skills/mb-start/SKILL.md
+++ b/.claude/skills/mb-start/SKILL.md
@@ -16,11 +16,9 @@ integrations, GitHub tasks/proposals, bets, dirty git, since-last-check, and
 `ranked_actions`. Do not duplicate those checks with ad hoc shell probes unless
 the status report says a section is unavailable.
 
-**Checkpoint facts first:** Also run `mb checkpoint --status --json` from the
-business repo. If `recent[]` has entries, summarize the latest checkpoint as
-"where we left off." If `pending.status` is `ready`, say there is unsaved work
-and offer to save a checkpoint before starting new work. If `pending.status` is
-`blocked`, explain the safety block and do not commit around it.
+**Continuity facts:** Use `since_last_check`, dirty-git, and recent GitHub/git
+activity from status to explain "where we left off." The checkpoint CLI is
+future v0.3.x work; do not ask current PyPI users to run it.
 
 **Provider facts first:** When setup or routing depends on GitHub, Cloudflare,
 Google/Workspace, Meta Ads, or Apify, read the status `integrations` facts
@@ -100,11 +98,6 @@ Apply to: business repo selection, skill routing, any multiple choice.
 │   ├── readiness/drift blockers? ────→ use cited status repair commands
 │   └── unavailable section? ─────────→ use only the documented fallback for that section
 │
-├── Read checkpoint facts ────────────→ `mb checkpoint --status --json`
-│   ├── recent checkpoint? ───────────→ summarize "where we left off"
-│   ├── pending ready? ───────────────→ offer to save before new work
-│   └── pending blocked? ─────────────→ explain safety block; do not commit
-│
 ├── Check engine updates ──────────────→ Use status update severity and `mb update`
 │
 ├── Load config ──────────────────────→ See [config-system.md](references/config-system.md)
@@ -140,7 +133,7 @@ Apply to: business repo selection, skill routing, any multiple choice.
 ├── Ready to work? ───────────────────→ Route by intent:
 │   │
 │   ├── "research" / "decide" ────────→ /mb-think
-│   ├── "bet" / "launch test" ─────────→ /mb-bet (new/update/close/list/narrate)
+│   ├── "bet" / "launch test" ─────────→ /mb-bet (new/update/close/list/show)
 │   ├── "ads" / "copy" ───────────────→ /mb-ads (triages to static/video/review)
 │   ├── "vsl" / "sales video" ────────→ /mb-vsl (triages to skool/b2b)
 │   ├── "content" / "organic" ────────→ /mb-organic
@@ -182,27 +175,6 @@ Use this report before asking additional questions:
 Only run a narrower fallback command such as `mb onboard status --json`,
 `mb doctor`, `mb validate --cross-refs`, or `mb connect doctor --json` when status
 points at that section as unavailable, degraded, or needing repair.
-
-## Step 0b: Read Checkpoint Facts
-
-Then run:
-
-```bash
-mb checkpoint --status --json
-```
-
-Use this report for session continuity:
-
-- `recent[0]` is the latest checkpoint commit. Summarize it in plain English
-  before asking the user to choose work.
-- `pending.status == "ready"` means the repo has unsaved meaningful work. Ask:
-  "Want me to save a checkpoint before we start something new?"
-- If the user says yes, run:
-  `mb checkpoint --message "[checkpoint] <plain summary>" --yes`
-- `pending.status == "blocked"` means safety gates found a local bridge file,
-  secret-like content, conflict, or engine-repo write. Explain the block and do
-  not work around it with raw git commands.
-- `pending.status == "clean"` means there is no unsaved checkpoint work.
 
 ## Step 1: Pull Engine Updates
 

--- a/.claude/skills/mb-start/references/mcp-preflight.md
+++ b/.claude/skills/mb-start/references/mcp-preflight.md
@@ -34,7 +34,7 @@ account to connect or a selected workflow needs outside access, run:
 
 ```bash
 mb connect plan
-mb connect status --all --json
+mb connect doctor --json
 ```
 
 Required provider choices for the setup/provider loop:
@@ -42,10 +42,10 @@ Required provider choices for the setup/provider loop:
 | Provider | Business job | Check |
 |---|---|---|
 | GitHub | tasks, proposals, reviews, shipped history | `mb connect doctor --json` |
-| Cloudflare | sites, DNS, Pages, Workers | `mb connect status --all --json` |
-| Google / Workspace | Drive, Docs, Sheets, Slides | `mb connect status --all --json` |
-| Meta Ads | ad accounts, campaigns, pixels | `mb connect status --all --json` |
-| Apify | scraping, YouTube, Instagram, research sidecars | `mb connect status --all --json` |
+| Cloudflare | sites, DNS, Pages, Workers | `mb connect doctor --json` |
+| Google / Workspace | Drive, Docs, Sheets, Slides | `mb connect doctor --json` |
+| Meta Ads | ad accounts, campaigns, pixels | `mb connect doctor --json` |
+| Apify | scraping, YouTube, Instagram, research sidecars | `mb connect doctor --json` |
 
 Only continue to MCP/tool presence checks when the selected skill needs runtime
 tools that `mb connect` cannot inspect directly.
@@ -68,7 +68,8 @@ Look for tool presence:
 
 ### 4. Prompt if missing
 
-If routing to skill that needs missing MCP:
+If routing to a skill that needs a missing runtime tool after `mb connect`
+facts have been read:
 
 > "This action needs Apify research access. `mb connect plan` says Apify is [state].
 >
@@ -89,7 +90,8 @@ If user picks 1 → Show setup guide path, walk through it.
 
 ## Research Tools Check
 
-These tools enhance `/mb-think` but are optional (except Apify which is important):
+These runtime tools enhance `/mb-think` after provider readiness is known. They
+are optional and should not replace `mb connect` facts:
 
 | Tool | Check Method | If Missing |
 |------|--------------|------------|
@@ -100,7 +102,7 @@ These tools enhance `/mb-think` but are optional (except Apify which is importan
 
 ### Detection Order
 
-Run on first `/mb-think` invocation:
+Run only when the selected `/mb-think` path needs that runtime tool:
 
 ```bash
 # 1. Apify - check for MCP tools (most important)
@@ -137,6 +139,8 @@ which whisper-cli >/dev/null 2>&1 && echo "whisper-cli available"
 - Don't nag about missing optional tools
 - Only offer setup when user tries to use missing capability
 - Always provide fallback path
+- Use `mb connect plan` / `mb connect doctor --json` for provider setup and
+  repair language before any runtime-specific checks.
 
 ---
 

--- a/.claude/skills/mb-start/references/pull-engine-updates.md
+++ b/.claude/skills/mb-start/references/pull-engine-updates.md
@@ -5,7 +5,7 @@ Canonical command for pulling latest Main Branch updates at the start of any ski
 `mb update` owns the install-mode mechanics. It detects pipx vs clone installs, runs the correct update command, and refreshes skill links for the business repo.
 
 ```bash
-mb update --repo "${REPO_PATH:-.}" --json 2>&1
+mb update --repo . --json 2>&1
 ```
 
 ## Handle the Result

--- a/.claude/skills/mb-start/references/readiness-assessment.md
+++ b/.claude/skills/mb-start/references/readiness-assessment.md
@@ -1,6 +1,10 @@
 # Readiness Assessment Reference
 
-Complete reference for the readiness assessment run by `/mb-start` at Step 6. Contains scoring rubric, session state check, soul health check, routing gates, skill-specific readiness, and display format.
+Complete fallback reference for readiness assessment when `/mb-start` needs
+detail that `mb status --json --peek` does not expose. Use status `readiness`,
+`drift.items`, `onboarding`, `since_last_check`, and `ranked_actions` first.
+Only use the checks below for section-level detail or when status reports that
+a section is unavailable/degraded.
 
 ---
 

--- a/.claude/skills/mb-start/references/tool-status-audit.md
+++ b/.claude/skills/mb-start/references/tool-status-audit.md
@@ -1,37 +1,45 @@
 # Tool Status Audit
 
-Lightweight self-healing pass run during `/mb-start` before readiness scoring.
+Lightweight provider/readiness pass run during `/mb-start` before routing.
 
 ---
 
 ## Goal
 
-Repair stale false negatives in `.vip/config.yaml` without running a full research tool scan.
+Use deterministic `mb` facts for provider readiness, setup repair, and stale
+status before any skill-specific runtime checks. `/mb-start` should not
+reimplement provider probes or mutate provider state from prose.
 
 ---
 
 ## Audit Flow
 
-1. Read `.vip/config.yaml` `tools` section
-2. For each tool entry:
-   - If `status: false` and stale (`last_checked` missing, invalid, or older than 30 days), re-probe
-   - If entry exists and `last_checked` is missing, add `last_checked: [today]`
-3. Write config updates immediately
-4. Notify only on state changes:
-   - `false → true`: "Found [tool] installed — updated your config."
-   - `true → false`: "Warning: [tool] was previously available but is now missing."
-5. If no status changes, stay silent
+1. Read `mb status --json --peek`.
+2. If a provider, GitHub, runtime-wiring, or drift section is degraded, missing,
+   or selected by the operator, run:
+
+   ```bash
+   mb connect doctor --json
+   ```
+
+3. Use the CLI's `summary`, `next_command`, and `repair_command` in the
+   operator-facing answer.
+4. Run `mb connect plan` when the operator asks what to connect first.
+5. Stay silent when status reports the selected path as healthy.
 
 ---
 
 ## Scope Boundary
 
-- This is not full `/mb-think` tool detection.
-- Only stale false entries are probed.
-- `status: true` entries are not routinely re-probed here.
-- Full detection and tool surfacing remain in `/mb-think`.
+- This is not full `/mb-think` runtime detection.
+- Provider readiness belongs to `mb status`, `mb connect plan`, and
+  `mb connect doctor --json`.
+- Local runtime tool presence is checked only when a selected workflow needs it
+  and `mb` cannot inspect it directly.
+- Full research tool surfacing remains in `/mb-think`.
 
-Use probe methods defined in `/mb-think` (`Gemini`, `Grok`, `whisper`, document tools, and lazy `Pipeboard` handling).
+Use probe methods defined in `/mb-think` only for runtime-local tools after the
+provider facts have been read.
 
 ---
 

--- a/.claude/skills/mb-status/SKILL.md
+++ b/.claude/skills/mb-status/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: mb-status
 description: "Thin Main Branch status wrapper. Use when the operator asks what changed, what is healthy, what is stale, what to do next, or wants a daily briefing inside Claude Code."
+loops: [sense]
 ---
 
 # Status

--- a/.claude/skills/mb-think/SKILL.md
+++ b/.claude/skills/mb-think/SKILL.md
@@ -21,13 +21,11 @@ Something came your way — a video, a voice memo, a vague feeling, a problem to
 - Switching focus
 - Anytime you feel lost
 
-**Save checkpoints at natural boundaries.** After a research batch, accepted
-decision, codify pass, or major reference-file update, run
-`mb checkpoint --plan --json`. If the plan is ready, ask whether to save a
-checkpoint before moving to the next phase. If approved, run
-`mb checkpoint --message "[checkpoint] <plain business summary>" --yes`. If the
-plan is blocked, explain the safety block and do not work around it with raw
-git.
+**Save progress at natural boundaries.** After a research batch, accepted
+decision, codify pass, or major reference-file update, ask whether to save a
+checkpoint before moving to the next phase. Use the current repo's git workflow
+with explicit operator approval. When the v0.3.x checkpoint contract ships,
+this step should move to deterministic checkpoint plan/status facts.
 
 ---
 

--- a/.claude/skills/mb-think/SKILL.md
+++ b/.claude/skills/mb-think/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: mb-think
 description: "Combined research, decision, and codification workflow. Use when: (1) Exploring a question before committing (2) Making a decision that needs documentation (3) User says research, decide, figure out, explore, codify, enrich, add context (4) Updating reference files based on decisions (5) User wants to add new testimonials, angles, or proof to existing files. Supports modes: full flow, research-only, decide-only, codify."
+loops: [sense, decide, ship]
 ---
 
 # Think

--- a/.claude/skills/mb-think/SKILL.md
+++ b/.claude/skills/mb-think/SKILL.md
@@ -52,11 +52,23 @@ See **[references/pull-engine-updates.md](references/pull-engine-updates.md)** f
 
 ---
 
-## Tool Detection (Config-First)
+## Tool Detection (CLI Facts First)
 
-Tool status persists in `.vip/config.yaml` under `tools:`. Read config first, only probe unknowns, always write results back.
+Provider readiness comes from `mb` first. Run or reuse:
 
-**Quick gist:** On first /mb-think invocation each session, read `tools` from config, re-probe unknowns or stale-false entries, write results back immediately, report once at experience-appropriate verbosity. Surface a tool option to the user only when their intent needs it and it's missing — once per session per tool.
+```bash
+mb status --json --peek
+mb connect doctor --json
+```
+
+Use those facts for GitHub, Google/Workspace, Meta Ads, Apify, and other
+provider repair language. Runtime-local tool checks happen only after a
+selected research path needs them and `mb` cannot inspect the tool directly.
+
+**Quick gist:** On first `/mb-think` invocation, read status/connect facts. When
+the user's intent needs a runtime-local tool, check only that tool, cache
+session knowledge, and offer the `mb connect` repair command or a fallback.
+Surface a missing-tool option once per session per tool.
 
 See **[references/tool-detection.md](references/tool-detection.md)** for the full status-value table, staleness rules, per-tool detection methods (Apify, Gemini, Grok, whisper, Nano Banana, Pipeboard, document tools), required config-update format, and the intent-based tool surfacing matrix.
 

--- a/.claude/skills/mb-think/references/document-ingestion.md
+++ b/.claude/skills/mb-think/references/document-ingestion.md
@@ -136,7 +136,8 @@ External conversion tools (markitdown, pandoc, marker) produce clean markdown th
 
 ## Tool Detection
 
-Check `.vip/config.yaml` tools section. If conversion tools aren't detected:
+This is runtime-local detection. Check conversion tools only when document
+ingestion is selected:
 
 ```bash
 which markitdown 2>/dev/null && echo "MARKITDOWN=1" || echo "MARKITDOWN=0"

--- a/.claude/skills/mb-think/references/local-transcription.md
+++ b/.claude/skills/mb-think/references/local-transcription.md
@@ -20,7 +20,9 @@ which mlx_whisper 2>/dev/null || which whisper-cli 2>/dev/null || echo "No whisp
 which ffmpeg 2>/dev/null || echo "No ffmpeg found"
 ```
 
-**IMPORTANT:** Check config first. If `tools.whisper.status: true` exists in `.vip/config.yaml`, read `tools.whisper.notes` to see which variant is installed. Skip detection.
+**IMPORTANT:** This is runtime-local detection, not provider readiness. If the
+session already knows which whisper variant works, use that. Otherwise check the
+needed runtime tool when local transcription is selected.
 
 ---
 

--- a/.claude/skills/mb-think/references/pull-engine-updates.md
+++ b/.claude/skills/mb-think/references/pull-engine-updates.md
@@ -5,7 +5,7 @@ Canonical command for pulling latest Main Branch updates at the start of any ski
 `mb update` owns the install-mode mechanics. It detects pipx vs clone installs, runs the correct update command, and refreshes skill links for the business repo.
 
 ```bash
-mb update --repo "${REPO_PATH:-.}" --json 2>&1
+mb update --repo . --json 2>&1
 ```
 
 ## Handle the Result

--- a/.claude/skills/mb-think/references/tool-detection.md
+++ b/.claude/skills/mb-think/references/tool-detection.md
@@ -1,6 +1,9 @@
-# Tool Detection (Config-First, Per-Probe Methods)
+# Tool Detection (CLI Facts First, Runtime Probes Second)
 
-Tool status persists in `.vip/config.yaml` under `tools:`. Read config first, only probe unknowns, always write results back.
+Provider readiness belongs to `mb status --json --peek`, `mb connect plan`, and
+`mb connect doctor --json`. Use those facts before probing local runtime tools.
+The checks below are for runtime-local capabilities that `mb` cannot inspect
+directly inside the current Claude Code session.
 
 ---
 
@@ -8,27 +11,31 @@ Tool status persists in `.vip/config.yaml` under `tools:`. Read config first, on
 
 | Value | Meaning | Action |
 |-------|---------|--------|
-| `true` | Verified working | Use tool, skip detection |
-| `false` | Known unavailable | Skip detection (unless stale) |
-| `null` | Unknown | Run detection |
-| (missing) | Never checked | Run detection |
+| `true` | Runtime tool verified in this session/config | Use tool, skip runtime probe |
+| `false` | Runtime tool known unavailable | Skip runtime probe unless the user selected this path |
+| `null` | Unknown | Run runtime probe only when needed |
+| (missing) | Never checked | Run runtime probe only when needed |
 
 ## Staleness Check
 
-Treat `status: false` as stale when `last_checked` is missing, invalid, or older than 30 days. Re-probe stale false entries.
+Do not routine re-probe stale provider entries here. If provider readiness is
+stale or degraded, use `mb connect doctor --json`. Runtime-local entries can be
+rechecked when a selected workflow needs that tool.
 
 ---
 
 ## Detection Flow
 
-On first /mb-think invocation each session:
+On first `/mb-think` invocation each session:
 
 ```
-1. Read .vip/config.yaml → tools section
-2. Detect unknown tools and re-detect stale false entries
-3. Normalize metadata (`last_checked`) on existing tool entries missing it
-4. WRITE config updates immediately (status + notes + last_checked for touched entries)
-5. Report once (experience-appropriate)
+1. Read `mb status --json --peek`.
+2. Run `mb connect doctor --json` if a selected provider is degraded/missing.
+3. If the selected research path needs a runtime-local tool, check only that
+   tool.
+4. Cache session knowledge and update local runtime notes only for the tool you
+   actually touched.
+5. Report once (experience-appropriate).
 ```
 
 For full self-healing contract (stale semantics, status-change messaging, and true-tool degradation handling), see [tool-status-self-healing.md](tool-status-self-healing.md).
@@ -37,7 +44,9 @@ For full self-healing contract (stale semantics, status-change messaging, and tr
 
 ## Detection Methods
 
-**Apify:** Check if `mcp__apify__search-actors` tool exists in session.
+**Apify:** Use `mb connect doctor --json` for provider readiness first. Then
+check if `mcp__apify__search-actors` exists in session when the selected path
+needs Apify runtime tools.
 
 **Gemini:**
 ```bash
@@ -62,13 +71,16 @@ pip3 list 2>/dev/null | grep -i "mlx-whisper" && echo "WHISPER=mlx_whisper"
 
 **Nano Banana** (image generation): Available when Gemini is configured (uses GOOGLE_API_KEY). Detect alongside Gemini.
 
-**Pipeboard** (Meta ad account access): Check for MCP tools, then probe:
+**Meta Ads account access:** Use `mb connect doctor --json` for provider
+readiness first. Then check for read-only ad account MCP tools only when the
+selected path needs live account context:
 ```bash
 # Detection: check if mcp__pipeboard__* tools exist in session
 # If found, probe with get_ad_accounts (lightweight call)
 # If probe succeeds, cache status: true
 ```
-Pipeboard is a remote MCP at `mcp.pipeboard.co/meta-ads-mcp` (OAuth, no local install). Free tier: 30 calls/week. Pro: $29.90/mo, 100 calls/week. **Lazy detection only** -- triggered when topic is ads-related, not on every /mb-think invocation. See `/mb-ads` SKILL.md for full Pipeboard integration details.
+Lazy runtime detection only -- triggered when topic is ads-related, not on every
+`/mb-think` invocation. See `/mb-ads` SKILL.md for the account-context flow.
 
 **Document tools:**
 ```bash
@@ -83,7 +95,8 @@ which marker_single >/dev/null 2>&1 && echo "MARKER=true"
 
 ## Config Update (REQUIRED)
 
-After detection, **immediately update config** using Edit tool:
+After a runtime-local detection that is not already represented by `mb`,
+optionally update local runtime notes:
 
 ```yaml
 tools:
@@ -97,7 +110,8 @@ tools:
     last_checked: 2026-03-02
 ```
 
-**Do not skip this step.** Config updates prevent re-probing next session. Use the self-healing contract in [tool-status-self-healing.md](tool-status-self-healing.md).
+Do not store secrets in repo files. Provider setup and repair language still
+comes from `mb connect`.
 
 ---
 
@@ -121,7 +135,7 @@ When user's intent matches an unavailable tool, **surface the option once per se
 | "X sentiment" | Grok | "X sentiment is best with Grok (real-time). Use web search? Set up Grok (5 min, $5 credit)?" |
 | "deep research" | Gemini | "Deep synthesis works best with Gemini (free tier). Web search fallback? Set up (3 min)?" |
 | Local file | whisper | "Local transcription needs whisper (10 min). Set up? External service? Skip?" |
-| "ad performance", "what's working", "check my CPA" | Pipeboard | "Pulling ad account data needs a Meta Ads connection (5 min setup, uses Pipeboard). Set up? Research from reference only? Skip?" |
+| "ad performance", "what's working", "check my CPA" | Meta Ads account context | "Pulling ad account data needs a Meta Ads connection. Run `mb connect plan`, research from reference only, or skip?" |
 
 **Rules:**
 - Surface once per session per tool (track in session state)

--- a/.claude/skills/mb-think/references/tool-detection.md
+++ b/.claude/skills/mb-think/references/tool-detection.md
@@ -18,7 +18,7 @@ directly inside the current Claude Code session.
 
 ## Staleness Check
 
-Do not routine re-probe stale provider entries here. If provider readiness is
+Do not routinely re-probe stale provider entries here. If provider readiness is
 stale or degraded, use `mb connect doctor --json`. Runtime-local entries can be
 rechecked when a selected workflow needs that tool.
 

--- a/.claude/skills/mb-think/references/tool-status-self-healing.md
+++ b/.claude/skills/mb-think/references/tool-status-self-healing.md
@@ -1,6 +1,8 @@
 # Tool Status Self-Healing
 
-Operational contract for tool status in `.vip/config.yaml`.
+Operational contract for runtime-local tool notes. Provider readiness and
+repair belong to `mb status --json --peek`, `mb connect plan`, and
+`mb connect doctor --json`.
 
 ---
 
@@ -11,7 +13,8 @@ A tool entry is **stale false** when all are true:
 - `status: false`
 - `last_checked` is missing, invalid, or older than 30 days
 
-Only stale false entries are re-probed during routine audits.
+Do not routine re-probe provider entries here. Runtime-local entries can be
+rechecked when a selected workflow needs that exact tool.
 
 ---
 
@@ -19,15 +22,13 @@ Only stale false entries are re-probed during routine audits.
 
 On first `/mb-think` invocation each session:
 
-1. Read `.vip/config.yaml` `tools` section
-2. Build detection list:
-   - `status: null` or missing → detect
-   - `status: false` + stale false → re-detect
-   - `status: true` or recent false → skip
-3. Normalize metadata:
-   - Add `last_checked: [today]` to any existing tool entry missing it
-4. Run probe methods from `SKILL.md`
-5. Write updates immediately
+1. Read `mb status --json --peek`.
+2. Run `mb connect doctor --json` if the selected provider is missing or
+   degraded.
+3. Build a runtime detection list only for the selected workflow.
+4. Run the relevant runtime probe methods from `SKILL.md`.
+5. Cache session knowledge and optionally update local runtime notes for tools
+   actually touched.
 
 Every touched entry must include:
 - `status`
@@ -51,13 +52,16 @@ If status does not change, use normal experience-level reporting.
 
 ## Degradation Rule for `status: true`
 
-If a tool marked `status: true` fails at use time (missing command, missing MCP tool, auth failure):
+If a runtime-local tool marked `status: true` fails at use time (missing command
+or missing MCP tool):
 
 1. Re-probe that tool immediately
 2. Update config to `status: false`, set `last_checked: [today]`, add explanatory notes
 3. Warn the user in the same turn
 
-Never let a previously-true tool fail silently.
+Never let a previously-true runtime-local tool fail silently. If the failure is
+provider auth/readiness, report the `mb connect doctor --json` repair command
+instead of inventing one.
 
 ---
 
@@ -73,13 +77,10 @@ tools:
     status: false
     notes: "No CLI or MCP tool detected"
     last_checked: 2026-03-02
-  pipeboard:
-    status: null
-    method: mcp
-    tier: null
-    notes: "unknown"
-    last_checked: null
-    weekly_calls_used: 0
+  document_tools:
+    status: true
+    notes: "markitdown verified"
+    last_checked: 2026-03-02
 ```
 
 ---

--- a/.claude/skills/mb-think/references/tool-status-self-healing.md
+++ b/.claude/skills/mb-think/references/tool-status-self-healing.md
@@ -13,7 +13,7 @@ A tool entry is **stale false** when all are true:
 - `status: false`
 - `last_checked` is missing, invalid, or older than 30 days
 
-Do not routine re-probe provider entries here. Runtime-local entries can be
+Do not routinely re-probe provider entries here. Runtime-local entries can be
 rechecked when a selected workflow needs that exact tool.
 
 ---

--- a/.claude/skills/mb-update/SKILL.md
+++ b/.claude/skills/mb-update/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: mb-update
 description: Update Main Branch. Use when the user says update, upgrade, pull latest, get latest Main Branch, asks whether they are current, or after Devon announces a new release. Preferred over legacy /mb-pull.
+loops: [ship]
 ---
 
 # Update
@@ -79,4 +80,3 @@ If no changelog is available, do not guess. Say:
 
 > "Update complete. I couldn't find the local changelog, so run `mb --version`
 > to confirm the installed version."
-

--- a/.claude/skills/mb-vsl/SKILL.md
+++ b/.claude/skills/mb-vsl/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: mb-vsl
 description: "Write high-converting Video Sales Letter scripts for any offer type. Routes to appropriate framework based on context. Use when: (1) Creating VSL scripts for Skool communities or membership offers (2) Writing sales videos for B2B high-ticket services ($3K-$50K+) (3) User says \"VSL\", \"video sales letter\", \"sales video script\", \"about page video\" (4) Need structured frameworks: 18-section for Skool/membership or 7-step Haynes for B2B. Produces camera-ready scripts optimized for spoken delivery. Never invents facts."
+loops: [ship]
 ---
 
 # VSL Script Writer

--- a/.claude/skills/mb-vsl/SKILL.md
+++ b/.claude/skills/mb-vsl/SKILL.md
@@ -13,6 +13,10 @@ Routes to the right framework based on your offer type.
 
 For the canonical engine resolution + pull bash block (and the failure warning), see [`references/pull-engine-updates.md`](references/pull-engine-updates.md). Run it at the start of every invocation.
 
+Then run `mb status --json --peek` from the business repo and use its
+`readiness`, `drift.items`, and `ranked_actions` facts before asking for missing
+setup or reference context. Do not duplicate repo-health checks in prose.
+
 ---
 
 ## Critical Rule: Never Invent Facts

--- a/.claude/skills/mb-vsl/references/pull-engine-updates.md
+++ b/.claude/skills/mb-vsl/references/pull-engine-updates.md
@@ -5,7 +5,7 @@ Canonical command for pulling latest Main Branch updates at the start of any ski
 `mb update` owns the install-mode mechanics. It detects pipx vs clone installs, runs the correct update command, and refreshes skill links for the business repo.
 
 ```bash
-mb update --repo "${REPO_PATH:-.}" --json 2>&1
+mb update --repo . --json 2>&1
 ```
 
 ## Handle the Result

--- a/.claude/skills/mb-wiki/SKILL.md
+++ b/.claude/skills/mb-wiki/SKILL.md
@@ -11,6 +11,7 @@ description: |
   (7) Generating "Recent Updates" notes from Git history
 
   Triggered by: /mb-wiki, "add a note", "publish wiki", "create wiki", "configure wiki", "personalize wiki"
+loops: [ship]
 ---
 
 # Wiki Skill

--- a/.claude/skills/mb-wiki/references/pull-engine-updates.md
+++ b/.claude/skills/mb-wiki/references/pull-engine-updates.md
@@ -5,7 +5,7 @@ Canonical command for pulling latest Main Branch updates at the start of any ski
 `mb update` owns the install-mode mechanics. It detects pipx vs clone installs, runs the correct update command, and refreshes skill links for the business repo.
 
 ```bash
-mb update --repo "${REPO_PATH:-.}" --json 2>&1
+mb update --repo . --json 2>&1
 ```
 
 ## Handle the Result

--- a/.claude/skills/mb-wiki/references/setup-mode.md
+++ b/.claude/skills/mb-wiki/references/setup-mode.md
@@ -7,11 +7,13 @@ Quick first-time wiki setup. Installs default template and deploys via wrangler 
 ## 1. Ask: Repo Name? Location?
 Default: `wiki` in home directory (`~/mb-wiki`)
 
-## 2. Check GitHub CLI
+## 2. Check GitHub Readiness
 ```bash
-gh auth status
+mb connect doctor --json
 ```
-If not authenticated, guide user to run `gh auth login`.
+If this is not a business repo or `mb` cannot inspect GitHub readiness here,
+fall back to `gh auth status`. If GitHub is not authenticated, guide user to
+run `gh auth login`.
 
 ## 3. Create GitHub Repo and Clone
 ```bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,9 +43,8 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   teams). Refs #306.
 - Updated bundled lifecycle and output skills to lean on deterministic
   `mb status --json --peek`, `mb connect plan`, `mb connect doctor --json`,
-  `mb update --repo .`, and `mb checkpoint --status --json` facts instead of
-  duplicating repo-health, provider-readiness, update, and continuity probes in
-  skill prose. Refs #263.
+  and `mb update --repo .` facts instead of duplicating repo-health,
+  provider-readiness, and update probes in skill prose. Refs #263.
 - Clarified beginner, migration, and `/mb-help` docs that `.mb/` is the current
   repo-local Main Branch state folder and `.mb-vip/` is not required. Refs
   #296.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,9 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 - Updated bundled lifecycle and output skills to lean on deterministic
   `mb status --json --peek`, `mb connect plan`, `mb connect doctor --json`,
   and `mb update --repo .` facts instead of duplicating repo-health,
-  provider-readiness, and update probes in skill prose. Refs #263.
+  provider-readiness, and update probes in skill prose. Added `loops:`
+  frontmatter aligned to Sense, Decide, Ship, and Reflect from the #307
+  taxonomy work. Refs #263 and #306.
 - Clarified beginner, migration, and `/mb-help` docs that `.mb/` is the current
   repo-local Main Branch state folder and `.mb-vip/` is not required. Refs
   #296.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,11 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   operators and small teams running real businesses (solo founders, small
   agencies, course creators, productized services, indie SaaS, small ecom
   teams). Refs #306.
+- Updated bundled lifecycle and output skills to lean on deterministic
+  `mb status --json --peek`, `mb connect plan`, `mb connect doctor --json`,
+  `mb update --repo .`, and `mb checkpoint --status --json` facts instead of
+  duplicating repo-health, provider-readiness, update, and continuity probes in
+  skill prose. Refs #263.
 - Clarified beginner, migration, and `/mb-help` docs that `.mb/` is the current
   repo-local Main Branch state folder and `.mb-vip/` is not required. Refs
   #296.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,9 +44,11 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 - Updated bundled lifecycle and output skills to lean on deterministic
   `mb status --json --peek`, `mb connect plan`, `mb connect doctor --json`,
   and `mb update --repo .` facts instead of duplicating repo-health,
-  provider-readiness, and update probes in skill prose. Added `loops:`
-  frontmatter aligned to Sense, Decide, Ship, and Reflect from the #307
-  taxonomy work. Refs #263 and #306.
+  provider-readiness, and update probes in skill prose. Added a `loops:` field
+  to the SKILL.md frontmatter schema and extended `mb skill validate` to require
+  it on every bundled skill. Skill authors maintaining third-party skills must
+  backfill the `loops:` field before upgrading; existing installations with
+  skills lacking the field will fail `mb skill validate`. Refs #263 and #306.
 - Clarified beginner, migration, and `/mb-help` docs that `.mb/` is the current
   repo-local Main Branch state folder and `.mb-vip/` is not required. Refs
   #296.

--- a/mb/mb/skill_validate.py
+++ b/mb/mb/skill_validate.py
@@ -17,9 +17,10 @@ from mb.validate import _check_one, _read_frontmatter
 
 MAX_SKILL_LINES = 500
 SKILL_NAME_PREFIX = "mb-"
+VALID_LOOP_SLUGS = {"sense", "decide", "ship", "reflect"}
 SKILL_SCHEMA: dict[str, Any] = {
     "glob": "SKILL.md",
-    "required": ["name", "description"],
+    "required": ["name", "description", "loops"],
     "enums": {},
 }
 
@@ -190,6 +191,24 @@ def _validate_skill_at(name: str, skill_root: Path) -> dict[str, Any]:
             skill_errors.append(f"name={skill_name!r} does not match skill directory {name!r}")
         if not isinstance(description, str) or not description.strip():
             skill_errors.append("description must be a non-empty string")
+        loops = fm.get("loops")
+        if (
+            not isinstance(loops, list)
+            or not loops
+            or not all(isinstance(loop, str) for loop in loops)
+        ):
+            skill_errors.append(
+                f"loops must be a non-empty list using canonical slugs: {sorted(VALID_LOOP_SLUGS)}"
+            )
+        else:
+            invalid_loops = sorted(set(loops) - VALID_LOOP_SLUGS)
+            if invalid_loops:
+                skill_errors.append(
+                    f"loops contains invalid slugs {invalid_loops}; "
+                    f"expected only {sorted(VALID_LOOP_SLUGS)}"
+                )
+            if len(set(loops)) != len(loops):
+                skill_errors.append("loops must not contain duplicate slugs")
 
     if line_count > MAX_SKILL_LINES:
         skill_errors.append(f"SKILL.md has {line_count} lines; limit is {MAX_SKILL_LINES}")

--- a/mb/tests/test_skill_validate.py
+++ b/mb/tests/test_skill_validate.py
@@ -28,7 +28,7 @@ def _skill(
 ) -> Path:
     skill_root = root / ".claude" / "skills" / name
     if frontmatter is None:
-        frontmatter = f"---\nname: {name}\ndescription: Test skill.\n---\n"
+        frontmatter = f"---\nname: {name}\ndescription: Test skill.\nloops: [sense]\n---\n"
     _write(skill_root / "SKILL.md", frontmatter + "\n# Test\n\n" + body)
     _write(skill_root / "references" / "details.md", "# Details\n")
     return skill_root
@@ -64,7 +64,7 @@ def test_skill_validate_passes_frontmatter_references_and_line_gate(
 def test_skill_validate_flags_missing_description(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    _skill(tmp_path, "mb-alpha", frontmatter="---\nname: mb-alpha\n---\n")
+    _skill(tmp_path, "mb-alpha", frontmatter="---\nname: mb-alpha\nloops: [sense]\n---\n")
     _patch_engine(monkeypatch, tmp_path)
 
     report = skill_validate_mod.run("mb-alpha")
@@ -77,7 +77,11 @@ def test_skill_validate_flags_missing_description(
 def test_skill_validate_flags_unprefixed_bundled_skill(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    _skill(tmp_path, "alpha", frontmatter="---\nname: alpha\ndescription: Test skill.\n---\n")
+    _skill(
+        tmp_path,
+        "alpha",
+        frontmatter="---\nname: alpha\ndescription: Test skill.\nloops: [sense]\n---\n",
+    )
     _patch_engine(monkeypatch, tmp_path)
 
     report = skill_validate_mod.run("alpha")
@@ -85,6 +89,44 @@ def test_skill_validate_flags_unprefixed_bundled_skill(
     assert report is not None
     assert report["ok"] is False
     assert "must use the 'mb-' vendor prefix" in report["files"][0]["errors"][0]
+
+
+def test_skill_validate_flags_missing_loops(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _skill(
+        tmp_path,
+        "mb-alpha",
+        frontmatter="---\nname: mb-alpha\ndescription: Test skill.\n---\n",
+    )
+    _patch_engine(monkeypatch, tmp_path)
+
+    report = skill_validate_mod.run("mb-alpha")
+
+    assert report is not None
+    assert report["ok"] is False
+    assert "missing key: loops" in report["files"][0]["errors"]
+
+
+def test_skill_validate_flags_invalid_loops(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _skill(
+        tmp_path,
+        "mb-alpha",
+        frontmatter=(
+            "---\nname: mb-alpha\ndescription: Test skill.\nloops: [sense, narrate, sense]\n---\n"
+        ),
+    )
+    _patch_engine(monkeypatch, tmp_path)
+
+    report = skill_validate_mod.run("mb-alpha")
+
+    assert report is not None
+    assert report["ok"] is False
+    errors = report["files"][0]["errors"]
+    assert any("invalid slugs ['narrate']" in error for error in errors)
+    assert "loops must not contain duplicate slugs" in errors
 
 
 def test_skill_validate_flags_missing_local_reference(


### PR DESCRIPTION
## Summary

- Reconciles bundled lifecycle/output skills around deterministic `mb` facts instead of hand-rolled repo-health, provider-readiness, status, and update probes.
- Adds `loops:` frontmatter to bundled skills and extends `mb skill validate` to require the four canonical PR #307 loop slugs: `sense`, `decide`, `ship`, and `reflect`.
- Aligns skill routing prose with the PR #307 structure while keeping skills judgment-heavy: routing, synthesis, writing, review, and show/reflect work stay in the runtime layer.

## Scope

In scope:
- `.claude/skills/` reconciliation for shipped CLI fact surfaces.
- Skill validator support for required `loops:` metadata.
- Changelog disclosure for the new validation requirement.

Out of scope:
- Runtime ports beyond Claude Code.
- Marketplace, dashboard, or sidecar work.
- Moving conversation state or model calls into `mb`.
- Renaming skills wholesale.

## Release / Issues

Refs #263 / MAIN-218.
Refs #306 and depends on the canonical loop taxonomy from PR #307.

Hold merge until PR #307 lands so the `loops:` references resolve to canonical docs on `main`.

## Commit List

- `4116546` `[update] MAIN-218 reconcile skill CLI facts`
- `f183f54` `[update] MAIN-218 align skills with shipped CLI`
- `2d0e2c0` `[fix] MAIN-218 address skill review`
- `a06e4d1` `[update] MAIN-218 align skills with operator loops`
- `1f50e04` `[fix] MAIN-218 address approved polish`

## Validation

Level 1 / static:
- `scripts/check.sh` from repo root: passed.
- Gate evidence included `228 passed in 46.10s` and `mb skill validate --all` JSON summary with `skills: 17`, `passed: 17`, `failed: 0`, `errors: 0`, `warnings: 0`.

Focused validator checks:
- `cd mb && python3 -m pytest tests/test_skill_validate.py -q`: `14 passed in 0.24s`.
- Old five-loop smoke rejects `loops: [know, see, execute, narrate]` with: `expected only ['decide', 'reflect', 'sense', 'ship']`.
- `cd mb && python3 -m mb skill validate --all`: `17` skills passed, including `mb-start` at `472` lines.

Runtime/manual:
- Claude Code runtime smoke from a fresh temp business repo ran `/mb-bet narrate ...` and returned: `mb-bet skill loaded. Mode token selected: narrate.` No files were edited.

## Public / Private Boundary

No private paths, credentials, customer/member data, or untested runtime support claims were added to public files.

## Follow-Ups

- `.claude/educational/provider-readiness.md` still references older provider readiness copy and should be reconciled separately.
- `.claude/skills/mb-ads/references/entry-points.md` still has Pipeboard-leading phrasing that can be cleaned up in a narrow follow-up.
- The validator's duplicate missing-field reporting for `loops:` matches existing name/description behavior; clean those together later if desired.
