### PR TITLE
[fix] Harden legacy layout migration

### DIFF
--- a/.claude/skills/mb-ads/references/entry-points.md
+++ b/.claude/skills/mb-ads/references/entry-points.md
@@ -71,7 +71,7 @@ Each entry point assembles different components. Components are modular -- they 
 
 | Component | What It Does | Reference |
 |-----------|-------------|-----------|
-| **Pre-flight** | Score reference files, check readiness | [preflight-algorithm.md](preflight-algorithm.md) |
+| **Pre-flight** | Score core files, check readiness | [preflight-algorithm.md](preflight-algorithm.md) |
 | **Account Check** | Pull live account data when `mb connect` and runtime tools are verified | [meta-ads-integration.md](meta-ads-integration.md) |
 | **Copy Engine** | Generate primaries, headlines, hooks | SKILL.md (Static Ads section) |
 | **Hook Library** | Generate N creative variations (also called "one-liners") | [one-liner-methodology.md](one-liner-methodology.md) |

--- a/.claude/skills/mb-ads/references/preflight-algorithm.md
+++ b/.claude/skills/mb-ads/references/preflight-algorithm.md
@@ -215,9 +215,9 @@ Check for a common stuck state:
 
 ```
 if decisions/ has 3+ files with status: accepted
-AND reference/ has gaps (composite < 12)
+AND core/ has gaps (composite < 12)
 THEN surface:
-  "You have accepted decisions that haven't been applied to reference.
+  "You have accepted decisions that haven't been applied to core files.
    Want to run parallel agents to codify them?"
 ```
 

--- a/.claude/skills/mb-help/references/content-strategy-help.md
+++ b/.claude/skills/mb-help/references/content-strategy-help.md
@@ -33,7 +33,7 @@ choices: pillars, platforms, cadence, hooks, and metrics. It is not an
 operations file. Use `core/operations/` for delivery systems like classroom,
 membership, funnel, and fulfillment.
 
-You still need enough core reference before a content strategy makes sense.
+You still need enough core file context before a content strategy makes sense.
 The file usually emerges through `/mb-think` cycles after the operator has
 some real content experience: what platforms they like, what topics land, and
 what hooks work.
@@ -144,8 +144,8 @@ Loop back to newsletter
 **Q: Do I need content-strategy.md to use /mb-organic?**
 No. `/mb-organic` works without it. But with it, your content is strategically aligned instead of ad hoc.
 
-**Q: Can I skip straight to content-strategy.md without core reference?**
-Not recommended. Your pillars derive from soul + offer + audience. Without those, your pillars will be generic. Build core reference first.
+**Q: Can I skip straight to content-strategy.md without core files?**
+Not recommended. Your pillars derive from soul + offer + audience. Without those, your pillars will be generic. Build core files first.
 
 **Q: How often should I update content-strategy.md?**
 - Hooks Library and Framework Library: weekly (as you discover what works)

--- a/.claude/skills/mb-help/references/task-tracking-options.md
+++ b/.claude/skills/mb-help/references/task-tracking-options.md
@@ -106,7 +106,7 @@ gh issue close 123
 
 Single lightweight file showing current state.
 
-**Create:** `reference/focus.md`
+**Create:** `log/focus.md`
 
 ```markdown
 # Current Focus

--- a/.claude/skills/mb-help/references/troubleshooting.md
+++ b/.claude/skills/mb-help/references/troubleshooting.md
@@ -90,25 +90,23 @@ mb skill repair --repo .
 mb doctor
 ```
 
-If the `mb` CLI is unavailable and you are repairing an old clone-based setup by hand, add compatibility links without replacing local folders. First resolve `$ENGINE_PATH` per **[vip-path-resolution.md](vip-path-resolution.md)**, then:
+If the `mb` CLI is unavailable and you are repairing an old clone-based setup by hand, add skill compatibility links without replacing local folders. First resolve `$ENGINE_PATH` per **[vip-path-resolution.md](vip-path-resolution.md)**, then:
 
 ```bash
 # Create bridge links only for missing entries
-mkdir -p .claude/skills .claude/lenses .claude/reference
+mkdir -p .claude/skills
 for d in "$ENGINE_PATH"/.claude/skills/*; do
   [ -d "$d" ] || continue
   n=$(basename "$d")
   [ -e ".claude/skills/$n" ] || ln -s "$d" ".claude/skills/$n"
 done
-for p in "$ENGINE_PATH"/.claude/lenses/* "$ENGINE_PATH"/.claude/reference/*; do
-  [ -e "$p" ] || continue
-  base=$(basename "$p")
-  parent=$(basename "$(dirname "$p")")
-  [ -e ".claude/$parent/$base" ] || ln -s "$p" ".claude/$parent/$base"
-done
 ```
 
 **Why this bridge?** It preserves project-local custom skills in `.claude/skills/` while adding missing Main Branch entries when discovery is inconsistent.
+
+Old clone-based repos may also have `.claude/lenses/` or `.claude/reference/`
+symlinks. Treat those as legacy link dirs; `mb doctor repair` can move stale
+ones into `.mb/backups/`.
 
 **Check 2: Is Main Branch loaded as an additional directory?**
 ```bash

--- a/.claude/skills/mb-organic/references/first-time-setup.md
+++ b/.claude/skills/mb-organic/references/first-time-setup.md
@@ -1,6 +1,6 @@
 # First-Time Setup
 
-Before running `/mb-organic`, you need three core reference files. This guide helps you create minimal versions to get started.
+Before running `/mb-organic`, you need three core files. This guide helps you create minimal versions to get started.
 
 ---
 

--- a/.claude/skills/mb-setup/SKILL.md
+++ b/.claude/skills/mb-setup/SKILL.md
@@ -123,7 +123,7 @@ This check is simple and non-intrusive. If they say yes, note it and move on —
 
 ### 3. Gather Bounded Context
 
-Your job is to collect enough to create a useful core reference, not every fact
+Your job is to collect enough to create useful core files, not every fact
 possible. Users provide context in batches. Keep the first pass bounded by
 `mb onboard status --json` and its missing inputs.
 
@@ -149,7 +149,7 @@ See **[references/context-gathering.md](references/context-gathering.md)** for:
 - Completeness criteria
 
 **Opening prompt:**
-> Share the essentials for the core reference: what you sell, who it helps, why
+> Share the essentials for the core files: what you sell, who it helps, why
 > it works, proof you can share, and a few voice samples.
 >
 > **Pro tip:** You can drag screenshots directly into this terminal window and I'll read them. If you have a Skool community, screenshot your about page, classroom, pricing — drag them all in. Fastest way to get me up to speed.
@@ -157,7 +157,7 @@ See **[references/context-gathering.md](references/context-gathering.md)** for:
 > Paste text, share file paths, give me URLs to fetch, or drag in images. I'll sort it all into the right files.
 
 **After each batch, assess gaps:**
-> "Got it. I still need [X, Y, Z] to complete your reference files. Can you share those?"
+> "Got it. I still need [X, Y, Z] to complete your core files. Can you share those?"
 
 **Only say "we have enough" when you can fill:**
 - offer.md (price, mechanism, deliverables, guarantee)
@@ -172,7 +172,7 @@ See **[references/context-gathering.md](references/context-gathering.md)** for:
 # Always create:
 mkdir -p .vip
 mkdir -p core core/offers core/finance core/brand core/proof/angles core/operations
-mkdir -p research decisions bets log campaigns documents
+mkdir -p research decisions bets log pushes documents
 ```
 
 Do not create a canonical `reference/` folder in new repos. If an old repo
