### PR TITLE
[update] Remove leftover vibe prose

### DIFF
--- a/.claude/skills/mb-ads/references/image-prompt-templates.md
+++ b/.claude/skills/mb-ads/references/image-prompt-templates.md
@@ -154,11 +154,11 @@ Subtle visual interest in margins (texture, gradient, atmospheric elements).
 
 ---
 
-## Vibe Preservation for Variants
+## Mood Preservation for Variants
 
-When generating multiple images for the same campaign, use the vibe preservation pattern from X/Twitter practitioners:
+When generating multiple images for the same campaign, use the mood preservation pattern from X/Twitter practitioners:
 
-> "Generate a new image with SIGNIFICANTLY different composition, objects, and color palette compared to the previous image. CRITICAL: Strictly preserve the original 'vibe', 'aesthetic', and 'mood'."
+> "Generate a new image with SIGNIFICANTLY different composition, objects, and color palette compared to the previous image. CRITICAL: Strictly preserve the original mood, aesthetic, and tone."
 
 This produces diverse-but-cohesive ad sets that satisfy Andromeda's need for genuine visual variety while maintaining campaign coherence.
 

--- a/.claude/skills/mb-organic/references/static-template.md
+++ b/.claude/skills/mb-organic/references/static-template.md
@@ -169,7 +169,7 @@ Concept: Reframing consistency advice
 
 ## Image Context
 
-Photo of creator at desk, casual/authentic vibe. Or graphic with pull quote.
+Photo of creator at desk, casual/authentic feel. Or graphic with pull quote.
 
 ---
 

--- a/decisions/2026-05-04-skill-cli-runtime-adapter-contract.md
+++ b/decisions/2026-05-04-skill-cli-runtime-adapter-contract.md
@@ -35,7 +35,7 @@ operator. They may call `mb` to inspect state or perform mechanical repairs, but
 they must not make `mb` responsible for model invocation, chat memory, retries,
 streaming UI, or runtime-specific conversation branching.
 
-Runtime adapters are explicit contracts, not compatibility vibes. A runtime is
+Runtime adapters are explicit contracts, not compatibility intent. A runtime is
 not supported until it has adapter code or documented wiring, command/JSON
 contracts, generated-file and state rules, and smoke evidence from a fresh
 business repo. Claude Code is the reference adapter today. Codex, Cursor,

--- a/docs/ETHOS.md
+++ b/docs/ETHOS.md
@@ -104,7 +104,7 @@ ads metrics, bookkeeping, transcription, analytics, or deployment helpers.
 Sidecars should be optional providers behind stable contracts, not hard
 dependencies of the core engine.
 
-### 8. Evidence Beats Vibes
+### 8. Evidence Beats Hunches
 
 Do not ship runtime claims, migration paths, packaging changes, or first-run
 flows without evidence. Use the validation ladder in [AGENTS.md](../AGENTS.md):


### PR DESCRIPTION
## Summary
- Replaces stale generic `vibe` wording in public docs and bundled skill reference prose.
- Keeps the `/mb-site` dial terminology aligned with the locked `brand` vocabulary.
- Leaves intentional audit hits in place for the master vocabulary-lock row and `starvibe/youtube-video-transcript` proper-noun actor IDs.

## Scope
- In: docs/skill prose cleanup for stale `vibe` wording, plus audit evidence for every remaining hit.
- Out: CLI behavior, schema changes, package/install changes, runtime wiring, broad lint hooks, and dated research relitigation.

## Commits
- `55bf25c` — `[update] MAIN-148 Remove leftover vibe prose`.

## Release / Issues
- Release: none / nice-to-have cleanup.
- Linear ID(s): MAIN-148.
- Closes: #148.
- Refs: none.
- Follow-ups: none.

## Success Metric
- `git grep -n -i vibe -- .` returns only intentional hits: the master `"vibe" -> brand` vocabulary-lock row and `starvibe/youtube-video-transcript` proper-noun actor IDs.

## Validation
- Level 0 docs/decision: reviewed the prose diff and confirmed the remaining grep hits are intentional.
- Level 1 static: `scripts/check.sh` passed from the repo root; `git grep -n -i vibe -- .` leaves only intentional hits.
- Level 2 CLI: not required; no CLI behavior changed.
- Level 3 package/install: not required; no packaging or bundled data behavior changed.
- Level 4 fixture repo: not required; no first-run or repo-shape behavior changed.
- Level 5 runtime smoke: not required; skill discovery and invocation did not change.

## Public / Private Boundary
- No private Devon, Conductor, credential, customer, member, or runtime-local details were added; `.context/cold-start.md` remains uncommitted collaboration scratch.