### PR TITLE
[add] /mb-think grok-8 researched brief

### DIFF
--- a/.claude/skills/mb-ads/SKILL.md
+++ b/.claude/skills/mb-ads/SKILL.md
@@ -228,6 +228,12 @@ load `mb-think/references/winning-ad-research.md`. Customer language, review
 mining, competitor gap maps, comment mining, and winning script teardown should
 save to `research/` and codify into `core/` before this skill generates ads.
 Do not paste raw review/comment dumps or copied prompt libraries into ad output.
+If the selected research file has `brief_format: grok-8`, use its downstream
+handoff first: business/offering for the promise, ICP for hooks, journey for
+funnel stage, competitive landscape for differentiation, brand story for voice,
+content/assets for proof and creative inputs, and metrics/constraints for the
+review bar. If the brief names a resource-delivery or provider workflow, draft
+or update a push playbook as a plan only; do not execute provider mutation.
 
 ### Proactive Account Awareness
 

--- a/.claude/skills/mb-organic/SKILL.md
+++ b/.claude/skills/mb-organic/SKILL.md
@@ -94,6 +94,13 @@ Mining competitor content is research work. It belongs in `/mb-think` because:
 - A topic they want to turn into content
 - Inspiration from their own research
 
+If a selected research file has `brief_format: grok-8`, use its downstream
+handoff before generating: ICP and audience language for hooks, journey stage
+for format and CTA, competitive landscape for contrast, brand story for voice,
+content/assets for proof, and metrics/constraints for the success bar. If the
+brief names a resource-delivery mechanic, write or update a push playbook as a
+plan only; do not execute provider mutation.
+
 For the full mining methodology (Visual/Audible/Emotional framework, AI capabilities and limits, why mining flows into reference) see [references/mining-methodology.md](references/mining-methodology.md).
 
 ---

--- a/.claude/skills/mb-site/SKILL.md
+++ b/.claude/skills/mb-site/SKILL.md
@@ -81,6 +81,11 @@ Four behaviors `/mb-site` uses on every run:
 4. **Publish-first, then iterate.** Commit the rawest durable brief and rawest working concept before iterating. Git history is the memory across context clears.
 
 When research subagents record findings, they follow the `/mb-think` research pattern: dated `research/YYYY-MM-DD-slug-claude-code.md` files with frontmatter and `linked_decisions: []`.
+When the operator needs a broad researched brief before the site brief, run or
+reuse `/mb-think --brief-format=grok-8`. Its eight categories feed the site
+flow directly: offering, ICP, journey, competitive landscape, brand story,
+technical requirements, assets, and metrics/constraints. Keep the `grok-8`
+brief in `research/`; the locked site brief still belongs in `decisions/`.
 
 ## Invocation Mode
 

--- a/.claude/skills/mb-site/references/minisite-brief.md
+++ b/.claude/skills/mb-site/references/minisite-brief.md
@@ -10,6 +10,9 @@ The brief is the locked source of truth for the minisite. Compose it from:
 - resolved `audience.md`: pain frame, language, objections;
 - `voice.md`: tone, register, named enemies, "never say";
 - persisted research files from [`minisite-research.md`](minisite-research.md);
+- any `brief_format: grok-8` researched brief that names the offer, audience,
+  journey, competitive gaps, brand story, requirements, assets, and success
+  constraints;
 - the conversion endpoint kind, once the operator picks it.
 
 Draft the brief into one markdown artifact in the business repo:

--- a/.claude/skills/mb-site/references/minisite-research.md
+++ b/.claude/skills/mb-site/references/minisite-research.md
@@ -40,6 +40,11 @@ status: complete
 
 Keep private raw customer/member data, credentials, and unapproved account exports out of public repos. Summarize safely or keep raw material outside the repo when it is not public-safe.
 
+For broad site or launch research, prefer the `/mb-think --brief-format=grok-8`
+shape. It covers business/offering, ICP, customer journey, competitive
+landscape, brand story, technical requirements, content/assets, and
+metrics/constraints before the brief is drafted.
+
 ## Exit Criteria
 
 Research is ready to feed the brief when:

