### PR TITLE
[add] Beginner education catalog

### DIFF
--- a/.claude/educational/anti-cloud-backup.md
+++ b/.claude/educational/anti-cloud-backup.md
@@ -1,86 +1,93 @@
 ---
 type: educational
 topic: anti-cloud-backup
-status: stub
-last-updated: 2026-04-29
+status: draft
+last-updated: 2026-05-08
 ---
 
-# Why your financial ledger doesn't belong in iCloud, Drive, or Dropbox
+# Why sensitive business records should not live in consumer cloud sync
 
-## Why we don't recommend consumer cloud sync
+Main Branch is local-first because some business records should not be treated
+like casual synced documents.
 
-Consumer cloud sync products (iCloud Drive, Google Drive, Dropbox, OneDrive) are designed for convenience: a folder on your laptop that mirrors to a server you don't own. That convenience comes from defaults that are wrong for financial records.
+Consumer cloud sync tools are convenient. They are also the wrong default for
+raw finance, legal, customer, credential, and account-export material.
 
-First, **subpoena exposure**. Every major US cloud provider publishes a transparency report documenting thousands of warrants and subpoenas served against user data per year. iCloud Drive content is decryptable by Apple under standard legal process unless you've explicitly enabled Advanced Data Protection (still off by default in 2026). Google and Dropbox encrypt at rest with keys they hold. Your `core/finance/ledger.beancount` becomes a third-party record under the third-party doctrine the moment it touches their servers — which means the bar to access it is a subpoena, not a warrant.
+## The beginner version
 
-Second, **encryption-at-rest is not end-to-end encryption**. Marketing copy on these products often blurs the line. "Encrypted at rest" means the disk is encrypted; the provider holds the key. Anyone who compels the provider — or breaches them — gets plaintext. Beancount files are plaintext. Account numbers, vendor names, transaction memos, headcount payroll details: all of it readable by anyone the provider hands the key to.
+Use this rule:
 
-Third, **silent corruption and conflict resolution**. Dropbox famously creates `filename (Devon's Mac Studio's conflicted copy 2026-04-12).beancount` files when two devices touch a file at once. iCloud has truncated files mid-sync more than once in documented cases. For a ledger you are going to balance and audit, "the cloud quietly corrupted line 4,182" is not an acceptable failure mode.
+- durable business memory can live in the business repo;
+- raw sensitive records need stricter boundaries;
+- secrets never belong in committed markdown;
+- cloud sync is not the same thing as a deliberate backup plan.
 
-Fourth, **vendor lock-in**. The day Dropbox raises prices, removes a feature, or terminates your account for a TOS dispute, your data is wherever they say it is. With self-hosted git you carry the repo to a new origin in one `git remote set-url`.
+The business repo is for durable, safe operating truth: offers, audience notes,
+research, decisions, pushes, logs, documents, and summaries. Sensitive source
+material should either stay out of the repo or live in a separate private repo
+with explicit access rules.
 
-## What we recommend instead
+## Why not iCloud Drive, Google Drive, Dropbox, or OneDrive?
 
-A three-layer setup that keeps you in control:
+**Sync is not review.** A synced folder copies whatever lands in it. That is
+dangerous for ledgers, exports, customer lists, legal docs, and tokens because
+one accidental file can spread to every device and vendor copy before anyone
+reviews it.
 
-1. **Forgejo** (self-hosted git) is the primary working copy. You commit to a repo on a server you own — a Mac mini in a closet, a Hetzner box, a Synology NAS running Docker. `git push` is the sync mechanism. Conflicts surface as merge conflicts, not silent overwrites.
-2. **Backblaze B2** is the encrypted off-site backup. `restic` snapshots the working tree (and the Forgejo data dir) on a schedule. The encryption key lives on your machine; B2 holds ciphertext. Subpoenaed B2 hands over noise.
-3. **Time Machine** is the local snapshot recovery. macOS already does this if you plug in an external drive. It saves you from "I just `rm -rf core/finance/`" within seconds, not hours.
+**Conflict handling is not audit handling.** Cloud sync tools try to keep files
+available. They are not designed to preserve a clean accounting or legal audit
+story. A conflicted copy may be survivable for a draft, but it is unacceptable
+for records you must reconcile later.
 
-The combination is cheaper than Dropbox Pro, gives you forensic git history, and keeps the encryption key out of any vendor's hands.
+**Provider access is not the same as owner custody.** Even when a provider is
+reputable, the business has less control over account access, legal process,
+retention, and recovery than it does over a repo plus a tested backup plan.
 
-## Setup walkthrough
+**Agents can accidentally read what you put nearby.** If a runtime has access
+to a folder, assume it can inspect files in that folder. Keep private raw data
+outside the normal business repo unless a workflow explicitly needs a safe
+summary.
 
-1. Stand up Forgejo on a machine you own. Easiest path is Docker on a home server:
-   ```bash
-   docker run -d --name forgejo \
-     -p 3000:3000 -p 222:22 \
-     -v /opt/forgejo:/data \
-     codeberg.org/forgejo/forgejo:7
-   ```
-   Visit `http://your-server.local:3000`, create the admin user, create a private repo named after your business.
+## What Main Branch recommends
 
-2. Point your `core/finance/` directory at it:
-   ```bash
-   cd ~/your-business
-   git init
-   git remote add origin git@your-server.local:devon/your-business.git
-   git add core/finance/
-   git commit -m "[init] finance ledger"
-   git push -u origin main
-   ```
+For everyday business memory, use the normal repo created by:
 
-3. Install `restic` and configure a B2 bucket:
-   ```bash
-   brew install restic
-   # Create a B2 application key with read+write on a new private bucket.
-   export B2_ACCOUNT_ID="<keyID>"
-   export B2_ACCOUNT_KEY="<applicationKey>"
-   export RESTIC_REPOSITORY="b2:your-bucket-name:/"
-   export RESTIC_PASSWORD="$(openssl rand -base64 32)"  # WRITE THIS DOWN
-   restic init
-   ```
-   Save `RESTIC_PASSWORD` somewhere offline (paper, hardware key, password manager you trust). Without it, the backup is unrecoverable — that is the point.
+```bash
+mb onboard --name "My Business" --path my-business
+```
 
-4. Schedule a daily snapshot via `launchd` (macOS) or `cron`:
-   ```bash
-   restic backup ~/your-business --exclude='node_modules' --exclude='.venv'
-   restic forget --keep-daily 7 --keep-weekly 4 --keep-monthly 12 --prune
-   ```
+For raw sensitive material, choose a stricter home:
 
-5. Confirm Time Machine is on and pointed at an external SSD. macOS does the rest.
+1. Keep secrets in the OS keychain, a password manager, runtime local config,
+   or environment variables.
+2. Keep raw finance or legal files in a separate private repo or system with
+   explicit access boundaries.
+3. Put only durable summaries, provider-safe IDs, and decisions in the shared
+   business repo.
+4. Test restore before you trust any backup.
 
-6. Run a recovery drill once. Pick a non-critical file, delete it, and restore it from each of the three layers (`git checkout`, `restic restore`, Time Machine). If any layer fails the drill, fix it now, not when you actually need it.
+## Where Beancount fits
 
-Cost at typical scale: Forgejo on existing hardware is free. B2 storage runs roughly $6/TB/month, and a finance ledger plus business repo will sit comfortably under 1 GB for years. Total operating cost: under $1/month.
+Beancount-style plain-text ledgers are useful because they are inspectable and
+versionable. That does not mean every ledger belongs in the shared business
+repo. A safe pattern is:
 
-## Honest limitations
+- raw ledger and statements in a private finance repo;
+- business-readable summaries in `core/finance/` or `log/`;
+- no account numbers, credentials, or customer-private rows in shared docs.
 
-This stack does not solve **availability**. If your home server is offline, your collaborators can't push. If you travel and your laptop is lost, you're cloning from B2, which takes longer than a Dropbox sync. For a single-operator business the trade-off is fine; for a 5-person team you want a managed Forgejo or Gitea on a VPS instead of a closet box. It also requires you to remember the restic password — losing it loses the backup. A 30-second failover plan and a hardware-key-stored copy of the password is part of the deal.
+See:
 
-## Resources
+```bash
+mb educational beancount
+```
 
-- Forgejo docs: https://forgejo.org/docs/
-- Restic docs: https://restic.readthedocs.io/
-- Backblaze B2 pricing: https://www.backblaze.com/cloud-storage/pricing
-- Apple's "Government Information Requests" transparency report: https://www.apple.com/legal/transparency/
+## What Main Branch does not claim
+
+Main Branch does not provide legal, accounting, tax, or security advice. It
+provides a repo-backed operating model and guardrails that keep sensitive raw
+data from becoming casual context.
+
+If you are unsure whether a file is safe to commit, do not commit it. Ask
+Claude to summarize it without copying private details, or keep it outside the
+business repo.

--- a/.claude/educational/beancount.md
+++ b/.claude/educational/beancount.md
@@ -1,0 +1,55 @@
+---
+type: educational
+topic: beancount
+status: draft
+last-updated: 2026-05-08
+---
+
+# Beancount: plain-text finance without leaking raw finance data
+
+Beancount is a plain-text accounting format. It fits Main Branch's philosophy
+because ledgers can be inspected, versioned, reviewed, and backed up like code
+or markdown.
+
+That does not mean raw finance data belongs in every shared business repo.
+
+## When you need this
+
+Use Beancount-style thinking when the business needs durable financial memory:
+
+- revenue and expense summaries;
+- offer-level profitability;
+- payout and provider reconciliation;
+- monthly operating review;
+- bookkeeping handoff notes;
+- finance decisions that should feed future planning.
+
+## The safe boundary
+
+Recommended pattern:
+
+1. Keep raw ledgers, statements, receipts, and account exports in a private
+   finance repo or accounting system with explicit access rules.
+2. Keep business-readable summaries in the main business repo.
+3. Link decisions, offers, pushes, and outcomes to the relevant safe summary.
+4. Never commit bank credentials, account numbers, tax IDs, payroll rows,
+   customer-private rows, or secrets.
+
+## Why not a normal accounting SaaS only?
+
+Accounting SaaS can be useful and may still be required for bookkeeping, tax,
+payroll, or accountant collaboration. The Main Branch concern is operating
+memory: can the business inspect the financial lesson later, connect it to the
+offer or push, and preserve the decision in a repo-backed way?
+
+Plain-text summaries and ledgers make that possible without forcing every
+operator into a vendor-specific dashboard.
+
+## What Main Branch does not claim
+
+Main Branch does not provide accounting, tax, legal, or financial advice.
+Beancount is a planned/optional finance rail, not a guarantee that `mb` can
+automate your books end to end.
+
+When in doubt, store less raw finance data in the shared repo and more safe
+summary context for business decisions.

--- a/.claude/educational/cal-com.md
+++ b/.claude/educational/cal-com.md
@@ -1,0 +1,59 @@
+---
+type: educational
+topic: cal-com
+status: draft
+last-updated: 2026-05-08
+---
+
+# Cal.com: booking calls without making scheduling the business brain
+
+Cal.com is a scheduling rail. It helps someone book a call, consultation,
+fitting, onboarding session, or sales conversation.
+
+Main Branch treats booking tools as provider rails around the business repo,
+not as the source of business memory.
+
+## When you need this
+
+Use a booking rail when a push, offer, site, or fulfillment process needs a
+scheduled appointment:
+
+- sales calls;
+- discovery calls;
+- consults;
+- onboarding sessions;
+- fittings or appointments;
+- customer interviews.
+
+The durable Main Branch record should still live in the repo: the offer, the
+push, the page, the playbook, the outcome, and the decision about why booking
+is the right conversion path.
+
+## What to store in the repo
+
+Safe, useful records:
+
+- booking link URL;
+- event type name;
+- offer or push that uses the booking link;
+- tracking or thank-you page plan when relevant;
+- non-secret provider reference.
+
+Do not commit API keys, OAuth tokens, customer records, calendar exports, or
+private attendee details.
+
+## How it fits site work
+
+A Main Branch site or minisite can point its primary call to action at a booking
+URL when the conversion goal is "schedule." The repo should explain the choice:
+
+- why this offer needs a call;
+- which page sends people to the booking link;
+- what happens after the appointment is booked;
+- which outcome file records the result later.
+
+## What Main Branch does not claim
+
+Main Branch does not claim shipped Cal.com account automation today. Treat
+Cal.com as a useful external booking rail unless a current CLI/provider check
+states a specific automated path is ready.

--- a/.claude/educational/cli-vs-dashboard.md
+++ b/.claude/educational/cli-vs-dashboard.md
@@ -1,0 +1,77 @@
+---
+type: educational
+topic: cli-vs-dashboard
+status: draft
+last-updated: 2026-05-08
+---
+
+# CLI vs. dashboard: why Main Branch starts with `mb`
+
+`mb` is a command-line tool because Main Branch needs a deterministic control
+plane before it needs a prettier screen.
+
+That does not mean the product is "for developers only." It means the setup,
+status, repair, validation, graph, provider, update, and checkpoint facts should
+be scriptable and inspectable before any dashboard becomes a view over them.
+
+## The beginner version
+
+The terminal is just the place where you run exact commands.
+
+For normal setup:
+
+```bash
+mb onboard --name "My Business" --path my-business
+cd my-business
+claude
+/mb-start
+```
+
+For the daily loop:
+
+```bash
+cd /path/to/my-business
+claude
+/mb-start
+```
+
+You do not need to memorize hidden repair commands. `mb` and the skills should
+tell you the next exact command when something needs attention.
+
+## Why not start with a SaaS dashboard?
+
+**Dashboards can hide the source of truth.** If a dashboard becomes the place
+where business memory lives, the repo becomes a stale export. Main Branch wants
+the opposite: the repo is truth, and dashboards are views.
+
+**Commands are testable.** `mb status --json --peek` either reports the facts or
+it does not. Agents, scripts, tests, and future dashboards can all read the same
+contract.
+
+**Repair needs exactness.** When a repo needs migration, skill relinking,
+provider readiness, or validation, a vague UI message is not enough. The user
+needs to know what broke, why it matters, and which command fixes the next
+step.
+
+**Power users and beginners share one rail.** Beginners get guided copy and
+numbered choices. Power users get quiet commands and JSON output. The control
+plane stays the same.
+
+## Where dashboards fit later
+
+A future Main Branch dashboard should show existing truth:
+
+- repo health from `mb status`;
+- graph relationships from `mb graph`;
+- provider readiness from `mb connect`;
+- tasks and proposals from GitHub;
+- saved checkpoints from git history;
+- business files from the repo.
+
+It should not become a second database that the files have to chase.
+
+## What Main Branch does not claim
+
+Main Branch does not ship a hosted SaaS dashboard today. Any future dashboard
+must stay optional, local-first or self-hostable, and honest about which files,
+GitHub threads, commits, and provider facts it is reading.

--- a/.claude/educational/cloudflare-pages.md
+++ b/.claude/educational/cloudflare-pages.md
@@ -1,0 +1,71 @@
+---
+type: educational
+topic: cloudflare-pages
+status: draft
+last-updated: 2026-05-08
+---
+
+# Cloudflare Pages: publishing repo-backed business sites
+
+Cloudflare Pages is the default Main Branch rail for static business sites:
+landing pages, minisites, offer pages, wikis, and other pages that should be
+easy to deploy from git.
+
+## When you need this
+
+Use Cloudflare Pages when the business is ready to publish or update a site:
+
+- offer landing page;
+- paid-traffic minisite;
+- proof or case-study page;
+- wiki or public knowledge surface;
+- simple static business site.
+
+Do not connect Cloudflare just because setup asks you to make accounts. Connect
+it when the next business action is publishing, deploying, or attaching a
+domain.
+
+## Why Pages fits Main Branch
+
+**The site can live in files.** A repo-backed site lets agents and operators
+inspect what changed.
+
+**Deploys follow commits.** Pushing a reviewed change can publish the site or
+trigger the provider pipeline.
+
+**DNS is close to deployment.** Cloudflare can own the domain, DNS, SSL, Pages,
+and future Workers rail, which reduces setup sprawl.
+
+**It is enough for the strongest early site wedge.** Main Branch's early site
+work is mostly static pages with clear conversion endpoints, not heavy
+application hosting.
+
+## The safe setup path
+
+From the business repo:
+
+```bash
+mb connect plan
+```
+
+When Cloudflare is the needed rail, follow the command Main Branch prints. For
+the broader provider explanation:
+
+```bash
+mb educational provider-readiness
+```
+
+For the platform comparison:
+
+```bash
+mb educational cloudflare-vs-vercel
+```
+
+## What Main Branch does not claim
+
+Main Branch does not claim every Pages, Workers, DNS, analytics, or domain flow
+is automated. Trust only the current CLI checks, bundled skill guidance, and
+smoke evidence for the specific path you are using.
+
+If your site already works on another host, migrate when a real business job
+needs the repo-backed Cloudflare rail.

