### PR TITLE
[add] mb status git journal

### DIFF
--- a/.claude/skills/mb-start/SKILL.md
+++ b/.claude/skills/mb-start/SKILL.md
@@ -30,12 +30,12 @@ integrations, GitHub tasks/proposals, bets, dirty git, since-last-check, and
 `ranked_actions`. Do not duplicate those checks with ad hoc shell probes unless
 the status report says a section is unavailable.
 
-**Continuity facts:** Use `since_last_check`, dirty-git, recent GitHub/git
-activity, and the `checkpoint` section from status to explain "where we left
-off." If the operator asks to save progress, run `mb checkpoint --plan --json`,
-show the proposal/blockers, validate the message with `mb checkpoint --validate
-"..." --json`, then after approval run `mb checkpoint --message "..." --yes`.
-Explain this as saving a checkpoint, not raw git ceremony.
+**Continuity facts:** Use `since_last_check.journal`, top-level `journal`,
+dirty-git, GitHub activity, and `checkpoint` from status to explain "where we
+left off." Do not run raw `git log` unless status says journal facts are
+unavailable. If the operator asks to save progress, run `mb checkpoint --plan
+--json`, validate with `mb checkpoint --validate "..." --json`, then after
+approval run `mb checkpoint --message "..." --yes`.
 
 **Provider facts first:** When setup or routing depends on GitHub, Cloudflare,
 Google/Workspace, Meta Ads, or Apify, read the status `integrations` facts
@@ -185,9 +185,9 @@ Use this report before asking additional questions:
 - `drift.items` names stale or broken status signals and repair commands.
 - `onboarding.summary` and `onboarding.checklist` replace separate onboarding
   probes unless the status report is unavailable.
-- `integrations.github`, `integrations.providers`, `github.sections`,
-  `measurement`, `brain.bets`, and `since_last_check` supply the continuity
-  facts for routing and triage.
+- `journal`, `since_last_check.journal`, `integrations.github`,
+  `integrations.providers`, `github.sections`, `measurement`, and
+  `brain.bets` supply continuity facts for routing and triage.
 
 Only run a narrower fallback command such as `mb onboard status --json`,
 `mb doctor`, `mb validate --cross-refs`, or `mb connect doctor --json` when status
@@ -332,7 +332,7 @@ See [readiness-assessment.md](references/readiness-assessment.md) for complete s
 ### Quick summary:
 
 1. **Score reference files** (soul, offer, audience, voice, testimonials, angles) on 0-3 scale each. Composite max = 18. Multi-offer: score active offer's files, not just core.
-2. **Check session state** — recent commits, open decisions, uncodified research. Surface what's in progress.
+2. **Check session state** — status journal activity, open decisions, uncodified research. Surface what's in progress.
 3. **Soul health check** — for returning users (last commit >3 days ago), read soul.md and ask: "Is your current work feeling like pull or push?" Skip for active or first-time users.
 4. **Gate routing** based on composite score:
 

--- a/.claude/skills/mb-start/references/readiness-assessment.md
+++ b/.claude/skills/mb-start/references/readiness-assessment.md
@@ -78,14 +78,15 @@ Surface what happened recently so the user sees continuity, not a blank slate.
 
 ### Recent Activity
 
-```bash
-# What happened in the last few sessions?
-git log --since="7 days ago" --oneline --no-merges 2>/dev/null | head -10
-```
+Prefer `since_last_check.journal` and top-level `journal` from
+`mb status --json --peek`. Summarize the newest grouped event in one line:
+"Last session: [journal summary]".
 
-If commits exist, summarize in one line: "Last session: [topic from most recent commit message]"
+Only run `git log --since="7 days ago" --oneline --no-merges` as a fallback
+when status says the journal section is unavailable or degraded.
 
-If no commits in 7+ days, note the gap -- this feeds into the soul health check (Section 3).
+If status reports no journal events in 7+ days, note the gap -- this feeds into
+the soul health check (Section 3).
 
 ### Open Decisions
 
@@ -152,11 +153,10 @@ Flag any file that scored 3/3 structurally but has `status: draft` in frontmatte
 
 ### Check B: Staleness Detection (1 call)
 
-```bash
-git log --format="%ai" -1 -- [repo-path]/core/soul.md [repo-path]/core/offer.md [repo-path]/core/audience.md [repo-path]/core/voice.md
-```
+Use `journal.events[].files` from status first. Fall back to:
+`git log --format="%ai" -1 -- [repo-path]/core/soul.md [repo-path]/core/offer.md [repo-path]/core/audience.md [repo-path]/core/voice.md`
 
-Flag any core file not modified in 30+ days. Not a score penalty — an observation.
+Flag any core file not modified in 30+ days. Not a score penalty -- an observation.
 
 **Flag:** `! stale (Xd)` (inline next to file)
 
@@ -259,7 +259,7 @@ Modeled on /mb-end's crystallize pattern. For returning users, reconnection at s
 
 **Trigger conditions (ALL must be true):**
 1. `core/soul.md` exists and has substance (score 2+)
-2. Last commit was >3 days ago (returning after absence)
+2. Last journal event or commit was >3 days ago (returning after absence)
 3. This is not the user's first session ever (config exists with `user.name`)
 
 **Skip conditions (ANY skips this check):**
@@ -270,10 +270,8 @@ Modeled on /mb-end's crystallize pattern. For returning users, reconnection at s
 
 ### How to Check
 
-```bash
-# Days since last commit
-git log -1 --format="%ar" 2>/dev/null
-```
+Use the newest status journal event date. If journal facts are unavailable,
+fall back to `git log -1 --format="%ar"`.
 
 ### The Ask
 

