### PR TITLE
[update] Route skills and legacy outputs through pushes

### DIFF
--- a/.claude/skills/mb-ads/SKILL.md
+++ b/.claude/skills/mb-ads/SKILL.md
@@ -8,6 +8,27 @@ loops: [ship, reflect]
 
 Create ads, generate creative variations, review for compliance, and check ad account performance.
 
+## Output destinations and operator vocabulary
+
+This skill writes new coordinated work to `pushes/<YYYY-MM-DD-slug>/` (the
+canonical engine primitive). Examples below say "push" for the wrapping
+record; this is the engine's word. If `core/vocabulary.md` defines a
+display word — for example `terms.push.singular: drop` — speak the
+operator's word ("drop") in conversation while still writing canonical
+files (`pushes/...`, `type: push`, `linked_pushes`). Never rename folders,
+frontmatter, link fields, JSON keys, or commands based on vocabulary.
+
+If the repo still has legacy `campaigns/` records, preview the migration
+**before** creating new push work:
+
+```text
+mb doctor                       # confirms legacy campaigns/ drift
+mb migrate campaigns --plan     # read-only preview of moves
+```
+
+The word "campaign" elsewhere in this skill refers to Meta Ads campaigns
+(the provider's term for its object) — not the Main Branch primitive.
+
 ## Step 0: Pre-Flight Readiness
 
 **Before triage, find the business repo, read deterministic Main Branch facts,
@@ -367,7 +388,7 @@ If context was compacted mid-task, check:
 1. **Which offer?** Read `.vip/local.yaml` for `current_offer` to restore offer context
 2. **What entry point?** Full pipeline, copy only, hook library, video scripts, review, account check
 3. **What stage?** Planning angles, writing hooks, generating prompts, reviewing, pulling account data
-4. **What's done?** Check campaigns/ folder for partial work
+4. **What's done?** Check `pushes/` (and legacy `campaigns/` on unmigrated repos) for partial work
 5. **Ad account status?** Re-run `mb status --json --peek`; if needed, run `mb connect doctor --json`
 6. **Resume:** Continue from the last completed step
 

--- a/.claude/skills/mb-ads/references/entry-points.md
+++ b/.claude/skills/mb-ads/references/entry-points.md
@@ -130,7 +130,7 @@ User message arrives
 │
 ├─ Execute pipeline:
 │   ├─ Copy/Hooks/Video generation
-│   ├─ Save output to campaigns/
+│   ├─ Save output to pushes/
 │   └─ Post-Gen Pipeline (auto: commit + compliance + images)
 │
 └─ Done (write operations like Duplicate + Swap are on the roadmap)
@@ -143,7 +143,7 @@ User message arrives
 Campaign name is still required before saving output. The entry point doesn't change this -- all output paths include the campaign name:
 
 ```
-campaigns/YYYY-MM-DD-{type}-[offer]-{campaign}/
+pushes/YYYY-MM-DD-{type}-[offer]-{campaign}/
 ```
 
 Where `{type}` maps from the entry point:

--- a/.claude/skills/mb-ads/references/image-generation-workflow.md
+++ b/.claude/skills/mb-ads/references/image-generation-workflow.md
@@ -319,7 +319,7 @@ If retry fails: return status "fail" with error message. Do NOT keep retrying.
 ## Output Structure
 
 ```
-campaigns/YYYY-MM-DD-static-ads-{campaign}/
+pushes/YYYY-MM-DD-static-ads-{campaign}/
 ├── static-ads-batch-001.md        ← Copy (Batch 1)
 ├── proposed-compliance-fixes.json ← Compliance proposals
 ├── review-log.md                  ← Compliance changes after approval

--- a/.claude/skills/mb-ads/references/mode-hook-library.md
+++ b/.claude/skills/mb-ads/references/mode-hook-library.md
@@ -50,7 +50,7 @@ Every variation **MUST** include at least one specific element:
 
 1. Ask for campaign name (required)
 2. Confirm quantity: "How many? A few to test (5-10) or a full batch (30+)?" -- or use the number they already specified
-3. Create folder: `campaigns/YYYY-MM-DD-creative-variations-[offer]-{campaign}/` (include offer slug in multi-offer mode; omit `[offer]-` in single-offer mode)
+3. Create folder: `pushes/YYYY-MM-DD-creative-variations-[offer]-{campaign}/` (include offer slug in multi-offer mode; omit `[offer]-` in single-offer mode)
 4. Save full generation context + creative variations to: `creative-variations-batch-001.md`
 5. Tell user: "Saved {N} creative variations. Running automatic post-generation pipeline..."
 6. Run the **Automatic Post-Generation Pipeline** (see SKILL.md). This handles git commit, compliance review, and image generation automatically.

--- a/.claude/skills/mb-ads/references/mode-static-ads.md
+++ b/.claude/skills/mb-ads/references/mode-static-ads.md
@@ -55,7 +55,7 @@ platform: meta
 ---
 ```
 
-7. Save to `campaigns/YYYY-MM-DD-static-ads-[offer]-{campaign}/static-ads-batch-001.md` (include offer slug in multi-offer mode; omit `[offer]-` in single-offer mode)
+7. Save to `pushes/YYYY-MM-DD-static-ads-[offer]-{slug}/static-ads-batch-001.md` (include offer slug in multi-offer mode; omit `[offer]-` in single-offer mode). On legacy repos that still have `campaigns/`, run `mb migrate campaigns --plan` first; do not write new ad batches under `campaigns/`.
 8. Tell user: "Copy saved. Running automatic post-generation pipeline..."
 9. Run the **Automatic Post-Generation Pipeline** (see SKILL.md). This handles git commit, compliance review, and image generation automatically.
 

--- a/.claude/skills/mb-ads/references/mode-video-scripts.md
+++ b/.claude/skills/mb-ads/references/mode-video-scripts.md
@@ -24,7 +24,7 @@ platform: meta
 ---
 ```
 
-7. **Save Output:** `campaigns/YYYY-MM-DD-video-ads-[offer]-{campaign}/video-ads-batch-001.md` (include offer slug in multi-offer mode; omit `[offer]-` in single-offer mode)
+7. **Save Output:** `pushes/YYYY-MM-DD-video-ads-[offer]-{campaign}/video-ads-batch-001.md` (include offer slug in multi-offer mode; omit `[offer]-` in single-offer mode)
 8. Tell user: "Video scripts saved. Running automatic post-generation pipeline..."
 9. Run the **Automatic Post-Generation Pipeline** (see SKILL.md). This handles git commit and compliance review automatically. (No image generation for video scripts.)
 

--- a/.claude/skills/mb-ads/references/one-liner-methodology.md
+++ b/.claude/skills/mb-ads/references/one-liner-methodology.md
@@ -257,7 +257,7 @@ See [one-liner-examples.md](one-liner-examples.md) for more patterns and real ex
 
 ### Step 6: Output
 
-**Save to file, not chat.** Output goes to `campaigns/YYYY-MM-DD-creative-variations-{campaign-name}/batch.md`.
+**Save to file, not chat.** Output goes to `pushes/YYYY-MM-DD-creative-variations-{campaign-name}/batch.md`.
 
 The file should include:
 
@@ -393,7 +393,7 @@ If context was compacted mid-task, check:
 
 ```bash
 # Check for recent output in business repo
-ls -lt campaigns/*.md 2>/dev/null | head -3
+ls -ltd pushes/*-creative-variations-*/ 2>/dev/null | head -3
 ```
 
 Then confirm: "I see we were generating one-liners. Continue from #[X]?"

--- a/.claude/skills/mb-ads/references/post-generation-pipeline.md
+++ b/.claude/skills/mb-ads/references/post-generation-pipeline.md
@@ -5,7 +5,7 @@
 ## Step 1: Git Commit Pre-Review
 
 ```bash
-git add campaigns/YYYY-MM-DD-*
+git add pushes/YYYY-MM-DD-*
 git commit -m "[output] {type} batch pre-review"
 ```
 
@@ -89,7 +89,7 @@ When all agents return:
    - Run the compliance gate in dry-run mode before any source copy edit:
 
      ```bash
-     python -m mb.ads_compliance_gate campaigns/YYYY-MM-DD-{type}-{campaign}/{batch-file}.md campaigns/YYYY-MM-DD-{type}-{campaign}/proposed-compliance-fixes.json
+     python -m mb.ads_compliance_gate pushes/YYYY-MM-DD-{type}-{campaign}/{batch-file}.md pushes/YYYY-MM-DD-{type}-{campaign}/proposed-compliance-fixes.json
      ```
 
    - Show the full proposed diff to the user and ask: "Apply these compliance copy changes? (y/n)"
@@ -97,7 +97,7 @@ When all agents return:
    - If the user says yes, apply through the same gate with explicit approval:
 
      ```bash
-     python -m mb.ads_compliance_gate campaigns/YYYY-MM-DD-{type}-{campaign}/{batch-file}.md campaigns/YYYY-MM-DD-{type}-{campaign}/proposed-compliance-fixes.json --approve --review-log campaigns/YYYY-MM-DD-{type}-{campaign}/review-log.md
+     python -m mb.ads_compliance_gate pushes/YYYY-MM-DD-{type}-{campaign}/{batch-file}.md pushes/YYYY-MM-DD-{type}-{campaign}/proposed-compliance-fixes.json --approve --review-log pushes/YYYY-MM-DD-{type}-{campaign}/review-log.md
      ```
 
 2. **Image synthesis (if applicable):**
@@ -121,7 +121,7 @@ Pipeline complete:
   [If P2/P3 declined: say source copy was left unchanged]
 
   Files:
-    campaigns/YYYY-MM-DD-{type}-{campaign}/
+    pushes/YYYY-MM-DD-{type}-{campaign}/
     |- {batch-file}.md (copy, unchanged unless approved)
     |- proposed-compliance-fixes.json
     [|- review-log.md]
@@ -136,7 +136,7 @@ Pipeline complete:
 If user approves:
 
 ```bash
-git add campaigns/YYYY-MM-DD-*
+git add pushes/YYYY-MM-DD-*
 git commit -m "[review] {type} batch - N fixes applied"
 ```
 

--- a/.claude/skills/mb-ads/references/review-workflow.md
+++ b/.claude/skills/mb-ads/references/review-workflow.md
@@ -5,7 +5,7 @@
 Before reviewing, commit current state to preserve the original:
 
 ```bash
-git add campaigns/YYYY-MM-DD-{type}-{campaign}/
+git add pushes/YYYY-MM-DD-{type}-{campaign}/
 git commit -m "[output] {type} batch pre-review"
 ```
 
@@ -118,7 +118,7 @@ For each P2/P3 issue:
 2. Run the gate in dry-run mode:
 
    ```bash
-   python -m mb.ads_compliance_gate campaigns/YYYY-MM-DD-{type}-{campaign}/{batch-file}.md campaigns/YYYY-MM-DD-{type}-{campaign}/proposed-compliance-fixes.json
+   python -m mb.ads_compliance_gate pushes/YYYY-MM-DD-{type}-{campaign}/{batch-file}.md pushes/YYYY-MM-DD-{type}-{campaign}/proposed-compliance-fixes.json
    ```
 
 3. Show the resulting diff to the user.
@@ -126,7 +126,7 @@ For each P2/P3 issue:
 5. Only if the user says yes, run:
 
    ```bash
-   python -m mb.ads_compliance_gate campaigns/YYYY-MM-DD-{type}-{campaign}/{batch-file}.md campaigns/YYYY-MM-DD-{type}-{campaign}/proposed-compliance-fixes.json --approve --review-log campaigns/YYYY-MM-DD-{type}-{campaign}/review-log.md
+   python -m mb.ads_compliance_gate pushes/YYYY-MM-DD-{type}-{campaign}/{batch-file}.md pushes/YYYY-MM-DD-{type}-{campaign}/proposed-compliance-fixes.json --approve --review-log pushes/YYYY-MM-DD-{type}-{campaign}/review-log.md
    ```
 
 If the user says no, stop with the source file unchanged. Do not apply partial edits unless the user gives a narrower approval.
@@ -162,7 +162,7 @@ For P1 issues:
 After fixes are approved and applied:
 
 ```bash
-git add campaigns/YYYY-MM-DD-{type}-{campaign}/
+git add pushes/YYYY-MM-DD-{type}-{campaign}/
 git commit -m "[review] {type} batch - N fixes applied"
 ```
 

--- a/.claude/skills/mb-ads/references/static-output-template.md
+++ b/.claude/skills/mb-ads/references/static-output-template.md
@@ -181,7 +181,7 @@ Copy and paste into Ads Manager after images are ready.
 
 ## Naming Conventions
 
-**Folder:** `campaigns/YYYY-MM-DD-static-ads-{campaign}/`
+**Folder:** `pushes/YYYY-MM-DD-static-ads-{campaign}/`
 - Date: `YYYY-MM-DD`
 - Type: `static-ads`
 - Campaign name: lowercase with dashes (required)
@@ -189,7 +189,7 @@ Copy and paste into Ads Manager after images are ready.
 **Batch file:** `static-ads-batch-{###}.md`
 - Example: `static-ads-batch-001.md`
 
-**Full path example:** `campaigns/2026-01-15-static-ads-january-launch/static-ads-batch-001.md`
+**Full path example:** `pushes/2026-01-15-static-ads-january-launch/static-ads-batch-001.md`
 
 **Review log:** `review-log.md` (same folder)
 

--- a/.claude/skills/mb-bet/SKILL.md
+++ b/.claude/skills/mb-bet/SKILL.md
@@ -62,6 +62,7 @@ target: "10 qualified calls by deadline"
 result: ""
 linked_decisions: []
 linked_research: []
+linked_pushes: []
 linked_campaigns: []
 linked_outcomes: []
 public: false
@@ -76,7 +77,13 @@ Use repo-relative paths in link fields:
 
 - `linked_decisions`: `decisions/*.md`
 - `linked_research`: `research/*.md`
-- `linked_campaigns`: `campaigns/*/campaign.md` or campaign artifacts
+- `linked_pushes` (canonical): `pushes/YYYY-MM-DD-slug/push.md` or push artifacts
+- `linked_campaigns` (legacy compatibility, leave as `[]` for new bets):
+  `campaigns/*/campaign.md` records on existing repos that have not yet
+  migrated. New bets always include both fields with `linked_pushes`
+  populated and `linked_campaigns: []`. When the operator is on a legacy
+  campaigns/ repo, recommend `mb doctor` and `mb migrate campaigns --plan`
+  before creating new push work.
 - `linked_outcomes`: `log/*.md`, `documents/*.md`, or outcome artifacts
 
 When linking an existing file to a bet, add the reverse link too:
@@ -94,8 +101,8 @@ Use when the operator says they want to try, launch, test, prove, or make a bet.
    target, public/private posture, channels, and any known linked files.
 2. Create `bets/YYYY-MM-DD-slug.md`.
 3. Add reverse `linked_bets` frontmatter to linked decisions, research,
-   campaigns, and outcome files when those files already exist and the edit is
-   clearly safe.
+   pushes (or legacy campaigns), and outcome files when those files already
+   exist and the edit is clearly safe.
 4. End with the file path, deadline, target, and next action.
 
 Body template:
@@ -134,8 +141,8 @@ Use when work happened but the bet is not finished.
 
 1. Read the bet and linked files.
 2. Append a dated `Evidence Log` entry.
-3. Update `linked_decisions`, `linked_research`, `linked_campaigns`, or
-   `linked_outcomes` if new files now matter.
+3. Update `linked_decisions`, `linked_research`, `linked_pushes` (or legacy
+   `linked_campaigns`), or `linked_outcomes` if new files now matter.
 4. Keep `result` blank unless there is a real result.
 5. Repair reverse `linked_bets` fields on newly linked files.
 

--- a/.claude/skills/mb-end/SKILL.md
+++ b/.claude/skills/mb-end/SKILL.md
@@ -85,7 +85,7 @@ git diff --name-only --diff-filter=AM HEAD@{6am}..HEAD 2>/dev/null
 | Research files created | New files in `research/` |
 | Decisions made | New or modified files in `decisions/` |
 | Core files updated | Modified files in `core/` |
-| Campaign artifacts generated | New files in `campaigns/` |
+| Push artifacts generated | New files in `pushes/` |
 | Uncommitted changes | `git status --short` output |
 
 **Multi-offer detection (skip if no `core/offers/` folder — single-offer mode, everything reads from `core/`):** If `core/offers/` exists, note which offers had files changed:

--- a/.claude/skills/mb-help/references/organic-help.md
+++ b/.claude/skills/mb-help/references/organic-help.md
@@ -171,7 +171,7 @@ This makes them available for future generations across all skills.
 
 2. /mb-organic video "concept from research"
    → Script generated in your voice
-   → Saved to campaigns/
+   → Saved to pushes/
 
 3. Repeat for carousel, static as needed
 

--- a/.claude/skills/mb-organic/SKILL.md
+++ b/.claude/skills/mb-organic/SKILL.md
@@ -177,7 +177,7 @@ Generate multi-slide carousel copy from a concept.
 
 Generate single-post caption from a concept.
 
-**Output path (all script modes):** `campaigns/YYYY-MM-DD-organic-[offer]-{campaign}/organic-batch-001.md` (include offer slug in multi-offer mode; omit `[offer]-` in single-offer mode)
+**Output path (all script modes):** `pushes/YYYY-MM-DD-organic-[offer]-{slug}/organic-batch-001.md` (include offer slug in multi-offer mode; omit `[offer]-` in single-offer mode). On legacy repos that still have `campaigns/`, run `mb migrate campaigns --plan` first; do not write new content under `campaigns/`.
 
 **Output frontmatter:**
 ```yaml
@@ -234,7 +234,7 @@ Before saving: show file paths.
 3. **Select concept** — User picks from mined concepts or provides their own
 4. **Adapt to brand** — Map concept to user's offer, audience, voice
 5. **Generate scripts** — Use appropriate framework (video/carousel/static)
-6. **Save output** — Scripts to `campaigns/YYYY-MM-DD-organic-{campaign}/`
+6. **Save output** — Scripts to `pushes/YYYY-MM-DD-organic-{slug}/` (canonical). Never `campaigns/`; that folder is legacy compatibility only.
 7. **Commit prompt** — "Saved to [path]. Want me to commit this to git?"
 
 **Mining lives in `/mb-think` now.** If user needs to mine competitors, route them there first.

--- a/.claude/skills/mb-organic/SKILL.md
+++ b/.claude/skills/mb-organic/SKILL.md
@@ -10,6 +10,20 @@ Create organic content scripts in your voice — Reels, TikToks, carousels, stat
 
 **Need help?** Type `/mb-help` + your question anytime. If conversation compacts, `/mb-help` reloads fresh context.
 
+## Output destinations and operator vocabulary
+
+When this skill produces a coordinated push (a content sequence with a goal,
+audience, and review date), write the wrapping record to
+`pushes/<YYYY-MM-DD-slug>/push.md` (`type: push`, `linked_pushes` for inbound
+links). One-off scripts and source captures route to `documents/transcripts/`
+or `documents/prototypes/` per the artifact-routing rules in the system
+architecture doc; they don't need a push wrapper.
+
+If `core/vocabulary.md` defines display words (e.g. `terms.push.singular: drop`),
+speak the operator's word in conversation while still writing canonical files.
+If the repo still has legacy `campaigns/` records, recommend `mb doctor` and
+`mb migrate campaigns --plan` before creating new push work.
+
 ---
 
 ## Triage

--- a/.claude/skills/mb-organic/SKILL.md
+++ b/.claude/skills/mb-organic/SKILL.md
@@ -199,7 +199,7 @@ Campaign name is REQUIRED. Ask user if not provided. Examples: `january-hooks`, 
 **At session start, scan what's been done:**
 
 1. Check `research/*-competitor-mine.md` — Who was mined? When?
-2. Check `campaigns/*-organic-*/` — What scripts exist?
+2. Check `pushes/*-organic-*/` — What scripts exist? Treat `campaigns/` as a legacy fallback only.
 3. Don't suggest re-mining same handles from today
 4. Recommend generating from existing mining if concepts unused
 5. Check `core/content-strategy.md` — What pillars are defined? What platform is the target?

--- a/.claude/skills/mb-organic/references/carousel-template.md
+++ b/.claude/skills/mb-organic/references/carousel-template.md
@@ -6,9 +6,9 @@ Template for multi-slide Instagram carousels. Optimized for swipe-through engage
 
 ## Output Format
 
-Save carousels to: `campaigns/organic-scripts/YYYY-MM-DD-[concept-slug]-carousel.md`
+Save carousels to: `pushes/YYYY-MM-DD-organic-[concept-slug]/carousel.md`
 
-Example: `campaigns/organic-scripts/2026-01-19-content-mistakes-carousel.md`
+Example: `pushes/2026-01-19-organic-content-mistakes/carousel.md`
 
 ---
 

--- a/.claude/skills/mb-organic/references/examples.md
+++ b/.claude/skills/mb-organic/references/examples.md
@@ -36,9 +36,9 @@ Claude: What should we call this batch? (e.g., "morning-routine", "productivity-
 User: morning-routine
 
 Claude: [Generates script using story framework]
-[Saves to campaigns/2026-01-26-organic-morning-routine/organic-batch-001.md]
+[Saves to pushes/2026-01-26-organic-morning-routine/organic-batch-001.md]
 
-Saved to campaigns/2026-01-26-organic-morning-routine/organic-batch-001.md
+Saved to pushes/2026-01-26-organic-morning-routine/organic-batch-001.md
 Want me to commit this to git?
 ```
 
@@ -69,5 +69,5 @@ When conversations get long, Claude's memory compresses. If mid-/mb-organic and 
 **For Claude:** When resuming:
 
 1. Check `research/*-competitor-mine.md` for recent mining
-2. Check `campaigns/*-organic-*/` for existing scripts
+2. Check `pushes/*-organic-*/` for existing scripts; only inspect `campaigns/` as a legacy fallback
 3. Confirm with user: "I see today's mining has X concepts. Want to continue generating from those?"

--- a/.claude/skills/mb-organic/references/static-template.md
+++ b/.claude/skills/mb-organic/references/static-template.md
@@ -6,9 +6,9 @@ Template for single-post captions. Optimized for feed posts with images or graph
 
 ## Output Format
 
-Save static posts to: `campaigns/organic-scripts/YYYY-MM-DD-[concept-slug]-static.md`
+Save static posts to: `pushes/YYYY-MM-DD-organic-[concept-slug]/static-post.md`
 
-Example: `campaigns/organic-scripts/2026-01-19-content-tip-static.md`
+Example: `pushes/2026-01-19-organic-content-tip/static-post.md`
 
 ---
 

--- a/.claude/skills/mb-organic/references/video-script-template.md
+++ b/.claude/skills/mb-organic/references/video-script-template.md
@@ -6,9 +6,9 @@ Template for Reels and TikTok scripts. Optimized for talking-head, camera-facing
 
 ## Output Format
 
-Save scripts to: `campaigns/organic-scripts/YYYY-MM-DD-[concept-slug].md`
+Save scripts to: `pushes/YYYY-MM-DD-organic-[concept-slug]/video-script.md`
 
-Example: `campaigns/organic-scripts/2026-01-19-morning-routine-story.md`
+Example: `pushes/2026-01-19-organic-morning-routine-story/video-script.md`
 
 ---
 

--- a/.claude/skills/mb-setup/references/claude-md-guide.md
+++ b/.claude/skills/mb-setup/references/claude-md-guide.md
@@ -39,7 +39,7 @@ This repo contains your **business data**. It's powered by **Main Branch** (the 
 **How it works:**
 - Engine (Main Branch): Contains skills, lenses, frameworks. You pull updates but never edit.
 - Data (this repo): Contains your business context. You own and edit this.
-- Skills read from `core/`, `research/`, and `decisions/`, then write campaign work to `campaigns/`.
+- Skills read from `core/`, `research/`, and `decisions/`, then write coordinated work to `pushes/`.
 
 **If `/mb-start` isn't available:** Skills may need bridge links. Find the Main Branch path from `.claude/settings.local.json` (the `additionalDirectories` array), then read `[engine-path]/.claude/skills/mb-start/references/auto-heal.md` and follow the repair steps. After repair, tell the user to restart Claude.
 
@@ -65,7 +65,7 @@ This repo contains your **business data**. It's powered by **Main Branch** (the 
 │
 ├── research/              # Dated investigations
 ├── decisions/             # Dated choices with rationale
-└── campaigns/             # Generated campaign work
+└── pushes/                # Coordinated work records and generated output
 ```
 
 ---

--- a/.claude/skills/mb-setup/references/git-workflow.md
+++ b/.claude/skills/mb-setup/references/git-workflow.md
@@ -184,7 +184,7 @@ EOF
 ### After Output Generation
 
 ```bash
-git add campaigns/
+git add pushes/
 git commit -m "$(cat <<'EOF'
 [add] January email campaign batch
 

--- a/.claude/skills/mb-setup/references/templates.md
+++ b/.claude/skills/mb-setup/references/templates.md
@@ -594,7 +594,7 @@ ENGINE (mainbranch)     +     DATA (this repo)     =     OUTPUT
 ```
 
 Skills from the engine read your `core/`, `research/`, and `decisions/` files
-and generate campaign work under `campaigns/`.
+and generate coordinated work under `pushes/`.
 
 ---
 

--- a/.claude/skills/mb-site/SKILL.md
+++ b/.claude/skills/mb-site/SKILL.md
@@ -15,6 +15,26 @@ loops: [ship]
 
 Pick a site shape, build it from business context, and ship it through a linked site repo. Cloudflare Pages with git auto-deploy is the default deploy path.
 
+## Output destinations and operator vocabulary
+
+Site/lander records that wrap a coordinated push (a launch, drop, or
+challenge with a goal and timeline) live under `pushes/<YYYY-MM-DD-slug>/`
+on the business-repo side; the wrapping record is `push.md` (`type: push`),
+and the site record is typically `pushes/<YYYY-MM-DD-slug>/site.md`. Site
+files themselves live in the linked site repo (Cloudflare Pages, etc.) and
+are not duplicated in the business repo.
+
+Reverse references from the site repo's `.mainbranch/source.json` use
+canonical push paths (`campaign_path: pushes/<...>/push.md`); on legacy
+repos that still have `campaigns/`, those references continue to resolve
+via compatibility read.
+
+If `core/vocabulary.md` defines display words (e.g. `terms.push.singular:
+launch`), speak the operator's word in conversation while still writing
+canonical files. If the repo still has legacy `campaigns/` records,
+recommend `mb doctor` and `mb migrate campaigns --plan` before creating
+new push work.
+
 ## Re-Invoke Often
 
 Say `/mb-site` again after compaction, context loss, or switching focus. It reloads skill context. Do it whenever the conversation feels stale.

--- a/.claude/skills/mb-site/references/minisite-setup.md
+++ b/.claude/skills/mb-site/references/minisite-setup.md
@@ -100,12 +100,12 @@ Write `<site_repo>/.mainbranch/source.json`:
 {
   "business_repo": "/absolute/path/to/my-business",
   "offer_path": "core/offers/flagship/offer.md",
-  "campaign_path": "campaigns/2026-05-paid-minisite.md",
+  "campaign_path": "pushes/2026-05-06-paid-minisite/push.md",
   "safe_to_share": true
 }
 ```
 
-The business repo should keep the reverse site record in `campaigns/` or the relevant offer/campaign note: site repo path or URL, domain, Cloudflare project, environment, measurement state, launch status, and the next manual approval step.
+The business repo should keep the reverse site record in the relevant `pushes/` record or offer note: site repo path or URL, domain, Cloudflare project, environment, measurement state, launch status, and the next manual approval step. The `campaign_path` key is a historical compatibility name; point it at the current push record.
 
 Treat `~/.mainbranch/sites.json` as legacy fallback only when no repo-local link exists. If needed, write or extend:
 

--- a/.claude/skills/mb-site/references/site-repo-workflow.md
+++ b/.claude/skills/mb-site/references/site-repo-workflow.md
@@ -45,7 +45,7 @@ The site repo must include `.mainbranch/source.json`:
 {
   "business_repo": "/absolute/path/to/my-business",
   "offer_path": "core/offers/flagship/offer.md",
-  "campaign_path": "campaigns/2026-05-paid-minisite.md",
+  "campaign_path": "pushes/2026-05-06-paid-minisite/push.md",
   "safe_to_share": true
 }
 ```
@@ -56,8 +56,10 @@ infer the business repo from `source.json` when `--business-repo` is omitted.
 
 ## Reverse Link
 
-The business repo should keep a reverse site record in `campaigns/` or the
-relevant offer/campaign note:
+The business repo should keep a reverse site record in `pushes/<YYYY-MM-DD-slug>/`
+(canonical) or the relevant offer note. Legacy repos may still have the
+record under `campaigns/<slug>/`; `mb` reads both. The reverse record can
+include:
 
 - site repo path or GitHub URL;
 - deployed URL and domain;

--- a/.claude/skills/mb-site/references/troubleshooting.md
+++ b/.claude/skills/mb-site/references/troubleshooting.md
@@ -65,7 +65,7 @@ Website (Next.js): check `globals.css` for correct CSS variable names, `layout.t
 
 ## Business Context Not Found
 
-Check `.mainbranch/source.json` in the site repo or the reverse site record in `campaigns/`.
+Check `.mainbranch/source.json` in the site repo or the reverse site record in `pushes/`. Inspect `campaigns/` only for legacy repos.
 
 The `business_repo` path must point to a business repo with canonical `core/` files. Legacy `reference/core` and `reference/offers` paths are compatibility bridges only.
 

--- a/.claude/skills/mb-start/SKILL.md
+++ b/.claude/skills/mb-start/SKILL.md
@@ -10,6 +10,19 @@ Single entry point for Main Branch. Detect user state, context level, experience
 
 **Recommended workflow:** Start Claude in your business repo, run `/mb-start`. It handles everything. Main Branch is loaded through `additionalDirectories`, with bridge links as a compatibility fallback for skill discovery.
 
+## Output destinations and operator vocabulary
+
+This skill routes to other skills; it does not write coordinated work itself.
+When summarizing repo state, count records under `pushes/` (canonical) and
+flag `campaigns/` separately as legacy compatibility — `mb status` and
+`mb doctor` already do this. If `core/vocabulary.md` defines display words
+(e.g. `terms.push.singular: drop`), speak the operator's word in
+conversation while still referring to canonical paths in any commands.
+
+If the repo has legacy `campaigns/` records, surface the doctor warning
+and recommend `mb migrate campaigns --plan` as a triage option before
+routing the operator into a skill that creates new push work.
+
 **Status facts first:** Once the business repo path is known, run
 `mb status --json --peek` before asking setup or routing questions. Treat that
 JSON as the source of truth for update severity, readiness, drift, onboarding,

--- a/.claude/skills/mb-start/references/triage-agent.md
+++ b/.claude/skills/mb-start/references/triage-agent.md
@@ -84,7 +84,7 @@ Gather these in main and pass as structured text in each agent's prompt:
 | Past triage file names | `ls research/*-start-triage.md 2>/dev/null` | ~5 lines | Agent 3 |
 | Past crystallize file names | `ls research/*-end-of-day-crystallize.md 2>/dev/null` | ~5 lines | Agent 3 |
 | `current_offer` | From `.vip/local.yaml` | 1 line | All 3 agents |
-| Campaign lifecycle listing | `grep -rl "status: draft\|status: scheduled" campaigns/ 2>/dev/null` | ~10 lines | Agent 2 |
+| Push lifecycle listing | `grep -rl "status: draft\|status: planned\|status: active" pushes/ campaigns/ 2>/dev/null` | ~10 lines | Agent 2 |
 
 **What agents read themselves (in their own context, NOT in main):**
 - soul.md, offer.md, audience.md, voice.md — Agent 1 reads all, Agent 3 reads soul
@@ -203,13 +203,16 @@ and first 10 lines of each.]
 
 [Research files with linked_decisions: []. Include filename and date.]
 
-=== CAMPAIGN LIFECYCLE STATE ===
+=== PUSH LIFECYCLE STATE ===
 
-[Files in campaigns/ grouped by frontmatter status: draft, scheduled,
-published, final.
-Use: grep -rl "status: draft" campaigns/ 2>/dev/null
-or "No campaigns with lifecycle status" if none have status field.
-Also list most recent 5 items in campaigns/.]
+[Files in pushes/ (and legacy campaigns/) grouped by canonical
+frontmatter status: draft, planned, active, paused, completed,
+canceled, archived. Stale legacy statuses like "scheduled" or
+"published" come from pre-push records and signal that the operator
+should run `mb migrate campaigns --plan`.
+Use: grep -rl "status: draft" pushes/ campaigns/ 2>/dev/null
+or "No pushes with lifecycle status" if none have status field.
+Also list most recent 5 items in pushes/ (or campaigns/ on legacy repos).]
 
 === CONTENT STRATEGY ===
 
@@ -235,13 +238,13 @@ Analyze these dimensions:
    Scheduled? When was the last campaign asset published? Is there a gap
    between core readiness and campaign generation?
 
-4. **Campaign recency:** When was the last batch generated? What type?
-   Long gap between core updates and campaign generation = missed opportunity.
+4. **Push recency:** When was the last batch generated? What type?
+   Long gap between core updates and push generation = missed opportunity.
 
 5. **Velocity pattern:** What's the ratio of enrichment work (research/,
-   core/ changes) to campaign work (campaigns/)? All enrichment
-   with no campaign output = stuck in thinking. All campaign output with no enrichment =
-   running on stale context.
+   core/ changes) to push work (pushes/, or legacy campaigns/)? All
+   enrichment with no push output = stuck in thinking. All push output
+   with no enrichment = running on stale context.
 
 6. **Content strategy health:** Does content-strategy.md have populated pillars?
    Hooks library? Framework library? Metrics section? Or is it a skeleton?

