### PR TITLE
[update] Prepare 0.3.3 release

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mainbranch",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Main Branch Claude Code skills for running a business from markdown files in git.",
   "author": {
     "name": "Noontide"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,26 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+## [0.3.3] - 2026-05-06
+
+v0.3.3 turns the campaign architecture work into the clearer push primitive.
+It adds canonical `pushes/` scaffolding and validation, keeps legacy
+`campaigns/` readable during migration, and splits `/mb-site` into smaller
+runtime-loadable references.
+
+### What this means for you (plain English)
+
+- **Your business can use its own words.** Main Branch stores the canonical
+  primitive as a `push`, while `core/vocabulary.md` lets an operator call that
+  work a launch, drop, challenge, promo, campaign, or another local term.
+- **New repos start in the new shape.** `mb init` and `mb onboard` now scaffold
+  `pushes/`; existing `campaigns/` records still read as compatibility input.
+- **Push records are checkable.** `mb validate`, `mb status --json --peek`,
+  `mb start --json`, and `mb graph --json` now expose canonical push facts and
+  schema errors.
+- **Site work loads less context.** `/mb-site` is now a compact router with
+  focused minisite references instead of one large skill document.
+
 ### Added (MAIN-248 / #323)
 
 - `mb validate` now enforces the canonical `pushes/<YYYY-MM-DD-slug>/push.md`
@@ -103,6 +123,15 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ### Changed
 
+- Defined `campaigns/` as the first coordinated-push model, refreshed the
+  system architecture model around current business-repo folders, and blessed
+  `documents/transcripts/`, `documents/prototypes/`, and `documents/archive/`
+  for non-campaign artifacts before the later `pushes/` decision superseded the
+  storage name in part. Refs #321.
+- Refactored `/mb-site` into a compact router with progressively loadable
+  minisite step references, and split examples from troubleshooting so agents
+  can load only the detail needed for the current site step. Refs #107 and
+  #110.
 - The campaign primitive decision
   ([decisions/2026-05-06-campaign-primitive-and-architecture-model.md](decisions/2026-05-06-campaign-primitive-and-architecture-model.md))
   is superseded **in part**: the canonical storage shape moves to `push`,
@@ -140,10 +169,6 @@ guidance from real dogfood.
 
 ### Changed
 
-- Defined `campaigns/` as the canonical primitive for coordinated pushes,
-  refreshed the system architecture model around current business-repo folders,
-  and blessed `documents/transcripts/`, `documents/prototypes/`, and
-  `documents/archive/` for non-campaign artifacts. Refs #321.
 - Clarified quick start and beginner docs so daily users run `claude` then
   `/mb-start` without a separate `mb status` step. `mb status` is now framed as
   the terminal-only briefing that `/mb-start` reads internally.
@@ -176,10 +201,6 @@ guidance from real dogfood.
   canonical `core/` subfolders for proof, brand, strategy, and operations;
   expanded migration and skill validation to treat legacy `reference/*` paths
   as compatibility-only. Refs #318.
-- Refactored `/mb-site` into a compact router with progressively loadable
-  minisite step references, and split examples from troubleshooting so agents
-  can load only the detail needed for the current site step. Refs #107 and
-  #110.
 
 ## [0.3.1] - 2026-05-05
 

--- a/mb/mb/__init__.py
+++ b/mb/mb/__init__.py
@@ -7,6 +7,6 @@ file stays a thin dispatcher.
 
 from __future__ import annotations
 
-__version__ = "0.3.2"
+__version__ = "0.3.3"
 
 __all__ = ["__version__"]

--- a/mb/pyproject.toml
+++ b/mb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mainbranch"
-version = "0.3.2"
+version = "0.3.3"
 description = "Main Branch engine umbrella - scaffolds, validates, and graphs business-as-files repos. Claude Code first, runtime-agnostic by design."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- Prepares Main Branch `0.3.3` release metadata from the current `main` branch.
- Moves the post-`0.3.2` changelog entries into a dated `0.3.3` section.
- Aligns Python package, module, and Claude plugin version metadata at `0.3.3`.
- Keeps the already-published `0.3.2` changelog section limited to the notes that shipped with that release.

## Scope
- In: `CHANGELOG.md`, `mb/pyproject.toml`, `mb.__version__`, and `.claude-plugin/plugin.json`.
- Out: publishing `oe-v0.3.3`, PyPI publication, new product fixes, and marking the release shipped before post-merge install verification.

## Commits
- `105184f` — `[update] Prepare 0.3.3 release`.

## Release / Issues
- Release: `0.3.3`.
- Linear ID(s): none on this release-prep branch.
- Closes: none.
- Refs: #107, #110, #321, #323, #324, #328, #329.
- Follow-ups: publish `oe-v0.3.3`, verify PyPI, and run fresh PyPI/pipx install smoke after this lands on `main`.

## Success Metric
- Reviewers can merge a release-prep branch where changelog and version metadata agree on `0.3.3`, ready for GitHub Release and PyPI publication.

## Validation
- Level 0 docs/decision: Reviewed release notes for public release truth and corrected stale `0.3.2` changelog placement.
- Level 1 static: `scripts/check.sh` passed: format, lint, mypy, 276 tests, coverage, and bundled skill validation.
- Level 2 CLI: Covered by `scripts/check.sh` suite.
- Level 3 package/install: `python3 -m build` succeeded for `mainbranch-0.3.3` wheel and sdist; clean venv installed the wheel and `mb --version` returned `mb 0.3.3`; isolated pipx wheel install also passed.
- Level 4 fixture repo: Clean wheel smoke passed `mb onboard`, `mb doctor`, `mb doctor repair --plan`, `mb status --peek`, `mb start --json`, `mb graph --json`, `mb validate`, and `mb migrate campaigns --plan`; verified `pushes/` and `core/vocabulary.md` are scaffolded.
- Level 5 runtime smoke: Not run on this release-prep branch; final release should verify published PyPI/pipx install after merge.

## Public / Private Boundary
- No private Devon, Conductor, credential, customer, account-specific, or runtime-local details were added.