--- a/.claude/skills/mb-start/references/triage-agent.md
+++ b/.claude/skills/mb-start/references/triage-agent.md
@@ -52,12 +52,12 @@ Spawn three agents in a single message using the Task tool. Each gets a focused 
 
 ### Reuse Readiness Data (Token Efficiency)
 
-The triage agents receive the readiness assessment results (scores, gaps, session state, recent commits) as input context. They do NOT re-scan these. The readiness assessment (Step 6) already ran git log, scored files, detected open decisions, and checked for uncodified research. Triage agents go DEEPER -- reading file contents, checking section quality, analyzing patterns across files, and connecting dots between soul alignment and tactical work.
+The triage agents receive the readiness assessment results (scores, gaps, session state, journal summary) as input context. They do NOT re-scan these. The readiness assessment (Step 6) already read status journal facts, scored files, detected open decisions, and checked for uncodified research. Triage agents go DEEPER -- reading file contents, checking section quality, analyzing patterns across files, and connecting dots between soul alignment and tactical work.
 
 **What readiness already computed (pass as context, do not recompute):**
 - Per-file scores (soul, offer, audience, voice, testimonials, angles)
 - Composite score and status tier (EMPTY/MINIMAL/THIN/GOOD/FULL)
-- Recent commits summary
+- Recent journal summary
 - Open decision count and topics
 - Uncodified research count
 - Session gaps and last activity date
@@ -77,8 +77,8 @@ Gather these in main and pass as structured text in each agent's prompt:
 |---------|-----|------|-----------|
 | Readiness scores (from Step 6) | Already computed | ~20 lines | All 3 agents |
 | Absolute repo path | From Step 2 | 1 line | All 3 agents (agents use this to Read files themselves) |
-| Git log (30 days) | `git log --since="30 days ago" --oneline --no-merges` | ~30 lines | Agent 2 |
-| Core file change list (30 days) | `git log --since="30 days ago" --name-only -- core/` | ~20 lines | Agent 1, 3 |
+| Journal groups (30 days) | `journal.groups` from `mb status --json --peek`; fallback to `git log` only if degraded | ~30 lines | Agent 2 |
+| Core file change list (30 days) | `journal.events[].files` from status; fallback to `git log --since="30 days ago" --name-only -- core/` only if degraded | ~20 lines | Agent 1, 3 |
 | Open decision file names | `grep -rl "status: proposed\|status: accepted" decisions/ 2>/dev/null` | ~10 lines | Agent 2 |
 | Unlinked research count | `grep -rl "linked_decisions: \[\]" research/ 2>/dev/null \| wc -l` | 1 line | Agent 2 |
 | Past triage file names | `ls research/*-start-triage.md 2>/dev/null` | ~5 lines | Agent 3 |
@@ -256,7 +256,7 @@ Return:
 - Highest-value pending work item with reasoning
 ```
 
-**Token budget:** ~20-40K (reads git logs, scans file frontmatter, analyzes patterns)
+**Token budget:** ~20-40K (reads journal facts, scans file frontmatter, analyzes patterns)
 
 ---
 

--- a/.claude/skills/mb-status/SKILL.md
+++ b/.claude/skills/mb-status/SKILL.md
@@ -20,8 +20,8 @@ mb status --json --peek
 ```
 
 3. Treat the JSON as the source of truth for setup, update, drift, GitHub,
-   onboarding, integrations, bets, since-last-check, readiness, and ranked
-   actions.
+   onboarding, integrations, bets, journal activity, since-last-check,
+   readiness, and ranked actions.
 4. Summarize the top `ranked_actions` first. For each one, include:
    - title
    - command or slash command
@@ -29,6 +29,9 @@ mb status --json --peek
    - cited signal summaries
 5. Then summarize only the sections that matter for the operator's question.
    Do not re-run shell probes that duplicate status facts.
+   For "what changed?" or "what happened since last time?", answer from
+   `since_last_check.journal` first, then top-level `journal` for recent
+   context.
 6. If provider readiness is the question, use `integrations.github` and
    `integrations.providers` from status first. If the operator needs choices or
    repair commands, run:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   skips Git-generated merge/revert/fixup/squash/amend subjects, records the
   active `mb` executable for minimal-PATH Git clients, and includes checkpoint
   hook status, install, and uninstall controls on `mb checkpoint`. Refs #302.
+- `mb status` and `mb start` now expose a provisional git `journal` timeline
+  that groups business-readable commits by operator loop, preserves legacy
+  `[checkpoint]` history, and parses `Refs:` links to bets, pushes, decisions,
+  legacy campaigns, and GitHub issues. Refs #303.
 
 ### Changed
 
@@ -39,6 +43,9 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   business checkpoint hook wiring, and shipped skills use approved
   `mb checkpoint` planning/validation/save calls instead of raw git commit
   instructions. Refs #302.
+- `/mb-start` and `/mb-status` now treat status journal facts as the source of
+  truth for "what happened since last time?" instead of re-probing raw git logs.
+  Refs #303.
 
 ## [0.3.5] - 2026-05-06
 

--- a/mb/mb/journal.py
+++ b/mb/mb/journal.py
@@ -13,7 +13,7 @@ FIELD_SEP = "\x1f"
 JOURNAL_SCHEMA_VERSION = "0.current"
 DEFAULT_LIMIT = 12
 VALID_LOOPS = {"sense", "decide", "ship", "reflect"}
-SECTION_RE = re.compile(r"^[A-Z][A-Za-z /_-]*:\s*$")
+SECTION_RE = re.compile(r"^\S[^:]*:\s*$")
 GITHUB_ISSUE_RE = re.compile(r"(?:https?://github\.com/([^/\s]+)/([^/\s]+)/issues/(\d+)|#(\d+))")
 
 
@@ -167,7 +167,7 @@ def parse_refs(body: str) -> list[dict[str, Any]]:
         else:
             path = ref
 
