### PR TITLE
[fix] Detect Cloudflare account token prefix

### DIFF
--- a/.claude/skills/mb-site/SKILL.md
+++ b/.claude/skills/mb-site/SKILL.md
@@ -67,7 +67,7 @@ Say `/mb-site` again after compaction, context loss, or switching focus. It relo
      - **connect now:** `printf '%s' "$CLOUDFLARE_API_TOKEN" | mb connect cloudflare --token-stdin --metadata token_type=account --metadata account_id=... && mb connect test cloudflare`
      - **continue read-only:** availability checks, naming, brief, and research only; no buy, DNS, Pages, custom-domain, or deploy calls.
      - **skip for now:** record the blocker in the push/site notes and stage a follow-up task.
-   - User API tokens remain supported as a fallback by omitting `token_type=account`; prefer account-scoped tokens for multi-business operators.
+   - `cfat_` account tokens route automatically when `account_id` is present; keep `token_type=account` in examples because it is explicit and works on older `mb` versions. User API tokens remain supported as a fallback by omitting `token_type=account`.
 5. Resolve the active offer and required business context with [`references/site-context.md`](references/site-context.md).
 6. Ask what the operator is building, then load only the shape reference needed next.
 

--- a/.claude/skills/mb-site/references/cloudflare-pages-link.md
+++ b/.claude/skills/mb-site/references/cloudflare-pages-link.md
@@ -2,8 +2,33 @@
 
 Two scenarios live in this doc, in order of how often you'll hit them:
 
+0. **Provider readiness check** (must be green before Pages/DNS/domain tool calls)
 1. **First time on this Cloudflare account: bind the GitHub App** (the OAuth handshake step that gets you out of CF code `8000011`)
 2. **Manual Pages project creation via dashboard** (rare — `pages.py create-project` is the default; this is the dashboard fallback)
+
+---
+
+## 0. Provider readiness check
+
+Before Cloudflare Pages, DNS, custom-domain, deploy, or domain-purchase work,
+run this from the business repo:
+
+```bash
+mb connect doctor --json
+```
+
+If `provider:cloudflare` is not `ready`, connect the account token before
+continuing:
+
+```bash
+printf '%s' "$CLOUDFLARE_API_TOKEN" | mb connect cloudflare --token-stdin --metadata token_type=account --metadata account_id=...
+mb connect test cloudflare
+```
+
+`cfat_` account tokens route automatically when `account_id` metadata is
+present; `token_type=account` stays in the command because it is explicit and
+works on older `mb` versions. User API tokens remain supported as a fallback by
+omitting `token_type=account`.
 
 ---
 

--- a/.claude/skills/mb-site/scripts/setup_creds.sh
+++ b/.claude/skills/mb-site/scripts/setup_creds.sh
@@ -6,6 +6,11 @@
 # ~/.config/vip/env.sh with chmod 600. Idempotent — re-running replaces
 # existing values for these three vars without duplicating lines.
 #
+# This is the legacy env bridge for /mb-site atoms. From the business repo,
+# also run `mb connect cloudflare --token-stdin --metadata token_type=account
+# --metadata account_id=<account-id>` so Main Branch stores provider readiness
+# metadata in .mb/connect.yaml and keeps the secret outside git.
+#
 # Token must have these scopes on the account that owns the /mb-site assets
 # (registrar domains + Pages projects + DNS zones):
 #   Cloudflare Registrar:Edit
@@ -34,6 +39,9 @@ Vars set:  CLOUDFLARE_API_TOKEN, CLOUDFLARE_API_TOKEN_REGISTRAR, CF_ACCOUNT_ID
 
 Existing values for these three vars will be replaced (idempotent).
 Token input is hidden; nothing is echoed back to the terminal.
+
+This script writes the legacy atom env bridge. It does not replace the
+repo-scoped Main Branch connection stored by `mb connect`.
 
 EOF
 
@@ -89,12 +97,16 @@ else
   echo "WARNING: nothing matched after write — file may have unexpected format." >&2
 fi
 
-cat <<'EOF'
+cat <<EOF
 
 Next:
   source ~/.config/vip/env.sh
