### PR TITLE
[add] mb checkpoint business verbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+### Added
+
+- `mb checkpoint` now uses the accepted business-readable checkpoint verb
+  contract, proposes subjects such as `[added] market.md`, validates checkpoint
+  messages with `--validate` or stdin, and exposes parsed verb/loop/channel
+  metadata for future status and timeline consumers. Refs #301.
+
 ## [0.3.5] - 2026-05-06
 
 v0.3.5 tightens the Cloudflare account-token repair from v0.3.4. Main Branch

--- a/mb/mb/_data/checkpoint_verbs.yaml
+++ b/mb/mb/_data/checkpoint_verbs.yaml
@@ -1,0 +1,61 @@
+verbs:
+  - verb: added
+    prefix: "[added]"
+    loops: [sense, ship]
+    default_loop: sense
+    channel_hint: path-derived
+    use_when: New durable context, state, or reviewable artifact exists.
+  - verb: updated
+    prefix: "[updated]"
+    loops: [sense, ship]
+    default_loop: sense
+    channel_hint: path-derived
+    use_when: Existing durable context or artifact changed.
+  - verb: decided
+    prefix: "[decided]"
+    loops: [decide]
+    default_loop: decide
+    channel_hint: null
+    use_when: A choice and its rationale were accepted.
+  - verb: opened
+    prefix: "[opened]"
+    loops: [decide]
+    default_loop: decide
+    channel_hint: null
+    use_when: A bet or public issue became active.
+  - verb: closed
+    prefix: "[closed]"
+    loops: [reflect]
+    default_loop: reflect
+    channel_hint: null
+    use_when: A bet or public issue got a verdict.
+  - verb: drafted
+    prefix: "[drafted]"
+    loops: [ship]
+    default_loop: ship
+    channel_hint: path-derived
+    use_when: A reviewable artifact was produced, whether or not public yet.
+  - verb: shipped
+    prefix: "[shipped]"
+    loops: [ship]
+    default_loop: ship
+    channel_hint: path-derived
+    use_when: Work reached a recipient, deploy target, or public surface.
+  - verb: connected
+    prefix: "[connected]"
+    loops: [ship]
+    default_loop: ship
+    channel_hint: ops
+    use_when: A provider or local integration became usable.
+  - verb: ran
+    prefix: "[ran]"
+    loops: [ship]
+    default_loop: ship
+    channel_hint: ops
+    use_when: A maintenance, update, migration, validation, or import ran.
+  - verb: fixed
+    prefix: "[fixed]"
+    loops: [ship]
+    default_loop: ship
+    channel_hint: path-derived
+    use_when: A broken workflow, file, link, provider, or setup path was repaired.

--- a/mb/mb/checkpoint.py
+++ b/mb/mb/checkpoint.py
@@ -7,6 +7,7 @@ import subprocess
 from pathlib import Path
 from typing import Any
 
