### PR TITLE
[docs] Document packaged runtime compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+### Changed
+
+- Documented the packaged `mb` invocation contract, runtime repo-path discovery
+  rules, and adapter/readiness map for Codex, Cursor, OpenClaw, Hermes,
+  Paperclip-adjacent orchestration, and local runtimes without claiming
+  non-Claude runtime support. Refs #129.
+
 ## [0.3.8] - 2026-05-08
 
 v0.3.8 tightens the daily operating loop after the 0.3.7 release discipline

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ That's it. `mb onboard` guides the human setup, creates or connects your busines
 After the first session, the daily flow is:
 
 ```bash
-cd ~/Documents/GitHub/my-business
+cd /path/to/my-business
 claude
 /mb-start
 ```
@@ -320,6 +320,7 @@ repo understandable, current, and safe to operate from.
 
 - **Built for Claude Code today.** `mb` is runtime-agnostic by design, but Claude Code is the only first-class runtime currently supported end to end.
 - **The terminal front door is live.** Bare `mb`, `mb onboard`, `mb status`, `mb start`, and `mb update` are in the public package.
+- **Packaged callers can use the CLI directly.** Paperclip-style routines, local scripts, and future adapters should invoke deterministic `mb` commands against an explicit business repo path and read JSON/exit codes. See [docs/compatibility.md](docs/compatibility.md).
 - **Growth is the strongest shipped wedge.** Ads, organic, VSLs, sites, bets, pushes, status, and checkpoints are the most developed public workflows.
 - **Ops is the expansion path.** Meetings, fulfillment, bookkeeping/P&L, team daily logs, repo topology, and dashboard views use the same memory model, but they are less shipped than the growth surfaces.
 - **Provider automation is curated and gated.** GitHub and Cloudflare paths are the most concrete today. Google/Workspace, Meta Ads, Google Ads/GTM, Postiz, Apify, Beancount, and transcription are wired as planned or optional provider/sidecar surfaces until each path has matching smoke evidence for the claimed surface.
@@ -332,8 +333,14 @@ repo understandable, current, and safe to operate from.
 | Codex | Roadmap | Target runtime; no public adapter support claim yet. |
 | Cursor | Roadmap | Target runtime; no public adapter support claim yet. |
 | OpenClaw | Roadmap | First-tier compatibility target because users operate there; no adapter support claim yet. |
-| Hermes / Paperclip-adjacent orchestration | Roadmap | Target orchestration layer; must consume stable repo and JSON contracts. |
+| Hermes | Roadmap | Target runtime/memory surface; no public adapter support claim yet. |
+| Paperclip-adjacent orchestration | Roadmap | Target orchestration layer; should supervise shipped `mb` CLI/JSON commands without assuming Claude Code skills are present. |
 | Local runtimes | Roadmap | Long-range endpoint once adapter contracts are proven. |
+
+For the package/runtime caller contract, repo-path discovery rules, and the
+adapter/readiness map across invocation, workflow discovery, routing,
+automation, observability, and packaging, see
+[docs/compatibility.md](docs/compatibility.md).
 
 The engine v0.1.0 decision lives at [`decisions/2026-04-29-mb-vip-v0-1-0-master.md`](decisions/2026-04-29-mb-vip-v0-1-0-master.md). Some historical planning happened in private Noontide repos; public product truth now lives in this repository's decisions, docs, issues, changelog, and releases.
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -14,7 +14,7 @@ This page is the public compatibility contract for that surface.
 | Install mode | `pipx install mainbranch` | Canonical public install path. |
 | Developer mode | Git clone | For contributors who want to edit the engine or skills. |
 | Agent runtime | Claude Code | First-class today. |
