### PR TITLE
[add] Install checkpoint hook workflows

### DIFF
--- a/.claude/skills/mb-ads/SKILL.md
+++ b/.claude/skills/mb-ads/SKILL.md
@@ -362,9 +362,9 @@ See **[references/mode-review.md](references/mode-review.md)** for the full lens
 
 **Every generation entry point (Full Pipeline, Copy Only, Hook Library, Video Scripts) runs this pipeline automatically after saving output.** Do not ask the user whether to run compliance review -- it is automatic.
 
-See **[references/post-generation-pipeline.md](references/post-generation-pipeline.md)** for the complete pipeline: git commit pre-review, lens tier selection, Nano Banana check, parallel agent spawning (compliance + image), synthesis, proposed-change approval gate, unified report, and post-review commit.
+See **[references/post-generation-pipeline.md](references/post-generation-pipeline.md)** for the complete pipeline: checkpoint pre-review, lens tier selection, Nano Banana check, parallel agent spawning (compliance + image), synthesis, proposed-change approval gate, unified report, and post-review checkpoint.
 
-**Quick summary:** Commit pre-review state, spawn 5-6 compliance agents + optional image agents in parallel, synthesize P1/P2/P3 findings, surface P1 to user, show proposed P2/P3 copy edits as a dry-run diff, apply copy edits only after explicit approval, present unified report, commit post-review.
+**Quick summary:** Save a checkpoint for the pre-review state after operator approval, spawn 5-6 compliance agents + optional image agents in parallel, synthesize P1/P2/P3 findings, surface P1 to user, show proposed P2/P3 copy edits as a dry-run diff, apply copy edits only after explicit approval, present unified report, and offer a post-review checkpoint.
 
 **"While You Wait" pattern:** When spawning parallel agents that take >30 seconds, show a brief note so the user knows what's happening:
 > "Running compliance review across 6 lenses + generating images in parallel. This takes about 2-3 minutes. These run as sub-agents so they won't eat into your session context."

--- a/.claude/skills/mb-ads/references/image-generation-workflow.md
+++ b/.claude/skills/mb-ads/references/image-generation-workflow.md
@@ -235,7 +235,7 @@ For a typical ad campaign with 5 angles (15 images):
 
 ```
 1. Copy saved to output file
-2. Git commit pre-review (preserves original)
+2. Approved checkpoint pre-review (preserves original)
 3. Main conversation writes prompts.json to disk (keyed by target filename)
 4. PARALLEL (all agents spawned in a single message):
    a. Compliance agents (5-6 lenses, read-only) → findings report
@@ -249,7 +249,7 @@ For a typical ad campaign with 5 angles (15 images):
 5. Synthesize: collect all image agent results, retry any failures,
    surface P1s, show the P2/P3 proposed diff, apply copy fixes only after
    explicit approval, write review-log.md if approved, and write image-index.md
-6. Git commit post-review (user confirms)
+6. Approved checkpoint post-review (user confirms)
 ```
 
 ---

--- a/.claude/skills/mb-ads/references/mode-hook-library.md
+++ b/.claude/skills/mb-ads/references/mode-hook-library.md
@@ -53,7 +53,7 @@ Every variation **MUST** include at least one specific element:
 3. Create folder: `pushes/YYYY-MM-DD-creative-variations-[offer]-{campaign}/` (include offer slug in multi-offer mode; omit `[offer]-` in single-offer mode)
 4. Save full generation context + creative variations to: `creative-variations-batch-001.md`
 5. Tell user: "Saved {N} creative variations. Running automatic post-generation pipeline..."
-6. Run the **Automatic Post-Generation Pipeline** (see SKILL.md). This handles git commit, compliance review, and image generation automatically.
+6. Run the **Automatic Post-Generation Pipeline** (see SKILL.md). This handles approved checkpoints, compliance review, and image generation.
 
 **creative-variations-batch-001.md format:**
 

--- a/.claude/skills/mb-ads/references/mode-review.md
+++ b/.claude/skills/mb-ads/references/mode-review.md
@@ -20,7 +20,7 @@ Review ads through 6 compliance and quality lenses before shipping.
 ## Review Process
 
 1. Gather input (single ad, batch, or component)
-2. Git commit current state (preserves original): `[output] {type} batch pre-review`
+2. Run `mb checkpoint --plan --json`, validate a subject such as `[drafted] {type} ad batch`, and save the pre-review checkpoint only after operator approval.
 3. Spawn 6 parallel Task agents — one per lens. Use `subagent_type: "general-purpose"`. Each agent:
    - Reads the ad batch/copy being reviewed
    - Reads its assigned lens file from `.claude/lenses/`
@@ -33,7 +33,7 @@ Review ads through 6 compliance and quality lenses before shipping.
 7. Ask: "Apply these compliance copy changes? (y/n)"
 8. Only if approved, rerun the gate with `--approve --review-log ...`
 9. Tell user whether the source copy changed or was left unchanged
-10. If approved, ask whether to commit: `[review] {type} batch - N fixes applied`
+10. If approved, ask whether to save a post-review checkpoint with a subject such as `[updated] {type} ad batch after review`.
 
 ---
 

--- a/.claude/skills/mb-ads/references/mode-static-ads.md
+++ b/.claude/skills/mb-ads/references/mode-static-ads.md
@@ -57,7 +57,7 @@ platform: meta
 
 7. Save to `pushes/YYYY-MM-DD-static-ads-[offer]-{slug}/static-ads-batch-001.md` (include offer slug in multi-offer mode; omit `[offer]-` in single-offer mode). On legacy repos that still have `campaigns/`, run `mb migrate campaigns --plan` first; do not write new ad batches under `campaigns/`.
 8. Tell user: "Copy saved. Running automatic post-generation pipeline..."
-9. Run the **Automatic Post-Generation Pipeline** (see SKILL.md). This handles git commit, compliance review, and image generation automatically.
+9. Run the **Automatic Post-Generation Pipeline** (see SKILL.md). This handles approved checkpoints, compliance review, and image generation.
 
 ---
 

--- a/.claude/skills/mb-ads/references/mode-video-scripts.md
+++ b/.claude/skills/mb-ads/references/mode-video-scripts.md
@@ -26,7 +26,7 @@ platform: meta
 
 7. **Save Output:** `pushes/YYYY-MM-DD-video-ads-[offer]-{campaign}/video-ads-batch-001.md` (include offer slug in multi-offer mode; omit `[offer]-` in single-offer mode)
 8. Tell user: "Video scripts saved. Running automatic post-generation pipeline..."
-9. Run the **Automatic Post-Generation Pipeline** (see SKILL.md). This handles git commit and compliance review automatically. (No image generation for video scripts.)
+9. Run the **Automatic Post-Generation Pipeline** (see SKILL.md). This handles approved checkpoints and compliance review. (No image generation for video scripts.)
 
 ---
 

--- a/.claude/skills/mb-ads/references/post-generation-pipeline.md
+++ b/.claude/skills/mb-ads/references/post-generation-pipeline.md
@@ -2,14 +2,17 @@
 
 **Every generation mode (Static, One-Liner, Video) runs this pipeline automatically after saving output.** Do not ask the user whether to run compliance review -- it is automatic.
 
-## Step 1: Git Commit Pre-Review
+## Step 1: Checkpoint Pre-Review
 
 ```bash
-git add pushes/YYYY-MM-DD-*
-git commit -m "[output] {type} batch pre-review"
+mb checkpoint --plan --json
+mb checkpoint --validate "[drafted] {type} ad batch" --json
+mb checkpoint --message "[drafted] {type} ad batch" --yes
 ```
 
-This preserves the original before any fixes. The user can always `git diff HEAD~1` to see what changed.
+Run the plan first, show the proposed files/message and any blockers, then save
+only after operator approval. This preserves the original before any fixes. The
+user can always `git diff HEAD~1` to see what changed.
 
 ## Step 2: Select Lens Tier
 
@@ -128,17 +131,21 @@ Pipeline complete:
     [|- image-index.md]
     [|- images/ (N files)]
 
-  Commit reviewed copy [+ images]? (y/n)
+  Save reviewed copy [+ images] as a checkpoint? (y/n)
 ```
 
-## Step 7: Git Commit Post-Review
+## Step 7: Checkpoint Post-Review
 
 If user approves:
 
 ```bash
-git add pushes/YYYY-MM-DD-*
-git commit -m "[review] {type} batch - N fixes applied"
+mb checkpoint --plan --json
+mb checkpoint --validate "[updated] {type} ad batch after review" --json
+mb checkpoint --message "[updated] {type} ad batch after review" --yes
 ```
+
+Do not run raw `git add` or `git commit`; the checkpoint command stages only
+after its safety plan passes and the operator approves.
 
 ## Pipeline Timing
 

--- a/.claude/skills/mb-ads/references/review-workflow.md
+++ b/.claude/skills/mb-ads/references/review-workflow.md
@@ -1,15 +1,18 @@
 # Ad Review Workflow
 
-## Phase 0: Pre-Review Git Commit
+## Phase 0: Pre-Review Checkpoint
 
-Before reviewing, commit current state to preserve the original:
+Before reviewing, run the checkpoint plan to preserve the original after
+operator approval:
 
 ```bash
-git add pushes/YYYY-MM-DD-{type}-{campaign}/
-git commit -m "[output] {type} batch pre-review"
+mb checkpoint --plan --json
+mb checkpoint --validate "[drafted] {type} ad batch" --json
+mb checkpoint --message "[drafted] {type} ad batch" --yes
 ```
 
-This ensures the original version is preserved in git history.
+Show the planned files/message and any blockers before saving. This ensures the
+original version is preserved in git history without raw git ceremony.
 
 ## Phase 1: Gather Input
 
@@ -157,13 +160,14 @@ For P1 issues:
 - Document in the unified report and keep source copy unchanged until the user gives a specific fix approval
 - Status: BLOCKED until P1s resolved
 
-## Phase 5: Post-Review Git Commit
+## Phase 5: Post-Review Checkpoint
 
 After fixes are approved and applied:
 
 ```bash
