### PR TITLE
[fix] Tighten release simulation unknown-command scoring

### DIFF
--- a/mb/mb/dogfood_harness.py
+++ b/mb/mb/dogfood_harness.py
@@ -594,7 +594,9 @@ def run_claude_print(state: HarnessState, *, max_budget_usd: str, simulation_tie
     rubric = score_transcript(transcript_text)
     write_json(state.evidence_dir / "claude" / "rubric.json", rubric)
 
-    if transcript_text and "unknown command" in transcript_text.lower():
+    if transcript_text and release_simulation.contains_observed_unknown_command_failure(
+        transcript_text
+    ):
         state.fail("Claude print-mode transcript reported an unknown command")
 
     state.claude = {

--- a/mb/mb/dogfood_harness.py
+++ b/mb/mb/dogfood_harness.py
@@ -594,9 +594,11 @@ def run_claude_print(state: HarnessState, *, max_budget_usd: str, simulation_tie
     rubric = score_transcript(transcript_text)
     write_json(state.evidence_dir / "claude" / "rubric.json", rubric)
 
-    if transcript_text and release_simulation.contains_observed_unknown_command_failure(
-        transcript_text
-    ):
+    skill_discovery = rubric.get("checks", {}).get("skill_discovery", {})
+    observed_unknown_command = False
+    if isinstance(skill_discovery, dict):
+        observed_unknown_command = bool(skill_discovery.get("observed_unknown_command_failure"))
+    if transcript_text and observed_unknown_command:
         state.fail("Claude print-mode transcript reported an unknown command")
 
     state.claude = {

--- a/mb/mb/release_simulation.py
+++ b/mb/mb/release_simulation.py
@@ -122,11 +122,12 @@ def score_transcript(text: str, checks: tuple[BehaviorCheck, ...] | None = None)
     """
     active_checks = behavior_checks() if checks is None else checks
     normalized = text.lower()
+    observed_unknown_command = contains_observed_unknown_command_failure(text)
     results: dict[str, dict[str, Any]] = {}
     passed = 0
     for check in active_checks:
         ok = any(_keyword_matches(normalized, keyword) for keyword in check.keywords)
-        if check.id == "skill_discovery" and "unknown command" in normalized:
+        if check.id == "skill_discovery" and observed_unknown_command:
             ok = False
         if check.id == "runtime_provider_honesty" and _contains_overclaim(normalized):
             ok = False
@@ -135,6 +136,8 @@ def score_transcript(text: str, checks: tuple[BehaviorCheck, ...] | None = None)
             "description": check.description,
             "keywords": list(check.keywords),
         }
+        if check.id == "skill_discovery":
+            results[check.id]["observed_unknown_command_failure"] = observed_unknown_command
         if ok:
             passed += 1
     return {
@@ -146,6 +149,25 @@ def score_transcript(text: str, checks: tuple[BehaviorCheck, ...] | None = None)
             "categories before release acceptance."
         ),
     }
+
+
+def contains_observed_unknown_command_failure(text: str) -> bool:
+    """Return true when a transcript appears to report an observed slash failure.
+
+    Claude may correctly mention ``Unknown command: /mb-start`` while triaging a
+    repair path. Release acceptance should fail on observed runtime output or a
+    final diagnosis, not quoted symptom options or conditional repair guidance.
+    """
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        normalized = _normalize_unknown_command_line(line)
+        if "unknown command" not in normalized:
+            continue
+        if _is_observed_unknown_command_line(normalized):
+            return True
+        if _is_unknown_command_contextual_guidance(normalized):
+            continue
+    return False
 
 
 def validate_manifest(manifest: dict[str, Any] | None = None) -> list[str]:
@@ -190,6 +212,89 @@ def _contains_overclaim(text: str) -> bool:
         "spent money for you",
     )
     return any(term in text for term in overclaim_terms)
+
+
+def _normalize_unknown_command_line(line: str) -> str:
+    normalized = line.lower().strip()
+    normalized = re.sub(r"^[>\-\*\s]+", "", normalized)
+    normalized = normalized.replace("`", "").replace('"', "").replace("'", "")
+    normalized = normalized.replace("\u2014", "-").replace("\u2013", "-")
+    normalized = re.sub(r"\s+", " ", normalized)
+    return normalized.strip()
+
+
+def _is_unknown_command_contextual_guidance(line: str) -> bool:
+    if "?" in line and any(
+        marker in line
+        for marker in (
+            "did you see",
+            "do you see",
+            "have you seen",
+            "saw",
+            "was it",
+            "whether",
+            "which symptom",
+            "what symptom",
+        )
+    ):
+        return True
+    if re.search(r"\bif\b.+\bunknown command\b", line):
+        return True
+    if re.search(r"\bunknown command\b.+\b(if|then|run|repair|fix|use)\b", line):
+        return True
+    return any(
+        marker in line
+        for marker in (
+            "diagnostic option",
+            "possible symptom",
+            "symptom option",
+            "quoted symptom",
+            "example symptom",
+        )
+    )
+
+
+def _is_observed_unknown_command_line(line: str) -> bool:
+    if re.fullmatch(r"(error:\s*)?unknown command:?\s*/?mb-start\.?", line):
+        return True
+    if any(
+        marker in line
+        for marker in (
+            "false positive",
+            "not a discovery failure",
+            "not an actual failure",
+            "not a skill discovery failure",
+        )
+    ):
+        return False
+    if any(
+        marker in line
+        for marker in (
+            "final diagnosis",
+            "actual failure",
+            "observed runtime",
+            "runtime output",
+            "discovery failure",
+            "skill discovery failure",
+            "symptom confirmed",
+        )
+    ):
+        return True
+    if re.search(
+        r"\b(claude|runtime|slash command|/mb-start|mb-start)\b"
+        r".{0,80}\b(reported|returned|emitted|showed|failed with)\b"
+        r".{0,40}\bunknown command\b",
+        line,
+    ):
+        return True
+    return (
+        re.search(
+            r"\bunknown command\b.{0,40}\b"
+            r"(reported|returned|emitted|showed|observed|confirmed)\b",
+            line,
+        )
+        is not None
+    )
 
 
 def _keyword_matches(text: str, keyword: str) -> bool:

--- a/mb/mb/release_simulation.py
+++ b/mb/mb/release_simulation.py
@@ -158,13 +158,22 @@ def contains_observed_unknown_command_failure(text: str) -> bool:
     repair path. Release acceptance should fail on observed runtime output or a
     final diagnosis, not quoted symptom options or conditional repair guidance.
     """
-    for raw_line in text.splitlines():
+    raw_lines = text.splitlines()
+    for index, raw_line in enumerate(raw_lines):
         line = raw_line.strip()
         normalized = _normalize_unknown_command_line(line)
         if "unknown command" not in normalized:
             continue
         if _is_observed_unknown_command_line(normalized):
             return True
+        if index + 1 < len(raw_lines):
+            next_line = _normalize_unknown_command_line(raw_lines[index + 1].strip())
+            if next_line.startswith("/"):
+                combined = _normalize_unknown_command_line(f"{line} {raw_lines[index + 1]}")
+                if _is_observed_unknown_command_line(combined):
+                    return True
+                if _is_unknown_command_contextual_guidance(combined):
+                    continue
         if _is_unknown_command_contextual_guidance(normalized):
             continue
     return False
@@ -255,7 +264,7 @@ def _is_unknown_command_contextual_guidance(line: str) -> bool:
 
 
 def _is_observed_unknown_command_line(line: str) -> bool:
-    if re.fullmatch(r"(error:\s*)?unknown command:?\s*/?mb-start\.?", line):
+    if re.fullmatch(r"(error:\s*)?unknown command:?\s*/[a-z0-9-]+(?:[.!?].*)?", line):
         return True
     if any(
         marker in line

--- a/mb/mb/release_simulation.py
+++ b/mb/mb/release_simulation.py
@@ -164,18 +164,22 @@ def contains_observed_unknown_command_failure(text: str) -> bool:
         normalized = _normalize_unknown_command_line(line)
         if "unknown command" not in normalized:
             continue
-        if _is_observed_unknown_command_line(normalized):
+        if _is_raw_unknown_command_output(normalized):
             return True
         if index + 1 < len(raw_lines):
             next_line = _normalize_unknown_command_line(raw_lines[index + 1].strip())
             if next_line.startswith("/"):
                 combined = _normalize_unknown_command_line(f"{line} {raw_lines[index + 1]}")
-                if _is_observed_unknown_command_line(combined):
+                if _is_raw_unknown_command_output(combined):
                     return True
                 if _is_unknown_command_contextual_guidance(combined):
                     continue
+                if _is_observed_unknown_command_line(combined):
+                    return True
         if _is_unknown_command_contextual_guidance(normalized):
             continue
+        if _is_observed_unknown_command_line(normalized):
+            return True
     return False
 
 
@@ -263,9 +267,13 @@ def _is_unknown_command_contextual_guidance(line: str) -> bool:
     )
 
 
+def _is_raw_unknown_command_output(line: str) -> bool:
+    return (
+        re.fullmatch(r"(error:\s*)?unknown command:?\s*/[a-z0-9-]+(?:[.!?].*)?", line) is not None
+    )
+
+
 def _is_observed_unknown_command_line(line: str) -> bool:
-    if re.fullmatch(r"(error:\s*)?unknown command:?\s*/[a-z0-9-]+(?:[.!?].*)?", line):
-        return True
     if any(
         marker in line
         for marker in (

--- a/mb/tests/test_dogfood_harness.py
+++ b/mb/tests/test_dogfood_harness.py
@@ -3,12 +3,16 @@
 from __future__ import annotations
 
 import json
+import shutil
 import sys
 from argparse import Namespace
 from pathlib import Path
 from typing import Any
 
+import pytest
+
 from mb import dogfood_harness as harness
+from mb import release_simulation
 
 
 def test_score_transcript_detects_core_runtime_behaviors() -> None:
@@ -35,6 +39,86 @@ def test_score_transcript_flags_unknown_command_as_discovery_failure() -> None:
     score = harness.score_transcript("Unknown command: /mb-start")
 
     assert score["checks"]["skill_discovery"]["ok"] is False
+
+
+def test_run_claude_print_allows_unknown_command_repair_guidance(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    state = harness.HarnessState(
+        engine_repo=tmp_path / "engine",
+        root=tmp_path,
+        evidence_dir=tmp_path / "evidence",
+        fixture_repo=tmp_path / "fixture",
+        mb_path=tmp_path / "venv" / "bin" / "mb",
+    )
+    state.fixture_repo.mkdir(parents=True)
+
+    simulation = release_simulation.Simulation(
+        id="repair",
+        label="repair",
+        title="Repair",
+        tiers=("pr_smoke",),
+        prompt="/mb-start",
+        expected_route=("sense",),
+        expected_behaviors=("skill_discovery",),
+        must_observe=("repair guidance",),
+        must_not=(),
+    )
+
+    def fake_run_command(
+        state: harness.HarnessState,
+        label: str,
+        command: list[str],
+        *,
+        cwd: Path,
+        timeout: int | None = None,
+    ) -> harness.CommandResult:
+        del state, command, cwd, timeout
+        stdout_path = tmp_path / f"{label}.stdout"
+        stderr_path = tmp_path / f"{label}.stderr"
+        metadata_path = tmp_path / f"{label}.json"
+        stdout = json.dumps(
+            {
+                "result": {
+                    "content": [
+                        {
+                            "text": (
+                                "/mb-start was discovered. If Claude reports "
+                                "`Unknown command: /mb-start`, run mb doctor "
+                                "and mb skill repair before manual fixes."
+                            )
+                        }
+                    ]
+                }
+            }
+        )
+        stdout_path.write_text(stdout, encoding="utf-8")
+        stderr_path.write_text("", encoding="utf-8")
+        metadata_path.write_text("{}", encoding="utf-8")
+        return harness.CommandResult(
+            label=label,
+            command=["claude", "-p"],
+            cwd=tmp_path,
+            returncode=0,
+            stdout=stdout,
+            stderr="",
+            stdout_path=stdout_path,
+            stderr_path=stderr_path,
+            metadata_path=metadata_path,
+        )
+
+    monkeypatch.setattr(shutil, "which", lambda _: "/usr/local/bin/claude")
+    monkeypatch.setattr(
+        release_simulation,
+        "simulations_for_tier",
+        lambda _: (simulation,),
+    )
+    monkeypatch.setattr(harness, "run_command", fake_run_command)
+
+    harness.run_claude_print(state, max_budget_usd="0.01", simulation_tier="pr_smoke")
+
+    assert "Claude print-mode transcript reported an unknown command" not in state.failures
+    assert state.claude["rubric"]["checks"]["skill_discovery"]["ok"] is True
 
 
 def test_read_json_rejects_non_object_payload() -> None:

--- a/mb/tests/test_release_simulation.py
+++ b/mb/tests/test_release_simulation.py
@@ -105,6 +105,9 @@ def test_score_transcript_uses_tighter_discovery_and_loop_keywords() -> None:
     "transcript",
     [
         "Unknown command: /mb-start",
+        "Unknown command: /mb-think",
+        "Unknown command: /mb-start. Run /help to see available commands.",
+        "Unknown command:\n/mb-start",
         "Claude runtime output: Unknown command: /mb-start",
         "Final diagnosis: slash command discovery failure. Unknown command: /mb-start",
     ],

--- a/mb/tests/test_release_simulation.py
+++ b/mb/tests/test_release_simulation.py
@@ -99,3 +99,49 @@ def test_score_transcript_uses_tighter_discovery_and_loop_keywords() -> None:
     assert generic_score["checks"]["loop_routing"]["ok"] is False
     assert routed_score["checks"]["skill_discovery"]["ok"] is True
     assert routed_score["checks"]["loop_routing"]["ok"] is True
+
+
+@pytest.mark.parametrize(
+    "transcript",
+    [
+        "Unknown command: /mb-start",
+        "Claude runtime output: Unknown command: /mb-start",
+        "Final diagnosis: slash command discovery failure. Unknown command: /mb-start",
+    ],
+)
+def test_score_transcript_flags_observed_unknown_command_failures(transcript: str) -> None:
+    score = release_simulation.score_transcript(transcript)
+
+    assert release_simulation.contains_observed_unknown_command_failure(transcript) is True
+    assert score["checks"]["skill_discovery"]["ok"] is False
+    assert score["checks"]["skill_discovery"]["observed_unknown_command_failure"] is True
+
+
+def test_score_transcript_allows_unknown_command_diagnostic_wording() -> None:
+    transcript = """
+    /mb-start was discovered enough to route the repair conversation. When you
+    saw `/mb-start` "not showing up" - was it `Unknown command: /mb-start`, the
+    slash menu missing it, or something else?
+    This is a false positive, not a discovery failure: `Unknown command:
+    /mb-start` was quoted symptom language.
+    """
+
+    score = release_simulation.score_transcript(transcript)
+
+    assert release_simulation.contains_observed_unknown_command_failure(transcript) is False
+    assert score["checks"]["skill_discovery"]["ok"] is True
+    assert score["checks"]["skill_discovery"]["observed_unknown_command_failure"] is False
+
+
+def test_score_transcript_allows_unknown_command_repair_guidance() -> None:
+    transcript = """
+    /mb-start was discovered, and this is repair guidance. If Claude reports
+    `Unknown command: /mb-start`, run `mb start --json`, `mb doctor`, and
+    `mb skill repair --repo .` before manual fixes.
+    """
+
+    score = release_simulation.score_transcript(transcript)
+
+    assert release_simulation.contains_observed_unknown_command_failure(transcript) is False
+    assert score["checks"]["skill_discovery"]["ok"] is True
+    assert score["checks"]["supported_repair_path"]["ok"] is True

--- a/mb/tests/test_release_simulation.py
+++ b/mb/tests/test_release_simulation.py
@@ -148,3 +148,16 @@ def test_score_transcript_allows_unknown_command_repair_guidance() -> None:
     assert release_simulation.contains_observed_unknown_command_failure(transcript) is False
     assert score["checks"]["skill_discovery"]["ok"] is True
     assert score["checks"]["supported_repair_path"]["ok"] is True
+
+
+def test_score_transcript_allows_single_line_conditional_unknown_command_marker() -> None:
+    transcript = """
+    /mb-start was discovered. If Claude reports Unknown command: /mb-start,
+    that's a slash command discovery failure - run mb skill repair.
+    """
+
+    score = release_simulation.score_transcript(transcript)
+
+    assert release_simulation.contains_observed_unknown_command_failure(transcript) is False
+    assert score["checks"]["skill_discovery"]["ok"] is True
+    assert score["checks"]["supported_repair_path"]["ok"] is True


### PR DESCRIPTION
## Summary
- Tightens release simulation scoring so quoted or conditional `Unknown command` repair-triage language no longer fails `skill_discovery`.
- Keeps observed slash-command discovery failures release-blocking, including raw `/mb-*` unknown-command output, trailing help text, split-line output, runtime output, and final diagnosis wording.
- Updates the dogfood harness to reuse the rubric's observed unknown-command flag instead of rescanning transcripts.
- Adds focused regression coverage for actual failures, diagnostic wording, repair guidance, raw slash outputs, and same-line conditional guidance.

## Scope
- In: release simulation transcript scoring, dogfood harness failure routing, and focused tests for MAIN-271.
- Out: Claude Code skill discovery behavior, prompt fixture rewrites, docs changes, and any claim that `claude -p` replaces interactive TUI smoke.

## Commits
- `006588f` — `[fix] MAIN-271 tighten unknown-command scoring`.
- `5354e50` — `[fix] MAIN-271 catch raw unknown slash outputs`.
- `addef86` — `[fix] MAIN-271 prefer conditional unknown guidance`.

## Release / Issues
- Release: none assigned.
- Linear ID(s): MAIN-271.
- Closes: #378.
- Refs: none.
- Follow-ups: none.

## Success Metric
- The 0.3.7 false-positive transcript shape scores as repair-path guidance, while real unknown-command runtime output still fails the release simulation rubric.

## Validation
- Level 0 docs/decision: no docs changed; public evidence wording remains proxy-only for print mode.
- Level 1 static: `scripts/check.sh` passed, including Ruff format/check and mypy.
- Level 2 CLI: focused `pytest mb/tests/test_release_simulation.py mb/tests/test_dogfood_harness.py -q` passed with 26 tests.
- Level 3 package/install: not required; no packaging, entrypoint, bundled-data, or install path changes.
- Level 4 fixture repo: not required for this scoring-only harness change.
- Level 5 runtime smoke: optional editable print-mode PR smoke was recorded on #378 with no harness failures and proxy-evidence labeling intact; final follow-up was covered by focused tests and `scripts/check.sh`.

## Public / Private Boundary
- No private Devon, Conductor, customer, account, credential, or local runtime details were committed; `.context/` cold-start notes stayed out of durable public files.

## CHANGELOG
- N/A — internal release-validation heuristic and tests only.

## Breaking changes
- No.
