### PR TITLE
[update] CLI-first business CLAUDE bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ### Changed
 
+- Fresh business repo `CLAUDE.md` files now make the bootstrap CLI-first:
+  Claude Code is told to read `mb` status/start/doctor facts before setup or
+  repair advice, separate read-only checks from write/apply repairs, and return
+  technical repair results in business-owner language. Refs #353.
 - Documented the public build-vs-wrap-vs-sidecar boundary for provider CLIs,
   MCP servers, hosted workflows, and future sidecars, with concrete guidance
   for Cloudflare, Postiz, Apify/X research, Vercel-style platforms,

--- a/mb/mb/_data/templates/CLAUDE.md.tmpl
+++ b/mb/mb/_data/templates/CLAUDE.md.tmpl
@@ -2,6 +2,59 @@
 
 Your business as files. Claude reads these; you edit them; git remembers them.
 
+## Claude operating contract
+
+Main Branch CLI facts are the source of truth for repo health, setup, runtime
+wiring, updates, graph/status signals, provider readiness, and repair paths.
+The normal runtime path is: open a terminal in this repo, run `claude`, then
+type `/mb-start` inside Claude Code. From the terminal, `mb start --json`
+checks the handoff and `mb start --launch` can open Claude Code when available.
+Before giving setup, routing, migration, update, or repair advice, run the
+read-only checks that fit the situation from this business repo:
+
+```bash
+mb --version
+mb status --json --peek
+mb start --json
+mb doctor repair --plan
+```
+
+Use `mb status --json --peek` as the default daily briefing before routing the
+operator. It names readiness, drift, onboarding progress, update state, GitHub
+activity, provider signals, recent work, ranked actions, bets, pushes, and
+checkpoint state. Do not replace those facts with ad hoc shell inspection unless
+`mb` says a section is unavailable or the command itself is missing.
+
+Read-only commands can be run without asking first. Commands that write files,
+refresh local runtime wiring, move personal skill shadows, update packages,
+migrate business files, create checkpoints, publish, spend money, email, or
+mutate provider accounts require explicit operator approval before applying.
+Plan first, then apply only after approval:
+
+```bash
+mb doctor repair --plan
+mb skill repair --repo .
+mb skill link --repo .          # writes project-local Claude skill wiring
+mb skill repair --repo . --apply
+mb doctor repair --apply
+mb update
+```
+
+If `/mb-start` is not discoverable or Claude Code reports `Unknown command:
+/mb-start`, do not improvise from memory. From this business repo, check
+`mb --version`, run `mb start --json` and `mb status --json --peek`, inspect
+repair options with `mb doctor repair --plan`, then ask before running any
+write/apply command such as `mb skill link --repo .`, `mb skill repair --repo .
+--apply`, `mb doctor repair --apply`, or `mb update`. After repairing skill
+wiring, tell the operator to restart Claude Code from this repo and try
+`/mb-start` again.
+
+Do the technical work in technical commands, then translate the result back into
+business-owner language. Speak first in terms of bets, goals, offers, pushes,
+playbooks, outcomes, decisions, next actions, and saved checkpoints. Treat git,
+branches, pull requests, provider refs, and local wiring as the hidden memory
+layer unless the operator asks for the plumbing.
+
 ## Folders
 
 - `core/` — the business brain: offer, audience, voice, soul, proof, brand, strategy, operations, finance

--- a/mb/mb/init.py
+++ b/mb/mb/init.py
@@ -208,12 +208,12 @@ Your business as files. Claude reads these; you edit them; git remembers them.
 ## Claude operating contract
 
 Main Branch CLI facts are the source of truth for repo health, setup, runtime