-git add pushes/YYYY-MM-DD-{type}-{campaign}/
-git commit -m "[review] {type} batch - N fixes applied"
+mb checkpoint --plan --json
+mb checkpoint --validate "[updated] {type} ad batch after review" --json
+mb checkpoint --message "[updated] {type} ad batch after review" --yes
 ```
 
 **To see what review changed:** `git diff HEAD~1`

--- a/.claude/skills/mb-bet/SKILL.md
+++ b/.claude/skills/mb-bet/SKILL.md
@@ -211,8 +211,13 @@ internal retrospective instead.
 
 ## Exit
 
-Tell the operator what changed, which files were linked, whether validation
-passed, and the exact next command:
+Tell the operator what changed, which files were linked, and whether validation
+passed. If bet files or linked repo truth changed, run `mb checkpoint --plan
+--json`, show the proposed checkpoint and any blockers, validate the chosen
+message with `mb checkpoint --validate "..." --json`, and save with
+`mb checkpoint --message "..." --yes` only after operator approval.
+
+End with the exact next command:
 
 ```bash
 mb status

--- a/.claude/skills/mb-end/SKILL.md
+++ b/.claude/skills/mb-end/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mb-end
-description: "Session-closing skill that helps users wrap up intentionally. Use when: user says done, wrapping up, end my day, closing out, call it a day, goodnight, that's it for today, checkpoint, pause. Bookend to /mb-start. Scans git activity, surfaces what happened, spawns a crystallize agent for deep analysis, commits uncommitted work, and closes with a brief summary. Works for end-of-day, end-of-research-batch, end-of-decision-sprint, or mid-work checkpoints."
+description: "Session-closing skill that helps users wrap up intentionally. Use when: user says done, wrapping up, end my day, closing out, call it a day, goodnight, that's it for today, checkpoint, pause. Bookend to /mb-start. Scans git activity, surfaces what happened, spawns a crystallize agent for deep analysis, offers to save an approved checkpoint, and closes with a brief summary. Works for end-of-day, end-of-research-batch, end-of-decision-sprint, or mid-work checkpoints."
 loops: [reflect, ship]
 ---
 
@@ -44,7 +44,7 @@ This is not an audit. It is a thoughtful friend helping you close the session.
    5d. Present output to user as-is
    5e. If user engages: stay with it (engagement protocol)
    5f. Always save crystallize output as research file
-6. Commit & close
+6. Checkpoint & close
 ```
 
 Step 4 is optional. **Step 5 is NOT optional** -- if meaningful activity happened (decisions, research, core changes), you MUST spawn the crystallize agent. Do not try to do the crystallize analysis inline. Do not skip it. The subagent gets a fresh context window and spends real tokens reading the day's files. That depth is the whole point.
@@ -145,7 +145,7 @@ Ask once:
 
 **If the user shares something:**
 
-- If it is brief (a sentence or two), acknowledge it and note it in the commit message or suggest adding it to an existing research file.
+- If it is brief (a sentence or two), acknowledge it and include it in the checkpoint summary or suggest adding it to an existing research file.
 - If it is substantial (a paragraph or more), offer to save it: "Want me to save that as a quick research note? `research/YYYY-MM-DD-end-of-day-thoughts.md`"
 - Use today's date. Source suffix: `-end-of-day.md`
 
@@ -275,8 +275,8 @@ If an insight was substantial enough to update reference directly (soul.md, offe
 
 ## Step 6: Checkpoint & Close
 
-Use the current repo git workflow with explicit operator approval. The
-checkpoint CLI is future v0.3.x work; do not ask current PyPI users to run it.
+Run `mb checkpoint --plan --json` from the business repo. Summarize the changed
+surfaces/files, proposed message, and any blockers.
 
 **If there are unsaved changes:**
 
@@ -287,15 +287,16 @@ checkpoint CLI is future v0.3.x work; do not ask current PyPI users to run it.
 > Want me to save a checkpoint before we close?"
 
 If yes:
-- Stage only the intended business-repo files.
-- Commit with a readable operator subject.
+- Validate the intended subject with `mb checkpoint --validate "..." --json`.
+- After approval, save with `mb checkpoint --message "..." --yes`.
 - Use beginner-safe language: "saved checkpoint," not "ran git commit."
 - Include the crystallize research file in the checkpoint if one was created.
+Do not run raw `git add` or `git commit`.
 
 If no: Leave the work unchanged. Some people prefer to checkpoint at the start
 of next session.
 
-If safety is unclear, do not stage or commit. Explain the block and leave the
+If safety is unclear, do not save a checkpoint. Explain the block and leave the
 work unchanged.
 
 ### The Close
@@ -334,11 +335,13 @@ End with a brief, warm close. Not a performance review -- a goodbye.
 
 > "You have work in progress -- [describe what's open]. Want to finish that first, or close out and pick it up next time?"
 
-If they want to close: commit what exists, note the state in the commit message.
+If they want to close: run `mb checkpoint --plan --json`, summarize what exists,
+and save only after operator approval.
 
 ### Context window is nearly full
 
-Keep it ultra-brief. Scan, commit if needed, close. Skip Steps 4 and 5.
+Keep it ultra-brief. Scan, offer a checkpoint if needed, close. Skip Steps 4 and
+5.
 
 ### Multiple repos in session
 

--- a/.claude/skills/mb-organic/SKILL.md
+++ b/.claude/skills/mb-organic/SKILL.md
@@ -253,7 +253,7 @@ Before saving: show file paths.
 4. **Adapt to brand** — Map concept to user's offer, audience, voice
 5. **Generate scripts** — Use appropriate framework (video/carousel/static)
 6. **Save output** — Scripts to `pushes/YYYY-MM-DD-organic-{slug}/` (canonical). Never `campaigns/`; that folder is legacy compatibility only.
-7. **Commit prompt** — "Saved to [path]. Want me to commit this to git?"
+7. **Checkpoint prompt** — run `mb checkpoint --plan --json`, show the proposed checkpoint and blockers, validate the chosen message with `mb checkpoint --validate "..." --json`, then after operator approval save with `mb checkpoint --message "..." --yes`.
 
 **Mining lives in `/mb-think` now.** If user needs to mine competitors, route them there first.
 

--- a/.claude/skills/mb-organic/references/examples.md
+++ b/.claude/skills/mb-organic/references/examples.md
@@ -39,7 +39,7 @@ Claude: [Generates script using story framework]
 [Saves to pushes/2026-01-26-organic-morning-routine/organic-batch-001.md]
 
 Saved to pushes/2026-01-26-organic-morning-routine/organic-batch-001.md
-Want me to commit this to git?
+Want me to save this as a checkpoint?
 ```
 
 ## Example 3: Mining Redirect

--- a/.claude/skills/mb-start/SKILL.md
+++ b/.claude/skills/mb-start/SKILL.md
@@ -30,9 +30,12 @@ integrations, GitHub tasks/proposals, bets, dirty git, since-last-check, and
 `ranked_actions`. Do not duplicate those checks with ad hoc shell probes unless
 the status report says a section is unavailable.
 
-**Continuity facts:** Use `since_last_check`, dirty-git, and recent GitHub/git
-activity from status to explain "where we left off." The checkpoint CLI is
-future v0.3.x work; do not ask current PyPI users to run it.
+**Continuity facts:** Use `since_last_check`, dirty-git, recent GitHub/git
+activity, and the `checkpoint` section from status to explain "where we left
+off." If the operator asks to save progress, run `mb checkpoint --plan --json`,
+show the proposal/blockers, validate the message with `mb checkpoint --validate
+"..." --json`, then after approval run `mb checkpoint --message "..." --yes`.
+Explain this as saving a checkpoint, not raw git ceremony.
 
 **Provider facts first:** When setup or routing depends on GitHub, Cloudflare,
 Google/Workspace, Meta Ads, or Apify, read the status `integrations` facts

--- a/.claude/skills/mb-think/SKILL.md
+++ b/.claude/skills/mb-think/SKILL.md
@@ -24,9 +24,11 @@ Something came your way — a video, a voice memo, a vague feeling, a problem to
 
 **Save progress at natural boundaries.** After a research batch, accepted
 decision, codify pass, or major reference-file update, ask whether to save a
-checkpoint before moving to the next phase. Use the current repo's git workflow
-with explicit operator approval. When the v0.3.x checkpoint contract ships,
-this step should move to deterministic checkpoint plan/status facts.
+checkpoint before moving to the next phase. Run `mb checkpoint --plan --json`,
+show the proposed message, changed files, and blockers, then ask whether to save
+it. Validate the final message with `mb checkpoint --validate "..." --json`;
+after operator approval, run `mb checkpoint --message "..." --yes`. Do not save
+hidden checkpoints.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 - Accepted decisions now capture Postiz as the candidate social scheduling rail
   to smoke next, plus the growth-automation playbook boundary for future
   comment-to-DM and resource-delivery add-ons. Refs #341.
+- Fresh business repos now install a repo-local Main Branch `commit-msg` hook
+  that validates manual git commits through `mb checkpoint --validate -`, with
+  checkpoint hook status, install, and uninstall controls on `mb checkpoint`.
+  Refs #302.
 
 ### Changed
 
@@ -30,6 +34,10 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   guidance now distinguishes Apify public X post/profile/reply mining from
   Grok topic sentiment, and clarifies that DM/comment-keyword CTAs are draft
   strategy, not supported automation. Refs #341.
+- `mb doctor` and `mb doctor repair` now report, repair, and preserve
+  business checkpoint hook wiring, and shipped skills use approved
+  `mb checkpoint` planning/validation/save calls instead of raw git commit
+  instructions. Refs #302.
 
 ## [0.3.5] - 2026-05-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,10 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   to smoke next, plus the growth-automation playbook boundary for future
   comment-to-DM and resource-delivery add-ons. Refs #341.
 - Fresh business repos now install a repo-local Main Branch `commit-msg` hook