--- a/.claude/educational/cloudflare-vs-vercel.md
+++ b/.claude/educational/cloudflare-vs-vercel.md
@@ -1,66 +1,85 @@
 ---
 type: educational
 topic: cloudflare-vs-vercel
-status: stub
-last-updated: 2026-04-29
+status: draft
+last-updated: 2026-05-08
 ---
 
-# Why we ship sites on Cloudflare Pages, not Vercel or Netlify
+# Cloudflare vs. Vercel: why Main Branch defaults to boring site rails
 
-## Why we don't recommend Vercel or Netlify by default
+Main Branch uses Cloudflare for sites and DNS because most business operators
+need predictable publishing more than they need a fancy application platform.
 
-Vercel and Netlify are excellent products. The reason we don't pick them as the Main Branch default is not quality — it's pricing posture and lock-in.
+The beginner question is not "which platform is coolest?" The question is:
+"Can I publish the page, attach the domain, understand what changed, and avoid
+surprise infrastructure work?"
 
-**Pricing model risk.** Both Vercel and Netlify use a "free tier with metered overage" model. If your site goes viral, you pay for it after the fact, and the bill can be surprising. Vercel's bandwidth overages are billed at $40/TB after the included 100 GB on Hobby; Netlify's are $55/TB after 100 GB. We have seen Main Branch members hit $300 surprise bills from a single Reel that sent 500K visitors to a one-page site. Cloudflare's free Pages tier has unlimited bandwidth — that is not marketing copy, it is the actual policy as of 2026. The bill cannot surprise you because there is no meter.
+## The beginner version
 
-**Build minutes are a hidden meter.** Vercel includes 6,000 build-execution minutes per month on Pro; if you are deploying every commit on a busy week, you'll see throttling or upgrade prompts. Cloudflare Pages includes 500 builds per month on the free tier, then charges per build (not per minute). The pricing scales linearly and predictably.
+For Main Branch, a site should usually be:
 
-**Egress and image-optimization fees.** Vercel's image-optimization and edge-function minutes are separately metered. Each Next.js `<Image>` view counts. For a marketing site this is small, but for any site that grows organically over a year, it compounds. Cloudflare's image resizing and Workers requests are metered too, but the free tier ceiling is meaningfully higher and the per-unit cost is lower at every tier we have benchmarked.
+1. files in a repo;
+2. a GitHub-backed deploy;
+3. a Cloudflare Pages project;
+4. a domain connected through Cloudflare DNS;
+5. a clear provider-readiness check before publishing work depends on it.
 
-**Build-pipeline lock-in.** Vercel's build pipeline is tightly coupled to their platform. Their Next.js features (ISR, on-demand revalidation, edge middleware) work only on Vercel; the same code on a different host degrades. Cloudflare Pages is build-pipeline-agnostic — it accepts the static output of any framework, and the deploy is just a folder of files. This makes "leave Cloudflare" a one-day project. "Leave Vercel after writing Vercel-specific Next.js features" is a quarter-long project.
+That path keeps the site close to the same durable memory model as the business
+repo. A commit changes the site. Cloudflare publishes the result. The operator
+can inspect the repo, the deploy, and the domain.
 
-**Composability.** Cloudflare Pages, Workers, R2 (object storage), D1 (SQLite at the edge), Queues, and KV are one platform with one bill. The Main Branch stack uses Pages for the static site, Workers for any custom endpoint (e.g., the `mb claim` Skool-membership check), and R2 for ad-hoc artifact storage. On Vercel you'd reach for AWS or a third-party for the equivalents.
+## Why Cloudflare Pages is the default
 
-## What we recommend instead
+**It matches static marketing work.** Most Main Branch site work starts as a
+landing page, minisite, wiki, or offer page. Those surfaces should be easy to
+build, review, push, and roll back.
 
-Cloudflare Pages, deployed via `wrangler` from a GitHub repo, with a custom domain and SSL provisioned automatically. Builds run in Cloudflare's pipeline; deploys are atomic; rollbacks are one click. For any dynamic surface, Workers sit beside Pages in the same project.
+**DNS and publishing live together.** Domain setup is one of the places
+beginners get stuck. Cloudflare keeps DNS, Pages, SSL, and future Workers close
+enough that `mb` and skills can explain one rail instead of five disconnected
+vendor surfaces.
 
-## Setup walkthrough
+**It is git-friendly.** Git-connected Pages projects fit the Main Branch rule:
+files and commits are the source of truth, and the deploy is a view over that
+truth.
 
-1. Create a Cloudflare account at https://dash.cloudflare.com/sign-up. Free tier is enough.
+**It leaves room for simple dynamic edges.** If a future workflow needs a small
+endpoint, redirect, gate, or webhook, Cloudflare Workers sit near Pages without
+turning the whole site into a hosted SaaS app.
 
-2. Install `wrangler` (the Cloudflare CLI):
-   ```bash
-   npm install -g wrangler
-   wrangler login
-   ```
-   The login command opens a browser tab and authorizes the CLI.
+## When Vercel or Netlify can still be right
 
-3. Connect a GitHub repo as a Pages project. From the dashboard: `Workers & Pages → Create → Pages → Connect to Git`. Pick the repo, the branch (typically `main`), and the build settings. For a vanilla static site, set the build command to whatever your framework needs (e.g., `npm run build`) and the output directory to `dist/` or `public/`.
+Choose Vercel or Netlify when a project already depends on their platform
+features, when a team is already fluent there, or when a specific framework
+path is materially easier on that host.
 
-4. Set a custom domain. From the project page: `Custom domains → Set up a domain`. Cloudflare will provision an SSL cert automatically if your domain is on Cloudflare DNS. If it's elsewhere, you add a CNAME at your registrar.
+Main Branch's default is not a moral judgment. It is a bias toward boring,
+inspectable, low-surprise rails for business pages.
 
-5. Verify deploys. Push a commit to `main`. Within ~60 seconds Cloudflare builds and publishes. Open the project URL.
+## The safe setup path
 
-6. Optional but recommended: set up a `wrangler.toml` in the repo so you can `wrangler pages deploy` from your laptop without a GitHub round-trip:
-   ```toml
-   name = "your-site"
-   compatibility_date = "2026-04-29"
-   pages_build_output_dir = "dist"
-   ```
-   Then `wrangler pages deploy dist/` after a local build.
+Do not connect Cloudflare on day one unless a site job needs it. From the
+business repo, start with:
 
-Cost at typical Main Branch scale: $0/month for a marketing site under ~10K daily visitors. You start paying when you cross into Workers Paid ($5/month for 10M requests) or R2 storage above 10 GB.
+```bash
+mb connect plan
+```
 
-## Honest limitations
+When the next business action is publishing or attaching a domain, follow the
+Cloudflare step that `mb connect plan` prints. Use:
 
-Cloudflare Pages does not have first-class Next.js ISR or React Server Components support the way Vercel does. If you are building a heavy React app with dynamic SSR rendering and per-request edge logic, Vercel's developer experience is better and the lock-in cost may be worth it. For Main Branch sites — which are mostly static marketing surfaces with the occasional Worker for a form submit or a Skool gate — Pages is the right tool.
+```bash
+mb educational provider-readiness
+```
 
-The Cloudflare dashboard is also denser and less polished than Vercel's. First-time users will need 30 minutes to learn it. After that it's fine.
+for the plain-English version of what connected accounts mean.
 
-## Resources
+## What Main Branch does not claim
 
-- Cloudflare Pages docs: https://developers.cloudflare.com/pages/
-- Wrangler CLI: https://developers.cloudflare.com/workers/wrangler/
-- Pricing comparison (Cloudflare): https://developers.cloudflare.com/pages/platform/limits/
-- Vercel pricing (for comparison): https://vercel.com/pricing
+Main Branch does not claim every Cloudflare workflow is automated. Site and
+provider behavior should be trusted only where the CLI, bundled skills, and
+smoke evidence say that path is ready.
+
+Main Branch also does not require every business to leave an existing Vercel or
+Netlify site immediately. Migrate when the next business job benefits from the
+repo-backed Cloudflare path.

--- a/.claude/educational/cursor.md
+++ b/.claude/educational/cursor.md
@@ -1,0 +1,65 @@
+---
+type: educational
+topic: cursor
+status: draft
+last-updated: 2026-05-08
+---
+
+# Cursor: useful editor, not a supported Main Branch runtime yet
+
+Cursor is an AI code editor. It can be useful for reading and editing a Main
+Branch business repo because the repo is just files.
+
+That is different from saying Main Branch supports Cursor as a full runtime.
+
+## The beginner version
+
+You can open your business repo folder in Cursor to inspect or edit files:
+
+- `core/` for offer, audience, voice, proof, strategy, and operations;
+- `research/` for investigations;
+- `decisions/` for accepted or proposed choices;
+- `pushes/` for launches, drops, challenges, promos, and playbooks;
+- `log/` for operating notes;
+- `documents/` for long-form artifacts.
+
+Claude Code remains the supported slash-skill runtime today.
+
+## What Cursor is good for
+
+- reading markdown files;
+- making careful edits;
+- searching the repo;
+- reviewing diffs;
+- helping power users understand the folder tree.
+
+Because Main Branch keeps memory in markdown and git, tools like Cursor can
+operate on the files without a proprietary export.
+
+## What is not supported yet
+
+Do not assume Cursor can run `/mb-start`, `/mb-think`, `/mb-status`, or bundled
+Claude Code skills as first-class Main Branch workflows.
+
+Future adapter work should call deterministic `mb` commands, read JSON output
+where available, and prove runtime behavior with smoke evidence before public
+support is claimed.
+
+## The safe beginner path
+
+For supported workflows:
+
+```bash
+cd /path/to/your-business
+claude
+/mb-start
+```
+
+Use Cursor as an editor if it helps you see the files. Use Claude Code for the
+shipped Main Branch skill flows.
+
+## What Main Branch does not claim
+
+Cursor is a roadmap compatibility target, not a supported adapter today. Do not
+represent Cursor workflow behavior as shipped until there is adapter code,
+documentation, and smoke evidence.

--- a/.claude/educational/daily-owner-loop.md
+++ b/.claude/educational/daily-owner-loop.md
@@ -1,0 +1,77 @@
+---
+type: educational
+topic: daily-owner-loop
+status: draft
+last-updated: 2026-05-08
+---
+
+# The daily owner loop: what Main Branch asks you to do first
+
+Main Branch starts from the normal owner day, not from tool theory.
+
+The goal is simple: open the business folder, let Claude ground itself in repo
+facts, choose the next useful business move, ship or repair the next thing, and
+save what changed.
+
+## The beginner version
+
+After setup, the daily loop is:
+
+```bash
+cd /path/to/your-business
+claude
+/mb-start
+```
+
+That is the front door.
+
+`/mb-start` should make Claude read deterministic `mb` facts before advice:
+repo health, status, updates, graph links, provider readiness, runtime wiring,
+recent activity, and checkpoint readiness.
+
+## What happens in the loop
+
+1. **Open Terminal or Claude Code safely.**
+   Start in the business repo, not in the engine repo or a random downloads
+   folder.
+
+2. **Install or update through the product path.**
+   Use `mb onboard`, `/mb-update`, or `mb update --repo .` when Main Branch
+   tells you to. Do not start by debugging Python packaging or git internals.
+
+3. **Choose or create a business folder.**
+   That folder is the business brain: `core/`, `research/`, `decisions/`,
+   `bets/`, `pushes/`, `log/`, and `documents/`.
+
+4. **Run `/mb-start` or `mb status`.**
+   Claude should ground itself in `mb` facts before giving strategic advice.
+
+5. **Route work into a business primitive.**
+   A messy thought dump should become a bet, research note, decision, push,
+   playbook, outcome, log entry, or checkpoint plan.
+
+6. **Close with `/mb-end` or checkpoint guidance.**
+   The point is not to leave a long chat behind. The point is to preserve the
+   useful business memory in files and git history.
+
+## Why the tools exist
+
+- **Markdown files** make the business memory readable.
+- **Git history** turns saved work into a timeline.
+- **GitHub** gives durable tasks, blockers, proposals, and reviews.
+- **`mb`** checks the facts and prints exact next commands.
+- **Claude Code skills** do the judgment-heavy writing, routing, and review.
+- **Provider rails** connect outside tools only when a business job needs them.
+
+The philosophy matters because it protects the loop. Main Branch is not asking
+you to learn infrastructure for its own sake.
+
+## What Main Branch does not claim
+
+Main Branch does not expect beginners to manually manage branches, package
+repair, hidden git commands, or provider internals as the default workflow.
+
+When something needs repair, `mb` should explain what broke, why it matters,
+and the next exact command. When behavior depends on Claude Code runtime
+discovery, package install, provider mutation, or release quality, it needs
+matching evidence before Main Branch claims it works.

--- a/.claude/educational/forgejo.md
+++ b/.claude/educational/forgejo.md
@@ -1,0 +1,60 @@
+---
+type: educational
+topic: forgejo
+status: draft
+last-updated: 2026-05-08
+---
+
+# Forgejo: owning the git server when GitHub is not the right boundary
+
+GitHub is the default Main Branch public and team rail today because it gives
+issues, pull requests, releases, and broad tool support. Forgejo matters because
+some teams eventually need a self-hosted git forge.
+
+## When you need this
+
+Consider Forgejo when:
+
+- the business needs stronger custody over a private repo;
+- a finance, legal, client, or operations repo should not sit in a broad SaaS
+  account;
+- the team already runs self-hosted infrastructure;
+- GitHub is unavailable, inappropriate, or intentionally not the source of
+  truth for that repo boundary.
+
+For most beginners, GitHub is still the right starting point.
+
+## Why Forgejo fits the Main Branch philosophy
+
+**It keeps git as the substrate.** Main Branch wants durable files, git history,
+and inspectable changes. Forgejo preserves that model.
+
+**It is self-hostable.** A team can run the forge on infrastructure it controls
+when the access boundary matters.
+
+**It can keep sensitive repos separate.** A business repo can link to a
+separate finance, legal, site, client, or ops repo without copying raw private
+data into shared memory.
+
+## What changes if you use Forgejo
+
+You still need the same operating concepts:
+
+- issues or equivalent work threads;
+- proposals or review conversations;
+- readable commits;
+- backups and restore drills;
+- explicit access rules;
+- no secrets in committed files.
+
+The difference is who operates the forge and how much responsibility the team
+takes on for uptime, security updates, backups, and account recovery.
+
+## What Main Branch does not claim
+
+Main Branch does not claim Forgejo is a fully supported first-run provider
+today. GitHub remains the concrete public rail for issues, proposals, releases,
+and most current workflows.
+
+Forgejo is a compatible direction for teams that need self-hosted git, not a
+beginner requirement.

--- a/.claude/educational/git-history-vs-cloud-sync.md
+++ b/.claude/educational/git-history-vs-cloud-sync.md
@@ -1,0 +1,56 @@
+---
+type: educational
+topic: git-history-vs-cloud-sync
+status: draft
+last-updated: 2026-05-08
+---
+
+# Git history vs. cloud sync: why checkpoints matter
+
+Cloud sync answers "is this file on another device?" Git history answers "what
+changed, who changed it, and why did we preserve it?"
+
+Main Branch needs the second answer.
+
+## The beginner version
+
+A git commit is a saved checkpoint. It is not developer ceremony. It is the
+business saying:
+
+"This change matters enough to remember."
+
+When Main Branch talks about checkpoints, it means readable saved business
+progress: a decision accepted, a push drafted, an offer updated, a repair
+completed, or a lesson recorded.
+
+## Why cloud sync is not enough
+
+**Sync copies state.** It does not explain the business reason for the change.
+
+**Sync can spread mistakes quickly.** If a file is wrong, deleted, or conflicted,
+the sync tool may faithfully copy the problem.
+
+**Sync history is not a work thread.** GitHub issues can hold tasks, blockers,
+requests, and follow-ups. Pull requests can hold proposals and review
+conversations. Git commits hold the saved evolution story.
+
+**Agents need inspectable history.** An agent can read git history and answer
+questions such as "what changed since yesterday?" or "which decision updated
+the offer?" Cloud sync usually cannot provide that chain in a scriptable way.
+
+## What Main Branch gives you
+
+- `mb status` shows current facts and recent activity.
+- `/mb-start` grounds Claude Code in those facts before advice.
+- `mb checkpoint` plans or saves business-readable checkpoints.
+- `/mb-end` helps close the session and preserve what changed.
+- GitHub can share the task/proposal layer with a team.
+
+## What Main Branch does not claim
+
+Main Branch does not ask beginners to hand-manage branches, diffs, and merges
+as the normal day. Those primitives are the hidden save system underneath the
+business loop.
+
+If something breaks, use `mb doctor`, `/mb-start`, or the exact command Main
+Branch prints. Do not guess your way through git internals.