--- a/.claude/skills/mb-think/SKILL.md
+++ b/.claude/skills/mb-think/SKILL.md
@@ -37,6 +37,19 @@ approval gate, route the durable plan into
 Playbooks are plans, approval records, safe provider-state notes, validation
 evidence, and outcome hooks. They are not provider execution.
 
+When the operator asks for a researched brief, site brief, launch brief, or
+research meant to feed `/mb-ads`, `/mb-site`, or push playbooks, support:
+
+```text
+/mb-think --brief-format=grok-8 <topic>
+```
+
+Load [references/grok-8-brief-format.md](references/grok-8-brief-format.md).
+This mode structures findings across eight categories: business/offering, ICP,
+journey, competitive landscape, brand story, technical requirements, content
+assets, and metrics/constraints. Use it as an opt-in format, not the default
+unless the operator chooses it.
+
 ---
 
 ## Two Modes of Work
@@ -133,6 +146,7 @@ Detect mode from user's natural language:
 |-----------|------|-----------|
 | "figure out", "explore", "I'm trying to..." | Full Flow | - |
 | "research", "investigate", "what do we know about" | Research | [research-phase.md](references/research-phase.md) |
+| "--brief-format=grok-8", "researched brief", "site brief", "launch brief" | Research Brief | [grok-8-brief-format.md](references/grok-8-brief-format.md) |
 | "what are people saying", "sentiment", "X/Twitter", "trending" | Research (Grok) | [grok-social.md](references/grok-social.md) |
 | "winning ads", "review mining", "customer language", "competitor ads", "comment mining" | Research | [winning-ad-research.md](references/winning-ad-research.md) |
 | "decide", "we chose", "document decision" | Decide | [decide-phase.md](references/decide-phase.md) |
@@ -350,6 +364,10 @@ See [references/research-phase.md](references/research-phase.md) for full workfl
 For ad, customer, review, competitor, and social-comment mining, use
 [references/winning-ad-research.md](references/winning-ad-research.md) to keep
 the research structured before handing off to `/mb-ads` or `/mb-organic`.
+For broad researched briefs that should feed ads, sites, organic content, or a
+push playbook, use
+[references/grok-8-brief-format.md](references/grok-8-brief-format.md) and set
+`brief_format: grok-8` in frontmatter.
 
 ---
 
@@ -424,6 +442,7 @@ See [references/recovery.md](references/recovery.md) for details.
 ## Templates
 
 - [references/templates/research-template.md](references/templates/research-template.md)
+- [references/grok-8-brief-format.md](references/grok-8-brief-format.md)
 - [references/templates/decision-template.md](references/templates/decision-template.md)
 
 ---