--- a/.claude/skills/mb-vsl/SKILL.md
+++ b/.claude/skills/mb-vsl/SKILL.md
@@ -8,6 +8,20 @@ loops: [ship]
 
 Routes to the right framework based on your offer type.
 
+## Output destinations and operator vocabulary
+
+VSL scripts that wrap a coordinated push (a launch, drop, challenge, etc.)
+land under `pushes/<YYYY-MM-DD-slug>/` (canonical engine primitive). The
+push record itself is `pushes/<YYYY-MM-DD-slug>/push.md` (`type: push`).
+A one-off VSL that isn't part of a coordinated push can sit under the
+relevant offer in `core/offers/<offer>/` instead.
+
+If `core/vocabulary.md` defines display words (e.g. `terms.push.singular:
+launch`), speak the operator's word in conversation while still writing
+canonical files. If the repo still has legacy `campaigns/` records,
+recommend `mb doctor` and `mb migrate campaigns --plan` before creating
+new push work.
+
 ---
 
 ## Pull Latest Updates

--- a/.claude/skills/mb-vsl/SKILL.md
+++ b/.claude/skills/mb-vsl/SKILL.md
@@ -150,7 +150,7 @@ For high-ticket B2B services. Full reference: `references/frameworks/b2b-haynes.
 
 ## Output Path
 
-**Standard:** `campaigns/YYYY-MM-DD-vsl-[offer]-{campaign}/vsl-script.md` (include offer slug in multi-offer mode; omit `[offer]-` in single-offer mode)
+**Standard:** `pushes/YYYY-MM-DD-vsl-[offer]-{slug}/vsl-script.md` (include offer slug in multi-offer mode; omit `[offer]-` in single-offer mode). On legacy repos that still have `campaigns/`, run `mb migrate campaigns --plan` first; do not write new VSLs under `campaigns/`.
 
 Campaign name is REQUIRED. Ask user if not provided. Examples: `skool-about`, `agency-pitch`, `membership-sales`.
 

--- a/.claude/skills/mb-vsl/SKILL.md
+++ b/.claude/skills/mb-vsl/SKILL.md
@@ -199,7 +199,7 @@ Just say `/mb-vsl` again and describe where you were:
 2. **Check for in-progress scripts:**
 
 ```bash
