### PR TITLE
[update] Prepare 0.3.4 release

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mainbranch",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Main Branch Claude Code skills for running a business from markdown files in git.",
   "author": {
     "name": "Noontide"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,26 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+## [0.3.4] - 2026-05-06
+
+v0.3.4 repairs the Cloudflare setup path used by `/mb-site`. Account-scoped
+Cloudflare tokens can now validate cleanly, provider failures include safer
+diagnostics, and site workflows stop before Cloudflare-dependent work when the
+repo is not connected yet.
+
+### What this means for you (plain English)
+
+- **Cloudflare setup is less brittle.** Main Branch can validate account-scoped
+  Cloudflare tokens as well as the older user-token path.
+- **Credential errors are easier to fix.** `mb connect test cloudflare --json`
+  now reports safe endpoint-family, HTTP status, and provider error details
+  instead of hiding every failure behind a generic rejection.
+- **Worktrees share the right identity.** New connect metadata derives
+  credential identity from stable git facts so parallel worktrees do not split
+  keychain entries for the same business repo.
+- **`/mb-site` stops earlier.** Domain, DNS, Pages, custom-domain, and deploy
+  work now gate on Cloudflare readiness instead of failing halfway through.
+
 ### Changed
 
 - `/mb-site` now hard-gates Cloudflare-dependent domain, DNS, Pages, custom

--- a/mb/mb/__init__.py
+++ b/mb/mb/__init__.py
@@ -7,6 +7,6 @@ file stays a thin dispatcher.
 
 from __future__ import annotations
 
-__version__ = "0.3.3"
+__version__ = "0.3.4"
 
 __all__ = ["__version__"]

--- a/mb/pyproject.toml
+++ b/mb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mainbranch"
-version = "0.3.3"
+version = "0.3.4"
 description = "Main Branch engine umbrella - scaffolds, validates, and graphs business-as-files repos. Claude Code first, runtime-agnostic by design."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- Prepares Main Branch `0.3.4` release metadata from current `main`.
- Moves the Cloudflare `/mb-site` repair notes from `[Unreleased]` into a dated `0.3.4` section.
- Aligns Python package, module, and Claude plugin version metadata at `0.3.4`.
- Keeps this branch scoped to release truth only, with no product code changes.

## Scope
- In: `CHANGELOG.md`, `mb/pyproject.toml`, `mb.__version__`, and `.claude-plugin/plugin.json`.
- Out: publishing `oe-v0.3.4`, PyPI publication, new product fixes, and marking the release shipped before post-merge install verification.

## Commits
- `d13aa34` — `[update] Prepare 0.3.4 release`.

## Release / Issues
- Release: `0.3.4`.
- Linear ID(s): MAIN-252.
- Closes: none.
- Refs: #335, #336.
- Follow-ups: publish `oe-v0.3.4`, verify PyPI, and run fresh PyPI/pipx install smoke after this lands on `main`.

## Success Metric
- Reviewers can merge a release-prep branch where changelog and version metadata agree on `0.3.4`, ready for GitHub Release and PyPI publication.

## Validation
- Level 0 docs/decision: Reviewed release notes for public release truth and no private provider/account details.
- Level 1 static: `scripts/check.sh` passed: format, lint, mypy, 287 tests, coverage, and bundled skill validation.
- Level 2 CLI: Covered by `scripts/check.sh` suite, including the new connect/doctor/site tests from #336.
- Level 3 package/install: `python3 -m build` succeeded for `mainbranch-0.3.4` wheel and sdist; clean venv installed the wheel and `mb --version` returned `mb 0.3.4`; isolated pipx wheel install also passed.
- Level 4 fixture repo: Clean wheel smoke passed `mb onboard`, `mb doctor`, `mb doctor repair --plan`, `mb status --peek`, `mb start --json`, and `mb validate`; verified generated `.gitignore` includes `.mb/connect.yaml`.
- Level 5 runtime smoke: Not run on this release-prep branch; final release should verify published PyPI/pipx install after merge.

## Public / Private Boundary
- No private Devon, Conductor, credential, token, provider account, customer, or runtime-local details were added.