-        key_value = url or path or f"#{number}" if number else ref
+        key_value = (url or path or f"#{number}") if number else ref
         key = (kind, str(key_value))
         if key in seen:
             continue

--- a/mb/mb/journal.py
+++ b/mb/mb/journal.py
@@ -1,0 +1,435 @@
+"""Business-readable git journal facts for status and handoff surfaces."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from mb import checkpoint_verbs
+
+FIELD_SEP = "\x1f"
+JOURNAL_SCHEMA_VERSION = "0.current"
+DEFAULT_LIMIT = 12
+VALID_LOOPS = {"sense", "decide", "ship", "reflect"}
+SECTION_RE = re.compile(r"^[A-Z][A-Za-z /_-]*:\s*$")
+GITHUB_ISSUE_RE = re.compile(r"(?:https?://github\.com/([^/\s]+)/([^/\s]+)/issues/(\d+)|#(\d+))")
+
+
+def _run_git(repo: Path, args: list[str], timeout: float = 4.0) -> subprocess.CompletedProcess[str]:
+    try:
+        return subprocess.run(
+            ["git", *args],
+            cwd=str(repo),
+            text=True,
+            capture_output=True,
+            timeout=timeout,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        return subprocess.CompletedProcess(["git", *args], 127, "", str(exc))
+    except subprocess.TimeoutExpired:
+        return subprocess.CompletedProcess(["git", *args], 124, "", "timed out")
+    except subprocess.SubprocessError as exc:
+        return subprocess.CompletedProcess(["git", *args], 1, "", str(exc))
+
+
+def _git_root(repo: Path) -> tuple[Path | None, str]:
+    result = _run_git(repo, ["rev-parse", "--show-toplevel"])
+    if result.returncode != 0:
+        return None, (result.stderr or result.stdout).strip() or "not a git repo"
+    return Path(result.stdout.strip()).resolve(), ""
+
+
+def _commit_shas(
+    repo: Path,
+    *,
+    limit: int,
+    since: str | None = None,
+    rev_range: str | None = None,
+) -> tuple[list[str], str]:
+    args = ["log", f"--max-count={limit}", "--format=%H"]
+    if rev_range:
+        args.append(rev_range)
+    elif since:
+        args.append(f"--since={since}")
+    result = _run_git(repo, args)
+    if result.returncode != 0:
+        return [], (result.stderr or result.stdout).strip()
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()], ""
+
+
+def _commit_metadata(repo: Path, sha: str) -> dict[str, Any] | None:
+    result = _run_git(
+        repo,
+        [
+            "show",
+            "-s",
+            "--date=short",
+            f"--format=%H{FIELD_SEP}%h{FIELD_SEP}%aI{FIELD_SEP}%ad{FIELD_SEP}%s{FIELD_SEP}%b",
+            sha,
+        ],
+    )
+    if result.returncode != 0:
+        return None
+    parts = result.stdout.rstrip("\n").split(FIELD_SEP, 5)
+    if len(parts) != 6:
+        return None
+    full_sha, short_sha, authored_at, date, subject, body = parts
+    return {
+        "sha": full_sha,
+        "commit": short_sha,
+        "authored_at": authored_at,
+        "date": date,
+        "subject": subject,
+        "body": body,
+    }
+
+
+def _commit_files(repo: Path, sha: str) -> list[str]:
+    result = _run_git(repo, ["show", "--name-only", "--format=", "--no-renames", sha])
+    if result.returncode != 0:
+        return []
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def _strip_ref_marker(line: str) -> str:
+    stripped = line.strip()
+    if stripped.startswith("- "):
+        return stripped[2:].strip()
+    return stripped
+
+
+def _raw_refs_from_body(body: str) -> list[str]:
+    refs: list[str] = []
+    collecting = False
+    for raw_line in body.splitlines():
+        line = raw_line.strip()
+        if not line:
+            if collecting and refs:
+                break
+            continue
+        if line.lower().startswith("refs:"):
+            collecting = True
+            inline = line[5:].strip()
+            if inline:
+                refs.extend(part.strip() for part in re.split(r"[, ]+", inline) if part.strip())
+            continue
+        if collecting and SECTION_RE.match(line):
+            break
+        if collecting:
+            refs.append(_strip_ref_marker(line))
+    return [ref for ref in refs if ref]
+
+
+def parse_refs(body: str) -> list[dict[str, Any]]:
+    """Parse business refs from the commit body ``Refs:`` section."""
+    items: list[dict[str, Any]] = []
+    seen: set[tuple[str, str]] = set()
+    for raw_ref in _raw_refs_from_body(body):
+        ref = raw_ref.strip().strip("<>")
+        kind = "link"
+        slug = ""
+        number: int | None = None
+        legacy = False
+        path = ""
+        url = ""
+        github_match = GITHUB_ISSUE_RE.search(ref)
+        if github_match:
+            kind = "github_issue"
+            number_text = github_match.group(3) or github_match.group(4) or "0"
+            number = int(number_text)
+            if github_match.group(1) and github_match.group(2):
+                url = (
+                    f"https://github.com/{github_match.group(1)}/"
+                    f"{github_match.group(2)}/issues/{number}"
+                )
+        elif re.match(r"^bets/[^/]+\.md$", ref):
+            kind = "bet"
+            path = ref
+            slug = Path(ref).stem
+        elif re.match(r"^decisions/[^/]+\.md$", ref):
+            kind = "decision"
+            path = ref
+            slug = Path(ref).stem
+        elif re.match(r"^pushes/[^/]+/push\.md$", ref):
+            kind = "push"
+            path = ref
+            slug = Path(ref).parent.name
+        elif re.match(r"^campaigns/[^/]+/campaign\.md$", ref):
+            kind = "legacy_campaign"
+            path = ref
+            slug = Path(ref).parent.name
+            legacy = True
+        elif re.match(r"^https?://", ref):
+            url = ref
+        else:
+            path = ref
+
+        key_value = url or path or f"#{number}" if number else ref
+        key = (kind, str(key_value))
+        if key in seen:
+            continue
+        seen.add(key)
+        items.append(
+            {
+                "kind": kind,
+                "value": ref,
+                "path": path,
+                "slug": slug,
+                "url": url,
+                "number": number,
+                "legacy": legacy,
+            }
+        )
+    return items
+
+
+def _path_loop(path: str) -> str | None:
+    if path.startswith(("core/", "reference/core/", "research/", "documents/")):
+        return "sense"
+    if path.startswith("decisions/"):
+        return "decide"
+    if path.startswith(("pushes/", "campaigns/")):
+        return "ship"
+    if path.startswith(("bets/", "log/")):
+        return "reflect"
+    return None
+
+
+def _path_channel(path: str) -> str | None:
+    if path.startswith("pushes/") or path.startswith("campaigns/"):
+        return "pages" if "/site" in path or "lander" in path else None
+    if path.startswith(("core/operations/", "reference/core/operations/", ".mb/")):
+        return "ops"
+    return None
+
+
+def _best_loop(parsed: dict[str, Any], files: list[str], refs: list[dict[str, Any]]) -> str | None:
+    verb = str(parsed.get("verb") or "")
+    if verb in {"decided", "opened"}:
+        return "decide"
+    if verb == "closed":
+        return "reflect"
+    if verb in {"drafted", "shipped", "connected", "ran", "fixed"}:
+        return "ship"
+    for ref in refs:
+        kind = ref.get("kind")
+        if kind in {"bet", "legacy_campaign"} and verb == "closed":
+            return "reflect"
+        if kind == "bet" and verb == "opened":
+            return "decide"
+        if kind in {"push", "legacy_campaign"}:
+            return "ship"
+        if kind == "decision":
+            return "decide"
+    for file in files:
+        loop = _path_loop(file)
+        if loop:
+            return loop
+    loop = parsed.get("loop")
+    return str(loop) if loop in VALID_LOOPS else None
+
+
+def _best_channel(
+    parsed: dict[str, Any],
+    files: list[str],
+    refs: list[dict[str, Any]],
+) -> str | None:
+    hint = parsed.get("channel_hint")
+    if hint and hint != "path-derived":
+        return str(hint)
+    for file in files:
+        channel = _path_channel(file)
+        if channel:
+            return channel
+    if any(ref.get("kind") == "push" for ref in refs):
+        return "pages"
+    return None
+
+
+def _target_kind(parsed: dict[str, Any], files: list[str], refs: list[dict[str, Any]]) -> str:
+    for ref in refs:
+        kind = str(ref.get("kind") or "")
+        if kind in {"bet", "push", "decision", "legacy_campaign", "github_issue"}:
+            return kind
+    first_file = files[0] if files else ""
+    if first_file.startswith("bets/"):
+        return "bet"
+    if first_file.startswith("pushes/"):
+        return "push"
+    if first_file.startswith("campaigns/"):
+        return "legacy_campaign"
+    if first_file.startswith("decisions/"):
+        return "decision"
+    if first_file.startswith(("core/", "reference/core/")):
+        return "core"
+    if first_file.startswith("research/"):
+        return "research"
+    return str(parsed.get("object") or "work")
+
+
+def _event_summary(parsed: dict[str, Any], subject: str, recognized_as: str) -> str:
+    if recognized_as == "legacy_checkpoint":
+        remainder = subject.removeprefix("[checkpoint]").strip()
+        return f"Saved checkpoint: {remainder or subject}"
+    verb = str(parsed.get("verb") or "").strip()
+    obj = str(parsed.get("object") or "").strip()
+    result = str(parsed.get("result") or "").strip()
+    if not verb or not obj:
+        return subject
+    words = f"{verb.capitalize()} {obj}"
+    if result:
+        words += f": {result}"
+    return words
+
+
+def event_from_commit(commit: dict[str, Any], files: list[str]) -> dict[str, Any]:
+    """Turn one git commit into a business journal event."""
+    subject = str(commit.get("subject") or "")
+    parsed = checkpoint_verbs.parse_subject(subject)
+    legacy_checkpoint = subject.startswith("[checkpoint]")
+    refs = parse_refs(str(commit.get("body") or ""))
+    recognized_as = (
+        "legacy_checkpoint"
+        if legacy_checkpoint
+        else "business_verb"
+        if parsed.get("recognized")
+        else "unrecognized"
+    )
+    loop = _best_loop(parsed, files, refs)
+    channel = _best_channel(parsed, files, refs)
+    return {
+        "id": str(commit.get("sha") or ""),
+        "sha": str(commit.get("sha") or ""),
+        "commit": str(commit.get("commit") or ""),
+        "date": str(commit.get("date") or ""),
+        "authored_at": str(commit.get("authored_at") or ""),
+        "subject": subject,
+        "summary": _event_summary(parsed, subject, recognized_as),
+        "recognized_as": recognized_as,
+        "verb": parsed.get("verb"),
+        "object": parsed.get("object") or "",
+        "result": parsed.get("result") or "",
+        "loop": loop,
+        "loops": parsed.get("loops") or ([] if loop is None else [loop]),
+        "channel": channel,
+        "channel_hint": parsed.get("channel_hint"),
+        "target_kind": _target_kind(parsed, files, refs),
+        "refs": refs,
+        "files": files[:12],
+        "file_count": len(files),
+        "safe_to_share": True,
+    }
+
+
+def _group_label(loop: str | None) -> str:
+    return {
+        "sense": "Sensed business context",
+        "decide": "Made decisions",
+        "ship": "Shipped work",
+        "reflect": "Captured lessons",
+    }.get(loop or "", "Other activity")
+
+
+def group_events(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Group journal events into loop-oriented activity buckets."""
+    order = ["sense", "decide", "ship", "reflect", None]
+    groups: list[dict[str, Any]] = []
+    for loop in order:
+        matching = [event for event in events if event.get("loop") == loop]
+        if not matching:
+            continue
+        refs = [ref for event in matching for ref in event.get("refs", []) if isinstance(ref, dict)]
+        groups.append(
+            {
+                "loop": loop,
+                "label": _group_label(loop),
+                "count": len(matching),
+                "summaries": [
+                    str(event.get("summary") or event.get("subject")) for event in matching[:5]
+                ],
+                "events": [str(event.get("id") or "") for event in matching],
+                "refs": refs[:12],
+                "safe_to_share": True,
+            }
+        )
+    return groups
+
+
+def _summary(events: list[dict[str, Any]], groups: list[dict[str, Any]]) -> dict[str, Any]:
+    refs = [ref for event in events for ref in event.get("refs", []) if isinstance(ref, dict)]
+    recognized = [event for event in events if event.get("recognized_as") == "business_verb"]
+    legacy = [event for event in events if event.get("recognized_as") == "legacy_checkpoint"]
+    unrecognized = [event for event in events if event.get("recognized_as") == "unrecognized"]
+    return {
+        "events": len(events),
+        "groups": len(groups),
+        "recognized_events": len(recognized),
+        "legacy_checkpoints": len(legacy),
+        "unrecognized_events": len(unrecognized),
+        "refs": len(refs),
+    }
+
+
+def collect(
+    repo: str | Path = ".",
+    *,
+    limit: int = DEFAULT_LIMIT,
+    since: str | None = "14 days ago",
+    rev_range: str | None = None,
+) -> dict[str, Any]:
+    """Collect recent business-readable git journal events."""
+    target = Path(repo).resolve()
+    root, root_error = _git_root(target)
+    if root is None:
+        return {
+            "available": False,
+            "ok": False,
+            "repo": str(target),
+            "schema_version": JOURNAL_SCHEMA_VERSION,
+            "events": [],
+            "groups": [],
+            "summary": {
+                "events": 0,
+                "groups": 0,
+                "recognized_events": 0,
+                "legacy_checkpoints": 0,
+                "unrecognized_events": 0,
+                "refs": 0,
+            },
+            "error": root_error,
+            "safe_to_share": True,
+        }
+    shas, log_error = _commit_shas(root, limit=limit, since=since, rev_range=rev_range)
+    if log_error:
+        return {
+            "available": False,
+            "ok": False,
+            "repo": str(root),
+            "schema_version": JOURNAL_SCHEMA_VERSION,
+            "events": [],
+            "groups": [],
+            "summary": _summary([], []),
+            "error": log_error,
+            "safe_to_share": True,
+        }
+    events: list[dict[str, Any]] = []
+    for sha in shas:
+        metadata = _commit_metadata(root, sha)
+        if metadata is None:
+            continue
+        events.append(event_from_commit(metadata, _commit_files(root, sha)))
+    groups = group_events(events)
+    return {
+        "available": True,
+        "ok": True,
+        "repo": str(root),
+        "schema_version": JOURNAL_SCHEMA_VERSION,
+        "events": events,
+        "groups": groups,
+        "summary": _summary(events, groups),
+        "error": "",
+        "safe_to_share": True,
+    }

