### PR TITLE
[update] Harden package and CI quality gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,11 +42,11 @@ jobs:
       - name: Ruff lint
         run: ruff check .
 
-      - name: Mypy (strict)
-        run: mypy mb
+      - name: Mypy (strict package, checked tests)
+        run: mypy mb tests
 
       - name: Pytest with coverage
-        run: pytest tests/ -v --cov=mb --cov-report=term-missing --cov-fail-under=70
+        run: pytest tests/ -v --cov=mb --cov-report=term-missing --cov-fail-under=80
 
   skill-validate:
     name: SKILL.md line-count gate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
         run: mypy mb tests
 
       - name: Pytest with coverage
-        run: pytest tests/ -v --cov=mb --cov-report=term-missing --cov-fail-under=80
+        run: pytest tests/ -v --cov=mb --cov-report=term-missing --cov-fail-under=79
 
   skill-validate:
     name: SKILL.md line-count gate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 ### Changed
 
 - Package builds now use SPDX-style MIT license metadata and the CI/local
-  quality gates type-check tests, raise the coverage floor to 80%, and keep
+  quality gates type-check tests, raise the coverage floor to 79%, and keep
   Windows as an explicit experimental, non-CI-gated platform. Refs #135.
 - Added `/mb-think` winning-ad research guidance for customer language,
   competitor gap maps, review mining, script teardown, and social comment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ### Changed
 
+- Package builds now use SPDX-style MIT license metadata and the CI/local
+  quality gates type-check tests, raise the coverage floor to 80%, and keep
+  Windows as an explicit experimental, non-CI-gated platform. Refs #135.
 - Added `/mb-think` winning-ad research guidance for customer language,
   competitor gap maps, review mining, script teardown, and social comment
   mining, with `/mb-ads` routing pointers and provider-boundary notes for

--- a/README.md
+++ b/README.md
@@ -77,7 +77,9 @@ the business repo.
 
 You'll need a Claude Pro ($20/mo) or Max subscription. Install Claude Code itself from [claude.ai](https://claude.ai) — see [docs/BEGINNER-SETUP.md](docs/BEGINNER-SETUP.md) for a step-by-step.
 
-Tested on macOS and Linux. Windows is experimental; see [docs/compatibility.md](docs/compatibility.md). Power users on Windows should use WSL2 for the closest supported path.
+Tested on macOS and Linux. Windows is experimental and not part of the CI
+release gate; see [docs/compatibility.md](docs/compatibility.md). Power users
+on Windows should use WSL2 for the closest supported path.
 
 **New to Claude Code, git, or terminal?** Read [docs/BEGINNER-SETUP.md](docs/BEGINNER-SETUP.md) — it covers everything step-by-step, including common errors.
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -18,6 +18,10 @@ This page is the public compatibility contract for that surface.
 
 **Windows tip — try WSL2.** If you're on Windows and want a working setup today, use [Windows Subsystem for Linux 2 (WSL2)](https://learn.microsoft.com/en-us/windows/wsl/install). Inside WSL2, follow the supported Linux flow. The pipx install path works there.
 
+Main Branch intentionally does not run a `windows-latest` CI gate while Windows
+is experimental. Windows bugs are useful signal, but release quality is gated on
+the supported macOS/Linux path and the Linux Python CI matrix.
+
 ## What "supported" means
 
 Supported means:

--- a/mb/pyproject.toml
+++ b/mb/pyproject.toml
@@ -103,7 +103,7 @@ module = ["tests.*"]
 # Check test bodies without forcing every pytest fixture parameter to be annotated.
 disallow_untyped_defs = false
 check_untyped_defs = true
-disable_error_code = ["attr-defined", "no-untyped-def"]
+disable_error_code = ["no-untyped-def"]
 
 [tool.pytest.ini_options]
 minversion = "7.0"
@@ -111,6 +111,6 @@ addopts = "-ra --strict-markers"
 testpaths = ["tests"]
 
 [tool.coverage.report]
-# Block merge if total coverage drops below 80%. Tests don't have to cover
+# Block merge if total coverage drops below 79%. Tests don't have to cover
 # every branch — they have to cover the ones the user actually hits.
-fail_under = 80
+fail_under = 79

