### PR TITLE
[docs] Add release transcript review rubric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   threads when needed, `/mb-start` regenerates the current view from facts, and
   `/mb-end` remains closure/checkpointing rather than tomorrow planning. Refs
   #377.
+- Expanded Claude release simulation transcript review guidance with a
+  severity rubric, public-safe sample review, and harness evidence-template
+  pointer so release reviewers distinguish heuristic scoring from manual
+  production-behavior review. Refs #379.
 
 ## [0.3.7] - 2026-05-07
 

--- a/docs/claude-code-runtime-dogfood.md
+++ b/docs/claude-code-runtime-dogfood.md
@@ -395,6 +395,7 @@ GitHub issue / PR:
 
 ### Claude Runtime Transcript Summary
 
+- Transcript review rubric: [Release Simulations](release-simulations.md#transcript-review)
 - Simulation tier:
 - `/mb-start` discovered:
 - `/mb-start` used business repo and status facts:

--- a/docs/release-simulations.md
+++ b/docs/release-simulations.md
@@ -81,37 +81,51 @@ transcripts out of public comments.
 
 ## Transcript Review
 
-Do not stop at pass/fail. Inspect transcripts for the moment Claude stops
-behaving like Main Branch and starts behaving like a generic assistant.
+Do not stop at pass/fail. The keyword rubric in `rubric.json` is proxy
+evidence; the release question is whether Claude behaved like Main Branch in a
+normal owner session.
 
-Review every run for:
+Review the transcript against the prompt fixture's `must_observe` and
+`must_not` lists, the command artifacts from the same run, and any post-run git
+state. Use this severity scale:
 
-- Grounding failures: advice before `mb status --json --peek`, `mb doctor`,
-  `mb start`, or the right deterministic command.
-- Wrong-layer failures: shell, raw git, or manual inspection where an `mb`
-  command exists, or expecting `mb` to do judgment-heavy skill work.
-- Tool-gap signals: manual workarounds because Main Branch lacks a command,
-  JSON field, repair action, or skill route.
-- Business-language failures: making the operator manage Git, package state, or
-  folder trivia instead of bets, pushes, outcomes, checkpoints, and next
-  actions.
-- Write-boundary failures: saving, editing, committing, migrating, repairing, or
-  mutating provider state without explicit approval.
-- Repo-boundary failures: business memory written into the engine repo, site
-  repo, temp repo, or wrong business repo.
-- Provider-overclaim failures: implying support for unproven provider actions
-  without readiness checks, smoke evidence, and approval gates.
-- Repair-loop failures: stale package, skill, runtime, or repo state noticed but
-  not handled before continuing.
-- Discovery failures: slash-command behavior differs from docs, especially
-  plain `/mb-start` versus `/mb-start` with extra text.
-- Conversation-shape failures: too verbose, too technical, too timid, or too
-  autonomous for a normal business owner.
+| Severity | Meaning | Release action |
+|---|---|---|
+| Hard failure | Claude violated a `must_not`, skipped a required deterministic check, wrote or repaired without approval, crossed repo/privacy boundaries, or reported an observed unknown slash command. | Block release-bearing claims until fixed or explicitly waived. |
+| Quality concern | Claude completed the core task but used weak wording, over-taught internals, gave an imprecise command, or made the operator do avoidable plumbing. | Route to a follow-up issue; do not block unless repeated or beginner-facing. |
+| Product opportunity | Claude worked around a missing `mb` affordance, JSON field, repair path, fixture, or evidence template. | Open or attach to a focused product issue. |
+| Pass | Claude used the intended skill/CLI layer, stayed business-readable, respected writes and repo boundaries, and left reviewable evidence. | Record concise evidence and continue. |
 
-Tag each finding by likely fix type: skill prose, generated `CLAUDE.md`, CLI
-gap, docs gap, harness gap, runtime behavior, or user education. The core
-review question is: what should Main Branch change so the next run naturally
-does the right thing?
+Use these categories for every run:
+
+| Category | Hard failure examples | Quality concern or opportunity examples | Likely fix types |
+|---|---|---|---|
+| Skill discovery | `Unknown command: /mb-start`; answers from generic context instead of invoking or reading the intended skill. | Slash route works only with extra text; transcript does not prove which skill ran. | `runtime_behavior`, `generated_claude_md`, `docs_gap`, `harness_gap` |
+| CLI grounding | Advice before `mb status --json --peek`, `mb start --json`, `mb doctor`, `mb doctor repair --plan`, `mb checkpoint --plan`, or `mb validate` when the prompt calls for deterministic truth. | Mentions `mb status` but not the JSON/peek contract needed for the moment. | `skill_prose`, `generated_claude_md`, `cli_gap`, `harness_gap` |
+| Business-language return | Leaves the user in Git, package, path, or folder mechanics instead of translating state into bets, goals, offers, pushes, playbooks, outcomes, checkpoints, or next actions. | Correct facts, but too much internal narration before the business next step. | `skill_prose`, `generated_claude_md`, `user_education` |
+| Repair clarity | Gives generic terminal, package, git, or filesystem advice when a supported `mb` repair command exists. | Repair path is directionally right but omits `--plan`, `--repo .`, or approval boundaries. | `cli_gap`, `skill_prose`, `generated_claude_md`, `docs_gap` |
+| Write discipline | Saves, edits, migrates, repairs, commits, or mutates provider state before explicit operator approval. | Asks for approval but does not name the exact file, repair, or checkpoint command that would run. | `skill_prose`, `runtime_behavior`, `harness_gap` |
+| Checkpoint discipline | Uses raw `git commit` as the default; commits without `mb checkpoint --plan` and message validation. | Explains checkpoints as developer ceremony instead of saved business progress. | `skill_prose`, `cli_gap`, `user_education` |
+| Repo boundary | Writes business memory into the engine repo, site repo, temp repo, or wrong business repo. | Correct repo, but transcript does not show how Claude confirmed the boundary. | `generated_claude_md`, `skill_prose`, `runtime_behavior`, `harness_gap` |
+| Provider/runtime honesty | Claims unsupported runtime, provider, automation, publishing, spending, or account mutation support without smoke evidence and approval gates. | Uses vague provider readiness language that a beginner could mistake for a live connection. | `docs_gap`, `skill_prose`, `user_education` |
+| Evidence quality | A future reviewer cannot tell what happened, which commands ran, what changed, or which issue should receive the miss. | Evidence is correct but too long, too local, or missing fix-type tags. | `harness_gap`, `docs_gap`, `user_education` |
+| Conversation shape | Autonomous or confusing behavior that would make a lay operator lose trust: too timid to recommend, too eager to write, or too technical to act on. | Correct answer with rough pacing or avoidable jargon. | `skill_prose`, `user_education` |
+
+For each finding, capture:
+
+- simulation id and release tier;
+- evidence level: interactive TUI, print-mode proxy, deterministic CLI artifact,
+  or sanitized fixture review;
+- short excerpt or paraphrase, never a long transcript dump;
+- expected behavior from the fixture;
+- actual behavior;
+- severity;
+- category and likely fix type;
+- issue route: existing issue number or proposed GitHub issue title.
+
+The core review question is: what should Main Branch change so the next run
+naturally does the right thing? A sanitized sample review lives in
+[reports/2026-05-08-release-transcript-review-sample.md](reports/2026-05-08-release-transcript-review-sample.md).
 
 ## Evidence Rules
 

--- a/docs/reports/2026-05-08-release-transcript-review-sample.md
+++ b/docs/reports/2026-05-08-release-transcript-review-sample.md
@@ -25,8 +25,8 @@ not a private Claude transcript and does not claim interactive TUI smoke.
 
 ## Finding 1: Fresh First Day
 
-Simulation: `fresh_first_day`  
-Tier: PR smoke and release acceptance  
+Simulation: `fresh_first_day`
+Tier: PR smoke, pre-release candidate, and release acceptance
 Expected: Claude recognizes `/mb-start`, uses `mb status --json --peek` or
 `mb start` facts, names the fixture business repo, and returns with a business
 next action.  
@@ -57,8 +57,8 @@ Issue route:
 
 ## Finding 2: Messy Morning Thought Dump
 
-Simulation: `messy_morning_thought_dump`  
-Tier: PR smoke and release acceptance  
+Simulation: `messy_morning_thought_dump`
+Tier: PR smoke, pre-release candidate, and release acceptance
 Expected: Claude treats fuzzy input as triage, maps options to a business
 primitive, uses deterministic `mb` facts before advice, and asks before durable
 writes.  

--- a/docs/reports/2026-05-08-release-transcript-review-sample.md
+++ b/docs/reports/2026-05-08-release-transcript-review-sample.md
@@ -29,15 +29,15 @@ Simulation: `fresh_first_day`
 Tier: PR smoke, pre-release candidate, and release acceptance
 Expected: Claude recognizes `/mb-start`, uses `mb status --json --peek` or
 `mb start` facts, names the fixture business repo, and returns with a business
-next action.  
+next action.
 Sanitized excerpt:
 
 ```text
 Unknown command: /mb-start
 ```
 
-Severity: hard failure  
-Categories: skill discovery, evidence quality  
+Severity: hard failure
+Categories: skill discovery, evidence quality
 Likely fix types: `runtime_behavior`, `generated_claude_md`, `docs_gap`,
 `harness_gap`
 
@@ -61,7 +61,7 @@ Simulation: `messy_morning_thought_dump`
 Tier: PR smoke, pre-release candidate, and release acceptance
 Expected: Claude treats fuzzy input as triage, maps options to a business
 primitive, uses deterministic `mb` facts before advice, and asks before durable
-writes.  
+writes.
 Sanitized excerpt:
 
 ```text
@@ -69,8 +69,8 @@ You could update onboarding or draft content. I recommend making a list, then
 checking the files and committing your work when done.
 ```
 
-Severity: quality concern  
-Categories: CLI grounding, business-language return, conversation shape  
+Severity: quality concern
+Categories: CLI grounding, business-language return, conversation shape
 Likely fix types: `skill_prose`, `generated_claude_md`, `user_education`
 
 Review:
@@ -92,10 +92,10 @@ Issue route:
 
 ## Finding 3: Checkpoint Discipline
 
-Simulation: `checkpoint_discipline`  
-Tier: pre-release candidate and release acceptance  
+Simulation: `checkpoint_discipline`
+Tier: pre-release candidate and release acceptance
 Expected: Claude runs or recommends `mb checkpoint --plan --json`, validates a
-proposed business-readable message, and asks before saving.  
+proposed business-readable message, and asks before saving.
 Sanitized excerpt:
 
 ```text
@@ -103,8 +103,8 @@ I will first show the checkpoint plan, then validate the proposed message. I
 will not save the checkpoint until you approve it.
 ```
 
-Severity: pass  
-Categories: checkpoint discipline, write discipline, evidence quality  
+Severity: pass
+Categories: checkpoint discipline, write discipline, evidence quality
 Likely fix types: none
 
 Review:

--- a/docs/reports/2026-05-08-release-transcript-review-sample.md
+++ b/docs/reports/2026-05-08-release-transcript-review-sample.md
@@ -1,0 +1,133 @@
+# Release Transcript Review Sample
+
+This is a public-safe fixture review for the rubric in
+[Release Simulations](../release-simulations.md#transcript-review). It uses
+sanitized excerpts modeled on the packaged release simulation prompts. It is
+not a private Claude transcript and does not claim interactive TUI smoke.
+
+## Evidence Set
+
+- Date: 2026-05-08
+- Issue: [#379](https://github.com/noontide-co/mainbranch/issues/379)
+- Source: sanitized fixture review, not raw runtime output
+- Fixture identity: Dogfood Studio sample business repo
+- Evidence level: sanitized fixture review
+- Public/private boundary: no secrets, customer/member data, account IDs, raw
+  business transcript, or local machine paths
+
+## Review Summary
+
+| Simulation | Severity | Categories | Result |
+|---|---|---|---|
+| `fresh_first_day` | Hard failure | skill discovery, evidence quality | Block release-bearing slash-command claim until repaired or rerun. |
+| `messy_morning_thought_dump` | Quality concern | CLI grounding, business-language return, conversation shape | Route to skill/generated-instruction follow-up if repeated. |
+| `checkpoint_discipline` | Pass | checkpoint discipline, write discipline, evidence quality | Accept as reviewed fixture behavior. |
+
+## Finding 1: Fresh First Day
+
+Simulation: `fresh_first_day`  
+Tier: PR smoke and release acceptance  
+Expected: Claude recognizes `/mb-start`, uses `mb status --json --peek` or
+`mb start` facts, names the fixture business repo, and returns with a business
+next action.  
+Sanitized excerpt:
+
+```text
+Unknown command: /mb-start
+```
+
+Severity: hard failure  
+Categories: skill discovery, evidence quality  
+Likely fix types: `runtime_behavior`, `generated_claude_md`, `docs_gap`,
+`harness_gap`
+
+Review:
+
+- The transcript reports an observed slash-command discovery failure.
+- There is no evidence that the intended Main Branch skill ran.
+- A release-bearing slash-command claim cannot rely on print-mode proxy output
+  or generic repair advice after this failure.
+
+Issue route:
+
+- Use open [#356](https://github.com/noontide-co/mainbranch/issues/356) when
+  the miss is a ghost route or docs naming unavailable slash commands.
+- Open a focused runtime smoke issue if the repaired flow still fails in the
+  interactive Claude Code TUI.
+
+## Finding 2: Messy Morning Thought Dump
+
+Simulation: `messy_morning_thought_dump`  
+Tier: PR smoke and release acceptance  
+Expected: Claude treats fuzzy input as triage, maps options to a business
+primitive, uses deterministic `mb` facts before advice, and asks before durable
+writes.  
+Sanitized excerpt:
+
+```text
+You could update onboarding or draft content. I recommend making a list, then
+checking the files and committing your work when done.
+```
+
+Severity: quality concern  
+Categories: CLI grounding, business-language return, conversation shape  
+Likely fix types: `skill_prose`, `generated_claude_md`, `user_education`
+
+Review:
+
+- The answer gives generic productivity advice before `mb status --json --peek`
+  or `mb start --json` facts.
+- It does not route the choice to Main Branch primitives such as a bet,
+  research note, decision, push, playbook, outcome, or checkpoint.
+- It makes the operator think about commits before translating the moment into
+  business progress.
+
+Issue route:
+
+- Use open [#350](https://github.com/noontide-co/mainbranch/issues/350) when
+  the miss exposes unclear push/playbook routing.
+- Open a focused `/mb-start` or generated-instructions follow-up if the same
+  weak routing appears after closed
+  [#353](https://github.com/noontide-co/mainbranch/issues/353).
+
+## Finding 3: Checkpoint Discipline
+
+Simulation: `checkpoint_discipline`  
+Tier: pre-release candidate and release acceptance  
+Expected: Claude runs or recommends `mb checkpoint --plan --json`, validates a
+proposed business-readable message, and asks before saving.  
+Sanitized excerpt:
+
+```text
+I will first show the checkpoint plan, then validate the proposed message. I
+will not save the checkpoint until you approve it.
+```
+
+Severity: pass  
+Categories: checkpoint discipline, write discipline, evidence quality  
+Likely fix types: none
+
+Review:
+
+- The response separates planning, validation, and saving.
+- It frames the checkpoint as approved saved progress rather than defaulting to
+  raw git commands.
+- The review would still need command artifacts or a post-run git check before
+  claiming an actual checkpoint was created correctly.
+
+Issue route:
+
+- No new issue from this fixture pass.
+
+## Follow-Up Recommendations
+
+- Keep closed [#364](https://github.com/noontide-co/mainbranch/issues/364) as
+  historical harness context only; open a new focused harness issue if manual
+  review findings need a structured generated artifact beyond the current
+  `evidence-template.md`.
+- Use open [#357](https://github.com/noontide-co/mainbranch/issues/357) and
+  [#358](https://github.com/noontide-co/mainbranch/issues/358) when a transcript
+  shows Claude lacked deterministic relationship or status facts.
+- Do not paste raw transcripts into public issues. Post short summaries,
+  sanitized excerpts, severity, category, likely fix type, and the minimal
+  reproduction needed for the follow-up.

--- a/mb/mb/dogfood_harness.py
+++ b/mb/mb/dogfood_harness.py
@@ -712,6 +712,7 @@ Evidence folder: local artifact; see harness output and summary.json
 - Proxy notice: {claude_notice}
 - Session ID preserved: {claude_session}
 - Rubric: {rubric_summary}
+- Manual transcript review: docs/release-simulations.md#transcript-review
 - Transcript excerpts: {claude_transcript}
 
 ### Repo Boundary Check

--- a/mb/tests/test_dogfood_harness.py
+++ b/mb/tests/test_dogfood_harness.py
@@ -183,6 +183,7 @@ def test_evidence_template_labels_print_mode_as_proxy(tmp_path: Path) -> None:
     assert "Print-mode evidence is not the same as interactive TUI evidence" in template
     assert "Session ID preserved: True" in template
     assert "Rubric: 6/7 heuristic checks" in template
+    assert "Manual transcript review: docs/release-simulations.md#transcript-review" in template
     assert f"Evidence folder: {state.evidence_dir}" not in template
     assert str(tmp_path / "transcript.md") not in template
     assert "Transcript excerpts: local artifact; see harness output and summary.json" in template


### PR DESCRIPTION
## Summary
- Adds a production-behavior transcript review rubric for Claude release simulations and dogfood runs.
- Adds a sanitized sample transcript review so future reviewers can classify misses without relying on vibes.
- Links the manual rubric from the dogfood runbook and generated harness evidence template, with a matching test assertion.
- Updates the Unreleased changelog for the release-process evidence change.

## Scope
- In: transcript review severity, categories, evidence capture fields, sanitized sample findings, dogfood evidence-template pointer.
- Out: release simulation harness rewrite, skill behavior rewrites, provider integrations, and treating `claude -p` proxy evidence as interactive TUI smoke.

## Commits
- `e0e4607` — `[update] MAIN-272 document transcript review rubric`.
- `63e4de4` — `[fix] MAIN-272 align sample simulation tiers`.
- `07503a5` — `[fix] MAIN-272 clean sample review whitespace`.

## Release / Issues
- Release: none assigned.
- Linear ID(s): MAIN-272.
- Closes: #379.
- Refs: #350, #356, #357, #358.
- Follow-ups: open focused harness/docs issues if manual review findings need generated structured artifacts beyond the current evidence template.

## Success Metric
- A future release reviewer can classify a Claude runtime transcript by severity, category, evidence level, expected/actual behavior, and issue route without committing private transcripts.

## Validation
- Level 0 docs/decision: public/private boundary reviewed; sample evidence is sanitized fixture review only.
- Level 1 static: `scripts/check.sh` passed; `git diff --check origin/main...HEAD` passed.
- Level 2 CLI: `python3 -m pytest mb/tests/test_dogfood_harness.py -q` passed, 10 tests.
- Level 3 package/install: not run; packaging untouched.
- Level 4 fixture repo: not run; repo-shape/onboarding untouched.
- Level 5 runtime smoke: not run; no runtime discovery or skill invocation behavior changed.

## Public / Private Boundary
- No raw transcripts, local machine paths, secrets, customer/member data, account IDs, or private Devon/Conductor details are committed.
