### PR TITLE
[fix] Keep mb status relationship health cheap

### DIFF
--- a/mb/mb/status.py
+++ b/mb/mb/status.py
@@ -14,7 +14,6 @@ import yaml
 
 from mb import __version__, github_activity, relationships
 from mb import connect as connect_mod
-from mb import graph as graph_mod
 from mb import journal as journal_mod
 from mb import onboard as onboard_mod
 from mb import pushes as pushes_mod
@@ -301,15 +300,20 @@ def _journal_since_last_seen(
 
 def _read_frontmatter(path: Path) -> dict[str, Any]:
     try:
-        text = path.read_text(encoding="utf-8")
+        with path.open("r", encoding="utf-8") as handle:
+            first = handle.readline()
+            if first.rstrip("\n\r") != "---":
+                return {}
+            lines: list[str] = []
+            for line in handle:
+                if line.rstrip("\n\r") == "---":
+                    break
+                lines.append(line)
+            else:
+                return {}
     except OSError:
         return {}
-    if not text.startswith("---"):
-        return {}
-    end = text.find("\n---", 3)
-    if end == -1:
-        return {}
-    raw = text[3:end].strip()
+    raw = "".join(lines).strip()
     try:
         parsed = yaml.safe_load(raw) or {}
     except yaml.YAMLError:
@@ -380,10 +384,11 @@ def _file_summary(
 
 def _title_from_markdown(path: Path) -> str:
     try:
-        for line in path.read_text(encoding="utf-8").splitlines():
-            stripped = line.strip()
-            if stripped.startswith("# "):
-                return stripped[2:].strip()
+        with path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                stripped = line.strip()
+                if stripped.startswith("# "):
+                    return stripped[2:].strip()
     except OSError:
         pass
     return path.stem.replace("-", " ")
@@ -525,6 +530,105 @@ def _relationship_adjacency(edges: list[dict[str, Any]]) -> dict[str, dict[str, 
     return adjacency
 
 
+def _relationship_slug(value: str) -> str:
+    lowered = value.strip().lower()
+    slug = re.sub(r"[^a-z0-9]+", "-", lowered).strip("-")
+    return slug or "unknown"
+
+
+def _coerce_relationship_refs(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, list):
+        return [item for item in value if isinstance(item, str)]
+    return []
+
+
+def _is_hidden_or_generated(path: Path, repo: Path) -> bool:
+    try:
+        rel_parts = path.relative_to(repo).parts
+    except ValueError:
+        return True
+    is_bundled_data = rel_parts[:2] == ("mb", "_data") or rel_parts[:1] == ("_data",)
+    return (
+        any(
+            part.startswith(".") or part in {"__pycache__", "node_modules", ".venv", "venv"}
+            for part in rel_parts
+        )
+        or is_bundled_data
+    )
+
+
+def _relationship_markdown_files(repo: Path) -> list[Path]:
+    return [
+        path
+        for path in sorted(repo.rglob("*.md"))
+        if path.is_file() and not _is_hidden_or_generated(path, repo)
+    ]
+
+
+def _resolve_relationship_ref(repo: Path, ref: str) -> Path | None:
+    clean_ref = relationships.clean_ref(ref)
+    if not clean_ref:
+        return None
+    target = (repo / clean_ref).resolve()
+    try:
+        target.relative_to(repo)
+    except ValueError:
+        return None
+    return target
+
+
+def _relationship_reference_edges(repo: Path) -> list[dict[str, Any]]:
+    edges: list[dict[str, Any]] = []
+    seen_edges: set[tuple[str, str, str, tuple[tuple[str, str], ...]]] = set()
+    if not repo.exists():
+        return edges
+
+    for file_path in _relationship_markdown_files(repo):
+        frontmatter = _read_frontmatter(file_path)
+        if not frontmatter:
+            continue
+        source_rel = file_path.relative_to(repo).as_posix()
+        source_id = f"file:{source_rel}"
+        for field in relationships.relationship_fields_for_source(source_rel):
+            rel_type = relationships.normalize_relationship(
+                field,
+                source_path=source_rel,
+                fallback=field,
+            )
+            for ref in _coerce_relationship_refs(frontmatter.get(field)):
+                clean_ref = relationships.clean_ref(ref)
+                if not clean_ref and not relationships.is_external_ref(ref):
+                    continue
+                target = _resolve_relationship_ref(repo, ref)
+                if target is not None and target.exists():
+                    target_id = f"file:{target.relative_to(repo).as_posix()}"
+                elif relationships.is_external_ref(ref):
+                    target_id = f"external:{_relationship_slug(ref)}"
+                else:
+                    target_id = f"missing:{_relationship_slug(ref)}"
+                evidence = {"kind": "frontmatter", "field": field, "path": source_rel}
+                key = (source_id, target_id, rel_type, tuple(sorted(evidence.items())))
+                if key in seen_edges:
+                    continue
+                seen_edges.add(key)
+                edges.append(
+                    {
+                        "source": source_id,
+                        "target": target_id,
+                        "type": field,
+                        "rel_type": rel_type,
+                        "original_field": field,
+                        "evidence": evidence,
+                        "target_ref": ref,
+                    }
+                )
+    return edges
+
+
 def _linked_paths(
     adjacency: dict[str, dict[str, set[str]]],
     path: str,
@@ -587,8 +691,7 @@ def _relationship_health(
     brain: dict[str, Any],
     today: date,
 ) -> dict[str, Any]:
-    graph_index = graph_mod.build_index(str(repo))
-    edges = [edge for edge in graph_index.get("edges", []) if isinstance(edge, dict)]
+    edges = _relationship_reference_edges(repo)
     adjacency = _relationship_adjacency(edges)
     all_bets = [_bet_summary(repo, path) for path in _relative_markdown_files(repo, "bets")]
     active_bets = [
@@ -650,11 +753,6 @@ def _relationship_health(
     relationship_types = {
         relationship.canonical_type for relationship in relationships.RELATIONSHIPS
     }
-    graph_nodes = {
-        str(node.get("id") or ""): node
-        for node in graph_index.get("nodes", [])
-        if isinstance(node, dict)
-    }
     missing_relationship_targets: list[dict[str, Any]] = []
     for edge in edges:
         rel_type = str(edge.get("rel_type") or "")
@@ -663,13 +761,12 @@ def _relationship_health(
             continue
         raw_evidence = edge.get("evidence")
         evidence: dict[str, Any] = raw_evidence if isinstance(raw_evidence, dict) else {}
-        target_node: dict[str, Any] = graph_nodes.get(target) or {}
         missing_relationship_targets.append(
             {
                 "source": str(evidence.get("path") or _file_path_from_graph_id(edge.get("source"))),
                 "relationship": rel_type,
                 "field": str(edge.get("original_field") or evidence.get("field") or ""),
-                "target": str(target_node.get("label") or target.removeprefix("missing:")),
+                "target": str(edge.get("target_ref") or target.removeprefix("missing:")),
             }
         )
 

--- a/mb/mb/status.py
+++ b/mb/mb/status.py
@@ -302,11 +302,11 @@ def _read_frontmatter(path: Path) -> dict[str, Any]:
     try:
         with path.open("r", encoding="utf-8") as handle:
             first = handle.readline()
-            if first.rstrip("\n\r") != "---":
+            if first.strip() != "---":
                 return {}
             lines: list[str] = []
             for line in handle:
-                if line.rstrip("\n\r") == "---":
+                if line.strip() == "---":
                     break
                 lines.append(line)
             else:
@@ -850,7 +850,7 @@ def _relationship_health(
     active_gaps = [gap_item for gap_item in gaps if gap_item is not None]
     return {
         "ok": not active_gaps,
-        "source": "mb graph",
+        "source": "mb status relationship scan",
         "registry_version": relationships.REGISTRY_VERSION,
         "summary": {
             "gaps": len(active_gaps),

--- a/mb/tests/test_status.py
+++ b/mb/tests/test_status.py
@@ -427,12 +427,11 @@ def test_status_relationship_health_flags_closed_bet_without_outcome(
 def test_status_relationship_health_uses_lightweight_scan_on_large_repos(
     tmp_path: Path, monkeypatch
 ) -> None:
+    def fail_if_graph_builds(_path: str) -> None:
+        raise AssertionError("status built the full graph")
+
     monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
-    monkeypatch.setattr(
-        graph_mod,
-        "build_index",
-        lambda _path: (_ for _ in ()).throw(AssertionError("status built the full graph")),
-    )
+    monkeypatch.setattr(graph_mod, "build_index", fail_if_graph_builds)
     repo = tmp_path / "acme"
     init_run(path=str(repo), name="Acme")
     documents = repo / "documents"
@@ -772,6 +771,13 @@ def test_status_brain_includes_active_bets(tmp_path: Path) -> None:
     assert brain["recent_research"][0]["title"] == "Market"
     assert brain["bets"]["active"][0]["title"] == "Launch bet"
     assert brain["bets"]["active"][0]["deadline"] == deadline.isoformat()
+
+
+def test_status_frontmatter_reader_accepts_delimiter_whitespace(tmp_path: Path) -> None:
+    path = tmp_path / "note.md"
+    path.write_text("--- \nstatus: open\n--- \n# Note\n", encoding="utf-8")
+
+    assert status_mod._read_frontmatter(path)["status"] == "open"
 
 
 def test_status_readiness_mentions_due_bets(tmp_path: Path) -> None:

--- a/mb/tests/test_status.py
+++ b/mb/tests/test_status.py
@@ -12,6 +12,7 @@ from typing import Any
 from typer.testing import CliRunner
 
 from mb import connect as connect_mod
+from mb import graph as graph_mod
 from mb import status as status_mod
 from mb.cli import app
 from mb.init import run as init_run
@@ -421,6 +422,57 @@ def test_status_relationship_health_flags_closed_bet_without_outcome(
         report["relationship_health"]["sections"]["bets"]["closed_without_outcome"][0]["path"]
         == "bets/2026-05-01-closed.md"
     )
+
+
+def test_status_relationship_health_uses_lightweight_scan_on_large_repos(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
+    monkeypatch.setattr(
+        graph_mod,
+        "build_index",
+        lambda _path: (_ for _ in ()).throw(AssertionError("status built the full graph")),
+    )
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+    documents = repo / "documents"
+    documents.mkdir(exist_ok=True)
+    large_body = "# Notes\n\n" + ("Relationship-free working note.\n" * 100)
+    for index in range(300):
+        (documents / f"2026-05-01-note-{index:03d}.md").write_text(
+            large_body,
+            encoding="utf-8",
+        )
+    (repo / "bets" / "2026-05-01-launch.md").write_text(
+        (
+            "---\n"
+            "status: open\n"
+            "opened: 2026-05-01\n"
+            "deadline: 2026-05-31\n"
+            "appetite: 2 weeks\n"
+            "hypothesis: A launch push will create calls.\n"
+            "metric: calls\n"
+            "target: 5 calls\n"
+            "linked_pushes:\n"
+            "  - pushes/missing-launch/push.md\n"
+            "---\n\n"
+            "# Launch bet\n"
+        ),
+        encoding="utf-8",
+    )
+
+    report = status_mod.run(path=str(repo), update_marker=False)
+
+    health = report["relationship_health"]
+    assert report["brain"]["counts"]["documents"] == 300
+    assert health["summary"]["active_bets_without_push"] == 1
+    assert health["summary"]["missing_relationship_targets"] == 1
+    assert health["sections"]["outcomes"]["missing_targets"][0] == {
+        "source": "bets/2026-05-01-launch.md",
+        "relationship": "push",
+        "field": "linked_pushes",
+        "target": "pushes/missing-launch/push.md",
+    }
 
 
 def test_status_human_output_mentions_core_sections(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- Keeps the daily `mb status --json --peek` relationship-health surface cheap on large business repos.
- Replaces the status path's full graph index build with a lightweight relationship-registry frontmatter scan.
- Preserves the additive `relationship_health` JSON shape while updating its source label to the status-side scan.
- Adds regression coverage that fails if status calls `graph.build_index()` and covers tolerant frontmatter delimiters.

## Scope
- In: `mb status` relationship-health internals, missing relationship target reporting, large-repo regression coverage.
- Out: dashboard work, provider polling, graph relationship semantic changes, cache state, package/install behavior, runtime skill discovery.

## Commits
- `9eb8f44` — `[fix] Keep MAIN-273 status relationship scan cheap`.
- `8713164` — `[fix] Address MAIN-273 status review polish`.

## Release / Issues
- Release: none assigned.
- Linear ID(s): MAIN-273.
- Closes: #390.
- Refs: #358.
- Follow-ups: none known.

## Success Metric
- `mb status --json --peek` reports the same relationship-health contract without paying the full `mb graph` index cost on large markdown repos.

## Validation
- Level 0 docs/decision: N/A, no durable docs or decisions changed.
- Level 1 static: `scripts/check.sh` passed from repo root; formatting, lint, mypy, coverage, and skill validation were clean.
- Level 2 CLI: `cd mb && pytest tests/test_status.py -q` passed with 34 tests; full suite passed with 384 tests.
- Level 3 package/install: N/A, no packaging, entrypoint, bundled data, install, or update behavior changed.
- Level 4 fixture repo: Local 800-file measurement showed `graph.build_index` at ~0.266s and the lightweight relationship scan at ~0.024s.
- Level 5 runtime smoke: N/A, no Claude Code skill discovery, invocation, or runtime workflow changed.

## Public / Private Boundary
- Only public-safe CLI implementation and tests changed; local Conductor notes and measurement scratch stayed out of committed files.