-  that validates manual git commits through `mb checkpoint --validate -`, with
-  checkpoint hook status, install, and uninstall controls on `mb checkpoint`.
-  Refs #302.
+  that validates manual git commits through `mb checkpoint --validate -`,
+  skips Git-generated merge/revert/fixup/squash/amend subjects, records the
+  active `mb` executable for minimal-PATH Git clients, and includes checkpoint
+  hook status, install, and uninstall controls on `mb checkpoint`. Refs #302.
 
 ### Changed
 

--- a/mb/mb/checkpoint.py
+++ b/mb/mb/checkpoint.py
@@ -33,15 +33,53 @@ SECRET_RE = re.compile(
     r")"
 )
 
+HOOK_NAME = "commit-msg"
+HOOK_BEGIN = "# >>> mainbranch checkpoint hook >>>"
+HOOK_END = "# <<< mainbranch checkpoint hook <<<"
+HOOK_BODY = f"""\
+#!/bin/sh
+{HOOK_BEGIN}
+# Main Branch business repos use readable checkpoint subjects.
+# This hook validates only the commit subject through the installed mb CLI.
+
+if [ "$#" -lt 1 ]; then
+  exit 0
+fi
+
+if ! command -v mb >/dev/null 2>&1; then
+  echo "Main Branch checkpoint hook could not find the mb CLI." >&2
+  echo "Repair: install or update Main Branch, then run: mb doctor repair --apply" >&2
+  exit 1
+fi
+
+if ! mb checkpoint --validate - < "$1"; then
+  echo "" >&2
+  echo "Main Branch rejected this checkpoint because the message is not business-readable." >&2
+  echo "Use a subject like: [updated] offer.md -- clarified guarantee" >&2
+  echo "For a suggested checkpoint, run: mb checkpoint --plan --json" >&2
+  echo "If the hook itself is damaged, run: mb doctor repair --apply" >&2
+  exit 1
+fi
+{HOOK_END}
+"""
+
 
 def _run_git(repo: Path, args: list[str]) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(
-        ["git", *args],
-        cwd=str(repo),
-        text=True,
-        capture_output=True,
-        check=False,
-    )
+    try:
+        return subprocess.run(
+            ["git", *args],
+            cwd=str(repo),
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        return subprocess.CompletedProcess(
+            ["git", *args],
+            127,
+            "",
+            str(exc),
+        )
 
 
 def _git_error(label: str, result: subprocess.CompletedProcess[str]) -> str:
@@ -67,10 +105,221 @@ def _git_dir(repo: Path) -> Path | None:
     return path.resolve()
 
 
+def _hook_path(repo: Path) -> tuple[Path | None, str | None, Path | None]:
+    root, root_error = _git_root(repo)
+    if root is None:
+        return None, root_error or "not a git repo", None
+    git_dir = _git_dir(root)
+    if git_dir is None:
+        return root, "could not resolve .git directory", None
+    return root, None, git_dir / "hooks" / HOOK_NAME
+
+
 def _is_engine_repo(repo: Path) -> bool:
     pyproject = repo / "mb" / "pyproject.toml"
     cli = repo / "mb" / "mb" / "cli.py"
     return pyproject.is_file() and cli.is_file()
+
+
+def _is_managed_hook(text: str) -> bool:
+    return HOOK_BEGIN in text and HOOK_END in text
+
+
+def _hook_state_from_text(text: str) -> str:
+    if not _is_managed_hook(text):
+        return "blocked_existing_hook"
+    return "installed" if text == HOOK_BODY else "broken"
+
+
+def hook_status(repo: str | Path = ".") -> dict[str, Any]:
+    """Inspect the repo-local checkpoint commit-message hook."""
+    target = Path(repo).expanduser().resolve()
+    root, root_error, hook = _hook_path(target)
+    if root is None or hook is None:
+        return {
+            "ok": False,
+            "state": "error",
+            "repo": str(target),
+            "installed": False,
+            "hook": "",
+            "managed": False,
+            "safe_to_install": False,
+            "safe_to_uninstall": False,
+            "summary": root_error or "could not inspect git hook",
+            "repair_command": "git init",
+            "errors": [root_error or "could not inspect git hook"],
+        }
+    if _is_engine_repo(root):
+        return {
+            "ok": True,
+            "state": "engine_repo",
+            "repo": str(root),
+            "installed": False,
+            "hook": str(hook),
+            "managed": False,
+            "safe_to_install": False,
+            "safe_to_uninstall": False,
+            "summary": "engine repo is not governed by business checkpoint hook rules",
+            "repair_command": "",
+            "errors": [],
+        }
+    if not hook.exists():
+        return {
+            "ok": False,
+            "state": "missing",
+            "repo": str(root),
+            "installed": False,
+            "hook": str(hook),
+            "managed": False,
+            "safe_to_install": True,
+            "safe_to_uninstall": False,
+            "summary": "Main Branch checkpoint commit-message hook is not installed",
+            "repair_command": "mb checkpoint --install-hook",
+            "errors": [],
+        }
+    try:
+        text = hook.read_text(encoding="utf-8")
+    except OSError as exc:
+        return {
+            "ok": False,
+            "state": "error",
+            "repo": str(root),
+            "installed": False,
+            "hook": str(hook),
+            "managed": False,
+            "safe_to_install": False,
+            "safe_to_uninstall": False,
+            "summary": f"could not read checkpoint hook: {exc}",
+            "repair_command": "mb doctor repair --plan",
+            "errors": [str(exc)],
+        }
+    state = _hook_state_from_text(text)
+    managed = _is_managed_hook(text)
+    installed = state == "installed"
+    safe = state in {"installed", "broken"}
+    summary = {
+        "installed": "Main Branch checkpoint commit-message hook is installed",
+        "broken": "Main Branch checkpoint hook is present but differs from the current template",
+        "blocked_existing_hook": (
+            "an existing commit-msg hook is present; Main Branch will not overwrite it"
+        ),
+    }[state]
+    return {
+        "ok": installed,
+        "state": state,
+        "repo": str(root),
+        "installed": installed,
+        "hook": str(hook),
+        "managed": managed,
+        "safe_to_install": safe,
+        "safe_to_uninstall": safe,
+        "summary": summary,
+        "repair_command": "mb checkpoint --install-hook"
+        if safe
+        else "review .git/hooks/commit-msg, then run mb checkpoint --install-hook",
+        "errors": [],
+    }
+
+
+def install_commit_hook(repo: str | Path = ".") -> dict[str, Any]:
+    """Install or repair the repo-local Main Branch checkpoint hook."""
+    status_report = hook_status(repo)
+    state = str(status_report["state"])
+    if state == "engine_repo":
+        return {
+            **status_report,
+            "ok": True,
+            "installed": False,
+            "changed": False,
+            "summary": "skipped engine repo; business checkpoint hook not installed",
+        }
+    if state == "blocked_existing_hook":
+        return {
+            **status_report,
+            "ok": False,
+            "changed": False,
+            "errors": [
+                (
+                    "existing .git/hooks/commit-msg is not managed by Main Branch; "
+                    "review or move it before installing the checkpoint hook"
+                )
+            ],
+        }
+    if state == "error":
+        return {**status_report, "changed": False}
+    hook = Path(str(status_report["hook"]))
+    try:
+        hook.parent.mkdir(parents=True, exist_ok=True)
+        previous = hook.read_text(encoding="utf-8") if hook.exists() else ""
+        hook.write_text(HOOK_BODY, encoding="utf-8")
+        hook.chmod(0o755)
+    except OSError as exc:
+        return {
+            **status_report,
+            "ok": False,
+            "state": "error",
+            "changed": False,
+            "summary": f"could not install checkpoint hook: {exc}",
+            "errors": [str(exc)],
+        }
+    changed = previous != HOOK_BODY
+    return {
+        **hook_status(status_report["repo"]),
+        "ok": True,
+        "changed": changed,
+        "summary": (
+            "installed Main Branch checkpoint commit-message hook"
+            if changed
+            else "Main Branch checkpoint commit-message hook already installed"
+        ),
+        "errors": [],
+    }
+
+
+def uninstall_commit_hook(repo: str | Path = ".") -> dict[str, Any]:
+    """Remove only the Main Branch-managed checkpoint hook."""
+    status_report = hook_status(repo)
+    state = str(status_report["state"])
+    if state == "missing":
+        return {
+            **status_report,
+            "ok": True,
+            "changed": False,
+            "summary": "Main Branch checkpoint commit-message hook is already absent",
+            "errors": [],
+        }
+    if state == "engine_repo":
+        return {**status_report, "ok": True, "changed": False, "errors": []}
+    if state == "blocked_existing_hook":
+        return {
+            **status_report,
+            "ok": False,
+            "changed": False,
+            "errors": [
+                "existing commit-msg hook is not managed by Main Branch; leaving it in place"
+            ],
+        }
+    if state == "error":
+        return {**status_report, "changed": False}
+    hook = Path(str(status_report["hook"]))
+    try:
+        hook.unlink()
+    except OSError as exc:
+        return {
+            **status_report,
+            "ok": False,
+            "state": "error",
+            "changed": False,
+            "summary": f"could not uninstall checkpoint hook: {exc}",
+            "errors": [str(exc)],
+        }
+    return {
+        **hook_status(status_report["repo"]),
+        "ok": True,
+        "changed": True,
+        "summary": "removed Main Branch checkpoint commit-message hook",
+        "errors": [],
+    }
 
 
 def _status_records(repo: Path) -> tuple[list[dict[str, Any]], str | None]:
@@ -679,6 +928,17 @@ def render_human(result: dict[str, Any]) -> None:
     print("mb checkpoint")
     if result.get("repo"):
         print(f"repo: {result.get('repo')}")
+    if "hook" in result and status not in {"valid", "invalid"}:
+        hook_state = result.get("state", status)
+        print(f"hook: {result.get('hook')}")
+        print(f"state: {hook_state}")
+        if result.get("summary"):
+            print(str(result["summary"]))
+        if result.get("repair_command"):
+            print(f"repair: {result['repair_command']}")
+        for error in result.get("errors", []):
+            print(f"error: {error}")
+        return
     if "validation" in result and status in {"valid", "invalid"}:
         validation = result.get("validation", {})
         subject = validation.get("subject", "") if isinstance(validation, dict) else ""

--- a/mb/mb/checkpoint.py
+++ b/mb/mb/checkpoint.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import re
+import shlex
+import shutil
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -36,23 +39,62 @@ SECRET_RE = re.compile(
 HOOK_NAME = "commit-msg"
 HOOK_BEGIN = "# >>> mainbranch checkpoint hook >>>"
 HOOK_END = "# <<< mainbranch checkpoint hook <<<"
-HOOK_BODY = f"""\
+
+
+def _resolved_mb_path() -> str:
+    current_command = Path(sys.argv[0])
+    if current_command.name == "mb":
+        if current_command.is_absolute() and current_command.exists():
+            return str(current_command.resolve())
+        resolved_command = shutil.which(str(current_command))
+        if resolved_command:
+            return resolved_command
+    return shutil.which("mb") or ""
+
+
+def _hook_body(mb_path: str = "") -> str:
+    quoted_mb = shlex.quote(mb_path)
+    return f"""\
 #!/bin/sh
 {HOOK_BEGIN}
 # Main Branch business repos use readable checkpoint subjects.
 # This hook validates only the commit subject through the installed mb CLI.
+MB_BIN={quoted_mb}
 
 if [ "$#" -lt 1 ]; then
   exit 0
 fi
 
-if ! command -v mb >/dev/null 2>&1; then
+subject=$(sed -n '1p' "$1")
+case "$subject" in
+  Merge\\ *|Revert\\ *|fixup!\\ *|squash!\\ *|amend!\\ *)
+    exit 0
+    ;;
+esac
+
+git_dir=$(git rev-parse --git-dir 2>/dev/null || true)
+if [ -n "$git_dir" ]; then
+  case "$1" in
+    "$git_dir/MERGE_MSG"|"$git_dir/SQUASH_MSG")
+      exit 0
+      ;;
+  esac
+  if [ -e "$git_dir/CHERRY_PICK_HEAD" ]; then
+    exit 0
+  fi
+fi
+
+if [ -n "$MB_BIN" ] && [ -x "$MB_BIN" ]; then
+  MB_CHECKPOINT="$MB_BIN"
+elif command -v mb >/dev/null 2>&1; then
+  MB_CHECKPOINT=$(command -v mb)
+else
   echo "Main Branch checkpoint hook could not find the mb CLI." >&2
   echo "Repair: install or update Main Branch, then run: mb doctor repair --apply" >&2
   exit 1
 fi
 