--- a/mb/mb/start.py
+++ b/mb/mb/start.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any
 
 from mb import checkpoint as checkpoint_mod
+from mb import journal as journal_mod
 from mb.engine import install_mode, link_status
 from mb.freshness import format_update_alert, package_update_status
 from mb.status import _looks_like_mainbranch_repo, push_facts
@@ -235,6 +236,7 @@ def run(repo: str = ".", launch: bool = False) -> dict[str, Any]:
     wiring = link_status(repo_path)
     update = package_update_status(repo_path)
     checkpoint = checkpoint_mod.status(repo_path)
+    journal = journal_mod.collect(repo_path, limit=8, since="14 days ago")
     push_report = push_facts(repo_path)
     checks = _build_checks(repo_shape, git, claude_path, wiring, update)
     hard_failures = _hard_failures(checks)
@@ -267,6 +269,7 @@ def run(repo: str = ".", launch: bool = False) -> dict[str, Any]:
         "repo": {"path": str(repo_path), **repo_shape},
         "update": update,
         "checkpoint": checkpoint,
+        "journal": journal,
         "pushes": push_report["records"],
         "active_pushes": push_report["active"],
         "push_count": push_report["count"],
@@ -308,6 +311,7 @@ def render_human(report: dict[str, Any]) -> None:
     command = report["command"]
     launch = report["launch"]
     checkpoint = report.get("checkpoint", {})