--- a/.claude/educational/github-vs-gdocs.md
+++ b/.claude/educational/github-vs-gdocs.md
@@ -1,85 +1,96 @@
 ---
 type: educational
 topic: github-vs-gdocs
-status: stub
-last-updated: 2026-04-29
+status: draft
+last-updated: 2026-05-08
 ---
 
-# Why your business reference belongs in git, not Google Docs
+# GitHub vs. Google Docs: why your business repo lives in files
 
-## Why we don't recommend Google Docs as the company brain
+Main Branch is not asking you to become a developer. It is asking you to put
+important business memory in a place that you, your team, and your agent can
+inspect later.
 
-Google Docs is the default place businesses put their thinking — meeting notes, briefs, SOPs, brand guidelines, decision logs. It works for a season and rots in three specific ways.
+Google Docs is good for live writing. GitHub plus markdown is better for
+durable operating memory.
 
-**Version history is opaque and losable.** Docs revision history exists, but it is not a forensic record. You cannot diff two arbitrary versions side-by-side as text. You cannot search "when did we change the pricing on the offer page" across the whole drive. You cannot revert a single paragraph from three months ago without manual copy-paste. And every Docs user has stories of revision history that quietly disappeared after a rename, a copy, or a long period of inactivity. Git's history is content-addressed, immutable, and forensic by default. Every change has an author, a timestamp, and a parent commit. This isn't a nice-to-have; it is the only honest way to know how your company's thinking evolved.
+## The beginner version
 
-**Search is shallow.** Google Drive search is keyword search across titles and visible content — it does not handle regex, does not respect word boundaries reliably, and silently truncates very large drives. Once your reference corpus passes ~200 docs, finding the one paragraph you remember writing six months ago becomes a project. With markdown in git, `rg "the exact phrase"` is instant and exact. Composability with the rest of your shell (`rg | xargs sed`, for example) means you can refactor terminology across 500 files in 30 seconds.
+Think of Google Docs as a whiteboard and GitHub as the business filing cabinet
+with a built-in change log.
 
-**Portability is a fiction.** "Export to .docx" or "Download all" produces a folder of files that lose the comments, the suggestion threads, the embedded images, and most of the formatting fidelity. Markdown is text. Markdown in git is text plus history. You own it forever, and every tool in your future stack will read it natively.
+When you run `mb onboard`, Main Branch creates a business folder on your
+computer. Inside it are plain markdown files for offers, audience notes,
+research, decisions, pushes, logs, documents, and outcomes. Git records how
+those files change over time. GitHub can back up and share that history.
 
-**Agent-friendliness.** Claude, Codex, Cursor, and every AI coding agent speak markdown-and-git natively. They can `git log --follow` a file, read its history, and reason about why it changed. They cannot reason about a Google Doc except by exporting it, parsing the export, and losing the threading. As "AI that knows your business" becomes the operating model, the substrate has to be one agents can read. Git is that substrate. Docs is not.
+You do not need to manage the plumbing every day. The normal loop is:
 
-**Lock-in.** Your company's thinking is in Google's database. Your account is one suspension away from being read-only. The TOS allows Google to terminate accounts at their discretion. Most businesses never hit this wall. The ones that do hit it discover that "export everything" is harder than they assumed.
+```bash
+cd /path/to/your-business
+claude
+/mb-start
+```
 
-## What we recommend instead
+`/mb-start` reads the files and the repo facts before it gives advice.
 
-A private GitHub (or Forgejo) repo with a CLAUDE.md at the root and a six-primitive folder structure: `core/`, `research/`, `decisions/`, `log/`, `campaigns/`, `documents/`. Markdown for everything. Frontmatter for status. The repo is the company brain. Conductor or any AI agent reads it as the working substrate.
+## Why not just use Google Docs?
 
-The pitch in one sentence: **your business is a tree of files**. Once it is, every agent that can read files becomes a coworker.
+**Docs are easy to write in, but hard to operate from.** A business usually
+starts with scattered documents: a brand doc, an offer doc, research notes,
+meeting notes, maybe a spreadsheet. Six months later, nobody knows which doc is
+current or why the old decision changed.
 
-## Setup walkthrough
+**Git keeps the story.** A commit is a saved checkpoint. It says what changed,
+when it changed, and what the operator meant to preserve. That matters when an
+agent asks, "what did we decide last time?" or "what changed since this offer
+worked?"
 
-1. Create a private repo. From the GitHub UI: `New repository → Private → Initialize with README`. Name it something like `your-business` or `your-business-brain`.
+**Markdown is easy for agents to read.** Claude Code, future adapters, and
+power-user tools can read files directly. They do not need to export a Doc,
+guess at formatting, or lose comment context before reasoning about the
+business.
 
-2. Clone it locally:
-   ```bash
-   git clone git@github.com:yourname/your-business.git
-   cd your-business
-   ```
+**GitHub gives shared work threads.** Issues can be tasks, blockers, requests,
+or follow-ups. Pull requests can be proposals and review conversations. You can
+use friendlier words in the daily loop, but the durable layer remains
+inspectable.
 
-3. Add a `CLAUDE.md` at the root. This is the always-loaded context for any AI agent that opens the repo. A minimal first version:
-   ```markdown
-   # <Business Name>
+## What still belongs in Google Docs?
 
-   <One-sentence thesis: what this business is and who it serves.>
+Use Google Docs when live multiplayer editing is the job: a call agenda that
+three people are typing in at once, a client-facing collaborative draft, or a
+source doc someone already gave you in Workspace.
 
-   ## Folder structure
+When the doc becomes business truth, summarize or move the durable part into
+the repo:
 
-   - core/ — soul, offer, audience, voice, visual identity, finance
-   - research/ — dated investigations, never deleted
-   - decisions/ — dated choices with rationale, frontmatter status field
-   - log/ — daily/weekly notes, inbox-style dumps
-   - campaigns/ — outputs grouped by campaign
-   - documents/ — long-form artifacts (briefs, SOPs, contracts)
-   ```
+- a decision goes in `decisions/`;
+- research goes in `research/`;
+- an operating note goes in `log/`;
+- offer, audience, voice, proof, and strategy updates go in `core/`;
+- coordinated launches, drops, promos, or challenges go in `pushes/`.
 
-4. Set up the six-primitive folders:
-   ```bash
-   mkdir -p core/{soul,offer,audience,voice,visual-identity,finance} \
-            research decisions log campaigns documents
-   git add . && git commit -m "[init] six-primitive structure"
-   git push
-   ```
+## The safe setup path
 
-5. Connect to a Conductor workspace (or open the repo in Claude Code directly):
-   ```bash
-   # In Conductor: New Workspace -> point at the repo path
-   # Or: cd into the repo and run `claude` to start a Claude Code session.
-   ```
+Start with the shipped beginner command:
 
-6. Migrate one Google Doc as a forcing function. Pick the most important one — usually a brand brief or a strategy doc. Paste it into `core/offer/offer.md` (or wherever it belongs). Commit. Notice how much faster every subsequent edit, search, and agent read becomes. Migrate the next doc when the next decision needs it. Don't try to bulk-migrate everything; that's a project that never ships.
+```bash
+mb onboard --name "My Business" --path my-business
+cd my-business
+claude
+/mb-start
+```
 
-Cost: $0/month for private repos on GitHub (free tier covers it for individuals and small teams). Forgejo on your own hardware is also free.
+Do not start by hand-writing git commands. Let `mb onboard`, `mb status`,
+`mb doctor`, and `/mb-start` tell you what is ready and what needs repair.
 
-## Honest limitations
+## What Main Branch does not claim
 
-Markdown in git does not solve **real-time multiplayer editing**. If two people are typing in the same paragraph at the same time, Google Docs still wins. Most reference work isn't actually concurrent — it's "someone writes, others react" — but the few cases where it is concurrent (live meeting notes during a call, brainstorm with three people typing) are friction. We solve this by writing first in a scratch tool (Apple Notes, a shared scratchpad) and porting to git at the end of the session, but that's a workflow gap, not a no-op.
+Main Branch does not replace Google Workspace. It gives the business a durable
+operating repo. Google Docs, Sheets, and Drive can still be useful source
+material when a workflow needs them.
 
-It also has a higher learning curve. A non-technical collaborator who is fluent in Docs needs an afternoon to learn `git pull / git commit / git push`. GitHub Desktop or the GitHub web editor lowers the bar; some collaborators will still bounce. Whether the learning curve is worth the durability gain is a per-person judgment call.
-
-## Resources
-
-- GitHub markdown reference: https://docs.github.com/en/get-started/writing-on-github
-- GitHub Desktop (no-CLI git client): https://desktop.github.com/
-- Conductor workspace docs: https://conductor.build/docs
-- "Your business is a tree of files" (Main Branch positioning, internal): see `decisions/2026-04-29-mb-vip-v0-1-0-master.md`
+Main Branch also does not claim broad runtime support yet. Claude Code is the
+supported runtime today; other runtimes are roadmap targets until adapter code
+and smoke evidence exist.

--- a/.claude/educational/markdown-vs-notion.md
+++ b/.claude/educational/markdown-vs-notion.md
@@ -1,0 +1,63 @@
+---
+type: educational
+topic: markdown-vs-notion
+status: draft
+last-updated: 2026-05-08
+---
+
+# Markdown vs. Notion: why Main Branch writes plain files
+
+Notion is useful for pages, databases, and team notes. Main Branch uses
+markdown because the business memory needs to stay portable, searchable, and
+easy for agents to read without a private app API.
+
+## The beginner version
+
+Markdown is plain text with light formatting:
+
+```markdown
+# Offer
+
+This is who we serve, what we sell, and why it matters.
+```
+
+That file can be opened in any text editor. Claude Code can read it directly.
+Git can show how it changed. GitHub can render it nicely.
+
+## Why markdown works for business memory
+
+**It is durable.** Plain text survives tool changes better than proprietary
+workspace pages.
+
+**It is easy to inspect.** You can search the whole business repo, compare
+versions, and ask an agent to read a folder without exporting anything.
+
+**It keeps structure close to the words.** Frontmatter can record status,
+links, dates, providers, bets, pushes, and outcomes without turning every note
+into a hidden database row.
+
+**It works with git.** Git can diff text well. That makes decisions, offer
+changes, and research updates easier to review.
+
+## What still belongs in Notion?
+
+Use Notion when it is already the team's collaborative scratch space, public
+wiki, lightweight CRM, or source material. Main Branch does not require a
+purge.
+
+Move the durable part into the repo when the note becomes operating truth:
+
+- a decision in `decisions/`;
+- research in `research/`;
+- a playbook or launch plan in `pushes/`;
+- a durable operating lesson in `log/` or `core/`;
+- a long-form artifact in `documents/`.
+
+## What Main Branch does not claim
+
+Markdown is not the best live multiplayer writing surface. If three people
+need to type into the same paragraph during a call, use the tool that fits that
+moment, then bring the durable result back into the repo.
+
+Main Branch is not trying to clone Notion. It is trying to make the business
+memory readable by the owner, the agent, git, GitHub, and future tools.

--- a/.claude/educational/provider-readiness.md
+++ b/.claude/educational/provider-readiness.md
@@ -2,17 +2,24 @@
 type: educational
 topic: provider-readiness
 status: draft
-last-updated: 2026-05-04
+last-updated: 2026-05-08
 ---
 
-# Provider readiness: connect tools when the business job needs them
+# Provider readiness: connect outside tools only when the job needs them
 
-Main Branch does not ask you to connect every account on day one. Setup should
-answer a business question:
+Providers are outside accounts Main Branch can use for business work: GitHub,
+Cloudflare, Google/Workspace, ads platforms, research sidecars, booking tools,
+payments, social scheduling, bookkeeping, and future adapters.
 
-1. What are you trying to do next?
+You do not need to connect everything during first setup.
+
+## The beginner version
+
+Ask four questions:
+
+1. What am I trying to do next?
 2. Which outside account is needed for that job?
-3. Does `mb` say that account is ready, missing, or optional?
+3. Does `mb` say that account is ready, missing, planned, or optional?
 4. What exact command fixes the next missing step?
 
 Run this from your business repo:
@@ -21,7 +28,7 @@ Run this from your business repo:
 mb connect plan
 ```
 
-For machine-readable status, use:
+For machine-readable status, agents and power users can use:
 
 ```bash
 mb status --json --peek
@@ -30,37 +37,37 @@ mb connect doctor --json
 
 ## The default order
 
-1. **GitHub** - durable work threads, proposals, reviews, and shipped history.
-   - Check: `mb connect doctor --json`
+1. **GitHub** - tasks, blockers, proposals, reviews, and shipped history.
    - Common fix: `gh auth login`
-   - You can start local setup without it, but shared work-thread and proposal loops are limited.
+   - You can start locally without it, but shared work threads and proposals
+     are limited.
 
 2. **Cloudflare** - sites, DNS, Pages, and future Workers.
-   - Check: `mb connect doctor --json`
-   - Preferred setup for multi-business operators: `printf '%s' "$CLOUDFLARE_API_TOKEN" | mb connect cloudflare --token-stdin --metadata token_type=account --metadata account_id=...`
-   - User API tokens remain supported as a fallback: omit `token_type=account` to use Cloudflare's user-token verify path.
-   - Connect it when you are ready to publish or attach a domain.
+   - Connect it when you are ready to publish, deploy, or attach a domain.
+   - Learn more: `mb educational cloudflare-pages`
 
-3. **Google / Workspace** - Drive, Docs, Sheets, Slides, and workspace source material.
-   - Check: `mb connect doctor --json`
-   - Common setup: `mb connect google --from-env`
-   - Connect it when a workflow needs existing Google files. Do not connect it just because you have a Google account.
+3. **Google / Workspace** - source material in Drive, Docs, Sheets, and Slides.
+   - Connect it when a workflow needs existing Google files.
+   - Do not connect it just because you have a Google account.
 
-4. **Meta Ads** - ad accounts, campaigns, pixels, and future performance context through the official Meta Ads CLI once Main Branch wiring is verified.
-   - Check: `mb connect doctor --json`
-   - Common setup: planned for `meta-ads` / `meta`; do not run `mb connect meta` until this provider is wired.
-   - Connect it when paid-ad work needs account facts and `mb` reports the CLI path ready.
+4. **Meta Ads / Google Ads** - account facts, campaign references, pixels, and
+   future performance context where official paths are verified.
+   - Connect only when paid work needs account facts and Main Branch reports the
+     path ready.
 
-5. **Apify** - research sidecar for scraping, YouTube, Instagram, and web mining.
-   - Check: `mb connect doctor --json`
-   - Common setup: `printf '%s' "$APIFY_TOKEN" | mb connect apify --token-stdin`
-   - Connect it when research or organic workflows need structured external data.
+5. **Apify and similar sidecars** - research, scraping, YouTube, Instagram, and
+   web mining.
+   - Connect when research or organic workflows need structured external data.
+
+6. **Specialized rails** - Cal.com, Stripe, Beancount, Forgejo, Postiz, and
+   other tools.
+   - These are chosen for a specific business job, not as a day-one checklist.
 
 ## Readiness states
 
 - `not_connected` means no repo-safe provider metadata exists yet.
-- `planned` means the provider is a supported direction, but this `mb` release
-  does not yet wire a safe setup, detection, or validation path.
+- `planned` means the provider is a supported direction, but this release does
+  not yet wire a safe setup, detection, or validation path.
 - `missing_secret` means metadata exists but the local secret is missing.
 - `unvalidated` means a credential is stored, but it has not been tested.
 - `invalid` means validation failed and the credential should be replaced.
@@ -73,7 +80,22 @@ or committed config.
 
 ## Why this is business onboarding
 
