### PR TITLE
[fix] Repair Cloudflare site workflow blockers

### DIFF
--- a/.claude/educational/provider-readiness.md
+++ b/.claude/educational/provider-readiness.md
@@ -37,7 +37,8 @@ mb connect doctor --json
 
 2. **Cloudflare** - sites, DNS, Pages, and future Workers.
    - Check: `mb connect doctor --json`
-   - Common setup: `printf '%s' "$CLOUDFLARE_API_TOKEN" | mb connect cloudflare --token-stdin --metadata account_id=...`
+   - Preferred setup for multi-business operators: `printf '%s' "$CLOUDFLARE_API_TOKEN" | mb connect cloudflare --token-stdin --metadata token_type=account --metadata account_id=...`
+   - User API tokens remain supported as a fallback: omit `token_type=account` to use Cloudflare's user-token verify path.
    - Connect it when you are ready to publish or attach a domain.
 
 3. **Google / Workspace** - Drive, Docs, Sheets, Slides, and workspace source material.
@@ -66,8 +67,9 @@ mb connect doctor --json
 - `ready` means the safest available check passed.
 
 Secrets stay outside the business repo. `.mb/connect.yaml` stores only safe
-metadata, labels, secret references, and last-check facts. Do not paste tokens
-into markdown files, GitHub issues, screenshots, or committed config.
+metadata, labels, secret references, and last-check facts, and is gitignored by
+default. Do not paste tokens into markdown files, GitHub issues, screenshots,
+or committed config.
 
 ## Why this is business onboarding
 

--- a/.claude/reference/minisite.md
+++ b/.claude/reference/minisite.md
@@ -297,7 +297,7 @@ For lead/appointment: standard pixel taxonomy events. The subagent uses the conv
 |---|---|---|
 | `offer.md` exists and has minimum fields | Generation | File presence + frontmatter parse |
 | `audience.md` exists | Generation | File presence |
-| Cloudflare creds + GitHub App | All tool calls | `verify_live.py` returns 3/3 (Cloudflare scopes + zone lookup + domain-check) |
+| Cloudflare connected + GitHub App | Domain/DNS/Pages/deploy tool calls | `mb connect doctor --json` shows `provider:cloudflare` ready before dispatch; `verify_live.py` is a deeper manual smoke |
 | Domain decision | Setup | Operator confirms own-or-buy |
 | Tracking IDs (if declared) | Generation | offer.md frontmatter parse — if any tracking field present, validate format |
 
