### PR TITLE
[add] Stable mb JSON result envelope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,10 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 - Added a shared additive v1 JSON result envelope to high-value `mb --json`
   surfaces: `mb status`, `mb start`, `mb checkpoint`, `mb issue`, `mb doctor`,
   and `mb onboard`. Existing command-specific payload keys remain top-level for
-  compatibility while shared metadata (`schema_version`, `mb_command`, `ok`,
-  `status`, `errors`, `warnings`, and `actions`) gives skills, harnesses, and
-  future dashboards one failure-handling convention. Refs #297.
+  compatibility while shared metadata (`result_envelope_version`,
+  `result_schema`, `mb_command`, `ok`, `result_status`, `errors`, `warnings`,
+  and `actions`) gives skills, harnesses, and future dashboards one
+  failure-handling convention. Refs #297.
 
 ## [0.3.8] - 2026-05-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+### Changed
+
+- Added a shared additive v1 JSON result envelope to high-value `mb --json`
+  surfaces: `mb status`, `mb start`, `mb checkpoint`, `mb issue`, `mb doctor`,
+  and `mb onboard`. Existing command-specific payload keys remain top-level for
+  compatibility while shared metadata (`schema_version`, `mb_command`, `ok`,
+  `status`, `errors`, `warnings`, and `actions`) gives skills, harnesses, and
+  future dashboards one failure-handling convention. Refs #297.
+
 ## [0.3.8] - 2026-05-08
 
 v0.3.8 tightens the daily operating loop after the 0.3.7 release discipline

--- a/README.md
+++ b/README.md
@@ -245,9 +245,9 @@ Full list: `mb --help`.
 
 Machine-readable command output follows the additive
 [JSON output contract](docs/json-output-contract.md): high-value `--json`
-surfaces expose shared `schema_version`, `mb_command`, `ok`, `status`, `errors`,
-`warnings`, and `actions` metadata while preserving their command-specific
-payload keys.
+surfaces expose shared `result_envelope_version`, `result_schema`,
+`mb_command`, `ok`, `result_status`, `errors`, `warnings`, and `actions`
+metadata while preserving their command-specific payload keys.
 
 ### Provider Connections
 

--- a/README.md
+++ b/README.md
@@ -243,6 +243,12 @@ The CLI surface for the engine. Built for Claude Code first; runtime-agnostic by
 
 Full list: `mb --help`.
 
+Machine-readable command output follows the additive
+[JSON output contract](docs/json-output-contract.md): high-value `--json`
+surfaces expose shared `schema_version`, `mb_command`, `ok`, `status`, `errors`,
+`warnings`, and `actions` metadata while preserving their command-specific
+payload keys.
+
 ### Provider Connections
 
 `mb connect` is the local-first foundation for supported, planned, and optional