+    journal = report.get("journal", {})
 
     console.print(f"\n[bold]mb start[/bold]  {repo['path']}\n")
     alert = format_update_alert(report.get("update", {}))
@@ -340,6 +344,12 @@ def render_human(report: dict[str, Any]) -> None:
         pending_status = pending.get("status") if isinstance(pending, dict) else "unknown"
         recent_label = recent[0]["subject"] if isinstance(recent, list) and recent else "none yet"
         console.print(f"[bold]Checkpoint[/bold]  pending={pending_status}  last={recent_label}")
+    if isinstance(journal, dict) and journal.get("events"):
+        latest = journal["events"][0]
+        console.print(
+            f"[bold]Journal[/bold]  {journal.get('summary', {}).get('events', 0)} event(s)  "
+            f"last={latest.get('summary')}"
+        )
 
     console.print("\n[bold]Command[/bold]")
     console.print(f"  {command['display']}")

--- a/mb/mb/status.py
+++ b/mb/mb/status.py
@@ -14,6 +14,7 @@ import yaml
 
 from mb import __version__, github_activity
 from mb import connect as connect_mod
+from mb import journal as journal_mod
 from mb import onboard as onboard_mod
 from mb import pushes as pushes_mod
 from mb import ranker as ranker_mod
@@ -249,6 +250,48 @@ def _git_since_last_seen(
         "changed_files": changed_files[:20],
         "error": "",
     }
