### PR TITLE
[docs] Prove Claude slash-command contract

### DIFF
--- a/.claude/skills/mb-start/SKILL.md
+++ b/.claude/skills/mb-start/SKILL.md
@@ -8,7 +8,7 @@ loops: [sense, decide]
 
 Single entry point for Main Branch. Detect user state, context level, experience — route to the right skill.
 
-**Recommended workflow:** Start Claude in your business repo, run `/mb-start`. It handles everything. Main Branch is loaded through `additionalDirectories`, with bridge links as a compatibility fallback for skill discovery.
+**Recommended workflow:** Start Claude in your business repo, run `/mb-start`. It handles everything. Claude Code discovers Main Branch through project-local `.claude/skills/mb-*` bridge links; `additionalDirectories` grants file access to the engine.
 
 ## Output destinations and operator vocabulary
 

--- a/.claude/skills/mb-start/references/auto-heal.md
+++ b/.claude/skills/mb-start/references/auto-heal.md
@@ -8,8 +8,8 @@ When a user launches Claude in their business repo and skills aren't showing, th
 
 This runs in two places:
 
-1. **Bootstrap path:** business repo `CLAUDE.md` points here when `/mb-start` is missing.
-2. **Main `/mb-start` path:** when `/mb-start` is invoked from vip, it resolves a selected business repo and runs this repair against that repo.
+1. **Bootstrap path:** a user or support agent can read this when `/mb-start` is missing.
+2. **Main `/mb-start` path:** when `/mb-start` is invoked from Main Branch, it resolves a selected business repo and runs this repair against that repo.
 
 ---
 
@@ -146,7 +146,7 @@ If HEAL_FAILED:
 
 ## Why this is needed
 
-`additionalDirectories` in `settings.local.json` grants file access to Main Branch but doesn't reliably trigger skill discovery in Claude Code v2.1.39. Bridge links (symlinks from `.claude/skills/[name]` to Main Branch skill directories) make Claude discover skills as if they're local. This is a compatibility layer — if Anthropic fixes discovery from additional directories, these links become redundant but harmless.
+`additionalDirectories` in `settings.local.json` grants file access to Main Branch but does not reliably trigger slash-command discovery in Claude Code. Runtime smoke on Claude Code 2.1.126 returned `Unknown command: /mb-start` after the project-local `.claude/skills/mb-start` bridge was removed while `additionalDirectories` still pointed at the engine. Bridge links (symlinks from `.claude/skills/[name]` to Main Branch skill directories) make Claude discover skills as if they're local.
 
 ---
 

--- a/.claude/skills/mb-start/references/config-system.md
+++ b/.claude/skills/mb-start/references/config-system.md
@@ -8,7 +8,7 @@ Four-file system: Main Branch engine linkage, personal settings, team settings, 
 
 | File | Location | Purpose | Git-tracked? |
 |------|----------|---------|--------------|
-| `settings.local.json` | `[repo]/.claude/` | Links the active Main Branch engine as additionalDirectory | No (auto git-ignored by Claude Code) |
+| `settings.local.json` | `[repo]/.claude/` | Grants Claude Code file access to the active Main Branch engine | No (auto git-ignored by Claude Code) |
 | `local.yaml` | `~/.config/vip/` | Legacy machine-local file for user identity, engine path, and default repo | No |
 | `env.sh` | `~/.config/vip/` | API keys for optional research tools | No |
 | `config.yaml` | `[repo]/.vip/` | Team/business settings, MCP requirements | Yes |
@@ -33,9 +33,13 @@ Created by `mb skill link` and `/mb-setup`. Tells Claude Code to load Main Branc
 
 **Auto git-ignored** by Claude Code (like `.claude/settings.local.json` is always local). Contains machine-specific absolute paths — never commit this.
 
-### .claude/ bridge links (compatibility fallback)
+### .claude/ bridge links (slash-command discovery)
 
