### PR TITLE
[release] 0.3.9

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mainbranch",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "Main Branch Claude Code skills for running a business from markdown files in git.",
   "author": {
     "name": "Noontide"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,27 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+## [0.3.9] - 2026-05-08
+
+v0.3.9 makes the daily operating loop more inspectable. Main Branch now exposes
+business relationship gaps in `mb status`, validates push playbooks as durable
+business commitments, gives JSON consumers a shared result envelope, and
+documents the packaged runtime boundary for non-Claude callers.
+
+### What this means for you (plain English)
+
+- **Status can explain missing business links.** `mb status` can now surface
+  disconnected bets, pushes, offers, and outcomes instead of only reporting file
+  and repo health.
+- **Playbooks become checkable plans.** Push playbooks now have a v1 schema so
+  provider work, approval gates, resources, outcomes, and safe state can be
+  reviewed before anyone mutates an external account.
+- **Agents get steadier JSON.** High-value `mb --json` commands now share a
+  non-colliding result envelope while preserving their command-specific payloads.
+- **Runtime claims stay scoped.** Packaged callers can use deterministic `mb`
+  subprocess calls today, while non-Claude slash/runtime adapters remain roadmap
+  targets until they have their own evidence.
+
 ### Added
 
 - Added `mb status` relationship-health JSON and human briefing signals for

--- a/mb/mb/__init__.py
+++ b/mb/mb/__init__.py
@@ -7,6 +7,6 @@ file stays a thin dispatcher.
 
 from __future__ import annotations
 
-__version__ = "0.3.8"
+__version__ = "0.3.9"
 
 __all__ = ["__version__"]

--- a/mb/pyproject.toml
+++ b/mb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mainbranch"
-version = "0.3.8"
+version = "0.3.9"
 description = "Main Branch engine umbrella - scaffolds, validates, and graphs business-as-files repos. Claude Code first, runtime-agnostic by design."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- Promote the merged runtime-compatibility, push-playbook, status relationship-health, and JSON-envelope work into `0.3.9`.
- Sync package, runtime `__version__`, and Claude plugin manifest versions.
- Add public changelog notes for the patch release.

## Scope
In scope: release metadata and changelog only.
Out of scope: new behavior beyond the PRs already merged into `main`.

## Validation
- Main push CI passed after #392 merged.
- `scripts/check.sh` passed locally: formatting, lint, mypy, 382 tests, coverage, and bundled skill validation.
- Package smoke passed from a clean venv: built `mainbranch-0.3.9`, installed the wheel, `mb --version` returned `mb 0.3.9`, and `mb skill list` returned all 17 bundled skills.
- Fixture smoke passed from installed wheel: `mb onboard --json`, `mb status --json --peek` with `relationship_health` and `result_envelope_version`, `mb start --json`, and `mb validate --cross-refs --json`.

## Runtime Smoke
No fresh interactive Claude Code runtime smoke for this release bump itself. The release branch only changes version metadata and changelog text; runtime-facing behavior was validated on the underlying feature PRs.

## Public / Private Boundary
No private paths, customer data, credentials, or local workflow details added.

Refs #129, #350, #358, #297