### PR TITLE
[fix] Patch MAIN-247 follow-ups: campaign validator + refuse-list and spine decisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,37 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+### Fixed
+
+- `mb validate` now checks `campaigns/*/campaign.md` `status:` against the
+  campaign lifecycle (`draft, planned, active, paused, completed, canceled,
+  archived`) defined in
+  [decisions/2026-05-06-campaign-primitive-and-architecture-model.md](decisions/2026-05-06-campaign-primitive-and-architecture-model.md).
+  The previous implementation reused the offer enum, so a campaign written
+  to the merged decision (`status: active`) failed validation. Refs #328.
+- Corrected the `linked_bets:` example in the campaign primitive decision
+  and supporting docs to use the dated `bets/2026-05-06-workshop-waitlist.md`
+  shape, matching every other primitive's path convention. Refs #328.
+
+### Added
+
+- New decision
+  [decisions/2026-05-06-campaigns-refuse-list.md](decisions/2026-05-06-campaigns-refuse-list.md)
+  publishes the fields the engine refuses to add to `campaign.md` (epic,
+  numeric priority, multi-assignee, story points, kpi_dashboard, linked_okrs,
+  free-text description, and others). The product is judged by what it
+  refuses; the refuse list is now the public default and a clear path to
+  changing it. Refs #328.
+- New decision
+  [decisions/2026-05-06-main-branch-operating-spine.md](decisions/2026-05-06-main-branch-operating-spine.md)
+  codifies Main Branch's operating philosophy as a durable product
+  decision: the system speaks Linear-quiet, the operator runs
+  Hormozi-volume, and the bets layer carries Robbins identity. Includes
+  ten cross-cutting principles, a voice/tone profile for operator-facing
+  surfaces, and the principle that the operator owns the vocabulary
+  (campaigns can be called *drops*, *launches*, *challenges*, *promos*
+  in operator-facing surfaces). Refs #328.
+
 ## [0.3.2] - 2026-05-06
 
 v0.3.2 makes Main Branch safer to repair and clearer about where business

--- a/decisions/2026-05-05-operator-readable-git-history.md
+++ b/decisions/2026-05-05-operator-readable-git-history.md
@@ -159,7 +159,7 @@ Next:
 - Draft the lander in /mb-site.
 
 Refs:
-- bets/workshop-waitlist.md
+- bets/2026-05-06-workshop-waitlist.md
 - decisions/2026-05-05-workshop-price.md
 - https://github.com/noontide-co/mainbranch/issues/300
 ```

--- a/decisions/2026-05-06-campaign-primitive-and-architecture-model.md
+++ b/decisions/2026-05-06-campaign-primitive-and-architecture-model.md
@@ -152,7 +152,7 @@ linked_strategy:
 linked_offers:
   - core/offers/workshop/offer.md
 linked_bets:
-  - bets/workshop-waitlist.md
+  - bets/2026-05-06-workshop-waitlist.md
 linked_decisions:
   - decisions/2026-05-06-workshop-price.md
 linked_research: []

--- a/decisions/2026-05-06-campaigns-refuse-list.md
+++ b/decisions/2026-05-06-campaigns-refuse-list.md
@@ -33,7 +33,7 @@ decision says what a campaign is. This one says what a campaign is not.
 | `estimated_hours` / `story_points` | Performative precision. Operators don't track campaigns by hour. | Use `deadline:` and `review_on:` — calendar dates that already exist. |
 | `kpi_dashboard` | Visualization is not the campaign record. | Point at the metric source via `metrics_sources[]` or the future flat `external_refs[]`. |
 | `linked_okrs` | OKR theater. Most small businesses don't run OKRs and the ones that do already use Linear/Tability/Lattice. | Use `linked_bets` for hypothesis tracking. Use `linked_decisions` for direction. |
-| `description` (free-text) | Free-text descriptions go stale and don't drive any decision the operator has to make. The structured goal answers "what are we trying to do?"; `review-log.md` carries the narrative. | Use `goal:` (structured), `promise:` (≤140 chars, future schema), and `review-log.md` for narrative. |
+| `description` (free-text frontmatter) | Always rots when it tries to carry the campaign's whole story. It also duplicates the markdown body, where narrative belongs. | Use `goal:` (structured), `promise:` (<=140 chars, future schema), and `review-log.md` for narrative. |
 | `tier` / `severity` | Imports incident-management vocabulary into a marketing primitive. | If the push is high-stakes, that's evident from the linked offer and bet. |
 | `confidence_score` | Performative quantification of judgment. | Operator judgment lives in the linked bet hypothesis. |
 | `sentiment` / `mood` | Subjective and stale within a day. | If a push needs a feeling note, it goes in `review-log.md`. |

--- a/decisions/2026-05-06-campaigns-refuse-list.md
+++ b/decisions/2026-05-06-campaigns-refuse-list.md
@@ -33,7 +33,7 @@ decision says what a campaign is. This one says what a campaign is not.
 | `estimated_hours` / `story_points` | Performative precision. Operators don't track campaigns by hour. | Use `deadline:` and `review_on:` — calendar dates that already exist. |
 | `kpi_dashboard` | Visualization is not the campaign record. | Point at the metric source via `metrics_sources[]` or the future flat `external_refs[]`. |
 | `linked_okrs` | OKR theater. Most small businesses don't run OKRs and the ones that do already use Linear/Tability/Lattice. | Use `linked_bets` for hypothesis tracking. Use `linked_decisions` for direction. |
-| `description` (free-text) | Always rots. HubSpot retired exactly this field on 2025-07-09 because operators stopped reading it. | Use `goal:` (structured), `promise:` (≤140 chars, future schema), and `review-log.md` for narrative. |
+| `description` (free-text) | Free-text descriptions go stale and don't drive any decision the operator has to make. The structured goal answers "what are we trying to do?"; `review-log.md` carries the narrative. | Use `goal:` (structured), `promise:` (≤140 chars, future schema), and `review-log.md` for narrative. |
 | `tier` / `severity` | Imports incident-management vocabulary into a marketing primitive. | If the push is high-stakes, that's evident from the linked offer and bet. |
 | `confidence_score` | Performative quantification of judgment. | Operator judgment lives in the linked bet hypothesis. |
 | `sentiment` / `mood` | Subjective and stale within a day. | If a push needs a feeling note, it goes in `review-log.md`. |

--- a/decisions/2026-05-06-campaigns-refuse-list.md
+++ b/decisions/2026-05-06-campaigns-refuse-list.md
@@ -1,0 +1,92 @@
+---
+type: decision
+date: 2026-05-06
+status: accepted
+topic: Campaigns refuse-list — fields the engine will not add
+linked_issues:
+  - https://github.com/noontide-co/mainbranch/issues/328
+linked_decisions:
+  - decisions/2026-05-06-campaign-primitive-and-architecture-model.md
+  - decisions/2026-05-06-main-branch-operating-spine.md
+tags: [v0-3, campaigns, schema, taste]
+---
+
+# Campaigns Refuse-List
+
+## Decision
+
+The `campaign.md` frontmatter will not grow the following fields. This refusal
+is a feature, not an oversight. Listing it publicly so future PRs and skills
+can be evaluated against it.
+
+This is the engineering-taste counterpart to
+`decisions/2026-05-06-campaign-primitive-and-architecture-model.md`. That
+decision says what a campaign is. This one says what a campaign is not.
+
+## Refused Fields
+
+| Field | Why refused | What to do instead |
+| --- | --- | --- |
+| `epic` / `parent_epic` | Bundles unrelated work under a heading no operator will look at again. | Use `decisions/` for direction. Use `linked_bets:` when one push is part of a learning sequence. |
+| `priority` (numeric: P0/P1/P2) | Fake precision. Two pushes can't both be P1, and the operator is the priority arbiter. | Surface one push at a time in `mb status`. Use `this_week_lever:` (separate issue) to name the single move. |
+| `assignee` (multi-person list) | Splits accountability. Coordinated pushes already have one DRI. | Use `owner:` (single, future schema) — one DRI per push. |
+| `estimated_hours` / `story_points` | Performative precision. Operators don't track campaigns by hour. | Use `deadline:` and `review_on:` — calendar dates that already exist. |
+| `kpi_dashboard` | Visualization is not the campaign record. | Point at the metric source via `metrics_sources[]` or the future flat `external_refs[]`. |
+| `linked_okrs` | OKR theater. Most small businesses don't run OKRs and the ones that do already use Linear/Tability/Lattice. | Use `linked_bets` for hypothesis tracking. Use `linked_decisions` for direction. |
+| `description` (free-text) | Always rots. HubSpot retired exactly this field on 2025-07-09 because operators stopped reading it. | Use `goal:` (structured), `promise:` (≤140 chars, future schema), and `review-log.md` for narrative. |
+| `tier` / `severity` | Imports incident-management vocabulary into a marketing primitive. | If the push is high-stakes, that's evident from the linked offer and bet. |
+| `confidence_score` | Performative quantification of judgment. | Operator judgment lives in the linked bet hypothesis. |
+| `sentiment` / `mood` | Subjective and stale within a day. | If a push needs a feeling note, it goes in `review-log.md`. |
+| `automation_trigger` / `webhook_url` | The `campaign.md` is a record, not a runtime. | Provider integrations belong in sidecars; webhooks belong in the provider. |
+| `tags` (free-tagging) | Without governance, tags drift. With governance, they duplicate `kind:`. | Use `kind:` (future schema) for the small bounded set of push types. |
+
+## What This Decision Does
+
+- Future PRs that propose any of these fields must explicitly cite this
+  decision and argue why the field is no longer refused.
+- `mb validate` should not learn to read these fields. If a user-authored
+  campaign carries one, it is tolerated as an extra (the schema tolerates
+  extras), but no engine surface treats it as load-bearing.
+- Skill prompts (`/mb-ads`, `/mb-organic`, `/mb-site`, future `/mb-push new`)
+  must not ask the operator for any of these fields.
+- `decisions/2026-05-06-main-branch-operating-spine.md` cites this decision
+  as evidence of the principle "the system is judged by what it refuses."
+
+## Reasoning
+
+The merged campaign decision (#327) names the smallest schema that supports
+the operator loops. The next pressure on that schema will not come from
+operators asking for these fields — it will come from contributors importing
+shapes from Salesforce, Jira, HubSpot, or whatever ticketing tool they used
+last. Each import looks reasonable in isolation and creates rot in
+aggregate. Publishing the refuse list moves that conversation to the front
+of the PR, not the middle of a code review.
+
+The Linear precedent: Linear refused estimate fields, story points, and
+nested epics for years and was clearer for it. The product's character came
+as much from what it didn't ship as from what it did.
+
+## Consequences
+
+- Future schema deltas (Issue: schema deltas v1) cannot quietly land any
+  refused field. They land new fields like `owner`, `audience`, `offer`,
+  `promise`, `goal: { metric, target, by }`, `health` — which earn their
+  place because they answer questions the operator actually asks.
+- Migration of legacy `outputs/` content does not import refused fields,
+  even if the source artifact carried them.
+- Operators with strong preferences for refused fields can store them in
+  `documents/` or in their own private repo. They do not become canonical
+  campaign memory.
+
+## Open Door
+
+A refused field can be promoted by:
+
+1. A new accepted decision that supersedes this one (in part) and names the
+   refused field, the question it answers, and why no existing field can
+   answer it.
+2. Operator evidence that the omission causes loss in the field — not in
+   theory, in dogfood.
+
+This is not a permanent ban. It is a public default with a clear path to
+change.

--- a/decisions/2026-05-06-main-branch-operating-spine.md
+++ b/decisions/2026-05-06-main-branch-operating-spine.md
@@ -38,10 +38,16 @@ from Linear, dbt, YC, ADRs, Diataxis. Operator-facing language must speak
 business-owner.
 
 This is a contract. Engine internals can carry their stable engineering
-names (`primitive`, `schema`, `frontmatter`, `validate`, `graph`,
-`provider refs`, `sidecar`). Operator-facing surfaces — skill prompts,
-`mb status` output, error messages, doc copy in `README.md` — must not
-expose those words. A glossary can translate them when needed.
+names (`primitive`, `schema`, `frontmatter`, `provider refs`, `sidecar`,
+`graph`). Public CLI command names (`mb validate`, `mb graph`, `mb status`)
+and concrete file concepts (`frontmatter`, `decisions/`, `bets/`) may
+appear in command reference and `docs/` technical material because that
+is what operators type and inspect. The rule is narrower: **avoid
+unexplained internal jargon in beginner and operator-facing copy** —
+skill prompts, conversational `mb status` output, error messages, the
+top of `README.md`, onboarding flows, and any first-touch surface should
+not require a glossary lookup to read. A glossary can translate when
+needed.
 
 ## Ten Cross-Cutting Principles
 
@@ -74,9 +80,9 @@ them.
    writes `core/` files in timeless language.
 
 7. **The system refuses loudly.** `mb` exits non-zero with a clear reason
-   when an operator tries to do the wrong thing. The refused-fields
-   decision (#324 follow-up) is part of this principle. The product is
-   judged by what it refuses.
+   when an operator tries to do the wrong thing. The companion
+   [campaigns refuse-list decision](2026-05-06-campaigns-refuse-list.md)
+   is part of this principle. The product is judged by what it refuses.
 
 8. **The system asks better questions.** Skills do not fill out forms;
    they have conversations that produce real artifacts. The artifact
@@ -111,9 +117,11 @@ them.
 - Filler phrases that read like tutorials.
 - Enterprise jargon: *stakeholder, initiative, alignment, synergy,
   blocker, OKR, KPI, deliverable*.
-- Engineer jargon at the operator surface: *primitive, schema, frontmatter,
-  validate, graph, enum, provider refs, sidecar, canonical, ADR, runtime,
-  adapter, fixture, smoke test*.
+- Unexplained internal jargon in beginner copy: *primitive, schema, enum,
+  provider refs, sidecar, canonical, ADR, runtime, adapter, fixture,
+  smoke test*. (Public CLI command names like `mb validate` and `mb graph`
+  may appear in command reference; the test is whether a first-time
+  operator could read the line without a glossary lookup.)
 - Numeric priorities (P0/P1) — see the refuse-list decision.
 - False urgency. Scarcity theater. Hype.
 
@@ -122,10 +130,12 @@ them.
 - Every future PR is evaluated against the ten principles. The PR description
   should call out which principle the change serves and any principle it
   bends.
-- The voice profile applies to all operator-facing copy: `README.md`,
-  `mb status` output, skill prompts in `.claude/skills/*/SKILL.md`, error
-  messages, and onboarding flows. AGENTS.md and engine-internal docs may
-  use engineering language because their audience is contributors.
+- The voice profile applies to beginner and operator-facing copy: the top
+  of `README.md`, `mb status` conversational output, skill prompts in
+  `.claude/skills/*/SKILL.md`, error messages, and onboarding flows.
+  Command reference, `docs/` technical material, AGENTS.md, and
+  engine-internal docs may use engineering language because their audience
+  is operators-as-readers or contributors.
 - Issue grooming uses the principles as a rubric. An issue that violates
   a principle either gets reshaped or is rejected with the principle cited.
 
@@ -155,13 +165,25 @@ them.
 
 ## Sources
 
-This decision is the synthesis of 8 parallel research reports written for
-MAIN-247 and stored in `.context/` of the originating workspace. The reports
-surveyed Hormozi / Brunson / Walker / Hormozi / direct-response heritage
-(volume archetype), YC / Linear / Stripe / Basecamp / Apple HIG (taste
-archetype), and Robbins / Naval / Munger / Buffett / Dalio / Clear (identity
-archetype), then resolved the tensions between them.
+The three archetypes are deliberately drawn from public bodies of work:
 
-The reports are not committed (workspace `.context/` is gitignored). The
-durable artifacts are this decision, the campaigns refuse-list decision,
-and the campaign primitive decision they sit alongside.
+- **Volume archetype** — Russell Brunson (DotCom Secrets, Expert Secrets),
+  Alex Hormozi ($100M Offers, $100M Leads), Jeff Walker (Product Launch
+  Formula), and the direct-response copywriting heritage (Schwartz,
+  Halbert, Kennedy). Lessons borrowed: offers come before features,
+  reps are the unit, double down on winners, name the promise.
+- **Taste archetype** — Y Combinator's startup writing, Linear's product
+  philosophy and method, Stripe's documentation craft, Basecamp's Shape
+  Up, and Apple's Human Interface Guidelines. Lessons borrowed: sharp
+  primitives, opinionated defaults, lifecycle that maps to reality, the
+  product is judged by what it refuses.
+- **Identity archetype** — Tony Robbins (RPM), Naval Ravikant (leverage,
+  specific knowledge), Charlie Munger and Warren Buffett (clarity in
+  one paragraph), Ray Dalio (principles), James Clear (identity-based
+  habits). Lessons borrowed: long-arc vision tied to weekly execution,
+  identity is reference not goal, weekly state of the business in one
+  paragraph.
+
+The decision is durable on its own merits; the archetype list above
+exists to make the lineage of the principles legible to future
+contributors.

--- a/decisions/2026-05-06-main-branch-operating-spine.md
+++ b/decisions/2026-05-06-main-branch-operating-spine.md
@@ -1,0 +1,167 @@
+---
+type: decision
+date: 2026-05-06
+status: accepted
+topic: Main Branch operating spine — taste, volume, identity
+linked_issues:
+  - https://github.com/noontide-co/mainbranch/issues/328
+linked_decisions:
+  - decisions/2026-05-02-github-native-business-os.md
+  - decisions/2026-05-05-operator-loops-taxonomy.md
+  - decisions/2026-05-06-campaign-primitive-and-architecture-model.md
+  - decisions/2026-05-06-campaigns-refuse-list.md
+tags: [v0-3, foundation, philosophy, voice]
+---
+
+# Main Branch Operating Spine
+
+## Decision
+
+Main Branch is built on three operating archetypes, braided. Every product
+decision passes through this filter.
+
+| Layer | Archetype | Job |
+| --- | --- | --- |
+| **The system itself** (CLI, validate, status, doctor, graph) | YC + Linear taste — opinionated minimalism, sharp primitives, refuses bad defaults | Quiet, fast, decisive. Earns trust through restraint. |
+| **The operator's daily push** (campaigns, ads, organic, sites) | ClickFunnels + Hormozi craft — volume, reps, offer-discipline, double down on winners | The system makes shipping easier, not slower. Reps are the unit. |
+| **The operator's identity** (bets, soul, voice, weekly state) | Robbins / Naval / Buffett — long-arc vision, identity-level commitment, one-paragraph state of the business | The system protects this from the noise. Identity is reference, not a goal. |
+
+**The rule when they fight:** taste wins on the system surface, volume wins
+on the operator's behalf, identity wins at weekly cadence.
+
+## Audience
+
+Main Branch users are non-technical small business owners — coaches,
+creators, agencies, community/membership operators, course sellers,
+consultants, local service businesses. Engineering principles can come
+from Linear, dbt, YC, ADRs, Diataxis. Operator-facing language must speak
+business-owner.
+
+This is a contract. Engine internals can carry their stable engineering
+names (`primitive`, `schema`, `frontmatter`, `validate`, `graph`,
+`provider refs`, `sidecar`). Operator-facing surfaces — skill prompts,
+`mb status` output, error messages, doc copy in `README.md` — must not
+expose those words. A glossary can translate them when needed.
+
+## Ten Cross-Cutting Principles
+
+These are the durable rules. Future PRs and decisions are graded against
+them.
+
+1. **The repo is the business.** Not the dashboard, not the SaaS, not the
+   Notion. Files in git are the source of truth. Provider systems and
+   dashboards are inputs and views, not memory.
+
+2. **The primitive is the product.** A primitive earns its place by enabling
+   a question the operator actually asks. No primitive without a question.
+   When in doubt, do not add one.
+
+3. **Every push names its offer and its promise.** A coordinated push without
+   a named offer is a task. A push without a one-sentence promise is
+   theater. The system enforces both as the schema work lands.
+
+4. **Lifecycle includes doubling down.** Most systems treat "completed" as
+   the end. Real operators find a winner and pour fuel. This is a
+   first-class state, not an implicit "start a new campaign."
+
+5. **Surface what matters most this week.** Not everything you could do.
+   One push, one lever, one number. `mb status` is a triage, not a
+   dashboard.
+
+6. **Identity is reference, not a goal.** `core/soul.md` is who the
+   operator is. `bets/` are what they're trying. `campaigns/` are what
+   they're shipping. The system does not blur these layers, and it
+   writes `core/` files in timeless language.
+
+7. **The system refuses loudly.** `mb` exits non-zero with a clear reason
+   when an operator tries to do the wrong thing. The refused-fields
+   decision (#324 follow-up) is part of this principle. The product is
+   judged by what it refuses.
+
+8. **The system asks better questions.** Skills do not fill out forms;
+   they have conversations that produce real artifacts. The artifact
+   exists from turn one — the operator edits, never starts blank.
+
+9. **Reps are the unit of progress.** Volume is honest. Theater is not.
+   The system shows the rep count (pushes shipped, bets closed,
+   decisions made), not the hype.
+
+10. **Operator owns the vocabulary. Engine owns the taste.** The operator's
+    business calls campaigns *drops*, *launches*, *challenges*, *promos*,
+    *plays*, *rounds*, *waves*. The engine speaks the operator's word back
+    to them. Engine internals stay stable; operator surface mirrors the
+    operator. (The vocabulary-storage mechanism is a follow-up issue; the
+    principle lands here.)
+
+## Voice / Tone Profile For Operator-Facing Surfaces
+
+### Do
+
+- "Your active push: Workshop waitlist. Day 14. 11 of 40 signups. Today's
+  lever: cold-traffic ad refresh."
+- "Closed cleanly. Saved a research note from what surprised you. Want me
+  to draft a newsletter post?"
+- "I matched a bet — say if I'm wrong."
+- "Rough is fine. We can sharpen on the way."
+- "This push has no offer. Pick one or skip."
+
+### Don't
+
+- "Awesome!" / "Great job!" / "Let's go ahead and..." / emoji in `mb status`
+- Filler phrases that read like tutorials.
+- Enterprise jargon: *stakeholder, initiative, alignment, synergy,
+  blocker, OKR, KPI, deliverable*.
+- Engineer jargon at the operator surface: *primitive, schema, frontmatter,
+  validate, graph, enum, provider refs, sidecar, canonical, ADR, runtime,
+  adapter, fixture, smoke test*.
+- Numeric priorities (P0/P1) — see the refuse-list decision.
+- False urgency. Scarcity theater. Hype.
+
+## What This Decision Authorizes
+
+- Every future PR is evaluated against the ten principles. The PR description
+  should call out which principle the change serves and any principle it
+  bends.
+- The voice profile applies to all operator-facing copy: `README.md`,
+  `mb status` output, skill prompts in `.claude/skills/*/SKILL.md`, error
+  messages, and onboarding flows. AGENTS.md and engine-internal docs may
+  use engineering language because their audience is contributors.
+- Issue grooming uses the principles as a rubric. An issue that violates
+  a principle either gets reshaped or is rejected with the principle cited.
+
+## What This Decision Refuses
+
+- Dashboards, web UIs, or hosted services as the canonical memory. The repo
+  is the business.
+- Configurability that papers over a missing decision. Defaults beat knobs.
+- Productivity-porn surfaces (streaks, gamification, leaderboards).
+- Engineering-blog tone in operator-facing copy.
+
+## Consequences
+
+- Bundle 1 (this issue, #328) ships the refuse-list decision and this spine
+  decision together — the philosophy is durable before the schema work in
+  the upcoming issues expands.
+- Future issues for schema deltas, lifecycle v1.1, operator-vocab rename,
+  `mb push close` ritual, `mb push open` interview, and the operate-in-public
+  narration loop all inherit this spine. They cite it in their issue body.
+- Operator-vocabulary storage (the mechanism that lets a coach's local
+  Claude Code session see *drops* instead of *campaigns*) is the first
+  follow-up where principle 10 becomes code.
+- Skills that already ship (`/mb-ads`, `/mb-organic`, `/mb-site`, `/mb-vsl`,
+  `/mb-bet`, `/mb-start`) are graded against the voice profile in their
+  next material change. No bulk rewrite — improvements happen on the path
+  of normal work.
+
+## Sources
+
+This decision is the synthesis of 8 parallel research reports written for
+MAIN-247 and stored in `.context/` of the originating workspace. The reports
+surveyed Hormozi / Brunson / Walker / Hormozi / direct-response heritage
+(volume archetype), YC / Linear / Stripe / Basecamp / Apple HIG (taste
+archetype), and Robbins / Naval / Munger / Buffett / Dalio / Clear (identity
+archetype), then resolved the tensions between them.
+
+The reports are not committed (workspace `.context/` is gitignored). The
+durable artifacts are this decision, the campaigns refuse-list decision,
+and the campaign primitive decision they sit alongside.

--- a/decisions/2026-05-06-main-branch-operating-spine.md
+++ b/decisions/2026-05-06-main-branch-operating-spine.md
@@ -38,16 +38,11 @@ from Linear, dbt, YC, ADRs, Diataxis. Operator-facing language must speak
 business-owner.
 
 This is a contract. Engine internals can carry their stable engineering
-names (`primitive`, `schema`, `frontmatter`, `provider refs`, `sidecar`,
-`graph`). Public CLI command names (`mb validate`, `mb graph`, `mb status`)
-and concrete file concepts (`frontmatter`, `decisions/`, `bets/`) may
-appear in command reference and `docs/` technical material because that
-is what operators type and inspect. The rule is narrower: **avoid
-unexplained internal jargon in beginner and operator-facing copy** —
-skill prompts, conversational `mb status` output, error messages, the
-top of `README.md`, onboarding flows, and any first-touch surface should
-not require a glossary lookup to read. A glossary can translate when
-needed.
+names (`primitive`, `schema`, `frontmatter`, `validate`, `graph`,
+`provider refs`, `sidecar`). Beginner and operator workflow copy should
+avoid unexplained internal jargon. Command reference, contributor docs,
+and technical troubleshooting may name exact commands, file concepts, and
+schemas when precision matters.
 
 ## Ten Cross-Cutting Principles
 
@@ -80,9 +75,9 @@ them.
    writes `core/` files in timeless language.
 
 7. **The system refuses loudly.** `mb` exits non-zero with a clear reason
-   when an operator tries to do the wrong thing. The companion
-   [campaigns refuse-list decision](2026-05-06-campaigns-refuse-list.md)
-   is part of this principle. The product is judged by what it refuses.
+   when an operator tries to do the wrong thing. The campaigns refuse-list
+   decision is part of this principle. The product is judged by what it
+   refuses.
 
 8. **The system asks better questions.** Skills do not fill out forms;
    they have conversations that produce real artifacts. The artifact
@@ -127,9 +122,8 @@ them.
 
 ## What This Decision Authorizes
 
-- Every future PR is evaluated against the ten principles. The PR description
-  should call out which principle the change serves and any principle it
-  bends.
+- Product-shape PRs should be reviewed against the ten principles. When a
+  change bends one of them, the PR description should name the tradeoff.
 - The voice profile applies to beginner and operator-facing copy: the top
   of `README.md`, `mb status` conversational output, skill prompts in
   `.claude/skills/*/SKILL.md`, error messages, and onboarding flows.
@@ -165,25 +159,10 @@ them.
 
 ## Sources
 
-The three archetypes are deliberately drawn from public bodies of work:
+This decision synthesizes research across direct-response operating systems
+(Hormozi, Brunson, Walker), product-taste systems (YC, Linear, Stripe,
+Basecamp, Apple HIG), and long-arc identity/investing systems (Robbins,
+Naval, Munger, Buffett, Dalio, Clear).
 
-- **Volume archetype** — Russell Brunson (DotCom Secrets, Expert Secrets),
-  Alex Hormozi ($100M Offers, $100M Leads), Jeff Walker (Product Launch
-  Formula), and the direct-response copywriting heritage (Schwartz,
-  Halbert, Kennedy). Lessons borrowed: offers come before features,
-  reps are the unit, double down on winners, name the promise.
-- **Taste archetype** — Y Combinator's startup writing, Linear's product
-  philosophy and method, Stripe's documentation craft, Basecamp's Shape
-  Up, and Apple's Human Interface Guidelines. Lessons borrowed: sharp
-  primitives, opinionated defaults, lifecycle that maps to reality, the
-  product is judged by what it refuses.
-- **Identity archetype** — Tony Robbins (RPM), Naval Ravikant (leverage,
-  specific knowledge), Charlie Munger and Warren Buffett (clarity in
-  one paragraph), Ray Dalio (principles), James Clear (identity-based
-  habits). Lessons borrowed: long-arc vision tied to weekly execution,
-  identity is reference not goal, weekly state of the business in one
-  paragraph.
-
-The decision is durable on its own merits; the archetype list above
-exists to make the lineage of the principles legible to future
-contributors.
+The durable artifacts are this decision, the campaigns refuse-list decision,
+and the campaign primitive decision they sit alongside.

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -215,7 +215,7 @@ linked_strategy:
 linked_offers:
   - core/offers/workshop/offer.md
 linked_bets:
-  - bets/workshop-waitlist.md
+  - bets/2026-05-06-workshop-waitlist.md
 linked_decisions:
   - decisions/2026-05-06-workshop-price.md
 linked_research: []

--- a/mb/mb/validate.py
+++ b/mb/mb/validate.py
@@ -29,6 +29,15 @@ OFFER_STATUS = {
 }
 RESEARCH_STATUS = {"complete", "in-progress", "stale"}
 BET_STATUS = {"open", "paused", "closed", "canceled"}
+CAMPAIGN_STATUS = {
+    "draft",
+    "planned",
+    "active",
+    "paused",
+    "completed",
+    "canceled",
+    "archived",
+}
 
 LINK_FIELDS = (
     "linked_bets",
@@ -76,6 +85,15 @@ OFFER_STATUS_ORDER = {
     "graduated": 3,
     "died": 3,
 }
+CAMPAIGN_STATUS_ORDER = {
+    "draft": 0,
+    "planned": 1,
+    "active": 2,
+    "paused": 2,
+    "completed": 3,
+    "canceled": 3,
+    "archived": 4,
+}
 
 SCHEMAS: dict[str, dict[str, Any]] = {
     "decisions": {
@@ -122,7 +140,7 @@ SCHEMAS: dict[str, dict[str, Any]] = {
     "campaigns": {
         "glob": "campaigns/*/campaign.md",
         "required": ["slug", "status"],
-        "enums": {"status": OFFER_STATUS},
+        "enums": {"status": CAMPAIGN_STATUS},
     },
     "documents": {
         "glob": "documents/*.md",
@@ -293,7 +311,9 @@ def _status_order_for(path: Path) -> dict[str, int] | None:
     parts = path.parts
     if "decisions" in parts:
         return DECISION_STATUS_ORDER
-    if "offers" in parts or "campaigns" in parts:
+    if "campaigns" in parts:
+        return CAMPAIGN_STATUS_ORDER
+    if "offers" in parts:
         return OFFER_STATUS_ORDER
     return None
 

--- a/mb/tests/test_validate.py
+++ b/mb/tests/test_validate.py
@@ -507,3 +507,48 @@ def test_validate_cli_cross_refs_default_warns_strict_fails(tmp_path: Path) -> N
     payload = json.loads(result.stdout)
     assert payload["ok"] is False
     assert payload["files"][0]["ok"] is False
+
+
+def _campaign(status: str) -> str:
+    return f"---\nslug: workshop-waitlist\nstatus: {status}\n---\n# Workshop waitlist\n"
+
+
+def test_validate_accepts_campaign_lifecycle_statuses(tmp_path: Path) -> None:
+    for status in ("draft", "planned", "active", "paused", "completed", "canceled", "archived"):
+        path = tmp_path / "campaigns" / f"2026-05-{status}-push" / "campaign.md"
+        _write(path, _campaign(status))
+
+    report = run(path=str(tmp_path))
+
+    assert report["ok"] is True, report
+    campaign_files = [f for f in report["files"] if "campaigns/" in f["path"]]
+    assert len(campaign_files) == 7
+    assert all(f["ok"] for f in campaign_files)
+
+
+def test_validate_rejects_offer_only_status_on_campaign(tmp_path: Path) -> None:
+    # `running` and `scaling` are valid offer statuses but invalid for campaigns;
+    # the merged decision tells operators to use `active`.
+    _write(
+        tmp_path / "campaigns" / "2026-05-bad" / "campaign.md",
+        _campaign("scaling"),
+    )
+
+    report = run(path=str(tmp_path))
+
+    assert report["ok"] is False
+    bad = [f for f in report["files"] if not f["ok"]]
+    assert any("status" in e for f in bad for e in f["errors"])
+
+
+def test_validate_flags_unknown_campaign_status(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "campaigns" / "2026-05-typo" / "campaign.md",
+        _campaign("live"),  # operator-vocab synonym; not yet wired
+    )
+
+    report = run(path=str(tmp_path))
+
+    assert report["ok"] is False
+    bad = [f for f in report["files"] if not f["ok"]]
+    assert any("status" in e for f in bad for e in f["errors"])

--- a/mb/tests/test_validate.py
+++ b/mb/tests/test_validate.py
@@ -552,3 +552,38 @@ def test_validate_flags_unknown_campaign_status(tmp_path: Path) -> None:
     assert report["ok"] is False
     bad = [f for f in report["files"] if not f["ok"]]
     assert any("status" in e for f in bad for e in f["errors"])
+
+
+def test_cross_refs_flag_campaign_status_transition_regressions(tmp_path: Path) -> None:
+    # A newer campaign supersedes an older one but reports a status earlier
+    # in the campaign lifecycle. The status-transition checker should flag it
+    # against CAMPAIGN_STATUS_ORDER, not the offer order.
+    _write(
+        tmp_path / "campaigns" / "2026-05-old-push" / "campaign.md",
+        (
+            "---\n"
+            "slug: old-push\n"
+            "status: completed\n"  # order = 3
+            "---\n"
+            "# old push\n"
+        ),
+    )
+    _write(
+        tmp_path / "campaigns" / "2026-05-new-push" / "campaign.md",
+        (
+            "---\n"
+            "slug: new-push\n"
+            "status: draft\n"  # order = 0 — backward
+            "supersedes: campaigns/2026-05-old-push/campaign.md\n"
+            "---\n"
+            "# new push\n"
+        ),
+    )
+
+    report = run(path=str(tmp_path), cross_refs=True)
+
+    transition_warnings = [
+        w for w in report["cross_refs"]["warnings"] if w["code"] == "status-transition"
+    ]
+    assert len(transition_warnings) == 1
+    assert "move backward" in transition_warnings[0]["message"]


### PR DESCRIPTION
## Summary
- Validator now checks `campaigns/*/campaign.md` `status:` against the campaign lifecycle from the merged decision (`draft, planned, active, paused, completed, canceled, archived`) instead of the offer enum, so a coach who follows the doc and writes `status: active` no longer fails validation.
- Two new accepted decisions land alongside the existing campaign primitive: a campaigns refuse-list (the engine is judged by what it refuses) and a Main Branch operating spine (Linear-quiet × Hormozi-volume × Robbins-identity, with the principle that the operator owns the vocabulary).
- Doc fixes: `linked_bets:` examples in the campaign decision, system architecture, and git-history decision now use the dated `bets/2026-05-06-workshop-waitlist.md` shape so copied examples resolve under cross-reference validation.

## Scope
- In: validator enum + cross-ref status order for campaigns; targeted tests; example path corrections in three docs; two new accepted decisions; CHANGELOG entry.
- Out: schema deltas (structured `goal`, `owner`, `audience`, `offer`, `promise`); lifecycle v1.1 (`status × health`, `reviewing`, `doubling_down`); operator-vocab `push` migration; `mb push close` keystone ritual; operate-in-public narration loop. Each is a separate follow-up issue.

## Commits
- 0c08092 — [fix] Validate campaigns against the campaign lifecycle
- 9cab7e1 — [fix] Use dated bet paths in campaign primitive examples
- 9c6f319 — [add] Operating spine and campaigns refuse-list decisions
- fa319f1 — [docs] Note MAIN-247 follow-up fixes and new decisions in changelog
- 545d580 — [fix] Patch decision-doc accuracy from review
- d9163fe — [add] Pin campaign supersedes status-transition order
- 8ef10f3 — [fix] Apply reviewer patch spec to MAIN-247 follow-up decisions

## Release / Issues
- Release: Unreleased (under [Unreleased] in CHANGELOG.md)
- Linear ID(s): MAIN-250
- Closes: #328
- Refs: #321, #327, #323, #324
- Follow-ups: schema deltas; lifecycle v1.1; operator-vocab + push migration ("Align push primitive, operator vocabulary, and campaign compatibility"); `mb push close` keystone ritual; `mb push open` interview; operate-in-public narration loop; `mb status` weekly briefing.

## Success Metric
A coach who copy-pastes the `campaign.md` example from the merged decision and writes `status: active` passes `mb validate`. Future PRs proposing fields on the refuse-list cite the refuse-list decision and supersede it explicitly. Operator-facing copy is graded against the spine voice profile in normal review.

## Validation
- Level 0 docs/decision: refuse-list and spine decisions accepted; example paths in three docs aligned with the dated bet convention.
- Level 1 static: `scripts/check.sh` green — formatting, ruff, mypy, 247 tests with coverage, 17/17 bundled skills validated.
- Level 2 CLI: four new validator tests cover lifecycle acceptance, offer-only rejection, unknown-status rejection, and `supersedes` status-transition ordering against `CAMPAIGN_STATUS_ORDER`.
- Level 3 package/install: not applicable (no packaging touched).
- Level 4 fixture repo: not applicable (no first-run / scaffolding behavior changed).
- Level 5 runtime smoke: not applicable (no skill discovery, template, packaged data, or workflow behavior changed).

## Public / Private Boundary
No private dogfood data, credentials, member exports, or finances. The decisions are general philosophy; the refuse-list is a public default with an open-door supersession path. Internal coordination link to `.context/recommendations-main-247.md` lives only on the issue, not in committed product truth.