+
+
+def _empty_journal(repo: Path, *, available: bool) -> dict[str, Any]:
+    return {
+        "available": available,
+        "ok": True,
+        "repo": str(repo),
+        "schema_version": journal_mod.JOURNAL_SCHEMA_VERSION,
+        "events": [],
+        "groups": [],
+        "summary": {
+            "events": 0,
+            "groups": 0,
+            "recognized_events": 0,
+            "legacy_checkpoints": 0,
+            "unrecognized_events": 0,
+            "refs": 0,
+        },
+        "error": "",
+        "safe_to_share": True,
+    }
+
+
+def _journal_since_last_seen(
+    repo: Path,
+    git: dict[str, Any],
+    marker: dict[str, Any],
+) -> dict[str, Any]:
+    if not git.get("inside_work_tree"):
+        return _empty_journal(repo, available=False)
+
+    marker_git_raw = marker.get("git")
+    marker_git: dict[str, Any] = marker_git_raw if isinstance(marker_git_raw, dict) else {}
+    previous_commit = str(marker_git.get("commit") or "")
+    current_commit = str(git.get("commit") or "")
+    if previous_commit and current_commit and previous_commit != current_commit:
+        return journal_mod.collect(repo, limit=20, since=None, rev_range=f"{previous_commit}..HEAD")
+
+    previous_seen_at = _parse_timestamp(marker.get("seen_at"))
+    if previous_seen_at is None:
+        return _empty_journal(repo, available=True)
+    return journal_mod.collect(repo, limit=20, since=previous_seen_at.isoformat(), rev_range=None)
 
 
 def _read_frontmatter(path: Path) -> dict[str, Any]:
@@ -782,15 +825,23 @@ def _since_last_check(
             "error": "",
         }
     )
+    journal_since: dict[str, Any] = (
+        _journal_since_last_seen(repo, git, marker)
+        if marker_exists
+        else _empty_journal(repo, available=bool(git.get("inside_work_tree")))
+    )
     count_changes = _brain_count_changes(brain.get("counts") or {}, previous_counts)
     dirty_count = int(git.get("dirty_count") or 0)
     commits = git_since.get("commits") or []
     changed_files = git_since.get("changed_files") or []
