### PR TITLE
[release] 0.3.8

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mainbranch",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "Main Branch Claude Code skills for running a business from markdown files in git.",
   "author": {
     "name": "Noontide"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,27 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+## [0.3.8] - 2026-05-08
+
+v0.3.8 tightens the daily operating loop after the 0.3.7 release discipline
+landed. Main Branch now has a shared relationship registry for graph and
+cross-reference validation, safer runtime route checks, and clearer provider
+boundaries for Postiz and X-style resource delivery.
+
+### What this means for you (plain English)
+
+- **The business graph is more useful.** `mb graph --json` and
+  `mb validate --cross-refs` now agree on relationship fields, Markdown links,
+  push-to-offer links, and safe provider references.
+- **Claude gets fewer fake routes.** User-facing runtime guidance now points to
+  shipped Main Branch slash commands or clearly marks future commands as
+  unshipped.
+- **Provider claims stay honest.** Postiz remains a candidate scheduling rail
+  until connected-channel smoke exists, and Main Branch refuses X comment/DM
+  automation until an accepted provider path is proven.
+- **Release reviews are sharper.** Claude transcript reviews now have a public
+  rubric and sample so reviewers can turn simulation misses into product work.
+
 ### Changed
 
 - Aligned bundled skill and public docs language with the accepted work-continuity

--- a/mb/mb/__init__.py
+++ b/mb/mb/__init__.py
@@ -7,6 +7,6 @@ file stays a thin dispatcher.
 
 from __future__ import annotations
 
-__version__ = "0.3.7"
+__version__ = "0.3.8"
 
 __all__ = ["__version__"]

--- a/mb/pyproject.toml
+++ b/mb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mainbranch"
-version = "0.3.7"
+version = "0.3.8"
 description = "Main Branch engine umbrella - scaffolds, validates, and graphs business-as-files repos. Claude Code first, runtime-agnostic by design."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- Promote the merged graph, runtime-route, provider-boundary, and transcript-review work into `0.3.8`.
- Sync package, runtime `__version__`, and Claude plugin manifest versions.
- Add public changelog notes for the patch release.

## Scope
In scope: release metadata and changelog only.
Out of scope: new CLI or skill behavior beyond the PRs already merged into `main`.

## Validation
- `scripts/check.sh` passed after the plugin manifest version sync: Ruff, mypy, 357 tests, coverage, and bundled skill validation.
- Focused plugin manifest smoke passed: `pytest tests/test_smoke_coverage.py::test_claude_plugin_manifest_points_at_prefixed_skills -q`.
- Package/install smoke passed from a clean venv: built `mainbranch-0.3.8`, installed the wheel, `mb --version` returned `mb 0.3.8`, and `mb skill list` returned all 17 bundled skills.

## Runtime Smoke
No fresh interactive Claude Code runtime smoke for this release bump itself; the release branch only changes version metadata and changelog text. Runtime-facing behavior was validated on the underlying feature PRs.

## Public / Private Boundary
No private paths, customer data, credentials, or local workflow details added.

Refs #357, #356, #351, #352, #379, #377