### PR TITLE
[add] mb status relationship health

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+### Added
+
+- Added `mb status` relationship-health JSON and human briefing signals for
+  disconnected bets, pushes, offers, and outcomes so daily status can surface
+  business-loop gaps from graph facts. Refs #358.
+
 ## [0.3.8] - 2026-05-08
 
 v0.3.8 tightens the daily operating loop after the 0.3.7 release discipline

--- a/mb/mb/ranker.py
+++ b/mb/mb/ranker.py
@@ -20,6 +20,7 @@ WEIGHTS: dict[str, int] = {
     "attention_requests": 70,
     "assigned_tasks": 65,
     "blocked_or_stale_tasks": 60,
+    "relationship_health_gaps": 82,
     "due_bets": 58,
     "stale_decisions": 50,
     "stale_research": 35,
@@ -49,6 +50,7 @@ def rank_status_report(
     actions: list[dict[str, Any]] = []
     _add_readiness_actions(actions, report)
     _add_drift_actions(actions, report)
+    _add_relationship_actions(actions, report)
     _add_bet_actions(actions, report)
     _add_github_actions(actions, report)
     _add_since_last_check_action(actions, report)
@@ -341,6 +343,38 @@ def _add_bet_actions(actions: list[dict[str, Any]], report: dict[str, Any]) -> N
                 ],
             )
         )
+
+
+def _add_relationship_actions(actions: list[dict[str, Any]], report: dict[str, Any]) -> None:
+    relationship_health = _dict(report.get("relationship_health"))
+    gaps = [_dict(item) for item in _list(relationship_health.get("gaps"))]
+    if not gaps:
+        return
+    warnings = [item for item in gaps if item.get("severity") == "warn"]
+    first_gap = gaps[0]
+    score = WEIGHTS["relationship_health_gaps"] + min(len(gaps) * 3, 18)
+    actions.append(
+        _action(
+            action_id="review_relationship_health",
+            title="Review business relationship gaps",
+            command="mb status --verbose --peek",
+            severity="warn" if warnings else "info",
+            score=score,
+            reason=str(
+                first_gap.get("summary") or f"{len(gaps)} business relationship gap(s) need review."
+            ),
+            signals=[
+                _signal(
+                    "relationship_health.gaps",
+                    severity="warn" if warnings else "info",
+                    summary="business graph has actionable relationship gaps",
+                    evidence=[str(item.get("id") or "") for item in gaps[:5]],
+                    weight=WEIGHTS["relationship_health_gaps"],
+                    safe_to_share=all(bool(item.get("safe_to_share", True)) for item in gaps),
+                )
+            ],
+        )
+    )
 
 
 def _add_github_actions(actions: list[dict[str, Any]], report: dict[str, Any]) -> None:

--- a/mb/mb/status.py
+++ b/mb/mb/status.py
@@ -12,8 +12,9 @@ from typing import Any
 
 import yaml
 
-from mb import __version__, github_activity
+from mb import __version__, github_activity, relationships
 from mb import connect as connect_mod
+from mb import graph as graph_mod
 from mb import journal as journal_mod
 from mb import onboard as onboard_mod
 from mb import pushes as pushes_mod
@@ -39,6 +40,10 @@ LAST_STATUS_SEEN_GITIGNORE_ENTRY = ".mb/last-status-seen.json"
 STALE_DECISION_DAYS = 14
 STALE_RESEARCH_DAYS = 45
 ACTIVE_BET_STATUSES = {"open", "paused"}
+ACTIVE_PUSH_STATUSES = {"planned", "active", "paused"}
+COMPLETED_PUSH_STATUSES = {"completed"}
+INACTIVE_OFFER_STATUSES = {"killed", "died", "rejected"}
+STALE_PUSH_DAYS = 14
 
 
 def _utc_now() -> datetime:
@@ -501,6 +506,299 @@ def _bets(repo: Path) -> dict[str, Any]:
     }
 
 
