### PR TITLE
[update] Prepare 0.3.1 release

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mainbranch",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Main Branch Claude Code skills for running a business from markdown files in git.",
   "author": {
     "name": "Noontide"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,27 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-05-05
+
+v0.3.1 tightens the v0.3 product frame after the first public release. It
+locks the operator loop language, adds checkpoint primitives for long agent
+runs, removes stale third-party Meta Ads connector assumptions, and documents
+how Main Branch chooses dependencies.
+
+### What this means for you (plain English)
+
+- **Long agent sessions can checkpoint work.** `mb checkpoint` can inspect
+  dirty business repos, propose readable checkpoint messages, and save approved
+  commits.
+- **The product language is more stable.** Public docs and skills now use the
+  Sense -> Decide -> Ship -> Reflect loop taxonomy.
+- **Meta Ads setup is less misleading.** Main Branch no longer presents
+  Pipeboard as the Meta Ads path and keeps official Meta support planned until
+  detection and read-only smoke are wired.
+- **Dependency choices are public.** Contributors can see why a dependency,
+  sidecar, CLI, MCP server, or provider adapter is adopted, planned, removed,
+  or declined.
+
 ### Added
 
 - Added `docs/DEPENDENCY-CHOICES.md` to make dependency, integration, sidecar,

--- a/mb/mb/__init__.py
+++ b/mb/mb/__init__.py
@@ -7,6 +7,6 @@ file stays a thin dispatcher.
 
 from __future__ import annotations
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 __all__ = ["__version__"]

--- a/mb/pyproject.toml
+++ b/mb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mainbranch"
-version = "0.3.0"
+version = "0.3.1"
 description = "Main Branch engine umbrella - scaffolds, validates, and graphs business-as-files repos. Claude Code first, runtime-agnostic by design."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- Prepares Main Branch `0.3.1` release truth.
- Moves the current `[Unreleased]` entries into a dated `0.3.1` changelog section with plain-English notes.
- Bumps package and Claude plugin manifest versions from `0.3.0` to `0.3.1`.

## Scope
- In: version metadata, changelog release section, plugin manifest version.
- Out: product/code behavior changes beyond already-merged unreleased work.

## Commits
- `72f9e4d` — `[update] Prepare 0.3.1 release`.

## Release / Issues
- Release: `0.3.1` / `oe-v0.3.1`.
- Linear ID(s): none.
- Closes: none.
- Refs: #263, #290, #291, #292, #295, #300, #304, #305, #306.
- Follow-ups: none from release prep.

## Success Metric
- GitHub Release `oe-v0.3.1`, PyPI `mainbranch 0.3.1`, installed `mb --version`, and fresh first-run smoke all agree.

## Validation
- Level 0 docs/decision: CHANGELOG release truth reviewed for version/date and no shipped claims beyond merged work.
- Level 1 static: `scripts/check.sh` passed: 230 tests, 81.35% coverage, skill validation passed.
- Level 2 CLI: Version test covered by local gate; installed wheel reports `mb 0.3.1`.
- Level 3 package/install: Built `mainbranch-0.3.1` wheel and installed into `/tmp/mainbranch-smoke-031`; `mb --version`, `mb skill list`, `mb onboard --json`, and `mb start --json` passed.
- Level 4 fixture repo: `mb onboard --yes --name "Smoke Business" --path /tmp/mainbranch-smoke-business-031 --json` passed from installed wheel.
- Level 5 runtime smoke: Not run; release prep does not change runtime discovery or invocation.

## Public / Private Boundary
- No private Devon, Conductor, credential, customer, or account-specific details were added.