-ls -ltd campaigns/*-vsl-*/ 2>/dev/null | head -3
+ls -ltd pushes/*-vsl-*/ 2>/dev/null | head -3
 ```
 
 3. **Re-read key files:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,39 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+### Added (MAIN-249 / #324)
+
+- `mb init` and `mb onboard` now scaffold the canonical `pushes/` folder
+  instead of legacy `campaigns/`, and bundle an optional
+  `core/vocabulary.md` template so a business can name what it calls a
+  push (drop, launch, challenge, promo, campaign, etc.) without changing
+  any engine internals. Existing repos with `campaigns/` keep working as
+  compatibility reads. Refs #324.
+- `mb validate` and `mb graph` accept canonical `pushes/<YYYY-MM-DD-slug>/push.md`
+  records and the `linked_pushes` link field alongside legacy campaigns;
+  `mb status` indexes `pushes/` and surfaces legacy `campaigns/` count
+  as a parenthetical drift signal. Full kind/health/structured-goal
+  schema is left to #323. Refs #324, refs #323.
+- `mb doctor` warns when a repo still has legacy `campaigns/` records
+  ("Legacy campaigns folder detected. Main Branch now writes pushes/.
+  Run `mb migrate campaigns --plan` to preview a safe move.") and
+  exposes a structured `legacy_campaigns_to_pushes` repair item via
+  `mb doctor repair --plan --json`. Refs #324.
+- `mb migrate campaigns --plan` (read-only) prints a per-record plan
+  classifying each `campaigns/<slug>/campaign.md` record as a move
+  (deterministic destination), ambiguous (route to operator review),
+  or blocker (cannot infer a safe move). The apply path is explicitly
+  deferred to a follow-up PR with backups and explicit operator
+  approval. Implements the Migration Rubric from the issue body. Refs
+  #324.
+- Top-priority bundled skills (`/mb-ads`, `/mb-organic`, `/mb-vsl`,
+  `/mb-site`, `/mb-bet`, `/mb-start`) carry a new "Output destinations
+  and operator vocabulary" section telling them to write to `pushes/`,
+  read `core/vocabulary.md` when present, and recommend `mb doctor` /
+  `mb migrate campaigns --plan` on legacy repos. `linked_pushes` is
+  added to bet frontmatter alongside legacy `linked_campaigns`. Refs
+  #324.
+
 ### Fixed
 
 - `mb validate` now checks `campaigns/*/campaign.md` `status:` against the

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You're renting your business. Not just the dashboards — the operational memory
 
 The open-source gap closed in 2025. The tools to own your stack exist now. Almost nobody has carved time to migrate, because there's no coherent environment that ties it together.
 
-Main Branch is that environment. Your offer, audience, voice, decisions, research, bets, and campaigns live as markdown files in a git repo you own. The `mb` CLI scaffolds it. The bundled skills read those files and produce work that sounds like you — without re-prompting.
+Main Branch is that environment. Your offer, audience, voice, decisions, research, bets, and pushes (launches, drops, challenges, promos — whatever your business calls them) live as markdown files in a git repo you own. The `mb` CLI scaffolds it. The bundled skills read those files and produce work that sounds like you — without re-prompting.
 
 The end state isn't sitting at a terminal all day. It's the opposite — eventually you dump thoughts from your phone, drafts get made, you approve, it executes. We're not all the way there. The work is still real. But the substrate is the right one to build on.
 
@@ -32,7 +32,7 @@ Own the work. Rent only the rails.
 
 ## What it is
 
-Main Branch is the `mb` CLI plus MIT-licensed agent workflows for running business-as-files systems. It's built for operators and small teams running real businesses: solo founders, small agencies, course creators, productized services, indie SaaS, and small ecom teams. Today the workflows ship for Claude Code. Codex, Cursor, OpenClaw, Hermes, and local runtimes are next. Your offer, audience, voice, research, decisions, bets, and campaigns live in your own git repo — versioned, portable, agent-readable.
+Main Branch is the `mb` CLI plus MIT-licensed agent workflows for running business-as-files systems. It's built for operators and small teams running real businesses: solo founders, small agencies, course creators, productized services, indie SaaS, and small ecom teams. Today the workflows ship for Claude Code. Codex, Cursor, OpenClaw, Hermes, and local runtimes are next. Your offer, audience, voice, research, decisions, bets, and pushes live in your own git repo — versioned, portable, agent-readable.
 
 Read the product frame in [docs/ETHOS.md](docs/ETHOS.md), the four operator loops (Sense → Decide → Ship → Reflect) and the four channels (Paid, Organic, Pages, Ops) in [docs/OPERATOR-LOOPS.md](docs/OPERATOR-LOOPS.md), and the release direction in [docs/ROADMAP.md](docs/ROADMAP.md).
 Workspace, repo, dashboard, finance/legal, and team-log boundaries are defined
@@ -131,7 +131,7 @@ my-business/
 ├── decisions/
 ├── bets/
 ├── log/
-├── campaigns/
+├── pushes/
 └── documents/
 ```
 
@@ -147,8 +147,9 @@ or mutate customer accounts.
 
 The repo should keep useful non-secret identifiers where agents can inspect
 them: Stripe account/product/price IDs in offer or finance notes, Google Ads
-customer and campaign IDs in `campaigns/`, ad pixel IDs beside the site or
-campaign files they belong to, and MCP server names/scopes in `CLAUDE.md` or
+customer and campaign IDs (provider's term for their object) in
+`pushes/<push>/push.md` `provider_refs:`, ad pixel IDs beside the site or
+push files they belong to, and MCP server names/scopes in `CLAUDE.md` or
 local setup notes. Do not commit API keys, OAuth refresh tokens,
 service-account JSON, webhook secrets, MCP tokens, or bearer tokens. Keep
 secrets in a runtime's local config, the OS keychain, 1Password, `.env`, or
@@ -171,7 +172,7 @@ The CLI surface for the engine. Built for Claude Code first; runtime-agnostic by
 | `mb site check` | Check local paid-traffic measurement readiness for a site repo: GTM installation, Main Branch dataLayer events, consent posture, Google Ads plan metadata, and operator-review gates. |
 | `mb issue draft` | Create a local, privacy-scrubbed GitHub issue draft under `.mb/issue-drafts/` for bugs, feature gaps, or questions. |
 | `mb issue open` | Submit a reviewed issue draft with `gh issue create`, or print a browser/manual fallback when GitHub CLI is unavailable. |
-| `mb validate` | Frontmatter shape check across `core/`, `research/`, `decisions/`, `bets/`, `log/`, `campaigns/`, `documents/`. Pass/fail per file. |
+| `mb validate` | Frontmatter shape check across `core/`, `research/`, `decisions/`, `bets/`, `log/`, `pushes/` (and legacy `campaigns/` as compatibility), `documents/`. Pass/fail per file. |
 | `mb graph` | Build a repo graph index from frontmatter links, wikilinks, and entity tags. Emits Graphviz DOT by default, `--json` for agents/dashboards, and `--open` to render a PNG view. |
 | `mb think <topic>` | Print the `/mb-think` invocation hint. Run inside Claude Code for the full flow. |
 | `mb resolve <key>` | Resolve a reference path (checks free first, then paid). |

--- a/docs/BEGINNER-SETUP.md
+++ b/docs/BEGINNER-SETUP.md
@@ -79,7 +79,8 @@ cd my-business
 
 `mb onboard` walks you through the setup, explains why Main Branch uses local
 files, git, and GitHub, scaffolds the business folder taxonomy (`core/`,
-`research/`, `decisions/`, `bets/`, `log/`, `campaigns/`, `documents/`), and wires the
+`research/`, `decisions/`, `bets/`, `log/`, `pushes/`, `documents/` plus an
+optional `core/vocabulary.md` for operator-owned display words), and wires the
 bridge files Claude Code needs to find Main Branch's skills.
 
 You may also see a `.mb/` folder. That is normal. It stores Main Branch's local

--- a/docs/MIGRATING.md
+++ b/docs/MIGRATING.md
@@ -5,8 +5,10 @@ Main Branch has two repo shapes in the wild:
 - **Legacy shape:** `reference/core/`, `reference/domain/`,
   `reference/proof/`, `reference/visual-identity/`, and `outputs/`.
 - **Current shape:** `core/`, `research/`, `decisions/`, `bets/`, `log/`,
-  `campaigns/`, and `documents/`. `reference/` is compatibility-only for old
-  repos and old readers.
+  `pushes/`, and `documents/`. `reference/` is compatibility-only for old
+  repos and old readers; `campaigns/` is also compatibility-only and
+  detected by `mb doctor` with a preview path via
+  `mb migrate campaigns --plan`.
 
 Existing repos do not need an urgent file move. The safe path is to update the
 engine first, repair skill discovery, and only migrate file layout on a clean
@@ -421,9 +423,14 @@ ln -s ../core/offers reference/offers
 Then add the current empty working folders:
 
 ```bash
-mkdir -p bets log campaigns documents core/finance
-touch bets/.gitkeep log/.gitkeep campaigns/.gitkeep documents/.gitkeep core/finance/.gitkeep
+mkdir -p bets log pushes documents core/finance
+touch bets/.gitkeep log/.gitkeep pushes/.gitkeep documents/.gitkeep core/finance/.gitkeep
 ```
+
+If your repo already has a `campaigns/` folder from earlier Main Branch
+versions, leave it in place — `mb` reads it as compatibility. Run
+`mb doctor` and `mb migrate campaigns --plan` to preview the move to
+`pushes/` when you're ready.
 
 Validate before merging the branch:
 

--- a/docs/OPERATOR-LOOPS.md
+++ b/docs/OPERATOR-LOOPS.md
@@ -47,7 +47,7 @@ reference-file reads sit here.
 - `mb doctor`
 - `mb graph`
 - `mb connect status`
-- `core/`, `research/`, `decisions/`, `campaigns/`, `log/`, `documents/`
+- `core/`, `research/`, `decisions/`, `pushes/`, legacy `campaigns/`, `log/`, `documents/`
 - GitHub issues, pull requests, release history
 
 **Next improvements**

--- a/docs/markdown-link-conventions.md
+++ b/docs/markdown-link-conventions.md
@@ -22,7 +22,7 @@ Use stable, lowercase, hyphenated filenames:
 decisions/2026-05-04-pricing-model.md
 research/2026-05-04-audience-notes.md
 bets/2026-05-04-trial-offer.md
-campaigns/spring-launch/campaign.md
+pushes/2026-05-04-spring-launch/push.md
 core/offers/main-branch/offer.md
 ```
 
@@ -45,12 +45,15 @@ linked_decisions:
   - decisions/2026-05-04-pricing-model.md
 linked_research:
   - research/2026-05-04-audience-notes.md
-linked_campaigns:
-  - campaigns/spring-launch/campaign.md
+linked_pushes:
+  - pushes/2026-05-04-spring-launch/push.md
 ```
 
 Do not use Obsidian wikilink syntax in frontmatter. Do not omit the extension.
 Do not use absolute local paths.
+
+Legacy `linked_campaigns` frontmatter remains readable for migrated repos, but
+new records should use `linked_pushes`.
 
 Allowed external references:
 

--- a/docs/prd/v0-3-agent-checkpoints.md
+++ b/docs/prd/v0-3-agent-checkpoints.md
@@ -143,7 +143,7 @@ The commit body can carry the detail:
 ```text
 Changed:
 - core/offer.md
-- campaigns/2026-05-paid-site.md
+- pushes/2026-05-04-paid-site/push.md
 - decisions/2026-05-04-paid-site-plan.md
 
 Why:

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -7,22 +7,17 @@
 > model after the `core/` folder decision, the campaign primitive decision,
 > and the push primitive and operator-vocabulary decision.
 >
-> **Shipped vs accepted.** The accepted target architecture below names
-> `pushes/` as the canonical primitive and `core/vocabulary.md` as the
-> operator-owned vocabulary file. As of this writing, shipped `mb init` and
-> onboarding templates still scaffold `campaigns/` and do not scaffold
-> `pushes/` or `core/vocabulary.md`; `mb validate` validates
-> `campaigns/*/campaign.md` against the campaign lifecycle; the `mb push`
-> CLI surface and the `kind:` enum validator do not exist yet. The
-> deterministic engine work (validators, graph, status JSON, scaffolding)
-> lands in
-> [#323](https://github.com/noontide-co/mainbranch/issues/323); the skill,
-> runtime, and migration code (including `mb init` switching to `pushes/`,
-> reading `core/vocabulary.md`, and the migration command) lands in
-> [#324](https://github.com/noontide-co/mainbranch/issues/324). Until both
-> ship, this document describes the **target** that `mb` is moving toward,
-> not what `mb init` produces today. New writes by hand or by future skills
-> should follow the target; existing `campaigns/` repos keep working.
+> **Shipped vs accepted.** The accepted architecture below names `pushes/`
+> as the canonical primitive and `core/vocabulary.md` as the operator-owned
+> vocabulary file. Current `mb init` scaffolds those paths; validators, graph,
+> status, checkpoints, doctor, and the campaigns migration planner read
+> `pushes/` while preserving legacy `campaigns/` compatibility. The remaining
+> deterministic polish in
+> [#323](https://github.com/noontide-co/mainbranch/issues/323) is the advanced
+> push schema (`kind`, health, structured goal, owner, audience, promise),
+> JSON deprecation cleanup, and any future `mb push` command surface. Existing
+> `campaigns/` repos keep working, but new coordinated work should land in
+> `pushes/`.
 
 ## Architecture In One Sentence
 

--- a/mb/mb/_data/educational/github-vs-gdocs.md
+++ b/mb/mb/_data/educational/github-vs-gdocs.md
@@ -23,7 +23,7 @@ Google Docs is the default place businesses put their thinking — meeting notes
 
 ## What we recommend instead
 
-A private GitHub (or Forgejo) repo with a CLAUDE.md at the root and a primitive folder structure: `core/`, `research/`, `decisions/`, `bets/`, `log/`, `campaigns/`, `documents/`. Markdown for everything. Frontmatter for status. The repo is the company brain. Conductor or any AI agent reads it as the working substrate.
+A private GitHub (or Forgejo) repo with a CLAUDE.md at the root and a primitive folder structure: `core/`, `research/`, `decisions/`, `bets/`, `log/`, `pushes/`, `documents/`. Markdown for everything. Frontmatter for status. The repo is the company brain. Conductor or any AI agent reads it as the working substrate.
 
 The pitch in one sentence: **your business is a tree of files**. Once it is, every agent that can read files becomes a coworker.
 
@@ -50,14 +50,14 @@ The pitch in one sentence: **your business is a tree of files**. Once it is, eve
    - decisions/ — dated choices with rationale, frontmatter status field
    - bets/ — operating bets with targets, deadlines, and outcomes
    - log/ — daily/weekly notes, inbox-style dumps
-   - campaigns/ — outputs grouped by campaign
+   - pushes/ — coordinated pushes (launches, drops, challenges, promos)
    - documents/ — long-form artifacts (briefs, SOPs, contracts)
    ```
 
 4. Set up the primitive folders:
    ```bash
    mkdir -p core/{soul,offer,audience,voice,visual-identity,finance} \
-            research decisions bets log campaigns documents
+            research decisions bets log pushes documents
    git add . && git commit -m "[init] business primitive structure"
    git push
    ```