-if ! mb checkpoint --validate - < "$1"; then
+if ! "$MB_CHECKPOINT" checkpoint --validate - < "$1"; then
   echo "" >&2
   echo "Main Branch rejected this checkpoint because the message is not business-readable." >&2
   echo "Use a subject like: [updated] offer.md -- clarified guarantee" >&2
@@ -125,10 +167,10 @@ def _is_managed_hook(text: str) -> bool:
     return HOOK_BEGIN in text and HOOK_END in text
 
 
-def _hook_state_from_text(text: str) -> str:
+def _hook_state_from_text(text: str, expected: str) -> str:
     if not _is_managed_hook(text):
         return "blocked_existing_hook"
-    return "installed" if text == HOOK_BODY else "broken"
+    return "installed" if text == expected else "broken"
 
 
 def hook_status(repo: str | Path = ".") -> dict[str, Any]:
@@ -193,7 +235,7 @@ def hook_status(repo: str | Path = ".") -> dict[str, Any]:
             "repair_command": "mb doctor repair --plan",
             "errors": [str(exc)],
         }
-    state = _hook_state_from_text(text)
+    state = _hook_state_from_text(text, _hook_body(_resolved_mb_path()))
     managed = _is_managed_hook(text)
     installed = state == "installed"
     safe = state in {"installed", "broken"}
@@ -251,7 +293,8 @@ def install_commit_hook(repo: str | Path = ".") -> dict[str, Any]:
     try:
         hook.parent.mkdir(parents=True, exist_ok=True)
         previous = hook.read_text(encoding="utf-8") if hook.exists() else ""
-        hook.write_text(HOOK_BODY, encoding="utf-8")
+        hook_body = _hook_body(_resolved_mb_path())
+        hook.write_text(hook_body, encoding="utf-8")
         hook.chmod(0o755)
     except OSError as exc:
         return {
@@ -262,7 +305,7 @@ def install_commit_hook(repo: str | Path = ".") -> dict[str, Any]:
             "summary": f"could not install checkpoint hook: {exc}",
             "errors": [str(exc)],
         }
-    changed = previous != HOOK_BODY
+    changed = previous != hook_body
     return {
         **hook_status(status_report["repo"]),
         "ok": True,

--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -224,6 +224,7 @@ def _render_onboard_human(result: dict[str, Any]) -> None:
 
     tools = result["tools"]
     skill_wiring = result["skill_wiring"]
+    checkpoint_hook = result.get("checkpoint_hook") or {}
     git = tools["git"]
     github = tools["github_cli"]
     claude = tools["claude_code"]
@@ -233,6 +234,8 @@ def _render_onboard_human(result: dict[str, Any]) -> None:
     console.print(f"  {github_state}  GitHub CLI")
     console.print(f"  {'ok' if claude['found'] else 'warn'}  Claude Code")
     console.print(f"  {'ok' if skill_wiring['ok'] else 'fail'}  Claude Code skill discovery")
+    if checkpoint_hook:
+        console.print(f"  {'ok' if checkpoint_hook.get('ok') else 'warn'}  checkpoint save hook")
 
     warnings = result["warnings"]
     errors = result["errors"]
@@ -1011,6 +1014,21 @@ def checkpoint_cmd(
         "--validate",
         help="Validate a checkpoint message. Pass '-' to read the message from stdin.",
     ),
+    hook_status: bool = typer.Option(
+        False,
+        "--hook-status",
+        help="Inspect the repo-local checkpoint commit-message hook.",
+    ),
+    install_hook: bool = typer.Option(
+        False,
+        "--install-hook",
+        help="Install or repair the repo-local checkpoint commit-message hook.",
+    ),
+    uninstall_hook: bool = typer.Option(
+        False,
+        "--uninstall-hook",
+        help="Remove the Main Branch checkpoint commit-message hook.",
+    ),
     yes: bool = typer.Option(False, "--yes", help="Save the checkpoint after safety gates pass."),
     mode: str = typer.Option(
         "beginner",
@@ -1020,7 +1038,20 @@ def checkpoint_cmd(
     json_out: bool = typer.Option(False, "--json", help="Machine-readable output."),
 ) -> None:
     """Plan or save a git checkpoint."""
-    if validate:
+    hook_operations = sum(1 for item in (hook_status, install_hook, uninstall_hook) if item)
+    if hook_operations > 1:
+        typer.echo("mb checkpoint: choose only one hook operation", err=True)
+        raise typer.Exit(2)
+    if validate and hook_operations:
+        typer.echo("mb checkpoint: --validate cannot be combined with hook operations", err=True)
+        raise typer.Exit(2)
+    if install_hook:
+        result = checkpoint_mod.install_commit_hook(repo=repo)
+    elif uninstall_hook:
+        result = checkpoint_mod.uninstall_commit_hook(repo=repo)
+    elif hook_status:
+        result = checkpoint_mod.hook_status(repo=repo)
+    elif validate:
         validation_message = sys.stdin.read() if validate == "-" else validate
         result = checkpoint_mod.validate_message(validation_message)
     elif yes or message:

--- a/mb/mb/doctor.py
+++ b/mb/mb/doctor.py
@@ -19,6 +19,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from mb import checkpoint as checkpoint_mod
 from mb import connect as connect_mod
 from mb import engine as engine_mod
 from mb import graph as graph_mod
@@ -843,6 +844,24 @@ def run(path: str) -> dict[str, Any]:
     checks.append(_repo_layout_check(repo))
     checks.append(_schema_version_check(repo))
     checks.append(_legacy_campaigns_check(repo))
+    checkpoint_hook = checkpoint_mod.hook_status(repo)
+    hook_state = str(checkpoint_hook.get("state"))
+    checks.append(
+        {
+            "name": "checkpoint-hook",
+            "ok": bool(checkpoint_hook["ok"]),
+            "detail": str(checkpoint_hook["summary"]),
+            "severity": "ok"
+            if checkpoint_hook["ok"]
+            else "info"
+            if hook_state == "engine_repo"
+            else "warn",
+            "state": hook_state,
+            "repair": str(checkpoint_hook.get("summary") or ""),
+            "repair_command": str(checkpoint_hook.get("repair_command") or ""),
+            "safe_to_share": True,
+        }
+    )
     checks.append(connect_mod.doctor_check(repo, status=integration_status))
     onboarding = onboard_mod.onboarding_status(repo)
     onboarding_summary = onboarding["summary"]
@@ -1076,6 +1095,69 @@ def repair_plan(
                 for entry in LOCAL_GITIGNORE_ENTRIES
             ],
             actions=gitignore_actions,
+        )
+    )
+
+    checkpoint_hook = checkpoint_mod.hook_status(target)
+    checkpoint_state = str(checkpoint_hook.get("state"))
+    hook_check_state = (
+        "ok"
+        if checkpoint_hook.get("ok")
+        else "info"
+        if checkpoint_state == "engine_repo"
+        else "warn"
+        if checkpoint_state in {"missing", "broken", "blocked_existing_hook"}
+        else "error"
+    )
+    hook_actions: list[dict[str, Any]] = []
+    if checkpoint_state in {"missing", "broken"}:
+        action = _action(
+            id="checkpoint-hook-install",
+            title="Install business checkpoint commit-message hook",
+            state="warn",
+            mode="write",
+            command="mb checkpoint --install-hook",
+            safe_to_apply=True,
+            reason=(
+                "the repo-local commit-msg hook validates manual git commits "
+                "against the same business-readable checkpoint contract"
+            ),
+            writes=[".git/hooks/commit-msg"],
+        )
+        actions.append(action)
+        hook_actions.append(action)
+    elif checkpoint_state == "blocked_existing_hook":
+        action = _action(
+            id="checkpoint-hook-existing",
+            title="Review existing commit-message hook before installing checkpoint validation",
+            state="warn",
+            mode="manual",
+            command="review .git/hooks/commit-msg, then run mb checkpoint --install-hook",
+            safe_to_apply=False,
+            reason=(
+                "Main Branch will not overwrite an existing user hook; preserve or "
+                "compose it intentionally before installing checkpoint validation"
+            ),
+            writes=[".git/hooks/commit-msg"],
+        )
+        actions.append(action)
+        hook_actions.append(action)
+    sections.append(
+        _section(
+            "checkpoint-hook",
+            "Checkpoint Commit Hook",
+            hook_check_state,
+            str(checkpoint_hook.get("summary") or "checkpoint hook status unavailable"),
+            checks=[
+                {
+                    "name": "commit-msg",
+                    "state": hook_check_state,
+                    "summary": str(checkpoint_hook.get("summary") or ""),
+                    "hook": str(checkpoint_hook.get("hook") or ""),
+                    "repair_command": str(checkpoint_hook.get("repair_command") or ""),
+                }
+            ],
+            actions=hook_actions,
         )
     )
 