--- a/.claude/skills/mb-think/references/grok-8-brief-format.md
+++ b/.claude/skills/mb-think/references/grok-8-brief-format.md
@@ -1,0 +1,176 @@
+# Grok-8 Researched Brief Format
+
+Use this format when the operator asks for a researched brief, site brief,
+offer launch brief, or research that must feed `/mb-ads`, `/mb-site`, organic
+content, or a push playbook.
+
+The format is adapted from a private source attachment. Keep only the reusable
+structure in public repos. Do not copy private examples, client details, raw
+customer/member data, credentials, or long excerpts into committed files.
+
+## Invocation
+
+```text
+/mb-think --brief-format=grok-8 <research question>
+```
+
+`grok-8` is not the default yet. Use it only when requested, when a site or
+launch brief needs broad source coverage, or when the operator agrees that the
+research should become a downstream production brief.
+
+## Frontmatter
+
+```yaml
+---
+type: research
+date: YYYY-MM-DD
+source: claude-code
+model: opus-4.5
+status: complete
+brief_format: grok-8
+linked_decisions: []
+linked_pushes: []
+---
+```
+
+Use `linked_pushes` only when the research is tied to a coordinated push.
+
+## The 8 Categories
+
+### 1. Business And Offering Deep Dive
+
+Capture what the business sells, how it delivers, why it is different, pricing
+or package shape, the current brand story, goals, and the strongest objections
+or hesitations.
+
+Feeds:
+- `core/offer.md` or `core/offers/<offer>/offer.md`
+- `/mb-ads` offer promise, objections, and angle selection
+- `/mb-site` hero, mechanism, pricing, and proof sections
+
+### 2. ICP And Deep Audience Insights
+
+Capture the ideal customer profile, situation, values, fears, aspirations,
+desired transformation, buying triggers, online hangouts, and exact language
+the audience uses.
+
+Feeds:
+- `core/audience.md` or `core/offers/<offer>/audience.md`
+- `core/voice.md`
+- ad hooks, organic angles, and page section language
+
+### 3. Customer Journey And Story Mapping
+
+Map awareness, consideration, decision, onboarding, retention, and advocacy.
+Name friction points, drop-offs, emotional states, and what the site, ad, or
+playbook must do at each stage.
+
+Feeds:
+- site flow and CTA hierarchy
+- push playbook stage gates
+- ad funnel intent and retargeting notes
+
+### 4. Competitive And Market Landscape
+
+Summarize direct and indirect competitors, positioning, messaging, tone,
+category norms, market shifts, strengths, gaps, and what appears to be working.
+Mark inferred winners as inferred unless the operator has performance data.
+
+Feeds:
+- `core/proof/angles/`
+- competitor gap maps for `/mb-ads`
+- differentiation and proof placement for `/mb-site`
+
+### 5. Brand Archetype And Story Discovery
+
+Name the brand personality, customer role, story frame, emotional benefits,
+functional benefits, proof stories, and what the brand stands against. The
+operator chooses final positioning.
+
+Feeds:
+- `/mb-site` dial, archetype, voice, and do-not-state guidance
+- `core/voice.md`
+- creative review gates for ads and organic content
+
+### 6. Technical, Functional, And Experience Requirements
+
+Capture must-have features, forms, booking, payments, community login,
+integrations, SEO priorities, performance, mobile, accessibility, compliance,
+analytics, and tracking goals.
+
+Feeds:
+- `/mb-site` repo setup, conversion endpoint, and `mb site check`
+- provider-readiness notes from `mb connect`
+- playbook approval gates where external tools are involved
+
+### 7. Content And Asset Audit
+
+Inventory existing content, missing content, visual assets, videos, voice
+guidelines, testimonials, case studies, proof points, and approval status.
+
+Feeds:
+- ad proof, image prompts, and video scripts
+- site page assets and proof sections
+- `core/proof/testimonials.md` and `core/proof/typicality.md`
+
+### 8. Success Metrics And Constraints
+
+Name primary KPIs, secondary signals, timeline, budget, non-negotiables, red
+lines, and known risks.
+
+Feeds:
+- push goals and health checks
+- ad review criteria
+- site launch readiness and follow-up measurement
+
+## Output Shape
+
+Use this section order after the standard question, methodology, sources, and
+excerpts sections:
+
+```markdown
+## Grok-8 Researched Brief
+
+### 1. Business And Offering Deep Dive
+### 2. ICP And Deep Audience Insights
+### 3. Customer Journey And Story Mapping
+### 4. Competitive And Market Landscape
+### 5. Brand Archetype And Story Discovery
+### 6. Technical, Functional, And Experience Requirements
+### 7. Content And Asset Audit
+### 8. Success Metrics And Constraints
+```
+
+Then include the standard synthesis:
+
+- one-sentence summary;
+- key findings;
+- implications for reference files;
+- downstream handoff;
+- open questions;
+- citations.
+
+## Downstream Handoff
+
+End every `grok-8` brief with a compact handoff table:
+
+| Next Surface | Ready Input | Missing Or Risky |
+|---|---|---|
+| `/mb-ads` | Angles, objections, audience language, proof | What still needs operator confirmation |
+| `/mb-site` | Offer, audience, story, requirements, assets, metrics | What blocks the brief or launch |
+| Push playbook | Trigger, resource, approval gate, provider boundary, outcome hook | What must stay manual or unsupported |
+| Reference files | Exact files that should be updated | What should not be codified yet |
+
+If a resource-delivery or provider workflow emerges, create or recommend a
+`pushes/<push>/playbooks/<playbook>.md` plan only. Do not execute provider
+mutation, publishing, DM/reply automation, spend, or account changes unless a
+shipped provider path and explicit operator approval support it.
+
+## Quality Bar
+
+- Each category has either source-backed findings or an explicit "unknown".
+- Private data is summarized safely or left outside tracked files.
+- Source limitations are clear.
+- Provider-readiness language comes from `mb status` or `mb connect` facts
+  when available.
+- The brief can feed production without rereading raw sources.

