### PR TITLE
[fix] Audit legacy reference path guidance

### DIFF
--- a/.claude/skills/mb-ads/SKILL.md
+++ b/.claude/skills/mb-ads/SKILL.md
@@ -19,7 +19,7 @@ provider checks that `mb` already owns.
 
 **NEVER search the filesystem. NEVER use Explore or Task agents to find repos. NEVER scan ~/Documents/GitHub/.**
 
-**CWD-first:** If `reference/core/` exists in CWD, you're already in the business repo — use it.
+**CWD-first:** If `core/` or legacy `reference/core/` exists in CWD, you're already in the business repo — use it.
 
 If CWD is NOT a business repo:
 
@@ -52,7 +52,7 @@ At the repo path, resolve offer context first (see Offer Context Resolution abov
 ```
 [resolved offer.md]          → 0 (missing), 1 (<20 lines), 2 (20-80), 3 (80+)
 [resolved audience.md]       → same scoring
-reference/core/voice.md      → same scoring
+core/voice.md                → same scoring
 reference/proof/testimonials.md → same scoring
 reference/proof/angles/*.md  → count .md files EXCLUDING README.md: 0=0, 1=1, 2-3=2, 4+=3
 reference/visual-identity/visual-style.md → same scoring (optional)
@@ -232,9 +232,16 @@ These patterns that work in standard ads will get rejected in Employment:
 Before loading reference files, resolve the active offer:
 
 1. Check `.vip/local.yaml` for `current_offer`
-2. If set: load `reference/offers/[current_offer]/offer.md` as the active offer
-3. If not set AND `reference/offers/` exists: ask which offer
-4. If no `offers/` folder: use `reference/core/offer.md` (single-offer, backward compatible)
+2. If set: load `core/offers/[current_offer]/offer.md` as the active offer
+3. If not set AND `core/offers/` exists: ask which offer
+4. If no `core/offers/` folder: use `core/offer.md` (single-offer mode)
+5. Legacy fallback: if the repo does not have `core/`, read the old
+   `reference/core/` and `reference/offers/` paths.
+
+In current repos, `reference/core` and `reference/offers` are compatibility
+bridges to `core/` and `core/offers/`. Treat them as aliases, not duplicate
+files: read through them only as fallback, and never ask the user to update both
+paths.
 
 **Always-core files** (never per-offer): `soul.md`, `voice.md`, `content-strategy.md`
 **Offer-aware files** (check offers/ first, fall back to core/): `offer.md`, `audience.md`
@@ -251,10 +258,10 @@ Before creating ads, the business repo must have:
 
 | File | Path | Required |
 |------|------|----------|
-| Offer | `offers/[active]/offer.md` or `core/offer.md` (resolved via path resolution) | Yes |
-| Audience | `offers/[active]/audience.md` or `core/audience.md` (resolved via path resolution) | Yes |
-| Voice | `reference/core/voice.md` (always core) | Yes |
-| Testimonials | `reference/proof/testimonials.md` + `offers/[active]/testimonials.md` (accumulate) | Yes |
+| Offer | `core/offers/[active]/offer.md` or `core/offer.md` (resolved via path resolution) | Yes |
+| Audience | `core/offers/[active]/audience.md` or `core/audience.md` (resolved via path resolution) | Yes |
+| Voice | `core/voice.md` (always core) | Yes |
+| Testimonials | `reference/proof/testimonials.md` + `core/offers/[active]/testimonials.md` (accumulate) | Yes |
 | Angles | `reference/proof/angles/*.md` | Yes (at least 1) |
 | Visual Style | `reference/visual-identity/visual-style.md` | Optional (affects image gen) |
 | Content Strategy | `reference/domain/content-strategy.md` (always brand-level) | Optional (improves topic selection) |

--- a/.claude/skills/mb-ads/references/image-prompt-templates.md
+++ b/.claude/skills/mb-ads/references/image-prompt-templates.md
@@ -43,7 +43,7 @@ All templates follow the same JSON structure. Placeholders are filled at generat
 
 | Placeholder | Source |
 |-------------|--------|
-| `{{brand_name}}` | `reference/core/offer.md` → business name |
+| `{{brand_name}}` | `core/offer.md` -> business name |
 | `{{campaign_name}}` | User input at triage |
 | `{{angle_name}}` | Selected angle from Batch 1 |
 | `{{template_type}}` | graphic, lofi, interrupt, or textoverlay |

--- a/.claude/skills/mb-ads/references/mode-hook-library.md
+++ b/.claude/skills/mb-ads/references/mode-hook-library.md
@@ -39,7 +39,7 @@ Every variation **MUST** include at least one specific element:
 
 | Mode | How to Detect | What to Pull |
 |------|---------------|--------------|
-| **Has business repo** | Reference files exist | Resolved `offer.md`, resolved `audience.md`, `reference/core/voice.md`, testimonials |
+| **Has business repo** | Reference files exist | Resolved `offer.md`, resolved `audience.md`, `core/voice.md`, testimonials |
 | **No repo** | Nothing found | Ask user for materials |
 
 ---

--- a/.claude/skills/mb-ads/references/one-liner-methodology.md
+++ b/.claude/skills/mb-ads/references/one-liner-methodology.md
@@ -33,7 +33,7 @@ Each is a DIFFERENT reason to buy. Different psychological driver. Different mar
 
 | Mode | How to Detect | What to Pull |
 |------|---------------|--------------|
-| **Has business repo** | Reference files exist | `reference/core/offer.md`, `reference/core/audience.md`, `reference/core/voice.md` (if exists), testimonials |
+| **Has business repo** | Reference files exist | `core/offer.md`, `core/audience.md`, `core/voice.md` (if exists), testimonials |
 | **Alternate structure** | Systems files exist | `systems/01-the-offer.md`, `systems/02-the-customer.md` |
 | **No repo** | Nothing found | Ask user for materials |
 

--- a/.claude/skills/mb-ads/references/preflight-algorithm.md
+++ b/.claude/skills/mb-ads/references/preflight-algorithm.md
@@ -41,9 +41,12 @@ Score each file 0-3 based on line count + section presence.
 Use canonical path resolution for offer and audience files (multi-offer aware):
 
 1. Check `.vip/local.yaml` for `current_offer`
-2. If `current_offer` is set and `offers/{current_offer}/offer.md` exists, score that file
-3. Otherwise fall back to `reference/core/offer.md`
+2. If `current_offer` is set and `core/offers/{current_offer}/offer.md` exists, score that file
+3. Otherwise fall back to `core/offer.md`
 4. Same resolution for `audience.md`
+5. Legacy fallback: if `core/` is absent, read old `reference/core/` and
+   `reference/offers/` paths. In current repos, those are compatibility bridges
+   to canonical `core/` paths, not duplicate files.
 
 See `docs/system-architecture.md` (Canonical Path Resolution) for the full algorithm.
 
@@ -51,7 +54,7 @@ See `docs/system-architecture.md` (Canonical Path Resolution) for the full algor
 |------|-------------|--------|
 | `offer.md` (resolved) | Price, mechanism, benefits, guarantee | Required |
 | `audience.md` (resolved) | Pains, desires, demographics, psychographics | Required |
-| `reference/core/voice.md` | Tone, phrases, personality, don'ts | Required |
+| `core/voice.md` | Tone, phrases, personality, don'ts | Required |
 | `reference/proof/testimonials.md` | Named testimonials with outcomes | Required |
 | `reference/proof/angles/` | At least 1 angle file beyond README | Required |
 | `reference/visual-identity/visual-style.md` | Colors, typography, mood, prompt fragments | Optional (affects image gen) |

--- a/.claude/skills/mb-ads/references/review-workflow.md
+++ b/.claude/skills/mb-ads/references/review-workflow.md
@@ -177,7 +177,7 @@ git commit -m "[review] {type} batch - N fixes applied"
 **From business repo:**
 - `reference/proof/testimonials.md` — Available testimonials for substantiation check
 - `reference/proof/typicality.md` — Outcome data for claim validation
-- `reference/core/offer.md` — To verify claims match actual offering
+- `core/offer.md` — To verify claims match actual offering
 
 ## Quick Review (Single Lens)
 

--- a/.claude/skills/mb-end/SKILL.md
+++ b/.claude/skills/mb-end/SKILL.md
@@ -55,7 +55,7 @@ A quick `/mb-end` (user says "just commit and close") can be steps 1-3 and 6. Bu
 
 ## Step 1: Find the Business Repo
 
-**CWD-first:** If `reference/core/` exists in CWD, you're already in the business repo — use it. Otherwise, read `~/.config/vip/local.yaml` for `default_repo` as fallback.
+**CWD-first:** If `core/` or legacy `reference/core/` exists in CWD, you're already in the business repo — use it. Otherwise, read `~/.config/vip/local.yaml` for `default_repo` as fallback.
 
 **If no repo found:** Skip to a simple close. No business repo means no git activity to scan.
 
@@ -88,9 +88,9 @@ git diff --name-only --diff-filter=AM HEAD@{6am}..HEAD 2>/dev/null
 | Outputs generated | New files in `outputs/` |
 | Uncommitted changes | `git status --short` output |
 
-**Multi-offer detection (skip if no `offers/` folder — single-offer mode, everything reads from `core/`):** If `reference/offers/` exists, note which offers had files changed:
+**Multi-offer detection (skip if no `core/offers/` folder — single-offer mode, everything reads from `core/`):** If `core/offers/` exists, note which offers had files changed:
 ```bash
-git diff --name-only HEAD@{midnight}..HEAD -- reference/offers/ 2>/dev/null | head -20
+git diff --name-only HEAD@{midnight}..HEAD -- core/offers/ 2>/dev/null | head -20
 ```
 Report: "Offers affected: community, newsletter" (or "Brand-level changes only" if only core/ changed)
 
@@ -194,8 +194,8 @@ Before spawning the agent, read and collect:
 | Today's git summary | From Step 2 output | Always |
 | Today's decision files (full text) | Read each file detected in 5a | Always |
 | Today's research files (full text) | Read each file detected in 5a | Always |
-| Reference file diffs | `git diff HEAD@{6am}..HEAD -- reference/` | If reference changed |
-| `reference/core/soul.md` | Read full file | Always |
+| Reference file diffs | `git diff HEAD@{6am}..HEAD -- core/ reference/` | If reference changed |
+| `core/soul.md` | Read full file | Always |
 | `reference/domain/content-strategy.md` | Read full file | If it exists |
 | Past crystallize outputs | Read `research/*-end-of-day-crystallize.md` | If any exist |
 

--- a/.claude/skills/mb-end/references/crystallize-agent.md
+++ b/.claude/skills/mb-end/references/crystallize-agent.md
@@ -29,7 +29,7 @@ If none exist, write: "First crystallize session. No prior outputs."]
 
 === SOUL.MD ===
 
-[Full text of reference/core/soul.md]
+[Full text of core/soul.md]
 
 === CONTENT STRATEGY ===
 

--- a/.claude/skills/mb-help/SKILL.md
+++ b/.claude/skills/mb-help/SKILL.md
@@ -13,7 +13,7 @@ Answer questions, troubleshoot issues, explain philosophy, suggest next steps.
 ## Workflow
 
 1. **Triage** — Parse user's question/brain-dump
-2. **Detect business type** — Check `reference/core/*.md` (Skool? Ecommerce?)
+2. **Detect business type** — Check `core/*.md` (Skool? Ecommerce?), with legacy `reference/core/*.md` fallback only if `core/` is absent
 3. **Load reference** — Find topic in references/ table below
 4. **Answer** — Explain "why" not just "what"
 5. **Route** — End with next skill or action
@@ -77,9 +77,9 @@ Answer questions, troubleshoot issues, explain philosophy, suggest next steps.
 | What are subagents? | Claude can spawn parallel agents to research or review simultaneously. You'll see it happen automatically in `/mb-think` (multi-source research) and `/mb-ads review` (6 compliance lenses). Each agent gets its own context window so your main conversation stays clean. |
 | How do I manage context/tokens? | Context management is a skill that develops over time. Your files (research/, decisions/, reference/) survive compaction — only conversation memory compresses. After compaction, help Claude rebuild by pointing it at recent files or running /mb-start. Save insights to research files early — if it's in a file, it's safe. |
 | How do I close a session? | Run `/mb-end`. It summarizes what happened, asks if you have final thoughts, offers a crystallize moment if you made decisions, commits uncommitted work, and says goodbye. Bookend to `/mb-start`. |
-| What is multi-offer? | Multiple products under one brand, one repo. Each offer gets its own `reference/offers/[name]/offer.md`. Soul and voice stay in `core/` because they're brand-level. Use when you sell multiple things (community + newsletter + done-for-you). If you have no `offers/` folder, you're in single-offer mode — everything reads from `core/` and nothing changes. |
+| What is multi-offer? | Multiple products under one brand, one repo. Each offer gets its own `core/offers/[name]/offer.md`. Soul and voice stay in `core/` because they're brand-level. Use when you sell multiple things (community + newsletter + done-for-you). If you have no `core/offers/` folder, you're in single-offer mode — everything reads from `core/` and nothing changes. |
 | How do I switch offers? | Say `/mb-start [offer-name]` or answer when /mb-start prompts. The active offer is stored in `.vip/local.yaml`. |
-| Where do offer files go? | `reference/offers/[name]/offer.md` for offer-specific details. `reference/core/offer.md` stays as the brand-level thesis. |
+| Where do offer files go? | `core/offers/[name]/offer.md` for offer-specific details. `core/offer.md` stays as the brand-level thesis. Legacy `reference/offers` and `reference/core` may point at those folders as compatibility bridges; do not edit both. |
 | What stays in core with multiple offers? | `soul.md` (always), `voice.md` (always), `audience.md` (base, with optional per-offer overrides), `content-strategy.md` (brand-level distribution). |
 | How do I add another offer? | Run `/mb-setup` -- it detects your existing setup and offers a migration path. Or use `/mb-think` to plan the new offer first. |
 | Do I need separate repos for separate businesses? | If they share `soul.md` and `voice.md`, same repo with `offers/`. If they have different identities, different repos. The test: shared soul = shared repo. |

--- a/.claude/skills/mb-help/references/content-strategy-help.md
+++ b/.claude/skills/mb-help/references/content-strategy-help.md
@@ -25,7 +25,7 @@ reference/
     └── content-strategy.md
 ```
 
-It lives in `reference/domain/`, not `reference/core/`. Core files (soul, offer, audience, voice) are required for every business. Content strategy is domain-level -- it emerges over time through `/mb-think` cycles, not at setup.
+It lives in `reference/domain/`, not `core/`. Core files (soul, offer, audience, voice) are required for every business. Content strategy is domain-level -- it emerges over time through `/mb-think` cycles, not at setup.
 
 **Why domain and not core?** You need to have your core reference solid before a content strategy makes sense. You also need some real content experience (what platforms you like, what topics land, what hooks work) before you can codify a strategy. It is emergent, not foundational.
 

--- a/.claude/skills/mb-help/references/gpt-migration.md
+++ b/.claude/skills/mb-help/references/gpt-migration.md
@@ -86,9 +86,9 @@ For complex GPT outputs:
 
 | GPT Content | Main Branch Location |
 |-------------|---------------------|
-| Offer details, pricing | reference/core/offer.md |
-| Audience insights | reference/core/audience.md |
-| Voice/tone examples | reference/core/voice.md |
+| Offer details, pricing | core/offer.md |
+| Audience insights | core/audience.md |
+| Voice/tone examples | core/voice.md |
 | Testimonials | reference/proof/testimonials.md |
 | Winning ad copy | reference/proof/angles/ |
 | Strategy discussions | research/ (dated) |

--- a/.claude/skills/mb-help/references/organic-help.md
+++ b/.claude/skills/mb-help/references/organic-help.md
@@ -10,9 +10,9 @@ Before using `/mb-organic`, you need three files in your business repo:
 
 | File | What It Contains |
 |------|------------------|
-| `reference/core/voice.md` | How you sound on camera |
-| `reference/core/audience.md` | Who watches your content |
-| `reference/core/offer.md` | What you do/sell |
+| `core/voice.md` | How you sound on camera |
+| `core/audience.md` | Who watches your content |
+| `core/offer.md` | What you do/sell |
 
 **Don't have these?** Run `/mb-setup` first.
 
@@ -59,7 +59,7 @@ The complete generation workflow:
 Generate a Reels/TikTok script:
 - From a concept in your saved research
 - From a topic you provide
-- Applies your voice from `reference/core/voice.md`
+- Applies your voice from `core/voice.md`
 
 ### Carousel: `/mb-organic carousel "topic"`
 
@@ -99,9 +99,9 @@ The skill needs these files in your business repo:
 
 | File | Required? | Purpose |
 |------|-----------|---------|
-| `reference/core/offer.md` | Yes | Context for CTAs |
-| `reference/core/audience.md` | Yes | Who you're creating for |
-| `reference/core/voice.md` | Yes | How you sound on camera |
+| `core/offer.md` | Yes | Context for CTAs |
+| `core/audience.md` | Yes | Who you're creating for |
+| `core/voice.md` | Yes | How you sound on camera |
 | `research/*.md` | No | Saved research from `/mb-think` (competitor mining, content ideas) |
 
 If missing core files, run `/mb-setup` first.
@@ -138,7 +138,7 @@ Same structure. Different words. Your topic.
 
 ### "How is voice applied?"
 
-The skill reads `reference/core/voice.md` and:
+The skill reads `core/voice.md` and:
 - Matches your tone (casual, professional, energetic)
 - Uses your vocabulary
 - Avoids your "never say" phrases
@@ -206,7 +206,7 @@ Mining happens through `/mb-think`, not `/mb-organic`. Each competitor uses ~3-5
 
 ### "Output doesn't sound like me"
 
-Check `reference/core/voice.md`:
+Check `core/voice.md`:
 - Is it detailed enough?
 - Does it have examples of how you talk?
 - Does it list phrases to avoid?

--- a/.claude/skills/mb-help/references/task-tracking-options.md
+++ b/.claude/skills/mb-help/references/task-tracking-options.md
@@ -47,7 +47,7 @@ status: proposed  # ← This is your progress indicator
 ## What Changes
 
 Reference files affected:
-- `reference/core/offer.md` — update pricing section with new tier structure
+- `core/offer.md` — update pricing section with new tier structure
 - `reference/proof/angles/` — create new value-stack angle
 
 Outside reference:

--- a/.claude/skills/mb-help/references/the-think-cycle.md
+++ b/.claude/skills/mb-help/references/the-think-cycle.md
@@ -44,7 +44,7 @@ Claude will:
 |------|----------|---------|
 | Research | `research/2026-01-19-topic-claude-code.md` | Dated investigations |
 | Decisions | `decisions/2026-01-19-topic.md` | Choices with rationale |
-| Reference | `reference/core/offer.md` | Evergreen truth skills consume |
+| Reference | `core/offer.md` | Evergreen truth skills consume |
 
 ---
 

--- a/.claude/skills/mb-organic/SKILL.md
+++ b/.claude/skills/mb-organic/SKILL.md
@@ -65,9 +65,16 @@ For the full mining methodology (Visual/Audible/Emotional framework, AI capabili
 Before loading reference files, resolve the active offer:
 
 1. Check `.vip/local.yaml` for `current_offer`
-2. If set: load `reference/offers/[current_offer]/offer.md` as the active offer
-3. If not set AND `reference/offers/` exists: ask which offer
-4. If no `offers/` folder: use `reference/core/offer.md` (single-offer, backward compatible)
+2. If set: load `core/offers/[current_offer]/offer.md` as the active offer
+3. If not set AND `core/offers/` exists: ask which offer
+4. If no `core/offers/` folder: use `core/offer.md` (single-offer mode)
+5. Legacy fallback: if the repo does not have `core/`, read the old
+   `reference/core/` and `reference/offers/` paths.
+
+In current repos, `reference/core` and `reference/offers` are compatibility
+bridges to `core/` and `core/offers/`. Treat them as aliases, not duplicate
+files. Read through them only as fallback, and write once to the canonical
+`core/` path when reference updates are needed.
 
 **Always-core files** (never per-offer): `soul.md`, `voice.md`, `content-strategy.md`
 **Offer-aware files** (check offers/ first, fall back to core/): `offer.md`, `audience.md`
@@ -80,13 +87,13 @@ If offer specified, overrides session `current_offer` for this run.
 
 ## First-Time Setup
 
-Requires `reference/core/voice.md` (always core), plus resolved `offer.md` and `audience.md` (offer-aware — checks `offers/[active]/` first, falls back to `core/`).
+Requires `core/voice.md` (always core), plus resolved `offer.md` and `audience.md` (offer-aware — checks `core/offers/[active]/` first, falls back to `core/`).
 
 **Optional but recommended:** `reference/domain/content-strategy.md` — If present, /mb-organic reads content pillars to align generated content and platform strategy for format selection. Note that `content-strategy.md` is brand-level, but content can be offer-specific. Works perfectly without it.
 
 **Congruence check:** If `reference/domain/funnel/skool-surfaces.md` exists, read it. Organic content should echo the same positioning and claims visible on the Skool about page and pricing cards. No contradictions between organic and the landing experience.
 
-**CWD-first:** If `reference/core/` exists in CWD, you're already in the business repo. Otherwise, run `mb status --json --peek` and use its repo/readiness facts if available. If status cannot identify a repo, ask the user or run `/mb-setup`.
+**CWD-first:** If `core/` or legacy `reference/core/` exists in CWD, you're already in the business repo. Otherwise, run `mb status --json --peek` and use its repo/readiness facts if available. If status cannot identify a repo, ask the user or run `/mb-setup`.
 
 Missing files? See [references/first-time-setup.md](references/first-time-setup.md).
 
@@ -255,7 +262,7 @@ See [references/static-template.md](references/static-template.md).
 
 ## Voice Adaptation
 
-Read `reference/core/voice.md`. Match tone, use their vocabulary, avoid their "never say" list.
+Read `core/voice.md` (or legacy `reference/core/voice.md` only when `core/` is absent). Match tone, use their vocabulary, avoid their "never say" list.
 
 **Authenticity:** Sounds like creator (not copywriter). Uses contractions. Matches energy. No AI tells ("dive into", "unlock", "game-changer").
 

--- a/.claude/skills/mb-organic/references/first-time-setup.md
+++ b/.claude/skills/mb-organic/references/first-time-setup.md
@@ -151,6 +151,7 @@ Once you have the three core files:
 3. Want to research competitors first? Run `/mb-think` -- mining saves to `research/`, then `/mb-organic` generates from it
 
 The skill will guide you from there.
+
 If the repo has no `core/` folder, use legacy `reference/core/` as a temporary
 read fallback until the repo is migrated. In current repos, `reference/core` is
 a compatibility bridge to `core/`, not a second file to edit.

--- a/.claude/skills/mb-organic/references/first-time-setup.md
+++ b/.claude/skills/mb-organic/references/first-time-setup.md
@@ -8,9 +8,9 @@ Before running `/mb-organic`, you need three core reference files. This guide he
 
 | File | Purpose | Minimum |
 |------|---------|---------|
-| `reference/core/voice.md` | How you sound on camera | 1 paragraph |
-| `reference/core/audience.md` | Who watches your content | 2-3 sentences |
-| `reference/core/offer.md` | What you do/sell | 1 sentence |
+| `core/voice.md` | How you sound on camera | 1 paragraph |
+| `core/audience.md` | Who watches your content | 2-3 sentences |
+| `core/offer.md` | What you do/sell | 1 sentence |
 
 **Don't have these?** Run `/mb-setup` first, or create them manually below.
 
@@ -151,3 +151,6 @@ Once you have the three core files:
 3. Want to research competitors first? Run `/mb-think` -- mining saves to `research/`, then `/mb-organic` generates from it
 
 The skill will guide you from there.
+If the repo has no `core/` folder, use legacy `reference/core/` as a temporary
+read fallback until the repo is migrated. In current repos, `reference/core` is
+a compatibility bridge to `core/`, not a second file to edit.

--- a/.claude/skills/mb-organic/references/minimal-voice-template.md
+++ b/.claude/skills/mb-organic/references/minimal-voice-template.md
@@ -1,6 +1,10 @@
 # Minimal Voice Template
 
-Copy this template to `reference/core/voice.md` and fill in your details.
+Copy this template to `core/voice.md` and fill in your details.
+
+If this is an old repo without `core/`, `reference/core/voice.md` is the legacy
+fallback. In current repos, `reference/core` points at `core/`; do not maintain
+both paths separately.
 
 ---
 

--- a/.claude/skills/mb-organic/references/mining-template.md
+++ b/.claude/skills/mb-organic/references/mining-template.md
@@ -230,8 +230,8 @@ Most effective hook types observed:
 | File | Potential Update |
 |------|------------------|
 | reference/proof/angles/*.md | [New angles discovered — create or update angle files] |
-| reference/core/voice.md | [Voice patterns to adopt/avoid] |
-| reference/core/audience.md | [New understanding of what resonates with them] |
+| core/voice.md | [Voice patterns to adopt/avoid] |
+| core/audience.md | [New understanding of what resonates with them] |
 | reference/visual-identity/guardrails.md | [Patterns to avoid, anti-patterns spotted] |
 
 ### Before You Generate: Update Reference First

--- a/.claude/skills/mb-setup/SKILL.md
+++ b/.claude/skills/mb-setup/SKILL.md
@@ -108,7 +108,7 @@ After business type, determine offer structure:
 
 > "How many distinct products or services do you sell?"
 
-**If one:** "Single offer — clean and simple. All your details go in `reference/core/`. Most people start here."
+**If one:** "Single offer — clean and simple. All your details go in `core/`. Most people start here."
 
 **If multiple:** "Multiple offers under one brand. You share the same soul and voice, but each offer has its own specifics."
 - Ask: "What should we call each offer? Short slugs work best (e.g., 'community', 'newsletter', 'done-for-you')"
@@ -171,16 +171,21 @@ See **[references/context-gathering.md](references/context-gathering.md)** for:
 ```bash
 # Always create:
 mkdir -p .vip
-mkdir -p reference/core reference/visual-identity reference/proof/angles reference/domain
+mkdir -p core core/offers core/finance reference/visual-identity reference/proof/angles reference/domain
 mkdir -p research decisions bets log campaigns documents
 ```
+
+If the repo needs compatibility bridges for older skills, create
+`reference/core -> ../core` and `reference/offers -> ../core/offers`. Treat
+those as aliases, not duplicate files. Write user reference content once under
+`core/` or `core/offers/`.
 
 **Multi-offer only (if user has multiple offers from Step 2.5):**
 
 ```bash
 # Create offer folders for each offer
 for offer in [offer-names]; do
-  mkdir -p "reference/offers/$offer"
+  mkdir -p "core/offers/$offer"
 done
 
 # Write initial current_offer
@@ -204,12 +209,16 @@ Full structure (single-offer):
 ├── .vip/                  # VIP configuration (git-tracked)
 │   └── config.yaml        # User preferences, infrastructure refs
 │
-├── reference/             # Evergreen truth
-│   ├── core/              # REQUIRED
-│   │   ├── offer.md       # What you sell
-│   │   ├── audience.md    # Who buys
-│   │   └── voice.md       # How you sound
-│   ├── brand/             # Deep brand systems (optional)
+├── core/                  # Evergreen brand truth
+│   ├── soul.md            # Why you exist
+│   ├── offer.md           # What you sell / brand thesis
+│   ├── audience.md        # Who buys
+│   ├── voice.md           # How you sound
+│   ├── finance/           # Ledger and tax artifacts
+│   └── offers/            # Per-offer specifics when multi-offer
+│
+├── reference/             # Proof/domain files plus compatibility bridges
+│   ├── visual-identity/
 │   ├── proof/
 │   │   ├── testimonials.md
 │   │   └── angles/        # Proven messaging entry points
@@ -309,7 +318,8 @@ git add -A
 git commit -m "$(cat <<'EOF'
 [init] Bootstrap business repo with Main Branch structure
 
-- Created reference/core/ (offer, audience, voice)
+- Created core/ (soul, offer, audience, voice)
+- Created core/offers/ (per-offer specifics)
 - Created reference/proof/ (testimonials, angles)
 - Created reference/domain/ ([domain-type] specific)
 - Drafted CLAUDE.md and README.md
@@ -335,7 +345,7 @@ EOF
 
 | File | Status |
 |------|--------|
-| offers/[name]/offer.md | [OK] Complete / [WARN] Thin (< 20 lines) / [FAIL] Missing |
+| core/offers/[name]/offer.md | [OK] Complete / [WARN] Thin (< 20 lines) / [FAIL] Missing |
 | domain/product-ladder.md | [OK] Complete / [WARN] Placeholder |
 | .vip/local.yaml | [OK] Set to [offer] / [FAIL] Missing |
 
@@ -372,7 +382,7 @@ If conversation compacts mid-setup:
 - "You created the folder structure but we haven't sorted content"
 
 **For Claude:** When resuming:
-1. Check if business repo exists (look for `reference/core/`)
+1. Check if business repo exists (look for `core/`, with legacy `reference/core/` fallback)
 2. If exists, check which files are populated vs empty
 3. Resume from the appropriate step based on what's done
 4. Confirm with user: "I see [business-name] with [X] files. Looks like we're at step [N]. Continue?"

--- a/.claude/skills/mb-setup/SKILL.md
+++ b/.claude/skills/mb-setup/SKILL.md
@@ -173,12 +173,14 @@ See **[references/context-gathering.md](references/context-gathering.md)** for:
 mkdir -p .vip
 mkdir -p core core/offers core/finance reference/visual-identity reference/proof/angles reference/domain
 mkdir -p research decisions bets log campaigns documents
+
+# Compatibility bridges for older skills/tools:
+ln -sfn ../core reference/core
+ln -sfn ../core/offers reference/offers
 ```
 
-If the repo needs compatibility bridges for older skills, create
-`reference/core -> ../core` and `reference/offers -> ../core/offers`. Treat
-those as aliases, not duplicate files. Write user reference content once under
-`core/` or `core/offers/`.
+Treat `reference/core` and `reference/offers` as aliases, not duplicate files.
+Write user reference content once under `core/` or `core/offers/`.
 
 **Multi-offer only (if user has multiple offers from Step 2.5):**
 

--- a/.claude/skills/mb-setup/references/claude-md-guide.md
+++ b/.claude/skills/mb-setup/references/claude-md-guide.md
@@ -93,7 +93,7 @@ This repo contains your **business data**. It's powered by **Main Branch** (the 
 - [Characteristic 1]
 - [Characteristic 2]
 
-**Full profile:** `reference/core/audience.md`
+**Full profile:** `core/audience.md`
 
 ---
 
@@ -105,7 +105,7 @@ This repo contains your **business data**. It's powered by **Main Branch** (the 
 - "[Phrase 1]"
 - "[Phrase 2]"
 
-**Full system:** `reference/core/voice.md`
+**Full system:** `core/voice.md`
 
 ---
 
@@ -123,7 +123,7 @@ This repo contains your **business data**. It's powered by **Main Branch** (the 
 | Tier | What | When Loaded |
 |------|------|-------------|
 | **Always** | This CLAUDE.md | Every session |
-| **Core** | reference/core/*.md | When generating content |
+| **Core** | core/*.md | When generating content |
 | **On-demand** | research/, decisions/ | When reasoning about choices |
 | **Deep reference** | reference/visual-identity/, reference/proof/ | When writing copy |
 | **Domain** | reference/domain/ | When business-type matters |
@@ -172,7 +172,7 @@ CLAUDE.md is **Tier 1** — always loaded, so keep it lean.
 
 Pattern:
 1. **Summary in CLAUDE.md** — Quick reference
-2. **Pointer to full file** — "Full system: `reference/core/voice.md`"
+2. **Pointer to full file** — "Full system: `core/voice.md`"
 3. **Claude loads on-demand** — When actually needed
 
 Example:
@@ -182,7 +182,7 @@ Example:
 **Tone:** Calm, grounded, never preachy
 **Key phrases:** "Wearable notes to self", "Stay awake. Stay happy."
 
-**Full system:** `reference/core/voice.md`
+**Full system:** `core/voice.md`
 ```
 
 ---

--- a/.claude/skills/mb-setup/references/file-education.md
+++ b/.claude/skills/mb-setup/references/file-education.md
@@ -27,7 +27,7 @@ Present each blurb before writing the corresponding file.
 For multi-offer setups, also explain:
 
 ### offer.md (brand-level)
-> "This is your brand-level offer.md — the umbrella story. It covers what your brand stands for across all offers. Each specific offer gets its own file in `offers/[name]/offer.md` with pricing, mechanism, and details."
+> "This is your brand-level offer.md — the umbrella story. It covers what your brand stands for across all offers. Each specific offer gets its own file in `core/offers/[name]/offer.md` with pricing, mechanism, and details."
 
 ### product-ladder.md
 > "product-ladder.md maps how your offers relate. Which one do people discover first? Where do they go next? This helps us create content and ads that guide people through your world."
@@ -36,10 +36,10 @@ For multi-offer setups, also explain:
 
 ## Priority Order (Single-Offer)
 
-1. `reference/core/soul.md` — Why you exist (reconnection fuel)
-2. `reference/core/offer.md` — What you sell (or brand thesis if multi-offer)
-3. `reference/core/audience.md` — Who buys
-4. `reference/core/voice.md` — How you sound
+1. `core/soul.md` — Why you exist (reconnection fuel)
+2. `core/offer.md` — What you sell (or brand thesis if multi-offer)
+3. `core/audience.md` — Who buys
+4. `core/voice.md` — How you sound
 5. `reference/proof/testimonials.md` — Social proof
 6. `reference/proof/angles/` — Messaging entry points
 7. `reference/visual-identity/visual-style.md` — Visual brand identity (colors, typography, mood, image prompt fragments)
@@ -48,8 +48,8 @@ For multi-offer setups, also explain:
 
 ### Multi-Offer Additional Files (if applicable)
 
-10. `reference/offers/[name]/offer.md` — Offer-specific details for each offer
-11. `reference/offers/[name]/audience.md` — Only if this offer targets a different segment
+10. `core/offers/[name]/offer.md` — Offer-specific details for each offer
+11. `core/offers/[name]/audience.md` — Only if this offer targets a different segment
 12. `reference/domain/product-ladder.md` — How offers relate to each other
 
 > **Note:** content-strategy.md and visual-style.md start as templates and get filled through `/mb-think` cycles. Not required at setup — scaffolded with placeholder sections.

--- a/.claude/skills/mb-setup/references/git-workflow.md
+++ b/.claude/skills/mb-setup/references/git-workflow.md
@@ -63,7 +63,7 @@ Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
 ```
 [init] Bootstrap business repo with Main Branch structure
 
-- Created reference/core/ (offer, audience, voice)
+- Created core/ (soul, offer, audience, voice)
 - Created reference/proof/ (testimonials, angles)
 - Created reference/domain/products/
 - Drafted CLAUDE.md and README.md
@@ -135,7 +135,7 @@ EOF
 git add -A
 
 # Stage specific files
-git add reference/core/offer.md reference/core/audience.md
+git add core/offer.md core/audience.md
 
 # Stage by folder
 git add reference/proof/

--- a/.claude/skills/mb-setup/references/migration-multi-offer.md
+++ b/.claude/skills/mb-setup/references/migration-multi-offer.md
@@ -6,7 +6,7 @@ When an existing user with `core/offer.md` wants to add another offer (detected 
 
 Check for existing single-offer structure:
 ```bash
-ls reference/core/offer.md 2>/dev/null && ! ls reference/offers/*/offer.md 2>/dev/null
+ls core/offer.md 2>/dev/null && ! ls core/offers/*/offer.md 2>/dev/null
 ```
 
 If `core/offer.md` exists and no `offers/` folder: this is a migration.
@@ -25,11 +25,11 @@ If `core/offer.md` exists and no `offers/` folder: this is a migration.
 4. **Execute atomically:**
    ```bash
    # Move existing offer to its own folder
-   mkdir -p "reference/offers/[existing-name]"
-   git mv reference/core/offer.md "reference/offers/[existing-name]/offer.md"
+   mkdir -p "core/offers/[existing-name]"
+   git mv core/offer.md "core/offers/[existing-name]/offer.md"
 
    # Create new offer folder
-   mkdir -p "reference/offers/[new-name]"
+   mkdir -p "core/offers/[new-name]"
    # (new offer.md will be written in the guide-writing step below)
 
    # Create product-ladder.md

--- a/.claude/skills/mb-setup/references/templates.md
+++ b/.claude/skills/mb-setup/references/templates.md
@@ -4,7 +4,7 @@ Copy and customize these templates when creating reference files.
 
 ---
 
-## reference/core/offer.md
+## core/offer.md
 
 ```markdown
 ---
@@ -67,7 +67,7 @@ How it works — the unique approach that delivers the transformation:
 
 ---
 
-## reference/core/audience.md
+## core/audience.md
 
 ```markdown
 ---
@@ -151,7 +151,7 @@ Words and phrases they use to describe their problem:
 
 ---
 
-## reference/core/voice.md
+## core/voice.md
 
 ```markdown
 ---

--- a/.claude/skills/mb-site/SKILL.md
+++ b/.claude/skills/mb-site/SKILL.md
@@ -76,7 +76,7 @@ The skill reads from the business repo and writes to the site repo. These are se
 
 Detect mode at the start of every invocation.
 
-**Business repo mode = plan/create/link.** If CWD has `core/` or `reference/core/`, say:
+**Business repo mode = plan/create/link.** If CWD has `core/` or legacy `reference/core/`, say:
 > "I'm reading business context here and will create or select a site repo."
 
 Use this mode for planning, research, the site brief, offer selection, campaign records, and first site creation.

--- a/.claude/skills/mb-site/references/examples-and-troubleshooting.md
+++ b/.claude/skills/mb-site/references/examples-and-troubleshooting.md
@@ -106,7 +106,7 @@ Website (Next.js): check `globals.css` for correct CSS variable names. Check `la
 
 ### "Reference files not found"
 
-Check `~/.mainbranch/sites.json` — the `business_repo` path must point to your business repo with `reference/core/` files (or `reference/offers/<active>/` for multi-offer setups).
+Check `~/.mainbranch/sites.json` — the `business_repo` path must point to your business repo with `core/` files (or `core/offers/<active>/` for multi-offer setups). Legacy `reference/core` and `reference/offers` paths are only compatibility bridges to those canonical folders.
 
 ### Site looks generic / like AI
 

--- a/.claude/skills/mb-site/references/website-build.md
+++ b/.claude/skills/mb-site/references/website-build.md
@@ -81,7 +81,7 @@ git push -u origin main
 - **Cloudflare Pages (default):** `python3 .claude/skills/mb-site/scripts/pages.py create-project <name> --repo-owner <owner> --repo-name <repo> --branch main` — git-connected, auto-deploys on push. Configure build command (`pnpm build`) + output directory (`out` or `dist`) in the CF dashboard once.
 - **Netlify (legacy):** see [`deployment.md`](deployment.md). Key settings: Build command = `pnpm build`, Publish directory = `out`, NODE_VERSION = `20`.
 
-**10. Detect business repo.** Ask: "Where is your business repo with reference files?" Confirm the path has `reference/core/` files. If the business repo has `reference/offers/`, ask which offer this site is for. Store the offer in the sites.json config.
+**10. Detect business repo.** Ask: "Where is your business repo with reference files?" Confirm the path has `core/` files, with legacy `reference/core/` fallback only if `core/` is absent. If the business repo has `core/offers/`, ask which offer this site is for. Store the offer in the sites.json config. Treat `reference/core` and `reference/offers` as compatibility bridges, not duplicate files.
 
 **11. Save config.** Write `~/.mainbranch/sites.json`:
 ```json

--- a/.claude/skills/mb-site/scripts/stripe.py
+++ b/.claude/skills/mb-site/scripts/stripe.py
@@ -340,7 +340,7 @@ def _classify_error(result: StripeResult) -> tuple[StripeErrorCode, str]:
 # ---------------------------------------------------------------------------
 
 # Lowercased slug: alphanumeric + hyphen + underscore. Matches typical offer
-# directory naming under reference/offers/<slug>/.
+# directory naming under core/offers/<slug>/.
 OFFER_SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,62}$")
 
 
@@ -476,7 +476,7 @@ def create_payment_link(
             error=StripeError(
                 code="invalid_offer_slug",
                 message=slug_err,
-                suggestion="Use the offer's directory name from reference/offers/.",
+                suggestion="Use the offer's directory name from core/offers/.",
             ),
         )
         sys.exit(emit(env))

--- a/.claude/skills/mb-start/SKILL.md
+++ b/.claude/skills/mb-start/SKILL.md
@@ -43,7 +43,7 @@ are `missing`, `blocked`, `ready_for_preview`, `ready_for_operator_review`, and
 
 ## CRITICAL: Repo Selection Rules
 
-**CWD-first wins.** If `reference/core/` or `core/` exists in CWD, the user is already in their business repo — no selection needed. Just confirm: "Working in **[repo-name]**."
+**CWD-first wins.** If `core/` or legacy `reference/core/` exists in CWD, the user is already in their business repo — no selection needed. Just confirm: "Working in **[repo-name]**."
 
 **Only ask which repo when CWD is NOT a business repo** (fallback to config). In that case, list ALL validated repos from `recent_repos`:
 
@@ -67,7 +67,7 @@ are `missing`, `blocked`, `ready_for_preview`, `ready_for_operator_review`, and
 **DO NOT skip this question when in fallback mode.** Users have multiple repos. The saved default is a suggestion, not automatic.
 
 **Exceptions (skip selection entirely):**
-- CWD has `reference/core/` or `core/` — user chose their repo by cd'ing into it
+- CWD has `core/` or legacy `reference/core/` — user chose their repo by cd'ing into it
 - User explicitly ran `/mb-start [repo-name]` with a specific path
 
 **After user selects a repo:** If the selected repo is not the current `default_repo`, ask: "Want me to save [repo-name] as your default? (faster startup next time)" If yes, update `default_repo` in `~/.config/vip/local.yaml`.
@@ -90,7 +90,7 @@ Apply to: business repo selection, skill routing, any multiple choice.
 ├── Check context level ──────────────→ Fresh? Full load. Heavy? Warn user.
 │
 ├── Detect business repo ─────────────→ CWD-first detection (see Step 2)
-│   ├── CWD has reference/core/ or core/? → This IS the repo. Proceed.
+│   ├── CWD has core/ or legacy reference/core/? → This IS the repo. Proceed.
 │   ├── CWD has .claude/skills/? ─────→ User is in the engine repo (old workflow). Trigger migration.
 │   └── Neither? ────────────────────→ Check config, then ask user.
 │
@@ -207,7 +207,7 @@ The user starts Claude in their business repo. Check CWD first before falling ba
 **Quick gist:**
 
 ```
-1. test -d "reference/core" || test -d "core"  → THIS IS the business repo. Skip to config.
+1. test -d "core" || test -d "reference/core"  → THIS IS the business repo. Skip to config.
 2. test -f ".claude/skills/mb-start/SKILL.md"  → user is in the engine repo; migrate.
 3. Otherwise → fall back to ~/.config/vip/local.yaml.
 ```
@@ -351,8 +351,12 @@ Adapt display to `user.experience` level (beginner = full breakdown, advanced = 
 After loading core context, check for multi-offer:
 
 ```bash
-find "$REPO_PATH/reference/offers" -mindepth 2 -maxdepth 2 -name "offer.md" 2>/dev/null
+find "$REPO_PATH/core/offers" -mindepth 2 -maxdepth 2 -name "offer.md" 2>/dev/null
 ```
+
+If `core/offers` is absent but legacy `reference/offers` exists and `core/` is
+also absent, use `reference/offers` as the fallback. In current repos,
+`reference/offers` is a bridge to `core/offers`, not a separate offer tree.
 
 **If no offers/ folder:** Single-offer mode. Skip to Step 2. Everything reads from `core/`.
 
@@ -377,7 +381,8 @@ Use `readiness`, `onboarding`, `drift.items`, and `ranked_actions` from
 `mb status --json --peek` first. If those sections are unavailable, use this
 fallback check.
 
-Fallback: check `reference/core/*.md`. No folder → `/mb-setup`. If two or more
+Fallback: check `core/*.md`, then legacy `reference/core/*.md` only when
+`core/` is absent. No folder → `/mb-setup`. If two or more
 core files are missing/thin, route to `/mb-think codify`; otherwise route by
 intent. Use [readiness-assessment.md](references/readiness-assessment.md) for
 the exact fallback thresholds.

--- a/.claude/skills/mb-start/references/config-system.md
+++ b/.claude/skills/mb-start/references/config-system.md
@@ -188,7 +188,7 @@ cat ~/.claude/settings.json 2>/dev/null | grep business_repo_path
 
 ## Creating Missing Config
 
-If repo has `reference/core/` but no `.vip/config.yaml`:
+If repo has `core/` or legacy `reference/core/` but no `.vip/config.yaml`:
 
 > "Your repo exists but doesn't have VIP config. Create it?
 > Benefits: faster startups, synced preferences, MCP tracking."
@@ -276,7 +276,7 @@ Users rename folders, move repos, or clone to new locations. Config paths go sta
 **Before presenting ANY repo as a numbered option, verify the path exists:**
 
 ```bash
-test -d "[path]/reference/core" && echo "valid" || echo "invalid"
+if test -d "[path]/core" || test -d "[path]/reference/core"; then echo "valid"; else echo "invalid"; fi
 ```
 
 Never show a dead path. Never load a dead path and show "0/18 EMPTY" for a repo that simply moved.
@@ -286,7 +286,7 @@ Never show a dead path. Never load a dead path and show "0/18 EMPTY" for a repo 
 When a config path is invalid:
 
 1. **Check parent directory** — if the parent exists, the folder was likely renamed
-2. **Scan siblings** — look for `reference/core/` in adjacent folders
+2. **Scan siblings** — look for `core/` or legacy `reference/core/` in adjacent folders
 3. **If match found** — tell the user: "Looks like **[old-name]** moved to **[new-name]**. Updating your config."
 4. **If no match** — silently drop the stale entry from the list
 

--- a/.claude/skills/mb-start/references/readiness-assessment.md
+++ b/.claude/skills/mb-start/references/readiness-assessment.md
@@ -41,7 +41,7 @@ When checking section markers, search for these headings (case-insensitive). The
 
 **CRITICAL: Use absolute paths for ALL file reads and searches.** The repo path from Step 2 is an absolute path (e.g., `/Users/devon/Documents/GitHub/my-business`). Always use it — never use `~` or relative paths. The Glob and Read tools do not expand `~`, so `~/Documents/GitHub/repo/reference/proof` will silently return 0 results even when files exist.
 
-1. **Read each file** with the Read tool using the absolute repo path (e.g., `[repo-path]/reference/core/soul.md`). If the read fails or returns empty, score 0.
+1. **Read each file** with the Read tool using the absolute repo path (e.g., `[repo-path]/core/soul.md`). If the read fails or returns empty, score 0.
 2. **Count lines** for the primary threshold check.
 3. **Check for section markers** (case-insensitive grep for key headings from the table above) as a quality override -- a 25-line soul.md with a "Beliefs" section shows intentional work and scores 2, not 1. Use specific markers to identify exactly what's missing.
 4. **For testimonials:** Read `[repo-path]/reference/proof/testimonials.md`. Count occurrences of `###` or `**"` patterns (each indicates one testimonial).
@@ -51,12 +51,16 @@ When checking section markers, search for these headings (case-insensitive). The
 
 When `.vip/local.yaml` has `current_offer` set:
 
-1. Score `reference/core/soul.md` and `reference/core/voice.md` from core (these are always brand-level).
+1. Score `core/soul.md` and `core/voice.md` from core (these are always brand-level).
 2. For offer and audience, resolve using the canonical path algorithm:
-   - Check `reference/offers/[current_offer]/offer.md` first. If it exists, score it.
-   - If it does not exist, score `reference/core/offer.md`.
+   - Check `core/offers/[current_offer]/offer.md` first. If it exists, score it.
+   - If it does not exist, score `core/offer.md`.
    - Same for `audience.md`.
-3. Testimonials and angles: check both `reference/proof/` (brand-level) and `reference/offers/[current_offer]/` if offer-specific proof exists.
+3. Testimonials and angles: check both `reference/proof/` (brand-level) and `core/offers/[current_offer]/` if offer-specific proof exists.
+
+Legacy fallback: if the repo has no `core/`, read `reference/core/` and
+`reference/offers/`. In current repos those paths are compatibility bridges to
+canonical `core/` paths. Do not score or report them as duplicate files.
 
 ### Composite Score
 
@@ -139,7 +143,7 @@ Lightweight metadata checks that catch common decay without reading full file co
 ### Check A: Frontmatter Status Scan (1 call)
 
 ```bash
-grep -l "status: draft" [repo-path]/reference/core/*.md 2>/dev/null
+grep -l "status: draft" [repo-path]/core/*.md 2>/dev/null
 ```
 
 Flag any file that scored 3/3 structurally but has `status: draft` in frontmatter. Highest-signal check — the user explicitly declared this file unfinished.
@@ -149,7 +153,7 @@ Flag any file that scored 3/3 structurally but has `status: draft` in frontmatte
 ### Check B: Staleness Detection (1 call)
 
 ```bash
-git log --format="%ai" -1 -- [repo-path]/reference/core/soul.md [repo-path]/reference/core/offer.md [repo-path]/reference/core/audience.md [repo-path]/reference/core/voice.md
+git log --format="%ai" -1 -- [repo-path]/core/soul.md [repo-path]/core/offer.md [repo-path]/core/audience.md [repo-path]/core/voice.md
 ```
 
 Flag any core file not modified in 30+ days. Not a score penalty — an observation.
@@ -254,7 +258,7 @@ Modeled on /mb-end's crystallize pattern. For returning users, reconnection at s
 ### When to Trigger
 
 **Trigger conditions (ALL must be true):**
-1. `reference/core/soul.md` exists and has substance (score 2+)
+1. `core/soul.md` exists and has substance (score 2+)
 2. Last commit was >3 days ago (returning after absence)
 3. This is not the user's first session ever (config exists with `user.name`)
 
@@ -273,7 +277,7 @@ git log -1 --format="%ar" 2>/dev/null
 
 ### The Ask
 
-Read `reference/core/soul.md` (first 50 lines is enough to get the WHY). Then ask:
+Read `core/soul.md` (first 50 lines is enough to get the WHY). Then ask:
 
 > "Welcome back. Your last session was [N] days ago.
 >

--- a/.claude/skills/mb-start/references/repo-detection.md
+++ b/.claude/skills/mb-start/references/repo-detection.md
@@ -8,7 +8,7 @@ CWD-first detection of the business repo, with config fallback. The user starts 
 
 ```
 1. Check CWD for business repo fingerprint:
-   test -d "reference/core" || test -d "core"
+   test -d "core" || test -d "reference/core"
    ├── YES → This IS the business repo. Use CWD. Skip to config loading.
    └── NO → Continue to step 2.
 
@@ -55,7 +55,7 @@ Once business repo is identified (from CWD or config), load settings:
 
 If CWD detection fails (step 3 above), present options from config:
 
-**Validate EVERY path in config before showing it to the user.** Never present a dead path as an option. For each path in `default_repo` and `recent_repos`, check `test -d "[path]/reference/core" || test -d "[path]/core"`. If invalid, attempt recovery (check sibling folders for a renamed repo) and auto-prune dead entries. See [config-system.md](config-system.md) for the full recovery algorithm.
+**Validate EVERY path in config before showing it to the user.** Never present a dead path as an option. For each path in `default_repo` and `recent_repos`, check `test -d "[path]/core" || test -d "[path]/reference/core"`. If invalid, attempt recovery (check sibling folders for a renamed repo) and auto-prune dead entries. See [config-system.md](config-system.md) for the full recovery algorithm.
 
 **ALWAYS present numbered options** — even with ONE repo found:
 
@@ -76,14 +76,14 @@ If CWD detection fails (step 3 above), present options from config:
 
 Use fallbacks in order:
 
-1. **Scan additionalDirectories** for paths containing `reference/core/` or `core/`
+1. **Scan additionalDirectories** for paths containing `core/` or legacy `reference/core/`
 2. **Use bash to find repos** (if step 1 fails)
    ```bash
    find ~/Documents/GitHub -maxdepth 3 -type d \( -name "reference" -o -name "core" \) -print 2>/dev/null
    ```
 3. **Ask the user** (if nothing found)
 
-**Verify with Read, not Glob:** Use `Read` on `[path]/reference/core/soul.md` or `[path]/core/soul.md` to confirm it's a business repo. `soul.md` is always in `core/` (even multi-offer repos).
+**Verify with Read, not Glob:** Use `Read` on `[path]/core/soul.md` or legacy `[path]/reference/core/soul.md` to confirm it's a business repo. `soul.md` is always canonical in `core/` for current repos.
 
 **Skip the engine repo** - any path containing `.claude/skills/mb-start/SKILL.md` is the engine, not a business repo.
 

--- a/.claude/skills/mb-start/references/triage-agent.md
+++ b/.claude/skills/mb-start/references/triage-agent.md
@@ -125,7 +125,7 @@ testimonials X/3, angles X/3. Composite X/18.]
 
 === REFERENCE FILES ===
 
-[Full text of each reference file in core/, offers/[active]/ if multi-offer,
+[Full text of each reference file in core/, core/offers/[active]/ if multi-offer,
 proof/testimonials.md, proof/angles/*.md, domain/content-strategy.md,
 domain/product-ladder.md if multi-offer, domain/funnel/skool-surfaces.md if exists]
 

--- a/.claude/skills/mb-think/SKILL.md
+++ b/.claude/skills/mb-think/SKILL.md
@@ -80,9 +80,16 @@ For self-healing semantics (stale false handling, status-change messaging, true-
 Before loading reference files, resolve the active offer:
 
 1. Check `.vip/local.yaml` for `current_offer`
-2. If set: load `reference/offers/[current_offer]/offer.md` as the active offer
-3. If not set AND `reference/offers/` exists: ask which offer
-4. If no `offers/` folder: use `reference/core/offer.md` (single-offer, backward compatible)
+2. If set: load `core/offers/[current_offer]/offer.md` as the active offer
+3. If not set AND `core/offers/` exists: ask which offer
+4. If no `core/offers/` folder: use `core/offer.md` (single-offer mode)
+5. Legacy fallback: if the repo does not have `core/`, read the old
+   `reference/core/` and `reference/offers/` paths.
+
+In current repos, `reference/core` and `reference/offers` are compatibility
+bridges to `core/` and `core/offers/`. Treat them as aliases, not duplicate
+files: write once to the canonical `core/` path and never ask the user to edit
+both.
 
 **Always-core files** (never per-offer): `soul.md`, `voice.md`, `content-strategy.md`
 **Offer-aware files** (check offers/ first, fall back to core/): `offer.md`, `audience.md`
@@ -98,9 +105,10 @@ All files save to YOUR business repo, not the Main Branch engine.
 your-business-repo/          <- Files saved here
 ├── research/                 <- Research output
 ├── decisions/                <- Decision output
-└── reference/                <- Codify updates this
-    ├── core/                 <- Brand-level
-    ├── offers/               <- Per-offer (if multi-offer)
+├── core/                     <- Brand-level codify updates
+│   └── offers/               <- Per-offer codify updates
+└── reference/                <- Proof/domain files plus compatibility bridges
+    ├── proof/
     └── domain/
 
 mainbranch/ (engine)          <- Never modified
@@ -206,7 +214,7 @@ ls reference/domain/content-strategy.md 2>/dev/null
 | content-strategy.md exists but empty/thin | "Your content strategy file is a skeleton. Want to fill it in? We can derive pillars from your soul.md + offer.md + audience.md." |
 | content-strategy.md missing (community biz) | "You don't have a content strategy yet. Want to build one? It'll define your pillars, platforms, and cadence." |
 | skool-surfaces.md missing (community biz with live Skool) | "Your Skool about page and pricing card copy aren't in reference yet. Want to add them? Skills check this for congruence." |
-| `reference/offers/` exists | Multi-offer repo. Check `.vip/local.yaml` for `current_offer`. If not set, ask which offer this research/decision is about. |
+| `core/offers/` exists | Multi-offer repo. Check `.vip/local.yaml` for `current_offer`. If not set, ask which offer this research/decision is about. |
 | Nothing in progress | "What are you trying to figure out?" |
 
 **The goal is reference files.** Research and decisions are waypoints. Keep asking: "What needs to happen to get this into reference?"
@@ -309,7 +317,7 @@ See [decide-phase.md](references/decide-phase.md) for format details.
 
 Apply changes described in `## What Changes` to reference files. Mark decision as codified.
 
-**Codify targets include:** `reference/core/*.md`, `reference/core/voice.md` (named enemies section — each content pillar fights a named concept enemy), `reference/offers/[active]/offer.md`, `reference/offers/[active]/audience.md` (when multi-offer), `reference/proof/angles/*.md` (evolving library — new angles add, never replace), `reference/proof/testimonials.md`, **`reference/domain/content-strategy.md`** (pillars, hooks library, framework library, metrics — saves are #1 purchase intent signal), `reference/domain/funnel/skool-surfaces.md` (live Skool copy — update when about page or pricing changes), `reference/domain/product-ladder.md` (when multi-offer, cross-offer decisions).
+**Codify targets include:** `core/*.md`, `core/voice.md` (named enemies section — each content pillar fights a named concept enemy), `core/offers/[active]/offer.md`, `core/offers/[active]/audience.md` (when multi-offer), `reference/proof/angles/*.md` (evolving library — new angles add, never replace), `reference/proof/testimonials.md`, **`reference/domain/content-strategy.md`** (pillars, hooks library, framework library, metrics — saves are #1 purchase intent signal), `reference/domain/funnel/skool-surfaces.md` (live Skool copy — update when about page or pricing changes), `reference/domain/product-ladder.md` (when multi-offer, cross-offer decisions).
 
 ---
 

--- a/.claude/skills/mb-think/references/codify-phase.md
+++ b/.claude/skills/mb-think/references/codify-phase.md
@@ -88,8 +88,8 @@ When `current_offer` is set (multi-offer mode), audit offer-specific files first
 
 | File | Status | Gaps |
 |------|--------|------|
-| offers/[active]/offer.md | Good | - |
-| offers/[active]/audience.md | Thin | Missing objections |
+| core/offers/[active]/offer.md | Good | - |
+| core/offers/[active]/audience.md | Thin | Missing objections |
 | core/offer.md (brand-level) | Good | - |
 | core/audience.md (brand-level) | Good | - |
 | core/voice.md | Empty | Needs everything |
@@ -150,7 +150,7 @@ After codifying, show summary. Use offer-qualified paths when in multi-offer mod
 
 | File | Changes |
 |------|---------|
-| offers/community/offer.md | Added three-tier pricing section |
+| core/offers/community/offer.md | Added three-tier pricing section |
 | core/offer.md | Updated brand thesis to reflect multi-tier positioning |
 | core/voice.md | Added 5 phrases, 3 personality markers |
 | proof/testimonials.md | Added 3 new testimonials |
@@ -158,7 +158,13 @@ After codifying, show summary. Use offer-qualified paths when in multi-offer mod
 **Still missing:** [anything not addressed]
 ```
 
-**Target resolution:** When `current_offer` is set, offer-specific changes go to `offers/[active]/`. Brand-level changes go to `core/`. If unsure whether a change is offer-specific or brand-level, ask the user.
+**Target resolution:** When `current_offer` is set, offer-specific changes go to `core/offers/[active]/`. Brand-level changes go to `core/`. If unsure whether a change is offer-specific or brand-level, ask the user.
+
+**Compatibility bridges:** In current repos, `reference/core` points at
+`core/` and `reference/offers` points at `core/offers/`. These are aliases for
+older skill paths, not duplicate files. Write once to the canonical `core/` or
+`core/offers/` target. Only use `reference/core/` or `reference/offers/` as a
+legacy fallback when `core/` is absent.
 
 ---
 
@@ -220,7 +226,7 @@ When research surfaces a new emotional territory, buyer motivation, or competiti
 
 When research or decisions identify a named enemy:
 
-1. Check `reference/core/voice.md` for existing Named Enemies section
+1. Check `core/voice.md` for existing Named Enemies section
 2. Add the new enemy with its pillar mapping
 3. Enemies are ALWAYS concepts, never people or companies
 4. Each content pillar should fight one primary enemy

--- a/.claude/skills/mb-think/references/decide-phase.md
+++ b/.claude/skills/mb-think/references/decide-phase.md
@@ -107,19 +107,19 @@ Outside reference: set up Stripe subscription, update sales page copy.
 ## What Changes
 
 Reference files affected:
-- `offers/community/offer.md` — updated pricing section
+- `core/offers/community/offer.md` — updated pricing section
 - `core/offer.md` — updated brand thesis
 - `reference/domain/product-ladder.md` — updated ascension logic
 
 Outside reference: update Skool pricing cards.
 ```
 
-**Be specific:** "Update offer" is bad. "offers/community/offer.md gets a 30-day guarantee section after pricing" is good. Name the files and describe the changes — but as prose, not checkboxes.
+**Be specific:** "Update offer" is bad. "`core/offers/community/offer.md` gets a 30-day guarantee section after pricing" is good. Name the files and describe the changes — but as prose, not checkboxes.
 
 ### Decision Scope
 
 When documenting a decision, note which offer it affects:
-- **Offer-specific:** affects one offer's files (e.g., `offers/community/offer.md`)
+- **Offer-specific:** affects one offer's files (e.g., `core/offers/community/offer.md`)
 - **Brand-level:** affects core/ files (e.g., `core/voice.md`, `core/offer.md` brand thesis)
 - **Cross-offer:** affects `domain/product-ladder.md` or multiple offers simultaneously
 

--- a/.claude/skills/mb-think/references/recovery.md
+++ b/.claude/skills/mb-think/references/recovery.md
@@ -99,7 +99,7 @@ If the file doesn't exist or `current_offer` is not set, check recent `research/
 
 Confirm with user: "Were you working on [offer]?"
 
-If the repo has `reference/offers/` but no `current_offer` is recoverable, ask before proceeding: "Which offer are you working on?"
+If the repo has `core/offers/` but no `current_offer` is recoverable, ask before proceeding: "Which offer are you working on?" Use legacy `reference/offers/` only when `core/` is absent.
 
 ---
 

--- a/.claude/skills/mb-think/references/research-phase.md
+++ b/.claude/skills/mb-think/references/research-phase.md
@@ -9,11 +9,11 @@ Detailed workflow for research mode in `/mb-think`.
 ## Offer Context Resolution
 
 When researching an offer-specific topic, load:
-- `offers/[active]/offer.md` (if exists) for offer-specific context
+- `core/offers/[active]/offer.md` (if exists) for offer-specific context
 - `core/offer.md` for brand-level context
 - Both may be relevant — offer-specific for details, core for brand positioning
 
-Check `.vip/local.yaml` for `current_offer` before starting research. If `reference/offers/` exists but `current_offer` is not set, ask which offer this research relates to.
+Check `.vip/local.yaml` for `current_offer` before starting research. If `core/offers/` exists but `current_offer` is not set, ask which offer this research relates to. Use legacy `reference/offers/` only when `core/` is absent.
 
 ---
 
@@ -82,7 +82,7 @@ When the user's research topic involves content pillars, platform selection, con
 
 **Research flow for content strategy topics:**
 1. Read existing `reference/domain/content-strategy.md` (if present) to understand current state
-2. Read `reference/core/soul.md` + `offer.md` + `audience.md` for pillar derivation context
+2. Read `core/soul.md` + resolved `offer.md` + resolved `audience.md` for pillar derivation context
 3. Conduct research (web, mining, competitor analysis)
 4. Synthesize into a research file as usual
 5. In the **Implications for Reference Files** section, note which sections of `content-strategy.md` should be updated
@@ -316,7 +316,7 @@ In multi-offer mode, use offer-qualified paths:
 
 | File | Potential Update |
 |------|------------------|
-| `offers/community/offer.md` | Add tier structure, update pricing |
+| `core/offers/community/offer.md` | Add tier structure, update pricing |
 | `core/offer.md` | Update brand-level positioning |
 | `core/audience.md` | Segment by tier |
 | `domain/product-ladder.md` | Update ascension logic |
@@ -325,11 +325,11 @@ In single-offer mode, paths stay standard:
 
 | File | Potential Update |
 |------|------------------|
-| `reference/core/offer.md` | Add tier structure, update pricing |
-| `reference/core/audience.md` | Segment by tier |
+| `core/offer.md` | Add tier structure, update pricing |
+| `core/audience.md` | Segment by tier |
 
 **Bad:** "Update offer.md"
-**Good:** "Update offers/community/offer.md — Add three-tier pricing with benefits per tier"
+**Good:** "Update core/offers/community/offer.md — Add three-tier pricing with benefits per tier"
 
 ### Open Questions
 

--- a/.claude/skills/mb-think/references/templates/research-template.md
+++ b/.claude/skills/mb-think/references/templates/research-template.md
@@ -98,8 +98,8 @@ linked_decisions: []
 
 | File | Potential Update |
 |------|------------------|
-| `reference/core/offer.md` | [What might change] |
-| `reference/core/audience.md` | [What might change] |
+| `core/offer.md` | [What might change] |
+| `core/audience.md` | [What might change] |
 | `reference/proof/angles/` | [What might change] |
 
 ### Open Questions
@@ -232,8 +232,8 @@ Three-tier pricing with free/paid/premium maximizes reach while creating natural
 
 | File | Potential Update |
 |------|------------------|
-| `reference/core/offer.md` | Add tier descriptions, pricing logic |
-| `reference/core/audience.md` | Segment by tier (free seeker vs committed buyer) |
+| `core/offer.md` | Add tier descriptions, pricing logic |
+| `core/audience.md` | Segment by tier (free seeker vs committed buyer) |
 | `reference/proof/angles/value.md` | Update ROI math for each tier |
 
 ### Open Questions

--- a/.claude/skills/mb-vsl/SKILL.md
+++ b/.claude/skills/mb-vsl/SKILL.md
@@ -53,9 +53,15 @@ If unclear, ask: "Is this for a Skool/membership community ($47-$497/month) or a
 Before loading reference files, resolve the active offer:
 
 1. Check `.vip/local.yaml` for `current_offer`
-2. If set: load `reference/offers/[current_offer]/offer.md` as the active offer
-3. If not set AND `reference/offers/` exists: ask which offer
-4. If no `offers/` folder: use `reference/core/offer.md` (single-offer, backward compatible)
+2. If set: load `core/offers/[current_offer]/offer.md` as the active offer
+3. If not set AND `core/offers/` exists: ask which offer
+4. If no `core/offers/` folder: use `core/offer.md` (single-offer mode)
+5. Legacy fallback: if the repo does not have `core/`, read the old
+   `reference/core/` and `reference/offers/` paths.
+
+In current repos, `reference/core` and `reference/offers` are compatibility
+bridges to `core/` and `core/offers/`. Treat them as aliases, not duplicate
+files, and write once to the canonical `core/` path.
 
 **Always-core files** (never per-offer): `soul.md`, `voice.md`, `content-strategy.md`
 **Offer-aware files** (check offers/ first, fall back to core/): `offer.md`, `audience.md`
@@ -70,9 +76,9 @@ If offer specified, overrides session `current_offer` for this run. If the activ
 
 | File | Path | Purpose |
 |------|------|---------|
-| Offer | `offers/[active]/offer.md` or `core/offer.md` (resolved via path resolution) | What you sell, price, inclusions, guarantee |
-| Audience | `offers/[active]/audience.md` or `core/audience.md` (resolved via path resolution) | Who buys, their pains, objections |
-| Testimonials | `reference/proof/testimonials.md` + `offers/[active]/testimonials.md` (accumulate) | Success stories with specifics |
+| Offer | `core/offers/[active]/offer.md` or `core/offer.md` (resolved via path resolution) | What you sell, price, inclusions, guarantee |
+| Audience | `core/offers/[active]/audience.md` or `core/audience.md` (resolved via path resolution) | Who buys, their pains, objections |
+| Testimonials | `reference/proof/testimonials.md` + `core/offers/[active]/testimonials.md` (accumulate) | Success stories with specifics |
 | Skool Surfaces | `reference/domain/funnel/skool-surfaces.md` | Live Skool about page + pricing copy (congruence) |
 
 **If missing:** Ask user to provide or run `/mb-think` first.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   not business repo work to commit.
 - Clarified migration runtime smoke language so agents distinguish slash-command
   discovery and read-only core access from a full `/mb-think` workflow.
+- Updated bundled skill guidance to treat `core/` and `core/offers/` as the
+  canonical write paths, with `reference/core` and `reference/offers` only as
+  legacy compatibility bridges, and added skill validation warnings for stale
+  direct legacy path guidance.
 
 ## [0.3.1] - 2026-05-05
 

--- a/docs/MIGRATING.md
+++ b/docs/MIGRATING.md
@@ -294,7 +294,13 @@ Current Main Branch commands understand that legacy shape:
 - `mb status` counts `reference/core/`.
 - `mb start` treats a repo with `reference/core/`, `research/`, and
   `decisions/` as a business repo.
-- Claude Code skills still read compatibility paths under `reference/`.
+- Claude Code skills can read compatibility paths under `reference/` when
+  `core/` is absent.
+
+After migration, `reference/core` and `reference/offers` are compatibility
+links back to `core/` and `core/offers/`. They are not duplicate files. Agents
+should write once to the canonical `core/` or `core/offers/` path and should
+not ask users to edit both a canonical path and its `reference/` bridge.
 
 The only thing legacy users usually need immediately is:
 
@@ -358,6 +364,9 @@ moves legacy core files into `core/`, moves legacy offer files into
 `core/offers/`, leaves compatibility links under `reference/`, updates stale
 `CLAUDE.md` path references, writes a migration decision artifact, and stamps
 `.mb/schema_version`.
+
+Those compatibility links exist so older readers keep working. Current skills
+and agents should treat `core/` and `core/offers/` as the write targets.
 
 After apply, `mb validate` may still report old frontmatter schema debt in
 research and decision files. That means the layout migration worked but older

--- a/mb/mb/_data/templates/CLAUDE.md.tmpl
+++ b/mb/mb/_data/templates/CLAUDE.md.tmpl
@@ -14,8 +14,9 @@ Your business as files. Claude reads these; you edit them; git remembers them.
 - `log/` — running activity log
 - `campaigns/` — paid + organic campaign work
 - `documents/` — anything that doesn't belong above
-- `reference/` — compatibility paths Claude Code skills read from
-  (`reference/core` points at `core/`)
+- `reference/` — proof/domain files plus compatibility paths for old readers
+  (`reference/core` points at `core/`; `reference/offers` points at
+  `core/offers/`; edit canonical `core/` paths, not both)
 
 ## Conventions
 

--- a/mb/mb/init.py
+++ b/mb/mb/init.py
@@ -153,7 +153,7 @@ def run(path: str, name: str) -> dict[str, Any]:
             keep.write_text("", encoding="utf-8")
             created.append(f"{sub}/.gitkeep")
 
-    # Current Claude Code skills read reference/core and reference/offers.
+    # Older Claude Code skills may read reference/core and reference/offers.
     # Keep those paths as compatibility bridges to the CLI's root core tree.
     for source_name, dest_name in (("core", "reference/core"), ("core/offers", "reference/offers")):
         mode = _link_or_mkdir(target / source_name, target / dest_name)
@@ -227,8 +227,9 @@ Your business as files. Claude reads these; you edit them; git remembers them.
 - `log/` — running activity log
 - `campaigns/` — paid + organic campaign work
 - `documents/` — anything that doesn't belong above
-- `reference/` — compatibility paths Claude Code skills read from
-  (`reference/core` points at `core/`)
+- `reference/` — proof/domain files plus compatibility paths for old readers
+  (`reference/core` points at `core/`; `reference/offers` points at
+  `core/offers/`; edit canonical `core/` paths, not both)
 
 ## Conventions
 

--- a/mb/mb/skill_validate.py
+++ b/mb/mb/skill_validate.py
@@ -30,7 +30,7 @@ _BARE_SKILL_REF_RE = re.compile(
     r"(?<![\w./(`-])((?:\.\/)?(?:references|examples|scripts|assets)/[^\s`()\[\]<>,]+)"
 )
 _REFERENCE_ROOTS = ("references", "examples", "scripts", "assets")
-_LEGACY_REFERENCE_PATH_RE = re.compile(r"reference/(?:core|offers)(?:/|`|$)")
+_LEGACY_REFERENCE_PATH_RE = re.compile(r"reference/(?:core|offers)(?![\w-])")
 _LEGACY_REFERENCE_ALLOW_TERMS = (
     "legacy",
     "fallback",

--- a/mb/mb/skill_validate.py
+++ b/mb/mb/skill_validate.py
@@ -30,6 +30,24 @@ _BARE_SKILL_REF_RE = re.compile(
     r"(?<![\w./(`-])((?:\.\/)?(?:references|examples|scripts|assets)/[^\s`()\[\]<>,]+)"
 )
 _REFERENCE_ROOTS = ("references", "examples", "scripts", "assets")
+_LEGACY_REFERENCE_PATH_RE = re.compile(r"reference/(?:core|offers)(?:/|`|$)")
+_LEGACY_REFERENCE_ALLOW_TERMS = (
+    "legacy",
+    "fallback",
+    "compatibility",
+    "bridge",
+    "older",
+    "old ",
+    "absent",
+    "points at",
+    "not duplicate",
+    "not a duplicate",
+    "do not edit both",
+    "never ask",
+    "test -d",
+    "read fallback",
+    "temporary",
+)
 
 
 def _clean_reference(raw: str) -> str | None:
@@ -134,6 +152,28 @@ def _check_references(skill_root: Path, source: Path, text: str) -> list[str]:
     return errors
 
 
+def _check_legacy_reference_guidance(text: str) -> list[str]:
+    warnings: list[str] = []
+    in_fence = False
+    lines = text.splitlines()
+    for line_number, line in enumerate(lines, start=1):
+        if line.lstrip().startswith(("```", "~~~")):
+            in_fence = not in_fence
+            continue
+        if in_fence or not _LEGACY_REFERENCE_PATH_RE.search(line):
+            continue
+        context = " ".join(lines[max(0, line_number - 2) : min(len(lines), line_number + 1)])
+        normalized = context.lower()
+        if any(term in normalized for term in _LEGACY_REFERENCE_ALLOW_TERMS):
+            continue
+        warnings.append(
+            f"line {line_number}: legacy reference/core or reference/offers path "
+            "mentioned without compatibility/fallback context; prefer canonical "
+            "core/ or core/offers/ write guidance"
+        )
+    return warnings
+
+
 def _iter_referenced_markdown(skill_root: Path) -> list[Path]:
     roots = [skill_root / "references", skill_root / "examples"]
     return [
@@ -149,7 +189,8 @@ def _validate_skill_at(name: str, skill_root: Path) -> dict[str, Any]:
     skill_file = skill_root / "SKILL.md"
     skill_errors: list[str] = []
     all_errors: list[str] = []
-    warnings: list[str] = []
+    skill_warnings: list[str] = []
+    all_warnings: list[str] = []
     line_count = 0
 
     if not skill_file.is_file():
@@ -164,7 +205,7 @@ def _validate_skill_at(name: str, skill_root: Path) -> dict[str, Any]:
                     "schema": "skill",
                     "ok": False,
                     "errors": skill_errors,
-                    "warnings": warnings,
+                    "warnings": skill_warnings,
                 }
             ],
             "summary": {"errors": len(skill_errors), "warnings": 0, "line_count": 0},
@@ -214,6 +255,8 @@ def _validate_skill_at(name: str, skill_root: Path) -> dict[str, Any]:
         skill_errors.append(f"SKILL.md has {line_count} lines; limit is {MAX_SKILL_LINES}")
 
     skill_errors.extend(_check_references(skill_root, skill_file, text))
+    skill_warnings.extend(_check_legacy_reference_guidance(text))
+    all_warnings.extend(skill_warnings)
     all_errors.extend(skill_errors)
 
     file_result = {
@@ -221,16 +264,18 @@ def _validate_skill_at(name: str, skill_root: Path) -> dict[str, Any]:
         "schema": "skill",
         "ok": not skill_errors,
         "errors": skill_errors,
-        "warnings": warnings,
+        "warnings": skill_warnings,
         "line_count": line_count,
     }
     files = [file_result]
     for referenced_file in _iter_referenced_markdown(skill_root):
+        referenced_text = referenced_file.read_text(encoding="utf-8")
         reference_errors = _check_references(
             skill_root,
             referenced_file,
-            referenced_file.read_text(encoding="utf-8"),
+            referenced_text,
         )
+        reference_warnings = _check_legacy_reference_guidance(referenced_text)
         rel_path = str(referenced_file.relative_to(skill_root))
         all_errors.extend(f"{rel_path}: {error}" for error in reference_errors)
         files.append(
@@ -239,16 +284,21 @@ def _validate_skill_at(name: str, skill_root: Path) -> dict[str, Any]:
                 "schema": "skill-reference",
                 "ok": not reference_errors,
                 "errors": reference_errors,
-                "warnings": [],
+                "warnings": reference_warnings,
             }
         )
+        all_warnings.extend(f"{rel_path}: {warning}" for warning in reference_warnings)
 
     return {
         "ok": not all_errors,
         "name": name,
         "path": str(skill_root),
         "files": files,
-        "summary": {"errors": len(all_errors), "warnings": len(warnings), "line_count": line_count},
+        "summary": {
+            "errors": len(all_errors),
+            "warnings": len(all_warnings),
+            "line_count": line_count,
+        },
     }
 
 

--- a/mb/tests/test_skill_validate.py
+++ b/mb/tests/test_skill_validate.py
@@ -170,7 +170,7 @@ def test_skill_validate_warns_on_legacy_reference_paths_without_fallback_context
     _skill(
         tmp_path,
         "mb-alpha",
-        body="Read `reference/core/offer.md` before writing.\n",
+        body="Read reference/core, then write.\n",
     )
     _patch_engine(monkeypatch, tmp_path)
 
@@ -197,6 +197,29 @@ def test_skill_validate_allows_legacy_reference_paths_with_fallback_context(
     assert report is not None
     assert report["ok"] is True
     assert report["summary"]["warnings"] == 0
+
+
+def test_skill_validate_warns_on_legacy_reference_paths_in_referenced_markdown(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    skill_root = _skill(
+        tmp_path,
+        "mb-alpha",
+        body="See [setup](references/setup.md).\n",
+    )
+    _write(skill_root / "references" / "setup.md", "Read reference/offers.\n")
+    _patch_engine(monkeypatch, tmp_path)
+
+    report = skill_validate_mod.run("mb-alpha")
+
+    assert report is not None
+    assert report["ok"] is True
+    assert report["summary"]["warnings"] == 1
+    reference_result = next(
+        item for item in report["files"] if item["path"] == "references/setup.md"
+    )
+    assert len(reference_result["warnings"]) == 1
+    assert "prefer canonical core/" in reference_result["warnings"][0]
 
 
 def test_skill_validate_ignores_reference_paths_inside_code_fences(

--- a/mb/tests/test_skill_validate.py
+++ b/mb/tests/test_skill_validate.py
@@ -164,6 +164,41 @@ def test_skill_validate_checks_reference_file_links(
     assert "missing-detail.md" in reference_result["errors"][0]
 
 
+def test_skill_validate_warns_on_legacy_reference_paths_without_fallback_context(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _skill(
+        tmp_path,
+        "mb-alpha",
+        body="Read `reference/core/offer.md` before writing.\n",
+    )
+    _patch_engine(monkeypatch, tmp_path)
+
+    report = skill_validate_mod.run("mb-alpha")
+
+    assert report is not None
+    assert report["ok"] is True
+    assert report["summary"]["warnings"] == 1
+    assert "prefer canonical core/" in report["files"][0]["warnings"][0]
+
+
+def test_skill_validate_allows_legacy_reference_paths_with_fallback_context(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _skill(
+        tmp_path,
+        "mb-alpha",
+        body=("Use `reference/core/offer.md` only as a legacy fallback when `core/` is absent.\n"),
+    )
+    _patch_engine(monkeypatch, tmp_path)
+
+    report = skill_validate_mod.run("mb-alpha")
+
+    assert report is not None
+    assert report["ok"] is True
+    assert report["summary"]["warnings"] == 0
+
+
 def test_skill_validate_ignores_reference_paths_inside_code_fences(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- Audits bundled skills for stale active `reference/core` and `reference/offers` guidance.
- Moves current write/read instructions to canonical `core/` and `core/offers/` paths while preserving legacy fallback language.
- Clarifies that `reference/core` and `reference/offers` are compatibility bridges, not duplicate files to edit separately.
- Adds `mb skill validate` warnings for stale direct legacy path guidance without fallback or compatibility context.
- Updates migration docs, generated repo `CLAUDE.md` guidance, setup/organic skill copy, and the changelog for the user-visible behavior.

## Scope
In: active skill/reference prose for `reference/core` and `reference/offers`, bridge-not-duplicate guidance, skill validation coverage, migration docs, scaffolded `CLAUDE.md`, `/mb-setup` bridge setup prose, and changelog notes.
Out: the broader product decision to eliminate committed business-repo `reference/` entirely, migration of `reference/proof`, `reference/domain`, or `reference/visual-identity`, doctor repair behavior, and runtime support claims beyond the verified smoke.

## Commits
- `f880e0c` — `[fix] MAIN-245 audit legacy reference path guidance`.
- `446261e` — `[fix] MAIN-245 address reference guidance review`.

## Release / Issues
Release: v0.3.x / unscheduled maintenance.
Linear ID(s): MAIN-245.
Closes: none.
Refs: #315.
Follow-ups: create a separate issue for the broader business repo folder-model decision and full `reference/` deprecation plan.

## Success Metric
Agents stop asking users to update both canonical `core/` files and legacy `reference/core` or `reference/offers` bridge paths for the same business truth.

## Validation
Level 0 docs/decision: migration docs, generated `CLAUDE.md` copy, skill copy, and changelog reviewed for public-safe path language.
Level 1 static: `scripts/check.sh` passed after review fixes.
Level 2 CLI: `cd mb && pytest tests/test_skill_validate.py -q` passed; `cd mb && python3 -m mb skill validate --all --json` passed with 0 warnings.
Level 3 package/install: wheel build and venv install passed before review fixes; `mb --version`, `mb skill list`, `mb onboard --yes`, and `mb start --json` passed from the installed wheel.
Level 4 fixture repo: fresh smoke business repo was created through `mb onboard --yes` and inspected through `mb start --json`.
Level 5 runtime smoke: not run; closest verified fallback was packaged skill listing/wiring plus `mb start --json` from a fresh smoke business repo.

## Public / Private Boundary
- No private Devon, Conductor, customer, or runtime credential details were committed; `.context/` notes stayed local.