-`additionalDirectories` is the canonical config for loading Main Branch. In some environments/versions, skill discovery can still be inconsistent. Compatibility links in local `.claude/` provide a fallback without changing user workflow.
+`additionalDirectories` grants file access to Main Branch, but project-local
+`.claude/skills/mb-*` bridge links are the supported slash-command discovery
+surface. Runtime smoke on Claude Code 2.1.126 returned `Unknown command:
+/mb-start` when the project-local `.claude/skills/mb-start` bridge was missing,
+even though `settings.local.json` still pointed at the engine.
 
 ```
 business-repo/.claude/
@@ -48,11 +52,11 @@ business-repo/.claude/
 └── reference/                # real local folder; missing Main Branch entries linked
 ```
 
-Created by `mb skill link` and `/mb-setup` as a compatibility layer. `/mb-start` can auto-repair missing links.
+Created by `mb skill link` and `/mb-setup`. `/mb-start` can auto-repair missing links.
 
 **Both are needed:**
 - `additionalDirectories` = file access (reading reference files across repos)
-- Bridge links = compatibility fallback for skill discovery in affected environments
+- Bridge links = slash-command discovery for Main Branch skills
 
 ---
 

--- a/.claude/skills/mb-start/references/repo-detection.md
+++ b/.claude/skills/mb-start/references/repo-detection.md
@@ -127,7 +127,7 @@ user:
 
 ---
 
-## Verify Main Branch Is Loaded (Config + Compatibility Links)
+## Verify Main Branch Is Loaded (Config + Skill Bridge Links)
 
 After detecting the business repo, confirm Main Branch is accessible and `/mb-start` bridge exists in the selected repo (`REPO_PATH`):
 
@@ -156,4 +156,4 @@ Tell the user: "Repaired missing Main Branch bridge links in **[repo-name]**. Lo
 
 **Why both are needed:**
 - `additionalDirectories` = file access (read reference files, compliance docs)
-- Bridge links = compatibility fallback for skill discovery in environments where settings-based discovery is inconsistent
+- Bridge links = slash-command discovery for Main Branch skills

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ### Added
 
+- Documented the proven Claude Code invocation contract for `/mb-start`,
+  including extra-text behavior, natural-language routing, the required
+  project-local `.claude/skills/mb-*` bridge links, and the repair path when
+  Claude Code reports `Unknown command: /mb-start`. Refs #354.
 - `mb checkpoint` now uses the accepted business-readable checkpoint verb
   contract, proposes subjects such as `[added] market.md`, validates checkpoint
   messages with `--validate` or stdin, and exposes parsed verb/loop/channel

--- a/README.md
+++ b/README.md
@@ -259,6 +259,11 @@ environment variables.
 ## Skills
 
 Skills are pre-built workflows you invoke with slash prompts. Instead of figuring out how to prompt Claude, you type `/mb-ads` and Claude knows exactly what to do — reads your business files, then generates output that matches your voice.
+The supported Claude Code contract is project-local skill discovery through the
+business repo's `.claude/skills/mb-*` bridge links. Plain `/mb-start` is the
+daily entrypoint; extra text after it is treated as normal instruction, not a
+stable `$ARGUMENTS` command API. See
+[docs/claude-code-invocation-contract.md](docs/claude-code-invocation-contract.md).
 
 Some skills ship growth work. Others maintain operating memory. `/mb-start`,
 `/mb-status`, `/mb-think`, `/mb-bet`, `/mb-end`, `mb checkpoint`, `mb graph`,