-| Codex, Cursor, OpenClaw, Hermes, local LLMs | Roadmap | `mb` is runtime-agnostic by design, but these adapters are not supported yet. |
+| Codex, Cursor, OpenClaw, Hermes, Paperclip-adjacent orchestration, local LLMs | Roadmap | `mb` is runtime-agnostic by design, but these adapters are not supported yet. |
 
 **Windows tip — try WSL2.** If you're on Windows and want a working setup today, use [Windows Subsystem for Linux 2 (WSL2)](https://learn.microsoft.com/en-us/windows/wsl/install). Inside WSL2, follow the supported Linux flow. The pipx install path works there.
 
@@ -56,6 +56,127 @@ For the exact supported Claude Code slash-command behavior, including
 `/mb-start`, extra text after the slash command, natural-language routing, and
 skill-link repair, see
 [Claude Code Invocation Contract](claude-code-invocation-contract.md).
+
+## Packaged CLI invocation
+
+`mb` is a normal console command in the `mainbranch` Python package:
+
+```bash
+pipx install mainbranch
+mb --version
+```
+
+If the package is installed in an environment where the console script is not
+on `PATH`, `python3 -m mb --version` exercises the same package entrypoint.
+
+Automation callers do not need to run inside Claude Code to use deterministic
+CLI facts. A Paperclip-style routine, local script, CI job, or future runtime
+adapter should treat `mb` as a subprocess with an explicit business repo:
+
+```bash
+repo="/absolute/path/to/business-repo"
+mb status "$repo" --json --peek
+mb start --repo "$repo" --json
+mb validate "$repo" --json
+mb graph "$repo" --json
+mb connect status --repo "$repo" --json
+```
+
+Use the command's exit code, stdout JSON, and stderr output as the automation
+contract. Do not scrape human Rich output when a `--json` form exists. Do not
+require Claude Code environment variables, Claude-specific local settings, or a
+human terminal session for these CLI checks.
+
+Common shipped automation-safe commands include:
+
+| Need | Command shape |
+|---|---|
+| Package/version check | `mb --version` |
+| Daily repo facts | `mb status "$repo" --json --peek` |
+| Runtime handoff metadata | `mb start --repo "$repo" --json` |
+| Repo health | `mb doctor "$repo" --json` |
+| Repair preview | `mb doctor repair --repo "$repo" --plan --json` |
+| Frontmatter/schema validation | `mb validate "$repo" --json` |
+| Graph/index facts | `mb graph "$repo" --json` |
+| Provider readiness | `mb connect status --repo "$repo" --json` |
+| Checkpoint preview | `mb checkpoint --repo "$repo" --plan --json` |
+| Update dry-run | `mb update --repo "$repo" --check --json` |
+| Bundled skill inventory | `mb skill list` |
+| Bundled skill validation | `mb skill validate --all --json` |
+| Claude Code skill-link repair preview | `mb skill repair --repo "$repo" --json` |
+
+Some current commands are runtime handoff hints, not workflow execution. For
+example, `mb think <topic>` prints the `/mb-think` hint for Claude Code today;
+it does not run a model and does not yet expose a stable JSON workflow launcher.
+Future commands such as bookkeeping reconciliation or packaged workflow runners
+should be documented only after the command and JSON contract exist.
+
+## Runtime path discovery
+
+Non-Claude callers must discover the business repo path from their own runtime
+or orchestration config, then pass it to `mb` or run with that repo as the
+working directory. Safe discovery sources include:
+
+- an explicit runtime setting such as `MAINBRANCH_REPO` or an equivalent
+  project config field;
+- the current working directory when the runtime was launched from a business
+  repo;
+- a user-selected workspace/project folder;
+- a caller-owned manifest that stores repo paths outside public docs and avoids
+  credentials.
+
+Docs, adapters, and examples should not hardcode maintainer-specific home
+directory paths. If a sample needs a path, use placeholders like
+`/absolute/path/to/business-repo` or shell variables such as `$repo`.
+
+Runtime config may point at a business repo, an engine install, and optional
+provider tools. Credentials, OAuth tokens, API keys, raw exports, and local
+machine preferences must stay outside tracked business files. Canonical
+business memory remains in the repo's tracked `core/`, `research/`,
+`decisions/`, `bets/`, `pushes/`, `log/`, and `documents/` files.
+
+## Runtime adapter readiness map
+
+This map compares runtime surfaces without claiming support before adapters and
+smoke evidence exist.
+
+| Runtime surface | Status | Invocation | Skill/workflow discovery | Routing and automation | Observability and packaging |
+|---|---|---|---|---|---|
+| Claude Code | Supported | `mb start --repo "$repo"` prints the `claude` handoff; `mb start --launch` may launch after readiness checks. | `mb skill link --repo "$repo"` writes project-local `.claude/skills/mb-*` bridge links and `.claude/settings.local.json`. | Slash commands such as `/mb-start` and `/mb-think` own conversation and judgment; they call deterministic `mb` commands for facts. | `mb doctor`, `mb status --json`, `mb start --json`, `mb skill repair`, and runtime dogfood evidence gate release claims. Skills ship inside the Python package today. |
+| Codex | Roadmap | Can call deterministic `mb` commands as a subprocess when pointed at a business repo. | No supported Main Branch Codex adapter or workflow packaging yet. | No supported routing contract. Any use is manual or contributor experimentation. | Needs adapter docs, generated-file rules, and fresh-repo smoke before experimental/support status. |
+| Cursor | Roadmap | Can call deterministic `mb` commands from terminal/tasks when pointed at a business repo. | No supported Cursor rules/package adapter yet. | No supported Main Branch routing contract. | Needs adapter docs, install/update rules, conflict handling, and smoke evidence. |
+| OpenClaw | Roadmap | Target public runtime surface. It should call `mb` through stable CLI/JSON commands rather than clone-era paths. | No supported OpenClaw adapter yet. | Main Branch should coexist with OpenClaw as the business repo/GitHub memory layer, not replace it. | Needs explicit adapter shape, migration notes, generated-file rules, and smoke evidence. |
+| Hermes | Roadmap | Target runtime/memory surface. It may supervise or host workflows that call packaged `mb` commands. | No supported Hermes adapter yet. | Hermes-specific routing belongs in the Hermes adapter, while `mb` remains deterministic and non-conversational. | Docs may describe internal-package expectations generically, but not as the only blessed public path. Smoke evidence is required before support claims. |
+| Paperclip-adjacent orchestration | Roadmap | Best understood as orchestration or supervision. A routine can run `mb status`, `mb validate`, `mb graph`, `mb connect status`, or other shipped deterministic commands against an explicit repo path. | Paperclip should not assume Claude Code skills are available unless a separate runtime adapter provides that discovery layer. | Paperclip may sequence deterministic checks and handoffs; model conversation, retries, and judgment stay in the hosted runtime/workflow layer. | Needs package install contract, repo-path config, log/exit-code handling, and smoke evidence before experimental/support status. |
+| Local runtimes | Roadmap | Can call deterministic `mb` commands as subprocesses when pointed at a business repo. | No supported local-runtime adapter yet. | No supported workflow routing, prompt packaging, or model invocation through `mb`. | Needs endpoint/runtime discovery, generated-file and secret rules, and fresh-repo smoke evidence. |
+
+## Workflow coverage today
+
+The CLI/repo contract and the slash-skill workflow contract have different
+support levels:
+
+| Surface | Claude Code | Other runtimes and orchestrators |
+|---|---|---|
+| Deterministic CLI facts (`mb status --json`, `mb validate --json`, `mb graph --json`, `mb connect status --json`) | Supported when `mb` is installed and pointed at a business repo. | Callable as packaged CLI subprocesses, but this does not make the hosting runtime supported. |
+| Runtime handoff (`mb start --json`, `mb start --launch`) | Supported for Claude Code handoff and launch readiness. | Roadmap. New adapters must define their own handoff metadata and smoke evidence. |
+| Lifecycle slash skills (`/mb-start`, `/mb-status`, `/mb-setup`, `/mb-update`, `/mb-end`, `/mb-help`) | Supported through Claude Code project-local skill discovery. | Roadmap. Markdown readability is not adapter support. |
+| Production slash skills (`/mb-think`, `/mb-ads`, `/mb-vsl`, `/mb-organic`, `/mb-site`, `/mb-wiki`, `/mb-bet`) | Supported through Claude Code skills, subject to each skill's provider and workflow limits. | Roadmap. Cursor rules, Codex prompts, OpenClaw workflows, Hermes packages, Paperclip routines, or local-runtime prompts need their own adapter/package contract before public support claims. |
+| Automation routines | May call CLI commands before handing judgment work to Claude Code. | May call shipped deterministic CLI commands against an explicit repo path. Conversation, retries, routing, and model invocation belong to the runtime adapter, not `mb`. |
+
+## Adapter checklist
+
+Before a non-Claude surface moves out of roadmap status, its PR or decision must
+document:
+
+- runtime executable, plugin, endpoint, or package discovery;
+- install, update, restart, and repair commands;
+- workflow discovery and human invocation syntax;
+- generated files, tracked-vs-gitignored rules, and secret handling;
+- `mb doctor`, `mb status --json`, and `mb start --json` readiness behavior;
+- exact fresh-repo smoke evidence and known limitations.
+
+That evidence should prove the runtime reads the business repo and does not
+write runtime state, credentials, or raw account data into tracked files.
 
 ## Recommended setup
 