@@ -329,8 +329,7 @@ The orchestration mode (lives in `/mb-start`, ships in #92) walks the operator t
 
 - Operator picks: own-existing or buy-new
 - If buy-new: route through `references/naming-heuristic.md`
-- For API-supported TLDs: `domain.py buy <name>` after explicit Y on price
-- For dashboard-only TLDs: route to https://dash.cloudflare.com/registrar with confirmation
+- `domain.py buy` is not live in this build; route new purchases through https://dash.cloudflare.com/registrar with confirmation
 
 ### Phase 3 — Infrastructure (tool chain)
 

--- a/.claude/skills/mb-site/SKILL.md
+++ b/.claude/skills/mb-site/SKILL.md
@@ -62,8 +62,14 @@ Say `/mb-site` again after compaction, context loss, or switching focus. It relo
 1. Load [`references/pull-engine-updates.md`](references/pull-engine-updates.md) and run the canonical update check.
 2. Detect business repo mode vs site repo mode. Load [`references/site-repo-workflow.md`](references/site-repo-workflow.md) for repo boundaries, source links, and reverse site records.
 3. When a business repo is known, run `mb status --json --peek` and use its `readiness`, `drift.items`, `integrations`, `measurement`, and `ranked_actions` facts before inventing setup, provider, or launch-readiness checks in prose.
-4. Resolve the active offer and required business context with [`references/site-context.md`](references/site-context.md).
-5. Ask what the operator is building, then load only the shape reference needed next.
+4. Before any domain purchase, DNS, Cloudflare Pages project, custom-domain attach, or deploy work, run `mb connect doctor --json` from the business repo and check `provider:cloudflare`.
+   - If Cloudflare is not `ready`, stop before dispatching site tools and present exactly three choices:
+     - **connect now:** `printf '%s' "$CLOUDFLARE_API_TOKEN" | mb connect cloudflare --token-stdin --metadata token_type=account --metadata account_id=... && mb connect test cloudflare`
+     - **continue read-only:** availability checks, naming, brief, and research only; no buy, DNS, Pages, custom-domain, or deploy calls.
+     - **skip for now:** record the blocker in the push/site notes and stage a follow-up task.
+   - User API tokens remain supported as a fallback by omitting `token_type=account`; prefer account-scoped tokens for multi-business operators.
+5. Resolve the active offer and required business context with [`references/site-context.md`](references/site-context.md).
+6. Ask what the operator is building, then load only the shape reference needed next.
 
 ## Operating Principles
 

--- a/.claude/skills/mb-site/references/minisite-setup.md
+++ b/.claude/skills/mb-site/references/minisite-setup.md
@@ -16,20 +16,23 @@ Use an empty repo. Do not merge a template into the minisite shape.
 
 ## 5b. Prerequisites
 
-Confirm credentials are in place:
+Hard-gate Cloudflare-dependent setup before tool dispatch:
 
 ```bash
-source ~/.config/vip/env.sh
-python3 .claude/skills/mb-site/scripts/verify_live.py
+mb connect doctor --json
 ```
 
-Expect Cloudflare scopes, zone lookup, and domain-check CLI to pass. If anything is red, route to:
+If `provider:cloudflare` is not `ready`, stop and offer three choices:
 
-```bash
-bash .claude/skills/mb-site/scripts/setup_creds.sh
-```
+- **connect now:** `printf '%s' "$CLOUDFLARE_API_TOKEN" | mb connect cloudflare --token-stdin --metadata token_type=account --metadata account_id=... && mb connect test cloudflare`
+- **continue read-only:** domain availability, naming, brief, and research only; no buy, DNS, Pages, custom-domain, or deploy calls.
+- **skip for now:** record the Cloudflare blocker in the push/site notes and stage a follow-up.
 
-Then re-run `verify_live.py`.
+Prefer Cloudflare account-scoped tokens for multi-business operators. User API
+tokens remain supported as a fallback by omitting `token_type=account`.
+
+After `mb connect` reports Cloudflare ready, `verify_live.py` can be used as a
+deeper manual smoke for Cloudflare scopes, zone lookup, and domain-check CLI.
 
 ## 5c. Domain: Existing Or New
 
@@ -42,13 +45,9 @@ Ask:
 python3 .claude/skills/mb-site/scripts/domain.py check <name> --tlds .com,.co,.io
 ```
 
-For API-supported TLDs and after explicit operator approval on price, proceed:
-
-```bash
-python3 .claude/skills/mb-site/scripts/domain.py buy <name>
-```
-
-For dashboard-only TLDs, fall back to https://dash.cloudflare.com/registrar.
+Main Branch cannot buy domains through `domain.py` yet. If the operator needs a
+new domain, route them to https://dash.cloudflare.com/registrar after the
+availability check, then resume once they confirm they own the full domain.
 
 ## 5d. DNS Ensure
 

--- a/.claude/skills/mb-site/references/minisite.md
+++ b/.claude/skills/mb-site/references/minisite.md
@@ -302,7 +302,7 @@ Do not push email, phone, full name, address, CRM notes, booking notes, raw cust
 |---|---|---|
 | `offer.md` exists and has minimum fields | Generation | File presence + frontmatter parse |
 | `audience.md` exists | Generation | File presence |
-| Cloudflare creds + GitHub App | All tool calls | `verify_live.py` returns 3/3 (Cloudflare scopes + zone lookup + domain-check) |
+| Cloudflare connected + GitHub App | Domain/DNS/Pages/deploy tool calls | `mb connect doctor --json` shows `provider:cloudflare` ready before dispatch; `verify_live.py` is a deeper manual smoke |
 | Domain decision | Setup | Operator confirms own-or-buy |
 | Tracking IDs (if declared) | Generation | offer.md frontmatter parse — if any tracking field present, validate format |
 | Paid-traffic measurement readiness | Paid launch recommendation | `mb site check "$SITE_REPO" --business-repo "$BUSINESS_REPO" --json` |
@@ -335,8 +335,7 @@ The orchestration mode (lives in `/mb-start`, ships in #92) walks the operator t
 
 - Operator picks: own-existing or buy-new
 - If buy-new: route through `references/naming-heuristic.md`
-- For API-supported TLDs: `domain.py buy <name>` after explicit Y on price
-- For dashboard-only TLDs: route to https://dash.cloudflare.com/registrar with confirmation
+- `domain.py buy` is not live in this build; route new purchases through https://dash.cloudflare.com/registrar with confirmation
 
 ### Phase 3 — Infrastructure (tool chain)
 

--- a/.claude/skills/mb-site/references/naming-heuristic.md
+++ b/.claude/skills/mb-site/references/naming-heuristic.md
@@ -86,7 +86,7 @@ Watch for:
 
 - "Parked by speculator with offer-for-sale page" — technically available via aftermarket but at $500–$5000+
 - "Active site, content unrelated" — domain is owned but unused; can't acquire without negotiation
-- "Truly available" — clean RDAP/WHOIS path, ready for `domain.py buy`
+- "Truly available" — clean RDAP/WHOIS path, ready for operator purchase through the Cloudflare Registrar dashboard
 
 Pick the one with the cleanest history + the strongest fit. Two-name shortlists tend to deadlock; three-name shortlists usually have a clear winner once you read the real WHOIS.
 

--- a/.claude/skills/mb-site/references/site-context.md
+++ b/.claude/skills/mb-site/references/site-context.md
@@ -10,18 +10,27 @@ Default deploy target is Cloudflare Pages. Netlify is supported only as a legacy
 |---|---|---|
 | Cloudflare account | All site shapes by default | https://dash.cloudflare.com |
 | `gh` CLI authenticated | Repo creation | `brew install gh` then `gh auth login` |
-| Cloudflare API token, account ID, GitHub App install | Domain/DNS/Pages flow | `bash .claude/skills/mb-site/scripts/setup_creds.sh`, then [`cloudflare-pages-link.md`](cloudflare-pages-link.md) |
+| Cloudflare API token, account ID, GitHub App install | Domain/DNS/Pages flow | `mb connect cloudflare --token-stdin --metadata token_type=account --metadata account_id=...`, then [`cloudflare-pages-link.md`](cloudflare-pages-link.md) |
 | `offer.md` and `audience.md` | Site generation | Build via `/mb-think` first if missing |
 | Node 18+ and pnpm | Website shape with Next.js or Astro build step | `brew install node && npm install -g pnpm` |
 
-Verify site-tool credentials with:
+Hard-gate Cloudflare-dependent work with:
 
 ```bash
-source ~/.config/vip/env.sh
-python3 .claude/skills/mb-site/scripts/verify_live.py
+mb connect doctor --json
 ```
 
-Expect Cloudflare scopes, zone lookup, and domain-check CLI to pass. Porkbun skipped is fine for the Cloudflare-registered path.
+If `provider:cloudflare` is not `ready`, do not run domain buy, DNS, Pages,
+custom-domain, or deploy tools. Offer the operator: connect now with
+`printf '%s' "$CLOUDFLARE_API_TOKEN" | mb connect cloudflare --token-stdin --metadata token_type=account --metadata account_id=... && mb connect test cloudflare`;
+continue read-only for availability checks, naming, brief, and research only;
+or skip for now and record the blocker. User API tokens remain supported by
+omitting `token_type=account`, but account-scoped tokens are preferred for
+multi-business operators.
+
+`verify_live.py` remains a deeper manual smoke after `mb connect` says
+Cloudflare is ready. Expect Cloudflare scopes, zone lookup, and domain-check CLI
+to pass. Porkbun skipped is fine for the Cloudflare-registered path.
 
 ## Active Offer Resolution
 

--- a/.claude/skills/mb-site/references/troubleshooting.md
+++ b/.claude/skills/mb-site/references/troubleshooting.md
@@ -25,17 +25,22 @@ See [`cloudflare-pages-link.md`](cloudflare-pages-link.md) for the full walkthro
 
 ## `verify_live.py` Fails
 
-```bash
-source ~/.config/vip/env.sh
-python3 .claude/skills/mb-site/scripts/verify_live.py
-```
-
-Expect Cloudflare scopes, zone lookup, and domain-check CLI to pass. If anything is red, route to:
+First check the canonical Main Branch provider state:
 
 ```bash
-bash .claude/skills/mb-site/scripts/setup_creds.sh
+mb connect doctor --json
 ```
 
+If `provider:cloudflare` is not `ready`, reconnect and retest before running
+Cloudflare-dependent `/mb-site` tools:
+
+```bash
+printf '%s' "$CLOUDFLARE_API_TOKEN" | mb connect cloudflare --token-stdin --metadata token_type=account --metadata account_id=...
+mb connect test cloudflare
+```
+
+Use a user API token only as a fallback by omitting `token_type=account`.
+After `mb connect` is ready, `verify_live.py` is the deeper manual smoke.
 Porkbun skipped is fine for the Cloudflare-registered path.
 
 ## Website Build Failing

--- a/.claude/skills/mb-site/scripts/domain.py
+++ b/.claude/skills/mb-site/scripts/domain.py
@@ -3,8 +3,8 @@
 
 Subcommands:
     check  Wraps the `domain-check` brew CLI (RDAP, no auth) for availability lookups.
-    buy    Registers via Cloudflare Registrar (default) or Porkbun (legacy/lifecycle).
-           [Code lands here; live integration deferred to first real-project domain.]
+    buy    Unavailable placeholder that emits a structured error; use the registrar
+           dashboard until live registration support lands behind guardrails.
 
 Invocation: `python3 domain.py <subcommand> [args]`
 Output: companyctx-shape envelope JSON on stdout, logs on stderr.
@@ -273,7 +273,7 @@ def check(name: str, tlds: str, full_domain: bool) -> None:
 
 
 # ---------------------------------------------------------------------------
-# domain buy (code only — live integration deferred to real-project domain)
+# domain buy (unavailable until live registrar support lands)
 # ---------------------------------------------------------------------------
 
 DomainBuyErrorCode = Literal[
@@ -335,7 +335,7 @@ def _select_registrar(explicit: str | None) -> tuple[str | None, DomainBuyError 
         message="No registrar credentials found.",
         suggestion=(
             "Add CLOUDFLARE_API_TOKEN_REGISTRAR (preferred) or "
-            "PORKBUN_API_KEY + PORKBUN_SECRET_KEY to ~/.config/vip/env.sh"
+            "PORKBUN_API_KEY + PORKBUN_SECRET_KEY to your local shell environment."
         ),
     )
 
@@ -365,10 +365,9 @@ def _select_registrar(explicit: str | None) -> tuple[str | None, DomainBuyError 
 def buy(name: str, registrar: str | None, years: int, max_price: float, assume_yes: bool) -> None:
     """Register a domain. NAME must be a full domain (e.g. 'mybrand.com').
 
-    NOTE: live registrar calls are not yet wired. This command currently
-    validates inputs, selects a registrar, and emits a structured
-    `registrar_unsupported` error. The actual API integration lands
-    against the first real-project domain (no junk asset purchases).
+    NOTE: live registrar calls are not wired. This command validates inputs
+    and emits a structured `registrar_unsupported` error so `/mb-site` cannot
+    imply that Main Branch can buy the domain.
     """
     name = name.strip().lower()
 
@@ -418,8 +417,8 @@ def buy(name: str, registrar: str | None, years: int, max_price: float, assume_y
             code="registrar_unsupported",
             message=f"Registrar API for {selected!r} not yet wired in this build.",
             suggestion=(
-                "Live registration is deferred to the first real-project domain. "
-                "Wire the API call before invoking with --yes against a real name."
+                "Buy the domain in the registrar dashboard, then rerun `/mb-site` "
+                "after you own the full domain."
             ),
         ),
     )

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,14 +24,19 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   validation via `--metadata token_type=account --metadata account_id=...`
   while preserving the existing user-token verify path. Failed provider checks
   include safe upstream diagnostics such as endpoint family, HTTP status, and
-  provider error codes/messages in JSON. Refs #335.
+  provider error codes/messages in JSON. Account-token validation falls back to
+  a read-only account probe if Cloudflare returns 404 for the token verify path,
+  so valid credentials are not immediately classified as bad solely because the
+  verify endpoint shape changed. Refs #335.
 - `mb connect` now derives repo-scoped credential identity from stable git
-  remote/common-dir facts before falling back to the local path, avoiding
-  separate keychain refs for parallel worktrees of the same business repo.
-  Refs #335.
+  remote/common-dir facts for new connect metadata before falling back to the
+  local path, avoiding separate keychain refs for parallel worktrees of the same
+  business repo. Existing non-empty `repo_id` values are preserved so previously
+  stored keychain refs are not orphaned. Refs #335.
 - New and repaired business repos now gitignore `.mb/connect.yaml` by default,
-  and interactive `mb connect <provider> --token-stdin` prints paste/EOF
-  instructions before reading from a TTY. Refs #335.
+  and doctor repair untracks an already-committed `.mb/connect.yaml` while
+  leaving the file on disk. Interactive `mb connect <provider> --token-stdin`
+  prints paste/EOF instructions before reading from a TTY. Refs #335.
 - `/mb-site` no longer tells operators to use `domain.py buy` for live domain
   purchases; the command remains a structured unavailable placeholder until
   registrar support lands behind explicit guardrails. Refs #335.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,31 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+### Changed
+
+- `/mb-site` now hard-gates Cloudflare-dependent domain, DNS, Pages, custom
+  domain, and deploy work on `mb connect doctor --json` readiness. The skill
+  offers connect-now, read-only, and skip-for-now paths instead of discovering
+  missing Cloudflare credentials halfway through setup. Refs #335.
+
+### Fixed
+
+- `mb connect test cloudflare` now supports Cloudflare account-scoped token
+  validation via `--metadata token_type=account --metadata account_id=...`
+  while preserving the existing user-token verify path. Failed provider checks
+  include safe upstream diagnostics such as endpoint family, HTTP status, and
+  provider error codes/messages in JSON. Refs #335.
+- `mb connect` now derives repo-scoped credential identity from stable git
+  remote/common-dir facts before falling back to the local path, avoiding
+  separate keychain refs for parallel worktrees of the same business repo.
+  Refs #335.
+- New and repaired business repos now gitignore `.mb/connect.yaml` by default,
+  and interactive `mb connect <provider> --token-stdin` prints paste/EOF
+  instructions before reading from a TTY. Refs #335.
+- `/mb-site` no longer tells operators to use `domain.py buy` for live domain
+  purchases; the command remains a structured unavailable placeholder until
+  registrar support lands behind explicit guardrails. Refs #335.
+
 ## [0.3.3] - 2026-05-06
 
 v0.3.3 turns the campaign architecture work into the clearer push primitive.

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ choices with the current readiness state and exact next command.
 ```bash
 mb connect plan
 mb connect list
-printf '%s' "$CLOUDFLARE_API_TOKEN" | mb connect cloudflare --token-stdin --metadata account_id=...
+printf '%s' "$CLOUDFLARE_API_TOKEN" | mb connect cloudflare --token-stdin --metadata token_type=account --metadata account_id=...
 mb connect test cloudflare
 mb connect doctor
 mb connect status --json
@@ -205,8 +205,9 @@ mb educational provider-readiness
 
 Secrets are stored outside the business repo, using the macOS Keychain when
 available and a local `~/.mainbranch/secrets/connect.json` fallback otherwise.
-The business repo only receives non-sensitive metadata in `.mb/connect.yaml`,
-such as the provider id, account label, credential backend, and last check time.
+The business repo only receives non-sensitive, gitignored metadata in
+`.mb/connect.yaml`, such as the provider id, account label, credential backend,
+account-token type, and last check time.
 Stored credentials start as `unvalidated` until `mb connect test <provider>`
 runs the safest available check. Providers with a safe API probe validate
 against the provider; providers without one record that local credential

--- a/docs/BEGINNER-SETUP.md
+++ b/docs/BEGINNER-SETUP.md
@@ -143,12 +143,13 @@ If a provider is missing, Main Branch prints the next command. Examples:
 
 ```bash
 gh auth login
-printf '%s' "$CLOUDFLARE_API_TOKEN" | mb connect cloudflare --token-stdin --metadata account_id=...
+printf '%s' "$CLOUDFLARE_API_TOKEN" | mb connect cloudflare --token-stdin --metadata token_type=account --metadata account_id=...
 mb connect doctor --json
 ```
 
 Secrets stay outside your repo. Main Branch stores only safe metadata in
-`.mb/connect.yaml`, such as provider name, account label, and last check time.
+`.mb/connect.yaml`, such as provider name, account label, account-token type,
+and last check time. The file is gitignored by default.
 For the longer plain-English explanation, run:
 
 ```bash

--- a/mb/mb/_data/educational/provider-readiness.md
+++ b/mb/mb/_data/educational/provider-readiness.md
@@ -37,7 +37,8 @@ mb connect doctor --json
 
 2. **Cloudflare** - sites, DNS, Pages, and future Workers.
    - Check: `mb connect doctor --json`
-   - Common setup: `printf '%s' "$CLOUDFLARE_API_TOKEN" | mb connect cloudflare --token-stdin --metadata account_id=...`
+   - Preferred setup for multi-business operators: `printf '%s' "$CLOUDFLARE_API_TOKEN" | mb connect cloudflare --token-stdin --metadata token_type=account --metadata account_id=...`
+   - User API tokens remain supported as a fallback: omit `token_type=account` to use Cloudflare's user-token verify path.
    - Connect it when you are ready to publish or attach a domain.
 
 3. **Google / Workspace** - Drive, Docs, Sheets, Slides, and workspace source material.
@@ -66,8 +67,9 @@ mb connect doctor --json
 - `ready` means the safest available check passed.
 
 Secrets stay outside the business repo. `.mb/connect.yaml` stores only safe
-metadata, labels, secret references, and last-check facts. Do not paste tokens
-into markdown files, GitHub issues, screenshots, or committed config.
+metadata, labels, secret references, and last-check facts, and is gitignored by
+default. Do not paste tokens into markdown files, GitHub issues, screenshots,
+or committed config.
 
 ## Why this is business onboarding
 

--- a/mb/mb/_data/templates/.gitignore.tmpl
+++ b/mb/mb/_data/templates/.gitignore.tmpl
@@ -11,6 +11,7 @@ node_modules/
 .venv/
 .claude/worktrees/
 .mb/backups/
+.mb/connect.yaml
 .mb/onboarding.json
 .mb/last-status-seen.json
 .mb/issue-drafts/

--- a/mb/mb/connect.py
+++ b/mb/mb/connect.py
@@ -12,7 +12,6 @@ import subprocess
 import sys
 import urllib.error
 import urllib.request
-import uuid
 from collections.abc import Callable
 from contextlib import suppress
 from dataclasses import dataclass
@@ -25,6 +24,7 @@ import yaml
 CONFIG_RELATIVE_PATH = Path(".mb") / "connect.yaml"
 SERVICE_NAME = "mainbranch"
 SENSITIVE_KEY_PARTS = ("token", "secret", "password", "credential", "api_key", "apikey", "key")
+SAFE_METADATA_KEYS = {"token_type", "token_scope", "api_token_type"}
 VALIDATION_TIMEOUT_SECONDS = 8
 CommandRunner = Callable[[list[str], Path | None, float], dict[str, Any]]
 Which = Callable[[str], str | None]
@@ -240,7 +240,7 @@ def _config_path(repo: Path) -> Path:
 
 
 def _empty_config() -> dict[str, Any]:
-    return {"version": 1, "repo_id": "", "providers": {}}
+    return {"version": 1, "repo_id": "", "repo_identity": {}, "providers": {}}
 
 
 def _read_config(repo: Path) -> dict[str, Any]:
@@ -263,16 +263,68 @@ def _read_config(repo: Path) -> dict[str, Any]:
     return {
         "version": version,
         "repo_id": str(raw.get("repo_id") or ""),
+        "repo_identity": raw.get("repo_identity")
+        if isinstance(raw.get("repo_identity"), dict)
+        else {},
         "providers": providers,
     }
 
 
-def _ensure_repo_id(config: dict[str, Any]) -> str:
-    repo_id = str(config.get("repo_id") or "")
-    if repo_id:
-        return repo_id
-    repo_id = uuid.uuid4().hex
+def _git_output(repo: Path, args: list[str]) -> str:
+    try:
+        proc = subprocess.run(
+            ["git", *args],
+            cwd=repo,
+            capture_output=True,
+            text=True,
+            timeout=3,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.SubprocessError):
+        return ""
+    if proc.returncode != 0:
+        return ""
+    return proc.stdout.strip()
+
+
+def _normalized_remote(value: str) -> str:
+    remote = value.strip()
+    if remote.startswith("git@github.com:"):
+        return "https://github.com/" + remote.removeprefix("git@github.com:").removesuffix(".git")
+    if remote.startswith("https://github.com/"):
+        return remote.removesuffix(".git")
+    return remote.removesuffix(".git")
+
+
+def _repo_identity(repo: Path) -> dict[str, str]:
+    remote = _git_output(repo, ["config", "--get", "remote.origin.url"])
+    if remote:
+        source = "git_remote"
+        basis = _normalized_remote(remote)
+    else:
+        common_dir = _git_output(repo, ["rev-parse", "--git-common-dir"])
+        if common_dir:
+            source = "git_common_dir"
+            basis = str(
+                (repo / common_dir).resolve()
+                if not Path(common_dir).is_absolute()
+                else Path(common_dir).resolve()
+            )
+        else:
+            source = "path"
+            basis = str(repo.resolve())
+    digest = hashlib.sha256(f"mainbranch-connect-v2:{source}:{basis}".encode()).hexdigest()
+    return {"source": source, "repo_id": digest[:32], "basis_sha256": digest}
+
+
+def _ensure_repo_id(config: dict[str, Any], repo: Path) -> str:
+    identity = _repo_identity(repo)
+    repo_id = identity["repo_id"]
     config["repo_id"] = repo_id
+    config["repo_identity"] = {
+        "source": identity["source"],
+        "basis_sha256": identity["basis_sha256"],
+    }
     return repo_id
 
 
@@ -492,10 +544,26 @@ def _parse_metadata(pairs: list[str]) -> dict[str, str]:
         if not key:
             raise ValueError("metadata keys cannot be empty")
         lowered = key.lower().replace("-", "_")
-        if any(part in lowered for part in SENSITIVE_KEY_PARTS):
+        if lowered not in SAFE_METADATA_KEYS and any(
+            part in lowered for part in SENSITIVE_KEY_PARTS
+        ):
             raise ValueError(f"metadata key {key!r} looks sensitive; use --token/--token-stdin")
         metadata[key] = value
     return metadata
+
+
+def _cloudflare_token_type(metadata: dict[str, Any]) -> str:
+    raw = (
+        metadata.get("token_type")
+        or metadata.get("token_scope")
+        or metadata.get("api_token_type")
+        or metadata.get("api_scope")
+        or ""
+    )
+    value = str(raw).strip().lower().replace("_", "-")
+    if value in {"account", "account-scoped", "account-owned", "account-token"}:
+        return "account"
+    return "user"
 
 
 def connect_provider(
@@ -517,7 +585,7 @@ def connect_provider(
         )
     target = Path(repo).resolve()
     config = _read_config(target)
-    repo_id = _ensure_repo_id(config)
+    repo_id = _ensure_repo_id(config, target)
     metadata = _parse_metadata(metadata_pairs or [])
     store = SecretStore(secret_backend)
 
@@ -668,6 +736,9 @@ def status_provider(provider_id: str, repo: str | Path = ".") -> dict[str, Any]:
             "state": str(validation.get("state") or state),
             "checked_at": str(validation.get("checked_at") or ""),
             "summary": str(validation.get("summary") or ""),
+            "upstream": validation.get("upstream")
+            if isinstance(validation.get("upstream"), dict)
+            else {},
             "safe_to_share": True,
         },
     }
@@ -685,41 +756,203 @@ def _stored_secret(provider: Provider, entry: dict[str, Any]) -> str:
     return SecretStore(backend).get(ref) if ref else ""
 
 
-def _http_get_json(url: str, headers: dict[str, str] | None = None) -> tuple[str, str]:
+def _provider_error_summary(provider_name: str, upstream: dict[str, Any]) -> str:
+    status = upstream.get("http_status")
+    messages = [str(item) for item in upstream.get("error_messages", []) if str(item)]
+    base = messages[0] if messages else ""
+    if status in {400, 401}:
+        return f"{provider_name} rejected the credential. Create a fresh token and reconnect it."
+    if status == 403:
+        return (
+            f"{provider_name} accepted the request shape but denied access. "
+            "Check token permissions, account binding, and account_id metadata."
+        )
+    if status == 404:
+        return (
+            f"{provider_name} could not find the requested account/token resource. "
+            "Check account_id metadata and token ownership."
+        )
+    if status == 429:
+        return f"{provider_name} rate-limited validation. Retry `mb connect test` later."
+    if isinstance(status, int) and status >= 500:
+        return (
+            f"{provider_name} validation returned HTTP {status}. Retry after the provider recovers."
+        )
+    if base:
+        return f"{provider_name} validation failed: {base}"
+    return f"{provider_name} validation could not complete."
+
+
+def _extract_upstream_errors(payload: Any) -> tuple[list[str], list[str]]:
+    if not isinstance(payload, dict):
+        return [], []
+    codes: list[str] = []
+    messages: list[str] = []
+    for field in ("errors", "messages"):
+        raw_items = payload.get(field)
+        if not isinstance(raw_items, list):
+            continue
+        for item in raw_items:
+            if not isinstance(item, dict):
+                continue
+            code = item.get("code")
+            message = item.get("message")
+            if code not in {None, ""}:
+                codes.append(str(code))
+            if message:
+                messages.append(str(message))
+    return codes, messages
+
+
+def _http_get_json(
+    url: str,
+    headers: dict[str, str] | None = None,
+    *,
+    provider_name: str = "provider",
+    endpoint_family: str = "unknown",
+) -> dict[str, Any]:
     request = urllib.request.Request(url, headers=headers or {})
+    upstream: dict[str, Any] = {
+        "endpoint_family": endpoint_family,
+        "http_status": None,
+        "response_received": False,
+        "error_codes": [],
+        "error_messages": [],
+        "safe_to_share": True,
+    }
     try:
         with urllib.request.urlopen(request, timeout=VALIDATION_TIMEOUT_SECONDS) as response:
             status = int(getattr(response, "status", 0) or 0)
             body = response.read(8192)
     except urllib.error.HTTPError as exc:
-        if exc.code in {400, 401, 403}:
-            return "invalid", "provider rejected the credential"
-        if exc.code in {408, 429} or exc.code >= 500:
-            return "unvalidated", f"provider validation returned HTTP {exc.code}"
-        return "unvalidated", f"provider validation returned HTTP {exc.code}"
+        body = b""
+        with suppress(OSError):
+            body = exc.read(8192)
+        payload: Any = {}
+        if body:
+            with suppress(json.JSONDecodeError, UnicodeDecodeError):
+                payload = json.loads(body.decode("utf-8"))
+        codes, messages = _extract_upstream_errors(payload)
+        upstream.update(
+            {
+                "http_status": int(exc.code),
+                "response_received": True,
+                "error_codes": codes,
+                "error_messages": messages,
+            }
+        )
+        state = "invalid" if exc.code in {400, 401, 403, 404} else "unvalidated"
+        return {
+            "ok": False,
+            "state": state,
+            "summary": _provider_error_summary(provider_name, upstream),
+            "upstream": upstream,
+            "safe_to_share": True,
+        }
     except (urllib.error.URLError, TimeoutError, OSError):
-        return "unvalidated", "provider validation could not reach the service"
-    if status < 200 or status >= 300:
-        if status in {400, 401, 403}:
-            return "invalid", "provider rejected the credential"
-        return "unvalidated", f"provider validation returned HTTP {status}"
+        return {
+            "ok": False,
+            "state": "unvalidated",
+            "summary": f"{provider_name} validation could not reach the service.",
+            "upstream": upstream,
+            "safe_to_share": True,
+        }
+    payload = {}
     if body:
         with suppress(json.JSONDecodeError, UnicodeDecodeError):
-            json.loads(body.decode("utf-8"))
-    return "ready", "credential validated with provider"
+            payload = json.loads(body.decode("utf-8"))
+    codes, messages = _extract_upstream_errors(payload)
+    upstream.update(
+        {
+            "http_status": status,
+            "response_received": True,
+            "error_codes": codes,
+            "error_messages": messages,
+        }
+    )
+    if status < 200 or status >= 300:
+        state = "invalid" if status in {400, 401, 403, 404} else "unvalidated"
+        return {
+            "ok": False,
+            "state": state,
+            "summary": _provider_error_summary(provider_name, upstream),
+            "upstream": upstream,
+            "safe_to_share": True,
+        }
+    if isinstance(payload, dict) and payload.get("success") is False:
+        return {
+            "ok": False,
+            "state": "invalid",
+            "summary": _provider_error_summary(provider_name, upstream),
+            "upstream": upstream,
+            "safe_to_share": True,
+        }
+    token_status = ""
+    if isinstance(payload, dict) and isinstance(payload.get("result"), dict):
+        token_status = str(payload["result"].get("status") or "")
+    if token_status and token_status != "active":
+        upstream["token_status"] = token_status
+        return {
+            "ok": False,
+            "state": "invalid",
+            "summary": f"{provider_name} token is {token_status}; reconnect an active token.",
+            "upstream": upstream,
+            "safe_to_share": True,
+        }
+    return {
+        "ok": True,
+        "state": "ready",
+        "summary": f"{provider_name} credential validated with provider.",
+        "upstream": upstream,
+        "safe_to_share": True,
+    }
 
 
-def _validate_with_provider(provider: Provider, secret: str) -> dict[str, Any]:
+def _validate_with_provider(
+    provider: Provider, secret: str, metadata: dict[str, Any] | None = None
+) -> dict[str, Any]:
     checked_at = _now()
+    metadata = metadata or {}
     if provider.id == "cloudflare":
-        state, summary = _http_get_json(
-            "https://api.cloudflare.com/client/v4/user/tokens/verify",
+        token_type = _cloudflare_token_type(metadata)
+        if token_type == "account":
+            account_id = str(metadata.get("account_id") or "").strip()
+            if not account_id:
+                return {
+                    "ok": False,
+                    "state": "invalid",
+                    "checked_at": checked_at,
+                    "summary": (
+                        "Cloudflare account-token validation requires non-secret "
+                        "`account_id` metadata."
+                    ),
+                    "safe_to_share": True,
+                    "upstream": {
+                        "endpoint_family": "cloudflare_account_token_verify",
+                        "http_status": None,
+                        "response_received": False,
+                        "error_codes": [],
+                        "error_messages": [],
+                        "safe_to_share": True,
+                    },
+                }
+            url = f"https://api.cloudflare.com/client/v4/accounts/{account_id}/tokens/verify"
+            endpoint_family = "cloudflare_account_token_verify"
+        else:
+            url = "https://api.cloudflare.com/client/v4/user/tokens/verify"
+            endpoint_family = "cloudflare_user_token_verify"
+        result = _http_get_json(
+            url,
             {"Authorization": f"Bearer {secret}"},
+            provider_name=provider.name,
+            endpoint_family=endpoint_family,
         )
     elif provider.id == "apify":
-        state, summary = _http_get_json(
+        result = _http_get_json(
             "https://api.apify.com/v2/users/me",
             {"Authorization": f"Bearer {secret}"},
+            provider_name=provider.name,
+            endpoint_family="apify_user_me",
         )
     else:
         return {
@@ -733,11 +966,12 @@ def _validate_with_provider(provider: Provider, secret: str) -> dict[str, Any]:
             "safe_to_share": True,
         }
     return {
-        "ok": state == "ready",
-        "state": state,
+        "ok": bool(result["ok"]),
+        "state": str(result["state"]),
         "checked_at": checked_at,
-        "summary": summary,
+        "summary": str(result["summary"]),
         "safe_to_share": True,
+        "upstream": result.get("upstream", {}),
     }
 
 
@@ -769,7 +1003,9 @@ def test_provider(provider_id: str, repo: str | Path = ".") -> dict[str, Any]:
                 "status": status_provider(provider.id, target),
                 "safe_to_share": True,
             }
-        validation = _validate_with_provider(provider, secret)
+        raw_metadata = entry.get("metadata")
+        metadata = raw_metadata if isinstance(raw_metadata, dict) else {}
+        validation = _validate_with_provider(provider, secret, metadata)
 
     entry["validation"] = {
         "state": validation["state"],
@@ -777,6 +1013,8 @@ def test_provider(provider_id: str, repo: str | Path = ".") -> dict[str, Any]:
         "summary": validation["summary"],
         "safe_to_share": True,
     }
+    if isinstance(validation.get("upstream"), dict):
+        entry["validation"]["upstream"] = validation["upstream"]
     entry["last_checked_at"] = validation["checked_at"]
     config["providers"][provider.id] = entry
     _write_config(target, config)
@@ -798,6 +1036,7 @@ def status_all(
 ) -> dict[str, Any]:
     target = Path(repo).resolve()
     config = _read_config(target)
+    identity = _repo_identity(target)
     configured = set(config["providers"].keys())
     providers = []
     for provider in PROVIDERS:
@@ -810,7 +1049,7 @@ def status_all(
         "ok": not broken,
         "repo": str(target),
         "config_path": str(_config_path(target)),
-        "repo_id": str(config.get("repo_id") or ""),
+        "repo_id": str(config.get("repo_id") or identity["repo_id"]),
         "providers": providers,
         "github": github or github_context(target),
         "safe_to_share": True,
@@ -1125,9 +1364,19 @@ def render_test_result(result: dict[str, Any]) -> None:
     status = result["status"]
     state = "ok" if result["ok"] else "warn"
     print(f"mb connect test {result['provider']}: {state} ({status['state']})")
-    summary = (result.get("validation") or status.get("validation") or {}).get("summary")
+    validation = result.get("validation") or status.get("validation") or {}
+    summary = validation.get("summary")
     if summary:
         print(f"summary: {summary}")
+    upstream = validation.get("upstream") if isinstance(validation, dict) else {}
+    if isinstance(upstream, dict) and upstream.get("endpoint_family"):
+        details = [f"endpoint: {upstream['endpoint_family']}"]
+        if upstream.get("http_status") is not None:
+            details.append(f"http: {upstream['http_status']}")
+        codes = upstream.get("error_codes")
+        if isinstance(codes, list) and codes:
+            details.append(f"codes: {', '.join(str(code) for code in codes[:3])}")
+        print("provider: " + "  ".join(details))
     if status.get("repair_command"):
         print(f"next: {status['repair_command']}")
 
@@ -1152,4 +1401,9 @@ def render_connect_result(result: dict[str, Any]) -> None:
 
 
 def read_stdin_token() -> str:
+    if sys.stdin.isatty():
+        print(
+            "Paste the credential, then press Ctrl-D on a new line to finish.",
+            file=sys.stderr,
+        )
     return sys.stdin.read().strip()

--- a/mb/mb/connect.py
+++ b/mb/mb/connect.py
@@ -11,6 +11,7 @@ import shutil
 import subprocess
 import sys
 import urllib.error
+import urllib.parse
 import urllib.request
 from collections.abc import Callable
 from contextlib import suppress
@@ -289,10 +290,15 @@ def _git_output(repo: Path, args: list[str]) -> str:
 
 def _normalized_remote(value: str) -> str:
     remote = value.strip()
-    if remote.startswith("git@github.com:"):
-        return "https://github.com/" + remote.removeprefix("git@github.com:").removesuffix(".git")
-    if remote.startswith("https://github.com/"):
-        return remote.removesuffix(".git")
+    if remote.startswith("git@") and ":" in remote:
+        host, path = remote.removeprefix("git@").split(":", 1)
+        return f"https://{host}/{path}".removesuffix(".git")
+    parsed = urllib.parse.urlparse(remote)
+    if parsed.scheme and parsed.netloc:
+        host = parsed.hostname or parsed.netloc
+        path = parsed.path.lstrip("/")
+        if path:
+            return f"https://{host}/{path}".removesuffix(".git")
     return remote.removesuffix(".git")
 
 
@@ -319,11 +325,13 @@ def _repo_identity(repo: Path) -> dict[str, str]:
 
 def _ensure_repo_id(config: dict[str, Any], repo: Path) -> str:
     identity = _repo_identity(repo)
-    repo_id = identity["repo_id"]
+    existing = str(config.get("repo_id") or "").strip()
+    repo_id = existing or identity["repo_id"]
     config["repo_id"] = repo_id
     config["repo_identity"] = {
         "source": identity["source"],
         "basis_sha256": identity["basis_sha256"],
+        "repo_id_source": "existing_config" if existing else identity["source"],
     }
     return repo_id
 
@@ -341,7 +349,22 @@ def _secret_ref(repo_id: str, provider_id: str, field: str) -> str:
     return f"mainbranch://{digest}/{provider_id}/{field}"
 
 
-def _repair(provider: Provider, state: str, missing: list[str] | None = None) -> dict[str, str]:
+def _repair(
+    provider: Provider,
+    state: str,
+    missing: list[str] | None = None,
+    validation: dict[str, Any] | None = None,
+) -> dict[str, str]:
+    validation = validation or {}
+    validation_repair = str(validation.get("repair") or "")
+    validation_repair_command = str(validation.get("repair_command") or "")
+    validation_summary = str(validation.get("summary") or "")
+    if validation_repair or validation_repair_command:
+        return {
+            "summary": validation_summary or f"{provider.name} needs metadata repair.",
+            "repair": validation_repair,
+            "repair_command": validation_repair_command,
+        }
     if provider.id == "meta":
         return {
             "summary": ("Meta Ads CLI support is planned but not wired in this mb release."),
@@ -642,7 +665,7 @@ def status_provider(provider_id: str, repo: str | Path = ".") -> dict[str, Any]:
         meta_validation: dict[str, Any] = (
             raw_meta_validation if isinstance(raw_meta_validation, dict) else {}
         )
-        repair = _repair(provider, "planned")
+        repair = _repair(provider, "planned", validation=meta_validation)
         return {
             "provider": provider.id,
             "name": provider.name,
@@ -717,7 +740,7 @@ def status_provider(provider_id: str, repo: str | Path = ".") -> dict[str, Any]:
         else:
             state = "unvalidated"
             ok = False
-    repair = _repair(provider, state, missing)
+    repair = _repair(provider, state, missing, validation)
     return {
         "provider": provider.id,
         "name": provider.name,
@@ -739,6 +762,8 @@ def status_provider(provider_id: str, repo: str | Path = ".") -> dict[str, Any]:
             "upstream": validation.get("upstream")
             if isinstance(validation.get("upstream"), dict)
             else {},
+            "repair": str(validation.get("repair") or ""),
+            "repair_command": str(validation.get("repair_command") or ""),
             "safe_to_share": True,
         },
     }
@@ -920,11 +945,20 @@ def _validate_with_provider(
             if not account_id:
                 return {
                     "ok": False,
-                    "state": "invalid",
+                    "state": "unvalidated",
                     "checked_at": checked_at,
                     "summary": (
                         "Cloudflare account-token validation requires non-secret "
                         "`account_id` metadata."
+                    ),
+                    "repair": (
+                        "Run `mb connect cloudflare --metadata token_type=account "
+                        "--metadata account_id=<account-id>`, then "
+                        "`mb connect test cloudflare`."
+                    ),
+                    "repair_command": (
+                        "mb connect cloudflare --metadata token_type=account "
+                        "--metadata account_id=<account-id>"
                     ),
                     "safe_to_share": True,
                     "upstream": {
@@ -947,6 +981,26 @@ def _validate_with_provider(
             provider_name=provider.name,
             endpoint_family=endpoint_family,
         )
+        raw_upstream = result.get("upstream")
+        upstream: dict[str, Any] = raw_upstream if isinstance(raw_upstream, dict) else {}
+        if token_type == "account" and upstream.get("http_status") == 404:
+            fallback = _http_get_json(
+                f"https://api.cloudflare.com/client/v4/accounts/{account_id}",
+                {"Authorization": f"Bearer {secret}"},
+                provider_name=provider.name,
+                endpoint_family="cloudflare_account_read",
+            )
+            raw_fallback_upstream = fallback.get("upstream")
+            fallback_upstream: dict[str, Any] = (
+                raw_fallback_upstream if isinstance(raw_fallback_upstream, dict) else {}
+            )
+            fallback_upstream["fallback_from"] = endpoint_family
+            fallback["upstream"] = fallback_upstream
+            if fallback.get("ok"):
+                fallback["summary"] = (
+                    "Cloudflare account-scoped credential validated with account read fallback."
+                )
+            result = fallback
     elif provider.id == "apify":
         result = _http_get_json(
             "https://api.apify.com/v2/users/me",
@@ -970,6 +1024,8 @@ def _validate_with_provider(
         "state": str(result["state"]),
         "checked_at": checked_at,
         "summary": str(result["summary"]),
+        "repair": str(result.get("repair") or ""),
+        "repair_command": str(result.get("repair_command") or ""),
         "safe_to_share": True,
         "upstream": result.get("upstream", {}),
     }
@@ -1013,6 +1069,9 @@ def test_provider(provider_id: str, repo: str | Path = ".") -> dict[str, Any]:
         "summary": validation["summary"],
         "safe_to_share": True,
     }
+    if validation.get("repair") or validation.get("repair_command"):
+        entry["validation"]["repair"] = validation.get("repair", "")
+        entry["validation"]["repair_command"] = validation.get("repair_command", "")
     if isinstance(validation.get("upstream"), dict):
         entry["validation"]["upstream"] = validation["upstream"]
     entry["last_checked_at"] = validation["checked_at"]

--- a/mb/mb/doctor.py
+++ b/mb/mb/doctor.py
@@ -44,17 +44,19 @@ LOCAL_GITIGNORE_ENTRIES = (
     ".claude/settings.local.json",
     ".claude/worktrees/",
     ".mb/backups/",
+    ".mb/connect.yaml",
     ".mb/onboarding.json",
     ".mb/last-status-seen.json",
     ".mb/issue-drafts/",
 )
 LOCAL_STATE_PATHS = (
     ".mb/backups",
+    ".mb/connect.yaml",
     ".mb/onboarding.json",
     ".mb/last-status-seen.json",
     ".mb/issue-drafts",
 )
-DURABLE_MB_PATHS = (".mb/schema_version", ".mb/connect.yaml")
+DURABLE_MB_PATHS = (".mb/schema_version",)
 LEGACY_CLAUDE_LINK_DIRS = (".claude/lenses", ".claude/reference")
 REFERENCE_COMPAT_LINKS = {
     "reference/core": "../core",

--- a/mb/mb/doctor.py
+++ b/mb/mb/doctor.py
@@ -461,6 +461,27 @@ def _missing_gitignore_entries(repo: Path) -> list[str]:
     ]
 
 
+def _tracked_local_state_paths(repo: Path) -> list[str]:
+    tracked: list[str] = []
+    for rel in LOCAL_STATE_PATHS:
+        result = _run_git(repo, ["ls-files", "--error-unmatch", rel])
+        if result["ok"]:
+            tracked.append(rel)
+    return tracked
+
+
+def _untrack_local_state_path(repo: Path, rel: str) -> dict[str, Any]:
+    path = repo / rel
+    result = _run_git(repo, ["rm", "--cached", "--", rel])
+    return {
+        "path": rel,
+        "ok": bool(result["ok"]),
+        "stdout": result["stdout"],
+        "stderr": result["stderr"],
+        "exists_on_disk": path.exists() or path.is_symlink(),
+    }
+
+
 def _local_state_summary(repo: Path) -> dict[str, Any]:
     local = [
         {"path": rel, "exists": (repo / rel).exists() or (repo / rel).is_symlink()}
@@ -473,18 +494,22 @@ def _local_state_summary(repo: Path) -> dict[str, Any]:
     missing_gitignore = [
         item["path"]
         for item in local
-        if item["exists"] and item["path"] not in _read_gitignore_entries(repo)
+        if item["exists"] and item["path"] in _missing_gitignore_entries(repo)
     ]
+    tracked = _tracked_local_state_paths(repo)
     return {
-        "state": "warn" if missing_gitignore else "ok",
+        "state": "warn" if missing_gitignore or tracked else "ok",
         "summary": (
             f"{len(missing_gitignore)} local .mb path(s) need gitignore coverage"
             if missing_gitignore
+            else f"{len(tracked)} local .mb path(s) are still tracked"
+            if tracked
             else ".mb local operational state is separated from durable markers"
         ),
         "local": local,
         "durable": durable,
         "missing_gitignore": missing_gitignore,
+        "tracked": tracked,
     }
 
 
@@ -1002,8 +1027,9 @@ def repair_plan(
     )
 
     missing_gitignore = _missing_gitignore_entries(target)
+    tracked_local_state = _tracked_local_state_paths(target)
     gitignore_actions: list[dict[str, Any]] = []
-    if missing_gitignore:
+    if missing_gitignore or tracked_local_state:
         action = _action(
             id="gitignore-local-state",
             title="Protect Main Branch local state in .gitignore",
@@ -1011,26 +1037,41 @@ def repair_plan(
             mode="write",
             command="mb doctor repair --apply",
             safe_to_apply=True,
-            reason="these entries are local operational state and should not be committed",
-            writes=[".gitignore"],
+            reason=(
+                "these entries are local operational state; doctor repair adds "
+                "gitignore coverage and untracks any already-committed local state"
+            ),
+            writes=[".gitignore", *tracked_local_state],
         )
         actions.append(action)
         gitignore_actions.append(action)
+    gitignore_state = "warn" if missing_gitignore or tracked_local_state else "ok"
     sections.append(
         _section(
             "gitignore",
             "Local State Gitignore",
-            "warn" if missing_gitignore else "ok",
+            gitignore_state,
             (
-                f"{len(missing_gitignore)} missing local-state entrie(s)"
+                f"{len(missing_gitignore)} missing gitignore entrie(s), "
+                f"{len(tracked_local_state)} tracked local-state file(s)"
                 if missing_gitignore
+                else f"{len(tracked_local_state)} tracked local-state file(s)"
+                if tracked_local_state
                 else "Main Branch local state is ignored"
             ),
             checks=[
                 {
                     "name": entry,
-                    "state": "warn" if entry in missing_gitignore else "ok",
-                    "summary": "missing" if entry in missing_gitignore else "covered",
+                    "state": "warn"
+                    if entry in missing_gitignore or entry in tracked_local_state
+                    else "ok",
+                    "summary": (
+                        "tracked; repair will untrack"
+                        if entry in tracked_local_state
+                        else "missing"
+                        if entry in missing_gitignore
+                        else "covered"
+                    ),
                 }
                 for entry in LOCAL_GITIGNORE_ENTRIES
             ],
@@ -1278,6 +1319,7 @@ def repair_apply(repo: str | Path = ".", *, include_migration: bool = False) -> 
     applied: list[dict[str, Any]] = []
 
     missing_gitignore = _missing_gitignore_entries(target)
+    tracked_local_state = _tracked_local_state_paths(target)
     if missing_gitignore:
         changed = _append_unique_lines(target / ".gitignore", missing_gitignore)
         applied.append(
@@ -1292,6 +1334,25 @@ def repair_apply(repo: str | Path = ".", *, include_migration: bool = False) -> 
                 writes=[".gitignore"],
                 applied=changed,
                 result={"added": missing_gitignore},
+            )
+        )
+    if tracked_local_state:
+        results = [_untrack_local_state_path(target, rel) for rel in tracked_local_state]
+        applied.append(
+            _action(
+                id="gitignore-local-state-untrack",
+                title="Untracked Main Branch local state from git",
+                state="ok" if all(item["ok"] for item in results) else "error",
+                mode="write",
+                command="mb doctor repair --apply",
+                safe_to_apply=True,
+                reason=(
+                    "removed local operational state from the git index while "
+                    "leaving the files on disk"
+                ),
+                writes=tracked_local_state,
+                applied=any(item["ok"] for item in results),
+                result={"untracked": results},
             )
         )
 

--- a/mb/mb/init.py
+++ b/mb/mb/init.py
@@ -48,6 +48,7 @@ node_modules/
 .venv/
 .claude/worktrees/
 .mb/backups/
+.mb/connect.yaml
 .mb/onboarding.json
 .mb/last-status-seen.json
 .mb/issue-drafts/

--- a/mb/tests/test_connect.py
+++ b/mb/tests/test_connect.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import stat
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -197,11 +198,39 @@ def test_connect_provider_stores_secret_outside_repo(tmp_path: Path, monkeypatch
     cloudflare = config["providers"]["cloudflare"]
     assert cloudflare["metadata"] == {"account_id": "acct_123"}
     assert cloudflare["account_label"] == "Acme CF"
+    assert config["repo_identity"]["source"] in {"git_common_dir", "path"}
 
     secret_file = tmp_path / "home" / "secrets" / "connect.json"
     assert "cf-test-token" in secret_file.read_text(encoding="utf-8")
     assert stat.S_IMODE(secret_file.parent.stat().st_mode) == 0o700
     assert stat.S_IMODE(secret_file.stat().st_mode) == 0o600
+
+
+def test_connect_repo_identity_is_stable_across_worktrees(tmp_path: Path, monkeypatch) -> None:
+    _local_secret_env(monkeypatch, tmp_path)
+    first = tmp_path / "biz-one"
+    second = tmp_path / "biz-two"
+    first.mkdir()
+    second.mkdir()
+
+    def fake_git(repo: Path, args: list[str]) -> str:
+        if args == ["config", "--get", "remote.origin.url"]:
+            return "git@github.com:acme/business.git"
+        return ""
+
+    monkeypatch.setattr(connect_mod, "_git_output", fake_git)
+
+    connect_mod.connect_provider("cloudflare", repo=first, token="first-token")
+    connect_mod.connect_provider("cloudflare", repo=second, token="second-token")
+
+    first_config = yaml.safe_load((first / ".mb" / "connect.yaml").read_text(encoding="utf-8"))
+    second_config = yaml.safe_load((second / ".mb" / "connect.yaml").read_text(encoding="utf-8"))
+    assert first_config["repo_id"] == second_config["repo_id"]
+    assert first_config["repo_identity"]["source"] == "git_remote"
+    assert (
+        first_config["providers"]["cloudflare"]["secrets"]["api_token"]["ref"]
+        == second_config["providers"]["cloudflare"]["secrets"]["api_token"]["ref"]
+    )
 
 
 def test_connect_provider_only_reads_env_when_explicit(tmp_path: Path, monkeypatch) -> None:
@@ -312,7 +341,20 @@ def test_connect_test_records_invalid_provider_without_leaking_secret(
     monkeypatch.setattr(
         connect_mod,
         "_http_get_json",
-        lambda url, headers=None: ("invalid", "provider rejected the credential"),
+        lambda url, headers=None, **kwargs: {
+            "ok": False,
+            "state": "invalid",
+            "summary": "Cloudflare rejected the credential. Create a fresh token and reconnect it.",
+            "safe_to_share": True,
+            "upstream": {
+                "endpoint_family": kwargs["endpoint_family"],
+                "http_status": 403,
+                "response_received": True,
+                "error_codes": ["9109"],
+                "error_messages": ["Invalid access token"],
+                "safe_to_share": True,
+            },
+        },
     )
 
     result = runner.invoke(app, ["connect", "test", "cloudflare", "--repo", str(repo), "--json"])
@@ -322,8 +364,129 @@ def test_connect_test_records_invalid_provider_without_leaking_secret(
     assert payload["ok"] is False
     assert payload["status"]["state"] == "invalid"
     assert payload["status"]["repair_command"] == "mb connect cloudflare --token-stdin"
-    assert payload["status"]["validation"]["summary"] == "provider rejected the credential"
+    assert "rejected the credential" in payload["status"]["validation"]["summary"]
+    assert payload["validation"]["upstream"]["endpoint_family"] == "cloudflare_user_token_verify"
+    assert payload["validation"]["upstream"]["http_status"] == 403
+    assert payload["validation"]["upstream"]["error_codes"] == ["9109"]
     assert "cf-secret-token" not in result.stdout
+
+
+def test_connect_test_routes_cloudflare_account_tokens_to_account_endpoint(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _local_secret_env(monkeypatch, tmp_path)
+    repo = tmp_path / "biz"
+    repo.mkdir()
+    runner.invoke(
+        app,
+        [
+            "connect",
+            "cloudflare",
+            "--repo",
+            str(repo),
+            "--token",
+            "cf-secret-token",
+            "--metadata",
+            "token_type=account",
+            "--metadata",
+            "account_id=0123456789abcdef0123456789abcdef",
+        ],
+    )
+    calls: list[str] = []
+
+    def fake_http(url: str, headers=None, **kwargs) -> dict[str, Any]:
+        calls.append(url)
+        return {
+            "ok": True,
+            "state": "ready",
+            "summary": "Cloudflare credential validated with provider.",
+            "safe_to_share": True,
+            "upstream": {
+                "endpoint_family": kwargs["endpoint_family"],
+                "http_status": 200,
+                "response_received": True,
+                "error_codes": [],
+                "error_messages": [],
+                "safe_to_share": True,
+            },
+        }
+
+    monkeypatch.setattr(connect_mod, "_http_get_json", fake_http)
+
+    result = runner.invoke(app, ["connect", "test", "cloudflare", "--repo", str(repo), "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["validation"]["upstream"]["endpoint_family"] == "cloudflare_account_token_verify"
+    assert calls == [
+        "https://api.cloudflare.com/client/v4/accounts/0123456789abcdef0123456789abcdef/tokens/verify"
+    ]
+
+
+def test_connect_test_routes_cloudflare_user_tokens_to_user_endpoint(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _local_secret_env(monkeypatch, tmp_path)
+    repo = tmp_path / "biz"
+    repo.mkdir()
+    runner.invoke(
+        app,
+        ["connect", "cloudflare", "--repo", str(repo), "--token", "cf-secret-token"],
+    )
+    calls: list[str] = []
+
+    def fake_http(url: str, headers=None, **kwargs) -> dict[str, Any]:
+        calls.append(url)
+        return {
+            "ok": True,
+            "state": "ready",
+            "summary": "Cloudflare credential validated with provider.",
+            "safe_to_share": True,
+            "upstream": {
+                "endpoint_family": kwargs["endpoint_family"],
+                "http_status": 200,
+                "response_received": True,
+                "error_codes": [],
+                "error_messages": [],
+                "safe_to_share": True,
+            },
+        }
+
+    monkeypatch.setattr(connect_mod, "_http_get_json", fake_http)
+
+    result = runner.invoke(app, ["connect", "test", "cloudflare", "--repo", str(repo), "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["validation"]["upstream"]["endpoint_family"] == "cloudflare_user_token_verify"
+    assert calls == ["https://api.cloudflare.com/client/v4/user/tokens/verify"]
+
+
+def test_connect_test_account_token_requires_account_id(tmp_path: Path, monkeypatch) -> None:
+    _local_secret_env(monkeypatch, tmp_path)
+    repo = tmp_path / "biz"
+    repo.mkdir()
+    runner.invoke(
+        app,
+        [
+            "connect",
+            "cloudflare",
+            "--repo",
+            str(repo),
+            "--token",
+            "cf-secret-token",
+            "--metadata",
+            "token_type=account",
+        ],
+    )
+
+    result = runner.invoke(app, ["connect", "test", "cloudflare", "--repo", str(repo), "--json"])
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["status"]["state"] == "invalid"
+    assert "account_id" in payload["validation"]["summary"]
+    assert payload["validation"]["upstream"]["response_received"] is False
 
 
 def test_connect_test_no_probe_provider_reaches_ready_without_loop(
@@ -362,7 +525,22 @@ def test_connect_test_transient_provider_failure_stays_unvalidated(
     monkeypatch.setattr(
         connect_mod,
         "_http_get_json",
-        lambda url, headers=None: ("unvalidated", "provider validation returned HTTP 503"),
+        lambda url, headers=None, **kwargs: {
+            "ok": False,
+            "state": "unvalidated",
+            "summary": (
+                "Cloudflare validation returned HTTP 503. Retry after the provider recovers."
+            ),
+            "safe_to_share": True,
+            "upstream": {
+                "endpoint_family": kwargs["endpoint_family"],
+                "http_status": 503,
+                "response_received": True,
+                "error_codes": [],
+                "error_messages": [],
+                "safe_to_share": True,
+            },
+        },
     )
 
     result = runner.invoke(app, ["connect", "test", "cloudflare", "--repo", str(repo), "--json"])
@@ -372,8 +550,24 @@ def test_connect_test_transient_provider_failure_stays_unvalidated(
     assert payload["ok"] is False
     assert payload["status"]["state"] == "unvalidated"
     assert payload["status"]["repair_command"] == "mb connect test cloudflare"
-    assert payload["status"]["validation"]["summary"] == "provider validation returned HTTP 503"
+    assert "HTTP 503" in payload["status"]["validation"]["summary"]
     assert "cf-secret-token" not in result.stdout
+
+
+def test_token_stdin_prints_interactive_eof_prompt(monkeypatch, capsys) -> None:
+    class FakeStdin:
+        def isatty(self) -> bool:
+            return True
+
+        def read(self) -> str:
+            return "secret-token\n"
+
+    monkeypatch.setattr(sys, "stdin", FakeStdin())
+
+    token = connect_mod.read_stdin_token()
+
+    assert token == "secret-token"
+    assert "Ctrl-D" in capsys.readouterr().err
 
 
 def test_connect_doctor_includes_github_context_and_provider_repairs(

--- a/mb/tests/test_connect.py
+++ b/mb/tests/test_connect.py
@@ -233,6 +233,39 @@ def test_connect_repo_identity_is_stable_across_worktrees(tmp_path: Path, monkey
     )
 
 
+def test_connect_normalizes_common_remote_protocol_variants() -> None:
+    assert connect_mod._normalized_remote("git@gitlab.com:team/business.git") == (
+        "https://gitlab.com/team/business"
+    )
+    assert connect_mod._normalized_remote("ssh://git@gitlab.com/team/business.git") == (
+        "https://gitlab.com/team/business"
+    )
+    assert connect_mod._normalized_remote("https://gitlab.com/team/business.git") == (
+        "https://gitlab.com/team/business"
+    )
+
+
+def test_connect_preserves_existing_repo_id_to_avoid_orphaned_secrets(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _local_secret_env(monkeypatch, tmp_path)
+    repo = tmp_path / "biz"
+    (repo / ".mb").mkdir(parents=True)
+    (repo / ".mb" / "connect.yaml").write_text(
+        yaml.safe_dump({"version": 1, "repo_id": "legacy-random-id", "providers": {}}),
+        encoding="utf-8",
+    )
+
+    connect_mod.connect_provider("cloudflare", repo=repo, token="cf-secret-token")
+
+    config = yaml.safe_load((repo / ".mb" / "connect.yaml").read_text(encoding="utf-8"))
+    assert config["repo_id"] == "legacy-random-id"
+    assert config["repo_identity"]["repo_id_source"] == "existing_config"
+    assert config["providers"]["cloudflare"]["secrets"]["api_token"]["ref"] == (
+        connect_mod._secret_ref("legacy-random-id", "cloudflare", "api_token")
+    )
+
+
 def test_connect_provider_only_reads_env_when_explicit(tmp_path: Path, monkeypatch) -> None:
     _local_secret_env(monkeypatch, tmp_path)
     monkeypatch.setenv("APIFY_TOKEN", "apify-test-token")
@@ -462,6 +495,83 @@ def test_connect_test_routes_cloudflare_user_tokens_to_user_endpoint(
     assert calls == ["https://api.cloudflare.com/client/v4/user/tokens/verify"]
 
 
+def test_connect_test_account_token_uses_account_read_fallback_on_verify_404(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _local_secret_env(monkeypatch, tmp_path)
+    repo = tmp_path / "biz"
+    repo.mkdir()
+    runner.invoke(
+        app,
+        [
+            "connect",
+            "cloudflare",
+            "--repo",
+            str(repo),
+            "--token",
+            "cf-secret-token",
+            "--metadata",
+            "token_type=account",
+            "--metadata",
+            "account_id=0123456789abcdef0123456789abcdef",
+        ],
+    )
+    calls: list[tuple[str, str]] = []
+
+    def fake_http(url: str, headers=None, **kwargs) -> dict[str, Any]:
+        endpoint = kwargs["endpoint_family"]
+        calls.append((endpoint, url))
+        if endpoint == "cloudflare_account_token_verify":
+            return {
+                "ok": False,
+                "state": "invalid",
+                "summary": "Cloudflare could not find the requested account/token resource.",
+                "safe_to_share": True,
+                "upstream": {
+                    "endpoint_family": endpoint,
+                    "http_status": 404,
+                    "response_received": True,
+                    "error_codes": ["1003"],
+                    "error_messages": ["Not found"],
+                    "safe_to_share": True,
+                },
+            }
+        return {
+            "ok": True,
+            "state": "ready",
+            "summary": "Cloudflare credential validated with provider.",
+            "safe_to_share": True,
+            "upstream": {
+                "endpoint_family": endpoint,
+                "http_status": 200,
+                "response_received": True,
+                "error_codes": [],
+                "error_messages": [],
+                "safe_to_share": True,
+            },
+        }
+
+    monkeypatch.setattr(connect_mod, "_http_get_json", fake_http)
+
+    result = runner.invoke(app, ["connect", "test", "cloudflare", "--repo", str(repo), "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["validation"]["upstream"]["endpoint_family"] == "cloudflare_account_read"
+    assert payload["validation"]["upstream"]["fallback_from"] == "cloudflare_account_token_verify"
+    assert "fallback" in payload["validation"]["summary"]
+    assert calls == [
+        (
+            "cloudflare_account_token_verify",
+            "https://api.cloudflare.com/client/v4/accounts/0123456789abcdef0123456789abcdef/tokens/verify",
+        ),
+        (
+            "cloudflare_account_read",
+            "https://api.cloudflare.com/client/v4/accounts/0123456789abcdef0123456789abcdef",
+        ),
+    ]
+
+
 def test_connect_test_account_token_requires_account_id(tmp_path: Path, monkeypatch) -> None:
     _local_secret_env(monkeypatch, tmp_path)
     repo = tmp_path / "biz"
@@ -484,8 +594,14 @@ def test_connect_test_account_token_requires_account_id(tmp_path: Path, monkeypa
 
     assert result.exit_code == 1
     payload = json.loads(result.stdout)
-    assert payload["status"]["state"] == "invalid"
+    assert payload["status"]["state"] == "unvalidated"
+    assert payload["status"]["repair_command"] == (
+        "mb connect cloudflare --metadata token_type=account --metadata account_id=<account-id>"
+    )
     assert "account_id" in payload["validation"]["summary"]
+    assert payload["validation"]["repair_command"] == (
+        "mb connect cloudflare --metadata token_type=account --metadata account_id=<account-id>"
+    )
     assert payload["validation"]["upstream"]["response_received"] is False
 
 

--- a/mb/tests/test_doctor.py
+++ b/mb/tests/test_doctor.py
@@ -173,6 +173,33 @@ def test_doctor_repair_plan_is_read_only_for_status_marker(tmp_path: Path) -> No
     assert not marker.exists()
 
 
+def test_doctor_repair_adds_connect_yaml_to_gitignore(tmp_path: Path) -> None:
+    repo = tmp_path / "biz"
+    init_run(path=str(repo), name="Acme")
+    gitignore = repo / ".gitignore"
+    gitignore.write_text(
+        gitignore.read_text(encoding="utf-8").replace(".mb/connect.yaml\n", ""),
+        encoding="utf-8",
+    )
+
+    plan = runner.invoke(app, ["doctor", "repair", "--repo", str(repo), "--plan", "--json"])
+
+    assert plan.exit_code in {0, 1}
+    plan_payload = json.loads(plan.stdout)
+    checks = {
+        check["name"]: check
+        for section in plan_payload["sections"]
+        if section["id"] == "gitignore"
+        for check in section["checks"]
+    }
+    assert checks[".mb/connect.yaml"]["state"] == "warn"
+
+    result = runner.invoke(app, ["doctor", "repair", "--repo", str(repo), "--apply", "--json"])
+
+    assert result.exit_code in {0, 1}
+    assert ".mb/connect.yaml" in gitignore.read_text(encoding="utf-8")
+
+
 def test_doctor_warns_on_legacy_campaigns_records(tmp_path: Path) -> None:
     repo = tmp_path / "legacy-pushes"
     init_run(path=str(repo), name="Acme")

--- a/mb/tests/test_doctor.py
+++ b/mb/tests/test_doctor.py
@@ -200,6 +200,35 @@ def test_doctor_repair_adds_connect_yaml_to_gitignore(tmp_path: Path) -> None:
     assert ".mb/connect.yaml" in gitignore.read_text(encoding="utf-8")
 
 
+def test_doctor_repair_untracks_existing_connect_yaml(tmp_path: Path) -> None:
+    repo = tmp_path / "biz"
+    init_run(path=str(repo), name="Acme")
+    connect_path = repo / ".mb" / "connect.yaml"
+    connect_path.write_text("version: 1\nrepo_id: legacy\nproviders: {}\n", encoding="utf-8")
+    doctor_mod._run_git(repo, ["add", "-f", ".mb/connect.yaml"])
+
+    plan = runner.invoke(app, ["doctor", "repair", "--repo", str(repo), "--plan", "--json"])
+
+    assert plan.exit_code in {0, 1}
+    plan_payload = json.loads(plan.stdout)
+    checks = {
+        check["name"]: check
+        for section in plan_payload["sections"]
+        if section["id"] == "gitignore"
+        for check in section["checks"]
+    }
+    assert checks[".mb/connect.yaml"]["summary"] == "tracked; repair will untrack"
+
+    result = runner.invoke(app, ["doctor", "repair", "--repo", str(repo), "--apply", "--json"])
+
+    assert result.exit_code in {0, 1}
+    payload = json.loads(result.stdout)
+    applied = {action["id"]: action for action in payload["applied_actions"]}
+    assert "gitignore-local-state-untrack" in applied
+    assert connect_path.exists()
+    assert not doctor_mod._run_git(repo, ["ls-files", "--error-unmatch", ".mb/connect.yaml"])["ok"]
+
+
 def test_doctor_warns_on_legacy_campaigns_records(tmp_path: Path) -> None:
     repo = tmp_path / "legacy-pushes"
     init_run(path=str(repo), name="Acme")

--- a/mb/tests/test_init.py
+++ b/mb/tests/test_init.py
@@ -46,6 +46,7 @@ def test_init_scaffolds_folders(tmp_path: Path) -> None:
     assert ".claude/worktrees/" in gitignore
     assert ".claude/skills/mb-start" in gitignore
     assert ".mb/backups/" in gitignore
+    assert ".mb/connect.yaml" in gitignore
     assert ".mb/onboarding.json" in gitignore
     assert ".mb/issue-drafts/" in gitignore
     claude_md = (target / "CLAUDE.md").read_text()

--- a/mb/tests/test_site.py
+++ b/mb/tests/test_site.py
@@ -11,6 +11,7 @@ from mb.cli import app
 from mb.init import run as init_run
 
 runner = CliRunner()
+REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 def _write_conversion(site: Path, payload: dict[str, object]) -> None:
@@ -50,6 +51,19 @@ def _write_dist_html(
     original = site / "index.html"
     _write_html(site, gtm_id=gtm_id, events=events)
     original.replace(site / "dist" / "index.html")
+
+
+def test_mb_site_skill_hard_gates_cloudflare_dependent_work() -> None:
+    skill = (REPO_ROOT / ".claude" / "skills" / "mb-site" / "SKILL.md").read_text(encoding="utf-8")
+    setup = (
+        REPO_ROOT / ".claude" / "skills" / "mb-site" / "references" / "minisite-setup.md"
+    ).read_text(encoding="utf-8")
+
+    assert "mb connect doctor --json" in skill
+    assert "continue read-only" in skill
+    assert "--metadata token_type=account --metadata account_id=..." in skill
+    assert "no buy, DNS, Pages, custom-domain, or deploy calls" in setup
+    assert "Main Branch cannot buy domains through `domain.py` yet" in setup
 
 
 def test_site_check_reports_ready_for_operator_review(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- Repairs the Cloudflare connect path so account-scoped tokens can validate with safe upstream diagnostics while user-token validation remains supported.
- Prevents `mb connect` from splitting credential identity across worktrees and preserves existing `repo_id` values to avoid orphaning stored secrets.
- Makes `.mb/connect.yaml` local-only for new and repaired repos, including untracking already-committed copies while leaving files on disk.
- Hard-gates `/mb-site` Cloudflare-dependent domain, DNS, Pages, custom-domain, and deploy work before tool dispatch.
- Keeps domain purchase honest by making `domain.py buy` a structured unavailable placeholder until live registrar support lands.

## Scope
In:
- Cloudflare account/user token validation routing, diagnostics, metadata repair paths, and account-read fallback.
- Connect repo identity, generated/repaired gitignore coverage, tracked `.mb/connect.yaml` repair, and interactive `--token-stdin` guidance.
- `/mb-site` Cloudflare pre-flight prose, provider-readiness docs, domain-buy availability copy, changelog, and focused tests.

Out:
- OSS site archetype work, visual/screenshot research harness, new section catalogue entries, Mintlify/docs-subdomain flow, and private stress-test/account details.

## Commits
- `9ffd781` — `[fix] Repair Cloudflare site workflow blockers`.
- `a49c305` — `[fix] Address connect review repairs`.

## Release / Issues
- Release: v0.3.x provider/site workflow repair.
- Linear ID(s): MAIN-252.
- Closes: none.
- Refs: #335.
- Follow-ups: live smoke with disposable Cloudflare account/user tokens before release; Claude Code runtime smoke for `/mb-site` provider gating when a runtime session is available.

## Success Metric
- A site workflow cannot proceed into Cloudflare domain/DNS/Pages/deploy work unless `mb connect doctor --json` reports Cloudflare ready, and `mb connect test cloudflare --json` gives safe, actionable diagnostics for both account-token and user-token paths.

## Validation
- Level 0 docs/decision: updated README, beginner/provider docs, `/mb-site` references, and `CHANGELOG.md`; no private stress-test details added.
- Level 1 static: `scripts/check.sh` passed.
- Level 2 CLI: focused connect/doctor/init/site tests passed, including account-token routing, metadata repair, upstream diagnostics, repo ID preservation, remote normalization, gitignore repair, and tracked `.mb/connect.yaml` untracking.
- Level 3 package/install: not run; package entrypoints and packaging metadata were not changed.
- Level 4 fixture repo: `mb onboard --yes`, dummy local Cloudflare connect metadata, `mb doctor`, `mb doctor repair --plan --json`, and tracked `.mb/connect.yaml` repair smoke passed.
- Level 5 runtime smoke: not run; no disposable Cloudflare provider token or Claude Code runtime session was available in this workspace.

## Public / Private Boundary
- Only generic provider endpoint-family/status/error facts are committed; no tokens, account data, private local paths, raw stress-test memo details, or customer/member context were added.