--- a/.claude/skills/mb-think/references/research-architecture.md
+++ b/.claude/skills/mb-think/references/research-architecture.md
@@ -83,10 +83,18 @@ Parse user's natural language to determine research type:
 | "transcribe this video", "pull down this YouTube" | YouTube mining | Apify YouTube Actor | Ask for manual transcript |
 | "what are people saying about...", "sentiment on X" | Social sentiment | Grok X search | Web search for X posts |
 | "research [complex topic]", "deep dive on..." | Deep research | Gemini 2.5 | Web search + synthesis |
-| "researched brief", "site brief", "launch brief", "--brief-format=grok-8" | 8-category brief | Research bundle + `grok-8` format | Standard research template |
 | "transcribe this file", user shares .mp4/.m4a | Local transcription | whisper-mcp | ffmpeg + CLI fallback |
 | "mine competitors", "what's [handle] posting" | Social mining | Apify Instagram Actor | Manual scraping guidance |
 | "research [specific question]" | General research | Codebase → Web → Ask user | Always works |
+
+### Format Selection
+
+The routing table chooses source tools. Output format is a separate decision.
+When the operator says "researched brief", "site brief", "launch brief", or
+passes `--brief-format=grok-8`, gather with the appropriate source route above,
+then write the synthesis using
+[grok-8-brief-format.md](grok-8-brief-format.md). If the broad format is not
+needed, use the standard research template.
 
 ### 3. Progressive Disclosure
 

--- a/.claude/skills/mb-think/references/research-architecture.md
+++ b/.claude/skills/mb-think/references/research-architecture.md
@@ -83,6 +83,7 @@ Parse user's natural language to determine research type:
 | "transcribe this video", "pull down this YouTube" | YouTube mining | Apify YouTube Actor | Ask for manual transcript |
 | "what are people saying about...", "sentiment on X" | Social sentiment | Grok X search | Web search for X posts |
 | "research [complex topic]", "deep dive on..." | Deep research | Gemini 2.5 | Web search + synthesis |
+| "researched brief", "site brief", "launch brief", "--brief-format=grok-8" | 8-category brief | Research bundle + `grok-8` format | Standard research template |
 | "transcribe this file", user shares .mp4/.m4a | Local transcription | whisper-mcp | ffmpeg + CLI fallback |
 | "mine competitors", "what's [handle] posting" | Social mining | Apify Instagram Actor | Manual scraping guidance |
 | "research [specific question]" | General research | Codebase → Web → Ask user | Always works |

