### PR TITLE
[update] Prepare 0.3.2 release

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mainbranch",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Main Branch Claude Code skills for running a business from markdown files in git.",
   "author": {
     "name": "Noontide"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,25 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+## [0.3.2] - 2026-05-06
+
+v0.3.2 makes Main Branch safer to repair and clearer about where business
+memory lives. It adds guided doctor repair, retires the old committed
+`reference/` folder model for new repos, and tightens migration/runtime
+guidance from real dogfood.
+
+### What this means for you (plain English)
+
+- **Doctor can now help repair a repo.** `mb doctor repair --plan` explains
+  what is stale or unsafe before anything writes, and `--apply` can fix safe
+  wiring/local-state issues.
+- **New business repos use `core/` as the business brain.** Legacy
+  `reference/*` paths are compatibility fallbacks, not places where new truth
+  should be written.
+- **Migration guidance is less confusing.** Claude-led updates now start with
+  Main Branch update/repair, use read-only checks by default, and pause before
+  git decisions that normal users should not have to judge alone.
+
 ### Added
 
 - Added `mb doctor repair --plan/--apply` as a guided repo reconciliation

--- a/mb/mb/__init__.py
+++ b/mb/mb/__init__.py
@@ -7,6 +7,6 @@ file stays a thin dispatcher.
 
 from __future__ import annotations
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"
 
 __all__ = ["__version__"]

--- a/mb/pyproject.toml
+++ b/mb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mainbranch"
-version = "0.3.1"
+version = "0.3.2"
 description = "Main Branch engine umbrella - scaffolds, validates, and graphs business-as-files repos. Claude Code first, runtime-agnostic by design."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- Prepares the Main Branch `0.3.2` release from current `main`.
- Moves the current changelog entries into a dated `0.3.2` section.
- Aligns package, module, and Claude plugin version metadata at `0.3.2`.
- Frames the release around guided doctor repair, the canonical `core/` business folder model, and clearer migration/runtime guidance.

## Scope
- In: changelog release section, Python package version, `mb.__version__`, and Claude plugin version metadata.
- Out: publishing the GitHub Release, tagging `oe-v0.3.2`, PyPI publication, new product fixes, and marking the release shipped before install verification after merge.

## Commits
- `c63586f` — `[update] Prepare 0.3.2 release`.

## Release / Issues
- Release: `0.3.2`.
- Linear ID(s): MAIN-244, MAIN-246.
- Closes: none.
- Refs: #314, #318.
- Follow-ups: #321 / MAIN-247 for the campaign primitive and refreshed architecture model.

## Success Metric
- Reviewers can merge a release-prep branch where changelog and version metadata agree on `0.3.2`, ready for the GitHub Release + PyPI publish step.

## Validation
- Level 0 docs/decision: Reviewed release notes for public/product accuracy and no private workflow details.
- Level 1 static: `scripts/check.sh` passed: format, lint, mypy, 243 tests, coverage, and bundled skill validation.
- Level 2 CLI: Covered by `scripts/check.sh` test suite.
- Level 3 package/install: `python3 -m build` succeeded; clean venv installed `mainbranch-0.3.2` wheel; `mb --version` returned `mb 0.3.2`; `mb skill list` passed.
- Level 4 fixture repo: Clean installed wheel passed `mb onboard`, `mb doctor`, `mb doctor repair --plan`, `mb status --peek`, `mb start --json`, and `mb validate` against a fresh smoke repo.
- Level 5 runtime smoke: Not rerun on this release-prep branch; prior feature PR runtime evidence covered `/mb-start` discovery and skill writes, but final release should still verify install/PyPI after merge.

## Public / Private Boundary
- No private Devon, Conductor, credential, customer, account-specific, or runtime-local details were added.