--- a/docs/json-output-contract.md
+++ b/docs/json-output-contract.md
@@ -9,11 +9,11 @@ metadata:
 
 ```json
 {
-  "schema_version": "1.0",
-  "schema": {"name": "mainbranch.status", "version": "1.0"},
+  "result_envelope_version": "1.0",
+  "result_schema": {"name": "mainbranch.status", "version": "1.0"},
   "mb_command": "mb status",
   "ok": true,
-  "status": "ok",
+  "result_status": "ok",
   "errors": [],
   "warnings": [],
   "actions": []
@@ -22,16 +22,17 @@ metadata:
 
 ## Shared Fields
 
-- `schema_version`: shared result-envelope version. Existing command-specific
-  schema versions are preserved where they already existed.
-- `schema`: command-specific schema identifier. Older command payloads that
-  already used a string schema keep that value for compatibility.
+- `result_envelope_version`: shared result-envelope version. This is separate
+  from any command-specific `schema_version` field.
+- `result_schema`: shared result-envelope schema identifier for the command
+  surface. This is separate from any command-specific `schema` field.
 - `mb_command`: the `mb` command surface that emitted the JSON. The field is
   prefixed so commands can keep existing domain keys such as `command`.
 - `ok`: boolean success flag suitable for automation.
-- `status`: concise machine-readable state. When a command already had a
-  domain `status` such as `ready`, `valid`, or `committed`, that value is
-  preserved.
+- `result_status`: concise machine-readable envelope state, currently `ok` or
+  `error`. Commands may still expose their own domain `status` field with
+  command-specific values such as `ready`, `valid`, `committed`, or structured
+  provider state.
 - `errors`: top-level list of failure messages or objects. Empty when there are
   no shared top-level errors.
 - `warnings`: top-level list of warnings. Empty when there are no shared
@@ -39,6 +40,16 @@ metadata:
 - `actions`: top-level list of recommended or repair actions when the command
   already exposes them. Empty for commands whose actions live in
   command-specific sections such as `ranked_actions` or `next_actions`.
+
+## Command-Specific Fields
+
+Existing command payload keys remain top-level and keep their command-specific
+meaning. In particular, `schema`, `schema_version`, `status`, and `command`
+are not shared envelope fields in v1. For example, `mb status --json` keeps its
+status schema object, `mb doctor repair --json` keeps
+`schema: "mb.doctor.repair"` and `schema_version: 1`, and `mb checkpoint --json`
+can keep a domain `status` such as `ready` while the envelope reports
+`result_status: "ok"`.
 
 ## First Migrated Surfaces
 

--- a/docs/json-output-contract.md
+++ b/docs/json-output-contract.md
@@ -1,0 +1,60 @@
+# JSON Output Contract
+
+Main Branch CLI JSON is for skills, runtime harnesses, dashboards, and scripts
+that need deterministic facts without parsing human terminal output.
+
+The v1 result envelope is additive. Commands keep their existing domain payload
+keys at the top level, and high-value `--json` surfaces also expose shared
+metadata:
+
+```json
+{
+  "schema_version": "1.0",
+  "schema": {"name": "mainbranch.status", "version": "1.0"},
+  "mb_command": "mb status",
+  "ok": true,
+  "status": "ok",
+  "errors": [],
+  "warnings": [],
+  "actions": []
+}
+```
+
+## Shared Fields
+
+- `schema_version`: shared result-envelope version. Existing command-specific
+  schema versions are preserved where they already existed.
+- `schema`: command-specific schema identifier. Older command payloads that
+  already used a string schema keep that value for compatibility.
+- `mb_command`: the `mb` command surface that emitted the JSON. The field is
+  prefixed so commands can keep existing domain keys such as `command`.
+- `ok`: boolean success flag suitable for automation.
+- `status`: concise machine-readable state. When a command already had a
+  domain `status` such as `ready`, `valid`, or `committed`, that value is
+  preserved.
+- `errors`: top-level list of failure messages or objects. Empty when there are
+  no shared top-level errors.
+- `warnings`: top-level list of warnings. Empty when there are no shared
+  top-level warnings.
+- `actions`: top-level list of recommended or repair actions when the command
+  already exposes them. Empty for commands whose actions live in
+  command-specific sections such as `ranked_actions` or `next_actions`.
+
+## First Migrated Surfaces
+
+The v1 envelope is present on:
+
+- `mb status --json`
+- `mb start --json`
+- `mb checkpoint --json`
+- `mb issue draft --json`
+- `mb issue open --json`
+- `mb doctor --json`
+- `mb doctor repair --json`
+- `mb onboard --json`
+- `mb onboard status --json`
+- `mb onboard plan --json`
+
+Future commands should use the same shared metadata when they add or revise
+`--json` output. Avoid moving existing payloads under a new `data` key unless a
+future schema version explicitly deprecates the top-level domain keys.

--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -35,6 +35,7 @@ from mb import think as think_mod
 from mb import update as update_mod
 from mb import validate as validate_mod
 from mb.freshness import format_update_alert, looks_like_business_repo, package_update_status
+from mb.json_result import envelope
 
 app = typer.Typer(
     name="mb",
@@ -96,6 +97,10 @@ def _version_callback(value: bool) -> None:
     if value:
         typer.echo(f"mb {__version__}")
         raise typer.Exit()
+
+
+def _json_payload(payload: dict[str, Any], *, command: str, schema_name: str) -> str:
+    return json.dumps(envelope(payload, command=command, schema_name=schema_name), indent=2)
 
 
 def _is_interactive_terminal() -> bool:
@@ -350,7 +355,9 @@ def onboard_cmd(
         typer.echo(f"mb onboard: {exc}", err=True)
         raise typer.Exit(2) from exc
     if json_out:
-        typer.echo(json.dumps(result, indent=2))
+        typer.echo(
+            _json_payload(result, command="mb onboard", schema_name="mainbranch.onboard.result")
+        )
     else:
         _render_onboard_human(result)
     raise typer.Exit(0 if result["ok"] else 1)
@@ -394,7 +401,13 @@ def onboard_status_cmd(
     """Show saved onboarding progress and inferred missing core inputs."""
     result = onboard_mod.onboarding_status(repo)
     if json_out:
-        typer.echo(json.dumps(result, indent=2))
+        typer.echo(
+            _json_payload(
+                result,
+                command="mb onboard status",
+                schema_name="mainbranch.onboard.status.result",
+            )
+        )
     else:
         _render_onboard_status_human(result)
     raise typer.Exit(0 if result["ok"] else 1)
@@ -432,7 +445,13 @@ def onboard_plan_cmd(
         typer.echo(f"mb onboard plan: {exc}", err=True)
         raise typer.Exit(2) from exc
     if json_out:
-        typer.echo(json.dumps(result, indent=2))
+        typer.echo(
+            _json_payload(
+                result,
+                command="mb onboard plan",
+                schema_name="mainbranch.onboard.plan.result",
+            )
+        )
     else:
         _render_onboard_status_human(result)
     raise typer.Exit(0 if result["ok"] else 1)
@@ -487,7 +506,13 @@ def _doctor_repair_from_args(args: list[str], *, json_out: bool) -> None:
         report = doctor_mod.repair_plan(repo=repo)
 
     if local_json:
-        typer.echo(json.dumps(report, indent=2))
+        typer.echo(
+            _json_payload(
+                report,
+                command="mb doctor repair",
+                schema_name="mainbranch.doctor.repair.result",
+            )
+        )
     else:
         doctor_mod.render_repair(report)
     raise typer.Exit(0 if report["ok"] else 1)
@@ -534,7 +559,9 @@ def doctor_cmd(
         raise typer.Exit(2)
     report = doctor_mod.run(path=path)
     if json_out:
-        typer.echo(json.dumps(report, indent=2))
+        typer.echo(
+            _json_payload(report, command="mb doctor", schema_name="mainbranch.doctor.result")
+        )
     else:
         doctor_mod.render_human(report)
         if not report["ok"]:
@@ -618,7 +645,13 @@ def issue_draft_cmd(
         typer.echo(f"mb issue draft: {exc}", err=True)
         raise typer.Exit(2) from exc
     if json_out:
-        typer.echo(json.dumps(result, indent=2))
+        typer.echo(
+            _json_payload(
+                result,
+                command="mb issue draft",
+                schema_name="mainbranch.issue.draft.result",
+            )
+        )
     else:
         typer.echo(f"drafted {result['kind']} issue: {result['relative_path']}")
         typer.echo("review it before submitting; drafts are local and gitignored by default.")
@@ -646,7 +679,13 @@ def issue_open_cmd(
         typer.echo(f"mb issue open: {exc}", err=True)
         raise typer.Exit(2) from exc
     if json_out:
-        typer.echo(json.dumps(result, indent=2))
+        typer.echo(
+            _json_payload(
+                result,
+                command="mb issue open",
+                schema_name="mainbranch.issue.open.result",
+            )
+        )
     elif result.get("submitted"):
         typer.echo(f"opened issue: {result['url']}")
     else:
@@ -820,7 +859,7 @@ def status_cmd(
     """Show a cheap daily briefing for a Main Branch repo."""
     report = status_mod.run(path=path, update_marker=not peek)
     if json_out:
-        typer.echo(json.dumps(report, indent=2))
+        typer.echo(_json_payload(report, command="mb status", schema_name="mainbranch.status"))
     else:
         status_mod.render_human(report, verbose=verbose, no_color=no_color)
 
@@ -849,12 +888,12 @@ def start_cmd(
         report["launch"]["safe"] = False
         report["launch"]["attempted"] = False
         report["launch"]["blocked_reason"] = message
-        typer.echo(json.dumps(report, indent=2))
+        typer.echo(_json_payload(report, command="mb start", schema_name="mainbranch.start.result"))
         raise typer.Exit(2)
 
     report = start_mod.run(repo=repo, launch=launch)
     if json_out:
-        typer.echo(json.dumps(report, indent=2))
+        typer.echo(_json_payload(report, command="mb start", schema_name="mainbranch.start.result"))
     else:
         start_mod.render_human(report)
     raise typer.Exit(0 if report["ok"] else 1)
@@ -1062,7 +1101,13 @@ def checkpoint_cmd(
         _ = plan
         result = checkpoint_mod.plan(repo=repo, mode=mode)
     if json_out:
-        typer.echo(json.dumps(result, indent=2))
+        typer.echo(
+            _json_payload(
+                result,
+                command="mb checkpoint",
+                schema_name="mainbranch.checkpoint.result",
+            )
+        )
     else:
         checkpoint_mod.render_human(result)
     raise typer.Exit(0 if result["ok"] else 1)

--- a/mb/mb/json_result.py
+++ b/mb/mb/json_result.py
@@ -2,24 +2,22 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
 from typing import Any
 
-JSON_RESULT_SCHEMA_VERSION = "1.0"
+JSON_RESULT_ENVELOPE_VERSION = "1.0"
 
 
 def _coerce_list(value: Any) -> list[Any]:
     if isinstance(value, list):
         return value
-    if value in (None, ""):
+    if isinstance(value, tuple):
+        return list(value)
+    if not value:
         return []
     return [value]
 
 
-def _status_from_payload(payload: dict[str, Any], errors: Sequence[Any]) -> str:
-    raw_status = payload.get("status")
-    if isinstance(raw_status, str) and raw_status.strip():
-        return raw_status.strip()
+def _result_status(payload: dict[str, Any], errors: list[Any]) -> str:
     if errors:
         return "error"
     return "ok" if bool(payload.get("ok", True)) else "error"
@@ -33,9 +31,10 @@ def envelope(
 ) -> dict[str, Any]:
     """Return ``payload`` with stable top-level result metadata added.
 
-    The first v1 contract is intentionally additive: existing command-specific
-    keys stay at the top level so current skills, harnesses, and scripts do not
-    need to move every read under a new ``data`` key in one release.
+    The first v1 contract is intentionally additive and non-colliding: existing
+    command-specific keys stay at the top level so current skills, harnesses,
+    and scripts do not need to move every read under a new ``data`` key in one
+    release.
     """
 
     result = dict(payload)
@@ -43,11 +42,14 @@ def envelope(
     warnings = _coerce_list(result.get("warnings"))
     actions = _coerce_list(result.get("actions"))
 
-    result.setdefault("schema_version", JSON_RESULT_SCHEMA_VERSION)
-    result.setdefault("schema", {"name": schema_name, "version": JSON_RESULT_SCHEMA_VERSION})
+    result["result_envelope_version"] = JSON_RESULT_ENVELOPE_VERSION
+    result["result_schema"] = {
+        "name": schema_name,
+        "version": JSON_RESULT_ENVELOPE_VERSION,
+    }
     result["mb_command"] = command
     result["ok"] = bool(result.get("ok", not errors))
-    result["status"] = _status_from_payload(result, errors)
+    result["result_status"] = _result_status(result, errors)
     result["errors"] = errors
     result["warnings"] = warnings
     result["actions"] = actions

--- a/mb/mb/json_result.py
+++ b/mb/mb/json_result.py
@@ -1,0 +1,54 @@
+"""Shared JSON result envelope helpers for ``mb --json`` surfaces."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+JSON_RESULT_SCHEMA_VERSION = "1.0"
+
+
+def _coerce_list(value: Any) -> list[Any]:
+    if isinstance(value, list):
+        return value
+    if value in (None, ""):
+        return []
+    return [value]
+
+
+def _status_from_payload(payload: dict[str, Any], errors: Sequence[Any]) -> str:
+    raw_status = payload.get("status")
+    if isinstance(raw_status, str) and raw_status.strip():
+        return raw_status.strip()
+    if errors:
+        return "error"
+    return "ok" if bool(payload.get("ok", True)) else "error"
+
+
+def envelope(
+    payload: dict[str, Any],
+    *,
+    command: str,
+    schema_name: str,
+) -> dict[str, Any]:
+    """Return ``payload`` with stable top-level result metadata added.
+
+    The first v1 contract is intentionally additive: existing command-specific
+    keys stay at the top level so current skills, harnesses, and scripts do not
+    need to move every read under a new ``data`` key in one release.
+    """
+
+    result = dict(payload)
+    errors = _coerce_list(result.get("errors"))
+    warnings = _coerce_list(result.get("warnings"))
+    actions = _coerce_list(result.get("actions"))
+
+    result.setdefault("schema_version", JSON_RESULT_SCHEMA_VERSION)
+    result.setdefault("schema", {"name": schema_name, "version": JSON_RESULT_SCHEMA_VERSION})
+    result["mb_command"] = command
+    result["ok"] = bool(result.get("ok", not errors))
+    result["status"] = _status_from_payload(result, errors)
+    result["errors"] = errors
+    result["warnings"] = warnings
+    result["actions"] = actions
+    return result

--- a/mb/tests/test_json_result.py
+++ b/mb/tests/test_json_result.py
@@ -15,7 +15,7 @@ from mb import start as start_mod
 from mb import status as status_mod
 from mb.cli import app
 from mb.init import run as init_run
-from mb.json_result import JSON_RESULT_SCHEMA_VERSION
+from mb.json_result import JSON_RESULT_ENVELOPE_VERSION
 
 runner = CliRunner()
 
@@ -59,12 +59,19 @@ def _assert_envelope(
     payload: dict[str, Any],
     *,
     command: str,
-    expected_status: str | None = None,
+    expected_result_status: str | None = None,
+    schema_name: str | None = None,
 ) -> None:
-    assert payload["schema_version"] == JSON_RESULT_SCHEMA_VERSION
+    assert payload["result_envelope_version"] == JSON_RESULT_ENVELOPE_VERSION
+    assert payload["result_schema"] == {
+        "name": schema_name or f"{command.replace(' ', '.')}.result",
+        "version": JSON_RESULT_ENVELOPE_VERSION,
+    }
     assert payload["mb_command"] == command
     assert isinstance(payload["ok"], bool)
-    assert payload["status"] == (expected_status or ("ok" if payload["ok"] else "error"))
+    assert payload["result_status"] == (
+        expected_result_status or ("ok" if payload["ok"] else "error")
+    )
     assert isinstance(payload["errors"], list)
     assert isinstance(payload["warnings"], list)
     assert isinstance(payload["actions"], list)
@@ -79,7 +86,7 @@ def test_status_json_uses_shared_result_envelope(tmp_path: Path, monkeypatch: An
 
     assert result.exit_code == 0
     payload = _load_json(result)
-    _assert_envelope(payload, command="mb status")
+    _assert_envelope(payload, command="mb status", schema_name="mainbranch.status")
     assert payload["schema"]["name"] == "mainbranch.status"
     assert payload["repo"]["looks_like_mainbranch_repo"] is True
     assert "ranked_actions" in payload
@@ -94,9 +101,34 @@ def test_start_json_uses_shared_result_envelope(tmp_path: Path, monkeypatch: Any
 
     assert result.exit_code == 0
     payload = _load_json(result)
-    _assert_envelope(payload, command="mb start")
+    _assert_envelope(payload, command="mb start", schema_name="mainbranch.start.result")
     assert payload["handoff_ready"] is True
     assert payload["runtime"]["skill_wiring"]["ok"] is True
+
+
+def test_start_json_launch_conflict_preserves_error_envelope(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    monkeypatch.setattr(start_mod, "_which", _with_claude)
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+
+    result = runner.invoke(app, ["start", "--repo", str(repo), "--json", "--launch"])
+
+    assert result.exit_code == 2
+    payload = _load_json(result)
+    _assert_envelope(
+        payload,
+        command="mb start",
+        expected_result_status="error",
+        schema_name="mainbranch.start.result",
+    )
+    assert payload["ok"] is False
+    assert payload["errors"] == [
+        "`--json` cannot be combined with `--launch`; run without `--json` to launch."
+    ]
+    assert payload["launch"]["requested"] is True
+    assert payload["launch"]["blocked_reason"] == payload["errors"][0]
 
 
 def test_checkpoint_json_uses_shared_result_envelope(tmp_path: Path) -> None:
@@ -110,7 +142,12 @@ def test_checkpoint_json_uses_shared_result_envelope(tmp_path: Path) -> None:
 
     assert result.exit_code == 0
     payload = _load_json(result)
-    _assert_envelope(payload, command="mb checkpoint", expected_status="ready")
+    _assert_envelope(
+        payload,
+        command="mb checkpoint",
+        schema_name="mainbranch.checkpoint.result",
+    )
+    assert payload["status"] == "ready"
     assert payload["summary"]["surfaces"] == {"research": 1}
     assert payload["proposal"]["message"] == "[added] market.md"
 
@@ -142,7 +179,7 @@ def test_issue_draft_json_uses_shared_result_envelope(tmp_path: Path) -> None:
 
     assert result.exit_code == 0
     payload = _load_json(result)
-    _assert_envelope(payload, command="mb issue draft")
+    _assert_envelope(payload, command="mb issue draft", schema_name="mainbranch.issue.draft.result")
     assert payload["privacy"]["requires_operator_review"] is True
     assert payload["next_command"].startswith("mb issue open .mb/issue-drafts/")
 
@@ -152,10 +189,24 @@ def test_doctor_json_uses_shared_result_envelope(tmp_path: Path) -> None:
 
     assert result.exit_code in {0, 1}
     payload = _load_json(result)
-    _assert_envelope(payload, command="mb doctor")
-    assert payload["schema"]["name"] == "mainbranch.doctor.result"
+    _assert_envelope(payload, command="mb doctor", schema_name="mainbranch.doctor.result")
     assert payload["repo"] == str(tmp_path.resolve())
     assert "checks" in payload
+
+
+def test_doctor_repair_json_preserves_domain_schema_shape(tmp_path: Path) -> None:
+    result = runner.invoke(app, ["doctor", "repair", "--repo", str(tmp_path), "--plan", "--json"])
+
+    assert result.exit_code in {0, 1}
+    payload = _load_json(result)
+    _assert_envelope(
+        payload,
+        command="mb doctor repair",
+        schema_name="mainbranch.doctor.repair.result",
+    )
+    assert payload["schema"] == "mb.doctor.repair"
+    assert payload["schema_version"] == 1
+    assert payload["mode"] == "plan"
 
 
 def test_onboard_json_uses_shared_result_envelope(tmp_path: Path, monkeypatch: Any) -> None:
@@ -170,7 +221,13 @@ def test_onboard_json_uses_shared_result_envelope(tmp_path: Path, monkeypatch: A
 
     assert result.exit_code == 0
     payload = _load_json(result)
-    _assert_envelope(payload, command="mb onboard", expected_status="ok")
+    _assert_envelope(
+        payload,
+        command="mb onboard",
+        expected_result_status="ok",
+        schema_name="mainbranch.onboard.result",
+    )
+    assert payload["status"] == "ok"
     assert payload["path"] == str(repo.resolve())
     assert payload["onboarding"]["summary"]["status"] == "in_progress"
 
@@ -199,20 +256,46 @@ def test_issue_open_json_fallback_uses_shared_result_envelope(tmp_path: Path) ->
 
     assert result.exit_code == 0
     payload = _load_json(result)
-    _assert_envelope(payload, command="mb issue open")
+    _assert_envelope(payload, command="mb issue open", schema_name="mainbranch.issue.open.result")
     assert payload["submitted"] is False
     assert payload["fallback"] is True
 
 
-def test_json_result_helper_preserves_existing_domain_schema() -> None:
+def test_json_result_helper_preserves_existing_domain_schema_and_status() -> None:
     from mb.json_result import envelope
 
     payload = envelope(
-        {"ok": True, "schema": "mb.doctor.repair", "schema_version": 1},
+        {
+            "ok": True,
+            "schema": "mb.doctor.repair",
+            "schema_version": 1,
+            "status": {"state": "connected"},
+        },
         command="mb doctor repair",
         schema_name="mainbranch.doctor.repair.result",
     )
 
     assert payload["schema"] == "mb.doctor.repair"
     assert payload["schema_version"] == 1
+    assert payload["status"] == {"state": "connected"}
+    assert payload["result_envelope_version"] == JSON_RESULT_ENVELOPE_VERSION
+    assert payload["result_schema"] == {
+        "name": "mainbranch.doctor.repair.result",
+        "version": JSON_RESULT_ENVELOPE_VERSION,
+    }
     assert payload["mb_command"] == "mb doctor repair"
+    assert payload["result_status"] == "ok"
+
+
+def test_json_result_helper_collapses_falsy_lists() -> None:
+    from mb.json_result import envelope
+
+    payload = envelope(
+        {"errors": False, "warnings": 0, "actions": ""},
+        command="mb status",
+        schema_name="mainbranch.status",
+    )
+
+    assert payload["errors"] == []
+    assert payload["warnings"] == []
+    assert payload["actions"] == []

--- a/mb/tests/test_json_result.py
+++ b/mb/tests/test_json_result.py
@@ -1,0 +1,218 @@
+"""Shared JSON envelope coverage for high-value ``mb --json`` surfaces."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from typer.testing import CliRunner
+
+from mb import onboard as onboard_mod
+from mb import start as start_mod
+from mb import status as status_mod
+from mb.cli import app
+from mb.init import run as init_run
+from mb.json_result import JSON_RESULT_SCHEMA_VERSION
+
+runner = CliRunner()
+
+
+def _tool_path(name: str) -> str:
+    if name == "git":
+        return shutil.which("git") or ""
+    return ""
+
+
+def _with_claude(name: str) -> str:
+    if name == "claude":
+        return "/usr/local/bin/claude"
+    return shutil.which(name) or ""
+
+
+def _without_github_or_claude(name: str) -> str:
+    if name in {"gh", "claude"}:
+        return ""
+    return shutil.which(name) or ""
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def _load_json(result: Any) -> dict[str, Any]:
+    assert result.stdout
+    payload = json.loads(result.stdout)
+    assert isinstance(payload, dict)
+    return payload
+
+
+def _assert_envelope(
+    payload: dict[str, Any],
+    *,
+    command: str,
+    expected_status: str | None = None,
+) -> None:
+    assert payload["schema_version"] == JSON_RESULT_SCHEMA_VERSION
+    assert payload["mb_command"] == command
+    assert isinstance(payload["ok"], bool)
+    assert payload["status"] == (expected_status or ("ok" if payload["ok"] else "error"))
+    assert isinstance(payload["errors"], list)
+    assert isinstance(payload["warnings"], list)
+    assert isinstance(payload["actions"], list)
+
+
+def test_status_json_uses_shared_result_envelope(tmp_path: Path, monkeypatch: Any) -> None:
+    monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+
+    result = runner.invoke(app, ["status", str(repo), "--json", "--peek"])
+
+    assert result.exit_code == 0
+    payload = _load_json(result)
+    _assert_envelope(payload, command="mb status")
+    assert payload["schema"]["name"] == "mainbranch.status"
+    assert payload["repo"]["looks_like_mainbranch_repo"] is True
+    assert "ranked_actions" in payload
+
+
+def test_start_json_uses_shared_result_envelope(tmp_path: Path, monkeypatch: Any) -> None:
+    monkeypatch.setattr(start_mod, "_which", _with_claude)
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+
+    result = runner.invoke(app, ["start", "--repo", str(repo), "--json"])
+
+    assert result.exit_code == 0
+    payload = _load_json(result)
+    _assert_envelope(payload, command="mb start")
+    assert payload["handoff_ready"] is True
+    assert payload["runtime"]["skill_wiring"]["ok"] is True
+
+
+def test_checkpoint_json_uses_shared_result_envelope(tmp_path: Path) -> None:
+    repo = tmp_path / "acme"
+    repo.mkdir()
+    assert _git(repo, "init").returncode == 0
+    (repo / "research").mkdir()
+    (repo / "research" / "market.md").write_text("# Market\n", encoding="utf-8")
+
+    result = runner.invoke(app, ["checkpoint", "--repo", str(repo), "--plan", "--json"])
+
+    assert result.exit_code == 0
+    payload = _load_json(result)
+    _assert_envelope(payload, command="mb checkpoint", expected_status="ready")
+    assert payload["summary"]["surfaces"] == {"research": 1}
+    assert payload["proposal"]["message"] == "[added] market.md"
+
+
+def test_issue_draft_json_uses_shared_result_envelope(tmp_path: Path) -> None:
+    repo = tmp_path / "biz"
+    repo.mkdir()
+
+    result = runner.invoke(
+        app,
+        [
+            "issue",
+            "draft",
+            "bug",
+            "--repo",
+            str(repo),
+            "--title",
+            "bug: status failed",
+            "--command",
+            "mb status",
+            "--what-happened",
+            "failed",
+            "--expected",
+            "status should render",
+            "--no-doctor",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = _load_json(result)
+    _assert_envelope(payload, command="mb issue draft")
+    assert payload["privacy"]["requires_operator_review"] is True
+    assert payload["next_command"].startswith("mb issue open .mb/issue-drafts/")
+
+
+def test_doctor_json_uses_shared_result_envelope(tmp_path: Path) -> None:
+    result = runner.invoke(app, ["doctor", str(tmp_path), "--json"])
+
+    assert result.exit_code in {0, 1}
+    payload = _load_json(result)
+    _assert_envelope(payload, command="mb doctor")
+    assert payload["schema"]["name"] == "mainbranch.doctor.result"
+    assert payload["repo"] == str(tmp_path.resolve())
+    assert "checks" in payload
+
+
+def test_onboard_json_uses_shared_result_envelope(tmp_path: Path, monkeypatch: Any) -> None:
+    monkeypatch.setattr(onboard_mod, "_which", _tool_path)
+    monkeypatch.setattr(onboard_mod, "is_interactive", lambda: False)
+    repo = tmp_path / "acme"
+
+    result = runner.invoke(
+        app,
+        ["onboard", "--yes", "--name", "Acme Brewing", "--path", str(repo), "--json"],
+    )
+
+    assert result.exit_code == 0
+    payload = _load_json(result)
+    _assert_envelope(payload, command="mb onboard", expected_status="ok")
+    assert payload["path"] == str(repo.resolve())
+    assert payload["onboarding"]["summary"]["status"] == "in_progress"
+
+
+def test_issue_open_json_fallback_uses_shared_result_envelope(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    draft = runner.invoke(
+        app,
+        [
+            "issue",
+            "draft",
+            "question",
+            "--repo",
+            str(repo),
+            "--title",
+            "question: fallback",
+            "--question",
+            "How?",
+            "--json",
+        ],
+    )
+    draft_payload = _load_json(draft)
+
+    result = runner.invoke(app, ["issue", "open", draft_payload["path"], "--json"])
+
+    assert result.exit_code == 0
+    payload = _load_json(result)
+    _assert_envelope(payload, command="mb issue open")
+    assert payload["submitted"] is False
+    assert payload["fallback"] is True
+
+
+def test_json_result_helper_preserves_existing_domain_schema() -> None:
+    from mb.json_result import envelope
+
+    payload = envelope(
+        {"ok": True, "schema": "mb.doctor.repair", "schema_version": 1},
+        command="mb doctor repair",
+        schema_name="mainbranch.doctor.repair.result",
+    )
+
+    assert payload["schema"] == "mb.doctor.repair"
+    assert payload["schema_version"] == 1
+    assert payload["mb_command"] == "mb doctor repair"

--- a/mb/tests/test_start.py
+++ b/mb/tests/test_start.py
@@ -67,7 +67,8 @@ def test_start_json_prints_ready_handoff(tmp_path: Path, monkeypatch) -> None:
     assert report["push_compatibility"]["legacy_campaigns_read"] is True
     assert "update" in report
     assert "ranked_actions" not in report
-    assert report["status"] == "ok"
+    assert report["result_status"] == "ok"
+    assert "status" not in report
 
 
 def test_start_json_exposes_push_and_legacy_campaign_facts(tmp_path: Path, monkeypatch) -> None:

--- a/mb/tests/test_start.py
+++ b/mb/tests/test_start.py
@@ -67,7 +67,7 @@ def test_start_json_prints_ready_handoff(tmp_path: Path, monkeypatch) -> None:
     assert report["push_compatibility"]["legacy_campaigns_read"] is True
     assert "update" in report
     assert "ranked_actions" not in report
-    assert "status" not in report
+    assert report["status"] == "ok"
 
 
 def test_start_json_exposes_push_and_legacy_campaign_facts(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- Adds an additive v1 JSON result envelope for high-value `mb --json` surfaces so skills, harnesses, scripts, and future dashboards can read shared result metadata consistently.
- Migrates `mb status`, `mb start`, `mb checkpoint`, `mb issue draft/open`, `mb doctor`, `mb doctor repair`, `mb onboard`, `mb onboard status`, and `mb onboard plan`.
- Preserves command-specific top-level payloads, including domain `schema`, `schema_version`, `status`, and `command`, while adding non-colliding `result_*` envelope fields.
- Documents the JSON output contract in README, CHANGELOG, and `docs/json-output-contract.md`.

## Scope
- In: shared helper, first migrated command surfaces, focused CLI contract tests, public docs/changelog.
- Out: dashboard implementation, provider account mutation, new runtime adapter claims, and rewriting every `mb --json` command.

## Commits
- `b8072e0` — `[add] Stable CLI JSON result envelope`.
- `16c42b2` — `[fix] Keep JSON envelope fields non-colliding`.

## Release / Issues
- Release: v0.3.x daily-loop infrastructure.
- Linear ID(s): MAIN-236.
- Closes: #297.
- Refs: #364, #350, #352, #286, #357, #358.
- Follow-ups: none from this slice.

## Success Metric
- Skills and future dashboards can depend on `result_envelope_version`, `result_schema`, `mb_command`, `ok`, `result_status`, `errors`, `warnings`, and `actions` across the first migrated JSON surfaces without losing command-specific payload fields.

## Validation
- Level 0 docs/decision: README, CHANGELOG, and `docs/json-output-contract.md` updated with the non-colliding envelope contract.
- Level 1 static: `scripts/check.sh` passed formatting, lint, mypy, 368 tests with coverage gate, and bundled skill validation.
- Level 2 CLI: `cd mb && python3 -m pytest tests/test_json_result.py tests/test_start.py -q` passed with 23 tests, including `mb start --json --launch`, doctor repair schema preservation, structured domain status preservation, and falsy list handling.
- Level 3 package/install: built wheel, installed into fresh `/tmp/mainbranch-smoke`, verified `mb --version`, `mb skill list`, `mb onboard --json`, `mb status --json --peek`, `mb start --json`, `mb doctor --json`, `mb validate`, and `mb doctor repair --plan --json`.
- Level 4 fixture repo: fresh `/tmp/mainbranch-smoke-business` repo created through installed `mb onboard --yes --json`; installed JSON outputs showed `result_envelope_version`, `result_schema`, and `result_status` while preserving command-specific fields.
- Level 5 runtime smoke: not run; this changes deterministic CLI JSON output and docs/tests, not Claude Code runtime discovery or skill invocation behavior.

## Public / Private Boundary
- No private Devon, Conductor, credential, customer, or runtime-session data is committed; smoke evidence used throwaway `/tmp` fixture paths only.

## CHANGELOG
- [x] Updated `CHANGELOG.md` `[Unreleased]` section.

## Breaking changes
- [x] No.