--- a/mb/mb/_data/templates/CLAUDE.md.tmpl
+++ b/mb/mb/_data/templates/CLAUDE.md.tmpl
@@ -16,15 +16,30 @@ Your business as files. Claude reads these; you edit them; git remembers them.
 - `decisions/` — dated choices, with rationale
 - `bets/` — operating bets with appetite, metric, target, and outcome
 - `log/` — running activity log
-- `campaigns/` — paid + organic campaign work
+- `pushes/` — coordinated pushes (launches, drops, challenges, promos, etc.)
 - `documents/` — anything that doesn't belong above
+
+If your repo has a legacy `campaigns/` folder from before the push primitive
+decision, `mb` continues to read it. New coordinated work should land in
+`pushes/`. Run `mb doctor` to see whether your repo is on the canonical shape
+and `mb migrate campaigns --plan` to preview a safe move.
+
+## Operator vocabulary (optional)
+
+`core/vocabulary.md` is an optional file where this business names what it
+calls coordinated pushes — *drops*, *launches*, *challenges*, *promos*,
+*plays*, *rounds*, *waves*. Skills and `mb status` speak the operator's
+words back when the file exists; engine internals (folder names, frontmatter,
+JSON keys, validators, commands) stay canonical regardless. See the file
+itself for the bounded shape.
 
 ## Conventions
 
-- Decisions, research, bets, offers, and campaigns carry a small block of metadata
+- Decisions, research, bets, offers, and pushes carry a small block of metadata
   at the top (frontmatter). Run `mb validate` to check it.
 - Status field: `proposed | running | scaling | killed | graduated | died`
-  (decisions also use `accepted | rejected | superseded`).
+  (decisions use `accepted | rejected | superseded`; pushes use
+  `draft | planned | active | paused | completed | canceled | archived`).
 - One owner per file via `.github/CODEOWNERS`.
 - Pull request titles use Conventional Commits.
 
@@ -39,10 +54,10 @@ agents choose the right account:
 
 - Stripe account IDs, product IDs, and price IDs can live in offer or finance
   notes such as `core/offers/<offer>/stripe.md`.