-Providers are not developer config. They are permissions for business actions:
-publishing a site, reading source documents, learning from ads, or collecting
-research. Connect the rail when the next business action needs it, then let
-`mb status` and `mb connect` explain what is ready.
+Connected accounts are permissions for business actions:
+
+- publish a site;
+- read source documents;
+- learn from ads;
+- collect research;
+- take a payment;
+- book a call;
+- keep operating summaries current.
+
+Main Branch should teach this while setup happens. Numbered choices,
+readiness checks, and exact next commands beat a long essay and a pile of
+manual account setup.
+
+## What Main Branch does not claim
+
+Main Branch does not claim all providers are fully automated. Trust the current
+CLI status, compatibility docs, and provider-specific smoke evidence. If a
+provider is marked planned, treat it as direction, not shipped support.

--- a/.claude/educational/stripe.md
+++ b/.claude/educational/stripe.md
@@ -1,0 +1,62 @@
+---
+type: educational
+topic: stripe
+status: draft
+last-updated: 2026-05-08
+---
+
+# Stripe: payments as a rail, not the business memory
+
+Stripe is a payment provider. Main Branch should use it when the business job
+needs to charge money, collect a deposit, or point a site at a payment page.
+
+The repo should remember the offer, decision, push, page, and outcome. Stripe
+processes the payment.
+
+## When you need this
+
+Use a Stripe rail when:
+
+- an offer needs a checkout link;
+- a minisite or landing page needs a payment call to action;
+- a deposit validates demand;
+- a push needs a simple conversion endpoint;
+- a finance summary needs safe provider references.
+
+## What to store in the repo
+
+Safe, useful records:
+
+- product or price IDs when they are not secret;
+- payment link URL when it is intended to be public;
+- offer slug and payment intent;
+- thank-you page path;
+- non-sensitive provider references;
+- summary outcomes such as purchase count or revenue range when safe.
+
+Do not commit secret keys, webhook secrets, customer records, raw payouts,
+cardholder data, account exports, or private transaction rows.
+
+## How it fits site work
+
+For a simple Main Branch site, Stripe can be one conversion endpoint among
+several:
+
+- payment page;
+- booking link;
+- lead form;
+- custom approved endpoint.
+
+The operator picks the conversion kind based on the offer. The site should not
+pretend every business action is a payment if the real next step is a call,
+lead form, or manual approval.
+
+## What Main Branch does not claim
+
+Main Branch does not claim full Stripe business automation today. Treat Stripe
+as a provider rail with explicit operator approval around money movement,
+customer contact, account mutation, and sensitive data.
+
+Main Branch also does not replace bookkeeping, tax, legal, or compliance
+review. Keep raw financial data out of shared repos unless a public decision
+and access boundary say otherwise.

--- a/.claude/educational/upgrading-mainbranch.md
+++ b/.claude/educational/upgrading-mainbranch.md
@@ -1,68 +1,99 @@
 ---
 type: educational
 topic: upgrading-mainbranch
-status: stub
-last-updated: 2026-05-01
+status: draft
+last-updated: 2026-05-08
 ---
 
-# How Main Branch updates work after pipx install
+# Updating Main Branch without becoming the package manager
 
-## If `mb --version` says `0.1.x`
+Main Branch changes quickly. You should not have to understand Python
+packaging, git remotes, or old clone layouts to stay current.
 
-Run the bootstrap upgrade once:
+The beginner path is:
+
+```text
+/mb-update
+```
+
+Run it inside Claude Code from your business repo. It delegates the mechanical
+work to `mb update`, explains what changed, and tells you the next command.
+
+## The terminal path
+
+Power users can run:
+
+```bash
+mb update --repo .
+```
+
+from the business repo.
+
+`/mb-start` also checks whether an important update exists before routing the
+session. You do not need to check for updates manually every day.
+
+## If your install is too old
+
+Very early public installs may not have `mb update` yet. If `mb --version`
+prints an old version and `/mb-update` cannot run, use the bootstrap command:
 
 ```bash
 pipx upgrade mainbranch
 mb --version
 ```
 
-`mb update` was added after the earliest public package, so old installs cannot
-run it yet. After the pipx upgrade, `mb update` and `/mb-update` become the normal
-path.
-
-## If you already have a business repo
-
-Repair Claude Code skill discovery from inside that repo:
+After that, return to the business repo and let Main Branch repair skill
+discovery if needed:
 
 ```bash
 cd /path/to/your-business
 mb skill link --repo .
 mb doctor
-mb start
 ```
 
-This rewrites `.claude/settings.local.json` and the local skill links so Claude
-Code sees the bundled skills from the installed package.
+Those commands are troubleshooting, not the everyday beginner loop.
 
-## Why this changed
+## Why updates work this way
 
-If you installed Main Branch with `pipx install mainbranch`, your skills live
-inside the installed Python package. That is good for clean setup: there is no
-engine repo to clone, and `mb init` can link Claude Code directly to the
-packaged skills.
-
-It also means updates come through PyPI. When Devon ships a new version, run:
+Most users install Main Branch with:
 
 ```bash
-pipx upgrade mainbranch
+pipx install mainbranch
 ```
 
-Then re-link your business repo if needed:
+That means the CLI and bundled Claude Code skills live inside the installed
+Python package. Updates come from PyPI. The business repo stays yours; it is not
+the engine repo.
+
+Main Branch keeps those roles separate:
+
+- `mb` updates the engine;
+- the business repo stores your durable memory;
+- `/mb-start` and `/mb-update` explain what to do next in business-owner
+  language.
+
+## Old business repos
+
+If you already have a business repo from an older setup, do not hand-move files
+first. Ask Claude to run read-only checks and show the plan:
+
+```text
+I want to update my existing Main Branch business repo. Please run read-only
+checks first, show me the exact commands you recommend, and ask before doing
+anything that writes files.
+```
+
+For old folder layouts, use the migration guide:
 
 ```bash
-mb skill link --repo /path/to/your-business
+mb migrate --check
 ```
 
-For old repos with `reference/core/`, do not move files first. That legacy
-layout is still supported while the automated `mb migrate` command is pending.
-Read `docs/MIGRATING.md` in the engine repo before doing any layout migration.
+Only run `mb migrate --apply` after the dry-run shows the planned moves,
+backup location, and no conflicts.
 
-If you use the older clone-based setup, updates still come from Git. Replace
-the example path with your actual engine checkout:
+## What Main Branch does not claim
 
-```bash
-git -C ~/Documents/GitHub/mainbranch pull origin main
-```
-
-`/mb-update` detects the install mode and chooses the right update path.
-`/mb-pull` still works as a legacy alias.
+Updating the engine is not the same as proving a runtime behavior. Claude Code
+is the supported runtime today. Other runtimes remain roadmap targets until
+adapter code and smoke evidence exist.

--- a/.claude/educational/why-mainbranch-not-saas.md
+++ b/.claude/educational/why-mainbranch-not-saas.md
@@ -1,0 +1,95 @@
+---
+type: educational
+topic: why-mainbranch-not-saas
+status: draft
+last-updated: 2026-05-08
+---
+
+# Why Main Branch is not another SaaS dashboard
+
+Start with the daily owner loop:
+
+```bash
+cd /path/to/your-business
+claude
+/mb-start
+```
+
+Main Branch's anti-SaaS philosophy exists to make that loop work. Your business
+memory should not reset every time you open a new chat or switch tools.
+
+Traditional SaaS tools are useful, but they usually own the database, the
+workflow, the pricing, and the export shape. Main Branch puts the durable
+operating memory in files you own, then lets `mb`, Claude Code skills, GitHub,
+and provider rails work around that repo.
+
+## The beginner version
+
+Main Branch has three layers:
+
+1. **Your business repo** - the durable memory: offers, audience, voice,
+   research, decisions, bets, pushes, logs, documents, outcomes, and safe
+   provider references.
+2. **`mb`** - the deterministic control plane: setup, status, validation,
+   graph links, provider readiness, updates, repair, and checkpoints.
+3. **Claude Code skills** - the judgment layer: research, decide, write,
+   review, ship, and reflect from the files.
+
+A SaaS dashboard usually hides those layers behind one account. Main Branch
+keeps them inspectable.
+
+## What this changes for a business owner
+
+**You stop rebuilding context.** The agent can read the repo instead of asking
+you to paste the same offer, audience, proof, and decisions every session.
+
+**You can inspect the work.** The files are regular markdown. The history is
+regular git. Issues and pull requests are durable work threads and proposals,
+not hidden rows in a vendor database.
+
+**You can switch tools later.** Claude Code is the supported runtime today, but
+the repo shape is not trapped inside Claude Code. Future adapters should read
+the same files and deterministic `mb` commands.
+
+**You keep SaaS tools as rails, not the brain.** GitHub, Cloudflare,
+Google/Workspace, ads tools, Apify, Stripe, Cal.com, and other providers can be
+useful. Main Branch connects them when the business job needs them. The repo
+remains the source of truth.
+
+## What the daily loop should feel like
+
+```bash
+cd /path/to/your-business
+claude
+/mb-start
+```
+
+Then:
+
+1. `/mb-start` senses the repo facts.
+2. You and Claude decide the next useful business move.
+3. A skill ships the artifact or `mb` repairs the rail.
+4. `/mb-end` or `mb checkpoint` helps preserve the lesson or saved work.
+
+The words should feel like business work: bets, goals, offers, pushes,
+playbooks, outcomes, and checkpoints. The philosophy is there to protect the
+loop: files you own, facts `mb` can check, and rails that stay inspectable.
+
+## Why this is harder at first
+
+Files, terminal commands, markdown, git, and GitHub are less familiar than a
+web app with a big button. Main Branch should make that safer with `mb
+onboard`, numbered choices, readiness checks, exact next commands, and Claude
+Code skills that explain the result.
+
+The learning curve exists because the payoff exists: your business memory is
+portable, inspectable, and compounding.
+
+## What Main Branch does not claim
+
+Main Branch is not a hosted dashboard, chat client, background daemon, vector
+database, scheduler, marketplace, or model host today.
+
+Claude Code is the supported runtime today. Codex, Cursor, OpenClaw, Hermes,
+Paperclip-adjacent orchestration, and local runtimes are compatibility targets
+until adapter code and smoke evidence prove support.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+### Added
+
+- Added a beginner education catalog for `mb educational`, including the
+  daily owner loop, Main Branch anti-SaaS why, CLI/dashboard, markdown/Notion,
+  git/cloud-sync, Cloudflare Pages, Cal.com, Beancount, Forgejo, Cursor, and
+  Stripe topics. Refs #144.
+
+### Changed
+
+- Refreshed the existing educational topics so setup, provider readiness,
+  updates, GitHub/Docs, Cloudflare/Vercel, and sensitive-data guidance teach
+  normal business owners through exact Main Branch commands without claiming
+  unshipped provider or runtime support. Refs #144.
+
 ## [0.3.9] - 2026-05-08
 
 v0.3.9 makes the daily operating loop more inspectable. Main Branch now exposes

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ The CLI surface for the engine. Built for Claude Code first; runtime-agnostic by
 | `mb checkpoint` | Plan or save a business-readable git checkpoint during long agent runs. |
 | `mb think <topic>` | Print the `/mb-think` invocation hint. Run inside Claude Code for the full flow. |
 | `mb resolve <key>` | Resolve a reference key from the curated library, local core files, or bundled stubs. |
-| `mb educational <topic>` | Print a beginner education topic such as `daily-owner-loop`, `why-mainbranch-not-saas`, `github-vs-gdocs`, `provider-readiness`, `cloudflare-pages`, or `stripe`. |
+| `mb educational <topic>` | Print a beginner education topic such as `daily-owner-loop`, `why-mainbranch-not-saas`, `github-vs-gdocs`, `provider-readiness`, `cloudflare-pages`, or `stripe`; also powers longer "tell me more" context from setup and doctor prompts. |
 | `mb skill list` | List the skills bundled with this engine. |
 | `mb skill path <name>` | Print the on-disk path to a bundled skill. |
 | `mb skill validate <name>` | Validate one bundled skill's frontmatter, local references, and 500-line gate. Use `--all --json` for CI. |
@@ -272,6 +272,8 @@ mb educational stripe
 mb educational forgejo
 mb educational cursor
 ```
+
+Common provider-readiness commands:
 
 ```bash
 mb connect plan

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ The CLI surface for the engine. Built for Claude Code first; runtime-agnostic by
 | `mb checkpoint` | Plan or save a business-readable git checkpoint during long agent runs. |
 | `mb think <topic>` | Print the `/mb-think` invocation hint. Run inside Claude Code for the full flow. |
 | `mb resolve <key>` | Resolve a reference key from the curated library, local core files, or bundled stubs. |