--- a/.claude/skills/mb-think/references/research-phase.md
+++ b/.claude/skills/mb-think/references/research-phase.md
@@ -26,6 +26,11 @@ Check `.vip/local.yaml` for `current_offer` before starting research. If `core/o
 5. **Synthesize** (required) — Distill findings into actionable insight
 6. **Save** — Write to `research/YYYY-MM-DD-topic-[source].md`
 
+If the operator passes `--brief-format=grok-8`, asks for a researched brief,
+or wants research to feed a site, ads, organic content, or a push playbook,
+load [grok-8-brief-format.md](grok-8-brief-format.md) before gathering. Save
+the output with `brief_format: grok-8` and include all eight categories.
+
 ---
 
 ## Defining Good Questions

--- a/.claude/skills/mb-think/references/templates/research-template.md
+++ b/.claude/skills/mb-think/references/templates/research-template.md
@@ -41,7 +41,9 @@ source: claude-code
 source_url:                    # Optional: Gemini/GPT share link for provenance
 model: opus-4.5
 status: draft
+brief_format: standard         # Use grok-8 for the 8-category researched brief
 linked_decisions: []
+linked_pushes: []
 ---
 
 # [Topic] Research
@@ -132,6 +134,55 @@ or long tweet threads into committed research files.
 - [Source 1 with link if available]
 - [Source 2]
 - [Source 3]
+```
+
+## Grok-8 Researched Brief Variant
+
+Use this variant when the operator passes `--brief-format=grok-8`, asks for a
+researched brief, or needs the research to feed `/mb-ads`, `/mb-site`, organic
+content, or a push playbook. See
+[../grok-8-brief-format.md](../grok-8-brief-format.md) for the full guidance.
+
+Add this frontmatter:
+
+```yaml
+brief_format: grok-8
+linked_pushes: []
+```
+
+After `## Source Excerpts Used`, add:
+
+```markdown
+## Grok-8 Researched Brief
+
+### 1. Business And Offering Deep Dive
+
+### 2. ICP And Deep Audience Insights
+
+### 3. Customer Journey And Story Mapping
+
+### 4. Competitive And Market Landscape
+
+### 5. Brand Archetype And Story Discovery
+
+### 6. Technical, Functional, And Experience Requirements
+
+### 7. Content And Asset Audit
+
+### 8. Success Metrics And Constraints
+```
+
+After `### Implications for Reference Files`, add:
+
+```markdown
+### Downstream Handoff
+
+| Next Surface | Ready Input | Missing Or Risky |
+|---|---|---|
+| `/mb-ads` | [Angles, objections, proof, audience language] | [Unknowns] |
+| `/mb-site` | [Offer, audience, story, requirements, assets, metrics] | [Unknowns] |
+| Push playbook | [Trigger, resource, approval gate, provider boundary] | [Unsupported/manual pieces] |
+| Reference files | [Specific files to update] | [What not to codify yet] |
 ```
 
 ---

--- a/.claude/skills/mb-think/references/templates/research-template.md
+++ b/.claude/skills/mb-think/references/templates/research-template.md
@@ -237,7 +237,9 @@ date: 2026-01-17
 source: claude-code
 model: opus-4.5
 status: complete
+brief_format: standard
 linked_decisions: []
+linked_pushes: []
 ---
 
 # Pricing Tier Strategy Research

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+### Added
+
+- Added an opt-in `grok-8` researched-brief format for `/mb-think`, including a
+  reusable eight-category research reference, downstream guidance for
+  `/mb-ads`, `/mb-site`, `/mb-organic`, and push-playbook use, plus a
+  public-safe example brief. Refs #147.
+
 ## [0.3.9] - 2026-05-08
 
 v0.3.9 makes the daily operating loop more inspectable. Main Branch now exposes

