### PR TITLE
[add] mb doctor repair reconciliation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 - Added `mb doctor repair --plan/--apply` as a guided repo reconciliation
   surface with read-only planning, JSON output, safe wiring/local-state repairs,
+  optional `--include-migration` migration apply after preview review,
   validation and graph summaries, git review guidance, and explicit runtime
   smoke reminders. Refs #314.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+### Added
+
+- Added `mb doctor repair --plan/--apply` as a guided repo reconciliation
+  surface with read-only planning, JSON output, safe wiring/local-state repairs,
+  validation and graph summaries, git review guidance, and explicit runtime
+  smoke reminders. Refs #314.
+
 ### Changed
 
 - Clarified quick start and beginner docs so daily users run `claude` then

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ The CLI surface for the engine. Built for Claude Code first; runtime-agnostic by
 | `mb onboard status` | Show durable onboarding progress from `.mb/onboarding.json`, including missing core-reference inputs and the next recommended action. |
 | `mb init` | Set up a fresh business repo (business folders, CLAUDE.md, git init). |
 | `mb status` | Show the local-first briefing in the terminal without opening Claude Code: ranked next actions, since-last-check changes, drift, repo health, runtime wiring, recent decisions/research/bets/git activity, and GitHub tasks when `gh` is authenticated. Use `--json` for the v1 status schema, `--verbose` for detail, and `--peek` for non-mutating reads. |
-| `mb doctor` | Check the environment — repo shape, frontmatter sanity, settings on disk. Walks you through fixes. |
+| `mb doctor` | Check the environment — repo shape, frontmatter sanity, settings on disk. Use `mb doctor repair --plan` / `--apply` for guided repo reconciliation. |
 | `mb connect` | Register provider credentials, test provider health, and inspect repair-safe integration status without committing secrets. |
 | `mb site check` | Check local paid-traffic measurement readiness for a site repo: GTM installation, Main Branch dataLayer events, consent posture, Google Ads plan metadata, and operator-review gates. |
 | `mb issue draft` | Create a local, privacy-scrubbed GitHub issue draft under `.mb/issue-drafts/` for bugs, feature gaps, or questions. |

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ The CLI surface for the engine. Built for Claude Code first; runtime-agnostic by
 | `mb onboard status` | Show durable onboarding progress from `.mb/onboarding.json`, including missing core-reference inputs and the next recommended action. |
 | `mb init` | Set up a fresh business repo (business folders, CLAUDE.md, git init). |
 | `mb status` | Show the local-first briefing in the terminal without opening Claude Code: ranked next actions, since-last-check changes, drift, repo health, runtime wiring, recent decisions/research/bets/git activity, and GitHub tasks when `gh` is authenticated. Use `--json` for the v1 status schema, `--verbose` for detail, and `--peek` for non-mutating reads. |
-| `mb doctor` | Check the environment — repo shape, frontmatter sanity, settings on disk. Use `mb doctor repair --plan` / `--apply` for guided repo reconciliation. |
+| `mb doctor` | Check the environment — repo shape, frontmatter sanity, settings on disk. Use `mb doctor repair --plan` / `--apply` for guided repo reconciliation; add `--include-migration` only after reviewing the migration preview. |
 | `mb connect` | Register provider credentials, test provider health, and inspect repair-safe integration status without committing secrets. |
 | `mb site check` | Check local paid-traffic measurement readiness for a site repo: GTM installation, Main Branch dataLayer events, consent posture, Google Ads plan metadata, and operator-review gates. |
 | `mb issue draft` | Create a local, privacy-scrubbed GitHub issue draft under `.mb/issue-drafts/` for bugs, feature gaps, or questions. |

--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -445,7 +445,10 @@ def _doctor_repair_from_args(args: list[str], *, json_out: bool) -> None:
     while idx < len(args):
         arg = args[idx]
         if arg == "--help":
-            typer.echo("Usage: mb doctor repair [--repo PATH] [--plan | --apply] [--json]")
+            typer.echo(
+                "Usage: mb doctor repair [--repo PATH] [--plan | --apply] "
+                "[--include-migration] [--json]"
+            )
             typer.echo("")
             typer.echo("Plan or apply guided business-repo reconciliation repairs.")
             raise typer.Exit(0)
@@ -484,12 +487,29 @@ def _doctor_repair_from_args(args: list[str], *, json_out: bool) -> None:
         typer.echo(json.dumps(report, indent=2))
     else:
         doctor_mod.render_repair(report)