@@ -1353,6 +1435,24 @@ def repair_apply(repo: str | Path = ".", *, include_migration: bool = False) -> 
                 writes=tracked_local_state,
                 applied=any(item["ok"] for item in results),
                 result={"untracked": results},
+            )
+        )
+
+    checkpoint_hook = checkpoint_mod.hook_status(target)
+    if checkpoint_hook.get("state") in {"missing", "broken"}:
+        installed = checkpoint_mod.install_commit_hook(target)
+        applied.append(
+            _action(
+                id="checkpoint-hook-install",
+                title="Installed business checkpoint commit-message hook",
+                state="ok" if installed["ok"] else "error",
+                mode="write",
+                command="mb checkpoint --install-hook",
+                safe_to_apply=True,
+                reason="installed repo-local validation for business-readable checkpoint subjects",
+                writes=[".git/hooks/commit-msg"],
+                applied=bool(installed.get("changed")),
+                result=installed,
             )
         )
 

--- a/mb/mb/init.py
+++ b/mb/mb/init.py
@@ -14,6 +14,7 @@ from importlib import resources
 from pathlib import Path
 from typing import Any
 
+from mb import checkpoint as checkpoint_mod
 from mb.engine import link_skills
 from mb.migrate import LATEST_SCHEMA_VERSION, SCHEMA_MARKER
 
@@ -107,6 +108,7 @@ def run(path: str, name: str) -> dict[str, Any]:
             "path": str(target),
             "created": link_result["created"],
             "skill_link": link_result,
+            "checkpoint_hook": checkpoint_mod.hook_status(target),
         }
 
     business_name = name.strip() or os.environ.get("MB_BUSINESS_NAME", "").strip()
@@ -178,12 +180,21 @@ def run(path: str, name: str) -> dict[str, Any]:
             # git init failure is not fatal for scaffolding
             pass
 
+    checkpoint_hook = (
+        checkpoint_mod.install_commit_hook(target)
+        if (target / ".git").exists()
+        else checkpoint_mod.hook_status(target)
+    )
+    if checkpoint_hook.get("changed"):
+        created.append(".git/hooks/commit-msg")
+
     return {
         "status": "ok",
         "path": str(target),
         "created": created,
         "business_name": business_name,
         "skill_link": link_result,
+        "checkpoint_hook": checkpoint_hook,
     }
 
 

--- a/mb/mb/onboard.py
+++ b/mb/mb/onboard.py
@@ -11,6 +11,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from mb import checkpoint as checkpoint_mod
 from mb import init as init_mod
 from mb.engine import link_skills, link_status
 
@@ -454,6 +455,7 @@ def _checklist(repo: Path, state: dict[str, Any], markers: dict[str, bool]) -> l
     core_inputs = _core_inputs(repo)
     missing_core = [key for key, ok in core_inputs.items() if not ok]
     wiring = link_status(repo)
+    checkpoint_hook = checkpoint_mod.hook_status(repo)
     return [
         _step(
             step_id="repo_scaffold",
@@ -492,6 +494,17 @@ def _checklist(repo: Path, state: dict[str, Any], markers: dict[str, bool]) -> l
             missing_inputs=[] if wiring["ok"] else ["Claude Code skill wiring"],
             next_action="Run `mb skill link --repo .`, then `mb start --json`.",
             owner="mb",
+        ),
+        _step(
+            step_id="checkpoint_hook",
+            title="Checkpoint save hook",
+            complete=bool(checkpoint_hook["ok"]),
+            missing_inputs=[]
+            if checkpoint_hook["ok"]
+            else ["business-readable checkpoint commit hook"],
+            next_action=("Run `mb doctor repair --plan`, then `mb doctor repair --apply`."),
+            owner="mb",
+            required=False,
         ),
     ]
 
