### PR TITLE
[update] Prepare 0.3.5 release

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mainbranch",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Main Branch Claude Code skills for running a business from markdown files in git.",
   "author": {
     "name": "Noontide"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,31 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+## [0.3.5] - 2026-05-06
+
+v0.3.5 tightens the Cloudflare account-token repair from v0.3.4. Main Branch
+now recognizes `cfat_` Cloudflare Account API tokens automatically when
+`account_id` metadata is present, and `/mb-site` setup docs show the safer
+account-token command shape.
+
+### What this means for you (plain English)
+
+- **Cloudflare account tokens need less ceremony.** A stored token beginning
+  with `cfat_` now routes to the account-token validation path automatically
+  when account metadata is present.
+- **The docs match the safer path.** `/mb-site` setup guidance now teaches the
+  account-scoped token command with `account_id` metadata instead of implying
+  every operator should use a personal user token.
+
+### Fixed
+
+- `mb connect test cloudflare` now auto-detects `cfat_` account tokens and uses
+  the account-token validation path when `account_id` metadata is present,
+  without requiring `token_type=account`. Refs #335.
+- `/mb-site` setup guidance, `setup_creds.sh`, and the Cloudflare Pages
+  reference now show the `mb connect cloudflare --token-stdin --metadata ...`
+  command shape for account-scoped Cloudflare tokens. Refs #335.
+
 ## [0.3.4] - 2026-05-06
 
 v0.3.4 repairs the Cloudflare setup path used by `/mb-site`. Account-scoped
@@ -42,14 +67,12 @@ repo is not connected yet.
 
 - `mb connect test cloudflare` now supports Cloudflare account-scoped token
   validation via `--metadata token_type=account --metadata account_id=...`
-  while preserving the existing user-token verify path. `cfat_` account tokens
-  now route to the account-token validation path automatically when
-  `account_id` metadata is present. Failed provider checks include safe
-  upstream diagnostics such as endpoint family, HTTP status, and provider error
-  codes/messages in JSON. Account-token validation falls back to a read-only
-  account probe if Cloudflare returns 404 for the token verify path, so valid
-  credentials are not immediately classified as bad solely because the verify
-  endpoint shape changed. Refs #335.
+  while preserving the existing user-token verify path. Failed provider checks
+  include safe upstream diagnostics such as endpoint family, HTTP status, and
+  provider error codes/messages in JSON. Account-token validation falls back to
+  a read-only account probe if Cloudflare returns 404 for the token verify path,
+  so valid credentials are not immediately classified as bad solely because the
+  verify endpoint shape changed. Refs #335.
 - `mb connect` now derives repo-scoped credential identity from stable git
   remote/common-dir facts for new connect metadata before falling back to the
   local path, avoiding separate keychain refs for parallel worktrees of the same

--- a/mb/mb/__init__.py
+++ b/mb/mb/__init__.py
@@ -7,6 +7,6 @@ file stays a thin dispatcher.
 
 from __future__ import annotations
 
-__version__ = "0.3.4"
+__version__ = "0.3.5"
 
 __all__ = ["__version__"]

--- a/mb/pyproject.toml
+++ b/mb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mainbranch"
-version = "0.3.4"
+version = "0.3.5"
 description = "Main Branch engine umbrella - scaffolds, validates, and graphs business-as-files repos. Claude Code first, runtime-agnostic by design."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- Prepares Main Branch `0.3.5` release metadata from current `main`.
- Adds dated `0.3.5` release notes for the Cloudflare `cfat_` account-token detection fix from #338.
- Aligns Python package, module, and Claude plugin version metadata at `0.3.5`.
- Keeps this branch scoped to release truth only, with no product code changes.

## Scope
- In: `CHANGELOG.md`, `mb/pyproject.toml`, `mb.__version__`, and `.claude-plugin/plugin.json`.
- Out: publishing `oe-v0.3.5`, PyPI publication, new product fixes, live Cloudflare credential validation, and marking the release shipped before post-merge install verification.

## Commits
- `f63d7bf` — `[update] Prepare 0.3.5 release`.

## Release / Issues
- Release: `0.3.5`.
- Linear ID(s): MAIN-252.
- Closes: none.
- Refs: #335, #338.
- Follow-ups: publish `oe-v0.3.5`, verify PyPI, and run fresh PyPI/pipx install smoke after this lands on `main`.

## Success Metric
- Reviewers can merge a release-prep branch where changelog and version metadata agree on `0.3.5`, ready for GitHub Release and PyPI publication.

## Validation
- Level 0 docs/decision: Reviewed release notes for public release truth and no private provider/account/token details.
- Level 1 static: `scripts/check.sh` passed: format, lint, mypy, 288 tests, coverage, and bundled skill validation.
- Level 2 CLI: Covered by `scripts/check.sh`, including the Cloudflare account-token prefix regression from #338.
- Level 3 package/install: `python3 -m build` succeeded for `mainbranch-0.3.5` wheel and sdist; clean venv installed the wheel and `mb --version` returned `mb 0.3.5`; isolated pipx wheel install also passed.
- Level 4 fixture repo: Clean wheel smoke passed `mb onboard`, `mb doctor`, `mb doctor repair --plan`, `mb status --peek`, `mb start --json`, and `mb validate`; isolated pipx smoke passed onboard, doctor, status, and start. Both verified generated `.gitignore` includes `.mb/connect.yaml`.
- Level 5 runtime smoke: Not run on this release-prep branch; final release should verify published PyPI/pipx install after merge. Live Cloudflare provider smoke was not run because it requires real provider credentials/state.

## Public / Private Boundary
- No private Devon, Conductor, credential, token, provider account, customer, or runtime-local details were added.