+from mb import checkpoint_verbs
 from mb.freshness import looks_like_business_repo
 
 SURFACE_ORDER = [
@@ -284,16 +285,70 @@ def _surface_phrase(surfaces: list[str]) -> str:
     return ", ".join(named[:-1]) + f", and {named[-1]}"
 
 
+def _object_from_single_change(change: dict[str, Any]) -> str:
+    path = str(change["path"])
+    surface = str(change["surface"])
+    path_obj = Path(path)
+    if surface == "bets":
+        stem = path_obj.stem if path_obj.suffix else path_obj.name
+        return f"bet {stem}"
+    if surface == "pushes":
+        return f"push {path_obj.parent.name}" if path_obj.name == "push.md" else path_obj.stem
+    if surface == "campaigns":
+        return (
+            f"campaign {path_obj.parent.name}" if path_obj.name == "campaign.md" else path_obj.stem
+        )
+    if surface == "decisions":
+        stem = path_obj.stem
+        return stem[11:] if re.match(r"^\d{4}-\d{2}-\d{2}-", stem) else stem
+    if surface in {"core", "research", "log", "documents"}:
+        return path_obj.name
+    if surface == "config":
+        return "setup"
+    return path_obj.stem or path_obj.name or path
+
+
+def _proposal_verb(changes: list[dict[str, Any]], surfaces: list[str]) -> tuple[str, str]:
+    if not changes:
+        return "updated", "default checkpoint action"
+    if "bets" in surfaces and all(change.get("untracked") for change in changes):
+        return "opened", "new bet files are being saved"
+    if surfaces == ["decisions"]:
+        return "decided", "decision files changed"
+    if surfaces and set(surfaces).issubset({"pushes", "campaigns", "outputs", "site"}):
+        if all(change.get("untracked") for change in changes):
+            return "drafted", "new reviewable artifact files were created"
+        return "updated", "existing shipped-work files changed"
+    if surfaces and set(surfaces).issubset({"config"}):
+        return "fixed", "setup or wiring files changed"
+    if all(change.get("untracked") for change in changes):
+        return "added", "new durable business context was created"
+    return "updated", "existing durable business context changed"
+
+
 def _proposal(changes: list[dict[str, Any]], blocks: list[dict[str, str]]) -> dict[str, Any] | None:
     if not changes or blocks:
         return None
     counts = _surface_counts(changes)
     surfaces = [surface for surface in SURFACE_ORDER if surface in counts]
-    phrase = _surface_phrase(surfaces)
+    verb, reason = _proposal_verb(changes, surfaces)
+    if len(changes) == 1:
+        phrase = _object_from_single_change(changes[0])
+    else:
+        phrase = _surface_phrase(surfaces)
     changed_paths = [str(change["path"]) for change in changes]
+    message = f"[{verb}] {phrase}"
+    parsed = checkpoint_verbs.parse_subject(message)
+    validation = checkpoint_verbs.validate_subject(message)
     return {
         "mode": "beginner",
-        "message": f"[checkpoint] Update {phrase}",
+        "message": message,
+        "verb": verb,
+        "loop": parsed.get("loop"),
+        "loops": parsed.get("loops", []),
+        "channel_hint": parsed.get("channel_hint"),
+        "reason": f"Chosen because {reason}.",
+        "validation": validation,
         "body": {
             "changed": changed_paths,
             "why": "Save meaningful business progress before moving on.",
@@ -340,7 +395,7 @@ def recent(repo: str | Path = ".", *, limit: int = 5) -> dict[str, Any]:
         [
             "log",
             f"--max-count={limit}",
-            "--grep=^\\[checkpoint\\]",
+            f"--grep={checkpoint_verbs.accepted_prefix_pattern()}",
             "--extended-regexp",
             "--format=%H%x1f%ct%x1f%s",
         ],
@@ -358,11 +413,23 @@ def recent(repo: str | Path = ".", *, limit: int = 5) -> dict[str, Any]:
         if len(parts) != 3:
             continue
         sha, timestamp, subject = parts
+        parsed = checkpoint_verbs.parse_subject(subject)
+        legacy_checkpoint = subject.startswith("[checkpoint]")
         commits.append(
             {
                 "sha": sha,
                 "timestamp": int(timestamp) if timestamp.isdigit() else 0,
                 "subject": subject,
+                "recognized_as": "legacy_checkpoint"
+                if legacy_checkpoint
+                else "business_verb"
+                if parsed.get("recognized")
+                else "unknown",
+                "verb": parsed.get("verb"),
+                "loop": parsed.get("loop"),
+                "loops": parsed.get("loops", []),
+                "channel_hint": parsed.get("channel_hint"),
+                "parsed": parsed,
             }
         )
     return {"ok": True, "repo": str(root), "commits": commits, "errors": []}
@@ -526,6 +593,17 @@ def commit(
 
     repo_path = Path(str(planned["repo"]))
     commit_message = message.strip() or str(proposal["message"])
+    validation = checkpoint_verbs.validate_subject(commit_message)
+    if not validation["ok"]:
+        return {
+            "ok": False,
+            "status": "invalid_message",
+            "repo": str(repo_path),
+            "committed": False,
+            "validation": validation,
+            "plan": planned,
+            "errors": ["checkpoint message is not business-readable"],
+        }
     paths = [str(change["path"]) for change in planned.get("changes", [])]
     if not paths:
         return {
@@ -574,11 +652,49 @@ def commit(
     }
 
 
+def validate_message(message: str) -> dict[str, Any]:
+    """Validate a proposed checkpoint message."""
+    validation = checkpoint_verbs.validate_subject(message)
+    return {
+        "ok": validation["ok"],
+        "status": "valid" if validation["ok"] else "invalid",
+        "validation": validation,
+        "verbs": {
+            verb: {
+                "prefix": entry.prefix,
+                "loops": list(entry.loops),
+                "loop": entry.default_loop,
+                "channel_hint": entry.channel_hint,
+                "use_when": entry.use_when,
+            }
+            for verb, entry in checkpoint_verbs.registry().items()
+        },
+        "errors": [problem["message"] for problem in validation.get("errors", [])],
+    }
+
+
 def render_human(result: dict[str, Any]) -> None:
     """Render a checkpoint plan for operators."""
     status = result.get("status")
     print("mb checkpoint")
-    print(f"repo: {result.get('repo')}")
+    if result.get("repo"):
+        print(f"repo: {result.get('repo')}")
+    if "validation" in result and status in {"valid", "invalid"}:
+        validation = result.get("validation", {})
+        subject = validation.get("subject", "") if isinstance(validation, dict) else ""
+        print(f"message: {subject}")
+        if status == "valid":
+            parsed = validation.get("parsed", {}) if isinstance(validation, dict) else {}
+            loop = parsed.get("loop") if isinstance(parsed, dict) else None
+            print("valid business checkpoint message.")
+            if loop:
+                print(f"loop: {loop}")
+            return
+        print("invalid checkpoint message.")
+        for error in validation.get("errors", []) if isinstance(validation, dict) else []:
+            print(f"  - {error['message']}")
+            print(f"    fix: {error['guidance']}")
+        return
     if status == "committed":
         commit_info = result.get("commit", {})
         sha = commit_info.get("sha", "") if isinstance(commit_info, dict) else ""
@@ -597,6 +713,13 @@ def render_human(result: dict[str, Any]) -> None:
     if status == "error":
         for error in result.get("errors", []):
             print(f"error: {error}")
+        return
+    if status == "invalid_message":
+        print("checkpoint message is not business-readable.")
+        validation = result.get("validation", {})
+        for error in validation.get("errors", []) if isinstance(validation, dict) else []:
+            print(f"  - {error['message']}")
+            print(f"    fix: {error['guidance']}")
         return
 
     summary = result.get("summary", {})
@@ -621,5 +744,7 @@ def render_human(result: dict[str, Any]) -> None:
         print("")
         print("suggested checkpoint:")
         print(f"  {proposal['message']}")
+        if proposal.get("reason"):
+            print(f"  {proposal['reason']}")
         print("")
         print("This is a plan only. Rerun with --message and --yes to save it.")

--- a/mb/mb/checkpoint_verbs.py
+++ b/mb/mb/checkpoint_verbs.py
@@ -1,0 +1,261 @@
+"""Business-readable checkpoint verb registry and validation."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from functools import lru_cache
+from importlib import resources
+from typing import Any
+
+import yaml
+
+VALID_LOOPS = {"sense", "decide", "ship", "reflect"}
+MAX_SUBJECT_LENGTH = 90
+
+PREFIX_RE = re.compile(r"^\[(?P<verb>[a-z]+)\]\s+(?P<object>.+?)\s*$")
+RESULT_SPLIT_RE = re.compile(r"\s+--\s+", re.ASCII)
+PRIVATE_PATH_RE = re.compile(
+    r"(?i)(^|\s)(/Users/[^/\s]+/|/home/[^/\s]+/|[A-Z]:\\Users\\[^\\\s]+\\|~/)"
+)
+SECRET_TEXT_RE = re.compile(
+    r"(?i)("
+    r"(api[_-]?key|access[_-]?token|secret|client[_-]?secret)\s*[:=]\s*['\"]?\S{6,}"
+    r"|authorization:\s*bearer\s+\S+"
+    r"|sk-[A-Za-z0-9_-]{12,}"
+    r"|-----BEGIN [A-Z ]*PRIVATE KEY-----"
+    r")"
+)
+FUTURE_TENSE_RE = re.compile(r"(?i)\b(will|going to|plan to|planning to|todo|next)\b")
+VAGUE_OBJECT_RE = re.compile(
+    r"(?i)^(work|stuff|things|misc|miscellaneous|updates?|changes?|checkpoint|wip)$"
+)
+VAGUE_SUBJECT_RE = re.compile(
+    r"(?i)^(wip|misc|stuff|things|updated things|fix stuff|work saved|checkpoint)$"
+)
+LOOP_PREFIXES = {"sense", "decide", "ship", "reflect"}
+
+
+@dataclass(frozen=True)
+class VerbEntry:
+    """One accepted business checkpoint verb."""
+
+    verb: str
+    prefix: str
+    loops: tuple[str, ...]
+    default_loop: str
+    channel_hint: str | None
+    use_when: str
+
+
+def _data_path() -> Any:
+    return resources.files("mb").joinpath("_data").joinpath("checkpoint_verbs.yaml")
+
+
+@lru_cache(maxsize=1)
+def registry() -> dict[str, VerbEntry]:
+    """Load accepted checkpoint verbs from packaged data."""
+    raw = yaml.safe_load(_data_path().read_text(encoding="utf-8")) or {}
+    entries: dict[str, VerbEntry] = {}
+    for item in raw.get("verbs", []):
+        if not isinstance(item, dict):
+            continue
+        verb = str(item.get("verb", "")).strip()
+        loops = tuple(str(loop).strip() for loop in item.get("loops", []) if str(loop).strip())
+        default_loop = str(item.get("default_loop", "")).strip()
+        if not verb or not loops or default_loop not in VALID_LOOPS:
+            continue
+        if any(loop not in VALID_LOOPS for loop in loops):
+            continue
+        channel_hint = item.get("channel_hint")
+        entries[verb] = VerbEntry(
+            verb=verb,
+            prefix=str(item.get("prefix") or f"[{verb}]"),
+            loops=loops,
+            default_loop=default_loop,
+            channel_hint=str(channel_hint) if channel_hint else None,
+            use_when=str(item.get("use_when", "")),
+        )
+    return entries
+
+
+def accepted_prefix_pattern() -> str:
+    """Return an extended-regexp alternation for git log prefix matching."""
+    verbs = "|".join(sorted(registry()))
+    return rf"^\[({verbs}|checkpoint)\]"
+
+
+def parse_subject(subject: str) -> dict[str, Any]:
+    """Parse a checkpoint subject without judging whether it is acceptable."""
+    first_line = subject.strip().splitlines()[0] if subject.strip() else ""
+    match = PREFIX_RE.match(first_line)
+    if not match:
+        return {
+            "recognized": False,
+            "subject": first_line,
+            "verb": None,
+            "prefix": None,
+            "loop": None,
+            "loops": [],
+            "channel_hint": None,
+            "object": "",
+            "result": "",
+        }
+
+    verb = match.group("verb")
+    entry = registry().get(verb)
+    body = match.group("object").strip()
+    parts = RESULT_SPLIT_RE.split(body, maxsplit=1)
+    obj = parts[0].strip()
+    result = parts[1].strip() if len(parts) > 1 else ""
+    return {
+        "recognized": entry is not None,
+        "subject": first_line,
+        "verb": verb if entry else None,
+        "prefix": f"[{verb}]",
+        "loop": entry.default_loop if entry else None,
+        "loops": list(entry.loops) if entry else [],
+        "channel_hint": entry.channel_hint if entry else None,
+        "object": obj,
+        "result": result,
+    }
+
+
+def _problem(code: str, message: str, guidance: str) -> dict[str, str]:
+    return {"code": code, "message": message, "guidance": guidance}
+
+
+def validate_subject(message: str) -> dict[str, Any]:
+    """Validate a business checkpoint message subject for ``mb checkpoint``."""
+    raw = message.strip()
+    subject = raw.splitlines()[0] if raw else ""
+    parsed = parse_subject(subject)
+    errors: list[dict[str, str]] = []
+    warnings: list[dict[str, str]] = []
+
+    if not subject:
+        errors.append(
+            _problem(
+                "empty_subject",
+                "Checkpoint subject is empty.",
+                "Use a business verb, for example `[updated] offer.md -- clarified price`.",
+            )
+        )
+    if len(subject) > MAX_SUBJECT_LENGTH:
+        errors.append(
+            _problem(
+                "overlong_subject",
+                (
+                    f"Checkpoint subject is {len(subject)} characters; "
+                    f"keep it under {MAX_SUBJECT_LENGTH}."
+                ),
+                "Move detail into the commit body and keep the subject scannable.",
+            )
+        )
+    if VAGUE_SUBJECT_RE.match(subject):
+        errors.append(
+            _problem(
+                "vague_subject",
+                "Checkpoint subject is too vague to help future you.",
+                "Name what changed, for example `[updated] offer.md -- clarified guarantee`.",
+            )
+        )
+    if PRIVATE_PATH_RE.search(subject):
+        errors.append(
+            _problem(
+                "private_local_path",
+                "Checkpoint subject includes a private local machine path.",
+                "Use the business object name instead of a path like `/Users/name/...`.",
+            )
+        )
+    if SECRET_TEXT_RE.search(subject):
+        errors.append(
+            _problem(
+                "secret_like_subject",
+                "Checkpoint subject looks like it may include a token or secret.",
+                "Remove credentials from the message and rotate the secret if it was exposed.",
+            )
+        )
+    if FUTURE_TENSE_RE.search(subject):
+        errors.append(
+            _problem(
+                "future_tense_subject",
+                "Checkpoint subjects should describe work that already happened.",
+                "Use a past-tense verb prefix such as `[updated]`, `[drafted]`, or `[ran]`.",
+            )
+        )
+
+    prefix = str(parsed.get("prefix") or "")
+    verb_text = prefix.strip("[]")
+    if not parsed.get("recognized"):
+        if verb_text == "checkpoint":
+            errors.append(
+                _problem(
+                    "generic_checkpoint_prefix",
+                    "`[checkpoint]` is not a business-readable checkpoint verb.",
+                    (
+                        "Replace it with an accepted verb such as `[updated]`, "
+                        "`[drafted]`, or `[ran]`."
+                    ),
+                )
+            )
+        elif verb_text in LOOP_PREFIXES:
+            errors.append(
+                _problem(
+                    "loop_prefix",
+                    "Loop names are metadata, not checkpoint subject prefixes.",
+                    "Use the business action instead, for example `[shipped] lander`.",
+                )
+            )
+        elif subject and not prefix:
+            errors.append(
+                _problem(
+                    "missing_prefix",
+                    "Checkpoint subject must start with an accepted business verb prefix.",
+                    (
+                        "Use `[verb] object -- result`, for example "
+                        "`[updated] offer.md -- raised price`."
+                    ),
+                )
+            )
+        elif subject:
+            errors.append(
+                _problem(
+                    "unknown_prefix",
+                    f"`{prefix}` is not an accepted business checkpoint verb.",
+                    "Use one of: " + ", ".join(entry.prefix for entry in registry().values()) + ".",
+                )
+            )
+
+    obj = str(parsed.get("object") or "").strip()
+    if parsed.get("recognized") and not obj:
+        errors.append(
+            _problem(
+                "missing_object",
+                "Checkpoint subject names a verb but not the business object.",
+                "Name the file, bet, provider, artifact, or workflow that changed.",
+            )
+        )
+    if parsed.get("recognized") and VAGUE_OBJECT_RE.match(obj):
+        errors.append(
+            _problem(
+                "vague_object",
+                "Checkpoint object is too vague.",
+                "Replace words like `stuff`, `things`, or `work` with the actual business object.",
+            )
+        )
+
+    severity = "error" if errors else "warning" if warnings else "ok"
+    guidance = [problem["guidance"] for problem in [*errors, *warnings]]
+    return {
+        "ok": not errors,
+        "status": "valid" if not errors else "invalid",
+        "message": raw,
+        "subject": subject,
+        "parsed": parsed,
+        "severity": severity,
+        "acceptable_for_beginner": not errors,
+        "errors": errors,
+        "warnings": warnings,
+        "guidance": guidance,
+    }

--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -1006,6 +1006,11 @@ def checkpoint_cmd(
         help="Show recent checkpoint commits plus pending checkpoint state.",
     ),
     message: str = typer.Option("", "--message", "-m", help="Commit message for --yes."),
+    validate: str = typer.Option(
+        "",
+        "--validate",
+        help="Validate a checkpoint message. Pass '-' to read the message from stdin.",
+    ),
     yes: bool = typer.Option(False, "--yes", help="Save the checkpoint after safety gates pass."),
     mode: str = typer.Option(
         "beginner",
@@ -1015,7 +1020,10 @@ def checkpoint_cmd(
     json_out: bool = typer.Option(False, "--json", help="Machine-readable output."),
 ) -> None:
     """Plan or save a git checkpoint."""
-    if yes or message:
+    if validate:
+        validation_message = sys.stdin.read() if validate == "-" else validate
+        result = checkpoint_mod.validate_message(validation_message)
+    elif yes or message:
         result = checkpoint_mod.commit(repo=repo, message=message, mode=mode, yes=yes)
     elif status_check:
         result = checkpoint_mod.status(repo=repo, mode=mode)

--- a/mb/tests/test_checkpoint.py
+++ b/mb/tests/test_checkpoint.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typer.testing import CliRunner
 
 from mb import checkpoint as checkpoint_mod
+from mb.checkpoint_verbs import registry as verb_registry
 from mb.cli import app
 from mb.init import run as init_run
 
@@ -47,6 +48,26 @@ def test_checkpoint_plan_clean_repo_returns_clean(tmp_path: Path) -> None:
     assert report["proposal"] is None
 
 
+def test_checkpoint_verb_registry_matches_operator_contract() -> None:
+    registry = verb_registry()
+
+    assert list(registry) == [
+        "added",
+        "updated",
+        "decided",
+        "opened",
+        "closed",
+        "drafted",
+        "shipped",
+        "connected",
+        "ran",
+        "fixed",
+    ]
+    assert registry["opened"].default_loop == "decide"
+    assert registry["closed"].default_loop == "reflect"
+    assert registry["connected"].channel_hint == "ops"
+
+
 def test_checkpoint_plan_classifies_dirty_business_files(tmp_path: Path) -> None:
     repo = _business_repo(tmp_path)
     (repo / "core" / "offer.md").write_text("# Offer\n", encoding="utf-8")
@@ -63,7 +84,10 @@ def test_checkpoint_plan_classifies_dirty_business_files(tmp_path: Path) -> None
         "pushes": 1,
         "decisions": 1,
     }
-    assert report["proposal"]["message"] == "[checkpoint] Update core, pushes, and decisions"
+    assert report["proposal"]["message"] == "[added] core, pushes, and decisions"
+    assert report["proposal"]["verb"] == "added"
+    assert report["proposal"]["loop"] == "sense"
+    assert report["proposal"]["validation"]["ok"] is True
     paths = {change["path"] for change in report["changes"]}
     assert paths == {
         "core/offer.md",
@@ -83,7 +107,71 @@ def test_checkpoint_cli_json_contract(tmp_path: Path) -> None:
     assert payload["status"] == "ready"
     assert payload["mode"] == "beginner"
     assert payload["summary"]["surfaces"] == {"research": 1}
-    assert payload["proposal"]["message"] == "[checkpoint] Update research"
+    assert payload["proposal"]["message"] == "[added] market.md"
+    assert (
+        payload["proposal"]["reason"] == "Chosen because new durable business context was created."
+    )
+
+
+def test_checkpoint_validate_accepts_business_verb_json() -> None:
+    result = runner.invoke(
+        app,
+        [
+            "checkpoint",
+            "--validate",
+            "[opened] bet workshop-waitlist -- target 40 signups",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "valid"
+    assert payload["validation"]["parsed"]["verb"] == "opened"
+    assert payload["validation"]["parsed"]["loop"] == "decide"
+    assert payload["validation"]["acceptable_for_beginner"] is True
+
+
+def test_checkpoint_validate_rejects_vague_subject() -> None:
+    result = runner.invoke(app, ["checkpoint", "--validate", "WIP", "--json"])
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "invalid"
+    codes = {error["code"] for error in payload["validation"]["errors"]}
+    assert "vague_subject" in codes
+    assert "missing_prefix" in codes
+
+
+def test_checkpoint_validate_rejects_private_path_and_secret_like_subject() -> None:
+    result = runner.invoke(
+        app,
+        [
+            "checkpoint",
+            "--validate",
+            "[updated] /Users/devon/private.md -- api_key=abcdefghi",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    codes = {error["code"] for error in payload["validation"]["errors"]}
+    assert "private_local_path" in codes
+    assert "secret_like_subject" in codes
+
+
+def test_checkpoint_validate_reads_stdin() -> None:
+    result = runner.invoke(
+        app,
+        ["checkpoint", "--validate", "-", "--json"],
+        input="[ran] mb update -- 0.2.6 to 0.3.0\n",
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["validation"]["parsed"]["verb"] == "ran"
+    assert payload["validation"]["parsed"]["channel_hint"] == "ops"
 
 
 def test_checkpoint_blocks_env_and_secret_like_content(tmp_path: Path) -> None:
@@ -180,7 +268,7 @@ def test_checkpoint_commit_requires_yes_after_plan_review(tmp_path: Path) -> Non
             "--repo",
             str(repo),
             "--message",
-            "[checkpoint] Update offer",
+            "[updated] offer.md",
             "--json",
         ],
     )
@@ -203,7 +291,7 @@ def test_checkpoint_commit_saves_readable_checkpoint(tmp_path: Path) -> None:
             "--repo",
             str(repo),
             "--message",
-            "[checkpoint] Update offer",
+            "[updated] offer.md",
             "--yes",
             "--json",
         ],
@@ -213,13 +301,38 @@ def test_checkpoint_commit_saves_readable_checkpoint(tmp_path: Path) -> None:
     payload = json.loads(result.stdout)
     assert payload["status"] == "committed"
     assert payload["committed"] is True
-    assert payload["commit"]["message"] == "[checkpoint] Update offer"
+    assert payload["commit"]["message"] == "[updated] offer.md"
     assert "core/offer.md" in payload["commit"]["body"]
     assert payload["commit"]["sha"]
     assert _git(repo, "status", "--porcelain").stdout == ""
     log = _git(repo, "log", "-1", "--pretty=%B").stdout
-    assert "[checkpoint] Update offer" in log
+    assert "[updated] offer.md" in log
     assert "Changed:\n- core/offer.md" in log
+
+
+def test_checkpoint_commit_rejects_invalid_business_message(tmp_path: Path) -> None:
+    repo = _business_repo(tmp_path)
+    (repo / "core" / "offer.md").write_text("# Offer\nUpdated\n", encoding="utf-8")
+
+    result = runner.invoke(
+        app,
+        [
+            "checkpoint",
+            "--repo",
+            str(repo),
+            "--message",
+            "[checkpoint] Update offer",
+            "--yes",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "invalid_message"
+    assert payload["committed"] is False
+    assert payload["validation"]["errors"][0]["code"] == "generic_checkpoint_prefix"
+    assert _git(repo, "status", "--porcelain").stdout
 
 
 def test_checkpoint_commit_refuses_blocked_plan_without_commit(tmp_path: Path) -> None:
@@ -234,7 +347,7 @@ def test_checkpoint_commit_refuses_blocked_plan_without_commit(tmp_path: Path) -
             "--repo",
             str(repo),
             "--message",
-            "[checkpoint] Unsafe",
+            "[updated] unsafe",
             "--yes",
             "--json",
         ],
@@ -257,7 +370,7 @@ def test_checkpoint_commit_clean_repo_is_noop(tmp_path: Path) -> None:
             "--repo",
             str(repo),
             "--message",
-            "[checkpoint] Nothing",
+            "[ran] daily checkpoint",
             "--yes",
             "--json",
         ],
@@ -274,7 +387,7 @@ def test_checkpoint_status_reports_recent_checkpoint_and_pending_work(tmp_path: 
     (repo / "core" / "offer.md").write_text("# Offer\nUpdated\n", encoding="utf-8")
     checkpoint_mod.commit(
         repo,
-        message="[checkpoint] Update offer",
+        message="[updated] offer.md",
         yes=True,
     )
     (repo / "research" / "next.md").write_text("# Next\n", encoding="utf-8")
@@ -284,6 +397,22 @@ def test_checkpoint_status_reports_recent_checkpoint_and_pending_work(tmp_path: 
     assert result.exit_code == 0
     payload = json.loads(result.stdout)
     assert payload["ok"] is True
-    assert payload["recent"][0]["subject"] == "[checkpoint] Update offer"
+    assert payload["recent"][0]["subject"] == "[updated] offer.md"
+    assert payload["recent"][0]["recognized_as"] == "business_verb"
+    assert payload["recent"][0]["verb"] == "updated"
+    assert payload["recent"][0]["loop"] == "sense"
     assert payload["pending"]["status"] == "ready"
     assert payload["pending"]["summary"]["surfaces"] == {"research": 1}
+
+
+def test_checkpoint_status_preserves_legacy_checkpoint_subjects(tmp_path: Path) -> None:
+    repo = _business_repo(tmp_path)
+    (repo / "core" / "offer.md").write_text("# Offer\nUpdated\n", encoding="utf-8")
+    _git(repo, "add", "core/offer.md")
+    _git(repo, "commit", "-m", "[checkpoint] Update offer")
+
+    payload = checkpoint_mod.status(repo)
+
+    assert payload["ok"] is True
+    assert payload["recent"][0]["subject"] == "[checkpoint] Update offer"
+    assert payload["recent"][0]["recognized_as"] == "legacy_checkpoint"

--- a/mb/tests/test_start.py
+++ b/mb/tests/test_start.py
@@ -222,7 +222,7 @@ def test_start_surfaces_recent_checkpoint_history(tmp_path: Path, monkeypatch) -
             "--repo",
             str(repo),
             "--message",
-            "[checkpoint] Update offer",
+            "[updated] offer.md",
             "--yes",
             "--json",
         ],
@@ -234,7 +234,8 @@ def test_start_surfaces_recent_checkpoint_history(tmp_path: Path, monkeypatch) -
 
     assert result.exit_code == 0
     report = json.loads(result.stdout)
-    assert report["checkpoint"]["recent"][0]["subject"] == "[checkpoint] Update offer"
+    assert report["checkpoint"]["recent"][0]["subject"] == "[updated] offer.md"
+    assert report["checkpoint"]["recent"][0]["verb"] == "updated"
     assert report["checkpoint"]["pending"]["status"] == "ready"
 
 


### PR DESCRIPTION
## Summary
- Adds the accepted business-readable checkpoint verb contract to `mb checkpoint` through packaged registry data.
- Makes checkpoint planning generate operator-readable subjects such as `[added] market.md` with parsed verb, loop, channel, validation, and plain-English proposal reason metadata.
- Adds `mb checkpoint --validate <message>` plus stdin validation, and rejects invalid checkpoint messages before staging or committing.
- Teaches checkpoint status/start consumers to recognize accepted verb commits while preserving legacy `[checkpoint]` subjects for display.

## Scope
- In: verb registry, checkpoint message parser/validator, plan proposal shape, commit-time validation, recent checkpoint recognition, focused tests, package smoke, changelog.
- Out: business repo hook installation (#302), broader status/timeline journal rendering (#303), model invocation, runtime adapter changes, engine repo contributor commit style changes.

## Commits
- `cad97e1` — `[add] MAIN-238 business checkpoint verbs`.

## Release / Issues
- Release: v0.3.x active follow-up.
- Linear ID(s): MAIN-238.
- Closes: #301.
- Refs: #302, #303.
- Follow-ups: #302 installs the workflow enforcement hook; #303 consumes the business git journal in status/timelines.

## Success Metric
- A user or agent can run `mb checkpoint --plan --json`, see a business-readable verb proposal, and trust `mb checkpoint --validate` to reject vague, unsafe, or non-business-shaped messages before they enter business history.

## Validation
- Level 0 docs/decision: checked accepted contract in `decisions/2026-05-05-operator-readable-git-history.md`, `docs/OPERATOR-LOOPS.md`, and updated `CHANGELOG.md` `[Unreleased]`.
- Level 1 static: `scripts/check.sh` passed from repo root: formatting, ruff, mypy, full tests, coverage, and skill validation.
- Level 2 CLI: `cd mb && pytest tests/test_checkpoint.py tests/test_start.py -q` passed with 33 tests; full suite passed with 295 tests.
- Level 3 package/install: `(cd mb && python3 -m build)`, fresh `/tmp/mainbranch-smoke` wheel install, `mb --version`, `mb skill list`, and installed `mb checkpoint --validate '[opened] bet workshop-waitlist -- target 40 signups' --json` passed.
- Level 4 fixture repo: not run; checkpoint behavior is covered by focused temporary business repo tests.
- Level 5 runtime smoke: not run; this is CLI-internal and does not change runtime discovery or skill invocation.

## Public / Private Boundary
- No private Devon, Conductor, customer, credential, or runtime-local details were added to public files; `.context/` stayed local scratch only.