+def _file_path_from_graph_id(value: Any) -> str:
+    if not isinstance(value, str) or not value.startswith("file:"):
+        return ""
+    return value[len("file:") :]
+
+
+def _relationship_adjacency(edges: list[dict[str, Any]]) -> dict[str, dict[str, set[str]]]:
+    adjacency: dict[str, dict[str, set[str]]] = {}
+    for edge in edges:
+        rel_type = str(edge.get("rel_type") or edge.get("type") or "")
+        source = _file_path_from_graph_id(edge.get("source"))
+        target = _file_path_from_graph_id(edge.get("target"))
+        if not rel_type or not source or not target:
+            continue
+        adjacency.setdefault(source, {}).setdefault(rel_type, set()).add(target)
+        adjacency.setdefault(target, {}).setdefault(rel_type, set()).add(source)
+    return adjacency
+
+
+def _linked_paths(
+    adjacency: dict[str, dict[str, set[str]]],
+    path: str,
+    rel_type: str,
+) -> set[str]:
+    return adjacency.get(path, {}).get(rel_type, set())
+
+
+def _offer_summaries(repo: Path) -> list[dict[str, Any]]:
+    paths: list[Path] = []
+    for folder in ("core/offers", "reference/core/offers"):
+        paths.extend(
+            path for path in _relative_markdown_files(repo, folder) if path.name == "offer.md"
+        )
+    for rel in ("core/offer.md", "reference/core/offer.md"):
+        path = repo / rel
+        if path.is_file():
+            paths.append(path)
+    unique_paths = sorted(set(paths), key=lambda path: path.stat().st_mtime, reverse=True)
+    return [_file_summary(repo, path, _read_frontmatter(path)) for path in unique_paths]
+
+
+def _gap(
+    *,
+    gap_id: str,
+    severity: str,
+    summary: str,
+    records: list[dict[str, Any]],
+    repair: str,
+) -> dict[str, Any]:
+    return {
+        "id": gap_id,
+        "severity": severity,
+        "summary": summary,
+        "count": len(records),
+        "evidence": [str(item.get("path") or item.get("source") or "") for item in records[:5]],
+        "records": records[:5],
+        "repair": repair,
+        "safe_to_share": True,
+    }
+
+
+def _is_push_stale(record: dict[str, Any], today: date) -> tuple[bool, int]:
+    review_on = _parse_explicit_date(record.get("review_on"))
+    if review_on is not None and review_on < today:
+        return True, (today - review_on).days
+    for key in ("started", "date"):
+        item_date = _parse_explicit_date(record.get(key))
+        if item_date is not None:
+            age_days = (today - item_date).days
+            if age_days > STALE_PUSH_DAYS:
+                return True, age_days
+            return False, age_days
+    return False, 0
+
+
+def _relationship_health(
+    repo: Path,
+    *,
+    brain: dict[str, Any],
+    today: date,
+) -> dict[str, Any]:
+    graph_index = graph_mod.build_index(str(repo))
+    edges = [edge for edge in graph_index.get("edges", []) if isinstance(edge, dict)]
+    adjacency = _relationship_adjacency(edges)
+    all_bets = [_bet_summary(repo, path) for path in _relative_markdown_files(repo, "bets")]
+    active_bets = [
+        item for item in all_bets if str(item.get("status", "")).lower() in ACTIVE_BET_STATUSES
+    ]
+    closed_bets = [
+        item
+        for item in all_bets
+        if str(item.get("status", "")).lower() == "closed" and not str(item.get("result") or "")
+    ]
+    push_report = brain.get("pushes") or {}
+    pushes = [item for item in push_report.get("records", []) if isinstance(item, dict)]
+    offers = _offer_summaries(repo)
+    current_push_paths = {
+        str(item.get("path") or "")
+        for item in pushes
+        if str(item.get("status", "")).lower() in ACTIVE_PUSH_STATUSES
+    }
+
+    active_bets_without_push = [
+        item for item in active_bets if not _linked_paths(adjacency, str(item["path"]), "push")
+    ]
+    closed_bets_without_outcome = [
+        item for item in closed_bets if not _linked_paths(adjacency, str(item["path"]), "outcome")
+    ]
+    active_pushes_without_offer = [
+        item
+        for item in pushes
+        if str(item.get("status", "")).lower() in ACTIVE_PUSH_STATUSES
+        and not _linked_paths(adjacency, str(item.get("path") or ""), "offer")
+    ]
+    completed_pushes_without_outcome = [
+        item
+        for item in pushes
+        if str(item.get("status", "")).lower() in COMPLETED_PUSH_STATUSES
+        and not _linked_paths(adjacency, str(item.get("path") or ""), "outcome")
+    ]
+    stale_pushes_without_outcome: list[dict[str, Any]] = []
+    for item in pushes:
+        if str(item.get("status", "")).lower() not in ACTIVE_PUSH_STATUSES:
+            continue
+        if _linked_paths(adjacency, str(item.get("path") or ""), "outcome"):
+            continue
+        stale, age_days = _is_push_stale(item, today)
+        if stale:
+            stale_item = dict(item)
+            stale_item["age_days"] = age_days
+            stale_pushes_without_outcome.append(stale_item)
+
+    offers_without_current_push_or_playbook: list[dict[str, Any]] = []
+    for item in offers:
+        status = str(item.get("status") or "").lower()
+        if status in INACTIVE_OFFER_STATUSES:
+            continue
+        path = str(item.get("path") or "")
+        offer_pushes = _linked_paths(adjacency, path, "offer")
+        has_current_push = bool(offer_pushes & current_push_paths)
+        has_playbook = bool(_linked_paths(adjacency, path, "playbook"))
+        if not has_current_push and not has_playbook:
+            offers_without_current_push_or_playbook.append(item)
+
+    relationship_types = {
+        relationship.canonical_type for relationship in relationships.RELATIONSHIPS
+    }
+    graph_nodes = {
+        str(node.get("id") or ""): node
+        for node in graph_index.get("nodes", [])
+        if isinstance(node, dict)
+    }
+    missing_relationship_targets: list[dict[str, Any]] = []
+    for edge in edges:
+        rel_type = str(edge.get("rel_type") or "")
+        target = str(edge.get("target") or "")
+        if rel_type not in relationship_types or not target.startswith("missing:"):
+            continue
+        raw_evidence = edge.get("evidence")
+        evidence: dict[str, Any] = raw_evidence if isinstance(raw_evidence, dict) else {}
+        target_node: dict[str, Any] = graph_nodes.get(target) or {}
+        missing_relationship_targets.append(
+            {
+                "source": str(evidence.get("path") or _file_path_from_graph_id(edge.get("source"))),
+                "relationship": rel_type,
+                "field": str(edge.get("original_field") or evidence.get("field") or ""),
+                "target": str(target_node.get("label") or target.removeprefix("missing:")),
+            }
+        )
+
+    outcome_edges = [edge for edge in edges if str(edge.get("rel_type") or "") == "outcome"]
+    gaps = [
+        _gap(
+            gap_id="active_bets_without_push",
+            severity="warn",
+            summary=f"{len(active_bets_without_push)} active bet(s) need a linked push.",
+            records=active_bets_without_push,
+            repair="Link each active bet to the push or playbook that supports it.",
+        )
+        if active_bets_without_push
+        else None,
+        _gap(
+            gap_id="closed_bets_without_outcome",
+            severity="warn",
+            summary=(
+                f"{len(closed_bets_without_outcome)} closed bet(s) need a result or outcome link."
+            ),
+            records=closed_bets_without_outcome,
+            repair="Record the bet result and link the outcome artifact.",
+        )
+        if closed_bets_without_outcome
+        else None,
+        _gap(
+            gap_id="active_pushes_without_offer",
+            severity="warn",
+            summary=(
+                f"{len(active_pushes_without_offer)} active/planned push(es) need an offer link."
+            ),
+            records=active_pushes_without_offer,
+            repair="Set the push `offer:` field to the repo-relative offer file.",
+        )
+        if active_pushes_without_offer
+        else None,
+        _gap(
+            gap_id="completed_pushes_without_outcome",
+            severity="warn",
+            summary=(
+                f"{len(completed_pushes_without_outcome)} completed push(es) need review/outcome."
+            ),
+            records=completed_pushes_without_outcome,
+            repair="Add `linked_outcomes` to the completed push after review.",
+        )
+        if completed_pushes_without_outcome
+        else None,
+        _gap(
+            gap_id="stale_pushes_without_outcome",
+            severity="warn",
+            summary=f"{len(stale_pushes_without_outcome)} stale push(es) have not closed the loop.",
+            records=stale_pushes_without_outcome,
+            repair="Review stale pushes, capture the outcome, or update the review date.",
+        )
+        if stale_pushes_without_outcome
+        else None,
+        _gap(
+            gap_id="offers_without_current_push_or_playbook",
+            severity="info",
+            summary=(
+                f"{len(offers_without_current_push_or_playbook)} offer(s) have no current push "
+                "or linked playbook."
+            ),
+            records=offers_without_current_push_or_playbook,
+            repair="Connect each live offer to a current push or reusable playbook.",
+        )
+        if offers_without_current_push_or_playbook
+        else None,
+        _gap(
+            gap_id="missing_relationship_targets",
+            severity="warn",
+            summary=(
+                f"{len(missing_relationship_targets)} relationship link(s) point at missing files."
+            ),
+            records=missing_relationship_targets,
+            repair="Run `mb validate --cross-refs` for exact missing-link warnings.",
+        )
+        if missing_relationship_targets
+        else None,
+    ]
+    active_gaps = [gap_item for gap_item in gaps if gap_item is not None]
+    return {
+        "ok": not active_gaps,
+        "source": "mb graph",
+        "registry_version": relationships.REGISTRY_VERSION,
+        "summary": {
+            "gaps": len(active_gaps),
+            "warnings": len([item for item in active_gaps if item["severity"] == "warn"]),
+            "info": len([item for item in active_gaps if item["severity"] == "info"]),
+            "active_bets_without_push": len(active_bets_without_push),
+            "closed_bets_without_outcome": len(closed_bets_without_outcome),
+            "active_pushes_without_offer": len(active_pushes_without_offer),
+            "completed_pushes_without_outcome": len(completed_pushes_without_outcome),
+            "stale_pushes_without_outcome": len(stale_pushes_without_outcome),
+            "offers_without_current_push_or_playbook": len(offers_without_current_push_or_playbook),
+            "missing_relationship_targets": len(missing_relationship_targets),
+        },
+        "gaps": active_gaps,
+        "sections": {
+            "bets": {
+                "active": len(active_bets),
+                "closed": len(
+                    [item for item in all_bets if str(item.get("status") or "").lower() == "closed"]
+                ),
+                "active_without_push": active_bets_without_push[:5],
+                "closed_without_outcome": closed_bets_without_outcome[:5],
+            },
+            "pushes": {
+                "records": len(pushes),
+                "active_without_offer": active_pushes_without_offer[:5],
+                "completed_without_outcome": completed_pushes_without_outcome[:5],
+                "stale_without_outcome": stale_pushes_without_outcome[:5],
+            },
+            "offers": {
+                "records": len(offers),
+                "without_current_push_or_playbook": offers_without_current_push_or_playbook[:5],
+            },
+            "outcomes": {
+                "linked_count": len(outcome_edges),
+                "missing_targets": missing_relationship_targets[:5],
+            },
+        },
+        "safe_to_share": True,
+    }
+
+
 def _repo_full_name(remote: str) -> str:
     return github_activity.repo_full_name(remote)
 