--- a/docs/examples/grok-8-researched-brief.md
+++ b/docs/examples/grok-8-researched-brief.md
@@ -1,0 +1,180 @@
+---
+type: research
+date: 2026-05-08
+source: claude-code
+model: opus-4.5
+status: complete
+brief_format: grok-8
+linked_decisions: []
+linked_pushes: []
+---
+
+# Team Knowledge Base Relaunch Research
+
+This is a sanitized example of the `grok-8` researched-brief format. It uses a
+fictional business and generic sources so the structure can be copied without
+carrying private customer data.
+
+## Question
+
+How should a small operations consultancy relaunch its team knowledge base
+offer so the site, ads, and push playbook all work from the same research?
+
+## Methodology
+
+Reviewed a generic offer note, audience summary, three public competitor pages,
+five anonymized sales-call themes supplied by the operator, and a simple asset
+inventory. No raw calls, private records, credentials, or customer names are
+included here.
+
+## Sources Checked
+
+| Source | What We Found |
+|---|---|
+| Operator offer notes | The service sells a two-week knowledge-base cleanup sprint. |
+| Audience summary | Buyers are ops leads at 10-50 person services businesses. |
+| Public competitor pages | Competitors sell broad transformation, not concrete cleanup speed. |
+| Anonymized sales-call themes | Buyers fear another documentation project that nobody maintains. |
+| Asset inventory | The business has screenshots, before/after diagrams, and three approved testimonials. |
+
+## Source Excerpts Used
+
+| Source | Concise Excerpt | Why It Matters |
+|---|---|---|
+| Anonymized call theme | "Nobody knows where the final answer lives." | Strong audience-language hook. |
+| Operator note | "Two weeks to one searchable operating manual." | Clear promise candidate. |
+
+## Grok-8 Researched Brief
+
+### 1. Business And Offering Deep Dive
+
+The offer is a fixed-scope cleanup sprint for service businesses with scattered
+standard operating procedures, onboarding notes, and delivery docs. Delivery is
+hands-on: audit, consolidate, rename, link, and train the team on maintenance.
+The likely promise is "one searchable operating manual in two weeks."
+
+Primary objections:
+
+- "Our team will not keep it updated."
+- "We already tried Notion and it became a mess."
+- "This will interrupt client delivery."
+
+### 2. ICP And Deep Audience Insights
+
+The ideal buyer is an operations lead or founder at a 10-50 person service
+business. They have enough team complexity to feel documentation pain but not
+enough internal ops capacity to rebuild the system alone.
+
+Audience language:
+
+- "Where is the latest version?"
+- "Only one person knows how this works."
+- "Onboarding depends on who has time that week."
+- "We have docs, but nobody trusts them."
+
+### 3. Customer Journey And Story Mapping
+
+Awareness starts when repeated Slack questions, delivery mistakes, or onboarding
+delays expose the cost of scattered knowledge. Consideration requires proof
+that the sprint is contained and practical. Decision requires low disruption,
+clear ownership, and examples of maintainable output.
+
+The site and ads should move the buyer from "documentation is endless" to "this
+is a bounded cleanup with a handoff plan."
+
+### 4. Competitive And Market Landscape
+
+Competitors tend to sell broad operations transformation, templates, or Notion
+buildouts. The gap is speed plus maintenance: a small service business does not
+want another elaborate workspace; it wants trusted answers and fewer repeated
+questions.
+
+Differentiation:
+
+- fixed two-week scope;
+- before/after knowledge map;
+- maintenance rule set;
+- team handoff call.
+
+### 5. Brand Archetype And Story Discovery
+
+The brand should act as a guide, not the hero. The customer is the operator who
+gets their team out of dependency and into shared clarity. The named enemy is
+"tribal knowledge theater": docs that exist but are not trusted.
+
+Do not state: "Your team will magically self-manage." Let the proof show lower
+confusion and faster onboarding.
+
+### 6. Technical, Functional, And Experience Requirements
+
+The site needs a lead form or booking link, example screenshots, a clear sprint
+scope, FAQ, and privacy-safe proof. Analytics should track booking clicks,
+form submits, and pricing-section engagement. If paid traffic is planned, run
+site readiness and measurement checks before recommending launch.
+
+### 7. Content And Asset Audit
+
+Ready assets:
+
+- three approved testimonials;
+- two before/after diagrams;
+- one short demo walkthrough;
+- generic screenshot set with client details removed.
+
+Missing assets:
+
+- pricing or starting-at range;
+- delivery timeline diagram;
+- FAQ answers for team interruption and upkeep.
+
+### 8. Success Metrics And Constraints
+
+Primary KPI: qualified strategy calls booked. Secondary signals: pricing-section
+views, demo video plays, and reply quality from outreach. Constraint: no client
+names, raw workspace screenshots, or private process docs can appear publicly.
+
+## Synthesis (REQUIRED)
+
+### One-Sentence Summary (20 words max)
+
+Sell a bounded cleanup sprint, not another open-ended documentation system.
+
+### Key Findings (5-10 bullets, 15 words each)
+
+1. Buyers distrust docs because ownership and latest-version rules are unclear.
+2. Competitors overpromise transformation; fixed scope is the opening.
+3. Proof should show reduced confusion, not aesthetic workspace polish.
+4. The guide frame fits better than heroic agency positioning.
+5. Paid traffic needs measurement readiness before launch recommendation.
+6. Public assets must remove client names and private workspace details.
+
+### Implications for Reference Files
+
+| File | Potential Update |
+|---|---|
+| `core/offer.md` | Add the two-week sprint promise, scope, and objections. |
+| `core/audience.md` | Add ops-lead pain language and buying triggers. |
+| `core/voice.md` | Add "tribal knowledge theater" as a named enemy. |
+| `core/proof/testimonials.md` | Add approved testimonial summaries only. |
+| `core/content-strategy.md` | Add cleanup-sprint hooks and demo walkthrough ideas. |
+
+### Downstream Handoff
+
+| Next Surface | Ready Input | Missing Or Risky |
+|---|---|---|
+| `/mb-ads` | Hooks, objections, proof themes, audience language. | Confirm pricing and approved claims. |
+| `/mb-site` | Offer promise, ICP, story frame, assets, CTA, metrics. | Need booking URL and sanitized screenshots. |
+| Push playbook | Sprint launch trigger, lead magnet, manual follow-up plan. | No provider automation is approved. |
+| Reference files | Offer, audience, voice, proof, content strategy updates. | Do not codify raw call notes. |
+
+### Open Questions
+
+- What price or starting-at range can be stated publicly?
+- Which testimonials are approved for ad and site use?
+- What conversion endpoint should the launch use first?
+
+## Citations
+
+- Operator-provided sanitized offer notes.
+- Public competitor pages reviewed during the research pass.
+- Anonymized sales-call themes summarized by the operator.