+  printf '%s' "\$CLOUDFLARE_API_TOKEN" | mb connect cloudflare --token-stdin --metadata token_type=account --metadata account_id=${CF_ACCT}
+  mb connect test cloudflare
   python3 .claude/skills/mb-site/scripts/verify_live.py
 
-Expected: 3/4 → 4/4 once Porkbun keys land. CF auth + zone lookup should
-flip green immediately. Token + account never printed; safe to scroll back.
+`cfat_` account tokens route automatically when account_id metadata is present;
+`token_type=account` stays in the command because it is explicit and works on
+older mb versions. Expected: CF auth + zone lookup should flip green
+immediately. The token is never printed; safe to scroll back.
 EOF

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,12 +42,14 @@ repo is not connected yet.
 
 - `mb connect test cloudflare` now supports Cloudflare account-scoped token
   validation via `--metadata token_type=account --metadata account_id=...`
-  while preserving the existing user-token verify path. Failed provider checks
-  include safe upstream diagnostics such as endpoint family, HTTP status, and
-  provider error codes/messages in JSON. Account-token validation falls back to
-  a read-only account probe if Cloudflare returns 404 for the token verify path,
-  so valid credentials are not immediately classified as bad solely because the
-  verify endpoint shape changed. Refs #335.
+  while preserving the existing user-token verify path. `cfat_` account tokens
+  now route to the account-token validation path automatically when
+  `account_id` metadata is present. Failed provider checks include safe
+  upstream diagnostics such as endpoint family, HTTP status, and provider error
+  codes/messages in JSON. Account-token validation falls back to a read-only
+  account probe if Cloudflare returns 404 for the token verify path, so valid
+  credentials are not immediately classified as bad solely because the verify
+  endpoint shape changed. Refs #335.
 - `mb connect` now derives repo-scoped credential identity from stable git
   remote/common-dir facts for new connect metadata before falling back to the
   local path, avoiding separate keychain refs for parallel worktrees of the same

--- a/mb/mb/connect.py
+++ b/mb/mb/connect.py
@@ -575,7 +575,9 @@ def _parse_metadata(pairs: list[str]) -> dict[str, str]:
     return metadata
 
 