-- Google Ads customer IDs and campaign IDs can live in campaign plans under
-  `campaigns/`.
+- Google Ads customer IDs and campaign IDs (provider's term for their object)
+  can live in `pushes/<push>/push.md` `provider_refs:`.
 - Meta, TikTok, Google, or other ad pixel IDs can live beside the site or
-  campaign files they belong to.
+  push files they belong to.
 - MCP server names and intended scopes can live in `CLAUDE.md` or a local setup
   note when they are not secret.
 

--- a/mb/mb/_data/templates/core_vocabulary.md.tmpl
+++ b/mb/mb/_data/templates/core_vocabulary.md.tmpl
@@ -1,0 +1,60 @@
+---
+type: vocabulary
+status: active
+terms:
+  push:
+    singular: push
+    plural: pushes
+  statuses: {}
+  channels: {}
+  kinds: {}
+---
+
+# Vocabulary
+
+This is an optional file. It tells skills and `mb status` what this business
+calls operating primitives, so a coach can see "drops" or "challenges" or
+"launches" instead of "pushes" in conversation.
+
+The engine stays canonical regardless. Folder names, frontmatter `type:`
+values, link fields, JSON keys, validator rules, and CLI command names do
+not change based on this file.
+
+## Bounded shape
+
+Only these top-level keys under `terms:` are recognized:
+
+- `push.singular` / `push.plural` — what this business calls one push and
+  many pushes.
+- `statuses` — display words for canonical statuses (e.g. `active: live`,
+  `completed: shipped`).
+- `channels` — display phrases for canonical channels (e.g. `paid: paid
+  traffic`, `organic: content`).
+- `kinds` — display words for canonical push kinds (e.g. `drop: drop`,
+  `launch: launch`).
+
+Anything outside this set is ignored.
+
+## Default behavior
+
+This template ships with neutral defaults — `push: pushes`. Edit the file to
+match this business's voice. If the file is deleted, the engine speaks its
+canonical words.
+
+## Example
+
+A coach who runs Skool challenges might use:
+
+    terms:
+      push:
+        singular: challenge
+        plural: challenges
+      statuses:
+        active: running
+        completed: wrapped
+      channels:
+        paid: paid traffic
+        community: inside Skool
+      kinds:
+        challenge: challenge
+        nurture: nurture

--- a/mb/mb/checkpoint.py
+++ b/mb/mb/checkpoint.py
@@ -11,6 +11,7 @@ from mb.freshness import looks_like_business_repo
 
 SURFACE_ORDER = [
     "core",
+    "pushes",
     "campaigns",
     "decisions",
     "research",
@@ -112,6 +113,8 @@ def _is_conflict_status(raw: str) -> bool:
 def _surface(path: str) -> str:
     if path.startswith("core/") or path == "core":
         return "core"
+    if path.startswith("pushes/") or path == "pushes":
+        return "pushes"
     if path.startswith("campaigns/") or path == "campaigns":
         return "campaigns"
     if path.startswith("decisions/") or path == "decisions":
@@ -261,6 +264,7 @@ def _surface_phrase(surfaces: list[str]) -> str:
         return "work"
     labels = {
         "core": "core",
+        "pushes": "pushes",
         "campaigns": "campaigns",
         "decisions": "decisions",
         "research": "research",

--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -1078,6 +1078,43 @@ def migrate_cmd(
         migrate_mod.render_status(result)
 
 
+@migrate_app.command("campaigns")
+def migrate_campaigns_cmd(
+    ctx: typer.Context,
+    plan: bool = typer.Option(
+        False,
+        "--plan",
+        help=(
+            "Print a read-only plan classifying campaigns/ records as moves, "
+            "ambiguous, or blockers."
+        ),
+    ),
+    json_out: bool = typer.Option(False, "--json", help="Machine-readable output."),
+) -> None:
+    """Preview the legacy ``campaigns/`` -> canonical ``pushes/`` migration.
+
+    Plan-only in this release. The apply path lands in a follow-up PR with
+    backups and explicit operator approval; running without ``--plan`` exits
+    with the same plan output and a notice that apply is not yet implemented.
+    """
+    repo_value = ctx.obj.get("repo", ".") if ctx.obj else "."
+    if not plan:
+        typer.echo(
+            "mb migrate campaigns: --plan is required (apply is not yet implemented)",
+            err=True,
+        )
+        raise typer.Exit(2)
+    result = migrate_mod.plan_campaigns_to_pushes(repo_value)
+    if json_out:
+        typer.echo(json.dumps(result, indent=2))
+    else:
+        migrate_mod.render_campaigns_plan(result)
+    summary = result["summary"]
+    has_blockers = summary.get("blockers", 0) > 0
+    has_anything = sum(summary.values()) > 0
+    raise typer.Exit(1 if has_blockers else (0 if has_anything else 0))
+
+
 @migrate_app.command("status")
 def migrate_status_cmd(
     ctx: typer.Context,

--- a/mb/mb/doctor.py
+++ b/mb/mb/doctor.py
@@ -337,6 +337,68 @@ def _repo_layout_check(repo: Path) -> dict[str, Any]:
     }
 
 
+def _legacy_campaigns_check(repo: Path) -> dict[str, Any]:
+    """Detect legacy `campaigns/` records as drift from the canonical `pushes/` shape.
+
+    Per the push primitive decision, ``pushes/`` is the canonical engine
+    primitive. ``campaigns/`` records remain as compatibility reads but new
+    coordinated work should land in ``pushes/``. This check warns when a repo
+    has any legacy campaign records so the operator can preview the migration.
+    """
+    campaigns_dir = repo / "campaigns"
+    if not campaigns_dir.is_dir():
+        return {
+            "name": "legacy-campaigns",
+            "ok": True,
+            "detail": "no legacy campaigns/ records",
+            "severity": "ok",
+        }
+
+    legacy_records: list[str] = []
+    ambiguous_files: list[str] = []
+    for child in sorted(campaigns_dir.rglob("*.md")):
+        if not child.is_file() or child.is_symlink():
+            continue
+        rel = child.relative_to(repo).as_posix()
+        if child.name == "campaign.md":
+            legacy_records.append(rel)
+        else:
+            ambiguous_files.append(rel)
+
+    total = len(legacy_records) + len(ambiguous_files)
+    if total == 0:
+        # Empty campaigns/ folder (e.g. just a .gitkeep). No drift to warn.
+        return {
+            "name": "legacy-campaigns",
+            "ok": True,
+            "detail": "campaigns/ folder is empty",
+            "severity": "ok",
+        }
+
+    parts: list[str] = []
+    if legacy_records:
+        parts.append(
+            f"{len(legacy_records)} legacy campaign record(s) found. "
+            "Main Branch now writes pushes/. Run "
+            "`mb migrate campaigns --plan` to preview a safe move."
+        )
+    if ambiguous_files:
+        parts.append(
+            f"{len(ambiguous_files)} ambiguous file(s) under campaigns/ that may "
+            "belong in pushes/, documents/, or stay in place; "
+            "review with `mb migrate campaigns --plan`."
+        )
+
+    return {
+        "name": "legacy-campaigns",
+        "ok": False,
+        "detail": " ".join(parts),
+        "severity": "warn",
+        "legacy_records": legacy_records,
+        "ambiguous_files": ambiguous_files,
+    }
+
+
 def _schema_version_check(repo: Path) -> dict[str, Any]:
     current = read_schema_version(repo)
     pending = pending_migrations(repo)
@@ -734,6 +796,7 @@ def run(path: str) -> dict[str, Any]:
     )
     checks.append(_repo_layout_check(repo))
     checks.append(_schema_version_check(repo))
+    checks.append(_legacy_campaigns_check(repo))
     checks.append(connect_mod.doctor_check(repo, status=integration_status))
     onboarding = onboard_mod.onboarding_status(repo)
     onboarding_summary = onboarding["summary"]
@@ -843,6 +906,10 @@ def repair_plan(
 
     migration = migrate_mod.check(target, include_diff=False)
     reference_state = _legacy_reference_state(target)
+    legacy_campaigns_check = next(
+        (check for check in doctor_report["checks"] if check["name"] == "legacy-campaigns"),
+        None,
+    )
     layout_checks = [
         {
             "name": check["name"],
@@ -850,7 +917,7 @@ def repair_plan(
             "summary": check["detail"],
         }
         for check in doctor_report["checks"]
-        if check["name"] in {"repo-layout", "schema-version"}
+        if check["name"] in {"repo-layout", "schema-version", "legacy-campaigns"}
     ]
     layout_checks.extend(
         {
@@ -886,6 +953,21 @@ def repair_plan(
                     "`--apply --include-migration` only after reviewing the preview"
                 ),
                 writes=["core/", "reference/core", "reference/offers", ".mb/schema_version"],
+            )
+        )
+    if legacy_campaigns_check and not legacy_campaigns_check["ok"]:
+        actions.append(
+            _action(
+                id="legacy_campaigns_to_pushes",
+                title="Preview campaigns -> pushes migration",
+                state="warn",
+                mode="read",
+                command="mb migrate campaigns --plan",
+                safe_to_apply=True,
+                reason=(
+                    "campaigns/ is legacy compatibility; new coordinated work "
+                    "writes to pushes/. Preview the move before applying."
+                ),
             )
         )
     sections.append(

--- a/mb/mb/doctor.py
+++ b/mb/mb/doctor.py
@@ -354,18 +354,31 @@ def _legacy_campaigns_check(repo: Path) -> dict[str, Any]:
             "severity": "ok",
         }
 
+    plan = migrate_mod.plan_campaigns_to_pushes(repo)
     legacy_records: list[str] = []
     ambiguous_files: list[str] = []
-    for child in sorted(campaigns_dir.rglob("*.md")):
-        if not child.is_file() or child.is_symlink():
-            continue
-        rel = child.relative_to(repo).as_posix()
-        if child.name == "campaign.md":
-            legacy_records.append(rel)
-        else:
-            ambiguous_files.append(rel)
+    blocker_paths: list[str] = []
 
-    total = len(legacy_records) + len(ambiguous_files)
+    for move in plan.get("moves", []):
+        from_path = str(move["from"])
+        legacy_records.append(f"{from_path}/campaign.md")
+        ambiguous_files.extend(str(path) for path in move.get("review_inside_folder", []))
+
+    for ambiguous in plan.get("ambiguous", []):
+        ambiguous_files.append(str(ambiguous["from"]))
+
+    for blocker in plan.get("blockers", []):
+        from_path = str(blocker["from"])
+        blocker_paths.append(from_path)
+        record = repo / from_path / "campaign.md"
+        if record.is_file():
+            legacy_records.append(f"{from_path}/campaign.md")
+
+    legacy_records = sorted(set(legacy_records))
+    ambiguous_files = sorted(set(ambiguous_files))
+    blocker_paths = sorted(set(blocker_paths))
+
+    total = len(legacy_records) + len(ambiguous_files) + len(blocker_paths)
     if total == 0:
         # Empty campaigns/ folder (e.g. just a .gitkeep). No drift to warn.
         return {
@@ -384,9 +397,14 @@ def _legacy_campaigns_check(repo: Path) -> dict[str, Any]:
         )
     if ambiguous_files:
         parts.append(
-            f"{len(ambiguous_files)} ambiguous file(s) under campaigns/ that may "
+            f"{len(ambiguous_files)} ambiguous path(s) under campaigns/ that may "
             "belong in pushes/, documents/, or stay in place; "
             "review with `mb migrate campaigns --plan`."
+        )
+    if blocker_paths:
+        parts.append(
+            f"{len(blocker_paths)} blocker(s) under campaigns/ require operator input "
+            "before migration can be planned."
         )
 
     return {
@@ -396,6 +414,7 @@ def _legacy_campaigns_check(repo: Path) -> dict[str, Any]:
         "severity": "warn",
         "legacy_records": legacy_records,
         "ambiguous_files": ambiguous_files,
+        "blockers": blocker_paths,
     }
 
 

--- a/mb/mb/graph.py
+++ b/mb/mb/graph.py
@@ -21,6 +21,7 @@ LINK_FIELDS = (
     "linked_research",
     "linked_decision",
     "linked_decisions",
+    "linked_pushes",
     "linked_campaigns",
     "linked_outcomes",
     "linked_prd",
@@ -68,6 +69,7 @@ LOCAL_REF_ROOTS = {
     "documents",
     "log",
     "outputs",
+    "pushes",
     "reference",
     "research",
 }

--- a/mb/mb/init.py
+++ b/mb/mb/init.py
@@ -30,7 +30,7 @@ DATA_FOLDERS = [
     "decisions",
     "bets",
     "log",
-    "campaigns",
+    "pushes",
     "documents",
 ]
 
@@ -143,6 +143,14 @@ def run(path: str, name: str) -> dict[str, Any]:
     (target / "CLAUDE.md").write_text(_render(claude_tmpl, mapping), encoding="utf-8")
     created.append("CLAUDE.md")
 
+    vocabulary_tmpl = _read_template("core_vocabulary.md.tmpl")
+    if vocabulary_tmpl:
+        vocabulary_path = target / "core" / "vocabulary.md"
+        vocabulary_path.parent.mkdir(parents=True, exist_ok=True)
+        if not vocabulary_path.exists():
+            vocabulary_path.write_text(_render(vocabulary_tmpl, mapping), encoding="utf-8")
+            created.append("core/vocabulary.md")
+
     codeowners_tmpl = _read_template("CODEOWNERS.tmpl") or f"* @{gh_user}\n"
     github_dir = target / ".github"
     github_dir.mkdir(exist_ok=True)
@@ -199,8 +207,38 @@ Your business as files. Claude reads these; you edit them; git remembers them.
 - `decisions/` — dated choices, with rationale
 - `bets/` — operating bets with appetite, metric, target, and outcome
 - `log/` — running activity log
-- `campaigns/` — paid + organic campaign work
+- `pushes/` — coordinated pushes (launches, drops, challenges, promos, etc.)
 - `documents/` — anything that doesn't belong above
+
+If your repo was created before the push primitive decision, you may also have
+a legacy `campaigns/` folder. `mb` continues to read it; new coordinated work
+should land in `pushes/`. Run `mb doctor` to see whether your repo is on the
+canonical shape and `mb migrate campaigns --plan` to preview a safe move.
+
+## Optional: operator vocabulary
+
+`core/vocabulary.md` is an optional file where the business names what it
+calls coordinated pushes. A coach might call them *drops*; a creator might
+call them *launches*; a community might call them *challenges*. The file
+shape:
+
+    ---
+    type: vocabulary
+    status: active
+    terms:
+      push:
+        singular: drop
+        plural: drops
+      statuses:
+        active: live
+        completed: shipped
+    ---
+
+    Optional prose explanation goes here.
+
+Vocabulary changes how skills and `mb status` speak in conversation. It does
+not rename folders, frontmatter types, link fields, JSON keys, validator
+rules, or commands. Engine internals stay canonical.
 
 ## Conventions
 
@@ -217,9 +255,9 @@ that business.
 
 Keep non-secret IDs in repo files when they help agents choose the right
 account: Stripe account/product/price IDs in `core/offers/<offer>/stripe.md`,
-Google Ads customer and campaign IDs in `campaigns/`, ad pixel IDs beside the
-site or campaign files they belong to, and MCP server names/scopes in local
-setup notes.
+Google Ads customer and campaign IDs (provider's term for their object) in
+`pushes/<push>/push.md` `provider_refs:`, ad pixel IDs beside the site or
+push files they belong to, and MCP server names/scopes in local setup notes.
 
 Never commit API keys, OAuth refresh tokens, service-account JSON, webhook
 secrets, MCP tokens, or bearer tokens. Put secrets in a runtime local config,

--- a/mb/mb/migrate.py
+++ b/mb/mb/migrate.py
@@ -774,10 +774,14 @@ def render_campaigns_plan(result: dict[str, Any]) -> None:
             print(f"  frontmatter: {change}")
         for note in move.get("notes", []):
             print(f"  note: {note}")
-        if move.get("folder_contents"):
-            print(
-                f"  folder contents to move with the push: {len(move['folder_contents'])} item(s)"
-            )
+        if move.get("move_with_push"):
+            print(f"  move with push: {len(move['move_with_push'])} item(s)")
+            for path in move["move_with_push"]:
+                print(f"    - {path}")
+        if move.get("review_inside_folder"):
+            print(f"  review before apply: {len(move['review_inside_folder'])} item(s)")
+            for path in move["review_inside_folder"]:
+                print(f"    - {path}")
     for ambiguous in result["ambiguous"]:
         print(f"\nambiguous: {ambiguous['from']}")
         print(f"  reason: {ambiguous['reason']}")

--- a/mb/mb/migrate.py
+++ b/mb/mb/migrate.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 
 import difflib
 import json
+import re
 import shutil
 from datetime import datetime
 from pathlib import Path
 from typing import Any
+
+import yaml
 
 from mb import migrations
 from mb.migrations.base import MigrationInfo, MigrationPlan, PlannedChange
@@ -433,3 +436,243 @@ def render_apply(result: dict[str, Any]) -> None:
     if backup.get("path"):
         print(f"backup: {backup['path']}")
     print(f"schema version: {result['current_version']}")
+
+
+# ---------------------------------------------------------------------------
+# campaigns -> pushes migration planner (preview-only)
+#
+# Per the MAIN-251 push primitive decision, the canonical engine primitive is
+# `pushes/`. This planner walks legacy `campaigns/<slug>/campaign.md` records
+# and proposes per-record moves to `pushes/<YYYY-MM-DD-slug>/push.md`.
+#
+# Plan-only in this release: the planner classifies records but does not move
+# files. Apply lands in a follow-up PR with explicit operator approval and
+# backup. Per the issue's Migration Rubric, no silent migration; ambiguous
+# generated folders surface for operator review.
+# ---------------------------------------------------------------------------
+
+CAMPAIGNS_PLAN_SCHEMA = "mb.migrate.campaigns"
+CAMPAIGNS_PLAN_SCHEMA_VERSION = 1
+
+_DATED_DAY_PREFIX = re.compile(r"^(\d{4}-\d{2}-\d{2})-")
+_DATED_MONTH_PREFIX = re.compile(r"^(\d{4}-\d{2})-")
+_PUSH_FOLDER_NAMES = {"ads", "emails", "posts", "reviews", "assets", "source"}
+_PUSH_FILE_NAMES = {
+    "ads.md",
+    "emails.md",
+    "posts.md",
+    "site.md",
+    "review-log.md",
+}
+
+
+def _read_campaign_frontmatter(path: Path) -> dict[str, Any]:
+    """Best-effort YAML frontmatter read; returns {} on failure."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return {}
+    if not text.startswith("---"):
+        return {}
+    try:
+        end = text.index("\n---", 3)
+    except ValueError:
+        return {}
+    block = text[3:end].lstrip("\n")
+    try:
+        data = yaml.safe_load(block)
+    except yaml.YAMLError:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _infer_push_date(folder_name: str, frontmatter: dict[str, Any]) -> tuple[str, str] | None:
+    """Return (YYYY-MM-DD date string, source-label) or None when ambiguous."""
+    day_match = _DATED_DAY_PREFIX.match(folder_name)
+    if day_match:
+        return day_match.group(1), "folder.day-prefix"
+    month_match = _DATED_MONTH_PREFIX.match(folder_name)
+    if month_match:
+        return f"{month_match.group(1)}-01", "folder.month-prefix"
+    for field in ("started", "review_on"):
+        value = frontmatter.get(field)
+        if isinstance(value, str) and re.fullmatch(r"\d{4}-\d{2}-\d{2}", value):
+            return value, f"frontmatter.{field}"
+        if hasattr(value, "isoformat"):
+            iso = value.isoformat()
+            if re.fullmatch(r"\d{4}-\d{2}-\d{2}", iso):
+                return iso, f"frontmatter.{field}"
+    return None
+
+
+def _slug_without_date_prefix(folder_name: str) -> str:
+    day_match = _DATED_DAY_PREFIX.match(folder_name)
+    if day_match:
+        return folder_name[len(day_match.group(0)) :]
+    month_match = _DATED_MONTH_PREFIX.match(folder_name)
+    if month_match:
+        return folder_name[len(month_match.group(0)) :]
+    return folder_name
+
+
+def _enumerate_folder_contents(folder: Path, repo: Path) -> list[str]:
+    contents: list[str] = []
+    for child in sorted(folder.iterdir()):
+        if child.name == "campaign.md":
+            continue
+        if child.name == ".gitkeep":
+            continue
+        rel = child.relative_to(repo).as_posix()
+        contents.append(rel)
+    return contents
+
+
+def _classify_campaign_folder(folder: Path, repo: Path) -> dict[str, Any]:
+    """Classify one direct child of campaigns/ as a move, ambiguous, or blocker."""
+    rel = folder.relative_to(repo).as_posix()
+    record = folder / "campaign.md"
+    if not record.is_file():
+        # No campaign.md -- this is generated material, not a coordinated push.
+        # Per the rubric, do not auto-promote into pushes/.
+        contents = _enumerate_folder_contents(folder, repo)
+        return {
+            "kind": "ambiguous",
+            "from": rel,
+            "reason": "no campaign.md inside this folder; cannot infer a coordinated push",
+            "suggestion": (
+                "review with the operator. Likely homes: documents/archive/, "
+                "documents/prototypes/, or leave in place with a warning."
+            ),
+            "contents": contents,
+        }
+
+    frontmatter = _read_campaign_frontmatter(record)
+    inferred = _infer_push_date(folder.name, frontmatter)
+    slug = _slug_without_date_prefix(folder.name)
+    if inferred is None:
+        return {
+            "kind": "blocker",
+            "from": rel,
+            "reason": (
+                "cannot infer a date for the push folder name. Folder has no "
+                "YYYY-MM-DD or YYYY-MM prefix and frontmatter has no `started` "
+                "or `review_on` date."
+            ),
+            "suggestion": (
+                "add `started: YYYY-MM-DD` to the campaign.md frontmatter or "
+                "rename the folder with a dated prefix, then re-run the plan."
+            ),
+        }
+    date_str, date_source = inferred
+    push_folder = f"pushes/{date_str}-{slug}"
+    push_record_rel = f"{push_folder}/push.md"
+    folder_contents = _enumerate_folder_contents(folder, repo)
+    frontmatter_changes: list[str] = []
+    if frontmatter.get("type") == "campaign":
+        frontmatter_changes.append("type: campaign -> type: push")
+    if "linked_campaigns" in frontmatter:
+        frontmatter_changes.append("linked_campaigns -> linked_pushes (rename)")
+    has_provider_meta_ads = (
+        isinstance(frontmatter.get("provider_refs"), dict)
+        and "meta_ads" in frontmatter["provider_refs"]
+    )
+    notes: list[str] = []
+    if has_provider_meta_ads:
+        notes.append(
+            "provider_refs.meta_ads.campaign_id preserved (Meta's term for its object, "
+            "not the engine primitive)"
+        )
+    return {
+        "kind": "move",
+        "from": rel,
+        "to": push_record_rel,
+        "date": date_str,
+        "date_source": date_source,
+        "slug": slug,
+        "frontmatter_changes": frontmatter_changes,
+        "folder_contents": folder_contents,
+        "notes": notes,
+    }
+
+
+def plan_campaigns_to_pushes(repo: str | Path = ".") -> dict[str, Any]:
+    """Read-only plan classifying every campaigns/ child as a move, ambiguous, or blocker.
+
+    Returns a structured dict that ``mb migrate campaigns --plan`` renders or
+    serializes to JSON. Does not write any files. Apply lands in a follow-up
+    PR with backups and explicit operator approval.
+    """
+    target = Path(repo).expanduser().resolve()
+    envelope: dict[str, Any] = {
+        "schema": CAMPAIGNS_PLAN_SCHEMA,
+        "schema_version": CAMPAIGNS_PLAN_SCHEMA_VERSION,
+        "repo": str(target),
+        "ok": True,
+        "moves": [],
+        "ambiguous": [],
+        "blockers": [],
+        "summary": {"moves": 0, "ambiguous": 0, "blockers": 0},
+        "next": (
+            "Plan-only in this release. `mb migrate campaigns --apply` is not yet "
+            "implemented; the apply path lands in a follow-up PR with backups and "
+            "explicit operator approval."
+        ),
+    }
+
+    campaigns_dir = target / "campaigns"
+    if not campaigns_dir.is_dir():
+        envelope["next"] = "no legacy campaigns/ folder; nothing to migrate"
+        return envelope
+
+    children = [child for child in sorted(campaigns_dir.iterdir()) if child.is_dir()]
+    if not children:
+        envelope["next"] = "campaigns/ folder is empty; nothing to migrate"
+        return envelope
+
+    for folder in children:
+        classification = _classify_campaign_folder(folder, target)
+        kind = classification.pop("kind")
+        if kind == "move":
+            envelope["moves"].append(classification)
+        elif kind == "ambiguous":
+            envelope["ambiguous"].append(classification)
+        else:
+            envelope["blockers"].append(classification)
+
+    envelope["summary"]["moves"] = len(envelope["moves"])
+    envelope["summary"]["ambiguous"] = len(envelope["ambiguous"])
+    envelope["summary"]["blockers"] = len(envelope["blockers"])
+    envelope["ok"] = len(envelope["blockers"]) == 0
+    return envelope
+
+
+def render_campaigns_plan(result: dict[str, Any]) -> None:
+    """Operator-facing rendering of `mb migrate campaigns --plan`."""
+    summary = result["summary"]
+    print(f"campaigns -> pushes plan for {result['repo']}")
+    print(
+        f"  moves: {summary['moves']}  "
+        f"ambiguous: {summary['ambiguous']}  "
+        f"blockers: {summary['blockers']}"
+    )
+    for move in result["moves"]:
+        print(f"\nmove: {move['from']}")
+        print(f"  -> {move['to']}")
+        print(f"  date: {move['date']}  (source: {move['date_source']})")
+        for change in move.get("frontmatter_changes", []):
+            print(f"  frontmatter: {change}")
+        for note in move.get("notes", []):
+            print(f"  note: {note}")
+        if move.get("folder_contents"):
+            print(
+                f"  folder contents to move with the push: {len(move['folder_contents'])} item(s)"
+            )
+    for ambiguous in result["ambiguous"]:
+        print(f"\nambiguous: {ambiguous['from']}")
+        print(f"  reason: {ambiguous['reason']}")
+        print(f"  suggestion: {ambiguous['suggestion']}")
+    for blocker in result["blockers"]:
+        print(f"\nblocker: {blocker['from']}")
+        print(f"  reason: {blocker['reason']}")
+        print(f"  suggestion: {blocker['suggestion']}")
+    print(f"\n{result['next']}")

--- a/mb/mb/migrate.py
+++ b/mb/mb/migrate.py
@@ -6,6 +6,7 @@ import difflib
 import json
 import re
 import shutil
+import subprocess
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -498,9 +499,10 @@ def _infer_push_date(folder_name: str, frontmatter: dict[str, Any]) -> tuple[str
         value = frontmatter.get(field)
         if isinstance(value, str) and re.fullmatch(r"\d{4}-\d{2}-\d{2}", value):
             return value, f"frontmatter.{field}"
-        if hasattr(value, "isoformat"):
-            iso = value.isoformat()
-            if re.fullmatch(r"\d{4}-\d{2}-\d{2}", iso):
+        iso_method = getattr(value, "isoformat", None)
+        if callable(iso_method):
+            iso = iso_method()
+            if isinstance(iso, str) and re.fullmatch(r"\d{4}-\d{2}-\d{2}", iso):
                 return iso, f"frontmatter.{field}"
     return None
 
@@ -515,16 +517,103 @@ def _slug_without_date_prefix(folder_name: str) -> str:
     return folder_name
 
 
-def _enumerate_folder_contents(folder: Path, repo: Path) -> list[str]:
-    contents: list[str] = []
+def _enumerate_folder_contents(folder: Path, repo: Path) -> tuple[list[str], list[str]]:
+    """Split a campaign folder's children into (recognized, unrecognized) artifacts.
+
+    Recognized = listed in the Migration Rubric (ads/, emails/, posts/, site.md,
+    review-log.md, assets/, source/, etc.). These are auto-moved with the push.
+    Unrecognized = anything else inside the folder; these are flagged as
+    ambiguous within the move and surfaced for operator review rather than
+    silently moved.
+    """
+    recognized: list[str] = []
+    unrecognized: list[str] = []
     for child in sorted(folder.iterdir()):
         if child.name == "campaign.md":
             continue
         if child.name == ".gitkeep":
             continue
         rel = child.relative_to(repo).as_posix()
-        contents.append(rel)
-    return contents
+        is_recognized_dir = child.is_dir() and child.name in _PUSH_FOLDER_NAMES
+        is_recognized_file = child.is_file() and child.name in _PUSH_FILE_NAMES
+        if is_recognized_dir or is_recognized_file:
+            recognized.append(rel)
+        else:
+            unrecognized.append(rel)
+    return recognized, unrecognized
+
+
+def _git_first_added_date(repo: Path, path: Path) -> str | None:
+    """Best-effort git first-added date (YYYY-MM-DD) for a file.
+
+    Returns None when not in a git repo, when the file has never been committed,
+    or when git is unavailable. Never raises.
+    """
+    try:
+        result = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(repo),
+                "log",
+                "--diff-filter=A",
+                "--follow",
+                "--format=%ad",
+                "--date=short",
+                "--",
+                str(path.relative_to(repo)),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    lines = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+    if not lines:
+        return None
+    candidate = lines[-1]
+    if re.fullmatch(r"\d{4}-\d{2}-\d{2}", candidate):
+        return candidate
+    return None
+
+
+def _infer_push_date_with_git(
+    folder_name: str,
+    frontmatter: dict[str, Any],
+    record_path: Path,
+    repo: Path,
+) -> tuple[str, str] | None:
+    """Apply the full Migration Rubric date inference, including git fallback."""
+    primary = _infer_push_date(folder_name, frontmatter)
+    if primary is not None:
+        return primary
+    git_date = _git_first_added_date(repo, record_path)
+    if git_date is not None:
+        return git_date, "git.first-added"
+    return None
+
+
+def _classify_loose_top_level_file(child: Path, repo: Path) -> dict[str, Any]:
+    """A file at the top of campaigns/ has no folder context and no record. Ambiguous."""
+    rel = child.relative_to(repo).as_posix()
+    return {
+        "kind": "ambiguous",
+        "from": rel,
+        "reason": (
+            "loose file at the top of campaigns/ (not inside a campaign folder). "
+            "No campaign.md context; cannot infer a coordinated push."
+        ),
+        "suggestion": (
+            "review with the operator. If it is generated content, consider "
+            "documents/prototypes/ or documents/archive/. If it belongs to a "
+            "specific push, move it inside the push folder by hand and re-run "
+            "the plan. If unsure, leave in place."
+        ),
+    }
 
 
 def _classify_campaign_folder(folder: Path, repo: Path) -> dict[str, Any]:
@@ -534,7 +623,8 @@ def _classify_campaign_folder(folder: Path, repo: Path) -> dict[str, Any]:
     if not record.is_file():
         # No campaign.md -- this is generated material, not a coordinated push.
         # Per the rubric, do not auto-promote into pushes/.
-        contents = _enumerate_folder_contents(folder, repo)
+        recognized, unrecognized = _enumerate_folder_contents(folder, repo)
+        contents = recognized + unrecognized
         return {
             "kind": "ambiguous",
             "from": rel,
@@ -547,7 +637,7 @@ def _classify_campaign_folder(folder: Path, repo: Path) -> dict[str, Any]:
         }
 
     frontmatter = _read_campaign_frontmatter(record)
-    inferred = _infer_push_date(folder.name, frontmatter)
+    inferred = _infer_push_date_with_git(folder.name, frontmatter, record, repo)
     slug = _slug_without_date_prefix(folder.name)
     if inferred is None:
         return {
@@ -555,8 +645,8 @@ def _classify_campaign_folder(folder: Path, repo: Path) -> dict[str, Any]:
             "from": rel,
             "reason": (
                 "cannot infer a date for the push folder name. Folder has no "
-                "YYYY-MM-DD or YYYY-MM prefix and frontmatter has no `started` "
-                "or `review_on` date."
+                "YYYY-MM-DD or YYYY-MM prefix, frontmatter has no `started` or "
+                "`review_on` date, and the file has no git history."
             ),
             "suggestion": (
                 "add `started: YYYY-MM-DD` to the campaign.md frontmatter or "
@@ -566,7 +656,7 @@ def _classify_campaign_folder(folder: Path, repo: Path) -> dict[str, Any]:
     date_str, date_source = inferred
     push_folder = f"pushes/{date_str}-{slug}"
     push_record_rel = f"{push_folder}/push.md"
-    folder_contents = _enumerate_folder_contents(folder, repo)
+    move_with_push, review_inside_folder = _enumerate_folder_contents(folder, repo)
     frontmatter_changes: list[str] = []
     if frontmatter.get("type") == "campaign":
         frontmatter_changes.append("type: campaign -> type: push")
@@ -582,6 +672,11 @@ def _classify_campaign_folder(folder: Path, repo: Path) -> dict[str, Any]:
             "provider_refs.meta_ads.campaign_id preserved (Meta's term for its object, "
             "not the engine primitive)"
         )
+    if review_inside_folder:
+        notes.append(
+            "unrecognized files inside this folder will NOT auto-move with the push; "
+            "see review_inside_folder for the operator-review list"
+        )
     return {
         "kind": "move",
         "from": rel,
@@ -590,7 +685,8 @@ def _classify_campaign_folder(folder: Path, repo: Path) -> dict[str, Any]:
         "date_source": date_source,
         "slug": slug,
         "frontmatter_changes": frontmatter_changes,
-        "folder_contents": folder_contents,
+        "move_with_push": move_with_push,
+        "review_inside_folder": review_inside_folder,
         "notes": notes,
     }
 
@@ -624,13 +720,28 @@ def plan_campaigns_to_pushes(repo: str | Path = ".") -> dict[str, Any]:
         envelope["next"] = "no legacy campaigns/ folder; nothing to migrate"
         return envelope
 
-    children = [child for child in sorted(campaigns_dir.iterdir()) if child.is_dir()]
-    if not children:
+    direct_children = [
+        child for child in sorted(campaigns_dir.iterdir()) if child.name != ".gitkeep"
+    ]
+    if not direct_children:
         envelope["next"] = "campaigns/ folder is empty; nothing to migrate"
         return envelope
 
-    for folder in children:
-        classification = _classify_campaign_folder(folder, target)
+    for child in direct_children:
+        if child.is_file():
+            classification = _classify_loose_top_level_file(child, target)
+        elif child.is_dir():
+            classification = _classify_campaign_folder(child, target)
+        else:
+            # Symlink or other; skip with a conservative ambiguous entry.
+            classification = {
+                "kind": "ambiguous",
+                "from": child.relative_to(target).as_posix(),
+                "reason": "non-file, non-directory entry under campaigns/",
+                "suggestion": (
+                    "review with the operator; the migrate planner does not touch symlinks."
+                ),
+            }
         kind = classification.pop("kind")
         if kind == "move":
             envelope["moves"].append(classification)

--- a/mb/mb/onboard.py
+++ b/mb/mb/onboard.py
@@ -169,7 +169,10 @@ def _initial_state(
             "state_path": str(ONBOARDING_STATE_RELATIVE_PATH),
             "canonical_business_truth": [
                 "accepted offer, audience, voice, proof, decisions, and durable summaries",
-                "files under core/, research/, decisions/, bets/, campaigns/, log/, and documents/",
+                (
+                    "files under core/, research/, decisions/, bets/, "
+                    "pushes/ (legacy campaigns/), log/, and documents/"
+                ),
             ],
             "operational_progress": [
                 "checklist state, missing input labels, persona/team-size routing, and next action",

--- a/mb/mb/status.py
+++ b/mb/mb/status.py
@@ -26,6 +26,7 @@ IMPORTANT_DIRS = (
     "research",
     "decisions",
     "bets",
+    "pushes",
     "campaigns",
     "log",
     "documents",
@@ -155,6 +156,7 @@ def _git_recent_activity(repo: Path, git: dict[str, Any]) -> dict[str, Any]:
         "reference/core",
         "research",
         "decisions",
+        "pushes",
         "campaigns",
         "log",
         "documents",
@@ -587,7 +589,8 @@ def _resolve_site_repo_path(repo: Path, value: Any) -> Path | None:
 
 
 def _candidate_site_repo_records(repo: Path) -> list[dict[str, Any]]:
-    paths = _relative_markdown_files(repo, "campaigns")
+    paths = _relative_markdown_files(repo, "pushes")
+    paths.extend(_relative_markdown_files(repo, "campaigns"))
     paths.extend(path for path in _relative_markdown_files(repo, "core") if path.name == "offer.md")
     paths.extend(
         path for path in _relative_markdown_files(repo, "reference/core") if path.name == "offer.md"
@@ -1200,11 +1203,16 @@ def render_human(
             console.print(f"  next: {measurement['repair']}")
 
     counts = brain["counts"]
+    pushes_count = counts.get("pushes", 0)
+    campaigns_count = counts.get("campaigns", 0)
+    pushes_segment = f"pushes {pushes_count}"
+    if campaigns_count:
+        pushes_segment += f" (legacy campaigns {campaigns_count})"
     console.print(
         "[bold]Brain[/bold] "
         f"core {counts['core'] + counts['reference/core']}  "
         f"research {counts['research']}  decisions {counts['decisions']}  "
-        f"bets {counts['bets']}  campaigns {counts['campaigns']}  "
+        f"bets {counts['bets']}  {pushes_segment}  "
         f"log {counts['log']}  documents {counts['documents']}"
     )
 

--- a/mb/mb/validate.py
+++ b/mb/mb/validate.py
@@ -44,6 +44,7 @@ LINK_FIELDS = (
     "linked_research",
     "linked_decision",
     "linked_decisions",
+    "linked_pushes",
     "linked_campaigns",
     "linked_outcomes",
     "linked_prd",
@@ -64,6 +65,7 @@ LOCAL_REF_ROOTS = {
     "documents",
     "log",
     "outputs",
+    "pushes",
     "reference",
     "research",
 }
@@ -113,6 +115,10 @@ SCHEMAS: dict[str, dict[str, Any]] = {
     },
     "bets": {
         "glob": "bets/*.md",
+        # `linked_campaigns` stays required for backward compatibility with
+        # every committed bet. New bet writes also include `linked_pushes`
+        # (canonical, recognized in LINK_FIELDS). A follow-up PR can drop
+        # `linked_campaigns` from required once the migration apply lands.
         "required": [
             "status",
             "opened",
@@ -139,6 +145,11 @@ SCHEMAS: dict[str, dict[str, Any]] = {
     },
     "campaigns": {
         "glob": "campaigns/*/campaign.md",
+        "required": ["slug", "status"],
+        "enums": {"status": CAMPAIGN_STATUS},
+    },
+    "pushes": {
+        "glob": "pushes/*/push.md",
         "required": ["slug", "status"],
         "enums": {"status": CAMPAIGN_STATUS},
     },
@@ -311,7 +322,7 @@ def _status_order_for(path: Path) -> dict[str, int] | None:
     parts = path.parts
     if "decisions" in parts:
         return DECISION_STATUS_ORDER
-    if "campaigns" in parts:
+    if "pushes" in parts or "campaigns" in parts:
         return CAMPAIGN_STATUS_ORDER
     if "offers" in parts:
         return OFFER_STATUS_ORDER
@@ -414,6 +425,8 @@ def _reverse_bet_field(source: Path, repo: Path) -> str:
         return "linked_decisions"
     if section == "research":
         return "linked_research"
+    if section == "pushes":
+        return "linked_pushes"
     if section == "campaigns":
         return "linked_campaigns"
     if section in {"log", "documents"}:
@@ -443,6 +456,7 @@ def _check_bet_backlink(
         in {
             "linked_decisions",
             "linked_research",
+            "linked_pushes",
             "linked_campaigns",
             "linked_outcomes",
         }

--- a/mb/tests/test_checkpoint.py
+++ b/mb/tests/test_checkpoint.py
@@ -51,7 +51,7 @@ def test_checkpoint_plan_classifies_dirty_business_files(tmp_path: Path) -> None
     repo = _business_repo(tmp_path)
     (repo / "core" / "offer.md").write_text("# Offer\n", encoding="utf-8")
     (repo / "decisions" / "2026-05-05-test.md").write_text("# Decision\n", encoding="utf-8")
-    (repo / "campaigns" / "paid.md").write_text("# Campaign\n", encoding="utf-8")
+    (repo / "pushes" / "paid.md").write_text("# Push\n", encoding="utf-8")
 
     report = checkpoint_mod.plan(repo)
 
@@ -60,15 +60,15 @@ def test_checkpoint_plan_classifies_dirty_business_files(tmp_path: Path) -> None
     assert report["summary"]["changed_files"] == 3
     assert report["summary"]["surfaces"] == {
         "core": 1,
-        "campaigns": 1,
+        "pushes": 1,
         "decisions": 1,
     }
-    assert report["proposal"]["message"] == "[checkpoint] Update core, campaigns, and decisions"
+    assert report["proposal"]["message"] == "[checkpoint] Update core, pushes, and decisions"
     paths = {change["path"] for change in report["changes"]}
     assert paths == {
         "core/offer.md",
         "decisions/2026-05-05-test.md",
-        "campaigns/paid.md",
+        "pushes/paid.md",
     }
 
 

--- a/mb/tests/test_doctor.py
+++ b/mb/tests/test_doctor.py
@@ -173,6 +173,60 @@ def test_doctor_repair_plan_is_read_only_for_status_marker(tmp_path: Path) -> No
     assert not marker.exists()
 
 
+def test_doctor_warns_on_legacy_campaigns_records(tmp_path: Path) -> None:
+    repo = tmp_path / "legacy-pushes"
+    init_run(path=str(repo), name="Acme")
+    legacy = repo / "campaigns" / "2026-04-spring-launch"
+    legacy.mkdir(parents=True)
+    (legacy / "campaign.md").write_text(
+        "---\nslug: spring-launch\nstatus: active\n---\n# spring launch\n",
+        encoding="utf-8",
+    )
+
+    report = doctor_mod.run(path=str(repo))
+
+    legacy_check = next(c for c in report["checks"] if c["name"] == "legacy-campaigns")
+    assert legacy_check["ok"] is False
+    assert legacy_check["severity"] == "warn"
+    assert "1 legacy campaign record" in legacy_check["detail"]
+    assert "mb migrate campaigns --plan" in legacy_check["detail"]
+    assert legacy_check["legacy_records"] == ["campaigns/2026-04-spring-launch/campaign.md"]
+
+
+def test_doctor_clean_repo_has_no_legacy_campaigns_warning(tmp_path: Path) -> None:
+    repo = tmp_path / "fresh"
+    init_run(path=str(repo), name="Acme")
+
+    report = doctor_mod.run(path=str(repo))
+
+    legacy_check = next(c for c in report["checks"] if c["name"] == "legacy-campaigns")
+    # `mb init` no longer scaffolds campaigns/, so there is nothing to warn on.
+    assert legacy_check["ok"] is True
+    assert legacy_check.get("severity") in {"ok", None}
+
+
+def test_doctor_repair_plan_exposes_legacy_campaigns_to_pushes_action(tmp_path: Path) -> None:
+    repo = tmp_path / "legacy-pushes-repair"
+    init_run(path=str(repo), name="Acme")
+    legacy = repo / "campaigns" / "2026-04-spring-launch"
+    legacy.mkdir(parents=True)
+    (legacy / "campaign.md").write_text(
+        "---\nslug: spring-launch\nstatus: active\n---\n# spring launch\n",
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["doctor", "repair", "--repo", str(repo), "--plan", "--json"])
+
+    assert result.exit_code in {0, 1}
+    payload = json.loads(result.stdout)
+    actions = {action["id"]: action for action in payload["actions"]}
+    assert "legacy_campaigns_to_pushes" in actions
+    item = actions["legacy_campaigns_to_pushes"]
+    assert item["mode"] == "read"
+    assert item["safe_to_apply"] is True
+    assert item["command"] == "mb migrate campaigns --plan"
+
+
 def test_doctor_repair_plan_distinguishes_read_and_write_actions(tmp_path: Path) -> None:
     repo = tmp_path / "legacy"
     (repo / "reference" / "core").mkdir(parents=True)

--- a/mb/tests/test_doctor.py
+++ b/mb/tests/test_doctor.py
@@ -193,6 +193,29 @@ def test_doctor_warns_on_legacy_campaigns_records(tmp_path: Path) -> None:
     assert legacy_check["legacy_records"] == ["campaigns/2026-04-spring-launch/campaign.md"]
 
 
+def test_doctor_uses_campaigns_migration_plan_for_ambiguous_artifacts(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "legacy-pushes-with-artifacts"
+    init_run(path=str(repo), name="Acme")
+    legacy = repo / "campaigns" / "2026-04-15-spring-launch"
+    legacy.mkdir(parents=True)
+    (legacy / "campaign.md").write_text(
+        "---\nslug: spring-launch\nstatus: active\n---\n# spring launch\n",
+        encoding="utf-8",
+    )
+    (legacy / "ads.md").write_text("# ads\n", encoding="utf-8")
+    (legacy / "random-notes.md").write_text("# random\n", encoding="utf-8")
+
+    report = doctor_mod.run(path=str(repo))
+
+    legacy_check = next(c for c in report["checks"] if c["name"] == "legacy-campaigns")
+    assert legacy_check["ok"] is False
+    assert legacy_check["legacy_records"] == ["campaigns/2026-04-15-spring-launch/campaign.md"]
+    assert "campaigns/2026-04-15-spring-launch/ads.md" not in legacy_check["ambiguous_files"]
+    assert "campaigns/2026-04-15-spring-launch/random-notes.md" in legacy_check["ambiguous_files"]
+
+
 def test_doctor_clean_repo_has_no_legacy_campaigns_warning(tmp_path: Path) -> None:
     repo = tmp_path / "fresh"
     init_run(path=str(repo), name="Acme")

--- a/mb/tests/test_init.py
+++ b/mb/tests/test_init.py
@@ -20,6 +20,15 @@ def test_init_scaffolds_folders(tmp_path: Path) -> None:
     assert (target / "core" / "strategy").is_dir()
     assert (target / "core" / "operations").is_dir()
     assert (target / "bets").is_dir()
+    # Canonical primitive is `pushes/`; legacy `campaigns/` is not scaffolded.
+    assert (target / "pushes").is_dir()
+    assert not (target / "campaigns").exists()
+    # Operator vocabulary is an optional file scaffolded by init.
+    assert (target / "core" / "vocabulary.md").exists()
+    vocab = (target / "core" / "vocabulary.md").read_text(encoding="utf-8")
+    assert "type: vocabulary" in vocab
+    assert "terms:" in vocab
+    assert "singular: push" in vocab
     assert (target / "CLAUDE.md").exists()
     assert (target / ".github" / "CODEOWNERS").exists()
     assert (target / ".gitignore").exists()
@@ -48,6 +57,11 @@ def test_init_scaffolds_folders(tmp_path: Path) -> None:
     assert "MCP tokens" in claude_md
     assert "Never commit API keys" in claude_md
     assert "`bets/`" in claude_md
+    # CLAUDE.md teaches the canonical push primitive and the optional
+    # vocabulary file; legacy campaigns/ appears only as compatibility.
+    assert "`pushes/`" in claude_md
+    assert "core/vocabulary.md" in claude_md
+    assert "legacy `campaigns/`" in claude_md
 
 
 def test_init_idempotent(tmp_path: Path) -> None:

--- a/mb/tests/test_migrate.py
+++ b/mb/tests/test_migrate.py
@@ -540,6 +540,30 @@ def test_migrate_campaigns_cli_plan_emits_machine_readable_json(tmp_path: Path) 
     assert payload["moves"][0]["to"] == "pushes/2026-04-15-spring-launch/push.md"
 
 
+def test_migrate_campaigns_cli_plan_renders_move_children_for_humans(
+    tmp_path: Path,
+) -> None:
+    folder = tmp_path / "campaigns" / "2026-04-15-spring-launch"
+    folder.mkdir(parents=True)
+    (folder / "campaign.md").write_text(
+        "---\nslug: spring-launch\nstatus: active\n---\n# spring\n",
+        encoding="utf-8",
+    )
+    (folder / "ads.md").write_text("# ads\n", encoding="utf-8")
+    (folder / "random-notes.md").write_text("# random\n", encoding="utf-8")
+
+    result = runner.invoke(
+        app,
+        ["migrate", "--repo", str(tmp_path), "campaigns", "--plan"],
+    )
+
+    assert result.exit_code == 0
+    assert "move with push: 1 item(s)" in result.stdout
+    assert "campaigns/2026-04-15-spring-launch/ads.md" in result.stdout
+    assert "review before apply: 1 item(s)" in result.stdout
+    assert "campaigns/2026-04-15-spring-launch/random-notes.md" in result.stdout
+
+
 def test_migrate_campaigns_cli_without_plan_flag_refuses(tmp_path: Path) -> None:
     """Apply is not yet implemented; the command refuses without --plan."""
     result = runner.invoke(

--- a/mb/tests/test_migrate.py
+++ b/mb/tests/test_migrate.py
@@ -299,3 +299,147 @@ def test_migrate_status_clean_current_repo(tmp_path: Path) -> None:
 
 def test_migration_version_map_is_derived_from_registered_metadata() -> None:
     assert migrations.version_map()["0.1"] == "mb.migrations.001_v01_to_v02_path_config"
+
+
+# ---------------------------------------------------------------------------
+# campaigns -> pushes plan-only migration (MAIN-249)
+# ---------------------------------------------------------------------------
+
+
+def test_plan_campaigns_no_legacy_folder_is_a_clean_noop(tmp_path: Path) -> None:
+    result = migrate_mod.plan_campaigns_to_pushes(tmp_path)
+
+    assert result["schema"] == migrate_mod.CAMPAIGNS_PLAN_SCHEMA
+    assert result["ok"] is True
+    assert result["summary"] == {"moves": 0, "ambiguous": 0, "blockers": 0}
+    assert "no legacy campaigns/" in result["next"]
+
+
+def test_plan_campaigns_classifies_dated_folder_as_move(tmp_path: Path) -> None:
+    folder = tmp_path / "campaigns" / "2026-04-15-spring-launch"
+    folder.mkdir(parents=True)
+    (folder / "campaign.md").write_text(
+        "---\n"
+        "type: campaign\n"
+        "slug: spring-launch\n"
+        "status: active\n"
+        "started: 2026-04-15\n"
+        "linked_campaigns: []\n"
+        "provider_refs:\n"
+        "  meta_ads:\n"
+        "    campaign_id: '123'\n"
+        "---\n"
+        "# Spring Launch\n",
+        encoding="utf-8",
+    )
+    (folder / "ads.md").write_text("# ads\n", encoding="utf-8")
+    (folder / "review-log.md").write_text("# review log\n", encoding="utf-8")
+
+    result = migrate_mod.plan_campaigns_to_pushes(tmp_path)
+
+    assert result["summary"] == {"moves": 1, "ambiguous": 0, "blockers": 0}
+    move = result["moves"][0]
+    assert move["from"] == "campaigns/2026-04-15-spring-launch"
+    assert move["to"] == "pushes/2026-04-15-spring-launch/push.md"
+    assert move["date"] == "2026-04-15"
+    assert move["date_source"] == "folder.day-prefix"
+    assert "type: campaign -> type: push" in move["frontmatter_changes"]
+    assert "linked_campaigns -> linked_pushes (rename)" in move["frontmatter_changes"]
+    assert any("provider_refs.meta_ads.campaign_id" in note for note in move["notes"])
+    assert "campaigns/2026-04-15-spring-launch/ads.md" in move["folder_contents"]
+
+
+def test_plan_campaigns_uses_month_prefix_when_only_month_is_present(tmp_path: Path) -> None:
+    folder = tmp_path / "campaigns" / "2026-04-spring"
+    folder.mkdir(parents=True)
+    (folder / "campaign.md").write_text(
+        "---\nslug: spring\nstatus: active\n---\n# spring\n",
+        encoding="utf-8",
+    )
+
+    result = migrate_mod.plan_campaigns_to_pushes(tmp_path)
+
+    assert result["summary"]["moves"] == 1
+    move = result["moves"][0]
+    assert move["date"] == "2026-04-01"
+    assert move["date_source"] == "folder.month-prefix"
+    assert move["to"] == "pushes/2026-04-01-spring/push.md"
+
+
+def test_plan_campaigns_uses_frontmatter_date_when_folder_has_no_prefix(tmp_path: Path) -> None:
+    folder = tmp_path / "campaigns" / "spring-launch"
+    folder.mkdir(parents=True)
+    (folder / "campaign.md").write_text(
+        "---\nslug: spring-launch\nstatus: active\nstarted: 2026-04-15\n---\n# spring\n",
+        encoding="utf-8",
+    )
+
+    result = migrate_mod.plan_campaigns_to_pushes(tmp_path)
+
+    assert result["summary"]["moves"] == 1
+    move = result["moves"][0]
+    assert move["date"] == "2026-04-15"
+    assert move["date_source"] == "frontmatter.started"
+
+
+def test_plan_campaigns_blocks_when_no_date_is_inferable(tmp_path: Path) -> None:
+    folder = tmp_path / "campaigns" / "spring-launch"
+    folder.mkdir(parents=True)
+    (folder / "campaign.md").write_text(
+        "---\nslug: spring-launch\nstatus: active\n---\n# spring\n",
+        encoding="utf-8",
+    )
+
+    result = migrate_mod.plan_campaigns_to_pushes(tmp_path)
+
+    assert result["summary"]["blockers"] == 1
+    assert result["ok"] is False
+    blocker = result["blockers"][0]
+    assert "cannot infer a date" in blocker["reason"]
+
+
+def test_plan_campaigns_routes_subfolder_without_campaign_md_to_ambiguous(tmp_path: Path) -> None:
+    # Per the rubric, ambiguous generated folders (e.g. campaigns/organic-scripts/)
+    # should not be auto-promoted to pushes. They surface for operator review.
+    folder = tmp_path / "campaigns" / "organic-scripts"
+    folder.mkdir(parents=True)
+    (folder / "post-1.md").write_text("# post 1\n", encoding="utf-8")
+    (folder / "post-2.md").write_text("# post 2\n", encoding="utf-8")
+
+    result = migrate_mod.plan_campaigns_to_pushes(tmp_path)
+
+    assert result["summary"] == {"moves": 0, "ambiguous": 1, "blockers": 0}
+    ambiguous = result["ambiguous"][0]
+    assert ambiguous["from"] == "campaigns/organic-scripts"
+    assert "no campaign.md" in ambiguous["reason"]
+
+
+def test_migrate_campaigns_cli_plan_emits_machine_readable_json(tmp_path: Path) -> None:
+    folder = tmp_path / "campaigns" / "2026-04-15-spring-launch"
+    folder.mkdir(parents=True)
+    (folder / "campaign.md").write_text(
+        "---\nslug: spring-launch\nstatus: active\n---\n# spring\n",
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(
+        app,
+        ["migrate", "--repo", str(tmp_path), "campaigns", "--plan", "--json"],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["schema"] == migrate_mod.CAMPAIGNS_PLAN_SCHEMA
+    assert payload["summary"]["moves"] == 1
+    assert payload["moves"][0]["to"] == "pushes/2026-04-15-spring-launch/push.md"
+
+
+def test_migrate_campaigns_cli_without_plan_flag_refuses(tmp_path: Path) -> None:
+    """Apply is not yet implemented; the command refuses without --plan."""
+    result = runner.invoke(
+        app,
+        ["migrate", "--repo", str(tmp_path), "campaigns"],
+    )
+
+    assert result.exit_code == 2
+    assert "--plan is required" in result.stderr or "--plan is required" in (result.output or "")

--- a/mb/tests/test_migrate.py
+++ b/mb/tests/test_migrate.py
@@ -346,7 +346,113 @@ def test_plan_campaigns_classifies_dated_folder_as_move(tmp_path: Path) -> None:
     assert "type: campaign -> type: push" in move["frontmatter_changes"]
     assert "linked_campaigns -> linked_pushes (rename)" in move["frontmatter_changes"]
     assert any("provider_refs.meta_ads.campaign_id" in note for note in move["notes"])
-    assert "campaigns/2026-04-15-spring-launch/ads.md" in move["folder_contents"]
+    # ads.md and review-log.md are recognized push artifacts and auto-move with the push.
+    assert "campaigns/2026-04-15-spring-launch/ads.md" in move["move_with_push"]
+    assert "campaigns/2026-04-15-spring-launch/review-log.md" in move["move_with_push"]
+    assert move["review_inside_folder"] == []
+
+
+def test_plan_campaigns_flags_unrecognized_files_inside_a_move_for_review(
+    tmp_path: Path,
+) -> None:
+    """Per the rubric, only recognized push artifacts auto-move with the push.
+
+    Unrecognized files inside the campaign folder (e.g. random notes, non-push
+    subfolders) should NOT be auto-promoted; they surface for operator review.
+    """
+    folder = tmp_path / "campaigns" / "2026-04-15-spring-launch"
+    folder.mkdir(parents=True)
+    (folder / "campaign.md").write_text(
+        "---\nslug: spring-launch\nstatus: active\nstarted: 2026-04-15\n---\n# spring\n",
+        encoding="utf-8",
+    )
+    (folder / "ads.md").write_text("# ads\n", encoding="utf-8")  # recognized
+    (folder / "random-notes.md").write_text("# random\n", encoding="utf-8")  # unrecognized
+    (folder / "weird-subdir").mkdir()  # unrecognized folder
+    (folder / "weird-subdir" / "thing.md").write_text("# thing\n", encoding="utf-8")
+
+    result = migrate_mod.plan_campaigns_to_pushes(tmp_path)
+
+    move = result["moves"][0]
+    assert "campaigns/2026-04-15-spring-launch/ads.md" in move["move_with_push"]
+    assert "campaigns/2026-04-15-spring-launch/random-notes.md" in move["review_inside_folder"]
+    assert "campaigns/2026-04-15-spring-launch/weird-subdir" in move["review_inside_folder"]
+    assert any(
+        "unrecognized files inside this folder will NOT auto-move" in note for note in move["notes"]
+    )
+
+
+def test_plan_campaigns_classifies_loose_top_level_file_as_ambiguous(tmp_path: Path) -> None:
+    """A file directly under campaigns/ (not inside a push folder) is ambiguous.
+
+    Doctor flags these as ambiguous_files; migrate must agree, not silently
+    skip them by walking only directories.
+    """
+    (tmp_path / "campaigns").mkdir()
+    (tmp_path / "campaigns" / "loose.md").write_text("# loose\n", encoding="utf-8")
+
+    result = migrate_mod.plan_campaigns_to_pushes(tmp_path)
+
+    assert result["summary"] == {"moves": 0, "ambiguous": 1, "blockers": 0}
+    ambiguous = result["ambiguous"][0]
+    assert ambiguous["from"] == "campaigns/loose.md"
+    assert "loose file at the top of campaigns/" in ambiguous["reason"]
+
+
+def test_plan_campaigns_uses_git_first_added_date_when_other_signals_are_missing(
+    tmp_path: Path,
+) -> None:
+    """Migration Rubric: folder prefix > frontmatter > git first-added.
+
+    A repo with a real git history exposes the file's first-added date; the
+    planner uses it when no other signal is available.
+    """
+    repo = tmp_path / "biz"
+    repo.mkdir()
+    folder = repo / "campaigns" / "spring-launch"
+    folder.mkdir(parents=True)
+    record = folder / "campaign.md"
+    record.write_text(
+        "---\nslug: spring-launch\nstatus: active\n---\n# spring\n",
+        encoding="utf-8",
+    )
+
+    import subprocess
+
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        cwd=repo,
+        check=True,
+    )
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=repo, check=True)
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "commit.gpgsign=false",
+            "commit",
+            "-m",
+            "initial",
+            "--date",
+            "2026-04-10T00:00:00",
+        ],
+        cwd=repo,
+        check=True,
+        env={
+            "GIT_AUTHOR_DATE": "2026-04-10T00:00:00",
+            "GIT_COMMITTER_DATE": "2026-04-10T00:00:00",
+            "PATH": "/usr/bin:/bin:/usr/local/bin",
+        },
+    )
+
+    result = migrate_mod.plan_campaigns_to_pushes(repo)
+
+    assert result["summary"]["moves"] == 1
+    move = result["moves"][0]
+    assert move["date"] == "2026-04-10"
+    assert move["date_source"] == "git.first-added"
 
 
 def test_plan_campaigns_uses_month_prefix_when_only_month_is_present(tmp_path: Path) -> None:

--- a/mb/tests/test_site.py
+++ b/mb/tests/test_site.py
@@ -363,7 +363,7 @@ def test_status_follows_business_repo_site_record_for_measurement(
         ),
         encoding="utf-8",
     )
-    (business / "campaigns" / "paid-site.md").write_text(
+    (business / "pushes" / "paid-site.md").write_text(
         f"---\nsite_repo_path: {site}\n---\n\n# Paid Site\n",
         encoding="utf-8",
     )
@@ -385,4 +385,4 @@ def test_status_follows_business_repo_site_record_for_measurement(
     assert payload["measurement"]["available"] is True
     assert payload["measurement"]["site_repo"] == str(site.resolve())
     assert payload["measurement"]["business_repo"] == str(business.resolve())
-    assert payload["measurement"]["source_record"] == "campaigns/paid-site.md"
+    assert payload["measurement"]["source_record"] == "pushes/paid-site.md"

--- a/mb/tests/test_validate.py
+++ b/mb/tests/test_validate.py
@@ -554,6 +554,82 @@ def test_validate_flags_unknown_campaign_status(tmp_path: Path) -> None:
     assert any("status" in e for f in bad for e in f["errors"])
 
 
+def _push(status: str, slug: str = "workshop-waitlist") -> str:
+    return f"---\nslug: {slug}\nstatus: {status}\n---\n# {slug}\n"
+
+
+def test_validate_accepts_push_lifecycle_statuses(tmp_path: Path) -> None:
+    for status in ("draft", "planned", "active", "paused", "completed", "canceled", "archived"):
+        path = tmp_path / "pushes" / f"2026-05-06-{status}-push" / "push.md"
+        _write(path, _push(status, slug=f"{status}-push"))
+
+    report = run(path=str(tmp_path))
+
+    assert report["ok"] is True, report
+    push_files = [f for f in report["files"] if "pushes/" in f["path"]]
+    assert len(push_files) == 7
+    assert all(f["ok"] for f in push_files)
+
+
+def test_validate_rejects_unknown_push_status(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "pushes" / "2026-05-06-typo" / "push.md",
+        _push("live"),  # operator-vocab synonym; not engine canonical
+    )
+
+    report = run(path=str(tmp_path))
+
+    assert report["ok"] is False
+
+
+def test_cross_refs_resolve_linked_pushes_field(tmp_path: Path) -> None:
+    """linked_pushes is recognized as a graph link field and must resolve."""
+    _write(
+        tmp_path / "pushes" / "2026-05-06-target" / "push.md",
+        _push("active", slug="target"),
+    )
+    _write(
+        tmp_path / "decisions" / "2026-05-06-with-link.md",
+        (
+            "---\n"
+            "date: 2026-05-06\n"
+            "status: accepted\n"
+            "linked_pushes:\n"
+            "  - pushes/2026-05-06-target/push.md\n"
+            "---\n"
+            "# decision\n"
+        ),
+    )
+
+    report = run(path=str(tmp_path), cross_refs=True)
+
+    assert report["ok"] is True
+    assert report["summary"]["warnings"] == 0
+
+
+def test_cross_refs_warn_on_missing_linked_pushes_target(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "decisions" / "2026-05-06-broken.md",
+        (
+            "---\n"
+            "date: 2026-05-06\n"
+            "status: accepted\n"
+            "linked_pushes:\n"
+            "  - pushes/2026-05-06-missing/push.md\n"
+            "---\n"
+            "# broken\n"
+        ),
+    )
+
+    report = run(path=str(tmp_path), cross_refs=True)
+
+    assert report["ok"] is True
+    assert report["summary"]["warnings"] == 1
+    finding = report["cross_refs"]["warnings"][0]
+    assert finding["code"] == "missing-target"
+    assert finding["field"] == "linked_pushes"
+
+
 def test_cross_refs_flag_campaign_status_transition_regressions(tmp_path: Path) -> None:
     # A newer campaign supersedes an older one but reports a status earlier
     # in the campaign lifecycle. The status-transition checker should flag it


### PR DESCRIPTION
## Summary
- Makes `pushes/` the current canonical home for coordinated work in fresh repos while preserving legacy `campaigns/` compatibility.
- Wires `pushes/` through init/onboard scaffolding, validation, graph/status/checkpoint indexing, and public setup docs.
- Adds warn-level legacy campaigns drift detection plus a read-only `mb migrate campaigns --plan` preview that classifies safe moves, ambiguous paths, and blockers.
- Updates the top write-heavy bundled skills to create new work under `pushes/`, read `core/vocabulary.md` when present, and keep provider use of "campaign" as provider vocabulary.
- Leaves the migration apply path and advanced push schema polish to follow-up work.

## Scope
- In: `mb init`/`mb onboard` scaffolding, `core/vocabulary.md` template, push validation/linking, graph/status/checkpoint indexing, doctor drift detection, read-only campaigns migration planning, priority skill routing, and public docs/changelog updates.
- Out: `mb migrate campaigns --apply`, private repo migration, `outputs/` bulk classification, advanced push fields from #323 (`kind`, health, structured goal, owner, audience, promise), and JSON key cleanup beyond additive compatibility.

## Commits
- fd5bce6 — `[update] mb init scaffolds pushes/ and optional core/vocabulary.md`
- 15d9f35 — `[add] Validate and graph index pushes/ as canonical alongside campaigns/`
- 812a5da — `[update] Status and checkpoint index pushes alongside campaigns`
- 7fdc0c8 — `[add] mb doctor detects legacy campaigns/ records as drift`
- c3d2579 — `[add] mb migrate campaigns --plan preview`
- ff39d19 — `[update] Top-priority skills route new coordinated work to pushes/`
- f680eaa — `[docs] Note MAIN-249 push routing in changelog`
- 4bb581b — `[fix] Tighten campaigns->pushes plan and silence mypy union-attr`
- a85c3ad — `[fix] Stop active skill paths from writing new campaigns/`
- e1ba818 — `[docs] Update first-run public docs to describe pushes/ as current`
- e593314 — `[fix] Close MAIN-249 review gaps`

## Release / Issues
- Release: Unreleased
- Linear ID(s): MAIN-249
- Closes: #324
- Refs: #323, #321, #327, #328, #330, #329, #331
- Follow-ups: implement `mb migrate campaigns --apply`; finish #323 deterministic push schema/JSON polish; run/record Claude Code runtime smoke if local auth/UI permits.

## Success Metric
- A fresh Main Branch repo no longer teaches users or priority skills to create new `campaigns/` debt, while existing legacy `campaigns/` repos remain readable and get an explicit doctor/migration-preview path.

## Validation
- Level 0 docs/decision: README, setup/migration docs, architecture docs, link conventions, PRD examples, and CHANGELOG reviewed for `pushes/` as current and `campaigns/` as legacy compatibility.
- Level 1 static: `scripts/check.sh` passed from repo root after the follow-up fixes.
- Level 2 CLI: focused doctor/migrate tests passed (`45 passed`), and the full check suite passed (`267 passed`, ruff, mypy, coverage, skill validation).
- Level 3 package/install: built wheel, installed into `/tmp/mainbranch-main249-package-smoke`, verified `mb --version`, `mb skill list`, fresh `mb init`, and `mb validate`.
- Level 4 fixture repo: fresh fixture smoke passed for `mb init`, `mb status --json --peek`, and `mb validate`; legacy campaigns fixture smoke passed for `mb doctor --json` and `mb migrate campaigns --plan` with recognized `ads.md` moved with the push and `random-notes.md` held for review.
- Level 5 runtime smoke: not run; Claude Code runtime discovery/manual invocation still needs a reviewer/operator smoke because bundled skill prose changed materially.

## Public / Private Boundary
- Public examples remain generic and repo-relative; no private Devon/Conductor paths, customer/member data, credentials, or raw provider data were added. Temporary smoke artifacts were kept under `/tmp`.