-| `mb educational <topic>` | Print an educational triage file (powers `mb doctor`'s "tell me more" prompts). |
+| `mb educational <topic>` | Print a beginner education topic such as `daily-owner-loop`, `why-mainbranch-not-saas`, `github-vs-gdocs`, `provider-readiness`, `cloudflare-pages`, or `stripe`. |
 | `mb skill list` | List the skills bundled with this engine. |
 | `mb skill path <name>` | Print the on-disk path to a bundled skill. |
 | `mb skill validate <name>` | Validate one bundled skill's frontmatter, local references, and 500-line gate. Use `--all --json` for CI. |
@@ -257,6 +257,21 @@ Beancount, and transcription providers.
 Use `mb connect plan` when you are not sure what to connect first; it explains
 GitHub, Cloudflare, Google/Workspace, Meta Ads, and Apify as numbered business
 choices with the current readiness state and exact next command.
+
+Beginner education topics explain why these rails exist before asking you to
+configure them:
+
+```bash
+mb educational daily-owner-loop
+mb educational why-mainbranch-not-saas
+mb educational provider-readiness
+mb educational cloudflare-pages
+mb educational beancount
+mb educational cal-com
+mb educational stripe
+mb educational forgejo
+mb educational cursor
+```
 
 ```bash
 mb connect plan

--- a/docs/BEGINNER-SETUP.md
+++ b/docs/BEGINNER-SETUP.md
@@ -10,6 +10,22 @@ If this feels over your head, that's okay. Most of this is one-time setup. After
 
 You need a terminal because Main Branch creates real files on your machine. That's the magic — your business context lives in files Claude reads every session, instead of resetting to zero. Don't let the unfamiliarity stop you. One step at a time.
 
+If you want the "why" while you set up, Main Branch has short educational
+topics you can print from the terminal:
+
+```bash
+mb educational daily-owner-loop
+mb educational why-mainbranch-not-saas
+mb educational github-vs-gdocs
+mb educational cli-vs-dashboard
+mb educational markdown-vs-notion
+mb educational git-history-vs-cloud-sync
+```
+
+Start with `daily-owner-loop`. The other topics explain the tool philosophy
+behind that loop: local files, markdown, git history, GitHub work threads, `mb`
+readiness checks, and Claude Code skills.
+
 ---
 
 ## Required Accounts
@@ -161,6 +177,22 @@ For the longer plain-English explanation, run:
 
 ```bash
 mb educational provider-readiness
+```
+
+Provider-specific education is available when a job needs that rail:
+
+```bash
+mb educational cloudflare-pages
+mb educational cal-com
+mb educational stripe
+mb educational beancount
+mb educational forgejo
+```
+
+For runtime/editor boundaries, use:
+
+```bash
+mb educational cursor
 ```
 
 ---

--- a/mb/mb/_data/educational/anti-cloud-backup.md
+++ b/mb/mb/_data/educational/anti-cloud-backup.md
@@ -1,86 +1,93 @@
 ---
 type: educational
 topic: anti-cloud-backup
-status: stub
-last-updated: 2026-04-29
+status: draft
+last-updated: 2026-05-08
 ---
 
-# Why your financial ledger doesn't belong in iCloud, Drive, or Dropbox
+# Why sensitive business records should not live in consumer cloud sync
 
-## Why we don't recommend consumer cloud sync
+Main Branch is local-first because some business records should not be treated
+like casual synced documents.
 
-Consumer cloud sync products (iCloud Drive, Google Drive, Dropbox, OneDrive) are designed for convenience: a folder on your laptop that mirrors to a server you don't own. That convenience comes from defaults that are wrong for financial records.
+Consumer cloud sync tools are convenient. They are also the wrong default for
+raw finance, legal, customer, credential, and account-export material.
 
-First, **subpoena exposure**. Every major US cloud provider publishes a transparency report documenting thousands of warrants and subpoenas served against user data per year. iCloud Drive content is decryptable by Apple under standard legal process unless you've explicitly enabled Advanced Data Protection (still off by default in 2026). Google and Dropbox encrypt at rest with keys they hold. Your `core/finance/ledger.beancount` becomes a third-party record under the third-party doctrine the moment it touches their servers — which means the bar to access it is a subpoena, not a warrant.
+## The beginner version
 
-Second, **encryption-at-rest is not end-to-end encryption**. Marketing copy on these products often blurs the line. "Encrypted at rest" means the disk is encrypted; the provider holds the key. Anyone who compels the provider — or breaches them — gets plaintext. Beancount files are plaintext. Account numbers, vendor names, transaction memos, headcount payroll details: all of it readable by anyone the provider hands the key to.
+Use this rule:
 
-Third, **silent corruption and conflict resolution**. Dropbox famously creates `filename (Devon's Mac Studio's conflicted copy 2026-04-12).beancount` files when two devices touch a file at once. iCloud has truncated files mid-sync more than once in documented cases. For a ledger you are going to balance and audit, "the cloud quietly corrupted line 4,182" is not an acceptable failure mode.
+- durable business memory can live in the business repo;
+- raw sensitive records need stricter boundaries;
+- secrets never belong in committed markdown;
+- cloud sync is not the same thing as a deliberate backup plan.
 
-Fourth, **vendor lock-in**. The day Dropbox raises prices, removes a feature, or terminates your account for a TOS dispute, your data is wherever they say it is. With self-hosted git you carry the repo to a new origin in one `git remote set-url`.
+The business repo is for durable, safe operating truth: offers, audience notes,
+research, decisions, pushes, logs, documents, and summaries. Sensitive source
+material should either stay out of the repo or live in a separate private repo
+with explicit access rules.
 
-## What we recommend instead
+## Why not iCloud Drive, Google Drive, Dropbox, or OneDrive?
 
-A three-layer setup that keeps you in control:
+**Sync is not review.** A synced folder copies whatever lands in it. That is
+dangerous for ledgers, exports, customer lists, legal docs, and tokens because
+one accidental file can spread to every device and vendor copy before anyone
+reviews it.
 
-1. **Forgejo** (self-hosted git) is the primary working copy. You commit to a repo on a server you own — a Mac mini in a closet, a Hetzner box, a Synology NAS running Docker. `git push` is the sync mechanism. Conflicts surface as merge conflicts, not silent overwrites.
-2. **Backblaze B2** is the encrypted off-site backup. `restic` snapshots the working tree (and the Forgejo data dir) on a schedule. The encryption key lives on your machine; B2 holds ciphertext. Subpoenaed B2 hands over noise.
-3. **Time Machine** is the local snapshot recovery. macOS already does this if you plug in an external drive. It saves you from "I just `rm -rf core/finance/`" within seconds, not hours.
+**Conflict handling is not audit handling.** Cloud sync tools try to keep files
+available. They are not designed to preserve a clean accounting or legal audit
+story. A conflicted copy may be survivable for a draft, but it is unacceptable
+for records you must reconcile later.
 
-The combination is cheaper than Dropbox Pro, gives you forensic git history, and keeps the encryption key out of any vendor's hands.
+**Provider access is not the same as owner custody.** Even when a provider is
+reputable, the business has less control over account access, legal process,
+retention, and recovery than it does over a repo plus a tested backup plan.
 
-## Setup walkthrough
+**Agents can accidentally read what you put nearby.** If a runtime has access
+to a folder, assume it can inspect files in that folder. Keep private raw data
+outside the normal business repo unless a workflow explicitly needs a safe
+summary.
 
-1. Stand up Forgejo on a machine you own. Easiest path is Docker on a home server:
-   ```bash
-   docker run -d --name forgejo \
-     -p 3000:3000 -p 222:22 \
-     -v /opt/forgejo:/data \
-     codeberg.org/forgejo/forgejo:7
-   ```
-   Visit `http://your-server.local:3000`, create the admin user, create a private repo named after your business.
+## What Main Branch recommends
 
-2. Point your `core/finance/` directory at it:
-   ```bash
-   cd ~/your-business
-   git init
-   git remote add origin git@your-server.local:devon/your-business.git
-   git add core/finance/
-   git commit -m "[init] finance ledger"
-   git push -u origin main
-   ```
+For everyday business memory, use the normal repo created by:
 
-3. Install `restic` and configure a B2 bucket:
-   ```bash
-   brew install restic
-   # Create a B2 application key with read+write on a new private bucket.
-   export B2_ACCOUNT_ID="<keyID>"
-   export B2_ACCOUNT_KEY="<applicationKey>"
-   export RESTIC_REPOSITORY="b2:your-bucket-name:/"
-   export RESTIC_PASSWORD="$(openssl rand -base64 32)"  # WRITE THIS DOWN
-   restic init
-   ```
-   Save `RESTIC_PASSWORD` somewhere offline (paper, hardware key, password manager you trust). Without it, the backup is unrecoverable — that is the point.
+```bash
+mb onboard --name "My Business" --path my-business
+```
 
-4. Schedule a daily snapshot via `launchd` (macOS) or `cron`:
-   ```bash
-   restic backup ~/your-business --exclude='node_modules' --exclude='.venv'
-   restic forget --keep-daily 7 --keep-weekly 4 --keep-monthly 12 --prune
-   ```
+For raw sensitive material, choose a stricter home:
 
-5. Confirm Time Machine is on and pointed at an external SSD. macOS does the rest.
+1. Keep secrets in the OS keychain, a password manager, runtime local config,
+   or environment variables.
+2. Keep raw finance or legal files in a separate private repo or system with
+   explicit access boundaries.
+3. Put only durable summaries, provider-safe IDs, and decisions in the shared
+   business repo.
+4. Test restore before you trust any backup.
 
-6. Run a recovery drill once. Pick a non-critical file, delete it, and restore it from each of the three layers (`git checkout`, `restic restore`, Time Machine). If any layer fails the drill, fix it now, not when you actually need it.
+## Where Beancount fits
 
-Cost at typical scale: Forgejo on existing hardware is free. B2 storage runs roughly $6/TB/month, and a finance ledger plus business repo will sit comfortably under 1 GB for years. Total operating cost: under $1/month.
+Beancount-style plain-text ledgers are useful because they are inspectable and
+versionable. That does not mean every ledger belongs in the shared business
+repo. A safe pattern is:
 
-## Honest limitations
+- raw ledger and statements in a private finance repo;
+- business-readable summaries in `core/finance/` or `log/`;
+- no account numbers, credentials, or customer-private rows in shared docs.
 
-This stack does not solve **availability**. If your home server is offline, your collaborators can't push. If you travel and your laptop is lost, you're cloning from B2, which takes longer than a Dropbox sync. For a single-operator business the trade-off is fine; for a 5-person team you want a managed Forgejo or Gitea on a VPS instead of a closet box. It also requires you to remember the restic password — losing it loses the backup. A 30-second failover plan and a hardware-key-stored copy of the password is part of the deal.
+See:
 
-## Resources
+```bash
+mb educational beancount
+```
 
-- Forgejo docs: https://forgejo.org/docs/
-- Restic docs: https://restic.readthedocs.io/
-- Backblaze B2 pricing: https://www.backblaze.com/cloud-storage/pricing
-- Apple's "Government Information Requests" transparency report: https://www.apple.com/legal/transparency/
+## What Main Branch does not claim
+
+Main Branch does not provide legal, accounting, tax, or security advice. It
+provides a repo-backed operating model and guardrails that keep sensitive raw
+data from becoming casual context.
+
+If you are unsure whether a file is safe to commit, do not commit it. Ask
+Claude to summarize it without copying private details, or keep it outside the
+business repo.

--- a/mb/mb/_data/educational/beancount.md
+++ b/mb/mb/_data/educational/beancount.md
@@ -1,0 +1,55 @@
+---
+type: educational
+topic: beancount
+status: draft
+last-updated: 2026-05-08
+---
+
+# Beancount: plain-text finance without leaking raw finance data
+
+Beancount is a plain-text accounting format. It fits Main Branch's philosophy
+because ledgers can be inspected, versioned, reviewed, and backed up like code
+or markdown.
+
+That does not mean raw finance data belongs in every shared business repo.
+
+## When you need this
+
+Use Beancount-style thinking when the business needs durable financial memory:
+
+- revenue and expense summaries;
+- offer-level profitability;
+- payout and provider reconciliation;
+- monthly operating review;
+- bookkeeping handoff notes;
+- finance decisions that should feed future planning.
+
+## The safe boundary
+
+Recommended pattern:
+
+1. Keep raw ledgers, statements, receipts, and account exports in a private
+   finance repo or accounting system with explicit access rules.
+2. Keep business-readable summaries in the main business repo.
+3. Link decisions, offers, pushes, and outcomes to the relevant safe summary.
+4. Never commit bank credentials, account numbers, tax IDs, payroll rows,
+   customer-private rows, or secrets.
+
+## Why not a normal accounting SaaS only?
+
+Accounting SaaS can be useful and may still be required for bookkeeping, tax,
+payroll, or accountant collaboration. The Main Branch concern is operating
+memory: can the business inspect the financial lesson later, connect it to the
+offer or push, and preserve the decision in a repo-backed way?
+
+Plain-text summaries and ledgers make that possible without forcing every
+operator into a vendor-specific dashboard.
+
+## What Main Branch does not claim
+
+Main Branch does not provide accounting, tax, legal, or financial advice.
+Beancount is a planned/optional finance rail, not a guarantee that `mb` can
+automate your books end to end.
+
+When in doubt, store less raw finance data in the shared repo and more safe
+summary context for business decisions.

--- a/mb/mb/_data/educational/cal-com.md
+++ b/mb/mb/_data/educational/cal-com.md
@@ -1,0 +1,59 @@
+---
+type: educational
+topic: cal-com
+status: draft
+last-updated: 2026-05-08
+---
+
+# Cal.com: booking calls without making scheduling the business brain
+
+Cal.com is a scheduling rail. It helps someone book a call, consultation,
+fitting, onboarding session, or sales conversation.
+
+Main Branch treats booking tools as provider rails around the business repo,
+not as the source of business memory.
+
+## When you need this
+
+Use a booking rail when a push, offer, site, or fulfillment process needs a
+scheduled appointment:
+
+- sales calls;
+- discovery calls;
+- consults;
+- onboarding sessions;
+- fittings or appointments;
+- customer interviews.
+
+The durable Main Branch record should still live in the repo: the offer, the
+push, the page, the playbook, the outcome, and the decision about why booking
+is the right conversion path.
+
+## What to store in the repo
+
+Safe, useful records:
+
+- booking link URL;
+- event type name;
+- offer or push that uses the booking link;
+- tracking or thank-you page plan when relevant;
+- non-secret provider reference.
+
+Do not commit API keys, OAuth tokens, customer records, calendar exports, or
+private attendee details.
+
+## How it fits site work
+
+A Main Branch site or minisite can point its primary call to action at a booking
+URL when the conversion goal is "schedule." The repo should explain the choice:
+
+- why this offer needs a call;
+- which page sends people to the booking link;
+- what happens after the appointment is booked;
+- which outcome file records the result later.
+
+## What Main Branch does not claim
+
+Main Branch does not claim shipped Cal.com account automation today. Treat
+Cal.com as a useful external booking rail unless a current CLI/provider check
+states a specific automated path is ready.

--- a/mb/mb/_data/educational/cli-vs-dashboard.md
+++ b/mb/mb/_data/educational/cli-vs-dashboard.md
@@ -1,0 +1,77 @@
+---
+type: educational
+topic: cli-vs-dashboard
+status: draft
+last-updated: 2026-05-08
+---
+
+# CLI vs. dashboard: why Main Branch starts with `mb`
+
+`mb` is a command-line tool because Main Branch needs a deterministic control
+plane before it needs a prettier screen.
+
+That does not mean the product is "for developers only." It means the setup,
+status, repair, validation, graph, provider, update, and checkpoint facts should
+be scriptable and inspectable before any dashboard becomes a view over them.
+
+## The beginner version
+
+The terminal is just the place where you run exact commands.
+
+For normal setup:
+
+```bash
+mb onboard --name "My Business" --path my-business
+cd my-business
+claude
+/mb-start
+```
+
+For the daily loop:
+
+```bash
+cd /path/to/my-business
+claude
+/mb-start
+```
+
+You do not need to memorize hidden repair commands. `mb` and the skills should
+tell you the next exact command when something needs attention.
+
+## Why not start with a SaaS dashboard?
+
+**Dashboards can hide the source of truth.** If a dashboard becomes the place
+where business memory lives, the repo becomes a stale export. Main Branch wants
+the opposite: the repo is truth, and dashboards are views.
+
+**Commands are testable.** `mb status --json --peek` either reports the facts or
+it does not. Agents, scripts, tests, and future dashboards can all read the same
+contract.
+
+**Repair needs exactness.** When a repo needs migration, skill relinking,
+provider readiness, or validation, a vague UI message is not enough. The user
+needs to know what broke, why it matters, and which command fixes the next
+step.
+
+**Power users and beginners share one rail.** Beginners get guided copy and
+numbered choices. Power users get quiet commands and JSON output. The control
+plane stays the same.
+
+## Where dashboards fit later
+
+A future Main Branch dashboard should show existing truth:
+
+- repo health from `mb status`;
+- graph relationships from `mb graph`;
+- provider readiness from `mb connect`;
+- tasks and proposals from GitHub;
+- saved checkpoints from git history;
+- business files from the repo.
+
+It should not become a second database that the files have to chase.
+
+## What Main Branch does not claim
+
+Main Branch does not ship a hosted SaaS dashboard today. Any future dashboard
+must stay optional, local-first or self-hostable, and honest about which files,
+GitHub threads, commits, and provider facts it is reading.

--- a/mb/mb/_data/educational/cloudflare-pages.md
+++ b/mb/mb/_data/educational/cloudflare-pages.md
@@ -1,0 +1,71 @@
+---
+type: educational
+topic: cloudflare-pages
+status: draft
+last-updated: 2026-05-08
+---
+
+# Cloudflare Pages: publishing repo-backed business sites
+
+Cloudflare Pages is the default Main Branch rail for static business sites:
+landing pages, minisites, offer pages, wikis, and other pages that should be
+easy to deploy from git.
+
+## When you need this
+
+Use Cloudflare Pages when the business is ready to publish or update a site:
+
+- offer landing page;
+- paid-traffic minisite;
+- proof or case-study page;
+- wiki or public knowledge surface;
+- simple static business site.
+
+Do not connect Cloudflare just because setup asks you to make accounts. Connect
+it when the next business action is publishing, deploying, or attaching a
+domain.
+
+## Why Pages fits Main Branch
+
+**The site can live in files.** A repo-backed site lets agents and operators
+inspect what changed.
+
+**Deploys follow commits.** Pushing a reviewed change can publish the site or
+trigger the provider pipeline.
+
+**DNS is close to deployment.** Cloudflare can own the domain, DNS, SSL, Pages,
+and future Workers rail, which reduces setup sprawl.
+
+**It is enough for the strongest early site wedge.** Main Branch's early site
+work is mostly static pages with clear conversion endpoints, not heavy
+application hosting.
+
+## The safe setup path
+
+From the business repo:
+
+```bash
+mb connect plan
+```
+
+When Cloudflare is the needed rail, follow the command Main Branch prints. For
+the broader provider explanation:
+
+```bash
+mb educational provider-readiness
+```
+
+For the platform comparison:
+
+```bash
+mb educational cloudflare-vs-vercel
+```
+
+## What Main Branch does not claim
+
+Main Branch does not claim every Pages, Workers, DNS, analytics, or domain flow
+is automated. Trust only the current CLI checks, bundled skill guidance, and
+smoke evidence for the specific path you are using.
+
+If your site already works on another host, migrate when a real business job
+needs the repo-backed Cloudflare rail.

--- a/mb/mb/_data/educational/cloudflare-vs-vercel.md
+++ b/mb/mb/_data/educational/cloudflare-vs-vercel.md
@@ -1,66 +1,85 @@
 ---
 type: educational
 topic: cloudflare-vs-vercel
-status: stub
-last-updated: 2026-04-29
+status: draft
+last-updated: 2026-05-08
 ---
 
-# Why we ship sites on Cloudflare Pages, not Vercel or Netlify
+# Cloudflare vs. Vercel: why Main Branch defaults to boring site rails
 
-## Why we don't recommend Vercel or Netlify by default
+Main Branch uses Cloudflare for sites and DNS because most business operators
+need predictable publishing more than they need a fancy application platform.
 
-Vercel and Netlify are excellent products. The reason we don't pick them as the Main Branch default is not quality — it's pricing posture and lock-in.
+The beginner question is not "which platform is coolest?" The question is:
+"Can I publish the page, attach the domain, understand what changed, and avoid
+surprise infrastructure work?"
 
-**Pricing model risk.** Both Vercel and Netlify use a "free tier with metered overage" model. If your site goes viral, you pay for it after the fact, and the bill can be surprising. Vercel's bandwidth overages are billed at $40/TB after the included 100 GB on Hobby; Netlify's are $55/TB after 100 GB. We have seen Main Branch members hit $300 surprise bills from a single Reel that sent 500K visitors to a one-page site. Cloudflare's free Pages tier has unlimited bandwidth — that is not marketing copy, it is the actual policy as of 2026. The bill cannot surprise you because there is no meter.
+## The beginner version
 
-**Build minutes are a hidden meter.** Vercel includes 6,000 build-execution minutes per month on Pro; if you are deploying every commit on a busy week, you'll see throttling or upgrade prompts. Cloudflare Pages includes 500 builds per month on the free tier, then charges per build (not per minute). The pricing scales linearly and predictably.
+For Main Branch, a site should usually be:
 
-**Egress and image-optimization fees.** Vercel's image-optimization and edge-function minutes are separately metered. Each Next.js `<Image>` view counts. For a marketing site this is small, but for any site that grows organically over a year, it compounds. Cloudflare's image resizing and Workers requests are metered too, but the free tier ceiling is meaningfully higher and the per-unit cost is lower at every tier we have benchmarked.
+1. files in a repo;
+2. a GitHub-backed deploy;
+3. a Cloudflare Pages project;
+4. a domain connected through Cloudflare DNS;
+5. a clear provider-readiness check before publishing work depends on it.
 
-**Build-pipeline lock-in.** Vercel's build pipeline is tightly coupled to their platform. Their Next.js features (ISR, on-demand revalidation, edge middleware) work only on Vercel; the same code on a different host degrades. Cloudflare Pages is build-pipeline-agnostic — it accepts the static output of any framework, and the deploy is just a folder of files. This makes "leave Cloudflare" a one-day project. "Leave Vercel after writing Vercel-specific Next.js features" is a quarter-long project.
+That path keeps the site close to the same durable memory model as the business
+repo. A commit changes the site. Cloudflare publishes the result. The operator
+can inspect the repo, the deploy, and the domain.
 
-**Composability.** Cloudflare Pages, Workers, R2 (object storage), D1 (SQLite at the edge), Queues, and KV are one platform with one bill. The Main Branch stack uses Pages for the static site, Workers for any custom endpoint (e.g., the `mb claim` Skool-membership check), and R2 for ad-hoc artifact storage. On Vercel you'd reach for AWS or a third-party for the equivalents.
+## Why Cloudflare Pages is the default
 
-## What we recommend instead
+**It matches static marketing work.** Most Main Branch site work starts as a
+landing page, minisite, wiki, or offer page. Those surfaces should be easy to
+build, review, push, and roll back.
 
-Cloudflare Pages, deployed via `wrangler` from a GitHub repo, with a custom domain and SSL provisioned automatically. Builds run in Cloudflare's pipeline; deploys are atomic; rollbacks are one click. For any dynamic surface, Workers sit beside Pages in the same project.
+**DNS and publishing live together.** Domain setup is one of the places
+beginners get stuck. Cloudflare keeps DNS, Pages, SSL, and future Workers close
+enough that `mb` and skills can explain one rail instead of five disconnected
+vendor surfaces.
 
-## Setup walkthrough
+**It is git-friendly.** Git-connected Pages projects fit the Main Branch rule:
+files and commits are the source of truth, and the deploy is a view over that
+truth.
 
-1. Create a Cloudflare account at https://dash.cloudflare.com/sign-up. Free tier is enough.
+**It leaves room for simple dynamic edges.** If a future workflow needs a small
+endpoint, redirect, gate, or webhook, Cloudflare Workers sit near Pages without
+turning the whole site into a hosted SaaS app.
 
-2. Install `wrangler` (the Cloudflare CLI):
-   ```bash
-   npm install -g wrangler
-   wrangler login
-   ```
-   The login command opens a browser tab and authorizes the CLI.
+## When Vercel or Netlify can still be right
 
-3. Connect a GitHub repo as a Pages project. From the dashboard: `Workers & Pages → Create → Pages → Connect to Git`. Pick the repo, the branch (typically `main`), and the build settings. For a vanilla static site, set the build command to whatever your framework needs (e.g., `npm run build`) and the output directory to `dist/` or `public/`.
+Choose Vercel or Netlify when a project already depends on their platform
+features, when a team is already fluent there, or when a specific framework
+path is materially easier on that host.
 
-4. Set a custom domain. From the project page: `Custom domains → Set up a domain`. Cloudflare will provision an SSL cert automatically if your domain is on Cloudflare DNS. If it's elsewhere, you add a CNAME at your registrar.
+Main Branch's default is not a moral judgment. It is a bias toward boring,
+inspectable, low-surprise rails for business pages.
 
-5. Verify deploys. Push a commit to `main`. Within ~60 seconds Cloudflare builds and publishes. Open the project URL.
+## The safe setup path
 
-6. Optional but recommended: set up a `wrangler.toml` in the repo so you can `wrangler pages deploy` from your laptop without a GitHub round-trip:
-   ```toml
-   name = "your-site"
-   compatibility_date = "2026-04-29"
-   pages_build_output_dir = "dist"
-   ```
-   Then `wrangler pages deploy dist/` after a local build.
+Do not connect Cloudflare on day one unless a site job needs it. From the
+business repo, start with:
 
-Cost at typical Main Branch scale: $0/month for a marketing site under ~10K daily visitors. You start paying when you cross into Workers Paid ($5/month for 10M requests) or R2 storage above 10 GB.
+```bash
+mb connect plan
+```
 
-## Honest limitations
+When the next business action is publishing or attaching a domain, follow the
+Cloudflare step that `mb connect plan` prints. Use:
 
-Cloudflare Pages does not have first-class Next.js ISR or React Server Components support the way Vercel does. If you are building a heavy React app with dynamic SSR rendering and per-request edge logic, Vercel's developer experience is better and the lock-in cost may be worth it. For Main Branch sites — which are mostly static marketing surfaces with the occasional Worker for a form submit or a Skool gate — Pages is the right tool.
+```bash
+mb educational provider-readiness
+```
 
-The Cloudflare dashboard is also denser and less polished than Vercel's. First-time users will need 30 minutes to learn it. After that it's fine.
+for the plain-English version of what connected accounts mean.
 
-## Resources
+## What Main Branch does not claim
 
-- Cloudflare Pages docs: https://developers.cloudflare.com/pages/
-- Wrangler CLI: https://developers.cloudflare.com/workers/wrangler/
-- Pricing comparison (Cloudflare): https://developers.cloudflare.com/pages/platform/limits/
-- Vercel pricing (for comparison): https://vercel.com/pricing
+Main Branch does not claim every Cloudflare workflow is automated. Site and
+provider behavior should be trusted only where the CLI, bundled skills, and
+smoke evidence say that path is ready.
+
+Main Branch also does not require every business to leave an existing Vercel or
+Netlify site immediately. Migrate when the next business job benefits from the
+repo-backed Cloudflare path.

--- a/mb/mb/_data/educational/cursor.md
+++ b/mb/mb/_data/educational/cursor.md
@@ -1,0 +1,65 @@
+---
+type: educational
+topic: cursor
+status: draft
+last-updated: 2026-05-08
+---
+
+# Cursor: useful editor, not a supported Main Branch runtime yet
+
+Cursor is an AI code editor. It can be useful for reading and editing a Main
+Branch business repo because the repo is just files.
+
+That is different from saying Main Branch supports Cursor as a full runtime.
+
+## The beginner version
+
+You can open your business repo folder in Cursor to inspect or edit files:
+
+- `core/` for offer, audience, voice, proof, strategy, and operations;
+- `research/` for investigations;
+- `decisions/` for accepted or proposed choices;
+- `pushes/` for launches, drops, challenges, promos, and playbooks;
+- `log/` for operating notes;
+- `documents/` for long-form artifacts.
+
+Claude Code remains the supported slash-skill runtime today.
+
+## What Cursor is good for
+
+- reading markdown files;
+- making careful edits;
+- searching the repo;
+- reviewing diffs;
+- helping power users understand the folder tree.
+
+Because Main Branch keeps memory in markdown and git, tools like Cursor can
+operate on the files without a proprietary export.
+
+## What is not supported yet
+
+Do not assume Cursor can run `/mb-start`, `/mb-think`, `/mb-status`, or bundled
+Claude Code skills as first-class Main Branch workflows.
+
+Future adapter work should call deterministic `mb` commands, read JSON output
+where available, and prove runtime behavior with smoke evidence before public
+support is claimed.
+
+## The safe beginner path
+
+For supported workflows:
+
+```bash
+cd /path/to/your-business
+claude
+/mb-start
+```
+
+Use Cursor as an editor if it helps you see the files. Use Claude Code for the
+shipped Main Branch skill flows.
+
+## What Main Branch does not claim
+
+Cursor is a roadmap compatibility target, not a supported adapter today. Do not
+represent Cursor workflow behavior as shipped until there is adapter code,
+documentation, and smoke evidence.

--- a/mb/mb/_data/educational/daily-owner-loop.md
+++ b/mb/mb/_data/educational/daily-owner-loop.md
@@ -1,0 +1,77 @@
+---
+type: educational
+topic: daily-owner-loop
+status: draft
+last-updated: 2026-05-08
+---
+
+# The daily owner loop: what Main Branch asks you to do first
+
+Main Branch starts from the normal owner day, not from tool theory.
+
+The goal is simple: open the business folder, let Claude ground itself in repo
+facts, choose the next useful business move, ship or repair the next thing, and
+save what changed.
+
+## The beginner version
+
+After setup, the daily loop is:
+
+```bash
+cd /path/to/your-business
+claude
+/mb-start
+```
+
+That is the front door.
+
+`/mb-start` should make Claude read deterministic `mb` facts before advice:
+repo health, status, updates, graph links, provider readiness, runtime wiring,
+recent activity, and checkpoint readiness.
+
+## What happens in the loop
+
+1. **Open Terminal or Claude Code safely.**
+   Start in the business repo, not in the engine repo or a random downloads
+   folder.
+
+2. **Install or update through the product path.**
+   Use `mb onboard`, `/mb-update`, or `mb update --repo .` when Main Branch
+   tells you to. Do not start by debugging Python packaging or git internals.
+
+3. **Choose or create a business folder.**
+   That folder is the business brain: `core/`, `research/`, `decisions/`,
+   `bets/`, `pushes/`, `log/`, and `documents/`.
+
+4. **Run `/mb-start` or `mb status`.**
+   Claude should ground itself in `mb` facts before giving strategic advice.
+
+5. **Route work into a business primitive.**
+   A messy thought dump should become a bet, research note, decision, push,
+   playbook, outcome, log entry, or checkpoint plan.
+
+6. **Close with `/mb-end` or checkpoint guidance.**
+   The point is not to leave a long chat behind. The point is to preserve the
+   useful business memory in files and git history.
+
+## Why the tools exist
+
+- **Markdown files** make the business memory readable.
+- **Git history** turns saved work into a timeline.
+- **GitHub** gives durable tasks, blockers, proposals, and reviews.
+- **`mb`** checks the facts and prints exact next commands.
+- **Claude Code skills** do the judgment-heavy writing, routing, and review.
+- **Provider rails** connect outside tools only when a business job needs them.
+
+The philosophy matters because it protects the loop. Main Branch is not asking
+you to learn infrastructure for its own sake.
+
+## What Main Branch does not claim
+
+Main Branch does not expect beginners to manually manage branches, package
+repair, hidden git commands, or provider internals as the default workflow.
+
+When something needs repair, `mb` should explain what broke, why it matters,
+and the next exact command. When behavior depends on Claude Code runtime
+discovery, package install, provider mutation, or release quality, it needs
+matching evidence before Main Branch claims it works.

--- a/mb/mb/_data/educational/forgejo.md
+++ b/mb/mb/_data/educational/forgejo.md
@@ -1,0 +1,60 @@
+---
+type: educational
+topic: forgejo
+status: draft
+last-updated: 2026-05-08
+---
+
+# Forgejo: owning the git server when GitHub is not the right boundary
+
+GitHub is the default Main Branch public and team rail today because it gives
+issues, pull requests, releases, and broad tool support. Forgejo matters because
+some teams eventually need a self-hosted git forge.
+
+## When you need this
+
+Consider Forgejo when:
+
+- the business needs stronger custody over a private repo;
+- a finance, legal, client, or operations repo should not sit in a broad SaaS
+  account;
+- the team already runs self-hosted infrastructure;
+- GitHub is unavailable, inappropriate, or intentionally not the source of
+  truth for that repo boundary.
+
+For most beginners, GitHub is still the right starting point.
+
+## Why Forgejo fits the Main Branch philosophy
+
+**It keeps git as the substrate.** Main Branch wants durable files, git history,
+and inspectable changes. Forgejo preserves that model.
+
+**It is self-hostable.** A team can run the forge on infrastructure it controls
+when the access boundary matters.
+
+**It can keep sensitive repos separate.** A business repo can link to a
+separate finance, legal, site, client, or ops repo without copying raw private
+data into shared memory.
+
+## What changes if you use Forgejo
+
+You still need the same operating concepts:
+
+- issues or equivalent work threads;
+- proposals or review conversations;
+- readable commits;
+- backups and restore drills;
+- explicit access rules;
+- no secrets in committed files.
+
+The difference is who operates the forge and how much responsibility the team
+takes on for uptime, security updates, backups, and account recovery.
+
+## What Main Branch does not claim
+
+Main Branch does not claim Forgejo is a fully supported first-run provider
+today. GitHub remains the concrete public rail for issues, proposals, releases,
+and most current workflows.
+
+Forgejo is a compatible direction for teams that need self-hosted git, not a
+beginner requirement.

--- a/mb/mb/_data/educational/git-history-vs-cloud-sync.md
+++ b/mb/mb/_data/educational/git-history-vs-cloud-sync.md
@@ -1,0 +1,56 @@
+---
+type: educational
+topic: git-history-vs-cloud-sync
+status: draft
+last-updated: 2026-05-08
+---
+
+# Git history vs. cloud sync: why checkpoints matter
+
+Cloud sync answers "is this file on another device?" Git history answers "what
+changed, who changed it, and why did we preserve it?"
+
+Main Branch needs the second answer.
+
+## The beginner version
+
+A git commit is a saved checkpoint. It is not developer ceremony. It is the
+business saying:
+
+"This change matters enough to remember."
+
+When Main Branch talks about checkpoints, it means readable saved business
+progress: a decision accepted, a push drafted, an offer updated, a repair
+completed, or a lesson recorded.
+
+## Why cloud sync is not enough
+
+**Sync copies state.** It does not explain the business reason for the change.
+
+**Sync can spread mistakes quickly.** If a file is wrong, deleted, or conflicted,
+the sync tool may faithfully copy the problem.
+
+**Sync history is not a work thread.** GitHub issues can hold tasks, blockers,
+requests, and follow-ups. Pull requests can hold proposals and review
+conversations. Git commits hold the saved evolution story.
+
+**Agents need inspectable history.** An agent can read git history and answer
+questions such as "what changed since yesterday?" or "which decision updated
+the offer?" Cloud sync usually cannot provide that chain in a scriptable way.
+
+## What Main Branch gives you
+
+- `mb status` shows current facts and recent activity.
+- `/mb-start` grounds Claude Code in those facts before advice.
+- `mb checkpoint` plans or saves business-readable checkpoints.
+- `/mb-end` helps close the session and preserve what changed.
+- GitHub can share the task/proposal layer with a team.
+
+## What Main Branch does not claim
+
+Main Branch does not ask beginners to hand-manage branches, diffs, and merges
+as the normal day. Those primitives are the hidden save system underneath the
+business loop.
+
+If something breaks, use `mb doctor`, `/mb-start`, or the exact command Main
+Branch prints. Do not guess your way through git internals.

--- a/mb/mb/_data/educational/github-vs-gdocs.md
+++ b/mb/mb/_data/educational/github-vs-gdocs.md
@@ -1,86 +1,96 @@
 ---
 type: educational
 topic: github-vs-gdocs
-status: stub
-last-updated: 2026-04-29
+status: draft
+last-updated: 2026-05-08
 ---
 
-# Why your business reference belongs in git, not Google Docs
+# GitHub vs. Google Docs: why your business repo lives in files
 
-## Why we don't recommend Google Docs as the company brain
+Main Branch is not asking you to become a developer. It is asking you to put
+important business memory in a place that you, your team, and your agent can
+inspect later.
 
-Google Docs is the default place businesses put their thinking — meeting notes, briefs, SOPs, brand guidelines, decision logs. It works for a season and rots in three specific ways.
+Google Docs is good for live writing. GitHub plus markdown is better for
+durable operating memory.
 
-**Version history is opaque and losable.** Docs revision history exists, but it is not a forensic record. You cannot diff two arbitrary versions side-by-side as text. You cannot search "when did we change the pricing on the offer page" across the whole drive. You cannot revert a single paragraph from three months ago without manual copy-paste. And every Docs user has stories of revision history that quietly disappeared after a rename, a copy, or a long period of inactivity. Git's history is content-addressed, immutable, and forensic by default. Every change has an author, a timestamp, and a parent commit. This isn't a nice-to-have; it is the only honest way to know how your company's thinking evolved.
+## The beginner version
 
-**Search is shallow.** Google Drive search is keyword search across titles and visible content — it does not handle regex, does not respect word boundaries reliably, and silently truncates very large drives. Once your reference corpus passes ~200 docs, finding the one paragraph you remember writing six months ago becomes a project. With markdown in git, `rg "the exact phrase"` is instant and exact. Composability with the rest of your shell (`rg | xargs sed`, for example) means you can refactor terminology across 500 files in 30 seconds.
+Think of Google Docs as a whiteboard and GitHub as the business filing cabinet
+with a built-in change log.
 
-**Portability is a fiction.** "Export to .docx" or "Download all" produces a folder of files that lose the comments, the suggestion threads, the embedded images, and most of the formatting fidelity. Markdown is text. Markdown in git is text plus history. You own it forever, and every tool in your future stack will read it natively.
+When you run `mb onboard`, Main Branch creates a business folder on your
+computer. Inside it are plain markdown files for offers, audience notes,
+research, decisions, pushes, logs, documents, and outcomes. Git records how
+those files change over time. GitHub can back up and share that history.
 
-**Agent-friendliness.** Claude, Codex, Cursor, and every AI coding agent speak markdown-and-git natively. They can `git log --follow` a file, read its history, and reason about why it changed. They cannot reason about a Google Doc except by exporting it, parsing the export, and losing the threading. As "AI that knows your business" becomes the operating model, the substrate has to be one agents can read. Git is that substrate. Docs is not.
+You do not need to manage the plumbing every day. The normal loop is:
 
-**Lock-in.** Your company's thinking is in Google's database. Your account is one suspension away from being read-only. The TOS allows Google to terminate accounts at their discretion. Most businesses never hit this wall. The ones that do hit it discover that "export everything" is harder than they assumed.
+```bash
+cd /path/to/your-business
+claude
+/mb-start
+```
 
-## What we recommend instead
+`/mb-start` reads the files and the repo facts before it gives advice.
 
-A private GitHub (or Forgejo) repo with a CLAUDE.md at the root and a primitive folder structure: `core/`, `research/`, `decisions/`, `bets/`, `log/`, `pushes/`, `documents/`. Markdown for everything. Frontmatter for status. The repo is the company brain. Conductor or any AI agent reads it as the working substrate.
+## Why not just use Google Docs?
 
-The pitch in one sentence: **your business is a tree of files**. Once it is, every agent that can read files becomes a coworker.
+**Docs are easy to write in, but hard to operate from.** A business usually
+starts with scattered documents: a brand doc, an offer doc, research notes,
+meeting notes, maybe a spreadsheet. Six months later, nobody knows which doc is
+current or why the old decision changed.
 
-## Setup walkthrough
+**Git keeps the story.** A commit is a saved checkpoint. It says what changed,
+when it changed, and what the operator meant to preserve. That matters when an
+agent asks, "what did we decide last time?" or "what changed since this offer
+worked?"
 
-1. Create a private repo. From the GitHub UI: `New repository → Private → Initialize with README`. Name it something like `your-business` or `your-business-brain`.
+**Markdown is easy for agents to read.** Claude Code, future adapters, and
+power-user tools can read files directly. They do not need to export a Doc,
+guess at formatting, or lose comment context before reasoning about the
+business.
 
-2. Clone it locally:
-   ```bash
-   git clone git@github.com:yourname/your-business.git
-   cd your-business
-   ```
+**GitHub gives shared work threads.** Issues can be tasks, blockers, requests,
+or follow-ups. Pull requests can be proposals and review conversations. You can
+use friendlier words in the daily loop, but the durable layer remains
+inspectable.
 
-3. Add a `CLAUDE.md` at the root. This is the always-loaded context for any AI agent that opens the repo. A minimal first version:
-   ```markdown
-   # <Business Name>
+## What still belongs in Google Docs?
 
-   <One-sentence thesis: what this business is and who it serves.>
+Use Google Docs when live multiplayer editing is the job: a call agenda that
+three people are typing in at once, a client-facing collaborative draft, or a
+source doc someone already gave you in Workspace.
 
-   ## Folder structure
+When the doc becomes business truth, summarize or move the durable part into
+the repo:
 
-   - core/ — soul, offer, audience, voice, visual identity, finance
-   - research/ — dated investigations, never deleted
-   - decisions/ — dated choices with rationale, frontmatter status field
-   - bets/ — operating bets with targets, deadlines, and outcomes
-   - log/ — daily/weekly notes, inbox-style dumps
-   - pushes/ — coordinated pushes (launches, drops, challenges, promos)
-   - documents/ — long-form artifacts (briefs, SOPs, contracts)
-   ```
+- a decision goes in `decisions/`;
+- research goes in `research/`;
+- an operating note goes in `log/`;
+- offer, audience, voice, proof, and strategy updates go in `core/`;
+- coordinated launches, drops, promos, or challenges go in `pushes/`.
 
-4. Set up the primitive folders:
-   ```bash
-   mkdir -p core/{soul,offer,audience,voice,visual-identity,finance} \
-            research decisions bets log pushes documents
-   git add . && git commit -m "[init] business primitive structure"
-   git push
-   ```
+## The safe setup path
 
-5. Connect to a Conductor workspace (or open the repo in Claude Code directly):
-   ```bash
-   # In Conductor: New Workspace -> point at the repo path
-   # Or: cd into the repo and run `claude` to start a Claude Code session.
-   ```
+Start with the shipped beginner command:
 
-6. Migrate one Google Doc as a forcing function. Pick the most important one — usually a brand brief or a strategy doc. Paste it into `core/offer/offer.md` (or wherever it belongs). Commit. Notice how much faster every subsequent edit, search, and agent read becomes. Migrate the next doc when the next decision needs it. Don't try to bulk-migrate everything; that's a project that never ships.
+```bash
+mb onboard --name "My Business" --path my-business
+cd my-business
+claude
+/mb-start
+```
 
-Cost: $0/month for private repos on GitHub (free tier covers it for individuals and small teams). Forgejo on your own hardware is also free.
+Do not start by hand-writing git commands. Let `mb onboard`, `mb status`,
+`mb doctor`, and `/mb-start` tell you what is ready and what needs repair.
 
-## Honest limitations
+## What Main Branch does not claim
 
-Markdown in git does not solve **real-time multiplayer editing**. If two people are typing in the same paragraph at the same time, Google Docs still wins. Most reference work isn't actually concurrent — it's "someone writes, others react" — but the few cases where it is concurrent (live meeting notes during a call, brainstorm with three people typing) are friction. We solve this by writing first in a scratch tool (Apple Notes, a shared scratchpad) and porting to git at the end of the session, but that's a workflow gap, not a no-op.
+Main Branch does not replace Google Workspace. It gives the business a durable
+operating repo. Google Docs, Sheets, and Drive can still be useful source
+material when a workflow needs them.
 
-It also has a higher learning curve. A non-technical collaborator who is fluent in Docs needs an afternoon to learn `git pull / git commit / git push`. GitHub Desktop or the GitHub web editor lowers the bar; some collaborators will still bounce. Whether the learning curve is worth the durability gain is a per-person judgment call.
-
-## Resources
-
-- GitHub markdown reference: https://docs.github.com/en/get-started/writing-on-github
-- GitHub Desktop (no-CLI git client): https://desktop.github.com/
-- Conductor workspace docs: https://conductor.build/docs
-- "Your business is a tree of files" (Main Branch positioning, internal): see `decisions/2026-04-29-mb-vip-v0-1-0-master.md`
+Main Branch also does not claim broad runtime support yet. Claude Code is the
+supported runtime today; other runtimes are roadmap targets until adapter code
+and smoke evidence exist.

--- a/mb/mb/_data/educational/markdown-vs-notion.md
+++ b/mb/mb/_data/educational/markdown-vs-notion.md
@@ -1,0 +1,63 @@
+---
+type: educational
+topic: markdown-vs-notion
+status: draft
+last-updated: 2026-05-08
+---
+
+# Markdown vs. Notion: why Main Branch writes plain files
+
+Notion is useful for pages, databases, and team notes. Main Branch uses
+markdown because the business memory needs to stay portable, searchable, and
+easy for agents to read without a private app API.
+
+## The beginner version
+
+Markdown is plain text with light formatting:
+
+```markdown
+# Offer
+
+This is who we serve, what we sell, and why it matters.
+```
+
+That file can be opened in any text editor. Claude Code can read it directly.
+Git can show how it changed. GitHub can render it nicely.
+
+## Why markdown works for business memory
+
+**It is durable.** Plain text survives tool changes better than proprietary
+workspace pages.
+
+**It is easy to inspect.** You can search the whole business repo, compare
+versions, and ask an agent to read a folder without exporting anything.
+
+**It keeps structure close to the words.** Frontmatter can record status,
+links, dates, providers, bets, pushes, and outcomes without turning every note
+into a hidden database row.
+
+**It works with git.** Git can diff text well. That makes decisions, offer
+changes, and research updates easier to review.
+
+## What still belongs in Notion?
+
+Use Notion when it is already the team's collaborative scratch space, public
+wiki, lightweight CRM, or source material. Main Branch does not require a
+purge.
+
+Move the durable part into the repo when the note becomes operating truth:
+
+- a decision in `decisions/`;
+- research in `research/`;
+- a playbook or launch plan in `pushes/`;
+- a durable operating lesson in `log/` or `core/`;
+- a long-form artifact in `documents/`.
+
+## What Main Branch does not claim
+
+Markdown is not the best live multiplayer writing surface. If three people
+need to type into the same paragraph during a call, use the tool that fits that
+moment, then bring the durable result back into the repo.
+
+Main Branch is not trying to clone Notion. It is trying to make the business
+memory readable by the owner, the agent, git, GitHub, and future tools.

--- a/mb/mb/_data/educational/provider-readiness.md
+++ b/mb/mb/_data/educational/provider-readiness.md
@@ -2,17 +2,24 @@
 type: educational
 topic: provider-readiness
 status: draft
-last-updated: 2026-05-04
+last-updated: 2026-05-08
 ---
 
-# Provider readiness: connect tools when the business job needs them
+# Provider readiness: connect outside tools only when the job needs them
 
-Main Branch does not ask you to connect every account on day one. Setup should
-answer a business question:
+Providers are outside accounts Main Branch can use for business work: GitHub,
+Cloudflare, Google/Workspace, ads platforms, research sidecars, booking tools,
+payments, social scheduling, bookkeeping, and future adapters.
 
-1. What are you trying to do next?
+You do not need to connect everything during first setup.
+
+## The beginner version
+
+Ask four questions:
+
+1. What am I trying to do next?
 2. Which outside account is needed for that job?
-3. Does `mb` say that account is ready, missing, or optional?
+3. Does `mb` say that account is ready, missing, planned, or optional?
 4. What exact command fixes the next missing step?
 
 Run this from your business repo:
@@ -21,7 +28,7 @@ Run this from your business repo:
 mb connect plan
 ```
 
-For machine-readable status, use:
+For machine-readable status, agents and power users can use:
 
 ```bash
 mb status --json --peek
@@ -30,37 +37,37 @@ mb connect doctor --json
 
 ## The default order
 
-1. **GitHub** - durable work threads, proposals, reviews, and shipped history.
-   - Check: `mb connect doctor --json`
+1. **GitHub** - tasks, blockers, proposals, reviews, and shipped history.
    - Common fix: `gh auth login`
-   - You can start local setup without it, but shared work-thread and proposal loops are limited.
+   - You can start locally without it, but shared work threads and proposals
+     are limited.
 
 2. **Cloudflare** - sites, DNS, Pages, and future Workers.
-   - Check: `mb connect doctor --json`
-   - Preferred setup for multi-business operators: `printf '%s' "$CLOUDFLARE_API_TOKEN" | mb connect cloudflare --token-stdin --metadata token_type=account --metadata account_id=...`
-   - User API tokens remain supported as a fallback: omit `token_type=account` to use Cloudflare's user-token verify path.
-   - Connect it when you are ready to publish or attach a domain.
+   - Connect it when you are ready to publish, deploy, or attach a domain.
+   - Learn more: `mb educational cloudflare-pages`
 
-3. **Google / Workspace** - Drive, Docs, Sheets, Slides, and workspace source material.
-   - Check: `mb connect doctor --json`
-   - Common setup: `mb connect google --from-env`
-   - Connect it when a workflow needs existing Google files. Do not connect it just because you have a Google account.
+3. **Google / Workspace** - source material in Drive, Docs, Sheets, and Slides.
+   - Connect it when a workflow needs existing Google files.
+   - Do not connect it just because you have a Google account.
 
-4. **Meta Ads** - ad accounts, campaigns, pixels, and future performance context through the official Meta Ads CLI once Main Branch wiring is verified.
-   - Check: `mb connect doctor --json`
-   - Common setup: planned for `meta-ads` / `meta`; do not run `mb connect meta` until this provider is wired.
-   - Connect it when paid-ad work needs account facts and `mb` reports the CLI path ready.
+4. **Meta Ads / Google Ads** - account facts, campaign references, pixels, and
+   future performance context where official paths are verified.
+   - Connect only when paid work needs account facts and Main Branch reports the
+     path ready.
 
-5. **Apify** - research sidecar for scraping, YouTube, Instagram, and web mining.
-   - Check: `mb connect doctor --json`
-   - Common setup: `printf '%s' "$APIFY_TOKEN" | mb connect apify --token-stdin`
-   - Connect it when research or organic workflows need structured external data.
+5. **Apify and similar sidecars** - research, scraping, YouTube, Instagram, and
+   web mining.
+   - Connect when research or organic workflows need structured external data.
+
+6. **Specialized rails** - Cal.com, Stripe, Beancount, Forgejo, Postiz, and
+   other tools.
+   - These are chosen for a specific business job, not as a day-one checklist.
 
 ## Readiness states
 
 - `not_connected` means no repo-safe provider metadata exists yet.
-- `planned` means the provider is a supported direction, but this `mb` release
-  does not yet wire a safe setup, detection, or validation path.
+- `planned` means the provider is a supported direction, but this release does
+  not yet wire a safe setup, detection, or validation path.
 - `missing_secret` means metadata exists but the local secret is missing.
 - `unvalidated` means a credential is stored, but it has not been tested.
 - `invalid` means validation failed and the credential should be replaced.
@@ -73,7 +80,22 @@ or committed config.
 
 ## Why this is business onboarding
 
-Providers are not developer config. They are permissions for business actions:
-publishing a site, reading source documents, learning from ads, or collecting
-research. Connect the rail when the next business action needs it, then let
-`mb status` and `mb connect` explain what is ready.
+Connected accounts are permissions for business actions:
+
+- publish a site;
+- read source documents;
+- learn from ads;
+- collect research;
+- take a payment;
+- book a call;
+- keep operating summaries current.
+
+Main Branch should teach this while setup happens. Numbered choices,
+readiness checks, and exact next commands beat a long essay and a pile of
+manual account setup.
+
+## What Main Branch does not claim
+
+Main Branch does not claim all providers are fully automated. Trust the current
+CLI status, compatibility docs, and provider-specific smoke evidence. If a
+provider is marked planned, treat it as direction, not shipped support.

--- a/mb/mb/_data/educational/stripe.md
+++ b/mb/mb/_data/educational/stripe.md
@@ -1,0 +1,62 @@
+---
+type: educational
+topic: stripe
+status: draft
+last-updated: 2026-05-08
+---
+
+# Stripe: payments as a rail, not the business memory
+
+Stripe is a payment provider. Main Branch should use it when the business job
+needs to charge money, collect a deposit, or point a site at a payment page.
+
+The repo should remember the offer, decision, push, page, and outcome. Stripe
+processes the payment.
+
+## When you need this
+
+Use a Stripe rail when:
+
+- an offer needs a checkout link;
+- a minisite or landing page needs a payment call to action;
+- a deposit validates demand;
+- a push needs a simple conversion endpoint;
+- a finance summary needs safe provider references.
+
+## What to store in the repo
+
+Safe, useful records:
+
+- product or price IDs when they are not secret;
+- payment link URL when it is intended to be public;
+- offer slug and payment intent;
+- thank-you page path;
+- non-sensitive provider references;
+- summary outcomes such as purchase count or revenue range when safe.
+
+Do not commit secret keys, webhook secrets, customer records, raw payouts,
+cardholder data, account exports, or private transaction rows.
+
+## How it fits site work
+
+For a simple Main Branch site, Stripe can be one conversion endpoint among
+several:
+
+- payment page;
+- booking link;
+- lead form;
+- custom approved endpoint.
+
+The operator picks the conversion kind based on the offer. The site should not
+pretend every business action is a payment if the real next step is a call,
+lead form, or manual approval.
+
+## What Main Branch does not claim
+
+Main Branch does not claim full Stripe business automation today. Treat Stripe
+as a provider rail with explicit operator approval around money movement,
+customer contact, account mutation, and sensitive data.
+
+Main Branch also does not replace bookkeeping, tax, legal, or compliance
+review. Keep raw financial data out of shared repos unless a public decision
+and access boundary say otherwise.

--- a/mb/mb/_data/educational/upgrading-mainbranch.md
+++ b/mb/mb/_data/educational/upgrading-mainbranch.md
@@ -1,38 +1,99 @@
 ---
 type: educational
 topic: upgrading-mainbranch
-status: stub
-last-updated: 2026-05-02
+status: draft
+last-updated: 2026-05-08
 ---
 
-# How Main Branch updates work after pipx install
+# Updating Main Branch without becoming the package manager
 
-The normal update path is `/mb-update` inside Claude Code, or `mb update` from
-the business repo for power users. Main Branch detects pipx vs clone installs
-and refreshes skill links for the repo.
+Main Branch changes quickly. You should not have to understand Python
+packaging, git remotes, or old clone layouts to stay current.
 
-Use raw `pipx` only as a bootstrap fallback for very old installs. If
-`mb --version` says `0.1.x`, run this once:
+The beginner path is:
+
+```text
+/mb-update
+```
+
+Run it inside Claude Code from your business repo. It delegates the mechanical
+work to `mb update`, explains what changed, and tells you the next command.
+
+## The terminal path
+
+Power users can run:
+
+```bash
+mb update --repo .
+```
+
+from the business repo.
+
+`/mb-start` also checks whether an important update exists before routing the
+session. You do not need to check for updates manually every day.
+
+## If your install is too old
+
+Very early public installs may not have `mb update` yet. If `mb --version`
+prints an old version and `/mb-update` cannot run, use the bootstrap command:
 
 ```bash
 pipx upgrade mainbranch
 mb --version
 ```
 
-`mb update` was added after the earliest public package, so old installs cannot
-run it yet. After the pipx upgrade, `/mb-update` and `mb update` become the
-normal path.
-
-If you already have a business repo, repair Claude Code skill discovery from
-inside that repo:
+After that, return to the business repo and let Main Branch repair skill
+discovery if needed:
 
 ```bash
 cd /path/to/your-business
 mb skill link --repo .
 mb doctor
-mb start
 ```
 
-Old repos with `reference/core/` do not need an urgent file move. That layout is
-still supported while automated migration is pending. Read `docs/MIGRATING.md`
-before moving files.
+Those commands are troubleshooting, not the everyday beginner loop.
+
+## Why updates work this way
+
+Most users install Main Branch with:
+
+```bash
+pipx install mainbranch
+```
+
+That means the CLI and bundled Claude Code skills live inside the installed
+Python package. Updates come from PyPI. The business repo stays yours; it is not
+the engine repo.
+
+Main Branch keeps those roles separate:
+
+- `mb` updates the engine;
+- the business repo stores your durable memory;
+- `/mb-start` and `/mb-update` explain what to do next in business-owner
+  language.
+
+## Old business repos
+
+If you already have a business repo from an older setup, do not hand-move files
+first. Ask Claude to run read-only checks and show the plan:
+
+```text
+I want to update my existing Main Branch business repo. Please run read-only
+checks first, show me the exact commands you recommend, and ask before doing
+anything that writes files.
+```
+
+For old folder layouts, use the migration guide:
+
+```bash
+mb migrate --check
+```
+
+Only run `mb migrate --apply` after the dry-run shows the planned moves,
+backup location, and no conflicts.
+
+## What Main Branch does not claim
+
+Updating the engine is not the same as proving a runtime behavior. Claude Code
+is the supported runtime today. Other runtimes remain roadmap targets until
+adapter code and smoke evidence exist.

--- a/mb/mb/_data/educational/why-mainbranch-not-saas.md
+++ b/mb/mb/_data/educational/why-mainbranch-not-saas.md
@@ -1,0 +1,95 @@
+---
+type: educational
+topic: why-mainbranch-not-saas
+status: draft
+last-updated: 2026-05-08
+---
+
+# Why Main Branch is not another SaaS dashboard
+
+Start with the daily owner loop:
+
+```bash
+cd /path/to/your-business
+claude
+/mb-start
+```
+
+Main Branch's anti-SaaS philosophy exists to make that loop work. Your business
+memory should not reset every time you open a new chat or switch tools.
+
+Traditional SaaS tools are useful, but they usually own the database, the
+workflow, the pricing, and the export shape. Main Branch puts the durable
+operating memory in files you own, then lets `mb`, Claude Code skills, GitHub,
+and provider rails work around that repo.
+
+## The beginner version
+
+Main Branch has three layers:
+
+1. **Your business repo** - the durable memory: offers, audience, voice,
+   research, decisions, bets, pushes, logs, documents, outcomes, and safe
+   provider references.
+2. **`mb`** - the deterministic control plane: setup, status, validation,
+   graph links, provider readiness, updates, repair, and checkpoints.
+3. **Claude Code skills** - the judgment layer: research, decide, write,
+   review, ship, and reflect from the files.
+
+A SaaS dashboard usually hides those layers behind one account. Main Branch
+keeps them inspectable.
+
+## What this changes for a business owner
+
+**You stop rebuilding context.** The agent can read the repo instead of asking
+you to paste the same offer, audience, proof, and decisions every session.
+
+**You can inspect the work.** The files are regular markdown. The history is
+regular git. Issues and pull requests are durable work threads and proposals,
+not hidden rows in a vendor database.
+
+**You can switch tools later.** Claude Code is the supported runtime today, but
+the repo shape is not trapped inside Claude Code. Future adapters should read
+the same files and deterministic `mb` commands.
+
+**You keep SaaS tools as rails, not the brain.** GitHub, Cloudflare,
+Google/Workspace, ads tools, Apify, Stripe, Cal.com, and other providers can be
+useful. Main Branch connects them when the business job needs them. The repo
+remains the source of truth.
+
+## What the daily loop should feel like
+
+```bash
+cd /path/to/your-business
+claude
+/mb-start
+```
+
+Then:
+
+1. `/mb-start` senses the repo facts.
+2. You and Claude decide the next useful business move.
+3. A skill ships the artifact or `mb` repairs the rail.
+4. `/mb-end` or `mb checkpoint` helps preserve the lesson or saved work.
+
+The words should feel like business work: bets, goals, offers, pushes,
+playbooks, outcomes, and checkpoints. The philosophy is there to protect the
+loop: files you own, facts `mb` can check, and rails that stay inspectable.
+
+## Why this is harder at first
+
+Files, terminal commands, markdown, git, and GitHub are less familiar than a
+web app with a big button. Main Branch should make that safer with `mb
+onboard`, numbered choices, readiness checks, exact next commands, and Claude
+Code skills that explain the result.
+
+The learning curve exists because the payoff exists: your business memory is
+portable, inspectable, and compounding.
+
+## What Main Branch does not claim
+
+Main Branch is not a hosted dashboard, chat client, background daemon, vector
+database, scheduler, marketplace, or model host today.
+
+Claude Code is the supported runtime today. Codex, Cursor, OpenClaw, Hermes,
+Paperclip-adjacent orchestration, and local runtimes are compatibility targets
+until adapter code and smoke evidence prove support.

--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -1015,7 +1015,7 @@ def resolve_cmd(
 def educational_cmd(
     topic: str = typer.Argument(..., help="Educational topic slug."),
 ) -> None:
-    """Print an educational triage file. Powers doctor's 'tell me more' prompts."""
+    """Print a beginner education topic for Main Branch rails and defaults."""
     educational_mod.run(topic=topic)
 
 

--- a/mb/mb/educational.py
+++ b/mb/mb/educational.py
@@ -14,6 +14,34 @@ from pathlib import Path
 
 from mb.engine import engine_root
 
+BEGINNER_CATALOG_TOPICS = (
+    "anti-cloud-backup",
+    "beancount",
+    "cal-com",
+    "cli-vs-dashboard",
+    "cloudflare-pages",
+    "cloudflare-vs-vercel",
+    "cursor",
+    "daily-owner-loop",
+    "forgejo",
+    "git-history-vs-cloud-sync",
+    "github-vs-gdocs",
+    "markdown-vs-notion",
+    "provider-readiness",
+    "stripe",
+    "upgrading-mainbranch",
+    "why-mainbranch-not-saas",
+)
+
+DEFAULT_TOPIC_HINTS = (
+    "daily-owner-loop",
+    "why-mainbranch-not-saas",
+    "github-vs-gdocs",
+    "provider-readiness",
+    "cloudflare-pages",
+    "upgrading-mainbranch",
+)
+
 
 def _engine_path() -> Path | None:
     """Return the active engine .claude/educational/ path."""
@@ -65,10 +93,7 @@ def run(topic: str) -> None:
     """Print the educational file or an honest error."""
     body = load(topic)
     if body is None:
-        available = ", ".join(topics()) or (
-            "daily-owner-loop, why-mainbranch-not-saas, github-vs-gdocs, "
-            "provider-readiness, cloudflare-pages, upgrading-mainbranch"
-        )
+        available = ", ".join(topics()) or ", ".join(DEFAULT_TOPIC_HINTS)
         print(
             f"educational topic not found: {topic}\nTry one of: {available}",
             file=sys.stderr,

--- a/mb/mb/educational.py
+++ b/mb/mb/educational.py
@@ -66,7 +66,8 @@ def run(topic: str) -> None:
     body = load(topic)
     if body is None:
         available = ", ".join(topics()) or (
-            "anti-cloud-backup, cloudflare-vs-vercel, github-vs-gdocs, upgrading-mainbranch"
+            "daily-owner-loop, why-mainbranch-not-saas, github-vs-gdocs, "
+            "provider-readiness, cloudflare-pages, upgrading-mainbranch"
         )
         print(
             f"educational topic not found: {topic}\nTry one of: {available}",

--- a/mb/tests/test_smoke_coverage.py
+++ b/mb/tests/test_smoke_coverage.py
@@ -63,31 +63,14 @@ def test_educational_provider_readiness_exists() -> None:
 
 
 def test_educational_beginner_catalog_exists() -> None:
-    from mb.educational import load, topics
+    from mb.educational import BEGINNER_CATALOG_TOPICS, load, topics
 
-    expected = {
-        "anti-cloud-backup",
-        "beancount",
-        "cal-com",
-        "cli-vs-dashboard",
-        "cloudflare-pages",
-        "cloudflare-vs-vercel",
-        "cursor",
-        "daily-owner-loop",
-        "forgejo",
-        "git-history-vs-cloud-sync",
-        "github-vs-gdocs",
-        "markdown-vs-notion",
-        "provider-readiness",
-        "stripe",
-        "upgrading-mainbranch",
-        "why-mainbranch-not-saas",
-    }
-
-    assert expected.issubset(set(topics()))
-    for topic in expected:
+    assert set(BEGINNER_CATALOG_TOPICS).issubset(set(topics()))
+    for topic in BEGINNER_CATALOG_TOPICS:
         result = load(topic)
         assert result is not None
+        # Every beginner topic must explicitly fence runtime/provider support
+        # claims so education copy does not drift into unsupported promises.
         assert "What Main Branch does not claim" in result
 
 

--- a/mb/tests/test_smoke_coverage.py
+++ b/mb/tests/test_smoke_coverage.py
@@ -62,6 +62,50 @@ def test_educational_provider_readiness_exists() -> None:
     assert "provider-readiness" in topics()
 
 
+def test_educational_beginner_catalog_exists() -> None:
+    from mb.educational import load, topics
+
+    expected = {
+        "anti-cloud-backup",
+        "beancount",
+        "cal-com",
+        "cli-vs-dashboard",
+        "cloudflare-pages",
+        "cloudflare-vs-vercel",
+        "cursor",
+        "daily-owner-loop",
+        "forgejo",
+        "git-history-vs-cloud-sync",
+        "github-vs-gdocs",
+        "markdown-vs-notion",
+        "provider-readiness",
+        "stripe",
+        "upgrading-mainbranch",
+        "why-mainbranch-not-saas",
+    }
+
+    assert expected.issubset(set(topics()))
+    for topic in expected:
+        result = load(topic)
+        assert result is not None
+        assert "What Main Branch does not claim" in result
+
+
+def test_educational_source_and_package_fallback_topics_stay_in_sync() -> None:
+    root = Path(__file__).resolve().parents[2]
+    source = root / ".claude" / "educational"
+    fallback = root / "mb" / "mb" / "_data" / "educational"
+
+    source_files = sorted(path.name for path in source.glob("*.md"))
+    fallback_files = sorted(path.name for path in fallback.glob("*.md"))
+
+    assert source_files == fallback_files
+    for name in source_files:
+        assert (source / name).read_text(encoding="utf-8") == (fallback / name).read_text(
+            encoding="utf-8"
+        )
+
+
 # ------------------------------------------------------------------------ think
 
 


### PR DESCRIPTION
## Summary
- Adds a beginner education catalog for `mb educational`, led by the daily owner loop instead of abstract tool theory.
- Refreshes existing education topics so setup, provider readiness, updates, GitHub/Docs, Cloudflare/Vercel, and sensitive-data guidance stay business-owner safe.
- Adds package-data parity and catalog tests so source checkout topics and packaged fallback topics cannot drift.
- Updates README, Beginner Setup, CLI help, and CHANGELOG so the new education surface is discoverable.

## Scope
- In: daily owner loop education, folded topic catalog, existing topic polish, source/package topic parity, docs/CLI discoverability.
- Out: new provider integrations, account mutation, runtime adapter claims, dashboard work, generated runtime template changes, and runtime discovery changes.

## Commits
- `9554959` — `[add] MAIN-144 beginner education catalog`.
- `13aaf27` — `[fix] MAIN-144 address education review notes`.

## Release / Issues
- Release: v0.3.x docs / beginner education direction.
- Linear ID(s): MAIN-144.
- Closes: #144.
- Refs: #145, #146, #394.
- Follow-ups: #394 remains the adjacent runtime proof gap for transcript/release simulation evidence.

## Success Metric
- A beginner who does not know GitHub, markdown, or terminal can start from the daily owner loop, understand why Main Branch asks for files/git/GitHub/CLI/provider rails, and see explicit boundaries around unshipped provider or runtime claims.

## Validation
- Level 0 docs/decision: README, Beginner Setup, educational topics, CHANGELOG, and public/private boundary reviewed.
- Level 1 static: `scripts/check.sh` passed formatting, mypy, and skill validation.
- Level 2 CLI: `cd mb && python3 -m pytest tests/test_smoke_coverage.py -q` passed, 19 tests; full gate passed 384 tests with 81.26% coverage.
- Level 3 package/install: Not run; package data changed, with source/package parity covered by tests.
- Level 4 fixture repo: Not run; no `mb onboard`, `mb start`, generated `CLAUDE.md`, or repo-shape behavior changed.
- Level 5 runtime smoke: Not run; no Claude Code runtime discovery or bundled skill invocation changed.

## Public / Private Boundary
- New educational files use generic examples only and keep Devon/Conductor/private runtime details out of public docs.