@@ -234,8 +234,8 @@ Full structure (single-offer):
 │
 ├── log/                   # Running activity log
 │
-└── campaigns/             # Campaign work and generated campaign artifacts
-    └── YYYY-MM-DD-batch-name/
+└── pushes/                # Coordinated pushes and their artifacts
+    └── YYYY-MM-DD-push-name/
 ```
 
 Full structure (multi-offer — adds offer folders and `product-ladder.md`):
@@ -265,7 +265,7 @@ Run these steps in order: create env.sh, add shell source line, create config.ya
 
 ### 5. Sort Content into Files
 
-**The repo is a precision instrument, not a dumping ground.** Not everything the user provides makes it into reference files. Filter for what helps LLMs produce great outputs.
+**The repo is a precision instrument, not a dumping ground.** Not everything the user provides makes it into core files. Filter for what helps LLMs produce great outputs.
 
 Use templates from `references/templates.md`.
 
@@ -404,13 +404,13 @@ Once setup is complete, tell the user:
 >
 > **Key skills to try:**
 > - `/mb-think` — Research topics, make decisions, update reference
-> - `/mb-think` — Build your content strategy (pillars, platforms, cadence) — start here after core reference is solid
+> - `/mb-think` — Build your content strategy (pillars, platforms, cadence) — start here after core files are solid
 > - `/mb-ads` — Generate image ads, video scripts, or review for compliance
 > - `/mb-vsl` — Write video sales letters (Skool or B2B)
 > - `/mb-organic` — Create social content aligned to your content pillars
 > - `/mb-help` — Get answers anytime you're stuck
 >
-> **The core loop:** Use `/mb-think` regularly. Research → Decide → Codify. This is how your reference files get smarter over time.
+> **The core loop:** Use `/mb-think` regularly. Research → Decide → Codify. This is how your core files get smarter over time.
 >
 > **Remember:** Type `/mb-help` + your question anytime. It has comprehensive answers about Terminal basics, the two-repo model, skills, troubleshooting, and more."
 

--- a/.claude/skills/mb-setup/references/context-gathering.md
+++ b/.claude/skills/mb-setup/references/context-gathering.md
@@ -124,6 +124,6 @@ Only say "we have enough" when you can fill:
 | domain/ | Business-type specific structure |
 
 After each batch of content, assess gaps:
-> "Got it. I still need [X, Y, Z] to complete your reference files. Can you share those?"
+> "Got it. I still need [X, Y, Z] to complete your core files. Can you share those?"
 
 Keep asking until YOU determine completeness. Users will provide in batches — that's normal.

--- a/.claude/skills/mb-setup/references/file-education.md
+++ b/.claude/skills/mb-setup/references/file-education.md
@@ -58,7 +58,7 @@ For multi-offer setups, also explain:
 
 ## Visual Style Scaffolding
 
-After core reference is drafted, ask 3 quick questions to seed `visual-style.md`:
+After core files are drafted, ask 3 quick questions to seed `visual-style.md`:
 
 1. "What's your brand's visual mood?" (minimal/bold/editorial/playful/dark)
 2. "What are your brand colors?" (hex codes or descriptions)

--- a/.claude/skills/mb-setup/references/repo-scaffolding.md
+++ b/.claude/skills/mb-setup/references/repo-scaffolding.md
@@ -181,21 +181,27 @@ EOF
 ```bash
 GITIGNORE="$REPO_PATH/.gitignore"
 
-if ! grep -q "MAIN BRANCH BRIDGE LINKS" "$GITIGNORE" 2>/dev/null; then
+ensure_gitignore_entry() {
+  entry="$1"
+  grep -qxF "$entry" "$GITIGNORE" 2>/dev/null || echo "$entry" >> "$GITIGNORE"
+}
+
+if ! grep -q "MAIN BRANCH MACHINE-LOCAL" "$GITIGNORE" 2>/dev/null; then
   cat >> "$GITIGNORE" << 'GITIGNORE_BLOCK'
 
-# === MAIN BRANCH BRIDGE LINKS (machine-local, do not commit) ===
-.claude/settings.local.json
-.claude/worktrees/
+# === MAIN BRANCH MACHINE-LOCAL (do not commit) ===
 GITIGNORE_BLOCK
-
-  # Add each Main Branch skill symlink individually (preserves custom skill tracking)
-  for d in "$ENGINE_PATH"/.claude/skills/*/; do
-    [ -d "$d" ] || continue
-    n=$(basename "$d")
-    echo ".claude/skills/$n" >> "$GITIGNORE"
-  done
 fi
+
+ensure_gitignore_entry ".claude/settings.local.json"
+ensure_gitignore_entry ".claude/worktrees/"
+
+# Add each Main Branch skill symlink individually (preserves custom skill tracking)
+for d in "$ENGINE_PATH"/.claude/skills/*/; do
+  [ -d "$d" ] || continue
+  n=$(basename "$d")
+  ensure_gitignore_entry ".claude/skills/$n"
+done
 ```
 
 **Why `.claude/settings.local.json` is git-ignored:** Claude Code auto-ignores this file, but we add it explicitly for safety. It contains machine-specific absolute paths to Main Branch (`additionalDirectories`) that differ per computer.

--- a/.claude/skills/mb-setup/references/repo-scaffolding.md
+++ b/.claude/skills/mb-setup/references/repo-scaffolding.md
@@ -185,8 +185,8 @@ if ! grep -q "MAIN BRANCH BRIDGE LINKS" "$GITIGNORE" 2>/dev/null; then
   cat >> "$GITIGNORE" << 'GITIGNORE_BLOCK'
 
 # === MAIN BRANCH BRIDGE LINKS (machine-local, do not commit) ===
-.claude/lenses/
-.claude/reference/
+.claude/settings.local.json
+.claude/worktrees/
 GITIGNORE_BLOCK
 
   # Add each Main Branch skill symlink individually (preserves custom skill tracking)
@@ -200,6 +200,6 @@ fi
 
 **Why `.claude/settings.local.json` is git-ignored:** Claude Code auto-ignores this file, but we add it explicitly for safety. It contains machine-specific absolute paths to Main Branch (`additionalDirectories`) that differ per computer.
 
-**Why per-skill entries (not `.claude/skills/`):** Users have custom skills (deck, pr-review, etc.) that ARE tracked in git. Ignoring the whole folder would hide those. We only ignore the Main Branch-linked symlinks. `.claude/lenses/` and `.claude/reference/` are blanket-ignored because they're 100% Main Branch content; no user files live there.
+**Why per-skill entries (not `.claude/skills/`):** Users have custom skills (deck, pr-review, etc.) that ARE tracked in git. Ignoring the whole folder would hide those. We only ignore the Main Branch-linked symlinks. Old clone-based `.claude/lenses/` and `.claude/reference/` dirs are legacy link dirs; repair them with `mb doctor repair` instead of teaching them as current setup.
 
 **Why `.vip/local.yaml` is git-ignored:** It stores session state like `current_offer` -- which offer you're working on right now. This is per-machine, per-session. The git-tracked `.vip/config.yaml` holds team/business settings that should be shared.

--- a/.claude/skills/mb-setup/references/templates.md
+++ b/.claude/skills/mb-setup/references/templates.md
@@ -588,7 +588,7 @@ It uses [Main Branch](https://github.com/noontide-co/mainbranch) as the **engine
 
 ```
 ENGINE (mainbranch)     +     DATA (this repo)     =     OUTPUT