@@ -412,7 +417,7 @@ For platform support and security reporting, see [SUPPORT.md](SUPPORT.md), [SECU
 
 - "404 error" or "Repository not found" — verify the URL and your network. The repo is public; no access request needed.
 - "Claude doesn't see my files" — make sure you started Claude in your business repo folder and ran `/mb-start`.
-- "Skills aren't working" — run `mb skill link --repo .` from your business repo to repair bridge symlinks, then restart Claude. If still broken, run `/mb-setup`.
+- "Skills aren't working" — run `mb skill repair --repo .`, then `mb skill link --repo .` from your business repo to repair bridge symlinks, then restart Claude. If still broken, run `/mb-setup`.
 - "Output sounds generic" — add more detail to your core files, especially `core/voice.md`.
 - "I edited Main Branch but can't push" — that's expected for most users. Main Branch is the shared engine. Your business data goes in YOUR repo.
 

--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ environment variables.
 ## Skills
 
 Skills are pre-built workflows you invoke with slash prompts. Instead of figuring out how to prompt Claude, you type `/mb-ads` and Claude knows exactly what to do — reads your business files, then generates output that matches your voice.
+
 The supported Claude Code contract is project-local skill discovery through the
 business repo's `.claude/skills/mb-*` bridge links. Plain `/mb-start` is the
 daily entrypoint; extra text after it is treated as normal instruction, not a
@@ -417,7 +418,7 @@ For platform support and security reporting, see [SUPPORT.md](SUPPORT.md), [SECU
 
 - "404 error" or "Repository not found" — verify the URL and your network. The repo is public; no access request needed.
 - "Claude doesn't see my files" — make sure you started Claude in your business repo folder and ran `/mb-start`.
-- "Skills aren't working" — run `mb skill repair --repo .`, then `mb skill link --repo .` from your business repo to repair bridge symlinks, then restart Claude. If still broken, run `/mb-setup`.
+- "Skills aren't working" — run `mb skill link --repo .` from your business repo to repair bridge symlinks and known stale Main Branch shadows, then restart Claude. If still broken, run `mb skill repair --repo .` to inspect unresolved personal-skill conflicts or run `/mb-setup`.
 - "Output sounds generic" — add more detail to your core files, especially `core/voice.md`.
 - "I edited Main Branch but can't push" — that's expected for most users. Main Branch is the shared engine. Your business data goes in YOUR repo.
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -13,7 +13,6 @@ mb doctor
 If Claude Code does not see `/mb-start`, run this from your business repo:
 
 ```bash
-mb skill repair --repo .
 mb skill link --repo .
 ```
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -13,6 +13,7 @@ mb doctor
 If Claude Code does not see `/mb-start`, run this from your business repo:
 
 ```bash
+mb skill repair --repo .
 mb skill link --repo .
 ```
 
@@ -24,6 +25,8 @@ Then restart Claude Code and run:
 
 For step-by-step setup, read [docs/BEGINNER-SETUP.md](docs/BEGINNER-SETUP.md).
 For platform support, read [docs/compatibility.md](docs/compatibility.md).
+For the supported Claude Code slash-command behavior, read
+[docs/claude-code-invocation-contract.md](docs/claude-code-invocation-contract.md).
 
 ## Where to ask
 

--- a/docs/BEGINNER-SETUP.md
+++ b/docs/BEGINNER-SETUP.md
@@ -103,6 +103,7 @@ Then in Claude Code:
 ```
 
 `/mb-start` walks you through the rest. It reads the same status facts as `mb status`, checks for updates or repair needs, and routes you to setup, thinking, shipping, or closing work.
+
 Plain `/mb-start` is the reliable beginner path. Extra text after `/mb-start`
 is treated as normal instruction, not as a project-command argument API.
 Natural-language requests can route into the skill, but setup docs teach the
@@ -271,14 +272,23 @@ For the full list: `mb --help`.
 
 ```bash
 mb skill link --repo .
-mb skill repair --repo .
 ```
 
 Then restart Claude. This re-wires skill discovery in your business repo and
-checks whether an old personal skill is taking precedence.
+clears known stale Main Branch personal-skill shadows.
+
 The project-local `.claude/skills/mb-start` bridge link is required for
 reliable slash-command discovery; `.claude/settings.local.json` alone is not
 enough.
+
+If `/mb-start` is still missing after relinking and restarting, run:
+
+```bash
+mb skill repair --repo .
+```
+
+That inspect-only command reports unresolved personal-skill conflicts so you can
+decide whether to move them with `mb skill repair --repo . --apply`.
 
 **I only see `.mb/`, not `.mb-vip/`:** good. `.mb/` is the current folder.
 `.mb-vip/` was old setup language and is not required.

--- a/docs/BEGINNER-SETUP.md
+++ b/docs/BEGINNER-SETUP.md
@@ -103,6 +103,12 @@ Then in Claude Code:
 ```
 
 `/mb-start` walks you through the rest. It reads the same status facts as `mb status`, checks for updates or repair needs, and routes you to setup, thinking, shipping, or closing work.
+Plain `/mb-start` is the reliable beginner path. Extra text after `/mb-start`
+is treated as normal instruction, not as a project-command argument API.
+Natural-language requests can route into the skill, but setup docs teach the
+explicit slash command because it is easier to recognize and repair. See the
+[Claude Code invocation contract](claude-code-invocation-contract.md) for the
+runtime details.
 
 That's it. From this point on:
 
@@ -270,6 +276,9 @@ mb skill repair --repo .
 
 Then restart Claude. This re-wires skill discovery in your business repo and
 checks whether an old personal skill is taking precedence.
+The project-local `.claude/skills/mb-start` bridge link is required for
+reliable slash-command discovery; `.claude/settings.local.json` alone is not
+enough.
 
 **I only see `.mb/`, not `.mb-vip/`:** good. `.mb/` is the current folder.
 `.mb-vip/` was old setup language and is not required.

--- a/docs/claude-code-invocation-contract.md
+++ b/docs/claude-code-invocation-contract.md
@@ -1,0 +1,93 @@
+# Claude Code Invocation Contract
+
+This is the supported Claude Code invocation contract for Main Branch. It is
+based on Claude Code 2.1.126 runtime smoke from a fresh `mb onboard` business
+repo on May 7, 2026.
+
+## Supported Path
+
+The reliable daily path is:
+
+```bash
+cd /path/to/your-business-repo
+claude
+```
+
+Then type:
+
+```text
+/mb-start
+```
+
+Main Branch skills are Claude Code skills under `.claude/skills/<name>/SKILL.md`.
+`mb onboard`, `mb init`, and `mb skill link --repo .` create project-local
+bridge links such as `.claude/skills/mb-start` in the business repo. Those
+bridge links are the supported slash-command discovery surface.
+
+`.claude/settings.local.json` also points Claude Code at the active Main Branch
+engine through `additionalDirectories`. That setting gives the runtime file
+access to the engine, but it is not sufficient by itself for `/mb-start`
+slash-command discovery. If `.claude/skills/mb-start` is missing, current
+Claude Code can report `Unknown command: /mb-start`.
+
+## Extra Text
+
+`/mb-start` may be followed by normal instructions:
+
+```text
+/mb-start I only have five minutes and want to keep this read-only.
+```
+
+Runtime smoke showed that Claude Code still invokes the `mb-start` skill and
+the extra text is treated as conversational instruction. Do not depend on
+Claude Code project-command `$ARGUMENTS` behavior here; Main Branch is not
+scaffolded as `.claude/commands/` project commands today.
+
+The only structured positional hints `/mb-start` currently teaches are an
+explicit repo path/name and, where relevant, an offer name. For beginner docs
+and first-run handoff, teach plain `/mb-start`.
+
+## Natural Language
+
+Natural-language requests such as "I am opening Main Branch for the day and I
+am not sure what to do next" can route into `mb-start` through the skill
+description. Runtime smoke confirmed that this works in Claude Code 2.1.126.
+
+That routing is useful, but it is not the beginner contract. Public setup and
+support docs should still tell users to type `/mb-start` when they want the
+daily entrypoint.
+
+## Repair Contract
+
+If `/mb-start` is missing or returns `Unknown command`, run these from the
+business repo:
+
+```bash
+mb skill repair --repo .
+mb skill link --repo .
+```
+
+Then restart Claude Code from the business repo and type `/mb-start` again.
+Claude Code loads skill discovery at session start, so relinking usually
+requires a restart before the slash command appears.
+
+`mb start --json` and `mb doctor` perform static checks for this wiring. Static
+checks prove the files are present and not shadowed by known personal skill
+conflicts; runtime smoke is still required when changing discovery,
+invocation, packaging, or first-run handoff behavior.
+
+## Runtime Evidence
+
+Fresh-repo smoke covered:
+
+- plain `/mb-start`: recognized `mb-start`, read the business repo, and used
+  `mb status --json --peek` facts;
+- `/mb-start` plus extra text: recognized `mb-start`, preserved CWD-first repo
+  routing, and treated extra text as instruction;
+- natural language: selected `/mb-start` from the skill description and read
+  business repo context;
+- missing project-local bridge: after removing `.claude/skills/mb-start` while
+  leaving `additionalDirectories`, Claude Code returned
+  `Unknown command: /mb-start`;
+- relink repair: `mb skill link --repo .` restored the project-local bridge and
+  `/mb-start` was recognized again.

--- a/docs/claude-code-invocation-contract.md
+++ b/docs/claude-code-invocation-contract.md
@@ -63,13 +63,19 @@ If `/mb-start` is missing or returns `Unknown command`, run these from the
 business repo:
 
 ```bash
-mb skill repair --repo .
 mb skill link --repo .
 ```
 
 Then restart Claude Code from the business repo and type `/mb-start` again.
 Claude Code loads skill discovery at session start, so relinking usually
 requires a restart before the slash command appears.
+
+`mb skill link --repo .` creates the project-local bridge links and also moves
+known stale or broken Main Branch personal-skill shadows to backups. If
+`/mb-start` is still missing afterward, run `mb skill repair --repo .` to
+inspect unresolved personal-skill conflicts. Use
+`mb skill repair --repo . --apply` only when you intentionally want the
+standalone repair command to move repairable shadows.
 
 `mb start --json` and `mb doctor` perform static checks for this wiring. Static
 checks prove the files are present and not shadowed by known personal skill

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -45,6 +45,11 @@ discovery rules, install/update behavior, generated-file and state rules,
 `mb doctor` / `mb status` / `mb start` expectations, and fresh-repo runtime
 smoke evidence. Claude Code is the reference adapter today.
 
+For the exact supported Claude Code slash-command behavior, including
+`/mb-start`, extra text after the slash command, natural-language routing, and
+skill-link repair, see
+[Claude Code Invocation Contract](claude-code-invocation-contract.md).
+
 ## Recommended setup
 
 For most users:
@@ -113,6 +118,11 @@ mb doctor
 - The CLI scaffolds, validates, graphs, resolves, and links the current Claude
   Code skill adapter. Most business workflows still happen through Claude Code
   slash commands.
+- Claude Code slash-command discovery depends on project-local
+  `.claude/skills/mb-*` bridge links in the business repo. The
+  `.claude/settings.local.json` `additionalDirectories` entry grants engine
+  file access, but it is not enough by itself for reliable `/mb-start`
+  discovery.
 - Codex, Cursor, OpenClaw, Hermes, Paperclip-adjacent orchestration, and local
   runtimes remain roadmap surfaces until each has a documented adapter and
   smoke evidence.

--- a/mb/tests/test_smoke_coverage.py
+++ b/mb/tests/test_smoke_coverage.py
@@ -201,6 +201,20 @@ def test_claude_plugin_manifest_points_at_prefixed_skills() -> None:
     assert (manifest_path.parents[1] / ".claude" / "skills" / "mb-start" / "SKILL.md").is_file()
 
 
+def test_claude_code_invocation_contract_documents_supported_skill_surface() -> None:
+    """Public docs keep the proven Claude Code skill contract visible."""
+    root = Path(__file__).resolve().parents[2]
+    contract = (root / "docs" / "claude-code-invocation-contract.md").read_text(encoding="utf-8")
+    compatibility = (root / "docs" / "compatibility.md").read_text(encoding="utf-8")
+
+    assert "project-local" in contract
+    assert "bridge links" in contract
+    assert ".claude/skills/mb-start" in contract
+    assert "Unknown command: /mb-start" in contract
+    assert "$ARGUMENTS" in contract
+    assert "Claude Code Invocation Contract" in compatibility
+
+
 def test_main_help_describes_engine() -> None:
     """Root help mentions the engine purpose."""
     result = runner.invoke(app, ["--help"])


### PR DESCRIPTION
## Summary
- Documents the proven Claude Code invocation contract for Main Branch, centered on `/mb-start` from a fresh business repo.
- Clarifies that project-local `.claude/skills/mb-*` bridge links are the supported slash-command discovery surface, while `additionalDirectories` grants engine file access but is not enough by itself.
- Records extra-text behavior, natural-language routing behavior, missing-bridge failure behavior, and the correct `mb skill link --repo .` repair path.
- Updates public setup/support docs, `/mb-start` reference copy, and a doc guard test so Main Branch stops promising an unsupported `.claude/commands` `$ARGUMENTS` surface.

## Scope
In:
- Prove and document the supported Claude Code `/mb-start` invocation/discovery contract.
- Align README, beginner setup, compatibility, support, changelog, and `/mb-start` references with runtime evidence.
- Add a lightweight test that keeps the public compatibility contract linked.

Out:
- Non-Claude runtime adapters.
- Broad generated `CLAUDE.md` hardening or bootstrap redesign.
- Durable runtime smoke runbook, dashboard behavior, or broad ghost-route cleanup.

## Commits
- `8d86338` — `[update] MAIN-259 Document Claude invocation contract`.
- `2d21abf` — `[fix] MAIN-259 Clarify skill relink repair docs`.

## Release / Issues
- Release: v0.3.x daily-loop reliability.
- Linear ID(s): MAIN-259.
- Closes: #354.
- Refs: #353, #355, #356.
- Follow-ups: none opened from this PR; those referenced issues own adjacent bootstrap, runbook, and route-cleanup work.

## Success Metric
A new or returning Claude Code user can rely on the documented `/mb-start` contract from a fresh business repo, and support docs no longer imply that `additionalDirectories` alone or `.claude/commands` `$ARGUMENTS` behavior is the supported Main Branch invocation surface.

## Validation
- Level 0 docs/decision: reviewed AGENTS, README, ETHOS, OSS checklist, operator loops, roadmap, CLI/runtime boundary, compatibility docs, GitHub #354 comments, and added `[Unreleased]` changelog entry.
- Level 1 static: `scripts/check.sh` passed: formatting, mypy, 314 tests, and all bundled skill validation.
- Level 2 CLI: focused doc guard test passed; `mb skill validate mb-start --json` passed with `SKILL.md` at 500 lines.
- Level 3 package/install: `cd mb && python3 -m build` passed; clean wheel venv smoke passed `mb --version`, `mb skill list`, `mb skill validate mb-start --json`, `mb onboard --yes`, `mb start --json`, `mb doctor`, `mb status --peek`, and `mb validate`.
- Level 4 fixture repo: fresh onboarded business repo was handoff-ready, reported wired skills, and produced expected status/doctor/validate output.
- Level 5 runtime smoke: Claude Code 2.1.126 recognized plain `/mb-start`, recognized `/mb-start` with extra text, routed a natural-language daily-start prompt into `/mb-start`, returned `Unknown command: /mb-start` when `.claude/skills/mb-start` was removed while `additionalDirectories` remained, and worked again after `mb skill link --repo .`; installed-wheel fixture runtime smoke also recognized `/mb-start`.

## Public / Private Boundary
- All committed text is public-facing and generic; local Conductor paths, private workflow notes, and raw runtime transcripts stayed in `.context` or issue comments rather than durable public docs.
