### PR TITLE
[update] Prepare 0.3.6 release

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mainbranch",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Main Branch Claude Code skills for running a business from markdown files in git.",
   "author": {
     "name": "Noontide"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,32 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+## [0.3.6] - 2026-05-07
+
+v0.3.6 makes Main Branch more disciplined about how business work gets saved,
+remembered, and resumed. Checkpoint verbs are now business-readable, fresh
+business repos install commit-message validation, `mb status` includes a
+provisional git journal, and growth research guidance is broader without
+pretending untested provider automation is shipped.
+
+### What this means for you (plain English)
+
+- **Your commits read like business progress.** Main Branch now accepts
+  checkpoint subjects such as `[added] market.md` and blocks vague raw commit
+  messages in business repos.
+- **`mb status` can remember what happened.** Status and start output now
+  include recent business-readable commit history so Claude can answer "what
+  changed since last time?" from repo facts.
+- **Growth research has a stronger path.** `/mb-think` now has winning-ad
+  research guidance for customer language, competitor gaps, review mining,
+  script teardown, and social comment mining.
+- **Provider boundaries stay honest.** Postiz, X/Grok, Apify, and
+  comment-to-DM/resource-delivery ideas are framed as researched or candidate
+  rails until smoke evidence proves support.
+- **The public framing is cleaner.** README, roadmap, architecture, ethos, and
+  contributor docs now describe Main Branch as durable operating memory for a
+  business, not just a growth-file scaffold.
+
 ### Added
 
 - `mb checkpoint` now uses the accepted business-readable checkpoint verb
@@ -29,6 +55,10 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   that groups business-readable commits by operator loop, preserves legacy
   `[checkpoint]` history, and parses `Refs:` links to bets, pushes, decisions,
   legacy campaigns, and GitHub issues. Refs #303.
+- README, roadmap, architecture, ethos, dependency choices, support, security,
+  and contributor docs now frame Main Branch around durable operating memory,
+  current Claude Code support, optional rails, and lower-maintenance roadmap
+  buckets instead of issue-by-issue release lists. Refs #340, #346.
 
 ### Changed
 
@@ -46,6 +76,9 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 - `/mb-start` and `/mb-status` now treat status journal facts as the source of
   truth for "what happened since last time?" instead of re-probing raw git logs.
   Refs #303.
+- Legacy campaign paths are now described as compatibility aliases while the
+  current working-folder model keeps `pushes/` as the active growth work home.
+  Refs #345.
 
 ## [0.3.5] - 2026-05-06
 

--- a/mb/mb/__init__.py
+++ b/mb/mb/__init__.py
@@ -7,6 +7,6 @@ file stays a thin dispatcher.
 
 from __future__ import annotations
 
-__version__ = "0.3.5"
+__version__ = "0.3.6"
 
 __all__ = ["__version__"]

--- a/mb/pyproject.toml
+++ b/mb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mainbranch"
-version = "0.3.5"
+version = "0.3.6"
 description = "Main Branch engine umbrella - scaffolds, validates, and graphs business-as-files repos. Claude Code first, runtime-agnostic by design."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Prepare the `0.3.6` patch release for the checkpoint, status journal, growth research, and public positioning work merged after `0.3.5`.

## Scope

In scope:

- bump package and plugin metadata from `0.3.5` to `0.3.6`;
- add the `0.3.6` CHANGELOG section with plain-English release notes;
- cover checkpoint verbs, checkpoint hook workflows, `mb status` git journal, growth research guidance, Postiz/playbook boundaries, roadmap framing, and legacy campaign compatibility.

Out of scope:

- changing runtime behavior;
- fixing the known setuptools license metadata warnings tracked in #135;
- running Claude Code runtime smoke for MAIN-259.

## Commits

- `f3c4cfc [update] Prepare 0.3.6 release`

## Release

Target tag: `oe-v0.3.6`

## Issues

Refs #301, #302, #303, #340, #341, #345, #346.

## Validation

- `scripts/check.sh` passed: 313 tests, lint/type checks, coverage gate, and bundled skill validation.
- Package build passed: `mainbranch-0.3.6.tar.gz` and `mainbranch-0.3.6-py3-none-any.whl`.
- Fresh venv wheel smoke passed:
  - `mb --version` -> `mb 0.3.6`
  - `mb skill list` listed bundled skills
  - `mb onboard --yes --name "Smoke Business" --path /tmp/mainbranch-smoke-business-036 --json`
  - `mb start --repo /tmp/mainbranch-smoke-business-036 --json`

## Public/Private Boundary

No private data, credentials, customer data, or local-only workflow details were added to public release files.

## Notes

Build still emits the known setuptools license metadata deprecation warnings. That is tracked separately in #135 and does not block this release because the wheel and sdist build/install successfully.