### PR DESCRIPTION
## Summary
- Adds an opt-in `grok-8` researched-brief format for `/mb-think` so broad research can become a consistent production-ready brief.
- Wires the brief handoff into `/mb-ads`, `/mb-site`, `/mb-organic`, and push playbooks without adding provider execution or CLI model behavior.
- Adds a sanitized public example brief and records the user-visible workflow change in `CHANGELOG.md`.

## Scope
- In: `/mb-think` skill/reference guidance, downstream skill consumption notes, sanitized `docs/examples/` artifact, and changelog entry.
- Out: making `grok-8` the default, adding a `mb think` CLI selector, provider mutation, runtime/discovery changes, and private source content.

## Commits
- `bd54ad2` — `[add] MAIN-147 grok-8 brief guidance`.
- `9c79efd` — `[fix] MAIN-147 align research brief references`.

## Release / Issues
- Release: next v0.3.x / `[Unreleased]`.
- Linear ID(s): MAIN-147.
- Closes: #147.
- Refs: #350, #351.
- Follow-ups: none.

## Success Metric
- A `/mb-think` research run can produce a public-safe `brief_format: grok-8` artifact that downstream ads, site, organic, and playbook workflows can consume without rereading raw/private source material.

## Validation
- Level 0 docs/decision: extracted only the reusable 8-category structure from the private source attachment and added a fictional sanitized example.
- Level 1 static: `scripts/check.sh` passed formatting, type checks, 382 tests, coverage 81.26%, and skill validation.
- Level 2 CLI: `cd mb && python3 -m pytest tests/test_smoke_coverage.py -q` passed; no CLI behavior was changed.
- Level 3 package/install: not run; no packaging, entrypoint, or bundled-data loading behavior changed.
- Level 4 fixture repo: not run; no repo shape, onboarding, migration, status, or start behavior changed.
- Level 5 runtime smoke: not run; this changes skill prose/reference behavior, not Claude Code discovery, invocation, packaging, or first-run handoff.

## Public / Private Boundary
- The private source attachment stays out of the repo; committed content is generic structure plus a fictional example with no customer/member data, credentials, private paths, raw account data, or unsupported provider claims.