-wiring, updates, status signals, provider readiness, and repair paths. The
-normal runtime path is: open a terminal in this repo, run `claude`, then type
-`/mb-start` inside Claude Code. From the terminal, `mb start --json` checks the
-handoff and `mb start --launch` can open Claude Code when available. Before
-giving setup, routing, migration, update, or repair advice, run the read-only
-checks that fit the situation from this business repo:
+wiring, updates, graph/status signals, provider readiness, and repair paths.
+The normal runtime path is: open a terminal in this repo, run `claude`, then
+type `/mb-start` inside Claude Code. From the terminal, `mb start --json`
+checks the handoff and `mb start --launch` can open Claude Code when available.
+Before giving setup, routing, migration, update, or repair advice, run the
+read-only checks that fit the situation from this business repo:
 
 ```bash
 mb --version
@@ -223,8 +223,10 @@ mb doctor repair --plan
 ```
 
 Use `mb status --json --peek` as the default daily briefing before routing the
-operator. Do not replace those facts with ad hoc shell inspection unless `mb`
-says a section is unavailable or the command itself is missing.
+operator. It names readiness, drift, onboarding progress, update state, GitHub
+activity, provider signals, recent work, ranked actions, bets, pushes, and
+checkpoint state. Do not replace those facts with ad hoc shell inspection unless
+`mb` says a section is unavailable or the command itself is missing.
 
 Read-only commands can be run without asking first. Commands that write files,
 refresh local runtime wiring, move personal skill shadows, update packages,
@@ -242,16 +244,19 @@ mb update
 ```
 
 If `/mb-start` is not discoverable or Claude Code reports `Unknown command:
-/mb-start`, check `mb --version`, run `mb start --json` and `mb status --json
---peek`, inspect repair options with `mb doctor repair --plan`, then ask before
-running any write/apply command such as `mb skill link --repo .`,
-`mb skill repair --repo . --apply`, `mb doctor repair --apply`, or `mb update`.
-After repairing skill wiring, tell the operator to restart Claude Code from this
-repo and try `/mb-start` again.
+/mb-start`, do not improvise from memory. From this business repo, check
+`mb --version`, run `mb start --json` and `mb status --json --peek`, inspect
+repair options with `mb doctor repair --plan`, then ask before running any
+write/apply command such as `mb skill link --repo .`, `mb skill repair --repo .
+--apply`, `mb doctor repair --apply`, or `mb update`. After repairing skill
+wiring, tell the operator to restart Claude Code from this repo and try
+`/mb-start` again.
 
 Do the technical work in technical commands, then translate the result back into
-business-owner language: bets, goals, offers, pushes, playbooks, outcomes,
-decisions, next actions, and saved checkpoints.
+business-owner language. Speak first in terms of bets, goals, offers, pushes,
+playbooks, outcomes, decisions, next actions, and saved checkpoints. Treat git,
+branches, pull requests, provider refs, and local wiring as the hidden memory
+layer unless the operator asks for the plumbing.
 
 ## Folders
 