-    raise typer.Exit(0)
+    raise typer.Exit(0 if report["ok"] else 1)
+
+
+def _doctor_help() -> None:
+    typer.echo("Usage: mb doctor [OPTIONS] [PATH]")
+    typer.echo("")
+    typer.echo("Check the health of a Main Branch repo. Exits 1 on red checks.")
+    typer.echo("")
+    typer.echo("Options:")
+    typer.echo("  --json   Machine-readable output.")
+    typer.echo("  --help   Show this message and exit.")
+    typer.echo("")
+    typer.echo("Repair:")
+    typer.echo("  mb doctor repair [--repo PATH] [--plan | --apply] [--include-migration] [--json]")
 
 
 @app.command(
     "doctor",
-    context_settings={"allow_extra_args": True, "ignore_unknown_options": True},
+    context_settings={
+        "allow_extra_args": True,
+        "ignore_unknown_options": True,
+        "help_option_names": [],
+    },
 )
 def doctor_cmd(
     ctx: typer.Context,
@@ -497,8 +517,18 @@ def doctor_cmd(
     json_out: bool = typer.Option(False, "--json", help="Machine-readable output."),
 ) -> None:
     """Check the health of a Main Branch repo. Exits 1 on red checks."""
+    if path == "--help":
+        _doctor_help()
+        raise typer.Exit(0)
     if path == "repair":
         _doctor_repair_from_args(list(ctx.args), json_out=json_out)
+        return
+    if path.startswith("-"):
+        typer.echo(f"mb doctor: unknown option {path}", err=True)
+        raise typer.Exit(2)
+    if ctx.args:
+        typer.echo(f"mb doctor: unknown option(s): {' '.join(ctx.args)}", err=True)
+        raise typer.Exit(2)
     report = doctor_mod.run(path=path)
     if json_out:
         typer.echo(json.dumps(report, indent=2))

--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -435,12 +435,70 @@ def onboard_plan_cmd(
     raise typer.Exit(0 if result["ok"] else 1)
 
 
-@app.command("doctor")
+def _doctor_repair_from_args(args: list[str], *, json_out: bool) -> None:
+    repo = "."
+    plan = False
+    apply_changes = False
+    include_migration = False
+    local_json = json_out
+    idx = 0
+    while idx < len(args):
+        arg = args[idx]
+        if arg == "--help":
+            typer.echo("Usage: mb doctor repair [--repo PATH] [--plan | --apply] [--json]")
+            typer.echo("")
+            typer.echo("Plan or apply guided business-repo reconciliation repairs.")
+            raise typer.Exit(0)
+        if arg == "--repo":
+            idx += 1
+            if idx >= len(args):
+                typer.echo("mb doctor repair: --repo requires a path", err=True)
+                raise typer.Exit(2)
+            repo = args[idx]
+        elif arg == "--plan":
+            plan = True
+        elif arg == "--apply":
+            apply_changes = True
+        elif arg == "--include-migration":
+            include_migration = True
+        elif arg == "--json":
+            local_json = True
+        else:
+            typer.echo(f"mb doctor repair: unknown option {arg}", err=True)
+            raise typer.Exit(2)
+        idx += 1
+
+    if plan and apply_changes:
+        typer.echo("mb doctor repair: choose only one of --plan or --apply", err=True)
+        raise typer.Exit(2)
+    if include_migration and not apply_changes:
+        typer.echo("mb doctor repair: --include-migration requires --apply", err=True)
+        raise typer.Exit(2)
+
+    if apply_changes:
+        report = doctor_mod.repair_apply(repo=repo, include_migration=include_migration)
+    else:
+        report = doctor_mod.repair_plan(repo=repo)
+
+    if local_json:
+        typer.echo(json.dumps(report, indent=2))
+    else:
+        doctor_mod.render_repair(report)
+    raise typer.Exit(0)
+
+
+@app.command(
+    "doctor",
+    context_settings={"allow_extra_args": True, "ignore_unknown_options": True},
+)
 def doctor_cmd(
+    ctx: typer.Context,
     path: str = typer.Argument(".", help="Repo to diagnose."),
     json_out: bool = typer.Option(False, "--json", help="Machine-readable output."),
 ) -> None:
     """Check the health of a Main Branch repo. Exits 1 on red checks."""
+    if path == "repair":
+        _doctor_repair_from_args(list(ctx.args), json_out=json_out)
     report = doctor_mod.run(path=path)
     if json_out:
         typer.echo(json.dumps(report, indent=2))

--- a/mb/mb/doctor.py
+++ b/mb/mb/doctor.py
@@ -9,15 +9,22 @@ triage per the master decision: prints a banner and offers
 
 from __future__ import annotations
 
+import json
 import os
 import shutil
 import socket
+import subprocess
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 from mb import connect as connect_mod
+from mb import engine as engine_mod
+from mb import graph as graph_mod
+from mb import migrate as migrate_mod
 from mb import onboard as onboard_mod
+from mb import validate as validate_mod
 from mb.engine import install_mode, link_status
 from mb.freshness import format_update_alert, package_update_status, version_key
 from mb.migrate import LATEST_SCHEMA_VERSION, pending_migrations, read_schema_version
@@ -31,11 +38,175 @@ CLOUD_PREFIXES = (
     "Dropbox",
     "OneDrive",
 )
+REPAIR_SCHEMA = "mb.doctor.repair"
+REPAIR_SCHEMA_VERSION = 1
+LOCAL_GITIGNORE_ENTRIES = (
+    ".claude/settings.local.json",
+    ".claude/worktrees/",
+    ".mb/backups/",
+    ".mb/onboarding.json",
+    ".mb/last-status-seen.json",
+    ".mb/issue-drafts/",
+)
+LOCAL_STATE_PATHS = (
+    ".mb/backups",
+    ".mb/onboarding.json",
+    ".mb/last-status-seen.json",
+    ".mb/issue-drafts",
+)
+DURABLE_MB_PATHS = (".mb/schema_version", ".mb/connect.yaml")
+LEGACY_CLAUDE_LINK_DIRS = (".claude/lenses", ".claude/reference")
+REFERENCE_COMPAT_LINKS = {
+    "reference/core": "../core",
+    "reference/offers": "../core/offers",
+}
+STATE_ORDER = {"ok": 0, "info": 1, "warn": 2, "error": 3}
 
 
 def _which(name: str) -> str:
     """Return path of binary or empty string."""
     return shutil.which(name) or ""
+
+
+def _utc_stamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _rel(repo: Path, path: Path) -> str:
+    try:
+        return path.relative_to(repo).as_posix()
+    except ValueError:
+        return str(path)
+
+
+def _state_from_check(check: dict[str, Any]) -> str:
+    if check.get("ok"):
+        severity = str(check.get("severity") or "ok")
+        return severity if severity in {"info"} else "ok"
+    severity = str(check.get("severity") or "error")
+    return severity if severity in {"info", "warn", "error"} else "error"
+
+
+def _max_state(states: list[str]) -> str:
+    if not states:
+        return "ok"
+    return max(states, key=lambda state: STATE_ORDER.get(state, 3))
+
+
+def _read_gitignore_entries(repo: Path) -> set[str]:
+    gitignore = repo / ".gitignore"
+    if not gitignore.exists():
+        return set()
+    try:
+        return {line.strip() for line in gitignore.read_text(encoding="utf-8").splitlines()}
+    except OSError:
+        return set()
+
+
+def _append_unique_lines(path: Path, entries: list[str]) -> bool:
+    existing = path.read_text(encoding="utf-8") if path.exists() else ""
+    existing_lines = set(existing.splitlines())
+    missing = [entry for entry in entries if entry not in existing_lines]
+    if not missing:
+        return False
+    prefix = "" if not existing or existing.endswith("\n") else "\n"
+    path.write_text(existing + prefix + "\n".join(missing) + "\n", encoding="utf-8")
+    return True
+
+
+def _run_git(repo: Path, args: list[str]) -> dict[str, Any]:
+    try:
+        proc = subprocess.run(
+            ["git", *args],
+            cwd=repo,
+            capture_output=True,
+            text=True,
+            timeout=3,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.SubprocessError):
+        return {"ok": False, "stdout": "", "stderr": "git unavailable"}
+    return {
+        "ok": proc.returncode == 0,
+        "stdout": proc.stdout.strip(),
+        "stderr": proc.stderr.strip(),
+        "returncode": proc.returncode,
+    }
+
+
+def _git_summary(repo: Path) -> dict[str, Any]:
+    inside = _run_git(repo, ["rev-parse", "--is-inside-work-tree"])
+    if not inside["ok"] or inside["stdout"] != "true":
+        return {
+            "inside_work_tree": False,
+            "branch": "",
+            "dirty": False,
+            "changed_files": [],
+            "state": "warn",
+            "summary": "not a git work tree; initialize git before reviewable repairs",
+        }
+    branch = _run_git(repo, ["branch", "--show-current"])
+    porcelain = _run_git(repo, ["status", "--short"])
+    changed = [line for line in porcelain["stdout"].splitlines() if line]
+    state = "warn" if changed else "ok"
+    return {
+        "inside_work_tree": True,
+        "branch": branch["stdout"],
+        "dirty": bool(changed),
+        "changed_files": changed,
+        "state": state,
+        "summary": (
+            f"{len(changed)} changed file(s); review before committing repair work"
+            if changed
+            else f"clean branch {branch['stdout'] or '(detached)'}"
+        ),
+    }
+
+
+def _action(
+    *,
+    id: str,
+    title: str,
+    state: str,
+    mode: str,
+    command: str,
+    safe_to_apply: bool,
+    reason: str,
+    writes: list[str] | None = None,
+    applied: bool = False,
+    result: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "id": id,
+        "title": title,
+        "state": state,
+        "mode": mode,
+        "command": command,
+        "safe_to_apply": safe_to_apply,
+        "reason": reason,
+        "writes": writes or [],
+        "applied": applied,
+        "result": result or {},
+    }
+
+
+def _section(
+    id: str,
+    title: str,
+    state: str,
+    summary: str,
+    *,
+    checks: list[dict[str, Any]] | None = None,
+    actions: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    return {
+        "id": id,
+        "title": title,
+        "state": state,
+        "summary": summary,
+        "checks": checks or [],
+        "actions": actions or [],
+    }
 
 
 def _net() -> tuple[bool, str]:
@@ -191,6 +362,258 @@ def _schema_version_check(repo: Path) -> dict[str, Any]:
         "name": "schema-version",
         "ok": True,
         "detail": f"schema {current} (latest {LATEST_SCHEMA_VERSION})",
+    }
+
+
+def _missing_gitignore_entries(repo: Path) -> list[str]:
+    entries = _read_gitignore_entries(repo)
+    if ".mb/" in entries:
+        mb_entries = {entry for entry in LOCAL_GITIGNORE_ENTRIES if entry.startswith(".mb/")}
+    else:
+        mb_entries = set()
+    return [
+        entry
+        for entry in LOCAL_GITIGNORE_ENTRIES
+        if entry not in entries and entry not in mb_entries
+    ]
+
+
+def _local_state_summary(repo: Path) -> dict[str, Any]:
+    local = [
+        {"path": rel, "exists": (repo / rel).exists() or (repo / rel).is_symlink()}
+        for rel in LOCAL_STATE_PATHS
+    ]
+    durable = [
+        {"path": rel, "exists": (repo / rel).exists() or (repo / rel).is_symlink()}
+        for rel in DURABLE_MB_PATHS
+    ]
+    missing_gitignore = [
+        item["path"]
+        for item in local
+        if item["exists"] and item["path"] not in _read_gitignore_entries(repo)
+    ]
+    return {
+        "state": "warn" if missing_gitignore else "ok",
+        "summary": (
+            f"{len(missing_gitignore)} local .mb path(s) need gitignore coverage"
+            if missing_gitignore
+            else ".mb local operational state is separated from durable markers"
+        ),
+        "local": local,
+        "durable": durable,
+        "missing_gitignore": missing_gitignore,
+    }
+
+
+def _legacy_reference_state(repo: Path) -> dict[str, Any]:
+    checks: list[dict[str, Any]] = []
+    for rel, expected_target in REFERENCE_COMPAT_LINKS.items():
+        path = repo / rel
+        if not path.exists() and not path.is_symlink():
+            checks.append(
+                {
+                    "path": rel,
+                    "state": "ok",
+                    "summary": "absent",
+                    "kind": "absent",
+                }
+            )
+            continue
+        if path.is_symlink():
+            target = path.readlink().as_posix()
+            exists = path.exists()
+            if target == expected_target and exists:
+                state = "info"
+                summary = f"compatibility link -> {target}"
+                kind = "compat-link"
+            elif not exists:
+                state = "warn"
+                summary = f"broken symlink -> {target}"
+                kind = "broken-link"
+            else:
+                state = "warn"
+                summary = f"unexpected symlink -> {target}"
+                kind = "unexpected-link"
+            checks.append({"path": rel, "state": state, "summary": summary, "kind": kind})
+            continue
+        if path.is_dir():
+            files = [
+                child.relative_to(repo).as_posix()
+                for child in path.rglob("*")
+                if child.is_file() and not child.is_symlink()
+            ]
+            canonical_rel = expected_target.removeprefix("../")
+            canonical = repo / canonical_rel
+            state = "warn"
+            kind = "legacy-content"
+            if canonical.exists():
+                summary = (
+                    f"{len(files)} legacy file(s) remain alongside {canonical_rel}; "
+                    "check for split truth before migrating"
+                )
+                kind = "split-truth"
+            else:
+                summary = f"{len(files)} legacy file(s) can be reviewed by `mb migrate --check`"
+            checks.append(
+                {
+                    "path": rel,
+                    "state": state,
+                    "summary": summary,
+                    "kind": kind,
+                    "files": files,
+                }
+            )
+            continue
+        checks.append(
+            {
+                "path": rel,
+                "state": "error",
+                "summary": "exists but is neither a directory nor a symlink",
+                "kind": "unexpected-file",
+            }
+        )
+    return {
+        "state": _max_state([str(item["state"]) for item in checks]),
+        "checks": checks,
+    }
+
+
+def _legacy_claude_symlinks(repo: Path) -> dict[str, Any]:
+    root = engine_mod.engine_root()
+    active_root = root or Path("/")
+    findings: list[dict[str, Any]] = []
+    for rel_dir in LEGACY_CLAUDE_LINK_DIRS:
+        directory = repo / rel_dir
+        if not directory.is_dir():
+            continue
+        for entry in sorted(directory.iterdir()):
+            if not entry.is_symlink():
+                continue
+            raw_target = entry.readlink()
+            target = raw_target
+            if not target.is_absolute():
+                target = entry.parent / target
+            target_text = str(target)
+            target_parts = {part.lower() for part in Path(target_text).parts}
+            raw_parts = {part.lower() for part in Path(str(raw_target)).parts}
+            clone_named = any(
+                "mb-vip" in part or "mainbranch" in part for part in target_parts | raw_parts
+            )
+            stale = engine_mod._is_stale_engine_path(target_text, active_root) or (
+                engine_mod._looks_like_missing_legacy_engine_path(str(raw_target))
+                or engine_mod._looks_like_missing_legacy_engine_path(target_text)
+                or clone_named
+            )
+            if stale:
+                state = "warn"
+                safe = True
+                summary = "stale Main Branch clone-path symlink can be moved to backup"
+            else:
+                state = "info"
+                safe = False
+                summary = "third-party or user-authored symlink; inspect manually"
+            findings.append(
+                {
+                    "path": _rel(repo, entry),
+                    "target": str(raw_target),
+                    "resolved_target": target_text,
+                    "state": state,
+                    "safe_to_repair": safe,
+                    "summary": summary,
+                }
+            )
+    return {
+        "state": _max_state([str(item["state"]) for item in findings]),
+        "findings": findings,
+        "repairable": sum(1 for item in findings if item["safe_to_repair"]),
+    }
+
+
+def _repair_legacy_claude_symlinks(repo: Path, findings: list[dict[str, Any]]) -> dict[str, Any]:
+    repairable = [item for item in findings if item.get("safe_to_repair")]
+    if not repairable:
+        return {"ok": True, "moved": [], "backup_dir": "", "errors": []}
+    backup_dir = repo / ".mb" / "backups" / f"doctor-repair-{_utc_stamp()}" / "claude-links"
+    moved: list[dict[str, str]] = []
+    errors: list[str] = []
+    for item in repairable:
+        source = repo / str(item["path"])
+        dest = backup_dir / str(item["path"])
+        try:
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            shutil.move(str(source), str(dest))
+            moved.append(
+                {
+                    "path": str(item["path"]),
+                    "target": str(item["target"]),
+                    "backup_path": _rel(repo, dest),
+                }
+            )
+        except OSError as exc:
+            errors.append(f"{item['path']}: {exc}")
+    if moved:
+        manifest = backup_dir / "manifest.json"
+        manifest.write_text(json.dumps({"moved": moved}, indent=2) + "\n", encoding="utf-8")
+    return {
+        "ok": not errors,
+        "moved": moved,
+        "backup_dir": _rel(repo, backup_dir) if moved else "",
+        "errors": errors,
+    }
+
+
+def _validation_summary(repo: Path) -> dict[str, Any]:
+    try:
+        report = validate_mod.run(str(repo), cross_refs=True)
+    except Exception as exc:  # pragma: no cover - defensive CLI boundary
+        return {
+            "ok": False,
+            "state": "error",
+            "summary": f"validation failed to run: {exc}",
+            "report": {},
+        }
+    summary = report.get("summary", {})
+    errors = int(summary.get("errors", 0) or 0)
+    warnings = int(summary.get("warnings", 0) or 0)
+    state = "error" if errors else ("warn" if warnings else "ok")
+    return {
+        "ok": report["ok"],
+        "state": state,
+        "summary": f"{errors} error(s), {warnings} warning(s)",
+        "report": {
+            "summary": summary,
+            "files": len(report.get("files", [])),
+            "legacy_repair": report.get("legacy_repair"),
+            "cross_refs": {
+                "enabled": report.get("cross_refs", {}).get("enabled", False),
+                "warnings": len(report.get("cross_refs", {}).get("warnings", [])),
+                "orphan_offers": len(report.get("cross_refs", {}).get("orphan_offers", [])),
+            },
+        },
+    }
+
+
+def _graph_summary(repo: Path) -> dict[str, Any]:
+    try:
+        index = graph_mod.build_index(str(repo))
+    except Exception as exc:  # pragma: no cover - defensive CLI boundary
+        return {
+            "ok": False,
+            "state": "warn",
+            "summary": f"graph summary failed to run: {exc}",
+            "report": {},
+        }
+    unresolved = sum(1 for node in index.get("nodes", []) if node.get("type") == "wikilink")
+    state = "warn" if unresolved else "ok"
+    summary = index.get("summary", {})
+    return {
+        "ok": unresolved == 0,
+        "state": state,
+        "summary": (
+            f"{summary.get('files', 0)} file(s), {summary.get('edges', 0)} edge(s), "
+            f"{unresolved} unresolved wikilink(s)"
+        ),
+        "report": {"summary": summary, "unresolved_wikilinks": unresolved},
     }
 
 
@@ -362,6 +785,528 @@ def run(path: str) -> dict[str, Any]:
         "update": update,
         "python": sys.version.split()[0],
     }
+
+
+def repair_plan(
+    repo: str | Path = ".",
+    *,
+    mode: str = "plan",
+    applied_actions: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Build the guided reconciliation plan without writing repo status markers."""
+    target = Path(repo).expanduser().resolve()
+    doctor_report = run(str(target))
+    actions: list[dict[str, Any]] = []
+    sections: list[dict[str, Any]] = []
+
+    update = doctor_report.get("update", {})
+    install_checks = [
+        {
+            "name": check["name"],
+            "state": _state_from_check(check),
+            "summary": check["detail"],
+        }
+        for check in doctor_report["checks"]
+        if check["name"]
+        in {"mainbranch-version", "claude-code", "github-context", "network", "librsvg"}
+    ]
+    if str(update.get("severity")) in {"required", "recommended"}:
+        actions.append(
+            _action(
+                id="mainbranch-update",
+                title="Update Main Branch install",
+                state="error" if update.get("severity") == "required" else "warn",
+                mode="write",
+                command=str(update.get("command") or "mb update"),
+                safe_to_apply=False,
+                reason="package updates are explicit operator actions outside doctor repair",
+            )
+        )
+    sections.append(
+        _section(
+            "install",
+            "Install And Environment",
+            _max_state([str(item["state"]) for item in install_checks]),
+            "Main Branch install, runtime tools, GitHub, network, and optional render tooling",
+            checks=install_checks,
+        )
+    )
+
+    migration = migrate_mod.check(target, include_diff=False)
+    reference_state = _legacy_reference_state(target)
+    layout_checks = [
+        {
+            "name": check["name"],
+            "state": _state_from_check(check),
+            "summary": check["detail"],
+        }
+        for check in doctor_report["checks"]
+        if check["name"] in {"repo-layout", "schema-version"}
+    ]
+    layout_checks.extend(
+        {
+            "name": item["path"],
+            "state": item["state"],
+            "summary": item["summary"],
+            "kind": item["kind"],
+        }
+        for item in reference_state["checks"]
+    )
+    if migration.get("plan", {}).get("has_changes") or migration.get("pending"):
+        actions.append(
+            _action(
+                id="migration-preview",
+                title="Preview layout migration",
+                state="warn",
+                mode="read",
+                command="mb migrate --repo . --check",
+                safe_to_apply=True,
+                reason="migration preview is read-only and should be reviewed before apply",
+            )
+        )
+        actions.append(
+            _action(
+                id="migration-apply",
+                title="Apply approved layout migration",
+                state="warn",
+                mode="write",
+                command="mb migrate --repo . --apply",
+                safe_to_apply=False,
+                reason=(
+                    "migration moves user-authored files; run doctor repair with "
+                    "`--apply --include-migration` only after reviewing the preview"
+                ),
+                writes=["core/", "reference/core", "reference/offers", ".mb/schema_version"],
+            )
+        )
+    sections.append(
+        _section(
+            "repo-shape",
+            "Repo Shape And Migration",
+            _max_state([str(item["state"]) for item in layout_checks]),
+            f"schema {migration.get('current_version')} -> {migration.get('latest_version')}",
+            checks=layout_checks,
+        )
+    )
+
+    missing_gitignore = _missing_gitignore_entries(target)
+    gitignore_actions: list[dict[str, Any]] = []
+    if missing_gitignore:
+        action = _action(
+            id="gitignore-local-state",
+            title="Protect Main Branch local state in .gitignore",
+            state="warn",
+            mode="write",
+            command="mb doctor repair --apply",
+            safe_to_apply=True,
+            reason="these entries are local operational state and should not be committed",
+            writes=[".gitignore"],
+        )
+        actions.append(action)
+        gitignore_actions.append(action)
+    sections.append(
+        _section(
+            "gitignore",
+            "Local State Gitignore",
+            "warn" if missing_gitignore else "ok",
+            (
+                f"{len(missing_gitignore)} missing local-state entrie(s)"
+                if missing_gitignore
+                else "Main Branch local state is ignored"
+            ),
+            checks=[
+                {
+                    "name": entry,
+                    "state": "warn" if entry in missing_gitignore else "ok",
+                    "summary": "missing" if entry in missing_gitignore else "covered",
+                }
+                for entry in LOCAL_GITIGNORE_ENTRIES
+            ],
+            actions=gitignore_actions,
+        )
+    )
+
+    wiring = link_status(target)
+    shadow_report = wiring.get("shadow_report", {})
+    legacy_links = _legacy_claude_symlinks(target)
+    wiring_checks = [
+        {
+            "name": "project-local-skills",
+            "state": "ok" if wiring.get("ok") else "error",
+            "summary": (
+                "Claude Code can discover mb-start"
+                if wiring.get("ok")
+                else "project-local skill wiring is missing or shadowed"
+            ),
+        },
+        {
+            "name": "personal-skill-shadowing",
+            "state": "ok"
+            if not int(shadow_report.get("summary", {}).get("findings", 0) or 0)
+            else (
+                "warn"
+                if int(shadow_report.get("summary", {}).get("repairable", 0) or 0)
+                else "error"
+            ),
+            "summary": (
+                f"{shadow_report.get('summary', {}).get('findings', 0)} finding(s), "
+                f"{shadow_report.get('summary', {}).get('repairable', 0)} repairable"
+            ),
+        },
+        {
+            "name": "legacy-claude-reference-links",
+            "state": legacy_links["state"],
+            "summary": (
+                f"{len(legacy_links['findings'])} symlink finding(s), "
+                f"{legacy_links['repairable']} repairable"
+            ),
+        },
+    ]
+    if not wiring.get("ok"):
+        actions.append(
+            _action(
+                id="skill-link",
+                title="Refresh project-local Claude Code skill wiring",
+                state="error",
+                mode="write",
+                command="mb skill link --repo . --json",
+                safe_to_apply=True,
+                reason="relinks bundled skills and repairs Main Branch local gitignore entries",
+                writes=[
+                    ".claude/settings.local.json",
+                    ".claude/skills/",
+                    ".gitignore",
+                ],
+            )
+        )
+    if int(shadow_report.get("summary", {}).get("repairable", 0) or 0):
+        actions.append(
+            _action(
+                id="skill-shadow-repair",
+                title="Move stale personal Main Branch skill symlinks to backup",
+                state="warn",
+                mode="write",
+                command="mb skill repair --repo . --apply",
+                safe_to_apply=True,
+                reason="only stale or broken Main Branch personal symlinks are moved",
+                writes=[str(shadow_report.get("personal_skills_dir") or "~/.claude/skills")],
+            )
+        )
+    if int(legacy_links["repairable"]):
+        actions.append(
+            _action(
+                id="legacy-claude-link-repair",
+                title="Move old clone-path lens/reference symlinks to backup",
+                state="warn",
+                mode="write",
+                command="mb doctor repair --apply",
+                safe_to_apply=True,
+                reason="only stale Main Branch clone-path symlinks are moved; user files stay put",
+                writes=[".claude/lenses/", ".claude/reference/", ".mb/backups/"],
+            )
+        )
+    sections.append(
+        _section(
+            "claude-wiring",
+            "Claude Code Wiring",
+            _max_state([str(item["state"]) for item in wiring_checks]),
+            "Project-local skills, personal shadowing, and old clone-path symlinks",
+            checks=wiring_checks,
+        )
+    )
+
+    local_state = _local_state_summary(target)
+    sections.append(
+        _section(
+            "mb-state",
+            ".mb State",
+            local_state["state"],
+            local_state["summary"],
+            checks=[
+                {
+                    "name": item["path"],
+                    "state": "info" if item["exists"] else "ok",
+                    "summary": "local operational state" if item["exists"] else "absent",
+                }
+                for item in local_state["local"]
+            ]
+            + [
+                {
+                    "name": item["path"],
+                    "state": "info" if item["exists"] else "ok",
+                    "summary": "durable repo marker" if item["exists"] else "absent",
+                }
+                for item in local_state["durable"]
+            ],
+        )
+    )
+
+    validation = _validation_summary(target)
+    if validation["state"] != "ok":
+        actions.append(
+            _action(
+                id="validate-frontmatter",
+                title="Repair validation and frontmatter debt",
+                state=validation["state"],
+                mode="manual",
+                command="mb validate --json",
+                safe_to_apply=False,
+                reason="validation failures are user-authored content repairs",
+            )
+        )
+    sections.append(
+        _section(
+            "validation",
+            "Validation And Cross-Refs",
+            validation["state"],
+            validation["summary"],
+            checks=[{"name": "mb validate --cross-refs", **validation}],
+        )
+    )
+
+    graph = _graph_summary(target)
+    if graph["state"] != "ok":
+        actions.append(
+            _action(
+                id="graph-links",
+                title="Review graph and wikilink health",
+                state=graph["state"],
+                mode="manual",
+                command="mb graph --json",
+                safe_to_apply=False,
+                reason="link meaning belongs to the operator or agent reviewing content",
+            )
+        )
+    sections.append(
+        _section(
+            "graph",
+            "Graph And Link Health",
+            graph["state"],
+            graph["summary"],
+            checks=[{"name": "mb graph --json", **graph}],
+        )
+    )
+
+    git = _git_summary(target)
+    sections.append(
+        _section(
+            "git",
+            "Git Review State",
+            git["state"],
+            git["summary"],
+            checks=[
+                {
+                    "name": "branch",
+                    "state": git["state"],
+                    "summary": git["branch"] or "(none)",
+                },
+                {
+                    "name": "dirty-state",
+                    "state": git["state"],
+                    "summary": f"{len(git['changed_files'])} changed file(s)",
+                },
+            ],
+        )
+    )
+
+    states = [str(section["state"]) for section in sections]
+    summary = {
+        "ok": sum(1 for state in states if state == "ok"),
+        "info": sum(1 for state in states if state == "info"),
+        "warn": sum(1 for state in states if state == "warn"),
+        "error": sum(1 for state in states if state == "error"),
+        "actions": len(actions),
+        "write_actions": sum(1 for action in actions if action["mode"] == "write"),
+        "safe_apply_actions": sum(
+            1 for action in actions if action["mode"] == "write" and action["safe_to_apply"]
+        ),
+    }
+    return {
+        "schema": REPAIR_SCHEMA,
+        "schema_version": REPAIR_SCHEMA_VERSION,
+        "ok": summary["error"] == 0,
+        "mode": mode,
+        "read_only": mode == "plan",
+        "repo": str(target),
+        "generated_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "summary": summary,
+        "sections": sections,
+        "actions": actions,
+        "applied_actions": applied_actions or [],
+        "post_apply": {
+            "structural_verification": "mb doctor repair --plan --json",
+            "validation_frontmatter_debt": "mb validate --cross-refs",
+            "runtime_smoke_required": (
+                "Static repair does not prove Claude Code runtime behavior. "
+                "From the business repo, run `claude`, confirm `/mb-start` is discoverable, "
+                "and verify it reads repo context without writing into the engine repo."
+            ),
+            "git_review": [
+                "git status --short",
+                "git diff",
+                "git add <reviewed repair files>",
+                "git commit -m '[fix] Reconcile Main Branch repo wiring'",
+            ],
+        },
+        "raw": {
+            "migration": migration,
+            "legacy_reference": reference_state,
+            "legacy_claude_links": legacy_links,
+            "validation": validation.get("report", {}),
+            "graph": graph.get("report", {}),
+            "git": git,
+        },
+    }
+
+
+def repair_apply(repo: str | Path = ".", *, include_migration: bool = False) -> dict[str, Any]:
+    """Apply safe doctor repairs and return a fresh reconciliation report."""
+    target = Path(repo).expanduser().resolve()
+    before = repair_plan(target)
+    applied: list[dict[str, Any]] = []
+
+    missing_gitignore = _missing_gitignore_entries(target)
+    if missing_gitignore:
+        changed = _append_unique_lines(target / ".gitignore", missing_gitignore)
+        applied.append(
+            _action(
+                id="gitignore-local-state",
+                title="Protected Main Branch local state in .gitignore",
+                state="ok",
+                mode="write",
+                command="mb doctor repair --apply",
+                safe_to_apply=True,
+                reason="added missing local-state gitignore entries",
+                writes=[".gitignore"],
+                applied=changed,
+                result={"added": missing_gitignore},
+            )
+        )
+
+    shadow = engine_mod.inspect_personal_skill_conflicts(target, apply=True)
+    if int(shadow.get("summary", {}).get("repaired", 0) or 0):
+        applied.append(
+            _action(
+                id="skill-shadow-repair",
+                title="Moved stale personal Main Branch skill symlinks to backup",
+                state="ok" if shadow["ok"] else "error",
+                mode="write",
+                command="mb skill repair --repo . --apply",
+                safe_to_apply=True,
+                reason="repaired stale or broken Main Branch personal symlinks",
+                writes=[str(shadow.get("personal_skills_dir") or "~/.claude/skills")],
+                applied=True,
+                result=shadow,
+            )
+        )
+
+    if not link_status(target).get("ok"):
+        linked = engine_mod.link_skills(target)
+        applied.append(
+            _action(
+                id="skill-link",
+                title="Refreshed project-local Claude Code skill wiring",
+                state="ok" if linked["ok"] else "error",
+                mode="write",
+                command="mb skill link --repo . --json",
+                safe_to_apply=True,
+                reason="refreshed Main Branch skill links and local settings",
+                writes=[".claude/settings.local.json", ".claude/skills/", ".gitignore"],
+                applied=True,
+                result=linked,
+            )
+        )
+
+    legacy_links = _legacy_claude_symlinks(target)
+    repaired_links = _repair_legacy_claude_symlinks(target, legacy_links["findings"])
+    if repaired_links["moved"] or repaired_links["errors"]:
+        _append_unique_lines(target / ".gitignore", [".mb/backups/"])
+        applied.append(
+            _action(
+                id="legacy-claude-link-repair",
+                title="Moved old clone-path lens/reference symlinks to backup",
+                state="ok" if repaired_links["ok"] else "error",
+                mode="write",
+                command="mb doctor repair --apply",
+                safe_to_apply=True,
+                reason="moved stale symlink entries, not user-authored files",
+                writes=[".claude/lenses/", ".claude/reference/", ".mb/backups/"],
+                applied=bool(repaired_links["moved"]),
+                result=repaired_links,
+            )
+        )
+
+    if include_migration:
+        migrated = migrate_mod.apply(target)
+        applied.append(
+            _action(
+                id="migration-apply",
+                title="Applied approved layout migration",
+                state="ok" if migrated["ok"] else "error",
+                mode="write",
+                command="mb migrate --repo . --apply",
+                safe_to_apply=False,
+                reason="operator explicitly opted into migration apply",
+                writes=["core/", "reference/core", "reference/offers", ".mb/schema_version"],
+                applied=bool(migrated.get("applied")),
+                result=migrated,
+            )
+        )
+
+    after = repair_plan(target, mode="apply", applied_actions=applied)
+    after["before_summary"] = before["summary"]
+    return after
+
+
+def render_repair(report: dict[str, Any]) -> None:
+    """Print the doctor repair plan/apply report for humans."""
+    from rich.console import Console
+
+    console = Console()
+    mode = "read-only plan" if report["read_only"] else "apply summary"
+    console.print(f"\n[bold]mb doctor repair[/bold]  {mode}")
+    console.print(f"repo: {report['repo']}\n")
+    for section in report["sections"]:
+        state = str(section["state"])
+        mark = {
+            "ok": "[green]ok[/green]",
+            "info": "[blue]info[/blue]",
+            "warn": "[yellow]warn[/yellow]",
+            "error": "[red]error[/red]",
+        }.get(state, "[red]error[/red]")
+        console.print(f"  {mark}  [bold]{section['title']}[/bold] - {section['summary']}")
+        for check in section.get("checks", [])[:6]:
+            check_state = str(check.get("state", "ok"))
+            if check_state == "ok":
+                prefix = "ok"
+            elif check_state == "info":
+                prefix = "info"
+            elif check_state == "warn":
+                prefix = "warn"
+            else:
+                prefix = "error"
+            console.print(f"       {prefix:<5} {check['name']}: {check['summary']}")
+    if report.get("applied_actions"):
+        console.print("\n[bold]Applied safe repairs[/bold]")
+        for action in report["applied_actions"]:
+            console.print(f"  - {action['title']}: {action['command']}")
+    if report["actions"]:
+        console.print("\n[bold]Repair plan[/bold]")
+        for action in report["actions"]:
+            mutability = "read-only" if action["mode"] == "read" else action["mode"]
+            safe = "safe apply" if action["safe_to_apply"] else "manual approval"
+            console.print(f"  - [{mutability}; {safe}] {action['title']}")
+            console.print(f"    command: {action['command']}")
+            console.print(f"    why: {action['reason']}")
+    else:
+        console.print("\n[green]No repair actions needed.[/green]")
+    console.print("\n[bold]After apply[/bold]")
+    console.print(f"  structural: {report['post_apply']['structural_verification']}")
+    console.print(f"  validation: {report['post_apply']['validation_frontmatter_debt']}")
+    console.print(f"  runtime: {report['post_apply']['runtime_smoke_required']}")
+    console.print("  git:")
+    for command in report["post_apply"]["git_review"]:
+        console.print(f"    {command}")
 
 
 def render_human(report: dict[str, Any]) -> None:

--- a/mb/mb/doctor.py
+++ b/mb/mb/doctor.py
@@ -496,13 +496,22 @@ def _legacy_claude_symlinks(repo: Path) -> dict[str, Any]:
             target_text = str(target)
             target_parts = {part.lower() for part in Path(target_text).parts}
             raw_parts = {part.lower() for part in Path(str(raw_target)).parts}
-            clone_named = any(
-                "mb-vip" in part or "mainbranch" in part for part in target_parts | raw_parts
-            )
-            stale = engine_mod._is_stale_engine_path(target_text, active_root) or (
-                engine_mod._looks_like_missing_legacy_engine_path(str(raw_target))
-                or engine_mod._looks_like_missing_legacy_engine_path(target_text)
-                or clone_named
+            clone_named = bool((target_parts | raw_parts) & {"mb-vip", "mainbranch"})
+            try:
+                inside_active_root = target.resolve(strict=True).is_relative_to(
+                    active_root.resolve(strict=True)
+                )
+            except (FileNotFoundError, OSError):
+                inside_active_root = False
+            stale = (
+                False
+                if inside_active_root
+                else engine_mod.is_stale_engine_path(target_text, active_root)
+                or (
+                    engine_mod.looks_like_missing_legacy_engine_path(str(raw_target))
+                    or engine_mod.looks_like_missing_legacy_engine_path(target_text)
+                    or clone_named
+                )
             )
             if stale:
                 state = "warn"

--- a/mb/mb/engine.py
+++ b/mb/mb/engine.py
@@ -147,6 +147,11 @@ def _looks_like_missing_legacy_engine_path(value: str) -> bool:
     return bool(parts & {"mb-vip", "mainbranch"})
 
 
+def looks_like_missing_legacy_engine_path(value: str) -> bool:
+    """Return whether a missing path looks like an old Main Branch engine clone."""
+    return _looks_like_missing_legacy_engine_path(value)
+
+
 def _is_stale_engine_path(value: str, active_root: Path) -> bool:
     candidate = Path(value).expanduser()
     try:
@@ -157,6 +162,11 @@ def _is_stale_engine_path(value: str, active_root: Path) -> bool:
     if candidate.exists():
         return _looks_like_engine_root_path(candidate)
     return _looks_like_missing_legacy_engine_path(value)
+
+
+def is_stale_engine_path(value: str, active_root: Path) -> bool:
+    """Return whether ``value`` points at a stale Main Branch engine root."""
+    return _is_stale_engine_path(value, active_root)
 
 
 def _write_settings(repo: Path, root: Path) -> tuple[bool, list[str]]:

--- a/mb/tests/test_doctor.py
+++ b/mb/tests/test_doctor.py
@@ -2,11 +2,17 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
+from typer.testing import CliRunner
+
 from mb import doctor as doctor_mod
+from mb.cli import app
 from mb.doctor import _detect_cloud_paths, _repo_layout_check, run
 from mb.init import run as init_run
+
+runner = CliRunner()
 
 
 def test_doctor_runs_on_empty_dir(tmp_path: Path) -> None:
@@ -141,3 +147,63 @@ def test_doctor_json_and_human_output_include_required_update(
     output = capsys.readouterr().out
     assert "Update required." in output
     assert "pipx upgrade mainbranch" in output
+
+
+def test_doctor_command_still_runs_after_repair_subcommand_added(tmp_path: Path) -> None:
+    result = runner.invoke(app, ["doctor", str(tmp_path), "--json"])
+
+    assert result.exit_code in {0, 1}
+    payload = json.loads(result.stdout)
+    assert payload["repo"] == str(tmp_path.resolve())
+    assert "checks" in payload
+
+
+def test_doctor_repair_plan_is_read_only_for_status_marker(tmp_path: Path) -> None:
+    repo = tmp_path / "biz"
+    init_run(path=str(repo), name="Acme")
+    marker = repo / ".mb" / "last-status-seen.json"
+    assert not marker.exists()
+
+    result = runner.invoke(app, ["doctor", "repair", "--repo", str(repo), "--plan", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["schema"] == "mb.doctor.repair"
+    assert payload["read_only"] is True
+    assert not marker.exists()
+
+
+def test_doctor_repair_plan_distinguishes_read_and_write_actions(tmp_path: Path) -> None:
+    repo = tmp_path / "legacy"
+    (repo / "reference" / "core").mkdir(parents=True)
+
+    result = runner.invoke(app, ["doctor", "repair", "--repo", str(repo), "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    actions = {action["id"]: action for action in payload["actions"]}
+    assert actions["migration-preview"]["mode"] == "read"
+    assert actions["migration-apply"]["mode"] == "write"
+    assert actions["migration-apply"]["safe_to_apply"] is False
+
+
+def test_doctor_repair_apply_moves_old_clone_symlink_to_backup(tmp_path: Path) -> None:
+    repo = tmp_path / "biz"
+    init_run(path=str(repo), name="Acme")
+    old_engine = tmp_path / "mb-vip-old"
+    old_lens = old_engine / ".claude" / "lenses" / "ops"
+    old_lens.mkdir(parents=True)
+    stale_link = repo / ".claude" / "lenses" / "ops"
+    stale_link.parent.mkdir(parents=True, exist_ok=True)
+    stale_link.symlink_to(old_lens, target_is_directory=True)
+
+    result = runner.invoke(app, ["doctor", "repair", "--repo", str(repo), "--apply", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    applied_ids = {action["id"] for action in payload["applied_actions"]}
+    assert "legacy-claude-link-repair" in applied_ids
+    assert not stale_link.exists()
+    backups = list((repo / ".mb" / "backups").rglob("claude-links/.claude/lenses/ops"))
+    assert backups
+    assert ".mb/backups/" in (repo / ".gitignore").read_text(encoding="utf-8")

--- a/mb/tests/test_doctor.py
+++ b/mb/tests/test_doctor.py
@@ -166,7 +166,7 @@ def test_doctor_repair_plan_is_read_only_for_status_marker(tmp_path: Path) -> No
 
     result = runner.invoke(app, ["doctor", "repair", "--repo", str(repo), "--plan", "--json"])
 
-    assert result.exit_code == 0
+    assert result.exit_code in {0, 1}
     payload = json.loads(result.stdout)
     assert payload["schema"] == "mb.doctor.repair"
     assert payload["read_only"] is True
@@ -199,7 +199,7 @@ def test_doctor_repair_apply_moves_old_clone_symlink_to_backup(tmp_path: Path) -
 
     result = runner.invoke(app, ["doctor", "repair", "--repo", str(repo), "--apply", "--json"])
 
-    assert result.exit_code == 0
+    assert result.exit_code in {0, 1}
     payload = json.loads(result.stdout)
     applied_ids = {action["id"] for action in payload["applied_actions"]}
     assert "legacy-claude-link-repair" in applied_ids

--- a/mb/tests/test_doctor.py
+++ b/mb/tests/test_doctor.py
@@ -179,7 +179,7 @@ def test_doctor_repair_plan_distinguishes_read_and_write_actions(tmp_path: Path)
 
     result = runner.invoke(app, ["doctor", "repair", "--repo", str(repo), "--json"])
 
-    assert result.exit_code == 0
+    assert result.exit_code == 1
     payload = json.loads(result.stdout)
     actions = {action["id"]: action for action in payload["actions"]}
     assert actions["migration-preview"]["mode"] == "read"
@@ -190,7 +190,7 @@ def test_doctor_repair_plan_distinguishes_read_and_write_actions(tmp_path: Path)
 def test_doctor_repair_apply_moves_old_clone_symlink_to_backup(tmp_path: Path) -> None:
     repo = tmp_path / "biz"
     init_run(path=str(repo), name="Acme")
-    old_engine = tmp_path / "mb-vip-old"
+    old_engine = tmp_path / "mb-vip"
     old_lens = old_engine / ".claude" / "lenses" / "ops"
     old_lens.mkdir(parents=True)
     stale_link = repo / ".claude" / "lenses" / "ops"
@@ -207,3 +207,50 @@ def test_doctor_repair_apply_moves_old_clone_symlink_to_backup(tmp_path: Path) -
     backups = list((repo / ".mb" / "backups").rglob("claude-links/.claude/lenses/ops"))
     assert backups
     assert ".mb/backups/" in (repo / ".gitignore").read_text(encoding="utf-8")
+
+
+def test_doctor_rejects_unknown_options_on_existing_path() -> None:
+    result = runner.invoke(app, ["doctor", "--jsonn"])
+
+    assert result.exit_code == 2
+    assert "unknown option" in result.stderr
+
+
+def test_doctor_repair_exits_nonzero_when_json_report_is_red(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(
+        doctor_mod,
+        "repair_plan",
+        lambda repo=".": {
+            "ok": False,
+            "read_only": True,
+            "repo": str(tmp_path),
+            "summary": {"error": 1},
+        },
+    )
+
+    result = runner.invoke(app, ["doctor", "repair", "--repo", str(tmp_path), "--json"])
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False
+
+
+def test_doctor_legacy_symlink_keeps_current_active_engine_root(
+    tmp_path: Path, monkeypatch
+) -> None:
+    repo = tmp_path / "biz"
+    repo.mkdir()
+    active_root = tmp_path / "Documents" / "GitHub" / "mainbranch"
+    active_lens = active_root / ".claude" / "lenses" / "ops"
+    active_lens.mkdir(parents=True)
+    lens_link = repo / ".claude" / "lenses" / "ops"
+    lens_link.parent.mkdir(parents=True)
+    lens_link.symlink_to(active_lens, target_is_directory=True)
+
+    monkeypatch.setattr(doctor_mod.engine_mod, "engine_root", lambda: active_root)
+
+    result = doctor_mod._legacy_claude_symlinks(repo)
+
+    assert result["repairable"] == 0
+    assert result["findings"][0]["state"] == "info"
+    assert result["findings"][0]["safe_to_repair"] is False


### PR DESCRIPTION
## Summary
- Adds `mb doctor repair --plan` / `--apply` as the guided reconciliation loop for existing business repos.
- Reports install freshness, repo shape, migration preview, `.gitignore` coverage, Claude Code wiring, old clone-path symlinks, `.mb/` local state, validation, graph health, and git review state in human output and JSON.
- Applies only safe wiring/local-state repairs by default and keeps file migration behind explicit `--include-migration` after preview review.
- Keeps static repair separate from runtime proof with post-apply Claude Code smoke instructions.

## Scope
In:
- Read-only reconciliation planning and machine-readable `mb.doctor.repair` JSON.
- Safe apply repairs for local-state gitignore entries, stale Main Branch personal skill symlinks, project-local skill wiring, and stale clone-path `.claude/lenses` / `.claude/reference` symlinks.
- README and CHANGELOG updates for the new user-visible doctor repair surface.

Out:
- Re-deciding the committed business-repo `reference/` folder model now tracked separately in #318.
- Auto-pushing, auto-merging, opening follow-up PRs from the repair command, or claiming Claude Code runtime success from static checks.
- Deleting user-authored skills, lenses, reference files, third-party symlinks, or business content.

## Commits
- `37924c8` — `[add] MAIN-244 guided doctor repair reconciliation`.
- `9fd9c77` — `[fix] MAIN-244 address doctor repair review`.

## Release / Issues
- Release: v0.3.x / next repair-loop work.
- Linear ID(s): MAIN-244.
- Closes: #314.
- Refs: #318.
- Follow-ups: #318 owns the remaining committed business-repo `reference/` folder-model decision and deprecation scope.

## Success Metric
- From an old Main Branch repo, an operator or Claude can run one read-only doctor repair plan, understand exactly what is outdated or unsafe, apply approved safe repairs, and end with current wiring, validation/link/graph summaries, git review guidance, and explicit remaining runtime-smoke instructions.

## Validation
- Level 0 docs/decision: README and CHANGELOG updated; public/private boundary checked for generic OSS-safe language.
- Level 1 static: `scripts/check.sh` passed, including format, lint, mypy, 242 tests with coverage, and bundled skill validation.
- Level 2 CLI: `pytest tests/test_doctor.py tests/test_cli.py tests/test_engine.py -q` passed with 32 tests; manual checks passed for `mb doctor --help`, `mb doctor repair --help`, `mb doctor --jsonn`, and `mb doctor . --json`.
- Level 3 package/install: not run; packaging and entrypoints were not changed.
- Level 4 fixture repo: passed `mb onboard --yes`, `mb doctor repair --plan --json`, `mb doctor repair --apply --json`, `mb validate --cross-refs --json`, and `mb start --json` on a temp business repo.
- Level 5 runtime smoke: not run; this PR does not claim Claude Code runtime success and the command output explicitly names the remaining `/mb-start` runtime smoke.

## Public / Private Boundary
- No private Devon, Conductor, Skool/member, credential, or customer data was committed.
- `.context/` remained scratch-only; durable product truth landed in CLI code, tests, README, and CHANGELOG.