+    journal_summary = journal_since.get("summary") or {}
     summary = {
         "commits": len(commits) if isinstance(commits, list) else 0,
         "files_changed": len(changed_files) if isinstance(changed_files, list) else 0,
         "dirty_files": dirty_count,
         "brain_count_changes": len(count_changes),
+        "journal_events": int(journal_summary.get("events") or 0),
+        "journal_groups": int(journal_summary.get("groups") or 0),
     }
     first_run = not marker_exists
     return {
@@ -802,6 +853,7 @@ def _since_last_check(
         "first_run": first_run,
         "summary": summary,
         "git": git_since,
+        "journal": journal_since,
         "brain_count_changes": count_changes,
         "error": str(marker.get("error") or ""),
         "safe_to_share": True,
@@ -1074,6 +1126,7 @@ def run(
         "runtime": _runtime(repo_path),
         "git": git,
         "git_activity": _git_recent_activity(repo_path, git),
+        "journal": journal_mod.collect(repo_path, limit=12, since="14 days ago"),
         "brain": brain,
         "pushes": push_report["records"],
         "active_pushes": push_report["active"],
@@ -1163,6 +1216,17 @@ def render_human(
         )
     if since.get("error"):
         console.print(f"  [yellow]degraded:[/yellow] {since['error']}")
+    since_journal = since.get("journal") or {}
+    since_groups = since_journal.get("groups") or []
+    if since_groups:
+        console.print("  journal:")
+        for group in since_groups[:3]:
+            console.print(f"  - {group.get('label', 'Activity')}: {group.get('count', 0)} event(s)")
+            if verbose:
+                for summary in (group.get("summaries") or [])[:3]:
+                    console.print(f"    - {summary}")
+    elif not since.get("first_run") and since_journal.get("available") is False:
+        console.print("  [yellow]journal unavailable[/yellow]")
 
     drift_summary = drift.get("summary") or {}
     if drift_summary.get("total", 0):
@@ -1277,6 +1341,16 @@ def render_human(
         if missing:
             console.print(f"  missing: {', '.join(missing[:5])}")
         console.print(f"  next: {onboarding_summary.get('next_recommended_action')}")
+
+    journal = report.get("journal") or {}
+    if verbose and journal.get("events"):
+        console.print("\n[bold]Business journal[/bold]")
+        for item in journal["events"][:5]:
+            refs = item.get("refs") or []
+            ref_label = f" refs {len(refs)}" if refs else ""
+            console.print(
+                f"  - {item.get('date')} {item.get('commit')}  {item.get('summary')}{ref_label}"
+            )
 
     if verbose and report["git_activity"]["items"]:
         console.print("\n[bold]Recent git activity[/bold]")

--- a/mb/tests/fixtures/status/schema-v1-basic.json
+++ b/mb/tests/fixtures/status/schema-v1-basic.json
@@ -16,6 +16,7 @@
     "github",
     "install",
     "integrations",
+    "journal",
     "marker_update",
     "measurement",
     "ok",
@@ -73,6 +74,17 @@
       "available",
       "error",
       "items"
+    ],
+    "journal": [
+      "available",
+      "error",
+      "events",
+      "groups",
+      "ok",
+      "repo",
+      "safe_to_share",
+      "schema_version",
+      "summary"
     ],
     "brain": [
       "bets",
@@ -133,6 +145,7 @@
       "error",
       "first_run",
       "git",
+      "journal",
       "marker_gitignore",
       "marker_path",
       "ok",

--- a/mb/tests/test_journal.py
+++ b/mb/tests/test_journal.py
@@ -1,0 +1,114 @@
+"""Business-readable git journal tests."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from mb import journal as journal_mod
+from mb.init import run as init_run
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def _business_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test User")
+    _git(repo, "add", ".")
+    result = _git(repo, "commit", "--no-verify", "-m", "[added] business scaffold")
+    assert result.returncode == 0, result.stderr
+    return repo
+
+
+def _commit(repo: Path, relative_path: str, content: str, subject: str, body: str = "") -> None:
+    target = repo / relative_path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(content, encoding="utf-8")
+    result = _git(repo, "add", relative_path)
+    assert result.returncode == 0, result.stderr
+    args = ["commit", "--no-verify", "-m", subject]
+    if body:
+        args.extend(["-m", body])
+    result = _git(repo, *args)
+    assert result.returncode == 0, result.stderr
+
+
+def test_parse_refs_supports_business_objects_and_github_issues() -> None:
+    refs = journal_mod.parse_refs(
+        "\n".join(
+            [
+                "Changed:",
+                "- pushes/workshop/push.md",
+                "",
+                "Refs:",
+                "- bets/2026-05-06-workshop.md",
+                "- pushes/workshop/push.md",
+                "- decisions/2026-05-05-price.md",
+                "- campaigns/legacy/campaign.md",
+                "- https://github.com/noontide-co/mainbranch/issues/303",
+            ]
+        )
+    )
+
+    assert [item["kind"] for item in refs] == [
+        "bet",
+        "push",
+        "decision",
+        "legacy_campaign",
+        "github_issue",
+    ]
+    assert refs[0]["slug"] == "2026-05-06-workshop"
+    assert refs[1]["slug"] == "workshop"
+    assert refs[3]["legacy"] is True
+    assert refs[4]["number"] == 303
+
+
+def test_collect_groups_business_commits_and_preserves_legacy_checkpoints(tmp_path: Path) -> None:
+    repo = _business_repo(tmp_path)
+    _commit(
+        repo,
+        "bets/2026-05-06-workshop.md",
+        "# Workshop bet\n",
+        "[opened] bet workshop -- target 40 signups",
+        "Refs:\n- bets/2026-05-06-workshop.md\n- #303",
+    )
+    _commit(
+        repo,
+        "pushes/workshop/push.md",
+        "# Workshop push\n",
+        "[shipped] workshop lander",
+        "Refs:\n- pushes/workshop/push.md\n- decisions/2026-05-05-price.md",
+    )
+    _commit(
+        repo,
+        "core/offer.md",
+        "# Offer\nUpdated\n",
+        "[checkpoint] Update offer",
+    )
+
+    report = journal_mod.collect(repo, limit=5, since=None)
+
+    assert report["ok"] is True
+    assert report["schema_version"] == "0.current"
+    assert report["summary"]["recognized_events"] >= 3
+    assert report["summary"]["legacy_checkpoints"] == 1
+    legacy = next(
+        event for event in report["events"] if event["recognized_as"] == "legacy_checkpoint"
+    )
+    assert legacy["summary"] == "Saved checkpoint: Update offer"
+    shipped = next(event for event in report["events"] if event["verb"] == "shipped")
+    assert shipped["loop"] == "ship"
+    assert shipped["target_kind"] == "push"
+    assert any(ref["kind"] == "push" for ref in shipped["refs"])
+    assert any(group["loop"] == "decide" for group in report["groups"])
+    assert any(group["loop"] == "ship" for group in report["groups"])

--- a/mb/tests/test_journal.py
+++ b/mb/tests/test_journal.py
@@ -73,6 +73,14 @@ def test_parse_refs_supports_business_objects_and_github_issues() -> None:
     assert refs[4]["number"] == 303
 
 
+def test_parse_refs_stops_at_lowercase_body_header() -> None:
+    refs = journal_mod.parse_refs("Refs:\n- pushes/workshop/push.md\nnotes:\n- not a ref\n")
+
+    assert len(refs) == 1
+    assert refs[0]["kind"] == "push"
+    assert refs[0]["path"] == "pushes/workshop/push.md"
+
+
 def test_collect_groups_business_commits_and_preserves_legacy_checkpoints(tmp_path: Path) -> None:
     repo = _business_repo(tmp_path)
     _commit(

--- a/mb/tests/test_start.py
+++ b/mb/tests/test_start.py
@@ -256,6 +256,8 @@ def test_start_surfaces_recent_checkpoint_history(tmp_path: Path, monkeypatch) -
     assert report["checkpoint"]["recent"][0]["subject"] == "[updated] offer.md"
     assert report["checkpoint"]["recent"][0]["verb"] == "updated"
     assert report["checkpoint"]["pending"]["status"] == "ready"
+    assert report["journal"]["events"][0]["summary"] == "Updated offer.md"
+    assert report["journal"]["events"][0]["loop"] == "sense"
 
 
 def test_start_asks_for_repo_when_path_is_not_business_repo(tmp_path: Path, monkeypatch) -> None:

--- a/mb/tests/test_status.py
+++ b/mb/tests/test_status.py
@@ -26,6 +26,33 @@ def _without_github_or_claude(name: str) -> str:
     return shutil.which(name) or ""
 
 
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def _configure_git_user(repo: Path) -> None:
+    assert _git(repo, "config", "user.email", "test@example.com").returncode == 0
+    assert _git(repo, "config", "user.name", "Test User").returncode == 0
+
+
+def _commit(repo: Path, relative_path: str, content: str, subject: str, body: str = "") -> None:
+    target = repo / relative_path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(content, encoding="utf-8")
+    assert _git(repo, "add", relative_path).returncode == 0
+    args = ["commit", "--no-verify", "-m", subject]
+    if body:
+        args.extend(["-m", body])
+    result = _git(repo, *args)
+    assert result.returncode == 0, result.stderr
+
+
 def test_status_json_degrades_without_github(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
     repo = tmp_path / "acme"
@@ -87,6 +114,7 @@ def test_status_schema_v1_matches_golden_fixture(tmp_path: Path, monkeypatch) ->
                 "runtime",
                 "git",
                 "git_activity",
+                "journal",
                 "brain",
                 "onboarding",
                 "integrations",
@@ -200,6 +228,59 @@ def test_status_since_last_check_uses_repo_marker(tmp_path: Path, monkeypatch) -
         "after": 1,
         "delta": 1,
     } in second_payload["since_last_check"]["brain_count_changes"]
+
+
+def test_status_since_last_check_includes_grouped_journal(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+    _configure_git_user(repo)
+    assert _git(repo, "add", ".").returncode == 0
+    result = _git(repo, "commit", "--no-verify", "-m", "[added] business scaffold")
+    assert result.returncode == 0, result.stderr
+
+    first = runner.invoke(app, ["status", str(repo), "--json"])
+    assert first.exit_code == 0
+
+    _commit(
+        repo,
+        "pushes/workshop/push.md",
+        "# Workshop\n",
+        "[shipped] workshop lander",
+        "Refs:\n- pushes/workshop/push.md\n- https://github.com/noontide-co/mainbranch/issues/303",
+    )
+    second = runner.invoke(app, ["status", str(repo), "--json", "--peek"])
+
+    assert second.exit_code == 0
+    payload = json.loads(second.stdout)
+    journal = payload["since_last_check"]["journal"]
+    assert payload["since_last_check"]["summary"]["journal_events"] == 1
+    assert journal["schema_version"] == "0.current"
+    assert journal["events"][0]["verb"] == "shipped"
+    assert journal["events"][0]["loop"] == "ship"
+    assert journal["events"][0]["refs"][0]["kind"] == "push"
+    assert journal["events"][0]["refs"][1]["kind"] == "github_issue"
+    assert journal["groups"][0]["label"] == "Shipped work"
+
+
+def test_status_human_output_summarizes_since_last_journal(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+    _configure_git_user(repo)
+    assert _git(repo, "add", ".").returncode == 0
+    result = _git(repo, "commit", "--no-verify", "-m", "[added] business scaffold")
+    assert result.returncode == 0, result.stderr
+    first = runner.invoke(app, ["status", str(repo), "--json"])
+    assert first.exit_code == 0
+    _commit(repo, "bets/workshop.md", "# Bet\n", "[opened] bet workshop")
+
+    human = runner.invoke(app, ["status", str(repo), "--verbose", "--no-color", "--peek"])
+
+    assert human.exit_code == 0
+    assert "journal:" in human.stdout
+    assert "Made decisions: 1 event(s)" in human.stdout
+    assert "Opened bet workshop" in human.stdout
 
 
 def test_status_peek_does_not_update_seen_marker(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- Adds a provisional `journal` timeline to `mb status` and `mb start` so the business git log becomes a readable product surface.
- Groups business-readable commits by operator loop, preserves legacy `[checkpoint]` commits, and parses `Refs:` trailers for bets, pushes, decisions, legacy campaigns, and GitHub issues.
- Updates `/mb-start` and `/mb-status` to answer continuity questions from status journal facts before falling back to raw git probes.

## Scope
- In: journal collection/parsing, status/start JSON wiring, human status summaries, skill prose updates, changelog, tests.
- Out: dashboard UI, model summarization, commit rewriting, hosted sync, new hook enforcement, broad JSON-envelope migration.

## Commits
- `46d9daf` — `[add] MAIN-240 business git journal status`.
- `0a29553` — `[fix] MAIN-240 clarify journal refs parsing`.

## Release / Issues
- Release: v0.3.x daily loop / business-readable history.
- Linear ID(s): MAIN-240.
- Closes: #303.
- Refs: #297 for future stable JSON envelope naming.
- Follow-ups: graduate `journal.schema_version: 0.current` through MAIN-236 if the envelope work lands later.

## Success Metric
- `mb status` can answer “what happened since last time?” from the business git journal, and the JSON output is usable by the next dashboard timeline spike.

## Validation
- Level 0 docs/decision: `CHANGELOG.md` updated; skill prose kept public-safe; `mb-start` remains at the 500-line gate.
- Level 1 static: `scripts/check.sh` passed; ruff format/check passed; mypy passed.
- Level 2 CLI: `pytest tests/test_journal.py tests/test_status.py tests/test_start.py -q` passed with 42 tests; full `scripts/check.sh` passed with 313 tests and 80.80% coverage.
- Level 3 package/install: N/A, no packaging or entrypoint install behavior changed.
- Level 4 fixture repo: `mb onboard`, `mb doctor`, `mb status --json --peek`, `mb start --json`, and `mb validate` passed on a fresh fixture business repo.
- Level 5 runtime smoke: Claude Code runtime smoke was not launched from this agent session; closest verified fallback is skill validation plus fixture `mb start --json` handoff readiness.

## Public / Private Boundary
- No private Devon, Conductor, customer/member, credential, or machine-specific details were added to public files; `.context/cold-start.md` stayed untracked scratch.