--- a/mb/mb/init.py
+++ b/mb/mb/init.py
@@ -205,6 +205,54 @@ _DEFAULT_CLAUDE = """\
 
 Your business as files. Claude reads these; you edit them; git remembers them.
 
+## Claude operating contract
+
+Main Branch CLI facts are the source of truth for repo health, setup, runtime
+wiring, updates, status signals, provider readiness, and repair paths. The
+normal runtime path is: open a terminal in this repo, run `claude`, then type
+`/mb-start` inside Claude Code. From the terminal, `mb start --json` checks the
+handoff and `mb start --launch` can open Claude Code when available. Before
+giving setup, routing, migration, update, or repair advice, run the read-only
+checks that fit the situation from this business repo:
+
+```bash
+mb --version
+mb status --json --peek
+mb start --json
+mb doctor repair --plan
+```
+
+Use `mb status --json --peek` as the default daily briefing before routing the
+operator. Do not replace those facts with ad hoc shell inspection unless `mb`
+says a section is unavailable or the command itself is missing.
+
+Read-only commands can be run without asking first. Commands that write files,
+refresh local runtime wiring, move personal skill shadows, update packages,
+migrate business files, create checkpoints, publish, spend money, email, or
+mutate provider accounts require explicit operator approval before applying.
+Plan first, then apply only after approval:
+
+```bash
+mb doctor repair --plan
+mb skill repair --repo .
+mb skill link --repo .          # writes project-local Claude skill wiring
+mb skill repair --repo . --apply
+mb doctor repair --apply
+mb update
+```
+
+If `/mb-start` is not discoverable or Claude Code reports `Unknown command:
+/mb-start`, check `mb --version`, run `mb start --json` and `mb status --json
+--peek`, inspect repair options with `mb doctor repair --plan`, then ask before
+running any write/apply command such as `mb skill link --repo .`,
+`mb skill repair --repo . --apply`, `mb doctor repair --apply`, or `mb update`.
+After repairing skill wiring, tell the operator to restart Claude Code from this
+repo and try `/mb-start` again.
+
+Do the technical work in technical commands, then translate the result back into
+business-owner language: bets, goals, offers, pushes, playbooks, outcomes,
+decisions, next actions, and saved checkpoints.
+
 ## Folders
 
 - `core/` — the business brain: offer, audience, voice, soul, proof, brand,

--- a/mb/tests/test_init.py
+++ b/mb/tests/test_init.py
@@ -5,7 +5,13 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from mb.init import DATA_FOLDERS, run
+from mb.init import _DEFAULT_CLAUDE, DATA_FOLDERS, _read_template, run
+
+
+def _section(text: str, start: str, end: str) -> str:
+    start_index = text.index(start)
+    end_index = text.index(end, start_index)
+    return text[start_index:end_index]
 
 
 def _assert_claude_md_cli_first_contract(text: str) -> None:
@@ -33,6 +39,15 @@ def _assert_claude_md_cli_first_contract(text: str) -> None:
     assert "Claude Desktop" not in text
     for unsupported_runtime in ("Codex", "Cursor", "OpenClaw", "Hermes"):
         assert unsupported_runtime not in text
+
+
+def test_default_claude_operating_contract_matches_template() -> None:
+    template = _read_template("CLAUDE.md.tmpl")
+    template_contract = _section(template, "## Claude operating contract", "## Folders")
+    fallback_contract = _section(_DEFAULT_CLAUDE, "## Claude operating contract", "## Folders")
+
+    assert fallback_contract == template_contract
+    _assert_claude_md_cli_first_contract(_DEFAULT_CLAUDE)
 
 
 def test_init_scaffolds_folders(tmp_path: Path) -> None:

--- a/mb/tests/test_init.py
+++ b/mb/tests/test_init.py
@@ -8,6 +8,33 @@ from pathlib import Path
 from mb.init import DATA_FOLDERS, run
 
 
+def _assert_claude_md_cli_first_contract(text: str) -> None:
+    assert "## Claude operating contract" in text
+    assert "Main Branch CLI facts are the source of truth" in text
+    assert "run `claude`" in text
+    assert "`/mb-start` inside Claude Code" in text
+    assert "mb start --launch" in text
+    assert "mb --version" in text
+    assert "mb status --json --peek" in text
+    assert "mb start --json" in text
+    assert "mb doctor repair --plan" in text
+    assert "Do not replace those facts with ad hoc shell inspection" in text
+    assert "Read-only commands can be run without asking first" in text
+    assert "require explicit operator approval before applying" in text
+    assert "mb skill repair --repo ." in text
+    assert "mb skill link --repo .          # writes project-local Claude skill wiring" in text
+    assert "mb skill repair --repo . --apply" in text
+    assert "mb doctor repair --apply" in text
+    assert "If `/mb-start` is not discoverable" in text
+    assert "restart Claude Code from this repo and try" in text
+    assert "business-owner language" in text
+    assert "bets, goals, offers, pushes" in text
+    assert "playbooks, outcomes" in text
+    assert "Claude Desktop" not in text
+    for unsupported_runtime in ("Codex", "Cursor", "OpenClaw", "Hermes"):
+        assert unsupported_runtime not in text
+
+
 def test_init_scaffolds_folders(tmp_path: Path) -> None:
     target = tmp_path / "acme"
     result = run(path=str(target), name="Acme Brewing")
@@ -68,6 +95,7 @@ def test_init_scaffolds_folders(tmp_path: Path) -> None:
     assert "`pushes/`" in claude_md
     assert "core/vocabulary.md" in claude_md
     assert "legacy `campaigns/`" in claude_md
+    _assert_claude_md_cli_first_contract(claude_md)
 
 
 def test_init_idempotent(tmp_path: Path) -> None:

--- a/mb/tests/test_onboard.py
+++ b/mb/tests/test_onboard.py
@@ -21,6 +21,18 @@ def _tool_path(name: str) -> str:
     return ""
 
 
+def _assert_onboard_claude_md_cli_first_contract(text: str) -> None:
+    assert "## Claude operating contract" in text
+    assert "Main Branch CLI facts are the source of truth" in text
+    assert "mb status --json --peek" in text
+    assert "mb start --json" in text
+    assert "mb doctor repair --plan" in text
+    assert "Read-only commands can be run without asking first" in text
+    assert "require explicit operator approval before applying" in text
+    assert "If `/mb-start` is not discoverable" in text
+    assert "business-owner language" in text
+
+
 def test_onboard_yes_creates_repo_and_reports_next_steps(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(onboard_mod, "_which", _tool_path)
     repo = tmp_path / "acme"
@@ -36,6 +48,8 @@ def test_onboard_yes_creates_repo_and_reports_next_steps(tmp_path: Path, monkeyp
     assert result["action"] == "created"
     assert result["level"] == "beginner"
     assert (repo / "CLAUDE.md").exists()
+    claude_md = (repo / "CLAUDE.md").read_text(encoding="utf-8")
+    _assert_onboard_claude_md_cli_first_contract(claude_md)
     assert (repo / ".claude" / "skills" / "mb-start" / "SKILL.md").exists()
     assert (repo / ".git" / "hooks" / "commit-msg").exists()
     assert result["checkpoint_hook"]["state"] == "installed"


### PR DESCRIPTION
## Summary
- Makes fresh business repo `CLAUDE.md` files enforce a CLI-first bootstrap: read deterministic `mb` facts before setup, routing, update, migration, or repair advice.
- Adds a missing `/mb-start` recovery path using shipped commands and approval gates for write/apply repairs.
- Keeps the embedded fallback `CLAUDE.md` operating contract in sync with the packaged template and adds regression coverage for both paths.

## Scope
- In: generated business `CLAUDE.md`, embedded fallback copy, init/onboard regression tests, and Unreleased changelog note.
- Out: new CLI behavior, hosted dashboard state, bundled skill rewrites, ghost-route cleanup, and new runtime adapter claims.

## Commits
- `5414e11` — `[update] MAIN-261 CLI-first CLAUDE bootstrap`.
- `9100bb2` — `[fix] MAIN-261 keep CLAUDE fallback in sync`.

## Release / Issues
- Release: v0.3.x direction.
- Linear ID(s): MAIN-261.
- Closes: #353.
- Refs: #356, #364, #365.
- Follow-ups: interactive Claude Code TUI smoke remains the release-bearing runtime evidence gap.

## Success Metric
- A fresh `mb init` or `mb onboard` repo gives Claude Code enough instructions to gather `mb` facts first, distinguish read-only checks from write/apply repairs, recover from missing `/mb-start`, and return to business-owner language.

## Validation
- Level 0 docs/decision: public/private boundary review; no new runtime support claims.
- Level 1 static: `scripts/check.sh` passed with 324 tests, 79.63% coverage, and skill validation green.
- Level 2 CLI: `pytest tests/test_init.py tests/test_onboard.py -q` passed with 17 tests.
- Level 3 package/install: not required; no packaging metadata or entrypoints changed.
- Level 4 fixture repo: fresh `mb onboard --yes` fixture rendered the reviewed `CLAUDE.md` contract; earlier fixture `mb start --json` returned follow-up `/mb-start`.
- Level 5 runtime smoke: deterministic dogfood harness `scripts/claude-runtime-dogfood.py --install-mode editable` passed. Optional `claude -p` proxy smoke was attempted with Claude Code 2.1.126 and `--max-budget-usd 0.25`, but hung during the checkpoint-plan turn and was not counted as passed.

## Public / Private Boundary
- Committed copy is public-safe and generic; local Conductor notes, temp evidence paths, and the hung proxy-smoke detail stay out of durable product docs except as validation evidence in PR/issue context.