### PR DESCRIPTION
## Summary
- Documents packaged `mb` invocation for non-Claude callers using explicit repo paths, JSON output, and exit codes.
- Adds runtime path discovery guidance and an adapter/readiness map across Claude Code, Codex, Cursor, OpenClaw, Hermes, Paperclip-adjacent orchestration, and local runtimes.
- Separates deterministic CLI subprocess use from slash-skill/runtime support claims, and updates README/CHANGELOG to point at that compatibility contract.

## Scope
- In: docs-only compatibility contract, safe command shapes, repo-path discovery, adapter/readiness map, workflow coverage table, and README/CHANGELOG alignment.
- Out: new runtime adapters, new CLI commands or JSON schemas, non-Claude support claims, package/install changes, fixture changes, and runtime smoke.

## Commits
- `3a98a3f` — `[update] Document packaged runtime compatibility`.

## Release / Issues
- Release: Unreleased / v0.3.x docs compatibility slice.
- Linear ID(s): MAIN-129.
- Closes: #129.
- Refs: none.
- Follow-ups: runtime-specific adapter specs and smoke evidence when a non-Claude surface is promoted beyond roadmap.

## Success Metric
- A contributor can add packaged runtime support or migration docs without hardcoding Claude Code, a maintainer machine path, or a private runtime preference into the public engine.

## Validation
- Level 0 docs/decision: reviewed public/private boundary, runtime support terms, command examples, and stale local-path language.
- Level 1 static: `scripts/check.sh` passed from repo root; 357 tests passed, coverage 80.80%, and `mb skill validate --all` passed for 17 bundled skills.
- Level 2 CLI: no CLI behavior changed; documented command shapes were checked against current Typer signatures during review.
- Level 3 package/install: not run; no packaging or entrypoint behavior changed.
- Level 4 fixture repo: not run; no repo-shape, onboarding, migration, status, or start behavior changed.
- Level 5 runtime smoke: not run; this PR adds no adapter and makes no new non-Claude runtime support claim.

## Public / Private Boundary
- Scrubbed the README daily-flow example from a hardcoded home-directory path to `/path/to/my-business`.
- Kept Hermes, Paperclip, OpenClaw, Codex, Cursor, and local runtimes framed as roadmap targets until adapter docs and smoke evidence exist.
- No credentials, customer/member data, private Conductor details, or Noontide-only runtime preference were added.