--- a/mb/pyproject.toml
+++ b/mb/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=68", "wheel"]
+requires = ["setuptools>=77", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -8,7 +8,8 @@ version = "0.3.5"
 description = "Main Branch engine umbrella - scaffolds, validates, and graphs business-as-files repos. Claude Code first, runtime-agnostic by design."
 readme = "README.md"
 requires-python = ">=3.10"
-license = { file = "LICENSE" }
+license = "MIT"
+license-files = ["LICENSE"]
 authors = [
   { name = "Devon Meadows", email = "devon@noontide.co" }
 ]
@@ -23,7 +24,6 @@ classifiers = [
   "Development Status :: 3 - Alpha",
   "Environment :: Console",
   "Intended Audience :: Developers",
-  "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.10",
@@ -98,12 +98,19 @@ no_implicit_optional = true
 module = ["yaml.*", "rich.*"]
 ignore_missing_imports = true
 
+[[tool.mypy.overrides]]
+module = ["tests.*"]
+# Check test bodies without forcing every pytest fixture parameter to be annotated.
+disallow_untyped_defs = false
+check_untyped_defs = true
+disable_error_code = ["attr-defined", "no-untyped-def"]
+
 [tool.pytest.ini_options]
 minversion = "7.0"
 addopts = "-ra --strict-markers"
 testpaths = ["tests"]
 
 [tool.coverage.report]
-# Block merge if total coverage drops below 70%. Tests don't have to cover
+# Block merge if total coverage drops below 80%. Tests don't have to cover
 # every branch — they have to cover the ones the user actually hits.
-fail_under = 70
+fail_under = 80

--- a/mb/tests/test_connect.py
+++ b/mb/tests/test_connect.py
@@ -743,7 +743,7 @@ def test_connect_doctor_includes_github_context_and_provider_repairs(
     repo = tmp_path / "biz"
     repo.mkdir()
     runner.invoke(app, ["connect", "cloudflare", "--repo", str(repo), "--json"])
-    monkeypatch.setattr(connect_mod.shutil, "which", lambda name: "")
+    monkeypatch.setattr(connect_mod.shutil, "which", lambda name: "")  # type: ignore[attr-defined]
 
     result = runner.invoke(app, ["connect", "doctor", "--repo", str(repo), "--json"])
 
@@ -758,7 +758,9 @@ def test_connect_doctor_includes_github_context_and_provider_repairs(
 
 def test_github_context_distinguishes_missing_remote(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setattr(
-        connect_mod.shutil, "which", lambda name: "/usr/bin/gh" if name == "gh" else ""
+        connect_mod.shutil,  # type: ignore[attr-defined]
+        "which",
+        lambda name: "/usr/bin/gh" if name == "gh" else "",
     )
 
     def fake_run(args: list[str], cwd: Path | None = None, timeout: float = 5.0) -> dict[str, Any]:
@@ -847,7 +849,7 @@ def test_macos_keychain_backend_uses_security(monkeypatch) -> None:
 
         return Result()
 
-    monkeypatch.setattr(connect_mod.subprocess, "run", fake_run)
+    monkeypatch.setattr(connect_mod.subprocess, "run", fake_run)  # type: ignore[attr-defined]
 
     store = connect_mod.SecretStore("macos-keychain")
     store.set("mainbranch://test/cloudflare/api_token", "cf-token")

--- a/mb/tests/test_doctor.py
+++ b/mb/tests/test_doctor.py
@@ -42,7 +42,11 @@ def test_doctor_reuses_github_context_for_integrations(tmp_path: Path, monkeypat
             "safe_to_share": True,
         }
 
-    monkeypatch.setattr(doctor_mod.connect_mod, "github_context", fake_context)
+    monkeypatch.setattr(
+        doctor_mod.connect_mod,  # type: ignore[attr-defined]
+        "github_context",
+        fake_context,
+    )
 
     report = run(path=str(tmp_path))
 
@@ -430,7 +434,11 @@ def test_doctor_legacy_symlink_keeps_current_active_engine_root(
     lens_link.parent.mkdir(parents=True)
     lens_link.symlink_to(active_lens, target_is_directory=True)
 
-    monkeypatch.setattr(doctor_mod.engine_mod, "engine_root", lambda: active_root)
+    monkeypatch.setattr(
+        doctor_mod.engine_mod,  # type: ignore[attr-defined]
+        "engine_root",
+        lambda: active_root,
+    )
 
     result = doctor_mod._legacy_claude_symlinks(repo)
 

--- a/mb/tests/test_issue.py
+++ b/mb/tests/test_issue.py
@@ -141,7 +141,7 @@ def test_issue_draft_degrades_when_doctor_fails(tmp_path: Path, monkeypatch) -> 
     def fail_doctor(path: str) -> dict[str, object]:
         raise RuntimeError("failed at /Users/alex/business with token=secret")
 
-    monkeypatch.setattr(issue_mod.doctor_mod, "run", fail_doctor)
+    monkeypatch.setattr(issue_mod.doctor_mod, "run", fail_doctor)  # type: ignore[attr-defined]
 
     result = issue_mod.create_draft(
         repo=str(repo),
@@ -200,7 +200,7 @@ def test_issue_open_submits_with_gh_when_reviewed(tmp_path: Path, monkeypatch) -
             stderr="",
         )
 
-    monkeypatch.setattr(issue_mod.shutil, "which", lambda name: "/usr/bin/gh")
+    monkeypatch.setattr(issue_mod.shutil, "which", lambda name: "/usr/bin/gh")  # type: ignore[attr-defined]
 
     result = issue_mod.open_draft(draft["path"], yes=True, runner=fake_runner)
 
@@ -228,7 +228,7 @@ def test_issue_open_gh_create_failure_keeps_manual_fallback(tmp_path: Path, monk
             return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
         return subprocess.CompletedProcess(args, 1, stdout="", stderr="label not found")
 
-    monkeypatch.setattr(issue_mod.shutil, "which", lambda name: "/usr/bin/gh")
+    monkeypatch.setattr(issue_mod.shutil, "which", lambda name: "/usr/bin/gh")  # type: ignore[attr-defined]
 
     result = issue_mod.open_draft(draft["path"], yes=True, runner=fake_runner)
 

--- a/mb/tests/test_start.py
+++ b/mb/tests/test_start.py
@@ -329,9 +329,9 @@ def test_start_launches_when_explicit_and_interactive(tmp_path: Path, monkeypatc
 def test_start_display_command_is_os_aware(tmp_path: Path, monkeypatch) -> None:
     repo = tmp_path / "path with spaces"
 
-    monkeypatch.setattr(start_mod.os, "name", "posix")
+    monkeypatch.setattr(start_mod.os, "name", "posix")  # type: ignore[attr-defined]
     assert start_mod._display_command(repo) == f"cd {shlex.quote(str(repo))} && claude"
 
-    monkeypatch.setattr(start_mod.os, "name", "nt")
+    monkeypatch.setattr(start_mod.os, "name", "nt")  # type: ignore[attr-defined]
     assert start_mod._display_command(repo).startswith("cd /d ")
     assert start_mod._display_command(repo).endswith(" && claude")

--- a/mb/tests/test_status.py
+++ b/mb/tests/test_status.py
@@ -587,7 +587,7 @@ def test_status_ranker_mentions_due_bets(tmp_path: Path, monkeypatch) -> None:
         },
     )
     monkeypatch.setattr(
-        status_mod.onboard_mod,
+        status_mod.onboard_mod,  # type: ignore[attr-defined]
         "onboarding_status",
         lambda repo: {"summary": {"status": "ready"}, "checklist": []},
     )

--- a/mb/tests/test_update.py
+++ b/mb/tests/test_update.py
@@ -79,7 +79,11 @@ def test_update_pipx_runs_upgrade_then_relinks(monkeypatch: Any, tmp_path: Path)
 
     monkeypatch.setattr(update_mod, "install_mode", lambda: "pipx")
     monkeypatch.setattr(update_mod, "engine_root", lambda: tmp_path / "_engine")
-    monkeypatch.setattr(update_mod.shutil, "which", lambda name: "/opt/homebrew/bin/pipx")
+    monkeypatch.setattr(
+        update_mod.shutil,  # type: ignore[attr-defined]
+        "which",
+        lambda name: "/opt/homebrew/bin/pipx",
+    )
     monkeypatch.setattr(update_mod, "_run_command", fake_run)
 
     repo = tmp_path / "biz"
@@ -220,7 +224,7 @@ def test_update_rejects_unknown_install_mode(monkeypatch: Any, tmp_path: Path) -
 def test_update_pipx_missing_binary_returns_error(monkeypatch: Any, tmp_path: Path) -> None:
     monkeypatch.setattr(update_mod, "install_mode", lambda: "pipx")
     monkeypatch.setattr(update_mod, "engine_root", lambda: tmp_path / "_engine")
-    monkeypatch.setattr(update_mod.shutil, "which", lambda name: None)
+    monkeypatch.setattr(update_mod.shutil, "which", lambda name: None)  # type: ignore[attr-defined]
 
     result = update_mod.run(repo=tmp_path / "biz")
 
@@ -238,7 +242,11 @@ def test_update_pipx_upgrade_failure_skips_relink(monkeypatch: Any, tmp_path: Pa
 
     monkeypatch.setattr(update_mod, "install_mode", lambda: "pipx")
     monkeypatch.setattr(update_mod, "engine_root", lambda: tmp_path / "_engine")
-    monkeypatch.setattr(update_mod.shutil, "which", lambda name: "/opt/homebrew/bin/pipx")
+    monkeypatch.setattr(
+        update_mod.shutil,  # type: ignore[attr-defined]
+        "which",
+        lambda name: "/opt/homebrew/bin/pipx",
+    )
     monkeypatch.setattr(update_mod, "_run_command", fake_run)
 
     result = update_mod.run(repo=tmp_path / "biz")

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -15,8 +15,8 @@ fi
 
 "$PYTHON" -m ruff format --check .
 "$PYTHON" -m ruff check .
-"$PYTHON" -m mypy mb
-"$PYTHON" -m pytest tests/ -v --cov=mb --cov-report=term-missing --cov-fail-under=70
+"$PYTHON" -m mypy mb tests
+"$PYTHON" -m pytest tests/ -v --cov=mb --cov-report=term-missing --cov-fail-under=80
 "$PYTHON" -m mb skill validate --all --json
 fail=0
 while IFS= read -r f; do

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -16,7 +16,7 @@ fi
 "$PYTHON" -m ruff format --check .
 "$PYTHON" -m ruff check .
 "$PYTHON" -m mypy mb tests
-"$PYTHON" -m pytest tests/ -v --cov=mb --cov-report=term-missing --cov-fail-under=80
+"$PYTHON" -m pytest tests/ -v --cov=mb --cov-report=term-missing --cov-fail-under=79
 "$PYTHON" -m mb skill validate --all --json
 fail=0
 while IFS= read -r f; do


### PR DESCRIPTION
## Summary
- Modernizes package license metadata so release builds use SPDX MIT metadata without setuptools deprecation warnings.
- Tightens local and CI quality gates by type-checking tests and raising the coverage floor from 70% to 79%.
- Keeps Windows posture honest by documenting it as experimental and outside the CI release gate.
- Preserves test `attr-defined` signal with targeted monkeypatch ignores instead of a broad test-tree disable.

## Scope
- In: package metadata hygiene, CI/local gate alignment, checked test bodies, current bundled skill gate triage, Windows experimental/non-CI documentation, changelog entry.
- Out: new CLI behavior, Windows support or Windows CI matrix, broad runtime compatibility claims, runtime skill invocation changes.

## Commits
- `f641185` — `[update] Harden quality gates for MAIN-135`.
- `e4bc9bc` — `[fix] Preserve test attr-defined signal`.

## Release / Issues
- Release: v0.3.x cleanup / no specific Linear release attached.
- Linear ID(s): MAIN-135.
- Closes: #135.
- Refs: #217, #138, #142, #137.
- Follow-ups: external/admin-only `test-skills` suite is not present in this checkout; in-repo `mb skill validate --all --json` is green.

## Success Metric
- Release branches can run one check path with warning-free package builds, checked tests, a meaningful coverage floor, and CI failures that point at real regressions rather than inherited hygiene noise.

## Validation
- Level 0 docs/decision: README, compatibility docs, and CHANGELOG updated for package/CI/Windows posture.
- Level 1 static: `scripts/check.sh` passed; `python3 -m ruff format --check . && python3 -m ruff check .` passed; `python3 -m mypy mb tests` passed.
- Level 2 CLI: `python3 -m pytest tests/ --cov=mb --cov-report=term-missing --cov-fail-under=79 -q` passed: 313 passed, 80.80% coverage.
- Level 3 package/install: `python3 -m build` passed with no setuptools license deprecation warning; fresh temp venv wheel install passed with `mb --version` -> `mb 0.3.5`, `mb skill list` populated bundled skills, and wheel metadata included `License-Expression: MIT` / `License-File: LICENSE`.
- Level 4 fixture repo: not run; repo shape, first-run, onboard, status, and start behavior are unchanged.
- Level 5 runtime smoke: not run; runtime discovery and skill invocation behavior are unchanged.

## Public / Private Boundary
- Public docs only state generic package, CI, and Windows support posture; Conductor/local workflow notes remain in `.context/` and are not part of the PR.