@@ -593,6 +606,15 @@ def run(
         warnings.append(str(tools["claude_code"]["repair"]))
     if not wiring["ok"]:
         warnings.append("Claude Code skill discovery is not wired. Run `mb doctor` for details.")
+    checkpoint_hook = (
+        init_result.get("checkpoint_hook")
+        if init_result
+        else checkpoint_mod.hook_status(target)
+        if target.exists()
+        else None
+    )
+    if isinstance(checkpoint_hook, dict) and not checkpoint_hook.get("ok"):
+        warnings.append(str(checkpoint_hook.get("summary") or "Checkpoint hook needs repair."))
 
     ok = not errors and wiring["ok"] and after["claude_md"]
     progress = (
@@ -626,6 +648,7 @@ def run(
         "warnings": [warning for warning in warnings if warning],
         "errors": errors,
         "doctor_command": f"mb doctor {target}",
+        "checkpoint_hook": checkpoint_hook,
         "onboarding": progress,
         "next_steps": _next_steps(target),
         "init": init_result,

--- a/mb/tests/test_checkpoint.py
+++ b/mb/tests/test_checkpoint.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
+import sys
 from pathlib import Path
 
 from typer.testing import CliRunner
@@ -27,13 +29,35 @@ def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
 
 
 def _business_repo(tmp_path: Path) -> Path:
+    _ensure_mb_shim(tmp_path)
     repo = tmp_path / "acme"
     init_run(path=str(repo), name="Acme")
     _git(repo, "config", "user.email", "test@example.com")
     _git(repo, "config", "user.name", "Test User")
     _git(repo, "add", ".")
-    _git(repo, "commit", "-m", "initial")
+    _git(repo, "commit", "-m", "[added] business scaffold")
     return repo
+
+
+def _ensure_mb_shim(tmp_path: Path) -> Path:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(exist_ok=True)
+    shim = bin_dir / "mb"
+    package_root = Path(__file__).resolve().parents[1]
+    shim.write_text(
+        f'#!/bin/sh\nPYTHONPATH="{package_root}" exec "{sys.executable}" -m mb "$@"\n',
+        encoding="utf-8",
+    )
+    shim.chmod(0o755)
+    current = os.environ.get("PATH", "")
+    if str(bin_dir) not in current.split(os.pathsep):
+        os.environ["PATH"] = f"{bin_dir}{os.pathsep}{current}"
+    return bin_dir
+
+
+def _install_mb_shim(tmp_path: Path, monkeypatch) -> None:
+    bin_dir = _ensure_mb_shim(tmp_path)
+    monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}")
 
 
 def test_checkpoint_plan_clean_repo_returns_clean(tmp_path: Path) -> None:
@@ -172,6 +196,81 @@ def test_checkpoint_validate_reads_stdin() -> None:
     payload = json.loads(result.stdout)
     assert payload["validation"]["parsed"]["verb"] == "ran"
     assert payload["validation"]["parsed"]["channel_hint"] == "ops"
+
+
+def test_checkpoint_hook_status_install_and_uninstall(tmp_path: Path) -> None:
+    repo = tmp_path / "manual"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+
+    missing = checkpoint_mod.hook_status(repo)
+    assert missing["state"] == "missing"
+    assert missing["safe_to_install"] is True
+
+    installed = checkpoint_mod.install_commit_hook(repo)
+    assert installed["ok"] is True
+    assert installed["state"] == "installed"
+    assert Path(installed["hook"]).exists()
+
+    uninstalled = checkpoint_mod.uninstall_commit_hook(repo)
+    assert uninstalled["ok"] is True
+    assert uninstalled["changed"] is True
+    assert not Path(installed["hook"]).exists()
+
+
+def test_checkpoint_hook_preserves_existing_user_hook(tmp_path: Path) -> None:
+    repo = tmp_path / "manual"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    hook = repo / ".git" / "hooks" / "commit-msg"
+    hook.write_text("#!/bin/sh\necho user hook\n", encoding="utf-8")
+
+    result = checkpoint_mod.install_commit_hook(repo)
+
+    assert result["ok"] is False
+    assert result["state"] == "blocked_existing_hook"
+    assert hook.read_text(encoding="utf-8") == "#!/bin/sh\necho user hook\n"
+
+
+def test_checkpoint_hook_skips_engine_repo(tmp_path: Path) -> None:
+    repo = tmp_path / "engine"
+    (repo / "mb" / "mb").mkdir(parents=True)
+    (repo / "mb" / "pyproject.toml").write_text("[project]\nname='mainbranch'\n")
+    (repo / "mb" / "mb" / "cli.py").write_text("# cli\n")
+    _git(repo, "init", "-q", "-b", "main")
+
+    result = checkpoint_mod.install_commit_hook(repo)
+
+    assert result["ok"] is True
+    assert result["state"] == "engine_repo"
+    assert not (repo / ".git" / "hooks" / "commit-msg").exists()
+
+
+def test_checkpoint_hook_rejects_vague_raw_git_commit(tmp_path: Path, monkeypatch) -> None:
+    _install_mb_shim(tmp_path, monkeypatch)
+    repo = _business_repo(tmp_path)
+    (repo / "core" / "offer.md").write_text("# Offer\nUpdated\n", encoding="utf-8")
+    _git(repo, "add", "core/offer.md")
+
+    result = _git(repo, "commit", "-m", "WIP")
+
+    assert result.returncode != 0
+    assert "not business-readable" in result.stderr
+    assert _git(repo, "status", "--porcelain").stdout
+
+
+def test_checkpoint_hook_accepts_business_raw_git_commit(tmp_path: Path, monkeypatch) -> None:
+    _install_mb_shim(tmp_path, monkeypatch)
+    repo = _business_repo(tmp_path)
+    (repo / "core" / "offer.md").write_text("# Offer\nUpdated\n", encoding="utf-8")
+    _git(repo, "add", "core/offer.md")
+
+    result = _git(repo, "commit", "-m", "[updated] offer.md -- clarified guarantee")
+
+    assert result.returncode == 0
+    assert (
+        "[updated] offer.md -- clarified guarantee" in _git(repo, "log", "-1", "--pretty=%s").stdout
+    )
 
 
 def test_checkpoint_blocks_env_and_secret_like_content(tmp_path: Path) -> None:
@@ -409,7 +508,7 @@ def test_checkpoint_status_preserves_legacy_checkpoint_subjects(tmp_path: Path) 
     repo = _business_repo(tmp_path)
     (repo / "core" / "offer.md").write_text("# Offer\nUpdated\n", encoding="utf-8")
     _git(repo, "add", "core/offer.md")
-    _git(repo, "commit", "-m", "[checkpoint] Update offer")
+    _git(repo, "commit", "--no-verify", "-m", "[checkpoint] Update offer")
 
     payload = checkpoint_mod.status(repo)
 

--- a/mb/tests/test_checkpoint.py
+++ b/mb/tests/test_checkpoint.py
@@ -6,7 +6,9 @@ import json
 import os
 import subprocess
 import sys
+from collections.abc import Mapping
 from pathlib import Path
+from typing import Any
 
 from typer.testing import CliRunner
 
@@ -18,18 +20,23 @@ from mb.init import run as init_run
 runner = CliRunner()
 
 
-def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+def _git(
+    repo: Path,
+    *args: str,
+    env: Mapping[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         ["git", *args],
         cwd=repo,
+        env=env,
         text=True,
         capture_output=True,
         check=False,
     )
 
 
-def _business_repo(tmp_path: Path) -> Path:
-    _ensure_mb_shim(tmp_path)
+def _business_repo(tmp_path: Path, monkeypatch: Any) -> Path:
+    _install_mb_shim(tmp_path, monkeypatch)
     repo = tmp_path / "acme"
     init_run(path=str(repo), name="Acme")
     _git(repo, "config", "user.email", "test@example.com")
@@ -39,7 +46,7 @@ def _business_repo(tmp_path: Path) -> Path:
     return repo
 
 
-def _ensure_mb_shim(tmp_path: Path) -> Path:
+def _install_mb_shim(tmp_path: Path, monkeypatch: Any) -> Path:
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir(exist_ok=True)
     shim = bin_dir / "mb"
@@ -49,19 +56,41 @@ def _ensure_mb_shim(tmp_path: Path) -> Path:
         encoding="utf-8",
     )
     shim.chmod(0o755)
-    current = os.environ.get("PATH", "")
-    if str(bin_dir) not in current.split(os.pathsep):
-        os.environ["PATH"] = f"{bin_dir}{os.pathsep}{current}"
+    monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}")
     return bin_dir
 
 
-def _install_mb_shim(tmp_path: Path, monkeypatch) -> None:
-    bin_dir = _ensure_mb_shim(tmp_path)
-    monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}")
+def _commit_file(repo: Path, relative_path: str, content: str, message: str) -> None:
+    target = repo / relative_path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(content, encoding="utf-8")
+    result = _git(repo, "add", relative_path)
+    assert result.returncode == 0, result.stderr
+    result = _git(repo, "commit", "-m", message)
+    assert result.returncode == 0, result.stderr
 
 
-def test_checkpoint_plan_clean_repo_returns_clean(tmp_path: Path) -> None:
-    repo = _business_repo(tmp_path)
+def test_checkpoint_resolves_current_absolute_mb_entrypoint(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    current_bin = tmp_path / "venv" / "bin"
+    current_bin.mkdir(parents=True)
+    current_mb = current_bin / "mb"
+    current_mb.write_text("#!/bin/sh\n", encoding="utf-8")
+    current_mb.chmod(0o755)
+    older_bin = tmp_path / "global" / "bin"
+    older_bin.mkdir(parents=True)
+    older_mb = older_bin / "mb"
+    older_mb.write_text("#!/bin/sh\n", encoding="utf-8")
+    older_mb.chmod(0o755)
+    monkeypatch.setattr(sys, "argv", [str(current_mb), "checkpoint", "--install-hook"])
+    monkeypatch.setenv("PATH", f"{older_bin}{os.pathsep}{os.environ.get('PATH', '')}")
+
+    assert checkpoint_mod._resolved_mb_path() == str(current_mb.resolve())
+
+
+def test_checkpoint_plan_clean_repo_returns_clean(tmp_path: Path, monkeypatch: Any) -> None:
+    repo = _business_repo(tmp_path, monkeypatch)
 
     report = checkpoint_mod.plan(repo)
 
@@ -92,8 +121,8 @@ def test_checkpoint_verb_registry_matches_operator_contract() -> None:
     assert registry["connected"].channel_hint == "ops"
 
 
-def test_checkpoint_plan_classifies_dirty_business_files(tmp_path: Path) -> None:
-    repo = _business_repo(tmp_path)
+def test_checkpoint_plan_classifies_dirty_business_files(tmp_path: Path, monkeypatch: Any) -> None:
+    repo = _business_repo(tmp_path, monkeypatch)
     (repo / "core" / "offer.md").write_text("# Offer\n", encoding="utf-8")
     (repo / "decisions" / "2026-05-05-test.md").write_text("# Decision\n", encoding="utf-8")
     (repo / "pushes" / "paid.md").write_text("# Push\n", encoding="utf-8")
@@ -120,8 +149,8 @@ def test_checkpoint_plan_classifies_dirty_business_files(tmp_path: Path) -> None
     }
 
 
-def test_checkpoint_cli_json_contract(tmp_path: Path) -> None:
-    repo = _business_repo(tmp_path)
+def test_checkpoint_cli_json_contract(tmp_path: Path, monkeypatch: Any) -> None:
+    repo = _business_repo(tmp_path, monkeypatch)
     (repo / "research" / "market.md").write_text("# Market\n", encoding="utf-8")
 
     result = runner.invoke(app, ["checkpoint", "--repo", str(repo), "--plan", "--json"])
@@ -246,9 +275,8 @@ def test_checkpoint_hook_skips_engine_repo(tmp_path: Path) -> None:
     assert not (repo / ".git" / "hooks" / "commit-msg").exists()
 
 
-def test_checkpoint_hook_rejects_vague_raw_git_commit(tmp_path: Path, monkeypatch) -> None:
-    _install_mb_shim(tmp_path, monkeypatch)
-    repo = _business_repo(tmp_path)
+def test_checkpoint_hook_rejects_vague_raw_git_commit(tmp_path: Path, monkeypatch: Any) -> None:
+    repo = _business_repo(tmp_path, monkeypatch)
     (repo / "core" / "offer.md").write_text("# Offer\nUpdated\n", encoding="utf-8")
     _git(repo, "add", "core/offer.md")
 