-def _cloudflare_token_type(metadata: dict[str, Any]) -> str:
+def _cloudflare_token_type(metadata: dict[str, Any], secret: str = "") -> str:
+    if secret.strip().startswith("cfat_"):
+        return "account"
     raw = (
         metadata.get("token_type")
         or metadata.get("token_scope")
@@ -939,7 +941,7 @@ def _validate_with_provider(
     checked_at = _now()
     metadata = metadata or {}
     if provider.id == "cloudflare":
-        token_type = _cloudflare_token_type(metadata)
+        token_type = _cloudflare_token_type(metadata, secret)
         if token_type == "account":
             account_id = str(metadata.get("account_id") or "").strip()
             if not account_id:

--- a/mb/tests/test_connect.py
+++ b/mb/tests/test_connect.py
@@ -456,6 +456,56 @@ def test_connect_test_routes_cloudflare_account_tokens_to_account_endpoint(
     ]
 
 
+def test_connect_test_detects_cloudflare_account_token_prefix(tmp_path: Path, monkeypatch) -> None:
+    _local_secret_env(monkeypatch, tmp_path)
+    repo = tmp_path / "biz"
+    repo.mkdir()
+    runner.invoke(
+        app,
+        [
+            "connect",
+            "cloudflare",
+            "--repo",
+            str(repo),
+            "--token",
+            "cfat_secret-token",
+            "--metadata",
+            "account_id=0123456789abcdef0123456789abcdef",
+        ],
+    )
+    calls: list[str] = []
+
+    def fake_http(url: str, headers=None, **kwargs) -> dict[str, Any]:
+        calls.append(url)
+        return {
+            "ok": True,
+            "state": "ready",
+            "summary": "Cloudflare credential validated with provider.",
+            "safe_to_share": True,
+            "upstream": {
+                "endpoint_family": kwargs["endpoint_family"],
+                "http_status": 200,
+                "response_received": True,
+                "error_codes": [],
+                "error_messages": [],
+                "safe_to_share": True,
+            },
+        }
+
+    monkeypatch.setattr(connect_mod, "_http_get_json", fake_http)
+
+    result = runner.invoke(app, ["connect", "test", "cloudflare", "--repo", str(repo), "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["validation"]["upstream"]["endpoint_family"] == (
+        "cloudflare_account_token_verify"
+    )
+    assert calls == [
+        "https://api.cloudflare.com/client/v4/accounts/0123456789abcdef0123456789abcdef/tokens/verify"
+    ]
+
+
 def test_connect_test_routes_cloudflare_user_tokens_to_user_endpoint(
     tmp_path: Path, monkeypatch
 ) -> None:

--- a/mb/tests/test_site.py
+++ b/mb/tests/test_site.py
@@ -58,10 +58,20 @@ def test_mb_site_skill_hard_gates_cloudflare_dependent_work() -> None:
     setup = (
         REPO_ROOT / ".claude" / "skills" / "mb-site" / "references" / "minisite-setup.md"
     ).read_text(encoding="utf-8")
+    setup_creds = (
+        REPO_ROOT / ".claude" / "skills" / "mb-site" / "scripts" / "setup_creds.sh"
+    ).read_text(encoding="utf-8")
+    pages_link = (
+        REPO_ROOT / ".claude" / "skills" / "mb-site" / "references" / "cloudflare-pages-link.md"
+    ).read_text(encoding="utf-8")
 
     assert "mb connect doctor --json" in skill
     assert "continue read-only" in skill
     assert "--metadata token_type=account --metadata account_id=..." in skill
+    assert "`cfat_` account tokens route automatically" in skill
+    assert "mb connect cloudflare --token-stdin --metadata token_type=account" in setup_creds
+    assert "mb connect doctor --json" in pages_link
+    assert "`cfat_` account tokens route automatically" in pages_link
     assert "no buy, DNS, Pages, custom-domain, or deploy calls" in setup
     assert "Main Branch cannot buy domains through `domain.py` yet" in setup
 


### PR DESCRIPTION
## Summary
- Auto-detects Cloudflare `cfat_` account tokens during `mb connect test cloudflare` so account-scoped tokens route to the account validation path when `account_id` metadata is present.
- Updates `/mb-site` setup guidance so `SKILL.md`, `setup_creds.sh`, and the Cloudflare Pages link reference teach the `mb connect cloudflare --token-stdin --metadata ...` invocation.
- Keeps account-token examples generic and avoids committing production account IDs or secrets.

## Scope
- In: Cloudflare token prefix classification, account-token doc guidance, focused regression coverage, changelog note.
- Out: live Cloudflare credential smoke, package release, Claude Code runtime smoke, domain purchase automation.

## Commits
- c0ee05d — `[fix] Detect Cloudflare account token prefix`.

## Release / Issues
- Release: Unreleased / next patch after 0.3.4.
- Linear ID(s): MAIN-252.
- Closes: none.
- Refs: #335.
- Follow-ups: run package/install smoke and runtime `/mb-site` smoke when cutting the next release; rotate any throwaway Cloudflare token outside this public repo.

## Success Metric
- A stored Cloudflare token beginning with `cfat_` plus `account_id` metadata validates through the account-token endpoint without requiring `token_type=account`, while operator docs still show the explicit metadata command for older `mb` versions.

## Validation
- Level 0 docs/decision: Updated `/mb-site` references and `CHANGELOG.md`; no private production account ID committed.
- Level 1 static: `scripts/check.sh` passes.
- Level 2 CLI: `pytest tests/test_connect.py tests/test_site.py -q` passes; full test suite passes under `scripts/check.sh`.
- Level 3 package/install: Not run; no packaging or entrypoint changes.
- Level 4 fixture repo: Not run for this narrow follow-up.
- Level 5 runtime smoke: Not run; production 0.3.4 smoke confirmed the metadata path, this PR adds prefix detection and docs.

## Public / Private Boundary
- The production account ID and token details from the operator note were kept out of committed files; docs use placeholders or values collected locally by `setup_creds.sh`.