@@ -932,6 +1230,29 @@ def _drift(report: dict[str, Any]) -> dict[str, Any]:
                 "safe_to_share": True,
             }
         )
+    relationship_health = report.get("relationship_health") or {}
+    relationship_summary = relationship_health.get("summary") or {}
+    if relationship_summary.get("gaps", 0):
+        top_gap = (relationship_health.get("gaps") or [{}])[0]
+        items.append(
+            {
+                "id": "relationship_health_gaps",
+                "severity": "warn" if relationship_summary.get("warnings", 0) else "info",
+                "summary": (
+                    f"{relationship_summary.get('gaps', 0)} business relationship gap(s) "
+                    "need review."
+                ),
+                "evidence": [
+                    str(item.get("id") or "")
+                    for item in (relationship_health.get("gaps") or [])[:5]
+                ],
+                "repair": str(
+                    top_gap.get("repair")
+                    or "Run `mb status --verbose --peek` to inspect relationship gaps."
+                ),
+                "safe_to_share": True,
+            }
+        )
     onboarding_summary = (report.get("onboarding") or {}).get("summary") or {}
     if onboarding_summary.get("status") == "in_progress":
         items.append(
@@ -1056,6 +1377,16 @@ def _readiness(report: dict[str, Any]) -> dict[str, Any]:
         next_actions.append("Close or update overdue active bets in `bets/`.")
     elif bets.get("due_soon"):
         next_actions.append("Review active bets with deadlines in the next 7 days.")
+    relationship_health = report.get("relationship_health") or {}
+    relationship_gaps = relationship_health.get("gaps") or []
+    if relationship_gaps:
+        first_gap = relationship_gaps[0]
+        next_actions.append(
+            str(
+                first_gap.get("repair")
+                or "Review relationship gaps with `mb status --verbose --peek`."
+            )
+        )
     onboarding_summary = (report.get("onboarding") or {}).get("summary") or {}
     if onboarding_summary.get("status") == "in_progress":
         next_actions.append(
@@ -1107,7 +1438,8 @@ def run(
 ) -> dict[str, Any]:
     """Build a deterministic daily briefing report."""
     repo_path = Path(path).resolve()
-    generated_at = _format_timestamp(now or _utc_now())
+    current_time = now or _utc_now()
+    generated_at = _format_timestamp(current_time)
     repo_shape = _looks_like_mainbranch_repo(repo_path)
     git = _git_info(repo_path)
     update = package_update_status(repo_path)
@@ -1142,6 +1474,11 @@ def run(
         "measurement": _measurement(repo_path),
         "github": github,
     }
+    report["relationship_health"] = _relationship_health(
+        repo_path,
+        brain=brain,
+        today=current_time.date(),
+    )
     report["since_last_check"] = _since_last_check(
         repo_path,
         marker=marker,
@@ -1189,6 +1526,10 @@ def render_human(
     readiness = report["readiness"]
     since = report.get("since_last_check") or {}
     drift = report.get("drift") or {"summary": {"total": 0}, "items": []}
+    relationship_health = report.get("relationship_health") or {
+        "summary": {"gaps": 0},
+        "gaps": [],
+    }
 
     console.print(f"\n[bold]mb status[/bold]  {repo['path']}")
     alert = format_update_alert(report.get("update", {}))
@@ -1242,6 +1583,20 @@ def render_human(
                 console.print(f"    next: {item['repair']}")
     else:
         console.print("[bold]Drift[/bold] no stale or broken status signals detected")
+
+    relationship_summary = relationship_health.get("summary") or {}
+    if relationship_summary.get("gaps", 0):
+        console.print(
+            "[bold]Relationship health[/bold] "
+            f"{relationship_summary.get('warnings', 0)} warning(s), "
+            f"{relationship_summary.get('info', 0)} info"
+        )
+        for gap in (relationship_health.get("gaps") or [])[:3]:
+            console.print(f"  - {gap['summary']}")
+            if verbose and gap.get("repair"):
+                console.print(f"    next: {gap['repair']}")
+    else:
+        console.print("[bold]Relationship health[/bold] no actionable business-link gaps detected")
 
     repo_mark = (
         "[green]yes[/green]" if repo["looks_like_mainbranch_repo"] else "[yellow]no[/yellow]"

--- a/mb/mb/status.py
+++ b/mb/mb/status.py
@@ -42,7 +42,7 @@ STALE_RESEARCH_DAYS = 45
 ACTIVE_BET_STATUSES = {"open", "paused"}
 ACTIVE_PUSH_STATUSES = {"planned", "active", "paused"}
 COMPLETED_PUSH_STATUSES = {"completed"}
-INACTIVE_OFFER_STATUSES = {"killed", "died", "rejected"}
+LIVE_OFFER_STATUSES = {"accepted", "graduated", "running", "scaling"}
 STALE_PUSH_DAYS = 14
 
 
@@ -594,11 +594,7 @@ def _relationship_health(
     active_bets = [
         item for item in all_bets if str(item.get("status", "")).lower() in ACTIVE_BET_STATUSES
     ]
-    closed_bets = [
-        item
-        for item in all_bets
-        if str(item.get("status", "")).lower() == "closed" and not str(item.get("result") or "")
-    ]
+    closed_bets = [item for item in all_bets if str(item.get("status", "")).lower() == "closed"]
     push_report = brain.get("pushes") or {}
     pushes = [item for item in push_report.get("records", []) if isinstance(item, dict)]
     offers = _offer_summaries(repo)
@@ -641,11 +637,12 @@ def _relationship_health(
     offers_without_current_push_or_playbook: list[dict[str, Any]] = []
     for item in offers:
         status = str(item.get("status") or "").lower()
-        if status in INACTIVE_OFFER_STATUSES:
+        if status not in LIVE_OFFER_STATUSES:
             continue
         path = str(item.get("path") or "")
         offer_pushes = _linked_paths(adjacency, path, "offer")
-        has_current_push = bool(offer_pushes & current_push_paths)
+        linked_pushes = _linked_paths(adjacency, path, "push")
+        has_current_push = bool((offer_pushes | linked_pushes) & current_push_paths)
         has_playbook = bool(_linked_paths(adjacency, path, "playbook"))
         if not has_current_push and not has_playbook:
             offers_without_current_push_or_playbook.append(item)

--- a/mb/tests/fixtures/status/schema-v1-basic.json
+++ b/mb/tests/fixtures/status/schema-v1-basic.json
@@ -26,6 +26,7 @@
     "pushes",
     "ranked_actions",
     "readiness",
+    "relationship_health",
     "repo",
     "runtime",
     "schema",
@@ -163,6 +164,15 @@
       "level",
       "next_actions",
       "score"
+    ],
+    "relationship_health": [
+      "gaps",
+      "ok",
+      "registry_version",
+      "safe_to_share",
+      "sections",
+      "source",
+      "summary"
     ],
     "marker_update": [
       "attempted",

--- a/mb/tests/test_status.py
+++ b/mb/tests/test_status.py
@@ -316,6 +316,73 @@ def test_status_relationship_health_flags_completed_and_stale_pushes(
     )
 
 
+def test_status_relationship_health_accepts_offer_side_push_links(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+    offer = repo / "core" / "offers" / "coaching"
+    offer.mkdir(parents=True)
+    (offer / "offer.md").write_text(
+        (
+            "---\n"
+            "slug: coaching\n"
+            "status: running\n"
+            "linked_pushes:\n"
+            "  - pushes/2026-05-01-launch/push.md\n"
+            "---\n\n"
+            "# Coaching\n"
+        ),
+        encoding="utf-8",
+    )
+    push = repo / "pushes" / "2026-05-01-launch"
+    push.mkdir(parents=True)
+    (push / "push.md").write_text(
+        (
+            "---\n"
+            "type: push\n"
+            "slug: launch\n"
+            "kind: launch\n"
+            "status: active\n"
+            "health: on-track\n"
+            "goal: booked calls\n"
+            "owner: Devon\n"
+            "audience: founders\n"
+            "offer: ''\n"
+            "started: 2026-05-01\n"
+            "review_on: 2026-05-20\n"
+            "---\n\n"
+            "# Launch\n"
+        ),
+        encoding="utf-8",
+    )
+
+    report = status_mod.run(
+        path=str(repo),
+        now=datetime(2026, 5, 8, 12, 0, tzinfo=timezone.utc),
+        update_marker=False,
+    )
+
+    assert report["relationship_health"]["summary"]["offers_without_current_push_or_playbook"] == 0
+
+
+def test_status_relationship_health_ignores_non_live_offer_stubs(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+    (repo / "core" / "offer.md").write_text(
+        "---\ntype: offer\nstatus: stub\n---\n\n# Offer stub\n",
+        encoding="utf-8",
+    )
+
+    report = status_mod.run(path=str(repo), update_marker=False)
+
+    assert report["relationship_health"]["summary"]["offers_without_current_push_or_playbook"] == 0
+
+
 def test_status_relationship_health_flags_closed_bet_without_outcome(
     tmp_path: Path, monkeypatch
 ) -> None:
@@ -332,7 +399,7 @@ def test_status_relationship_health_flags_closed_bet_without_outcome(
             "hypothesis: A follow-up push will create calls.\n"
             "metric: calls\n"
             "target: 5 calls\n"
-            "result: ''\n"
+            "result: win\n"
             "linked_decisions: []\n"
             "linked_research: []\n"
             "linked_pushes: []\n"

--- a/mb/tests/test_status.py
+++ b/mb/tests/test_status.py
@@ -123,6 +123,7 @@ def test_status_schema_v1_matches_golden_fixture(tmp_path: Path, monkeypatch) ->
                 "since_last_check",
                 "drift",
                 "readiness",
+                "relationship_health",
                 "ranked_actions",
                 "marker_update",
             ]
@@ -184,6 +185,175 @@ def test_status_json_exposes_push_and_legacy_campaign_facts(tmp_path: Path, monk
         "pushes/2026-05-06-workshop/push.md",
         "campaigns/2026-05-legacy/campaign.md",
     }
+
+
+def test_status_relationship_health_flags_active_bet_and_offer_gaps(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+    offer = repo / "core" / "offers" / "coaching"
+    offer.mkdir(parents=True)
+    (offer / "offer.md").write_text(
+        "---\nslug: coaching\nstatus: running\n---\n\n# Coaching\n",
+        encoding="utf-8",
+    )
+    (repo / "bets" / "2026-05-01-launch.md").write_text(
+        (
+            "---\n"
+            "status: open\n"
+            "opened: 2026-05-01\n"
+            "deadline: 2026-05-31\n"
+            "appetite: 2 weeks\n"
+            "hypothesis: A launch push will create calls.\n"
+            "metric: calls\n"
+            "target: 5 calls\n"
+            "result: ''\n"
+            "linked_decisions: []\n"
+            "linked_research: []\n"
+            "linked_pushes: []\n"
+            "linked_campaigns: []\n"
+            "linked_outcomes: []\n"
+            "public: true\n"
+            "channels: []\n"
+            "tags: []\n"
+            "---\n\n"
+            "# Launch bet\n"
+        ),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["status", str(repo), "--json", "--peek"])
+
+    assert result.exit_code == 0
+    report = json.loads(result.stdout)
+    health = report["relationship_health"]
+    assert health["ok"] is False
+    assert health["summary"]["active_bets_without_push"] == 1
+    assert health["summary"]["offers_without_current_push_or_playbook"] == 1
+    assert health["sections"]["bets"]["active_without_push"][0]["path"] == (
+        "bets/2026-05-01-launch.md"
+    )
+    assert any(item["id"] == "relationship_health_gaps" for item in report["drift"]["items"])
+    assert any(action["id"] == "review_relationship_health" for action in report["ranked_actions"])
+
+    human = runner.invoke(app, ["status", str(repo), "--no-color", "--peek"])
+
+    assert human.exit_code == 0
+    assert "Relationship health" in human.stdout
+    assert "active bet(s) need a linked push" in human.stdout
+
+
+def test_status_relationship_health_flags_completed_and_stale_pushes(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+    offer = repo / "core" / "offers" / "coaching"
+    offer.mkdir(parents=True)
+    (offer / "offer.md").write_text(
+        "---\nslug: coaching\nstatus: running\n---\n\n# Coaching\n",
+        encoding="utf-8",
+    )
+    completed = repo / "pushes" / "2026-05-01-completed"
+    completed.mkdir(parents=True)
+    (completed / "push.md").write_text(
+        (
+            "---\n"
+            "type: push\n"
+            "slug: completed\n"
+            "kind: launch\n"
+            "status: completed\n"
+            "health: on-track\n"
+            "goal: booked calls\n"
+            "owner: Devon\n"
+            "audience: founders\n"
+            "offer: core/offers/coaching/offer.md\n"
+            "started: 2026-05-01\n"
+            "review_on: 2026-05-07\n"
+            "---\n\n"
+            "# Completed push\n"
+        ),
+        encoding="utf-8",
+    )
+    stale = repo / "pushes" / "2026-04-01-stale"
+    stale.mkdir(parents=True)
+    (stale / "push.md").write_text(
+        (
+            "---\n"
+            "type: push\n"
+            "slug: stale\n"
+            "kind: launch\n"
+            "status: active\n"
+            "health: at-risk\n"
+            "goal: booked calls\n"
+            "owner: Devon\n"
+            "audience: founders\n"
+            "offer: core/offers/coaching/offer.md\n"
+            "started: 2026-04-01\n"
+            "review_on: 2026-04-15\n"
+            "---\n\n"
+            "# Stale push\n"
+        ),
+        encoding="utf-8",
+    )
+
+    report = status_mod.run(
+        path=str(repo),
+        now=datetime(2026, 5, 8, 12, 0, tzinfo=timezone.utc),
+        update_marker=False,
+    )
+
+    summary = report["relationship_health"]["summary"]
+    assert summary["completed_pushes_without_outcome"] == 1
+    assert summary["stale_pushes_without_outcome"] == 1
+    assert summary["offers_without_current_push_or_playbook"] == 0
+    assert (
+        report["relationship_health"]["sections"]["pushes"]["stale_without_outcome"][0]["path"]
+        == "pushes/2026-04-01-stale/push.md"
+    )
+
+
+def test_status_relationship_health_flags_closed_bet_without_outcome(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+    (repo / "bets" / "2026-05-01-closed.md").write_text(
+        (
+            "---\n"
+            "status: closed\n"
+            "opened: 2026-05-01\n"
+            "deadline: 2026-05-07\n"
+            "appetite: 1 week\n"
+            "hypothesis: A follow-up push will create calls.\n"
+            "metric: calls\n"
+            "target: 5 calls\n"
+            "result: ''\n"
+            "linked_decisions: []\n"
+            "linked_research: []\n"
+            "linked_pushes: []\n"
+            "linked_campaigns: []\n"
+            "linked_outcomes: []\n"
+            "public: false\n"
+            "channels: []\n"
+            "tags: []\n"
+            "---\n\n"
+            "# Closed bet\n"
+        ),
+        encoding="utf-8",
+    )
+
+    report = status_mod.run(path=str(repo), update_marker=False)
+
+    assert report["relationship_health"]["summary"]["closed_bets_without_outcome"] == 1
+    assert (
+        report["relationship_health"]["sections"]["bets"]["closed_without_outcome"][0]["path"]
+        == "bets/2026-05-01-closed.md"
+    )
 
 
 def test_status_human_output_mentions_core_sections(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- Adds `relationship_health` to `mb status --json` so agents and future dashboard views can consume business relationship gaps from graph facts.
- Surfaces business-readable relationship health in human `mb status` output and ranked next actions without dumping raw graph diagnostics.
- Covers active bets without pushes, closed bets without outcomes, completed or stale pushes without outcomes, active pushes without offers, live offers without current pushes/playbooks, and missing relationship targets.
- Tightens review follow-ups so offer-side `linked_pushes` counts, closed bets with filled results still require outcome links, and stub/draft offers do not create daily noise.

## Scope
- In: status JSON, human status output, drift/readiness/ranker integration, focused status tests, and changelog entry.
- Out: dashboard implementation, provider API polling, broad action ranking, MAIN-240 git-journal expansion, and large-repo relationship-health performance optimization.

## Commits
- `042237b` — `[add] Surface relationship health in status`.
- `3e4f6fa` — `[fix] Tighten status relationship gaps`.

## Release / Issues
- Release: v0.3.x daily loop direction / `[Unreleased]`.
- Linear ID(s): MAIN-264.
- Closes: #358.
- Refs: #390.
- Follow-ups: #390 tracks keeping status relationship health cheap on large repos.

## Success Metric
- `mb status --json --peek` exposes relationship-health facts for bets, pushes, offers, and outcomes, while human `mb status` surfaces the most important business-link gaps without false-positive noise from stub offers.

## Validation
- Level 0 docs/decision: updated `CHANGELOG.md` `[Unreleased]`; no public/private boundary concerns found.
- Level 1 static: `scripts/check.sh` passed formatting, lint, mypy, coverage, and skill validation.
- Level 2 CLI: `cd mb && python3 -m pytest tests/test_status.py -q` passed with 32 tests; focused graph/validate/status suite passed earlier with 87 tests.
- Level 3 package/install: `(cd mb && python3 -m build)`, fresh venv install from `mb/dist/*.whl`, installed `mb --version`, `mb skill list`, installed `mb status --json --peek` confirming `relationship_health`, and installed `mb start --json` all passed.
- Level 4 fixture repo: fresh source-tree fixture smoke passed with `mb onboard`, `mb doctor`, `mb status --json --peek`, human `mb status --peek`, `mb start --json`, and `mb validate`; installed-wheel fixture smoke also confirmed `relationship_health` with zero gaps.
- Level 5 runtime smoke: not run because this changes deterministic CLI status output, not Claude Code discovery or skill invocation; installed CLI smoke covered the JSON block `/mb-start` consumes.

## Public / Private Boundary
- Kept Conductor/local workflow details in `.context` and GitHub coordination comments only; committed changes contain public-safe CLI behavior, tests, and changelog text.