-├── Skills                             ├── reference/            ├── Ads
+├── Skills                             ├── core/                 ├── Ads
 ├── Lenses                             ├── research/             ├── Emails
 └── Pull updates, don't edit           └── You own this          └── Content
 ```

--- a/.claude/skills/mb-site/SKILL.md
+++ b/.claude/skills/mb-site/SKILL.md
@@ -89,7 +89,7 @@ Use [`references/site-repo-workflow.md`](references/site-repo-workflow.md).
 - **Business repo mode:** CWD has `core/` or legacy `reference/core/`. Say: "I'm reading business context here and will create or select a site repo."
 - **Site repo mode:** CWD has `.mainbranch/source.json`. Say: "I'm editing the site here and reading business context from the linked business repo."
 
-Business repo mode plans, researches, drafts the brief, picks an offer, records campaign state, and creates or selects the site repo. Site repo mode edits code, reviews pages, previews, deploys, and runs `mb site check`.
+Business repo mode plans, researches, drafts the brief, picks an offer, records push/site state, and creates or selects the site repo. Site repo mode edits code, reviews pages, previews, deploys, and runs `mb site check`.
 
 ## Triage
 

--- a/.claude/skills/mb-site/references/site-repo-workflow.md
+++ b/.claude/skills/mb-site/references/site-repo-workflow.md
@@ -13,10 +13,10 @@ claude
 ```
 
 Use this mode to read business context, pick the offer, draft the site brief,
-create or select the site repo, and record campaign/site state.
+create or select the site repo, and record push/site state.
 
 The business repo keeps durable truth: offer, audience, voice, research,
-briefs, campaign records, measurement state, launch status, and manual approval
+briefs, push records, measurement state, launch status, and manual approval
 notes.
 
 ## Site Repo Mode
@@ -64,7 +64,8 @@ include:
 - site repo path or GitHub URL;
 - deployed URL and domain;
 - Cloudflare project and environment;
-- offer path and campaign path;
+- offer path and push path (the JSON key may still be `campaign_path` for
+  compatibility);
 - measurement state from `mb site check`;
 - launch status and next manual approval step.
 

--- a/.claude/skills/mb-skill-review/references/review.md
+++ b/.claude/skills/mb-skill-review/references/review.md
@@ -59,7 +59,7 @@ Operators extend with their own sweeps by dropping `.md` files in their business
 
 ```
 your-business-repo/
-└── reference/review/
+└── core/review/
     ├── compliance-tier-1.md
     └── on-brand-tone.md
 ```

--- a/.claude/skills/mb-skill-review/references/review.md
+++ b/.claude/skills/mb-skill-review/references/review.md
@@ -59,7 +59,7 @@ Operators extend with their own sweeps by dropping `.md` files in their business
 
 ```
 your-business-repo/
-└── core/review/
+└── core/operations/review/
     ├── compliance-tier-1.md
     └── on-brand-tone.md
 ```

--- a/.claude/skills/mb-start/SKILL.md
+++ b/.claude/skills/mb-start/SKILL.md
@@ -132,7 +132,7 @@ Apply to: business repo selection, skill routing, any multiple choice.
 ├── Pull business repo updates ───────→ (your repo, silently)
 │
 ├── Onboarding progress check ────────→ Use status onboarding facts
-│   ├── missing core reference? ──────→ collect only current missing inputs
+│   ├── missing core files? ──────────→ collect only current missing inputs
 │   └── complete? ───────────────────→ continue to readiness/menu
 │
 ├── Offer detection ──────────────────→ (multi-offer only, see Step 8)
@@ -256,7 +256,7 @@ Use the JSON envelope as the source of truth for onboarding progress:
 
 If `core_reference` is pending, collect only enough to draft the missing core
 files. Do not ask for full finances, credentials, raw customer/member exports,
-or exhaustive operations details before the core reference exists.
+or exhaustive operations details before the core files exist.
 
 If the user's team size or current success stage is missing, ask briefly and
 update the plan:
@@ -331,7 +331,7 @@ See [readiness-assessment.md](references/readiness-assessment.md) for complete s
 
 ### Quick summary:
 
-1. **Score reference files** (soul, offer, audience, voice, testimonials, angles) on 0-3 scale each. Composite max = 18. Multi-offer: score active offer's files, not just core.
+1. **Score core files** (soul, offer, audience, voice, testimonials, angles) on 0-3 scale each. Composite max = 18. Multi-offer: score active offer's files, not just core.
 2. **Check session state** — status journal activity, open decisions, uncodified research. Surface what's in progress.
 3. **Soul health check** — for returning users (last commit >3 days ago), read soul.md and ask: "Is your current work feeling like pull or push?" Skip for active or first-time users.
 4. **Gate routing** based on composite score:
@@ -356,7 +356,7 @@ Adapt display to `user.experience` level (beginner = full breakdown, advanced = 
 
 **What main knows after Step 6:** Readiness scores, which files exist, composite score, gaps. That's enough to present the menu and gate routing.
 
-**Exception:** Read `[repo]/CLAUDE.md` (the business brain) — it's small and needed for personality/routing awareness. Skip the 4 core reference files.
+**Exception:** Read `[repo]/CLAUDE.md` (the business brain) — it's small and needed for personality/routing awareness. Skip the 4 full core files.
 
 **Multi-offer context:** If `current_offer` is set (see Step 8), note the active offer for routing. Don't load the offer file — the selected skill will.
 

--- a/.claude/skills/mb-start/references/auto-heal.md
+++ b/.claude/skills/mb-start/references/auto-heal.md
@@ -68,24 +68,16 @@ If empty: `settings.local.json` is missing or doesn't point to Main Branch. Tell
 
 ---
 
-## Step 2: Create bridge links
+## Step 2: Create skill bridge links
 
 ```bash
-mkdir -p "$REPO_PATH/.claude/skills" "$REPO_PATH/.claude/lenses" "$REPO_PATH/.claude/reference"
+mkdir -p "$REPO_PATH/.claude/skills"
 
 # Per-skill symlinks (preserves local custom skills)
 for d in "$ENGINE_PATH"/.claude/skills/*/; do
   [ -d "$d" ] || continue
   n=$(basename "$d")
   [ -e "$REPO_PATH/.claude/skills/$n" ] || ln -s "$d" "$REPO_PATH/.claude/skills/$n"
-done
-
-# Per-entry lenses and reference
-for p in "$ENGINE_PATH"/.claude/lenses/* "$ENGINE_PATH"/.claude/reference/*; do
-  [ -e "$p" ] || continue
-  base=$(basename "$p")
-  parent=$(basename "$(dirname "$p")")
-  [ -e "$REPO_PATH/.claude/$parent/$base" ] || ln -s "$p" "$REPO_PATH/.claude/$parent/$base"
 done
 ```
 
@@ -103,8 +95,8 @@ if ! grep -q "MAIN BRANCH BRIDGE LINKS" "$GITIGNORE" 2>/dev/null; then
   cat >> "$GITIGNORE" << 'GITIGNORE_BLOCK'
 
 # === MAIN BRANCH BRIDGE LINKS (machine-local, do not commit) ===
-.claude/lenses/
-.claude/reference/
+.claude/settings.local.json
+.claude/worktrees/
 GITIGNORE_BLOCK
 
   # Add each Main Branch skill symlink individually (preserves custom skill tracking)

--- a/.claude/skills/mb-start/references/auto-heal.md
+++ b/.claude/skills/mb-start/references/auto-heal.md
@@ -85,32 +85,39 @@ done
 
 ## Step 2.5: Update .gitignore
 
-Bridge links are machine-local symlinks — they must not be committed. After creating links, ensure `.gitignore` covers them.
+Main Branch machine-local files and skill bridge links must not be committed.
+After creating links, ensure `.gitignore` covers only missing entries.
 
 ```bash
 GITIGNORE="$REPO_PATH/.gitignore"
 
-# Add marker + entries if not already present
-if ! grep -q "MAIN BRANCH BRIDGE LINKS" "$GITIGNORE" 2>/dev/null; then
+ensure_gitignore_entry() {
+  entry="$1"
+  grep -qxF "$entry" "$GITIGNORE" 2>/dev/null || echo "$entry" >> "$GITIGNORE"
+}
+
+if ! grep -q "MAIN BRANCH MACHINE-LOCAL" "$GITIGNORE" 2>/dev/null; then
   cat >> "$GITIGNORE" << 'GITIGNORE_BLOCK'
 
-# === MAIN BRANCH BRIDGE LINKS (machine-local, do not commit) ===
-.claude/settings.local.json
-.claude/worktrees/
+# === MAIN BRANCH MACHINE-LOCAL (do not commit) ===
 GITIGNORE_BLOCK
-
-  # Add each Main Branch skill symlink individually (preserves custom skill tracking)
-  for d in "$ENGINE_PATH"/.claude/skills/*/; do
-    [ -d "$d" ] || continue
-    n=$(basename "$d")
-    echo ".claude/skills/$n" >> "$GITIGNORE"
-  done
 fi
+
+ensure_gitignore_entry ".claude/settings.local.json"
+ensure_gitignore_entry ".claude/worktrees/"
+
+# Add each Main Branch skill symlink individually (preserves custom skill tracking)
+for d in "$ENGINE_PATH"/.claude/skills/*/; do
+  [ -d "$d" ] || continue
+  n=$(basename "$d")
+  ensure_gitignore_entry ".claude/skills/$n"
+done
 ```
 
 **Why per-skill entries (not `.claude/skills/`):** Users have custom skills (deck, pr-review, etc.) that ARE tracked. Ignoring the whole folder would hide those. We only ignore the Main Branch-linked ones.
 
-**Idempotent:** The marker check (`MAIN BRANCH BRIDGE LINKS`) prevents duplicate entries on repeated heals.
+**Idempotent:** Every entry is checked before appending so freshly templated
+repos do not duplicate existing `.gitignore` lines.
 
 ---
 

--- a/.claude/skills/mb-start/references/config-system.md
+++ b/.claude/skills/mb-start/references/config-system.md
@@ -48,11 +48,12 @@ business-repo/.claude/
 │   ├── mb-start -> /path/to/mainbranch/.claude/skills/mb-start
 │   ├── mb-ads   -> /path/to/mainbranch/.claude/skills/mb-ads
 │   └── ... (only missing entries linked)
-├── lenses/                   # real local folder; missing Main Branch entries linked
-└── reference/                # real local folder; missing Main Branch entries linked
 ```
 
-Created by `mb skill link` and `/mb-setup`. `/mb-start` can auto-repair missing links.
+Created by `mb skill link` and `/mb-setup`. `/mb-start` can auto-repair missing
+links. Old clone-based repos may also have `.claude/lenses/` or
+`.claude/reference/` symlinks; those are legacy link dirs that `mb doctor
+repair` can move to backup when they point at stale engine clones.
 
 **Both are needed:**
 - `additionalDirectories` = file access (reading reference files across repos)

--- a/.claude/skills/mb-think/references/research-architecture.md
+++ b/.claude/skills/mb-think/references/research-architecture.md
@@ -307,7 +307,7 @@ Always available (no external dependencies)
 
 1. Search research/ for topic
 2. Search decisions/ for related choices
-3. Search reference/ for current state
+3. Search core/ for current evergreen business state
 4. Synthesize findings
 5. Save to: research/YYYY-MM-DD-topic-claude-code.md
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,9 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   technical repair results in business-owner language. Refs #353.
 - Hardened old-layout migration output so dry-runs show safe next commands,
   planned backup location, and source-to-target conflict context before apply;
-  refreshed docs and bundled skill guidance away from current `reference/` and
-  `campaigns/` write targets. Refs #284.
+  bumped the migration JSON envelope schema to v2 for the new per-action
+  `backup` and `next` fields; refreshed docs and bundled skill guidance away
+  from current `reference/` and `campaigns/` write targets. Refs #284.
 - Documented the public build-vs-wrap-vs-sidecar boundary for provider CLIs,
   MCP servers, hosted workflows, and future sidecars, with concrete guidance
   for Cloudflare, Postiz, Apify/X research, Vercel-style platforms,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   Claude Code is told to read `mb` status/start/doctor facts before setup or
   repair advice, separate read-only checks from write/apply repairs, and return
   technical repair results in business-owner language. Refs #353.
+- Hardened old-layout migration output so dry-runs show safe next commands,
+  planned backup location, and source-to-target conflict context before apply;
+  refreshed docs and bundled skill guidance away from current `reference/` and
+  `campaigns/` write targets. Refs #284.
 - Documented the public build-vs-wrap-vs-sidecar boundary for provider CLIs,
   MCP servers, hosted workflows, and future sidecars, with concrete guidance
   for Cloudflare, Postiz, Apify/X research, Vercel-style platforms,

--- a/decisions/2026-05-02-github-native-business-os.md
+++ b/decisions/2026-05-02-github-native-business-os.md
@@ -60,7 +60,11 @@ The git repo remains the source of truth:
 - `core/` for evergreen reference;
 - `research/` for investigations;
 - `decisions/` for choices and rationale;
-- `campaigns/`, `log/`, `documents/`, and finance files for operating history.
+- `bets/`, `pushes/`, `log/`, `documents/`, and finance files for operating
+  history.
+
+Legacy `campaigns/` records are compatibility reads after the push primitive
+decision; new coordinated work belongs under `pushes/`.
 
 Markdown stays human-readable. Git history stays inspectable. No database
 replaces the files.

--- a/decisions/2026-05-04-skill-cli-runtime-adapter-contract.md
+++ b/decisions/2026-05-04-skill-cli-runtime-adapter-contract.md
@@ -160,8 +160,9 @@ Lifecycle skills are the session and setup surface. They should be thin over
 Lifecycle skills should prioritize resumability. `/mb-start` and `/mb-setup`
 must use `mb onboard status --json` when onboarding may be incomplete. The
 progress file is operational state, not business truth; accepted business truth
-still belongs in `core/`, `research/`, `decisions/`, `campaigns/`, `log/`, or
-`documents/`.
+still belongs in `core/`, `research/`, `decisions/`, `bets/`, `pushes/`, `log/`,
+or `documents/`. Legacy `campaigns/` records remain compatibility reads, not
+the current write target for coordinated work.
 
 ## Production Skill Audit
 

--- a/decisions/2026-05-05-operator-readable-git-history.md
+++ b/decisions/2026-05-05-operator-readable-git-history.md
@@ -136,7 +136,7 @@ object gives a stronger signal, but it should start here.
 as `[fixed] checkout copy -- clarified guarantee`. For grouping, tooling should
 prefer stronger path signals over the row default. Path and body signals
 should reclassify by default: `core/` and `research/` usually map to Sense,
-accepted `decisions/` and opened `bets/` map to Decide, `campaigns/` and
+accepted `decisions/` and opened `bets/` map to Decide, `pushes/` and
 published artifacts map to Ship, and bet verdicts, retros, superseded
 decisions, and lessons map to Reflect.
 
@@ -150,7 +150,7 @@ Preferred body sections:
 ```text
 Changed:
 - core/offers/workshop.md
-- campaigns/workshop-waitlist/ads.md
+- pushes/2026-05-06-workshop-waitlist/ads.md
 
 Why:
 - Captures the next paid-traffic test before site generation starts.

--- a/decisions/2026-05-06-business-repo-folder-model-reference-deprecation.md
+++ b/decisions/2026-05-06-business-repo-folder-model-reference-deprecation.md
@@ -41,7 +41,7 @@ core/
 research/
 decisions/
 bets/
-campaigns/
+pushes/
 log/
 documents/
 ```
@@ -80,10 +80,11 @@ review. Automated migration can safely move general operating context under
 `core/operations/`; offer-specific promotion remains a human/agent judgment.
 
 `outputs/` is also legacy product language for generated work. Current
-campaign and production artifacts should live under `campaigns/` when they are
-campaign work, or under a more specific durable folder when another surface
+coordinated production artifacts should live under `pushes/` when they belong
+to a named push, or under a more specific durable folder when another surface
 owns the artifact. Old `outputs/` content should be read as historical work,
-not as the default write target for new skills.
+not as the default write target for new skills. Legacy `campaigns/` records
+remain compatibility reads under the later push primitive decision.
 
 ## Compatibility
 

--- a/docs/BEGINNER-SETUP.md
+++ b/docs/BEGINNER-SETUP.md
@@ -202,7 +202,14 @@ mb doctor
 ```
 
 For old `reference/core/` repos, read [MIGRATING.md](MIGRATING.md). You usually
-do not need to move files immediately.
+do not need to move files immediately. When you are ready, run the dry-run first:
+
+```bash
+mb migrate --check
+```
+
+Only run `mb migrate --apply` after the dry-run shows the old paths, move
+targets, backup location, and no conflicts.
 
 ### Already Using The Old Setup?
 
@@ -213,7 +220,9 @@ and paste:
 I want to migrate my existing Main Branch setup to the current pipx + /mb-start
 workflow. Please run read-only checks first, find my likely business repos,
 show me the exact commands you recommend, and ask before running anything that
-writes files. Use docs/MIGRATING.md as the source of truth.
+writes files. If an old `reference/` layout is present, run `mb migrate --check`
+first and do not run `mb migrate --apply` until I approve the dry-run. Use
+docs/MIGRATING.md as the source of truth.
 ```
 
 Claude may ask you to restart in a business repo after it repairs skill

--- a/docs/MIGRATING.md
+++ b/docs/MIGRATING.md
@@ -388,6 +388,13 @@ files, moves legacy core files into `core/`, moves legacy offer files into
 contents, apply refuses before writing and tells you to reconcile the conflict
 through another dry-run.
 
+Repos migrated by an earlier Main Branch release may already have
+`.mb/schema_version` set and a legacy empty `campaigns/` compatibility folder.
+The schema marker intentionally prevents rerunning the old layout migration.
+Those repos should add `pushes/` with `mb doctor repair` or normal current
+scaffolding, and should preview any existing campaign records separately with
+`mb migrate campaigns --plan`.
+
 Those compatibility links exist so older readers keep working. Current skills
 and agents should treat `core/` and `core/offers/` as the write targets.
 

--- a/docs/MIGRATING.md
+++ b/docs/MIGRATING.md
@@ -2,8 +2,9 @@
 
 Main Branch has two repo shapes in the wild:
 
-- **Legacy shape:** `reference/core/`, `reference/domain/`,
-  `reference/proof/`, `reference/visual-identity/`, and `outputs/`.
+- **Legacy shape:** old clone-era folders such as `reference/core/`,
+  `reference/domain/`, `reference/proof/`, `reference/visual-identity/`, and
+  generated `outputs/`.
 - **Current shape:** `core/`, `research/`, `decisions/`, `bets/`, `log/`,
   `pushes/`, and `documents/`. `reference/` is compatibility-only for old
   repos and old readers; `campaigns/` is also compatibility-only and
@@ -334,7 +335,7 @@ mb migrate --repo /path/to/your-business status
 mb migrate status --repo /path/to/your-business
 ```
 
-Preview the filesystem changes:
+Preview the filesystem changes before any layout write:
 
 ```bash
 mb migrate --check
@@ -344,28 +345,48 @@ mb migrate --check --json
 By default, `--check` is privacy-safe: it prints path/action summaries and JSON
 counts without embedding full file bodies from your legacy reference files.
 Those files can contain private strategy, proof, offer details, or customer
-language. Only print the full unified diff when it will stay local:
+language. It also tells you:
+
+- which old paths were found;
+- where each file would move;
+- whether a current-path file already exists with different contents;
+- whether manual reconciliation is required before apply;
+- that apply will create a timestamped backup under `.mb/backups/`;
+- the exact next command that is safe to run.
+
+If `--check` reports a conflict, stop. Do not run `--apply`. Open the current
+path and the old `reference/` source, decide which content should win, make that
+edit intentionally, and rerun:
+
+```bash
+mb migrate --check
+```
+
+Only print the full unified diff when it will stay local:
 
 ```bash
 mb migrate --check --diff
 mb migrate --check --diff --json
 ```
 
-`--check` exits non-zero when migrations are pending so scripts and agents can
-detect drift without writing files. The path migration ignores local OS metadata
-such as `.DS_Store`, `Thumbs.db`, `Desktop.ini`, and AppleDouble `._*` files.
+`--check` exits non-zero when migrations are pending or blocked so scripts and
+agents can detect drift without writing files. The path migration ignores local
+OS metadata such as `.DS_Store`, `Thumbs.db`, `Desktop.ini`, and AppleDouble
+`._*` files.
 
-Apply only after reading the diff:
+Apply only after reading the dry-run and confirming it is the move you want:
 
 ```bash
 mb migrate --apply
 ```
 
-`--apply` creates a repo-local backup under `.mb/backups/` before changing files,
-moves legacy core files into `core/`, moves legacy offer files into
+`--apply` creates a repo-local backup under `.mb/backups/` before changing
+files, moves legacy core files into `core/`, moves legacy offer files into
 `core/offers/`, leaves compatibility links under `reference/`, updates stale
 `CLAUDE.md` path references, writes a migration decision artifact, and stamps
-`.mb/schema_version`.
+`.mb/schema_version`. If a current-path file already exists with different
+contents, apply refuses before writing and tells you to reconcile the conflict
+through another dry-run.
 
 Those compatibility links exist so older readers keep working. Current skills
 and agents should treat `core/` and `core/offers/` as the write targets.
@@ -390,8 +411,10 @@ skill behavior, write paths, or runtime discovery.
 
 ## Manual Layout Migration
 
-The automated command above is preferred. Keep this manual process only as a
-fallback when you need to inspect or repair a repo by hand.
+The automated command above is preferred because it reports conflicts and
+creates backups before mutation. Keep this manual process only as a power-user
+fallback when `mb migrate --check` cannot model the repo and you need to inspect
+or repair a copy by hand.
 
 Only do this on a clean branch with everything committed:
 
@@ -401,23 +424,60 @@ git status --short
 git switch -c migrate-mainbranch-layout
 ```
 
-For repos with `reference/core/`, move the core files to the current root
-`core/` folder and leave a compatibility link behind:
+Create your own backup first. Do not delete or overwrite current-path files
+while doing a manual migration:
+
+```bash
+mkdir -p .mb/backups
+cp -a reference ".mb/backups/manual-reference-$(date +%Y%m%d-%H%M%S)"
+```
+
+For repos with old `reference/core/`, inspect the move first:
+
+```bash
+find reference/core -maxdepth 1 -type f -print
+find core -maxdepth 1 -type f -print 2>/dev/null || true
+```
+
+If a destination file already exists, reconcile it manually before moving the
+old source. Only move files when the target path is empty or you have already
+merged the content:
 
 ```bash
 mkdir -p core
-git mv reference/core/* core/
-rmdir reference/core
-ln -s ../core reference/core
+for file in reference/core/*; do
+  [ -e "$file" ] || continue
+  target="core/$(basename "$file")"
+  if [ -e "$target" ]; then
+    echo "conflict: $file -> $target"
+  else
+    git mv "$file" "$target"
+  fi
+done
 ```
 
-For repos with `reference/offers/`, do the same for offer-specific files:
+For repos with old `reference/offers/`, do the same for offer-specific files:
 
 ```bash
 mkdir -p core/offers
-git mv reference/offers/* core/offers/
-rmdir reference/offers
-ln -s ../core/offers reference/offers
+for file in reference/offers/*; do
+  [ -e "$file" ] || continue
+  target="core/offers/$(basename "$file")"
+  if [ -e "$target" ]; then
+    echo "conflict: $file -> $target"
+  else
+    git mv "$file" "$target"
+  fi
+done
+```
+
+After every conflict is resolved and the old folders are empty, leave
+compatibility links behind:
+
+```bash
+rmdir reference/core reference/offers 2>/dev/null || true
+[ -e reference/core ] || ln -s ../core reference/core
+[ -e reference/offers ] || ln -s ../core/offers reference/offers
 ```
 
 Then add the current empty working folders:

--- a/docs/OSS-OPERATING-CHECKLIST.md
+++ b/docs/OSS-OPERATING-CHECKLIST.md
@@ -48,7 +48,7 @@ that keep Main Branch usable as public infrastructure while it evolves quickly.
 ## 4. State Model
 
 - [ ] Canonical business truth stays in the business repo and git history:
-  reference files, research, decisions, plans, campaign artifacts, durable
+  core files, research, decisions, bets, pushes, logs, documents, durable
   summaries, and proposal changes.
 - [ ] `.mb/` is used only for explicit Main Branch operational state such as
   schema markers, repo-safe connection metadata, backups, indexes, or caches.

--- a/docs/onboarding-progress.md
+++ b/docs/onboarding-progress.md
@@ -53,7 +53,7 @@ mb onboard plan \
   --team-size solo \
   --business-type coaching \
   --success-stage working \
-  --desired-outcome "usable core reference"
+  --desired-outcome "usable core files"
 ```
 
 `mb onboard` also writes the initial plan when it creates or connects a repo.
@@ -78,11 +78,11 @@ surface.
 Manual runtime smoke for onboarding resume:
 
 1. create a fresh repo with `mb onboard --yes --name "Smoke Business" --path /tmp/mainbranch-onboard-smoke`;
-2. run `mb onboard plan --repo /tmp/mainbranch-onboard-smoke --team-size small-team --business-type agency --success-stage working --desired-outcome "usable core reference"`;
+2. run `mb onboard plan --repo /tmp/mainbranch-onboard-smoke --team-size small-team --business-type agency --success-stage working --desired-outcome "usable core files"`;
 3. `cd /tmp/mainbranch-onboard-smoke`;
 4. run `mb onboard status --json` and confirm missing core inputs are reported;
 5. launch `claude`;
 6. run `/mb-start`;
 7. verify `/mb-start` uses `mb onboard status --json` to resume and does not ask
    for full finances, credentials, or exhaustive operations details before the
-   core reference exists.
+   core files exist.

--- a/docs/prd/v0-2-first-run-daily-briefing.md
+++ b/docs/prd/v0-2-first-run-daily-briefing.md
@@ -216,7 +216,7 @@ Required sections:
   - skill wiring found/missing;
   - suggested repair command.
 - Brain:
-  - counts for core, research, decisions, campaigns/log/documents;
+  - counts for core, research, decisions, pushes, legacy campaigns, log, and documents;
   - recent research;
   - recent decisions;
   - stale proposed/running decisions if detectable.

--- a/mb/mb/migrate.py
+++ b/mb/mb/migrate.py
@@ -17,7 +17,7 @@ from mb import migrations
 from mb.migrations.base import MigrationInfo, MigrationPlan, PlannedChange
 
 ENVELOPE_SCHEMA = "mb.migrate"
-ENVELOPE_SCHEMA_VERSION = 1
+ENVELOPE_SCHEMA_VERSION = 2
 LATEST_SCHEMA_VERSION = "0.2"
 SCHEMA_MARKER = ".mb/schema_version"
 BACKUPS_GITIGNORE_ENTRY = ".mb/backups/"

--- a/mb/mb/migrate.py
+++ b/mb/mb/migrate.py
@@ -180,9 +180,51 @@ def _plan_dict(plan: MigrationPlan) -> dict[str, Any]:
     }
 
 
+def _plan_has_changes(plans: list[MigrationPlan]) -> bool:
+    return any(plan.has_changes for plan in plans)
+
+
+def _backup_hint(plans: list[MigrationPlan]) -> dict[str, Any]:
+    return {
+        "will_create": bool(plans and _plan_has_changes(plans)),
+        "directory": ".mb/backups/",
+        "note": (
+            "`mb migrate --apply` creates a timestamped repo-local backup before changing files."
+        ),
+    }
+
+
+def _next_after_status(result: dict[str, Any]) -> str:
+    if result.get("pending"):
+        return "Run `mb migrate --check` to preview the migration before applying it."
+    return "No layout migration is pending."
+
+
+def _next_after_check(result: dict[str, Any]) -> str:
+    if result.get("errors"):
+        return (
+            "Do not apply yet. Reconcile the reported conflicts, then rerun `mb migrate --check`."
+        )
+    plan = result.get("plan") or {}
+    if plan.get("has_changes"):
+        return "Review this dry-run. If it matches the move you want, run `mb migrate --apply`."
+    return "No layout migration is pending."
+
+
+def _next_after_apply(result: dict[str, Any]) -> str:
+    if result.get("errors"):
+        return (
+            "No further migration writes are safe yet. Review the backup path if "
+            "one was created, reconcile the error, then rerun `mb migrate --check`."
+        )
+    if result.get("applied"):
+        return "Run `mb doctor`, `mb validate`, and `mb start --json` from the migrated repo."
+    return "No layout migration was applied."
+
+
 def _base_envelope(repo: Path, action: str) -> dict[str, Any]:
     pending = pending_migrations(repo)
-    return {
+    result = {
         "schema": ENVELOPE_SCHEMA,
         "schema_version": ENVELOPE_SCHEMA_VERSION,
         "ok": True,
@@ -195,7 +237,10 @@ def _base_envelope(repo: Path, action: str) -> dict[str, Any]:
         "applied": [],
         "backup": None,
         "errors": [],
+        "next": "",
     }
+    result["next"] = _next_after_status(result)
+    return result
 
 
 def status(repo: str | Path = ".") -> dict[str, Any]:
@@ -225,7 +270,9 @@ def check(repo: str | Path = ".", *, include_diff: bool = False) -> dict[str, An
         ),
         "errors": errors,
     }
+    result["backup"] = _backup_hint(plans)
     result["errors"] = errors
+    result["next"] = _next_after_check(result)
     return result
 
 
@@ -350,9 +397,11 @@ def apply(repo: str | Path = ".") -> dict[str, Any]:
     _ensure_gitignore_plan(target, plans)
     if result["errors"]:
         result["ok"] = False
+        result["next"] = _next_after_apply(result)
         return result
     if not plans:
         result["ok"] = True
+        result["next"] = _next_after_apply(result)
         return result
 
     backup_dir = _backup_path(target, [plan.migration.id for plan in plans])
@@ -371,6 +420,7 @@ def apply(repo: str | Path = ".") -> dict[str, Any]:
                 result["ok"] = False
                 result["errors"].append(str(exc))
                 result["backup"] = {"path": str(backup_dir), "copied": copied}
+                result["next"] = _next_after_apply(result)
                 return result
 
     marker = _marker_path(target)
@@ -382,6 +432,7 @@ def apply(repo: str | Path = ".") -> dict[str, Any]:
     result["pending"] = []
     result["applied"] = [_migration_dict(plan.migration) for plan in plans]
     result["backup"] = {"path": str(backup_dir), "copied": copied}
+    result["next"] = _next_after_apply(result)
     return result
 
 
@@ -394,39 +445,61 @@ def render_status(result: dict[str, Any]) -> None:
             print(f"  {item['id']} {item['name']} ({item['from_version']} -> {item['to_version']})")
     else:
         print("pending migrations: none")
+    if result.get("next"):
+        print(f"next: {result['next']}")
+
+
+def _render_plan_summary(plan: dict[str, Any]) -> None:
+    print("pending migration changes:")
+    for migration in plan.get("migrations", []):
+        info = migration["migration"]
+        print(f"  {info['id']} {info['name']} ({info['from_version']} -> {info['to_version']})")
+        for change in migration.get("changes", []):
+            detail = change.get("path") or change.get("target") or change.get("source")
+            if change.get("kind") == "move_file":
+                detail = f"{change.get('source')} -> {change.get('target')}"
+            print(f"    - {change.get('kind')}: {detail}")
 
 
 def render_check(result: dict[str, Any]) -> None:
     plan = result.get("plan") or {}
     errors = result.get("errors", [])
     if errors:
+        print("migration blocked; no files changed.")
         for error in errors:
             print(f"error: {error}")
+        if plan.get("has_changes"):
+            print()
+            _render_plan_summary(plan)
+        if result.get("next"):
+            print()
+            print(f"next: {result['next']}")
         return
     diff = str(plan.get("diff", ""))
     if diff:
         print(diff, end="")
     elif plan.get("has_changes"):
-        print("pending migration changes:")
-        for migration in plan.get("migrations", []):
-            info = migration["migration"]
-            print(f"  {info['id']} {info['name']} ({info['from_version']} -> {info['to_version']})")
-            for change in migration.get("changes", []):
-                detail = change.get("path") or change.get("target") or change.get("source")
-                if change.get("kind") == "move_file":
-                    detail = f"{change.get('source')} -> {change.get('target')}"
-                print(f"    - {change.get('kind')}: {detail}")
+        _render_plan_summary(plan)
         print()
         print(plan.get("privacy_note", "Full diffs are hidden by default."))
         print("Run `mb migrate --check --diff` to print the full unified diff locally.")
+        backup = result.get("backup") or {}
+        if backup.get("will_create"):
+            print(f"Backup on apply: {backup['directory']}")
+        if result.get("next"):
+            print(f"next: {result['next']}")
     else:
         print("no migrations pending")
+        if result.get("next"):
+            print(f"next: {result['next']}")
 
 
 def render_apply(result: dict[str, Any]) -> None:
     if result.get("errors"):
         for error in result["errors"]:
             print(f"error: {error}")
+        if result.get("next"):
+            print(f"next: {result['next']}")
         return
     applied = result.get("applied", [])
     if not applied:
@@ -437,6 +510,8 @@ def render_apply(result: dict[str, Any]) -> None:
     if backup.get("path"):
         print(f"backup: {backup['path']}")
     print(f"schema version: {result['current_version']}")
+    if result.get("next"):
+        print(f"next: {result['next']}")
 
 
 # ---------------------------------------------------------------------------

--- a/mb/mb/migrations/001_v01_to_v02_path_config.py
+++ b/mb/mb/migrations/001_v01_to_v02_path_config.py
@@ -26,7 +26,7 @@ CURRENT_DIRS = (
     "decisions",
     "bets",
     "log",
-    "campaigns",
+    "pushes",
     "documents",
 )
 LEGACY_TREE_MOVES = (
@@ -140,7 +140,10 @@ def _plan_move_tree(
                     PlannedChange(kind="delete_file", path=source_path, source=source_path)
                 )
                 continue
-            plan.errors.append(f"{target_path} already exists with different contents")
+            plan.errors.append(
+                f"{target_path} already exists with different contents "
+                f"(from {source_path}); manual reconciliation required"
+            )
             continue
         plan.changes.append(
             PlannedChange(
@@ -180,7 +183,10 @@ def _plan_move_file(repo: Path, plan: MigrationPlan, source_rel: str, target_rel
                 PlannedChange(kind="delete_file", path=source_rel, source=source_rel)
             )
             return
-        plan.errors.append(f"{target_rel} already exists with different contents")
+        plan.errors.append(
+            f"{target_rel} already exists with different contents "
+            f"(from {source_rel}); manual reconciliation required"
+        )
         return
     plan.changes.append(
         PlannedChange(kind="move_file", path=target_rel, source=source_rel, target=target_rel)

--- a/mb/mb/onboard.py
+++ b/mb/mb/onboard.py
@@ -33,7 +33,7 @@ BOUNDARIES = {
         "full finances or ledgers",
         "raw customer/member exports",
         "credentials, tokens, and private account secrets",
-        "exhaustive operations documentation outside the core reference",
+        "exhaustive operations documentation outside the core files",
     ],
 }
 
@@ -479,7 +479,7 @@ def _checklist(repo: Path, state: dict[str, Any], markers: dict[str, bool]) -> l
         ),
         _step(
             step_id="core_reference",
-            title="Core reference",
+            title="Core files",
             complete=not missing_core,
             missing_inputs=missing_core,
             next_action=(

--- a/mb/tests/test_migrate.py
+++ b/mb/tests/test_migrate.py
@@ -79,7 +79,7 @@ def test_migrate_status_reports_pending_legacy_schema(tmp_path: Path) -> None:
     assert result.exit_code == 0
     payload = json.loads(result.stdout)
     assert payload["schema"] == "mb.migrate"
-    assert payload["schema_version"] == 1
+    assert payload["schema_version"] == 2
     assert payload["current_version"] == "0.1"
     assert payload["latest_version"] == "0.2"
     assert payload["pending"][0]["name"] == "001_v01_to_v02_path_config"

--- a/mb/tests/test_migrate.py
+++ b/mb/tests/test_migrate.py
@@ -119,6 +119,7 @@ def test_migrate_check_diff_is_explicit(tmp_path: Path) -> None:
     assert "+++ b/core/content-strategy.md" in result.stdout
     assert "+++ b/core/product-ladder.md" in result.stdout
     assert "+++ b/core/operations/funnel/skool-surfaces.md" in result.stdout
+    assert "+++ b/campaigns/.gitkeep" not in result.stdout
     assert "+++ b/.gitignore" in result.stdout
     assert "+.mb/backups/" in result.stdout
     assert "+++ b/.mb/schema_version" in result.stdout
@@ -138,6 +139,14 @@ def test_migrate_check_json_exposes_same_plan(tmp_path: Path) -> None:
     assert payload["plan"]["diff"] == ""
     assert "Full file diffs are hidden by default" in payload["plan"]["privacy_note"]
     assert payload["plan"]["migrations"][0]["migration"]["id"] == "001"
+    changes = payload["plan"]["migrations"][0]["changes"]
+    assert {"kind": "mkdir", "path": "pushes", "source": "", "target": ""} in changes
+    assert not any(change["path"] == "campaigns" for change in changes)
+    assert payload["backup"]["will_create"] is True
+    assert payload["backup"]["directory"] == ".mb/backups/"
+    assert payload["next"] == (
+        "Review this dry-run. If it matches the move you want, run `mb migrate --apply`."
+    )
 
 
 def test_migrate_check_json_diff_is_explicit(tmp_path: Path) -> None:
@@ -199,6 +208,8 @@ def test_migrate_apply_moves_files_backs_up_and_is_idempotent(tmp_path: Path) ->
     assert (repo / "core" / "content-strategy.md").exists()
     assert (repo / "core" / "product-ladder.md").exists()
     assert (repo / "core" / "operations" / "funnel" / "skool-surfaces.md").exists()
+    assert (repo / "pushes" / ".gitkeep").exists()
+    assert not (repo / "campaigns").exists()
     assert (repo / "reference" / "core").is_symlink()
     assert (repo / "reference" / "offers").is_symlink()
     assert not (repo / "reference" / "proof").exists()
@@ -265,9 +276,32 @@ def test_migrate_apply_aborts_before_writes_on_conflict(tmp_path: Path) -> None:
     assert result.exit_code == 1
     payload = json.loads(result.stdout)
     assert payload["ok"] is False
-    assert "core/offer.md already exists with different contents" in payload["errors"]
+    assert any(
+        "core/offer.md already exists with different contents" in error
+        for error in payload["errors"]
+    )
+    assert any("from reference/core/offer.md" in error for error in payload["errors"])
+    assert "rerun `mb migrate --check`" in payload["next"]
     assert not (repo / ".mb" / "backups").exists()
     assert (repo / "reference" / "core" / "offer.md").exists()
+
+
+def test_migrate_check_conflict_renders_plan_and_safe_next_command(tmp_path: Path) -> None:
+    repo = _legacy_repo(tmp_path)
+    (repo / "core").mkdir()
+    (repo / "core" / "offer.md").write_text("# Different\n", encoding="utf-8")
+
+    result = runner.invoke(app, ["migrate", "--repo", str(repo), "--check"])
+
+    assert result.exit_code == 1
+    assert "migration blocked; no files changed." in result.stdout
+    assert (
+        "error: core/offer.md already exists with different contents "
+        "(from reference/core/offer.md); manual reconciliation required"
+    ) in result.stdout
+    assert "pending migration changes:" in result.stdout
+    assert "move_file: reference/core/audience.md -> core/audience.md" in result.stdout
+    assert "next: Do not apply yet." in result.stdout
 
 
 def test_migrate_apply_reports_structured_error_when_legacy_dir_is_not_empty(

--- a/mb/tests/test_onboard.py
+++ b/mb/tests/test_onboard.py
@@ -86,7 +86,7 @@ def test_onboard_connect_repairs_existing_initialized_repo(tmp_path: Path, monke
         team_size="solo",
         business_type="coaching",
         success_stage="working",
-        desired_outcome="usable core reference",
+        desired_outcome="usable core files",
     )
     settings = repo / ".claude" / "settings.local.json"
     settings.unlink()
@@ -174,7 +174,7 @@ def test_onboard_status_reports_partial_small_team_progress(tmp_path: Path, monk
         team_size="small-team",
         business_type="agency",
         success_stage="working",
-        desired_outcome="usable core reference",
+        desired_outcome="usable core files",
     )
     (repo / "core" / "offer.md").write_text("# Offer\n", encoding="utf-8")
 
@@ -202,7 +202,7 @@ def test_onboard_status_unknown_team_size_is_not_larger_team(tmp_path: Path, mon
         level="power",
         business_type="agency",
         success_stage="working",
-        desired_outcome="usable core reference",
+        desired_outcome="usable core files",
     )
 
     payload = onboard_mod.onboarding_status(repo)
@@ -234,7 +234,7 @@ def test_onboard_plan_updates_profile_without_raw_business_state(
             "--success-stage",
             "successful",
             "--desired-outcome",
-            "document the core reference",
+            "document the core files",
             "--json",
         ],
     )
@@ -288,7 +288,7 @@ def test_status_includes_onboarding_progress(tmp_path: Path, monkeypatch) -> Non
         team_size="solo",
         business_type="coaching",
         success_stage="working",
-        desired_outcome="usable core reference",
+        desired_outcome="usable core files",
     )
 
     report = status_mod.run(path=str(repo))


### PR DESCRIPTION
## Summary
- Hardens old-layout `mb migrate` output so operators see pending moves, conflict context, backup intent, and safe next commands before applying changes.
- Sweeps current docs, bundled skills, and onboarding guidance away from active `reference/` and `campaigns/` write targets while preserving legacy/backcompat language where it is still true.
- Updates setup and auto-heal gitignore guidance to use idempotent `MAIN BRANCH MACHINE-LOCAL` entries for Claude settings, worktrees, and skill bridge links.
- Moves current scaffolding and migration guidance toward `pushes/`, including notes for repos already marked migrated by an earlier release.

## Scope
In:
- Old-layout migration status/check/apply clarity, JSON schema v2, backup/next guidance, conflict reporting, and tests.
- Public docs, decisions, PR template, bundled skills, and onboarding copy that still taught `reference/` or `campaigns/` as current destinations.
- Idempotent machine-local `.gitignore` guidance for Claude Code bridge files.

Out:
- No campaign-to-push apply behavior for existing campaign records; that remains follow-up migration policy.
- No removal of legacy compatibility links or readers.
- No new business repo folder taxonomy beyond using the current documented paths.

## Commits
- `bc8ad49` — `[fix] MAIN-228 harden reference layout migration`
- `3d5be1e` — `[update] MAIN-228 sweep legacy path guidance`
- `0f642d2` — `[fix] MAIN-228 address review guidance`

## Release / Issues
- Release: v0.3.x daily-loop hardening
- Linear ID(s): MAIN-228
- Closes: #284
- Refs: #324
- Follow-ups: campaign-to-push apply policy remains outside this PR.

## Success Metric
- Users and agents see current `core/`, `research/`, `decisions/`, `bets/`, `pushes/`, `log/`, and `documents/` paths as the normal business repo shape, while old-layout migration remains explicit, non-destructive, and previewable.

## Validation
- Level 0 docs/decision: public docs, decisions, bundled skill references, and migration guidance reviewed for stale current-path claims and public/private boundary.
- Level 1 static: `scripts/check.sh` passed; `git diff --check` passed.
- Level 2 CLI: `python3 -m pytest tests/test_migrate.py -q` passed; earlier focused migrate/onboard/skill validation and old-layout fixture smoke passed.
- Level 3 package/install: not required; no packaging entrypoint or install flow changed.
- Level 4 fixture repo: old-layout fixture smoke passed with `mb migrate status`, `mb migrate --check`, `mb migrate --apply`, `mb validate`, and verified `pushes/` creation without fresh `campaigns/`.
- Level 5 runtime smoke: Claude Code print-mode dogfood proxy passed with `/mb-start` discovery evidence in `.context/runtime-dogfood-main-228`; interactive TUI smoke remains separate release-bearing evidence.

## Public / Private Boundary
- No private Devon/Conductor/runtime evidence was committed; runtime evidence stayed in gitignored `.context/`.