@@ -259,9 +287,8 @@ def test_checkpoint_hook_rejects_vague_raw_git_commit(tmp_path: Path, monkeypatc
     assert _git(repo, "status", "--porcelain").stdout
 
 
-def test_checkpoint_hook_accepts_business_raw_git_commit(tmp_path: Path, monkeypatch) -> None:
-    _install_mb_shim(tmp_path, monkeypatch)
-    repo = _business_repo(tmp_path)
+def test_checkpoint_hook_accepts_business_raw_git_commit(tmp_path: Path, monkeypatch: Any) -> None:
+    repo = _business_repo(tmp_path, monkeypatch)
     (repo / "core" / "offer.md").write_text("# Offer\nUpdated\n", encoding="utf-8")
     _git(repo, "add", "core/offer.md")
 
@@ -273,8 +300,82 @@ def test_checkpoint_hook_accepts_business_raw_git_commit(tmp_path: Path, monkeyp
     )
 
 
-def test_checkpoint_blocks_env_and_secret_like_content(tmp_path: Path) -> None:
-    repo = _business_repo(tmp_path)
+def test_checkpoint_hook_uses_installed_mb_when_runtime_path_is_minimal(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    bin_dir = _install_mb_shim(tmp_path, monkeypatch)
+    repo = _business_repo(tmp_path, monkeypatch)
+    hook = (repo / ".git" / "hooks" / "commit-msg").read_text(encoding="utf-8")
+    assert f"MB_BIN={bin_dir / 'mb'}" in hook
+    (repo / "core" / "offer.md").write_text("# Offer\nUpdated\n", encoding="utf-8")
+    _git(repo, "add", "core/offer.md")
+
+    result = _git(
+        repo,
+        "commit",
+        "-m",
+        "[updated] offer.md -- clarified guarantee",
+        env={**os.environ, "PATH": "/usr/bin:/bin:/usr/sbin:/sbin"},
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_checkpoint_hook_allows_no_ff_merge_auto_message(tmp_path: Path, monkeypatch: Any) -> None:
+    repo = _business_repo(tmp_path, monkeypatch)
+    _commit_file(repo, "core/offer.md", "# Offer\nMain\n", "[updated] offer.md")
+    result = _git(repo, "checkout", "-b", "feature")
+    assert result.returncode == 0, result.stderr
+    _commit_file(repo, "research/feature.md", "# Feature\n", "[added] feature.md")
+    result = _git(repo, "checkout", "main")
+    assert result.returncode == 0, result.stderr
+    _commit_file(repo, "research/main.md", "# Main\n", "[added] main.md")
+
+    result = _git(repo, "merge", "--no-ff", "feature")
+
+    assert result.returncode == 0, result.stderr
+    assert _git(repo, "log", "-1", "--pretty=%s").stdout.startswith("Merge ")
+
+
+def test_checkpoint_hook_allows_revert_auto_message(tmp_path: Path, monkeypatch: Any) -> None:
+    repo = _business_repo(tmp_path, monkeypatch)
+    _commit_file(repo, "core/offer.md", "# Offer\nBefore\n", "[updated] offer.md")
+    _commit_file(
+        repo,
+        "core/offer.md",
+        "# Offer\nAfter\n",
+        "[updated] offer.md -- changed for revert",
+    )
+
+    result = _git(repo, "revert", "HEAD", "--no-edit")
+
+    assert result.returncode == 0, result.stderr
+    assert _git(repo, "log", "-1", "--pretty=%s").stdout.startswith("Revert ")
+
+
+def test_checkpoint_hook_allows_rebase_helper_subjects(tmp_path: Path, monkeypatch: Any) -> None:
+    repo = _business_repo(tmp_path, monkeypatch)
+
+    for index, subject in enumerate(
+        [
+            "fixup! [updated] offer.md",
+            "squash! [updated] offer.md",
+            "amend! [updated] offer.md",
+        ],
+        start=1,
+    ):
+        _commit_file(
+            repo,
+            "research/rebase-helper.md",
+            f"# Helper\n{index}\n",
+            subject,
+        )
+
+    assert "amend! [updated] offer.md" in _git(repo, "log", "-1", "--pretty=%s").stdout
+
+
+def test_checkpoint_blocks_env_and_secret_like_content(tmp_path: Path, monkeypatch: Any) -> None:
+    repo = _business_repo(tmp_path, monkeypatch)
     (repo / ".env").write_text("API_KEY=super-secret\n", encoding="utf-8")
     (repo / "core" / "credentials.md").write_text(
         "Authorization: Bearer abcdefghijklmnop\n",
@@ -292,8 +393,8 @@ def test_checkpoint_blocks_env_and_secret_like_content(tmp_path: Path) -> None:
     assert report["proposal"] is None
 
 
-def test_checkpoint_blocks_service_account_json(tmp_path: Path) -> None:
-    repo = _business_repo(tmp_path)
+def test_checkpoint_blocks_service_account_json(tmp_path: Path, monkeypatch: Any) -> None:
+    repo = _business_repo(tmp_path, monkeypatch)
     (repo / "core" / "service-account.json").write_text(
         '{"type":"service_account","private_key":"-----BEGIN PRIVATE KEY-----"}',
         encoding="utf-8",
@@ -305,8 +406,8 @@ def test_checkpoint_blocks_service_account_json(tmp_path: Path) -> None:
     assert report["safety"]["blocks"][0]["code"] == "service_account_json"
 
 
-def test_checkpoint_blocks_forced_local_bridge_files(tmp_path: Path) -> None:
-    repo = _business_repo(tmp_path)
+def test_checkpoint_blocks_forced_local_bridge_files(tmp_path: Path, monkeypatch: Any) -> None:
+    repo = _business_repo(tmp_path, monkeypatch)
     _git(repo, "add", "-f", ".claude/settings.local.json")
 
     report = checkpoint_mod.plan(repo)
@@ -316,8 +417,8 @@ def test_checkpoint_blocks_forced_local_bridge_files(tmp_path: Path) -> None:
     assert report["safety"]["blocks"][0]["code"] == "local_bridge_file"
 
 
-def test_checkpoint_blocks_forced_claude_code_worktrees(tmp_path: Path) -> None:
-    repo = _business_repo(tmp_path)
+def test_checkpoint_blocks_forced_claude_code_worktrees(tmp_path: Path, monkeypatch: Any) -> None:
+    repo = _business_repo(tmp_path, monkeypatch)
     worktree_state = repo / ".claude" / "worktrees" / "session" / "state.json"
     worktree_state.parent.mkdir(parents=True)
     worktree_state.write_text("{}", encoding="utf-8")
@@ -345,8 +446,8 @@ def test_checkpoint_blocks_engine_repo(tmp_path: Path) -> None:
     assert report["safety"]["blocks"][0]["code"] == "engine_repo"
 
 
-def test_checkpoint_rejects_invalid_mode(tmp_path: Path) -> None:
-    repo = _business_repo(tmp_path)
+def test_checkpoint_rejects_invalid_mode(tmp_path: Path, monkeypatch: Any) -> None:
+    repo = _business_repo(tmp_path, monkeypatch)
 
     result = runner.invoke(app, ["checkpoint", "--repo", str(repo), "--mode", "auto", "--json"])
 
@@ -356,8 +457,8 @@ def test_checkpoint_rejects_invalid_mode(tmp_path: Path) -> None:
     assert "mode must be beginner or concern" in payload["errors"][0]
 
 
-def test_checkpoint_commit_requires_yes_after_plan_review(tmp_path: Path) -> None:
-    repo = _business_repo(tmp_path)
+def test_checkpoint_commit_requires_yes_after_plan_review(tmp_path: Path, monkeypatch: Any) -> None:
+    repo = _business_repo(tmp_path, monkeypatch)
     (repo / "core" / "offer.md").write_text("# Offer\n", encoding="utf-8")
 
     result = runner.invoke(
@@ -379,8 +480,8 @@ def test_checkpoint_commit_requires_yes_after_plan_review(tmp_path: Path) -> Non
     assert "pass --yes" in payload["errors"][0]
 
 
-def test_checkpoint_commit_saves_readable_checkpoint(tmp_path: Path) -> None:
-    repo = _business_repo(tmp_path)
+def test_checkpoint_commit_saves_readable_checkpoint(tmp_path: Path, monkeypatch: Any) -> None:
+    repo = _business_repo(tmp_path, monkeypatch)
     (repo / "core" / "offer.md").write_text("# Offer\nUpdated\n", encoding="utf-8")
 
     result = runner.invoke(
@@ -409,8 +510,10 @@ def test_checkpoint_commit_saves_readable_checkpoint(tmp_path: Path) -> None:
     assert "Changed:\n- core/offer.md" in log
 
 
-def test_checkpoint_commit_rejects_invalid_business_message(tmp_path: Path) -> None:
-    repo = _business_repo(tmp_path)
+def test_checkpoint_commit_rejects_invalid_business_message(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    repo = _business_repo(tmp_path, monkeypatch)
     (repo / "core" / "offer.md").write_text("# Offer\nUpdated\n", encoding="utf-8")
 
     result = runner.invoke(
@@ -434,8 +537,10 @@ def test_checkpoint_commit_rejects_invalid_business_message(tmp_path: Path) -> N
     assert _git(repo, "status", "--porcelain").stdout
 
 
-def test_checkpoint_commit_refuses_blocked_plan_without_commit(tmp_path: Path) -> None:
-    repo = _business_repo(tmp_path)
+def test_checkpoint_commit_refuses_blocked_plan_without_commit(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    repo = _business_repo(tmp_path, monkeypatch)
     (repo / ".env").write_text("API_KEY=super-secret\n", encoding="utf-8")
     _git(repo, "add", "-f", ".env")
 
@@ -459,8 +564,8 @@ def test_checkpoint_commit_refuses_blocked_plan_without_commit(tmp_path: Path) -
     assert _git(repo, "log", "--oneline").stdout.count("\n") == 1
 
 
-def test_checkpoint_commit_clean_repo_is_noop(tmp_path: Path) -> None:
-    repo = _business_repo(tmp_path)
+def test_checkpoint_commit_clean_repo_is_noop(tmp_path: Path, monkeypatch: Any) -> None:
+    repo = _business_repo(tmp_path, monkeypatch)
 
     result = runner.invoke(
         app,
@@ -481,8 +586,10 @@ def test_checkpoint_commit_clean_repo_is_noop(tmp_path: Path) -> None:
     assert payload["committed"] is False
 
 
-def test_checkpoint_status_reports_recent_checkpoint_and_pending_work(tmp_path: Path) -> None:
-    repo = _business_repo(tmp_path)
+def test_checkpoint_status_reports_recent_checkpoint_and_pending_work(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    repo = _business_repo(tmp_path, monkeypatch)
     (repo / "core" / "offer.md").write_text("# Offer\nUpdated\n", encoding="utf-8")
     checkpoint_mod.commit(
         repo,
@@ -504,8 +611,10 @@ def test_checkpoint_status_reports_recent_checkpoint_and_pending_work(tmp_path: 
     assert payload["pending"]["summary"]["surfaces"] == {"research": 1}
 
 
-def test_checkpoint_status_preserves_legacy_checkpoint_subjects(tmp_path: Path) -> None:
-    repo = _business_repo(tmp_path)
+def test_checkpoint_status_preserves_legacy_checkpoint_subjects(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    repo = _business_repo(tmp_path, monkeypatch)
     (repo / "core" / "offer.md").write_text("# Offer\nUpdated\n", encoding="utf-8")
     _git(repo, "add", "core/offer.md")
     _git(repo, "commit", "--no-verify", "-m", "[checkpoint] Update offer")

--- a/mb/tests/test_doctor.py
+++ b/mb/tests/test_doctor.py
@@ -79,6 +79,8 @@ def test_doctor_skill_wiring_passes_after_init(tmp_path: Path) -> None:
     report = run(path=str(repo))
     wiring = next(c for c in report["checks"] if c["name"] == "skill-wiring")
     assert wiring["ok"] is True
+    checkpoint_hook = next(c for c in report["checks"] if c["name"] == "checkpoint-hook")
+    assert checkpoint_hook["ok"] is True
 
 
 def test_repo_layout_warns_on_legacy_reference_core(tmp_path: Path) -> None:
@@ -198,6 +200,52 @@ def test_doctor_repair_adds_connect_yaml_to_gitignore(tmp_path: Path) -> None:
 
     assert result.exit_code in {0, 1}
     assert ".mb/connect.yaml" in gitignore.read_text(encoding="utf-8")
+
+
+def test_doctor_repair_plan_reports_missing_checkpoint_hook(tmp_path: Path) -> None:
+    repo = tmp_path / "biz"
+    init_run(path=str(repo), name="Acme")
+    (repo / ".git" / "hooks" / "commit-msg").unlink()
+
+    result = runner.invoke(app, ["doctor", "repair", "--repo", str(repo), "--plan", "--json"])
+
+    assert result.exit_code in {0, 1}
+    payload = json.loads(result.stdout)
+    section = next(section for section in payload["sections"] if section["id"] == "checkpoint-hook")
+    assert section["state"] == "warn"
+    actions = {action["id"]: action for action in payload["actions"]}
+    assert actions["checkpoint-hook-install"]["safe_to_apply"] is True
+
+
+def test_doctor_repair_apply_installs_checkpoint_hook(tmp_path: Path) -> None:
+    repo = tmp_path / "biz"
+    init_run(path=str(repo), name="Acme")
+    hook = repo / ".git" / "hooks" / "commit-msg"
+    hook.unlink()
+
+    result = runner.invoke(app, ["doctor", "repair", "--repo", str(repo), "--apply", "--json"])
+
+    assert result.exit_code in {0, 1}
+    payload = json.loads(result.stdout)
+    applied = {action["id"]: action for action in payload["applied_actions"]}
+    assert "checkpoint-hook-install" in applied
+    assert hook.exists()
+    assert "mb checkpoint --validate -" in hook.read_text(encoding="utf-8")
+
+
+def test_doctor_repair_preserves_existing_checkpoint_hook(tmp_path: Path) -> None:
+    repo = tmp_path / "biz"
+    init_run(path=str(repo), name="Acme")
+    hook = repo / ".git" / "hooks" / "commit-msg"
+    hook.write_text("#!/bin/sh\necho user hook\n", encoding="utf-8")
+
+    result = runner.invoke(app, ["doctor", "repair", "--repo", str(repo), "--apply", "--json"])
+
+    assert result.exit_code in {0, 1}
+    payload = json.loads(result.stdout)
+    actions = {action["id"]: action for action in payload["actions"]}
+    assert actions["checkpoint-hook-existing"]["safe_to_apply"] is False
+    assert hook.read_text(encoding="utf-8") == "#!/bin/sh\necho user hook\n"
 
 
 def test_doctor_repair_untracks_existing_connect_yaml(tmp_path: Path) -> None:

--- a/mb/tests/test_doctor.py
+++ b/mb/tests/test_doctor.py
@@ -230,7 +230,9 @@ def test_doctor_repair_apply_installs_checkpoint_hook(tmp_path: Path) -> None:
     applied = {action["id"]: action for action in payload["applied_actions"]}
     assert "checkpoint-hook-install" in applied
     assert hook.exists()
-    assert "mb checkpoint --validate -" in hook.read_text(encoding="utf-8")
+    hook_text = hook.read_text(encoding="utf-8")
+    assert "MB_BIN=" in hook_text
+    assert '"$MB_CHECKPOINT" checkpoint --validate -' in hook_text
 
 
 def test_doctor_repair_preserves_existing_checkpoint_hook(tmp_path: Path) -> None:

--- a/mb/tests/test_init.py
+++ b/mb/tests/test_init.py
@@ -35,6 +35,10 @@ def test_init_scaffolds_folders(tmp_path: Path) -> None:
     assert (target / ".mb" / "schema_version").read_text(encoding="utf-8") == "0.2\n"
     assert (target / ".claude" / "settings.local.json").exists()
     assert (target / ".claude" / "skills" / "mb-start" / "SKILL.md").exists()
+    assert (target / ".git" / "hooks" / "commit-msg").exists()
+    hook = (target / ".git" / "hooks" / "commit-msg").read_text(encoding="utf-8")
+    assert "mb checkpoint --validate -" in hook
+    assert result["checkpoint_hook"]["state"] == "installed"
 
     settings = json.loads((target / ".claude" / "settings.local.json").read_text())
     dirs = settings["permissions"]["additionalDirectories"]
@@ -71,6 +75,7 @@ def test_init_idempotent(tmp_path: Path) -> None:
     second = run(path=str(target), name="Acme")
     assert first["status"] == "ok"
     assert second["status"] == "already-initialized"
+    assert second["checkpoint_hook"]["state"] == "installed"
 
 
 def test_init_requires_name(tmp_path: Path, monkeypatch) -> None:

--- a/mb/tests/test_init.py
+++ b/mb/tests/test_init.py
@@ -37,7 +37,8 @@ def test_init_scaffolds_folders(tmp_path: Path) -> None:
     assert (target / ".claude" / "skills" / "mb-start" / "SKILL.md").exists()
     assert (target / ".git" / "hooks" / "commit-msg").exists()
     hook = (target / ".git" / "hooks" / "commit-msg").read_text(encoding="utf-8")
-    assert "mb checkpoint --validate -" in hook
+    assert "MB_BIN=" in hook
+    assert '"$MB_CHECKPOINT" checkpoint --validate -' in hook
     assert result["checkpoint_hook"]["state"] == "installed"
 
     settings = json.loads((target / ".claude" / "settings.local.json").read_text())

--- a/mb/tests/test_onboard.py
+++ b/mb/tests/test_onboard.py
@@ -37,6 +37,8 @@ def test_onboard_yes_creates_repo_and_reports_next_steps(tmp_path: Path, monkeyp
     assert result["level"] == "beginner"
     assert (repo / "CLAUDE.md").exists()
     assert (repo / ".claude" / "skills" / "mb-start" / "SKILL.md").exists()
+    assert (repo / ".git" / "hooks" / "commit-msg").exists()
+    assert result["checkpoint_hook"]["state"] == "installed"
     assert result["skill_wiring"]["ok"] is True
     assert result["next_steps"] == [f"cd {repo.resolve()}", "claude", "/mb-start"]
     assert any("Claude Code" in warning for warning in result["warnings"])

--- a/mb/tests/test_start.py
+++ b/mb/tests/test_start.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import json
+import os
 import shlex
 import shutil
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -16,6 +18,19 @@ from mb.cli import app
 from mb.init import run as init_run
 
 runner = CliRunner()
+
+
+def _install_mb_shim(tmp_path: Path, monkeypatch) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(exist_ok=True)
+    shim = bin_dir / "mb"
+    package_root = Path(__file__).resolve().parents[1]
+    shim.write_text(
+        f'#!/bin/sh\nPYTHONPATH="{package_root}" exec "{sys.executable}" -m mb "$@"\n',
+        encoding="utf-8",
+    )
+    shim.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}")
 
 
 def _with_claude(name: str) -> str:
@@ -199,6 +214,7 @@ def test_start_does_not_run_full_status_pipeline(tmp_path: Path, monkeypatch) ->
 
 def test_start_surfaces_recent_checkpoint_history(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(start_mod, "_which", _with_claude)
+    _install_mb_shim(tmp_path, monkeypatch)
     repo = tmp_path / "acme"
     init_run(path=str(repo), name="Acme")
     subprocess_result = start_mod._run_command(
@@ -212,7 +228,10 @@ def test_start_surfaces_recent_checkpoint_history(tmp_path: Path, monkeypatch) -
     assert subprocess_result["ok"] is True
     subprocess_result = start_mod._run_command(["git", "add", "."], cwd=repo)
     assert subprocess_result["ok"] is True
-    subprocess_result = start_mod._run_command(["git", "commit", "-m", "initial"], cwd=repo)
+    subprocess_result = start_mod._run_command(
+        ["git", "commit", "-m", "[added] business scaffold"],
+        cwd=repo,
+    )
     assert subprocess_result["ok"] is True
     (repo / "core" / "offer.md").write_text("# Offer\n", encoding="utf-8")
     commit = runner.invoke(


### PR DESCRIPTION
## Summary
- Adds repo-local checkpoint commit hook workflows so business repos can reject vague commit subjects before they enter history.
- Wires `mb init`, `mb onboard`, `mb doctor`, and `mb doctor repair` into checkpoint hook install/status/repair while preserving existing hooks and skipping engine repos.
- Updates shipped skills to route checkpoint saves through the structured `mb checkpoint` planner/validator/approved-save flow instead of raw git prose.

## Scope
- In: checkpoint hook install/status/uninstall/repair, doctor repair wiring, fresh repo onboarding wiring, skill checkpoint-save prose, focused tests, package/fixture/runtime validation.
- Out: broader git-journal rendering in `mb status` and dashboard timeline consumption; that remains #303 / MAIN-240.

## Commits
- `227fd7d` — `[add] Install checkpoint commit hook workflows`.
- `c70e027` — `[update] Route skills through checkpoint saves`.

## Release / Issues
- Release: next patch release.
- Linear ID(s): MAIN-239.
- Closes: #302.
- Refs: #300, #301.
- Follow-ups: #303 consumes the readable checkpoint history in status/timeline surfaces; #135 tracks the pre-existing setuptools license metadata warning seen during package smoke.

## Success Metric
- A beginner working in a business repo gets readable checkpoint history by default, and raw vague commits such as `WIP` are rejected with repair-oriented guidance instead of silently entering the business journal.

## Validation
- Level 0 docs/decision: skill checkpoint prose updated to use Main Branch checkpoint language and avoid raw git ceremony for beginners.
- Level 1 static: `scripts/check.sh` passed, including ruff, mypy, 303 tests, coverage gate, and bundled skill validation.
- Level 2 CLI: focused checkpoint/doctor/init/onboard/start tests passed, 79 tests total.
- Level 3 package/install: build, fresh venv install, `mb --version`, and `mb skill list` passed.
- Level 4 fixture repo: `mb onboard`, bad raw `git commit -m "WIP"` rejection, valid checkpoint commit acceptance, uninstall, and doctor repair verified.
- Level 5 runtime smoke: Claude Code `/mb-start` from the fixture repo discovered the skill, read repo context, reported clean state, and made no file changes.

## Public / Private Boundary
- No private Devon/Conductor workflow details, local paths, credentials, or account data were added to committed files.
