### PR TITLE
[docs] Refresh public docs for 0.3.5 positioning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -183,7 +183,7 @@ Good issue slices look like:
 - one command surface, such as `mb status`;
 - one repair loop, such as `mb update`;
 - one validator, such as cross-reference validation;
-- one runtime proof, such as Claude Code `/start` discovery from a fresh repo.
+- one runtime proof, such as Claude Code `/mb-start` discovery from a fresh repo.
 - one product loop, such as "turn user friction into a GitHub issue draft" or
   "surface the next three actions from status signals."
 
@@ -328,7 +328,7 @@ Level 5, runtime smoke:
 
 - create a fresh business repo;
 - launch the relevant runtime from that repo;
-- verify `/start` or the equivalent runtime entrypoint is discoverable;
+- verify `/mb-start` or the equivalent runtime entrypoint is discoverable;
 - verify the skill reads the business repo and does not write into the engine
   repo;
 - record the evidence in the PR.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to `mb-vip` (the Main Branch engine) will be documented in
+All notable changes to Main Branch (`mainbranch` / `mb`) will be documented in
 this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,7 +104,7 @@ Specifically:
 
 Any change to `.claude/skills/*/SKILL.md` or its `references/` should:
 
-1. Run `/skill-creator` review (or equivalent self-review against [the skill-creator guide](https://github.com/anthropics/claude-code/blob/main/docs/skills.md)).
+1. Review the skill against the bundled skill maintenance rules in [AGENTS.md](AGENTS.md) and the skill line-count/frontmatter gates.
 2. Run skill regression: `test-skills` skill (admin-only) verifies the skill-system invariants.
 3. Keep `SKILL.md` under 500 lines (CI gates this). If it grows past, split content into `references/<topic>.md`.
 4. Add or update frontmatter: `name:`, `tier:` (skill | playbook), `calls:` (list of tool/skill names invoked by this skill).
@@ -140,6 +140,4 @@ Codex, Claude Code, and other agents.
 
 The engine v0.1.0 decision is `decisions/2026-04-29-mb-vip-v0-1-0-master.md`. It locks the first public ship list and historical launch vocabulary.
 
-The companion business-side master plan is tracked in `noontide-co/projects#119`. Read it when a contribution touches product positioning, public launch sequencing, pricing, the agency arm, or the four CLI pillars.
-
-If you're considering a contribution, read it first.
+Historical business-side planning also exists in private Noontide repos. Public contributors should treat this repository's decisions, docs, issues, changelog, and releases as the durable product truth.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,7 +107,11 @@ Any change to `.claude/skills/*/SKILL.md` or its `references/` should:
 1. Review the skill against the bundled skill maintenance rules in [AGENTS.md](AGENTS.md) and the skill line-count/frontmatter gates.
 2. Run skill regression: `test-skills` skill (admin-only) verifies the skill-system invariants.
 3. Keep `SKILL.md` under 500 lines (CI gates this). If it grows past, split content into `references/<topic>.md`.
-4. Add or update frontmatter: `name:`, `tier:` (skill | playbook), `calls:` (list of tool/skill names invoked by this skill).
+4. Add or update required frontmatter: `name:`, `description:`, and `loops:`
+   using canonical loop slugs (`sense`, `decide`, `ship`, `reflect`). Older
+   composable/internal skill files may also carry `tier:` and `calls:` while
+   they are being migrated, but new bundled skills should use `loops:` as the
+   routing contract.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ claude
 /mb-start
 ```
 
-That's it. `mb onboard` guides the human setup, creates or connects your business repo, wires Claude Code to the bundled skills, and shows the exact next commands. `mb init` still exists as the quiet scriptable primitive underneath it. `/mb-start` walks you through the rest — gathers your business context (offer, audience, voice), drafts the reference files, and routes you to the right workflow.
+That's it. `mb onboard` guides the human setup, creates or connects your business repo, wires Claude Code to the bundled skills, and shows the exact next commands. `mb init` still exists as the quiet scriptable primitive underneath it. `/mb-start` then reads the deterministic status facts, checks whether the repo needs repair or an update, and routes you to setup, thinking, shipping, or closing work.
 
 After the first session, the daily flow is:
 
@@ -73,7 +73,7 @@ the business repo.
 
 You'll need a Claude Pro ($20/mo) or Max subscription. Install Claude Code itself from [claude.ai](https://claude.ai) — see [docs/BEGINNER-SETUP.md](docs/BEGINNER-SETUP.md) for a step-by-step.
 
-Tested on macOS and Linux. Windows is experimental; see [docs/compatibility.md](docs/compatibility.md) and track [#137](https://github.com/noontide-co/mainbranch/issues/137).
+Tested on macOS and Linux. Windows is experimental; see [docs/compatibility.md](docs/compatibility.md). Power users on Windows should use WSL2 for the closest supported path.
 
 **New to Claude Code, git, or terminal?** Read [docs/BEGINNER-SETUP.md](docs/BEGINNER-SETUP.md) — it covers everything step-by-step, including common errors.
 
@@ -93,10 +93,10 @@ Once set up, you can:
 - Open, update, close, and narrate business bets
 - Generate batches of ad copy in your voice
 - Create video scripts for Meta ads
-- Generate organic content — Reels, TikTok, carousels — from your reference files and research
+- Generate organic content — Reels, TikTok, carousels — from your core files and research
 - Write VSL scripts for your community
 - Review ads for compliance before you run them
-- Build and deploy landing pages from your reference files
+- Build and deploy landing pages from your core files and research
 - Close sessions intentionally with crystallize moments
 
 All of this happens through simple slash commands. No prompting skills required.
@@ -135,7 +135,7 @@ my-business/
 └── documents/
 ```
 
-You fill in the reference files inside `core/`. Claude reads them when generating.
+You fill in the durable business files inside `core/`. Claude reads them when generating.
 
 ### Connected accounts live with the business repo
 
@@ -174,8 +174,10 @@ The CLI surface for the engine. Built for Claude Code first; runtime-agnostic by
 | `mb issue open` | Submit a reviewed issue draft with `gh issue create`, or print a browser/manual fallback when GitHub CLI is unavailable. |
 | `mb validate` | Frontmatter shape check across `core/`, `research/`, `decisions/`, `bets/`, `log/`, `pushes/` (and legacy `campaigns/` as compatibility), `documents/`. Pass/fail per file. |
 | `mb graph` | Build a repo graph index from frontmatter links, wikilinks, and entity tags. Emits Graphviz DOT by default, `--json` for agents/dashboards, and `--open` to render a PNG view. |
+| `mb similar-bets` | Find similar past bets and offer outcomes from repo truth so new work can learn from old attempts. |
+| `mb checkpoint` | Plan or save a business-readable git checkpoint during long agent runs. |
 | `mb think <topic>` | Print the `/mb-think` invocation hint. Run inside Claude Code for the full flow. |
-| `mb resolve <key>` | Resolve a reference path (checks free first, then paid). |
+| `mb resolve <key>` | Resolve a reference key from the curated library, local core files, or bundled stubs. |
 | `mb educational <topic>` | Print an educational triage file (powers `mb doctor`'s "tell me more" prompts). |
 | `mb skill list` | List the skills bundled with this engine. |
 | `mb skill path <name>` | Print the on-disk path to a bundled skill. |
@@ -232,12 +234,12 @@ Skills are pre-built workflows you invoke with slash prompts. Instead of figurin
 | `/mb-start` | Main entry point — figures out what you need and routes you there |
 | `/mb-status` | Thin Claude Code wrapper over `mb status --json --peek` for daily briefing facts and ranked next actions |
 | `/mb-setup` | Set up your business repo (run this first if you're new) |
-| `/mb-think` | Research, make decisions, add context, transcribe local recordings, update reference files |
+| `/mb-think` | Research, make decisions, add context, transcribe local recordings, update durable business files |
 | `/mb-bet` | Open, update, close, list, and narrate business bets |
 | `/mb-ads` | Create ad copy (static or video) and review for compliance |
 | `/mb-vsl` | Write video sales letter scripts (Skool or B2B) |
 | `/mb-organic` | Generate organic content — Reels, TikTok, carousels |
-| `/mb-site` | Generate and deploy landing pages from your reference files |
+| `/mb-site` | Generate and deploy landing pages from your core files and research |
 | `/mb-wiki` | Personal wiki with atomic notes |
 | `/mb-end` | Close session — summary, crystallize, commit |
 | `/mb-help` | Get answers, troubleshoot, learn the system |
@@ -262,13 +264,13 @@ Skills are pre-built workflows you invoke with slash prompts. Instead of figurin
 | Hermes / Paperclip-adjacent orchestration | Roadmap | Target orchestration layer; must consume stable repo and JSON contracts. |
 | Local runtimes | Roadmap | Long-range endpoint once adapter contracts are proven. |
 
-The engine v0.1.0 decision lives at [`decisions/2026-04-29-mb-vip-v0-1-0-master.md`](decisions/2026-04-29-mb-vip-v0-1-0-master.md). The business-side master plan amendment was merged in [`noontide-co/projects#119`](https://github.com/noontide-co/projects/pull/119).
+The engine v0.1.0 decision lives at [`decisions/2026-04-29-mb-vip-v0-1-0-master.md`](decisions/2026-04-29-mb-vip-v0-1-0-master.md). Some historical planning happened in private Noontide repos; public product truth now lives in this repository's decisions, docs, issues, changelog, and releases.
 
 ---
 
 ## Roadmap
 
-The current package is the CLI + Claude Code first-run foundation. Next work makes Main Branch better at knowing what changed, what is stale, and what to do next. See [docs/ROADMAP.md](docs/ROADMAP.md) for the public roadmap. Direction, not promises.
+The current package is the CLI + Claude Code first-run foundation plus the first daily decision surfaces: `mb status`, `/mb-status`, next-action ranking, bets, pushes, checkpoints, provider readiness, and privacy-safe issue drafting. Next work keeps tightening those loops and the public docs around them. See [docs/ROADMAP.md](docs/ROADMAP.md) for the public roadmap. Direction, not promises.
 
 The proposed long-range product direction is captured in
 [`decisions/2026-05-02-github-native-business-os.md`](decisions/2026-05-02-github-native-business-os.md):
@@ -276,9 +278,8 @@ Main Branch as a GitHub-native business operating system, with `mb` as the
 control plane, GitHub as the team layer, graph/structured data as the
 intelligence layer, and agent runtimes as execution.
 
-- **v0.3.0: Knows what to do next.** `mb status` v1, drift detection, next-action ranking, and `/mb-start` using the same deterministic substrate.
-- **v0.3.x: Improves itself in public.** Privacy-safe issue drafting, `doctor --json`, `/mb-status`, a small dashboard spike, and optional sidecar contracts.
-- **v0.4: Launches bets.** `bets/`, `/mb-bet`, public narration, and status integration for active business bets.
+- **v0.3.x: Tightens the daily operating loop.** Status/ranking, `/mb-start`, `/mb-status`, doctor repair, checkpoints, pushes, provider readiness, and issue drafting keep becoming clearer and more reliable.
+- **v0.4: Graduates bets into launch systems.** Stronger links between bets, offers, pages, ads, outcomes, and public narration.
 - **Longer range.** Runtime adapters, dashboard/server mode, structured data, deeper Ops surfaces (books, P&L, compliance), and richer Paid, Organic, and Pages workflows.
 
 See [CHANGELOG.md](CHANGELOG.md) for what's in this release. Each release ships a "What this means for you" plain-English section above the technical detail.
@@ -322,7 +323,7 @@ or operating history, move it into its own repo and keep the company repo as a
 hub.
 
 **What's a bet vs. an offer?**
-A bet is a time-boxed operating hypothesis: what you'll try, why, by when, and how you'll know if it worked. An offer is a durable thing you sell. A good bet can graduate into an offer, campaign, workflow, content pillar, or decision; a bad bet gets closed with learning.
+A bet is a time-boxed operating hypothesis: what you'll try, why, by when, and how you'll know if it worked. An offer is a durable thing you sell. A good bet can graduate into an offer, push, workflow, content pillar, or decision; a bad bet gets closed with learning.
 
 **What if I have multiple separate businesses?**
 Create a separate repo for each brand, legal entity, provider-account boundary,
@@ -373,7 +374,7 @@ For platform support and security reporting, see [SUPPORT.md](SUPPORT.md), [SECU
 - "404 error" or "Repository not found" — verify the URL and your network. The repo is public; no access request needed.
 - "Claude doesn't see my files" — make sure you started Claude in your business repo folder and ran `/mb-start`.
 - "Skills aren't working" — run `mb skill link --repo .` from your business repo to repair bridge symlinks, then restart Claude. If still broken, run `/mb-setup`.
-- "Output sounds generic" — add more detail to your reference files, especially `core/voice.md`.
+- "Output sounds generic" — add more detail to your core files, especially `core/voice.md`.
 - "I edited Main Branch but can't push" — that's expected for most users. Main Branch is the shared engine. Your business data goes in YOUR repo.
 
 **Turn friction into a public issue:** run `mb issue draft bug --command "mb doctor" --what-happened "..."` from your business repo. Review the local draft under `.mb/issue-drafts/`, then run `mb issue open <draft> --yes` when it is safe to submit. See [docs/issue-drafting.md](docs/issue-drafting.md).

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![PyPI version](https://img.shields.io/pypi/v/mainbranch?style=flat&label=PyPI)](https://pypi.org/project/mainbranch/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-**Run your business as files in git. Stop renting it from someone else's dashboard.**
+**Durable operating memory for AI-assisted businesses. Ship growth and ops work from files you own.**
 
 ---
 
@@ -16,11 +16,11 @@ You already feel it. Your offer lives in Notion. Your voice lives in a thousand 
 
 You're renting your business. Not just the dashboards — the operational memory itself.
 
-The open-source gap closed in 2025. The tools to own your stack exist now. Almost nobody has carved time to migrate, because there's no coherent environment that ties it together.
+The open-source gap closed in 2025. The tools to own your stack exist now. Almost nobody has carved time to migrate, because there is no coherent environment that ties it together.
 
-Main Branch is that environment. Your offer, audience, voice, decisions, research, bets, and pushes (launches, drops, challenges, promos — whatever your business calls them) live as markdown files in a git repo you own. The `mb` CLI scaffolds it. The bundled skills read those files and produce work that sounds like you — without re-prompting.
+Main Branch is that environment. Your offer, audience, voice, decisions, research, bets, pushes (launches, drops, challenges, promos — whatever your business calls them), meeting notes, fulfillment context, and operating lessons live as markdown files in a git repo you own. The `mb` CLI scaffolds and checks it. The bundled skills read those files and help ship work from what your business already knows.
 
-The end state isn't sitting at a terminal all day. It's the opposite — eventually you dump thoughts from your phone, drafts get made, you approve, it executes. We're not all the way there. The work is still real. But the substrate is the right one to build on.
+The end state isn't sitting at a terminal all day. It's the opposite — eventually you dump thoughts from your phone, drafts get made, finance and fulfillment signals roll up, the team sees what is moving, you approve the risky actions, and the system executes the boring rails. We're not all the way there. The work is still real. But the substrate is the right one to build on.
 
 Every bet you ship leaves a lesson. The lessons update your offer, your audience, your voice. Your business gets smarter every week — without you having to remember. The agent recommends; you make the call.
 
@@ -32,7 +32,11 @@ Own the work. Rent only the rails.
 
 ## What it is
 
-Main Branch is the `mb` CLI plus MIT-licensed agent workflows for running business-as-files systems. It's built for operators and small teams running real businesses: solo founders, small agencies, course creators, productized services, indie SaaS, and small ecom teams. Today the workflows ship for Claude Code. Codex, Cursor, OpenClaw, Hermes, and local runtimes are next. Your offer, audience, voice, research, decisions, bets, and pushes live in your own git repo — versioned, portable, agent-readable.
+Main Branch is the `mb` CLI plus MIT-licensed agent workflows for running a local-first business operating repo. It's built for operators and small teams running real businesses: solo founders, small agencies, course creators, productized services, indie SaaS, and small ecom teams. Today the workflows ship for Claude Code. Codex, Cursor, OpenClaw, Hermes, and local runtimes are compatibility targets, not supported adapters yet.
+
+The repo is the operating memory: offer, audience, voice, research, decisions, bets, pushes, logs, documents, meeting summaries, fulfillment notes, safe finance summaries, and provider refs. The CLI is the deterministic control plane: setup, status, validation, graph, provider readiness, updates, checkpoints, and repair. The skills are the judgment layer: research, decide, write, review, ship, and reflect.
+
+Main Branch is opinionated about rails. The point is not to connect every SaaS tool a business has accumulated. The point is to choose boring, inspectable paths: GitHub for tasks/proposals/history, Cloudflare for sites and DNS, provider paths such as Google/Workspace and official ads only where smoke-tested, planned optional rails such as Postiz for social scheduling and Beancount-style plain-text finance, and optional sidecars for enrichment. Those paths should be wrapped in deterministic commands agents can call without wasting tokens guessing provider setup.
 
 Read the product frame in [docs/ETHOS.md](docs/ETHOS.md), the four operator loops (Sense → Decide → Ship → Reflect) and the four channels (Paid, Organic, Pages, Ops) in [docs/OPERATOR-LOOPS.md](docs/OPERATOR-LOOPS.md), and the release direction in [docs/ROADMAP.md](docs/ROADMAP.md).
 Workspace, repo, dashboard, finance/legal, and team-log boundaries are defined
@@ -96,24 +100,31 @@ Once set up, you can:
 - Generate organic content — Reels, TikTok, carousels — from your core files and research
 - Write VSL scripts for your community
 - Review ads for compliance before you run them
-- Build and deploy landing pages from your core files and research
+- Build and deploy Cloudflare-backed landing pages from your core files and research when the repo is connected and readiness checks pass
+- Capture meeting transcripts, source material, and fulfillment notes into durable docs, logs, research, or decisions
 - Close sessions intentionally with crystallize moments
 
-All of this happens through simple slash commands. No prompting skills required.
+All of this happens through simple slash commands. No custom prompt engineering required for supported workflows.
 
 ---
 
 ## How it works
 
-Main Branch is the engine. Your business info is the fuel.
+Main Branch has three layers:
 
-```
-ENGINE (mb CLI + skills)    YOUR REPO (fuel)
-Has all the skills    +     Has your business info
-                      =     Outputs that sound like you
-```
+- **Your repo is canonical memory.** It holds the durable business truth:
+  core files, research, decisions, bets, pushes, logs, documents, and links to
+  child repos.
+- **`mb` is the deterministic control plane.** It scaffolds, validates, graphs,
+  briefs, repairs, checkpoints, updates, and checks provider readiness.
+- **Skills are the judgment layer.** Claude Code reads repo truth, asks the
+  operator questions, drafts work, reviews it, and routes artifacts back into
+  files.
 
-You create a separate folder for YOUR business. That's where your offer, audience, voice, and testimonials live. The engine reads those files. Then it generates content specific to you.
+You create a separate folder for YOUR business. That's where your offer,
+audience, voice, proof, operations, research, decisions, bets, pushes, logs, and
+documents live. The engine reads those files. Then it helps produce work and
+records what changed so the next session starts from the same memory.
 
 After running `mb init`, your business repo looks like this:
 
@@ -121,11 +132,20 @@ After running `mb init`, your business repo looks like this:
 my-business/
 ├── CLAUDE.md
 ├── .gitignore
+├── .github/
+│   └── CODEOWNERS
+├── .mb/
+│   └── schema_version
 ├── .claude/
 │   ├── settings.local.json    (gitignored — wires Claude Code to bundled skills)
 │   └── skills/                (gitignored — bridge symlinks)
 ├── core/
+│   ├── vocabulary.md
 │   ├── offers/
+│   ├── proof/
+│   ├── brand/
+│   ├── strategy/
+│   ├── operations/
 │   └── finance/
 ├── research/
 ├── decisions/
@@ -136,6 +156,15 @@ my-business/
 ```
 
 You fill in the durable business files inside `core/`. Claude reads them when generating.
+Old repos may still have `campaigns/`; `mb` reads it for compatibility, but
+new coordinated work belongs in `pushes/`.
+
+As a business grows, related work can graduate into child repos: sites,
+products/offers, client fulfillment repos, private finance repos, or ops repos.
+The business repo stays the hub. Future dashboard work should map those repos
+and their pushes, bets, commits, issues, PRs, checkpoints, provider-safe
+summaries, and open decisions. The dashboard is the map, not the source of
+truth.
 
 ### Connected accounts live with the business repo
 
@@ -189,8 +218,9 @@ Full list: `mb --help`.
 
 ### Provider Connections
 
-`mb connect` is the local-first foundation for integrations such as Google,
-Meta, Cloudflare, Postiz, Apify, Beancount, and transcription providers.
+`mb connect` is the local-first foundation for supported, planned, and optional
+provider rails such as GitHub, Cloudflare, Google, Meta, Postiz, Apify,
+Beancount, and transcription providers.
 Use `mb connect plan` when you are not sure what to connect first; it explains
 GitHub, Cloudflare, Google/Workspace, Meta Ads, and Apify as numbered business
 choices with the current readiness state and exact next command.
@@ -229,6 +259,11 @@ environment variables.
 
 Skills are pre-built workflows you invoke with slash prompts. Instead of figuring out how to prompt Claude, you type `/mb-ads` and Claude knows exactly what to do — reads your business files, then generates output that matches your voice.
 
+Some skills ship growth work. Others maintain operating memory. `/mb-start`,
+`/mb-status`, `/mb-think`, `/mb-bet`, `/mb-end`, `mb checkpoint`, `mb graph`,
+and `mb connect` are as important as the content skills because they keep the
+repo understandable, current, and safe to operate from.
+
 | Skill | What it does |
 |---|---|
 | `/mb-start` | Main entry point — figures out what you need and routes you there |
@@ -252,6 +287,9 @@ Skills are pre-built workflows you invoke with slash prompts. Instead of figurin
 
 - **Built for Claude Code today.** `mb` is runtime-agnostic by design, but Claude Code is the only first-class runtime currently supported end to end.
 - **The terminal front door is live.** Bare `mb`, `mb onboard`, `mb status`, `mb start`, and `mb update` are in the public package.
+- **Growth is the strongest shipped wedge.** Ads, organic, VSLs, sites, bets, pushes, status, and checkpoints are the most developed public workflows.
+- **Ops is the expansion path.** Meetings, fulfillment, bookkeeping/P&L, team daily logs, repo topology, and dashboard views use the same memory model, but they are less shipped than the growth surfaces.
+- **Provider automation is curated and gated.** GitHub and Cloudflare paths are the most concrete today. Google/Workspace, Meta Ads, Google Ads/GTM, Postiz, Apify, Beancount, and transcription are wired as planned or optional provider/sidecar surfaces until each path has smoke evidence.
 - **Schema is v1; will evolve.** Frontmatter shapes covered by `mb validate` are stable for the current major; breaking changes bump the major.
 - **Runtime compatibility is still ahead.** Codex, Cursor, OpenClaw, Hermes, and local LLMs are roadmap targets, not supported adapters yet.
 
@@ -270,7 +308,7 @@ The engine v0.1.0 decision lives at [`decisions/2026-04-29-mb-vip-v0-1-0-master.
 
 ## Roadmap
 
-The current package is the CLI + Claude Code first-run foundation plus the first daily decision surfaces: `mb status`, `/mb-status`, next-action ranking, bets, pushes, checkpoints, provider readiness, and privacy-safe issue drafting. Next work keeps tightening those loops and the public docs around them. See [docs/ROADMAP.md](docs/ROADMAP.md) for the public roadmap. Direction, not promises.
+The current package is the CLI + Claude Code first-run foundation plus the first daily operating surfaces: `mb status`, `/mb-status`, next-action ranking, bets, pushes, checkpoints, provider readiness, site checks, and privacy-safe issue drafting. Next work keeps tightening those loops, expands the curated provider rails, and prepares the future dashboard as a map over repo truth rather than a replacement for it. See [docs/ROADMAP.md](docs/ROADMAP.md) for the public roadmap. Direction, not promises.
 
 The proposed long-range product direction is captured in
 [`decisions/2026-05-02-github-native-business-os.md`](decisions/2026-05-02-github-native-business-os.md):
@@ -279,8 +317,8 @@ control plane, GitHub as the team layer, graph/structured data as the
 intelligence layer, and agent runtimes as execution.
 
 - **v0.3.x: Tightens the daily operating loop.** Status/ranking, `/mb-start`, `/mb-status`, doctor repair, checkpoints, pushes, provider readiness, and issue drafting keep becoming clearer and more reliable.
-- **v0.4: Graduates bets into launch systems.** Stronger links between bets, offers, pages, ads, outcomes, and public narration.
-- **Longer range.** Runtime adapters, dashboard/server mode, structured data, deeper Ops surfaces (books, P&L, compliance), and richer Paid, Organic, and Pages workflows.
+- **v0.4: Bets and pushes become operating systems.** Stronger links between bets, offers, pages, ads, outcomes, fulfillment, Ops, and public narration.
+- **Longer range.** Runtime adapters, dashboard/server mode, repo topology, structured data, deeper Ops surfaces (meetings, books, P&L, compliance), and richer Paid, Organic, and Pages workflows.
 
 See [CHANGELOG.md](CHANGELOG.md) for what's in this release. Each release ships a "What this means for you" plain-English section above the technical detail.
 
@@ -290,10 +328,10 @@ See [CHANGELOG.md](CHANGELOG.md) for what's in this release. Each release ships 
 
 Plain English boundary so nobody is surprised:
 
-- **Open-source (free, MIT)**: the `mb` CLI, all bundled skills, the schema, the framework, and the dashboard when it ships. Anyone can install and run — no account, no gating, no upsell wall.
-- **Paid community (Skool)**: Want to watch us build companies live with Main Branch? Free for 7 days, $19/mo after.
+- **Open-source (free, MIT)**: the `mb` CLI, bundled skills, schema, framework, docs, and future local dashboard surface when it ships. The engine is usable without joining the paid community.
+- **Paid community (Skool)**: Want to watch us build companies live with Main Branch? Free for 7 days, $19/mo after. The community can include live narration, calls, support, and curated examples that are not required for the open-source engine.
 
-Main Branch is fully usable on its own. The paid community is the live narration on top.
+Main Branch is usable on its own. The paid community is the live narration and support layer on top.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,9 @@ hosted Main Branch service in the open-source engine.
 
 | Version | Supported |
 |---|---|
-| 0.1.x | Yes |
+| 0.3.x | Yes |
+| 0.2.x | Security fixes only when practical |
+| 0.1.x | No |
 | Older versions | No |
 
 Security fixes ship in the next patch release when practical.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -10,7 +10,7 @@ Start local:
 mb doctor
 ```
 
-If Claude Code does not see `/start`, run this from your business repo:
+If Claude Code does not see `/mb-start`, run this from your business repo:
 
 ```bash
 mb skill link --repo .
@@ -19,7 +19,7 @@ mb skill link --repo .
 Then restart Claude Code and run:
 
 ```text
-/start
+/mb-start
 ```
 
 For step-by-step setup, read [docs/BEGINNER-SETUP.md](docs/BEGINNER-SETUP.md).

--- a/docs/BEGINNER-SETUP.md
+++ b/docs/BEGINNER-SETUP.md
@@ -293,7 +293,10 @@ checks whether an old personal skill is taking precedence.
 
 ## You've Got This
 
-After the install, you're mostly just talking to Claude in your business repo and watching it produce outputs that sound like you. The terminal becomes background.
+After the install, you're mostly talking to Claude in your business repo. The
+important part is that the work does not disappear into chat: status, decisions,
+bets, pushes, logs, checkpoints, and outputs persist locally and in git. The
+terminal becomes background.
 
 You don't need to memorize anything. The daily flow is three lines:
 

--- a/docs/BEGINNER-SETUP.md
+++ b/docs/BEGINNER-SETUP.md
@@ -41,7 +41,7 @@ Same flow as macOS — use `apt install pipx` (Debian/Ubuntu) or `dnf install pi
 
 ### Windows
 
-> **Windows is experimental.** It may work but isn't tested in CI; expect rough edges. See [compatibility](compatibility.md) and track [issue #137](https://github.com/noontide-co/mainbranch/issues/137) for status. Power users are welcome to try the steps below.
+> **Windows is experimental.** It may work but isn't tested in CI; expect rough edges. See [compatibility](compatibility.md). Power users should use WSL2 for the closest supported path.
 
 ```powershell
 # 1. Install Claude Code
@@ -102,7 +102,7 @@ Then in Claude Code:
 /mb-start
 ```
 
-`/mb-start` walks you through the rest — gathers your business context (offer, audience, voice), drafts the reference files, routes you to the right skill for what you want to do.
+`/mb-start` walks you through the rest. It reads the same status facts as `mb status`, checks for updates or repair needs, and routes you to setup, thinking, shipping, or closing work.
 
 That's it. From this point on:
 
@@ -220,7 +220,9 @@ starts, so repaired `/mb-start` links usually appear after restart.
 | Skill | What it does |
 |---|---|
 | `/mb-start` | Main entry point — figures out what you need and routes you. |
-| `/mb-think` | Research, decide, codify — turns thinking into reference files. |
+| `/mb-status` | Claude Code briefing over `mb status --json --peek`, including ranked next actions. |
+| `/mb-think` | Research, decide, codify — turns thinking into durable business files. |
+| `/mb-bet` | Open, update, close, list, and narrate business bets. |
 | `/mb-ads` | Generate ad copy and review for compliance. |
 | `/mb-vsl` | Write video sales letter scripts. |
 | `/mb-organic` | Generate organic content (Reels, TikTok, carousels). |
@@ -242,11 +244,14 @@ starts, so repaired `/mb-start` links usually appear after restart.
 | `mb status` | Show a terminal-only repo/runtime/GitHub briefing. `/mb-start` reads these facts internally. |
 | `mb start` | Check runtime handoff readiness and print or launch Claude Code with `--launch`. |
 | `mb connect plan` | Show numbered provider setup choices with readiness and exact next commands. |
+| `mb issue draft` | Draft a privacy-safe GitHub issue from a bug, confusing step, or feature gap. |
+| `mb checkpoint` | Plan or save a business-readable git checkpoint during long work. |
+| `mb similar-bets` | Find similar past bets and outcomes before starting a new one. |
 | `mb update` | Update Main Branch based on pipx vs clone install mode. |
 | `mb doctor` | Check that everything is set up correctly. Walks you through fixes. |
 | `mb skill link --repo .` | Repair Claude Code skill discovery if `/mb-start` doesn't show up. |
 | `mb skill repair --repo .` | Check for old personal Claude Code skills that can shadow Main Branch. |
-| `mb validate` | Check your reference files have correct frontmatter. |
+| `mb validate` | Check your business files have correct frontmatter. |
 | `mb graph` | Visualize or export the graph of files, links, wikilinks, and business entity tags. |
 | `mb skill list` | Show which skills your installed Main Branch ships. |
 
@@ -271,7 +276,7 @@ checks whether an old personal skill is taking precedence.
 
 **`mb` not found after install:** run `pipx ensurepath`, close your terminal completely, reopen it.
 
-**Output sounds generic:** add more detail to your reference files, especially `core/voice.md`. The richer those files, the more specific your outputs.
+**Output sounds generic:** add more detail to your core files, especially `core/voice.md`. The richer those files, the more specific your outputs.
 
 **You hit a 404:** the repo is public; no access request needed. Double-check the URL spelling.
 

--- a/docs/DEPENDENCY-CHOICES.md
+++ b/docs/DEPENDENCY-CHOICES.md
@@ -11,30 +11,34 @@ belong in accepted decisions, CLI tests, provider docs, or linked issues.
 
 ## Principles
 
-1. **Prefer official provider surfaces.** Use official CLIs, APIs, MCP servers,
+1. **Curate rails instead of connecting everything.** Main Branch should choose
+   a small set of boring, inspectable provider paths and make them easy to run
+   well. A user may have many SaaS tools; the product does not need to integrate
+   all of them.
+2. **Prefer official provider surfaces.** Use official CLIs, APIs, MCP servers,
    connectors, or adapter docs when they are stable, documented, and
    smoke-testable.
-2. **Prefer narrow deterministic CLIs over broad SDKs.** If the job is
+3. **Prefer narrow deterministic CLIs over broad SDKs.** If the job is
    inspectable, scriptable, exit-coded, and easy to test through a CLI, that is
    usually a better Main Branch surface than importing a large SDK into core.
-3. **Keep optional sidecars optional.** Specialized tools can enrich Sense and
+4. **Keep optional sidecars optional.** Specialized tools can enrich Sense and
    Ship workflows, but a missing sidecar must degrade gracefully instead of
    breaking the core install.
-4. **Add dependencies for user loops, not novelty.** A tool earns its place
+5. **Add dependencies for user loops, not novelty.** A tool earns its place
    when it makes Sense, Decide, Ship, or Reflect better for operators.
-5. **Remove redundant or fragile surfaces.** Decline or remove dependencies
+6. **Remove redundant or fragile surfaces.** Decline or remove dependencies
    that become redundant, unmaintained, private, fragile, confusing, or
    superseded by an official path.
-6. **Keep secrets out of repos.** Credentials belong in the OS keychain,
+7. **Keep secrets out of repos.** Credentials belong in the OS keychain,
    runtime-local config, environment variables, 1Password, or another explicit
    secret store. Repo files may hold only safe metadata.
-7. **Describe capabilities before vendors.** User-facing copy should say what
+8. **Describe capabilities before vendors.** User-facing copy should say what
    the operator can do. Name a vendor only when the vendor choice affects setup,
    support, credentials, cost, or a provider-specific workflow.
-8. **Do not claim support before evidence.** A path is supported only when the
+9. **Do not claim support before evidence.** A path is supported only when the
    adapter, docs, and smoke evidence exist. Until then, describe it as planned,
    experimental, or a target.
-9. **Leave an exit path.** Every dependency should have a plausible removal,
+10. **Leave an exit path.** Every dependency should have a plausible removal,
    replacement, or graceful-degradation story before it becomes product shape.
 
 ## Decision Rubric
@@ -76,10 +80,13 @@ why a tool disappeared.
 |---|---|---|---|---|---|---|
 | 2026-05-05 | Meta Ads account access | Pipeboard MCP/tools | Removed | A third-party connector should not remain a Main Branch dependency or fallback after the product direction moved to the official Meta path. Keeping it would preserve confusing setup, pricing, and tool-name assumptions. | Use provider-agnostic Meta account-access guidance now; evaluate Meta's official Ads CLI / Ads AI Connectors as the planned path after detection and read-only smoke are wired. | [#304](https://github.com/noontide-co/mainbranch/issues/304) |
 | 2026-05-05 | Meta Ads account access | Meta Ads CLI / Ads AI Connectors | Planned | Official provider surfaces are preferred, but Main Branch should not claim live support until setup, detection, and read-only smoke are verified. | Keep Meta readiness planned in `mb connect`; document exact supported commands only after smoke evidence exists. | [#304](https://github.com/noontide-co/mainbranch/issues/304) |
+| 2026-05-05 | Google Ads / GTM | Official Google Ads and Tag Manager surfaces | Planned | Paid traffic needs deterministic measurement and conversion checks before spend. Main Branch should prefer official Google paths and local site checks over broad browser automation. | Keep current `mb site check` readiness states; promote Google Ads/GTM automation only behind approval gates and smoke evidence. | [#286](https://github.com/noontide-co/mainbranch/issues/286) |
 | 2026-05-04 | Context enrichment | `companyctx` | Reference | Public company/domain context is useful across Sense and Ship workflows, but it should prove the sidecar contract without becoming a required core install. | Use the optional sidecar contract from [the sidecar enrichment decision](../decisions/2026-05-04-sidecar-enrichment-cli-contract.md). | [#265](https://github.com/noontide-co/mainbranch/issues/265) |
 | 2026-05-04 | Bookkeeping and P&L | Beancount | Optional future sidecar | Plain-text ledgers are useful, but real finance data has stricter privacy and access boundaries than normal business repo files. | Keep bookkeeping out of core until `mb books` scope is accepted; write approved summaries to shared repos and keep raw ledgers in private sources. | [#128](https://github.com/noontide-co/mainbranch/issues/128) |
 | 2026-05-04 | Research enrichment | Apify | Optional provider-readiness path | Scraping and research actors can enrich workflows, but they require explicit provider setup and should not make core install heavy. | Surface readiness through `mb connect plan` / `mb connect status`; promote only workflows with proven value and safe failure behavior. | [#273](https://github.com/noontide-co/mainbranch/issues/273) |
-| 2026-05-04 | Sites and DNS | Cloudflare CLI/API | Adopted where smoke-tested | Cloudflare is an official provider path for site and DNS work when a flow has a safe token boundary and validation evidence. | Keep credentials outside repos; expand only through explicit `mb connect` and site-readiness contracts. | [#89](https://github.com/noontide-co/mainbranch/issues/89) |
+| 2026-05-04 | Sites and DNS | Cloudflare CLI/API | Adopted where smoke-tested | Cloudflare is an official provider path for site, DNS, Pages, and future deterministic CMS/site operations when a flow has a safe token boundary and validation evidence. | Keep credentials outside repos; expand only through explicit `mb connect`, site-readiness contracts, GitHub-linked deploy flows, and operator approval gates. | [#89](https://github.com/noontide-co/mainbranch/issues/89) |
+| 2026-05-04 | Social scheduling | Postiz | Planned optional provider | Social scheduling is useful, but it should be a clear Ship rail rather than a hidden automation dependency. | Keep Postiz behind `mb connect` metadata until scheduling/publishing flows have docs and smoke evidence. | Follow-up issue needed |
+| 2026-05-04 | Workspace docs and sheets | Google Workspace | Planned optional provider | Many operators already have Docs, Sheets, and Drive source material. Main Branch should ingest or reference that material without making Google the canonical memory. | Treat Google Workspace as source/input and provider metadata; durable summaries and decisions flow back into the business repo. | Follow-up issue needed |
 | 2026-05-04 | GitHub-native task and release flow | GitHub CLI | Adopted core operational dependency | GitHub issues, pull requests, releases, and auth are central public primitives; `gh` is inspectable, scriptable, and already expected by contributor and issue-drafting flows. | Keep browser/manual fallbacks for user-facing issue submission where needed; use `gh` for GitHub truth and mutations in agent workflows. | [#264](https://github.com/noontide-co/mainbranch/issues/264) |
 
 ## Related Public Contracts

--- a/docs/ETHOS.md
+++ b/docs/ETHOS.md
@@ -13,6 +13,8 @@ operating substrate:
 - pull requests are proposals and review conversations;
 - git history is the evolution story.
 - checkpoints make long agent runs durable before chat context is lost.
+- dashboards, Obsidian graphs, and future team surfaces are views over the same
+  files, not replacements for them.
 
 The promise is simple: own the work, rent only the rails.
 
@@ -25,10 +27,11 @@ Main Branch should help an operator move through four loops:
 2. **Decide** - choose what to wager next: the bet, the priority, the override.
    Plain English: pick what matters and commit.
 3. **Ship** - produce and release the work: pages, ads, organic content, VSLs,
-   provider connections, system updates, the commit itself. One verb covers
-   producing the artifact and putting it in the world.
+   provider connections, fulfillment work, bookkeeping summaries, system
+   updates, the commit itself. One verb covers producing the artifact and
+   putting it in the world.
 4. **Reflect** - extract the lesson, usually scheduled: bet verdicts, retros,
-   decisions superseded, reference files updated from what you learned. The
+   decisions superseded, core files updated from what you learned. The
    output of Reflect feeds back into Sense.
 
 Those loops are described in detail in [OPERATOR-LOOPS.md](OPERATOR-LOOPS.md),
@@ -39,10 +42,14 @@ and the full reasoning lives in
 
 ### 1. Files First
 
-Canonical business truth belongs in git: reference files, research, decisions,
-campaigns, plans, public artifacts, durable summaries, and proposal changes.
-Rebuildable indexes, local caches, credentials, runtime preferences, and live
-process state can exist outside git, but they must not replace the repo.
+Canonical business truth belongs in git: core files, research, decisions, bets,
+pushes, plans, public artifacts, meeting summaries, fulfillment notes, durable
+finance summaries, and proposal changes. Rebuildable indexes, local caches,
+credentials, runtime preferences, raw finance/legal sources, and live process
+state can exist outside git, but they must not replace the repo.
+
+GitHub, Obsidian, `mb graph`, and future dashboards should all read the same
+durable memory. If two views disagree, the repo wins.
 
 ### 2. Thin CLI, Fat Workflows
 
@@ -104,7 +111,16 @@ ads metrics, bookkeeping, transcription, analytics, or deployment helpers.
 Sidecars should be optional providers behind stable contracts, not hard
 dependencies of the core engine.
 
-### 8. Evidence Beats Hunches
+### 8. Curated Rails Beat SaaS Sprawl
+
+Main Branch should not connect every tool an operator has accumulated. The team
+should make opinionated, explainable choices: prefer official provider paths,
+boring CLIs, portable files, and local-first state. Cloudflare, GitHub,
+Google/Workspace, official ads paths, Postiz, Beancount, Apify, transcription,
+and future sidecars earn their place by improving a loop and by failing in ways
+`mb` can explain.
+
+### 9. Evidence Beats Hunches
 
 Do not ship runtime claims, migration paths, packaging changes, or first-run
 flows without evidence. Use the validation ladder in [AGENTS.md](../AGENTS.md):
@@ -114,7 +130,7 @@ when the behavior depends on a real runtime.
 The product should feel alive, but the substrate should stay boring enough to
 debug.
 
-### 9. Git Is The Hidden App
+### 10. Git Is The Hidden App
 
 Main Branch should use git as the invisible save system for business work.
 Operators should not need to understand branches, diffs, or commits to benefit
@@ -133,4 +149,6 @@ model host, vector database, scheduler, or marketplace today.
 
 Those may become useful surfaces later. They earn their way in by preserving
 the same source of truth: the business repo, GitHub, git history, deterministic
-CLI contracts, and explicit runtime adapters.
+CLI contracts, and explicit runtime adapters. A future dashboard may include
+team communication, but chat is source material; durable operating truth lands
+in issues, proposals, decisions, pushes, logs, commits, and core updates.

--- a/docs/OPERATOR-LOOPS.md
+++ b/docs/OPERATOR-LOOPS.md
@@ -6,6 +6,10 @@ agencies, course creators, productized services, indie SaaS, and small ecom
 teams. The taxonomy works for one person and for two-to-five people sharing
 a business repo.
 
+Growth work is the first visible wedge, but the loops are not marketing-only.
+The same model covers meetings, fulfillment, bookkeeping summaries, team
+updates, repo topology, provider setup, and internal operating pushes.
+
 The four loops:
 
 1. **Sense** — pull state in
@@ -49,14 +53,19 @@ reference-file reads sit here.
 - `mb connect status`
 - `core/`, `research/`, `decisions/`, `pushes/`, legacy `campaigns/`, `log/`, `documents/`
 - GitHub issues, pull requests, release history
+- linked business, site, offer, finance, ops, and client repos when the team
+  chooses separate operating boundaries
 
 **Next improvements**
 
-- Drift detection for stale context, broken wiring, expired credentials
-- Provider-readiness signals for GitHub, Cloudflare, Google, Meta, Apify
-- An optional local dashboard that visualizes existing repo / GitHub / provider
-  truth without becoming the source of truth
-- "Since last check" deltas so the daily briefing answers "what changed?"
+- richer repo-topology views across business, site, offer, finance, ops, and
+  client repos;
+- provider-readiness signals that become more specific as official paths are
+  smoke-tested;
+- an optional local dashboard that visualizes existing repo / GitHub / provider
+  truth without becoming the source of truth;
+- meeting, transcript, fulfillment, and bookkeeping summaries routed into the
+  right durable artifacts instead of staying in chat.
 
 ## 2. Decide
 
@@ -76,15 +85,15 @@ options. Discrete moments, not continuous activity.
 - `/mb-start`
 - `/mb-think`
 - GitHub issues and priorities
-- `mb status` (the next-action ranker, when present)
+- `mb status` ranked actions
 
 **Next improvements**
 
-- A deterministic next-action ranker
-- Top-three recommendations in `mb status` and `/mb-start`
 - Explicit pin, skip, and defer controls
 - Decision trees for provider choices, paid-SaaS exceptions, sensitive data,
   and workspace/repo boundaries
+- clearer repo-boundary choices: when a site, offer, client, finance, or ops
+  surface graduates into its own repo
 
 ## 3. Ship
 
@@ -117,7 +126,8 @@ operators ship creatives, SaaS founders ship features.
 - **Paid** — Meta ads, sponsored placements
 - **Organic** — Reels, threads, newsletter, YouTube, Skool posts
 - **Pages** — landers, minisites, websites
-- **Ops** — bookkeeping, P&L, compliance, operating health
+- **Ops** — bookkeeping, P&L, compliance, meetings, fulfillment, provider setup,
+  repo topology, team updates, and operating health
 
 A Ship event is `(loop, channel)`. Posting an ad = Ship through Paid.
 Sending the newsletter = Ship through Organic. Running `mb update` = Ship
@@ -128,8 +138,10 @@ through Ops.
 - Skills leaning more heavily on CLI facts instead of duplicate checks
 - Optional provider and sidecar contracts
 - Beginner-safe connector flows for GitHub, Cloudflare, Google, Meta, Apify
-- Richer Paid, Organic, Pages, and Ops surfaces (books, P&L, compliance)
-- Agent checkpoints that save meaningful work before context is lost
+- deterministic site/CMS rails over Cloudflare, GitHub, and operator-approved
+  measurement checks
+- richer Paid, Organic, Pages, and Ops surfaces (books, P&L, meetings,
+  fulfillment, compliance)
 
 ## 4. Reflect
 
@@ -252,8 +264,8 @@ Underneath Ship sit the four channels every operator can recognize:
 - **Organic** — owned audience content (Reels, TikTok, threads, YouTube,
   newsletter, Skool posts)
 - **Pages** — landers, minisites, websites, public bet pages, deployed assets
-- **Ops** — bookkeeping (Beancount), P&L, compliance, integrations, operating
-  health
+- **Ops** — bookkeeping (Beancount), P&L, compliance, integrations, meetings,
+  fulfillment, repo topology, team updates, and operating health
 
 Skills cluster by channel today (`/mb-ads` for Paid, `/mb-organic` and
 `/mb-vsl` for Organic, `/mb-site` for Pages, `mb books` planned for Ops).

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -18,43 +18,54 @@ Main Branch already ships:
 - graph and status primitives for future dashboard and agent workflows;
 - privacy-safe GitHub issue drafting for user friction;
 - `bets/` and `/mb-bet` as the first Reflect primitive;
-- public contribution, support, security, compatibility, and agent guidance.
+- public contribution, support, security, compatibility, and agent guidance;
 - accepted workspace/repo/sensitive-data boundary guidance and
   GitHub/Obsidian-compatible markdown/link conventions for future dashboard,
-  team daily log, bookkeeping, and multi-repo work.
+  team daily log, bookkeeping, and multi-repo work;
 - initial paid-traffic site readiness checks through `mb site check`.
 
 Claude Code is the supported runtime today. Other runtimes are compatibility
 targets until adapter code and smoke evidence exist.
 
-## Next: v0.3.0 - Knows What To Do Next
+## Current: v0.3.x - Tighten The Daily Operating Loop
 
-The next major product step is turning `mb status` and `/mb-start` into a
-useful daily decision surface.
+The current product step is tightening `mb status`, `/mb-start`, `/mb-status`,
+doctor repair, checkpoints, pushes, provider readiness, and issue drafting into
+a reliable daily decision surface.
 
 Shipped scope:
 
 - `mb status` v1 with "since last check", drift detection, and a stable JSON
   schema ([#261](https://github.com/noontide-co/mainbranch/issues/261));
+- deterministic next-action ranking with cited status signals;
+- `/mb-start` and `/mb-status` reading the same status substrate instead of
+  duplicating repo probes;
+- shared readiness and repair surfaces through `mb doctor`, `mb doctor repair`,
+  `mb update`, `mb start`, and provider readiness JSON;
 - privacy-safe issue drafting for bugs, missing workflows, confusing errors,
   and feature ideas ([#264](https://github.com/noontide-co/mainbranch/issues/264));
 - `bets/` and `/mb-bet` as the first primitive for tracking and reflecting on
-  operator bets ([#266](https://github.com/noontide-co/mainbranch/issues/266)).
+  operator bets ([#266](https://github.com/noontide-co/mainbranch/issues/266));
+- `pushes/` as the canonical coordinated-work folder, with `campaigns/`
+  retained as compatibility read;
+- git checkpoints as business-readable save points during long agent runs.
 
-Remaining planned scope:
+Active follow-up scope:
 
-- a deterministic next-action ranker with top-three recommendations and cited
-  signals ([#262](https://github.com/noontide-co/mainbranch/issues/262));
-- `/mb-start` using the same status and ranker substrate
-  ([#262](https://github.com/noontide-co/mainbranch/issues/262));
-- `/mb-status` as a thin runtime wrapper over deterministic status facts;
-- shared readiness checks so skills call `mb` instead of duplicating probes
-  ([#263](https://github.com/noontide-co/mainbranch/issues/263));
-- cleaner beginner/provider onboarding that explains the tool philosophy and
-  proves GitHub/provider readiness before noob users get stuck
-  ([#273](https://github.com/noontide-co/mainbranch/issues/273)).
+- make checkpoint verbs business-readable and consistent
+  ([#301](https://github.com/noontide-co/mainbranch/issues/301));
+- install business commit validation into repo workflows
+  ([#302](https://github.com/noontide-co/mainbranch/issues/302));
+- use the business git journal in status and timelines
+  ([#303](https://github.com/noontide-co/mainbranch/issues/303));
+- define a stable JSON result envelope across `mb` commands
+  ([#297](https://github.com/noontide-co/mainbranch/issues/297));
+- harden old-layout migration and legacy reference-path repair
+  ([#284](https://github.com/noontide-co/mainbranch/issues/284));
+- move provider automation behind explicit approval gates
+  ([#286](https://github.com/noontide-co/mainbranch/issues/286)).
 
-Anti-scope for v0.3.0:
+Anti-scope for v0.3.x:
 
 - no dashboard as source of truth;
 - no broad multi-runtime support claims;
@@ -62,21 +73,19 @@ Anti-scope for v0.3.0:
 - no automatic model invocation from `mb`;
 - no provider setup that stores secrets in repo files.
 
-## Soon: v0.3.x - Improves Itself In Public
+## Soon: Dashboard, Sidecars, And Multi-Repo Views
 
-Once Main Branch knows enough to surface next actions, the product should make
-friction easier to turn into public improvement.
+Once the daily operating loop is boring, Main Branch should make the broader
+business system easier to see without replacing the repo as source of truth.
 
 Planned scope:
 
-- a small read-only local dashboard spike over existing JSON outputs
-  ([#189](https://github.com/noontide-co/mainbranch/issues/189));
-- sidecar enrichment contract for optional tools such as public company
-  context, analytics, bookkeeping, transcription, or deployment helpers
-  ([#265](https://github.com/noontide-co/mainbranch/issues/265)).
-- agent checkpoints as hidden Git memory so long Claude Code runs can be saved
-  throughout execution and resumed by `/mb-start`
-  ([#288](https://github.com/noontide-co/mainbranch/issues/288)).
+- a small read-only local dashboard over existing JSON outputs;
+- visual multi-repo inventory for business repos, site repos, offer repos, and
+  sensitive/private repos, with explicit access boundaries;
+- sidecar enrichment contracts for optional tools such as public company
+  context, analytics, bookkeeping, transcription, deployment helpers, and
+  provider metrics;
 - follow-up implementation work from the workspace/repo boundary decision and
   markdown/link conventions, including dashboard spikes, team daily log
   surfaces, finance/legal warnings, and broader link repair where issues prove
@@ -90,7 +99,7 @@ bets into offers, pages, ads, fulfillment, and public Ship surfaces.
 
 Planned scope:
 
-- links between bets, decisions, research, campaigns, and outcomes;
+- links between bets, decisions, research, pushes, and outcomes;
 - public bets feed generated through site workflows;
 - offer launch workflow: keyword gate, lander, ads, and `/mb-start`
   orchestration ([#89](https://github.com/noontide-co/mainbranch/issues/89));

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -4,6 +4,12 @@ This roadmap is direction, not a promise. GitHub issues and release notes are
 the detailed execution record. This file explains the product shape so users,
 contributors, and agents understand where Main Branch is going.
 
+Main Branch is not only a marketing-growth context folder. Growth is the first
+high-value wedge because ads, pages, content, and launches expose the memory
+problem quickly. The broader product is durable operating memory for
+AI-assisted businesses: meetings, fulfillment, bookkeeping summaries, provider
+refs, decisions, bets, pushes, logs, and lessons in repos the team owns.
+
 ## Shipped Foundation
 
 Main Branch already ships:
@@ -18,6 +24,7 @@ Main Branch already ships:
 - graph and status primitives for future dashboard and agent workflows;
 - privacy-safe GitHub issue drafting for user friction;
 - `bets/` and `/mb-bet` as the first Reflect primitive;
+- `mb checkpoint` as the first hidden GitOps save layer for long agent runs;
 - public contribution, support, security, compatibility, and agent guidance;
 - accepted workspace/repo/sensitive-data boundary guidance and
   GitHub/Obsidian-compatible markdown/link conventions for future dashboard,
@@ -83,16 +90,29 @@ Planned scope:
 - a small read-only local dashboard over existing JSON outputs;
 - visual multi-repo inventory for business repos, site repos, offer repos, and
   sensitive/private repos, with explicit access boundaries;
+- a dashboard map of repos, pushes, bets, commits, issues, PRs, checkpoints,
+  provider-safe summaries, and sidecar summaries;
 - sidecar enrichment contracts for optional tools such as public company
   context, analytics, bookkeeping, transcription, deployment helpers, and
   provider metrics;
+- team daily log surfaces built from commits, checkpoints, issues, PRs, and
+  explicit `log/` files instead of treating raw chat as source of truth;
 - follow-up implementation work from the workspace/repo boundary decision and
   markdown/link conventions, including dashboard spikes, team daily log
   surfaces, finance/legal warnings, and broader link repair where issues prove
   the need ([#274](https://github.com/noontide-co/mainbranch/issues/274),
   [#275](https://github.com/noontide-co/mainbranch/issues/275)).
 
-## Later: v0.4 - Launches Offers From Bets
+Anti-scope:
+
+- no dashboard database as canonical business memory;
+- no Slack replacement claim before repo truth, GitHub activity, team logs, and
+  permission boundaries are proven;
+- no finance/legal raw data in shared repos by default;
+- no "connect every SaaS" hub. Provider rails are curated, official where
+  possible, deterministic, smoke-tested, and optional.
+
+## Later: v0.4 - Bets And Pushes Become Operating Systems
 
 The next proof point after the daily decision loop is graduating real business
 bets into offers, pages, ads, fulfillment, and public Ship surfaces.
@@ -103,6 +123,8 @@ Planned scope:
 - public bets feed generated through site workflows;
 - offer launch workflow: keyword gate, lander, ads, and `/mb-start`
   orchestration ([#89](https://github.com/noontide-co/mainbranch/issues/89));
+- deterministic site/CMS rails over Cloudflare Pages, DNS, GitHub, and
+  operator-approved measurement checks;
 - decisions on Ops surfaces (books, P&L, compliance) and fulfillment scope;
 - bookkeeping/P&L primitives that respect finance-data privacy boundaries
   ([#128](https://github.com/noontide-co/mainbranch/issues/128)).
@@ -121,7 +143,10 @@ Likely directions:
 - structured data layer for metrics, ads, analytics, P&L, and ledgers, with
   explicit access boundaries before sensitive financial/legal data is surfaced;
 - richer sidecar ecosystem behind narrow JSON contracts;
-- deeper Paid, Organic, Pages, and Ops workflows under the four-pillar framing.
+- deeper Paid, Organic, Pages, and Ops workflows under the four-pillar framing;
+- optional chat or team-communication surfaces that convert important
+  conversation into durable artifacts: issues, proposals, decisions, pushes,
+  logs, and commits.
 
 ## Reading Order
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -9,7 +9,7 @@ This page is the public compatibility contract for that surface.
 |---|---|---|
 | macOS | Supported | Primary development path. Recommended for beginners. |
 | Linux | Supported for `mb`; supported when Claude Code is installed | CI runs the Python package on Linux. Claude Code must be installed separately. |
-| Windows | Experimental | Not tested in CI. Track [#137](https://github.com/noontide-co/mainbranch/issues/137). |
+| Windows | Experimental | Not tested in CI. Use WSL2 for the closest supported path. |
 | Python | 3.10, 3.11, 3.12 | CI gates all three versions. |
 | Install mode | `pipx install mainbranch` | Canonical public install path. |
 | Developer mode | Git clone | For contributors who want to edit the engine or skills. |

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -20,10 +20,10 @@
 
 ## Architecture In One Sentence
 
-Main Branch keeps canonical business memory in the business repo, uses `mb` as
-the deterministic control plane over that repo, and lets runtime skills perform
-judgment-heavy work while leaving provider data, secrets, caches, and dashboard
-state outside canonical memory.
+Main Branch keeps canonical business memory in repos the operator owns, uses
+`mb` as the deterministic control plane over those repos, and lets runtime
+skills perform judgment-heavy work while leaving provider data, secrets,
+caches, and dashboard state outside canonical memory.
 
 ```text
 Main Branch engine     +     business repo            +     optional systems
@@ -40,6 +40,12 @@ docs                         pushes/   (canonical)
 The engine is business-agnostic. The business repo is engine-readable but not
 engine-owned. Provider systems and dashboards are inputs or views; they do not
 replace the repo.
+
+Main Branch is not a marketing folder with extra files. Growth work is the
+first public wedge because ads, pages, content, launches, and bets make the
+memory problem obvious. The architecture is broader: meetings, fulfillment,
+bookkeeping summaries, provider setup, team updates, repo topology, and
+operating lessons use the same Sense -> Decide -> Ship -> Reflect model.
 
 ## Operating Loops
 
@@ -93,6 +99,29 @@ my-business/
 The canonical business brain is `core/`. The old committed business-repo
 `reference/` folder is compatibility-only for old repos, as defined in
 [decisions/2026-05-06-business-repo-folder-model-reference-deprecation.md](../decisions/2026-05-06-business-repo-folder-model-reference-deprecation.md).
+
+## Repo Topology
+
+A company can outgrow one repo without leaving the Main Branch model. The
+business repo stays the hub, and specialized repos become linked operating
+boundaries.
+
+Common repo roles:
+
+| Role | What it holds | Boundary |
+| --- | --- | --- |
+| `business` | Core operating memory, research, decisions, bets, pushes, logs, docs | Default team context |
+| `site` | Cloudflare Pages, landing page, minisite, website, or public bet feed | Public deployable surface |
+| `offer` | Graduated product, service, or internal tool that needs its own lifecycle | Linked back to the business repo |
+| `client` | Client-specific fulfillment context and deliverables | Separate when access or confidentiality differs |
+| `finance` | Beancount ledger, exports, tax docs, sensitive P&L sources | Private by default; share summaries intentionally |
+| `ops` | Private infrastructure, runbooks, provider setup, or team routines | Separate when operational authority differs |
+| `archive` | Inert imports, legacy projects, or cold storage | Read-only unless revived |
+
+Future dashboards should render this topology in business language: which repos
+exist, what role each plays, which pushes or bets created them, what is stale,
+and which access boundaries are intentional. GitHub alone does not express
+that hierarchy well enough for operators.
 
 ## Primitive Contracts
 
@@ -351,9 +380,12 @@ Use this routing rule when deciding where generated work belongs:
 | Landing-page launch record | `pushes/<push>/site.md` or child site repo |
 | Push review notes | `pushes/<push>/review-log.md` or `reviews/` |
 | Raw transcript or source capture | `documents/transcripts/...` |
+| Meeting summary or operator handoff | `log/YYYY-MM-DD.md` or `documents/meetings/...` |
 | Synthesized findings from source material | `research/YYYY-MM-DD-slug.md` |
 | Throwaway code, HTML, script, or image experiment | `documents/prototypes/...` |
 | Operational site, app, or offer repo | separate child repo with links back |
+| Fulfillment SOP, delivery note, or internal ops guide | `core/operations/...`, `documents/...`, or a client repo |
+| Finance source ledger | private finance repo or local sidecar; only safe summaries link back |
 | Session recovery or daily work record | `log/YYYY-MM-DD.md` |
 | Accepted architecture or product choice | `decisions/YYYY-MM-DD-slug.md` |
 | Engine coordination or review | GitHub issue or pull request |
@@ -393,6 +425,13 @@ In practice:
   intentionally chosen.
 - Reflection usually lands in a bet verdict, research note, decision update,
   push review log, or `log/` entry.
+- Meeting transcripts are source material until synthesized. The durable
+  artifact is the summary, decision, task, push, or core update that comes out
+  of the meeting.
+- Finance ledgers and legal files are higher-sensitivity sources. Main Branch
+  can link to them and store safe summaries, but raw ledgers should stay in
+  private repos or local sidecars unless an explicit boundary decision says
+  otherwise.
 
 ## State Boundaries
 
@@ -427,6 +466,35 @@ External or optional state:
 Secrets, bearer tokens, OAuth refresh tokens, service-account JSON, customer
 exports, raw member data, and sensitive finance/legal data do not belong in
 public examples or committed business repo files.
+
+## Curated Rails
+
+Main Branch should not become a "connect every SaaS" hub. The system earns
+trust by curating boring, inspectable rails and wrapping them in deterministic
+flows that agents can call cheaply.
+
+Preferred pattern:
+
+- official CLIs, APIs, or provider surfaces where they are stable and
+  smoke-testable;
+- `mb connect` for local credential metadata and repair-safe readiness checks;
+- deterministic commands before broad MCP schemas when a CLI can do the job;
+- provider-specific workflows only after the setup, failure states, and
+  operator approval gates are explicit;
+- graceful degradation when optional sidecars are missing.
+
+Examples of intended rails:
+
+- GitHub for issues, pull requests, reviews, repo history, and shipped-work
+  visibility;
+- Cloudflare for Pages, DNS, Workers-adjacent site workflows, and future
+  deterministic CMS/site operations;
+- Google/Workspace and Google Ads/GTM where official paths are smoke-tested;
+- Meta/Facebook Ads through the official path when detection and read-only
+  smoke exist;
+- Postiz for social scheduling when the provider path earns support;
+- Beancount/Fava-style plain-text finance as a private or sidecar-backed Ops
+  surface.
 
 ## `mb` Responsibilities
 
@@ -488,12 +556,38 @@ Incorrect pattern:
 push.md becomes a raw ads database
 dashboard database becomes the only place push truth exists
 .mb/cache is treated as business memory
+chat transcript is treated as the decision record
 ```
+
+## Dashboard And Team Communication
+
+The future dashboard is not the brain. It is the map: business repos, site
+repos, offer repos, private finance repos, pushes, bets, team work, agents,
+provider-safe summaries, finances, open decisions, and stale areas rendered
+from repo truth.
+
+Dashboard sources should be:
+
+- `mb status --json`;
+- `mb graph --json`;
+- git history and `mb checkpoint` records;
+- GitHub issues, pull requests, reviews, and releases;
+- repo topology metadata;
+- provider-safe summaries and optional sidecar outputs;
+- explicit `log/`, `decisions/`, `bets/`, and `pushes/` records.
+
+Chat can exist as an input surface, but it should not become the operating
+truth. A team chat replacement earns its place only when important conversation
+turns into durable artifacts: issues, proposals, decisions, pushes, logs, and
+commits. Raw chat history and meeting transcripts should be source material,
+not the final record.
 
 ## Graph And Status
 
 `mb graph` should index durable markdown relationships: linked decisions,
 research, bets, pushes (and legacy campaigns), offers, outcomes, and documents.
+The graph should remain friendly to GitHub links and Obsidian-style wikilinks so
+operators can inspect the same memory outside Main Branch.
 
 `mb status` should read those same durable relationships plus cheap local facts
 to answer:

--- a/mb/README.md
+++ b/mb/README.md
@@ -4,7 +4,7 @@ Engine umbrella for [Main Branch](https://github.com/noontide-co/mainbranch) —
 
 This package is the Python entry point. Workflows, playbooks, educational content, and consumer-repo templates ship as bundled package data. Today, the day-to-day "do work" surfaces are packaged as Claude Code skills (markdown), invoked from inside Claude Code. The `mb` CLI is runtime-agnostic by design: future adapters should let Codex, Cursor, OpenClaw, Hermes, and local runtimes operate against the same business-as-files repo.
 
-The source tree keeps the engine payload in one place: repo-root `.claude/`. During sdist/wheel builds, `setup.py` copies that tree into `mb/_engine/.claude/` inside the build artifact so installed wheels can resolve skills, playbooks, reference files, lenses, and educational prompts without a source checkout.
+The source tree keeps the engine payload in one place: repo-root `.claude/`. During sdist/wheel builds, `setup.py` copies that tree into `mb/_engine/.claude/` inside the build artifact so installed wheels can resolve skills, playbooks, reference materials, lenses, and educational prompts without a source checkout.
 
 ## Install
 
@@ -27,13 +27,19 @@ mb --version
 | `mb doctor` | Diagnostic. Checks Claude Code, gh auth, network, librsvg, runtime wiring, and package freshness. Warns on cloud-backed finance paths and offers educational triage. |
 | `mb status` | Daily briefing. Summarizes repo shape, install/runtime readiness, recent brain files, recent git activity, and GitHub tasks when `gh` is authenticated. Supports `--json`. |
 | `mb start` | Runtime handoff. Verifies the current business repo, git, Claude Code, and `/mb-start` skill wiring, then prints the exact `claude` command or launches it with `--launch`. Supports `--json`. |
-| `mb validate` | Frontmatter shape check across `decisions/`, `core/offers/`, `research/`, `bets/`, `log/`, `campaigns/`, `documents/`. Exit 1 on any fail. |
+| `mb validate` | Frontmatter shape check across `core/`, `research/`, `decisions/`, `bets/`, `log/`, `pushes/`, legacy `campaigns/`, and `documents/`. Exit 1 on any fail. |
 | `mb graph` | Walk linked_research / linked_decisions / supersedes; emit Graphviz DOT to stdout. `--open` shells to `dot` + `open`. |
+| `mb similar-bets` | Find similar past bets and offer outcomes from repo truth. |
+| `mb checkpoint` | Plan or save a business-readable git checkpoint. |
 | `mb update` | Refresh the Main Branch engine according to install mode (`pipx` upgrade or clone `git pull`) and repair skill links. `--check` dry-runs; `--json` emits an envelope. |
 | `mb migrate` | Inspect and apply numbered repo schema migrations. `status`, `--check`, and `--apply` support `--json`; `--check` prints privacy-safe summaries by default, with full diffs behind `--diff`. |
+| `mb connect` | Connect provider credentials without committing secrets, test provider health, and inspect repair-safe integration status. |
+| `mb site` | Inspect site readiness for launch-adjacent workflows. |
+| `mb issue` | Draft and open privacy-safe GitHub issues from local friction. |
 | `mb think <topic>` | Print the /mb-think workflow invocation hint for the currently supported runtime. |
-| `mb resolve <key>` | Resolve a reference path (checks free first, then paid). |
+| `mb resolve <key>` | Resolve a reference key from the curated library, local core files, or bundled stubs. |
 | `mb skill path <name>` | Print the on-disk path to a bundled skill. |
+| `mb skill validate <name>` | Validate bundled skill frontmatter, local references, and line-count gates. |
 | `mb skill link --repo <path>` | Wire or repair Claude Code skill discovery for a business repo. Future runtime adapters should get equivalent wiring commands. |
 | `mb skill repair --repo <path>` | Detect personal Claude Code skills that shadow Main Branch and safely back up stale Main Branch symlinks with `--apply`. |
 | `mb educational <topic>` | Print an educational triage file. Powers `mb doctor`'s "tell me more" prompts. |

--- a/tools/tool-dns/README.md
+++ b/tools/tool-dns/README.md
@@ -1,6 +1,6 @@
 # tool-dns
 
-Stub directory. The Go binary lands in v0.1.0 Phase 2 (the build week per the master decision).
+Stub directory. This Go binary never shipped in the public v0.3.x engine. Current DNS/site work lives in `/mb-site` and the packaged Python site/Cloudflare readiness atoms. Treat this folder as historical design material unless a new decision revives it.
 
 ## Planned shape
 

--- a/tools/tool-dns/SKILL.md
+++ b/tools/tool-dns/SKILL.md
@@ -3,9 +3,10 @@ name: tool-dns
 tier: tool
 calls: []
 status: stub
-description: "Stub. Implementation lands in v0.1.0 Phase 2."
+description: "Historical stub. This Go binary did not ship in public v0.3.x; current DNS/site work lives in /mb-site and packaged Python readiness checks."
 ---
 
 # tool-dns
 
-Stub. See README.md for the planned shape.
+Historical stub. See README.md for the planned shape and current public-engine
+boundary.

--- a/tools/tool-domain/README.md
+++ b/tools/tool-domain/README.md
@@ -1,6 +1,6 @@
 # tool-domain
 
-Stub directory. The Go binary lands in v0.1.0 Phase 2 (the build week per the master decision).
+Stub directory. This Go binary never shipped in the public v0.3.x engine. Current domain/site work lives in `/mb-site` and the packaged Python site/Cloudflare readiness atoms. Treat this folder as historical design material unless a new decision revives it.
 
 ## Planned shape
 

--- a/tools/tool-domain/SKILL.md
+++ b/tools/tool-domain/SKILL.md
@@ -3,9 +3,10 @@ name: tool-domain
 tier: tool
 calls: []
 status: stub
-description: "Stub. Implementation lands in v0.1.0 Phase 2."
+description: "Historical stub. This Go binary did not ship in public v0.3.x; current domain/site work lives in /mb-site and packaged Python readiness checks."
 ---
 
 # tool-domain
 
-Stub. See README.md for the planned shape.
+Historical stub. See README.md for the planned shape and current public-engine
+boundary.

--- a/tools/tool-pages/README.md
+++ b/tools/tool-pages/README.md
@@ -1,6 +1,6 @@
 # tool-pages
 
-Stub directory. The Go binary lands in v0.1.0 Phase 2 (the build week per the master decision).
+Stub directory. This Go binary never shipped in the public v0.3.x engine. Current Pages/Sites work lives in `/mb-site` and the packaged Python site/Cloudflare readiness atoms. Treat this folder as historical design material unless a new decision revives it.
 
 ## Planned shape
 

--- a/tools/tool-pages/SKILL.md
+++ b/tools/tool-pages/SKILL.md
@@ -3,9 +3,10 @@ name: tool-pages
 tier: tool
 calls: []
 status: stub
-description: "Stub. Implementation lands in v0.1.0 Phase 2."
+description: "Historical stub. This Go binary did not ship in public v0.3.x; current Pages/Sites work lives in /mb-site and packaged Python readiness checks."
 ---
 
 # tool-pages
 
-Stub. See README.md for the planned shape.
+Historical stub. See README.md for the planned shape and current public-engine
+boundary.

--- a/tools/tool-stripe/README.md
+++ b/tools/tool-stripe/README.md
@@ -1,6 +1,9 @@
 # tool-stripe
 
-Stub directory. The Go binary lands in v0.1.0 Phase 2 (the build week per the master decision).
+Stub directory. This Go binary never shipped in the public v0.3.x engine.
+Current provider/payment work should be revived only behind a fresh decision,
+explicit approval gates, and secret-safe connection checks. Treat this folder
+as historical design material unless a new decision revives it.
 
 ## Planned shape
 

--- a/tools/tool-stripe/SKILL.md
+++ b/tools/tool-stripe/SKILL.md
@@ -3,9 +3,10 @@ name: tool-stripe
 tier: tool
 calls: []
 status: stub
-description: "Stub. Implementation lands in v0.1.0 Phase 2."
+description: "Historical stub. This Go binary did not ship in public v0.3.x; current Stripe/payments work should be revived only behind a fresh decision and explicit provider gates."
 ---
 
 # tool-stripe
 
-Stub. See README.md for the planned shape.
+Historical stub. See README.md for the planned shape and current public-engine
+boundary.


### PR DESCRIPTION
## Summary
- Reconciles first-click public docs with the shipped `0.3.5` state: `/mb-start`, `/mb-status`, bets, pushes, checkpoints, provider readiness, current support/security language, and current command tables.
- Reframes Main Branch as durable operating memory for AI-assisted businesses, with growth as the strongest shipped wedge and Ops/dashboard/provider rails as expansion paths.
- Clarifies repo topology, dashboard-as-map, chat-as-input-not-truth, curated provider rails, and GitHub/Obsidian-compatible graph direction without changing product code.
- Marks old Go tool folders as historical stubs so they no longer imply planned v0.1 binaries are still pending.

## Scope
- In: public docs, contributor/agent docs, roadmap, architecture, dependency-choice framing, package README, support/security docs, and historical tool stub copy.
- Out: CLI behavior, package metadata, release versioning, bundled skill behavior, scaffold changes, provider automation, dashboard implementation, and any new runtime support claim.

## Commits
- `b7c549a` — `[docs] Refresh public docs for 0.3.5`.
- `208ccf5` — `[docs] Clarify operating memory positioning`.

## Release / Issues
- Release: docs follow-up after `0.3.5`.
- Linear ID(s): none.
- Closes: none.
- Refs: #284, #286, #297, #301, #302, #303.
- Follow-ups: open a separate implementation/decision issue if the dashboard/repo-topology/provider-rails architecture needs to become executable scope.

## Success Metric
- A public reader can land on the repo after `0.3.5` and understand what is shipped, what remains planned, where business memory lives, how docs map to current commands, and why dashboard/provider/runtime claims remain bounded.

## Validation
- Level 0 docs/decision: targeted stale-instruction scans passed for private project links, closed Windows tracker links, `/start` current instructions, dead Anthropic guide link, old `free first` resolver wording, and stale `v0.3.0` roadmap framing.
- Level 1 static: `scripts/check.sh` passed after each docs commit: format, lint, mypy, 288 tests, coverage, and bundled skill validation.
- Level 2 CLI: not applicable; no CLI behavior changed.
- Level 3 package/install: not applicable; no package, entrypoint, bundled data, install, or update behavior changed.
- Level 4 fixture repo: not applicable; no scaffold or first-run behavior changed.
- Level 5 runtime smoke: not applicable; no runtime discovery, invocation, or skill behavior changed.

## Public / Private Boundary
- Public docs now avoid public-looking links to private Noontide planning artifacts. Private Devon/Conductor workflow details, credentials, provider account data, and customer/member details stayed out of the committed files.
