### PR TITLE
[update] Prepare 0.3.7 release

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mainbranch",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Main Branch Claude Code skills for running a business from markdown files in git.",
   "author": {
     "name": "Noontide"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,26 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+## [0.3.7] - 2026-05-07
+
+v0.3.7 turns the new release discipline into something Main Branch can
+practice. Claude Code runtime dogfood now has an automated harness, release
+simulations turn real operator moments into reviewable evidence, generated
+business `CLAUDE.md` files push agents back through the CLI, and old-layout
+migration guidance is safer before it writes.
+
+### What this means for you (plain English)
+
+- **Claude gets stronger startup instructions.** Fresh business repos now tell
+  Claude Code to inspect `mb` facts before giving setup or repair advice.
+- **Releases have better evidence.** Main Branch can run a sanitized dogfood
+  harness and prompt simulation suite before claiming runtime behavior works.
+- **Migration is less surprising.** Old `reference/` and `campaigns/` guidance
+  has been swept toward the current folder model, and migration dry-runs now
+  show backups, conflicts, and safe next commands before apply.
+- **Provider choices are clearer.** The docs now explain when Main Branch
+  should wrap an existing CLI, call an MCP/server API, or build its own tool.
+
 ### Added
 
 - Added `scripts/claude-runtime-dogfood.py`, a repeatable Claude Code dogfood

--- a/mb/mb/__init__.py
+++ b/mb/mb/__init__.py
@@ -7,6 +7,6 @@ file stays a thin dispatcher.
 
 from __future__ import annotations
 
-__version__ = "0.3.6"
+__version__ = "0.3.7"
 
 __all__ = ["__version__"]

--- a/mb/pyproject.toml
+++ b/mb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mainbranch"
-version = "0.3.6"
+version = "0.3.7"
 description = "Main Branch engine umbrella - scaffolds, validates, and graphs business-as-files repos. Claude Code first, runtime-agnostic by design."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

- Bumps Main Branch package/plugin metadata to `0.3.7`.
- Promotes the merged post-0.3.6 work from `[Unreleased]` into a `0.3.7` changelog section.
- Frames the release around CLI-first Claude startup, automated dogfood evidence, release simulations, safer legacy migration guidance, and clearer provider build/wrap boundaries.

## Scope

In:
- `mb` package version.
- Claude plugin manifest version.
- `CHANGELOG.md` release section.

Out:
- No new runtime behavior beyond the already-merged PRs.
- No release tag yet; tag/PyPI publish should happen after this PR merges to `main`.

## Commits

- `2f1e1d6` — `[update] Prepare 0.3.7 release`

## Release / Issues

- Release: `0.3.7`
- Includes merged work from #363, #367, #369, #370, #372, #373, and #374.
- Refs #355, #364, #368, #353, #366, #284.

## Success Metric

- A fresh install of `mainbranch 0.3.7` exposes the new release dogfood/simulation surfaces and current CLI-first business repo startup guidance.

## Validation

- Level 1 static: `scripts/check.sh` passed after fixing plugin manifest version skew: formatting, lint, mypy, 332 tests, coverage, bundled skill validation.
- Level 3 package/install: `(cd mb && python3 -m build)` built `mainbranch-0.3.7.tar.gz` and `mainbranch-0.3.7-py3-none-any.whl`; fresh venv install passed; `mb --version` printed `mb 0.3.7`; `mb skill list` listed bundled skills.
- Level 4 fixture/release simulation: `scripts/claude-runtime-dogfood.py --install-mode wheel --wheel mb/dist/mainbranch-0.3.7-py3-none-any.whl --run-claude-print --simulation-tier prerelease_candidate --max-budget-usd 0.75` passed. Evidence template reported deterministic fixture checks green, clean business repo after run, no unexpected engine repo changes, and `claude -p` proxy rubric `9/10`.
- Runtime note: print-mode proxy evidence is not interactive Claude Code TUI proof. Manual TUI smoke remains required for release-bearing slash-command claims.

## Public / Private Boundary

- No private data committed.
- Dogfood evidence stayed in local temp artifacts and is summarized without raw local paths or transcripts.
