### PR TITLE
[update] Guide offer launch orchestration

### DIFF
--- a/.claude/skills/mb-ads/SKILL.md
+++ b/.claude/skills/mb-ads/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mb-ads
-description: "Create and review Meta/Facebook/Instagram ads. Flexible entry points: full pipeline (copy + images), copy only, images only, creative variations (hook library), video scripts, video repurpose, compliance review, or optional Meta ad account check. Use when asked to create ads, ad copy, image prompts, video scripts, creative variations, or review ads. Say /mb-ads or describe what you need."
+description: "Create and review ads, and prepare provider-safe launch plans/checks. Flexible entry points: full pipeline (copy + images), copy only, images only, creative variations (hook library), video scripts, video repurpose, compliance review, launch-plan, check, or optional Meta ad account check. Use when asked to create ads, ad copy, image prompts, video scripts, creative variations, review ads, plan paid traffic, or check launch performance. Say /mb-ads or describe what you need."
 loops: [ship, reflect]
 ---
 
@@ -214,6 +214,8 @@ Detect what the user wants from natural language. Route internally to the right 
 | "I'm repurposing a video", "I shot a video" | Video Repurpose | Transcribe + extract hooks + copy variants |
 | "I want ideas for an ad", "brainstorm" | Ideation | Account check (if available) + concept generation |
 | "research winning ads", "mine reviews", "analyze competitors first" | Research / Mining | Route to `/mb-think` winning-ad research before generation |
+| "launch ads", "paid traffic plan", "Google Ads launch", "$X/day for Y days" | Launch Plan | Provider-safe plan/check mode, no account mutation |
+| "check launch", "how are ads doing", "continue or kill" | Launch Check | Read status/outcomes/operator exports, recommend continue/change/stop |
 | "Check my ad performance", "what's working" | Account Check | Read-only Meta Ads context if `mb connect` and runtime tools are ready |
 | "Give me 5 variations of this winning ad" | Performance Iteration | Pull winner + generate variants if account context is ready |
 | "What's working before we create?" | Pre-Gen Account Check | Account overview + creative audit if account context is ready |
@@ -228,6 +230,11 @@ load `mb-think/references/winning-ad-research.md`. Customer language, review
 mining, competitor gap maps, comment mining, and winning script teardown should
 save to `research/` and codify into `core/` before this skill generates ads.
 Do not paste raw review/comment dumps or copied prompt libraries into ad output.
+
+**If launch/check is requested for paid traffic:** Load
+[references/launch-plan-check.md](references/launch-plan-check.md). Prepare
+campaign materials, policy findings, measurement readiness, manual provider
+steps, and approval records; do not mutate ad accounts or start spend.
 
 ### Proactive Account Awareness
 
@@ -439,3 +446,4 @@ For review: Which lenses completed?
 **Video scripts:** 15-30 diverse scripts, spoken-word optimized
 **Review:** 6 lenses, P1/P2/P3 report, fix suggestions
 **Account check:** read-only Meta Ads context -- campaigns, performance, creative audit when `mb connect` and runtime tools are ready
+**Launch plan/check:** provider-safe Google Ads/GTM/paid-traffic plan or outcome check; no account mutation without a shipped adapter and explicit approval

--- a/.claude/skills/mb-ads/references/entry-points.md
+++ b/.claude/skills/mb-ads/references/entry-points.md
@@ -22,6 +22,8 @@ Real ad workflows don't fit neat categories. Someone might have images but need 
 | "Just need images for existing copy" | Image Only | Nano Banana image gen only | No |
 | "Full from scratch" | Full Pipeline | Copy + compliance + images (classic static flow) | Optional |
 | "Check my ad performance" | Account Check | Read-only account context -- insights, winners/losers | Required |
+| "Launch ads", "paid traffic plan", "Google Ads launch" | Launch Plan | Readiness, policy, keyword, budget, approval plan | Plan-only |
+| "Check launch", "continue or kill", "how are ads doing" | Launch Check | Status/outcomes/manual exports, continue/change/stop call | Read-only |
 | "Give me 50 creative variations" | Hook Library | Bulk generation (flexible quantity) | No |
 | "Give me 5 variations of this winning ad" | Performance Iteration | Pull winner + generate variants | Read-only |
 | "Make me video scripts" | Video Scripts | Full video script pipeline | No |
@@ -78,6 +80,7 @@ Each entry point assembles different components. Components are modular -- they 
 | **Video Scripts** | Generate spoken-word scripts | [video-templates-hooks.md](video-templates-hooks.md) |
 | **Image Gen** | Nano Banana image prompts + generation | [image-generation-workflow.md](image-generation-workflow.md) |
 | **Compliance Review** | 6-lens review pipeline | [review-workflow.md](review-workflow.md) |
+| **Launch Plan / Check** | Provider-safe paid-traffic plan and outcome check | [launch-plan-check.md](launch-plan-check.md) |
 | **Post-Gen Pipeline** | Git commit + compliance + image gen | [post-generation-pipeline.md](post-generation-pipeline.md) |
 | **Transcription** | Video/audio transcription (whisper or manual) | `/mb-think` references |
 
@@ -185,5 +188,6 @@ proof, verified tool names, and approval gates. See
 ## See Also
 
 - [meta-ads-integration.md](meta-ads-integration.md) -- Account access details
+- [launch-plan-check.md](launch-plan-check.md) -- Paid-traffic launch-plan and check boundary
 - [one-liner-methodology.md](one-liner-methodology.md) -- Hook library methodology (Joel's cold-traffic work preserved)
 - [preflight-algorithm.md](preflight-algorithm.md) -- Pre-flight scoring

--- a/.claude/skills/mb-ads/references/launch-plan-check.md
+++ b/.claude/skills/mb-ads/references/launch-plan-check.md
@@ -26,8 +26,10 @@ mb site check "$SITE_REPO" --business-repo "$BUSINESS_REPO" --json
 
 ## Readiness States
 
-Use `mb site check` exactly:
+Use the returned `mb site check` state:
 
+- `missing`: measurement setup has not been declared; draft strategy only and
+  route setup through `/mb-site` or the measurement rubric before traffic.
 - `blocked`: stop launch planning after listing blockers and next commands.
 - `ready_for_preview`: draft ads only; operator still needs GTM Preview/Tag
   Assistant and provider metadata.

--- a/.claude/skills/mb-ads/references/launch-plan-check.md
+++ b/.claude/skills/mb-ads/references/launch-plan-check.md
@@ -1,0 +1,112 @@
+# Launch Plan And Check Modes
+
+Use this when the operator asks to launch/check paid traffic, especially Google
+Ads traffic for a lander or minisite.
+
+This mode prepares a reviewable plan and checks recorded readiness. It does not
+mutate Google Ads, GTM, Meta Ads, Stripe, or analytics providers unless a future
+adapter ships with approval gates and smoke evidence.
+
+## Launch-Plan Inputs
+
+From the business repo:
+
+- active offer and audience;
+- the launch push at `pushes/<push>/push.md`;
+- keyword-gate research, especially ready-to-buy terms and negative seeds;
+- site record or linked site repo;
+- `docs/google-ads-gtm-conversion-rubric.md`;
+- `mb status --json --peek`;
+- `mb connect plan` or `mb connect doctor --json`;
+- when a site repo exists:
+
+```bash
+mb site check "$SITE_REPO" --business-repo "$BUSINESS_REPO" --json
+```
+
+## Readiness States
+
+Use `mb site check` exactly:
+
+- `blocked`: stop launch planning after listing blockers and next commands.
+- `ready_for_preview`: draft ads only; operator still needs GTM Preview/Tag
+  Assistant and provider metadata.
+- `ready_for_operator_review`: prepare campaign materials and approval list.
+- `ready`: local checks passed; still require explicit operator approval before
+  provider mutation or spend.
+
+Never say `ready_for_launch`.
+
+## Output
+
+Write a provider-safe plan under the launch push, for example:
+
+```text
+pushes/<YYYY-MM-DD-slug>/ads.md
+```
+
+Sections:
+
+- `## Readiness`
+- `## Budget And Review Window`
+- `## Campaign Structure`
+- `## Keyword Targets`
+- `## Negative Seeds`
+- `## Headlines`
+- `## Descriptions`
+- `## Sitelinks`
+- `## Policy Preflight`
+- `## Measurement Checklist`
+- `## Manual Provider Steps`
+- `## Approval`
+
+If the work includes repeatable provider setup, resource delivery, or approval
+state, draft a `type: playbook` file under `pushes/<push>/playbooks/` instead
+of hiding the plan in prose.
+
+## Policy Preflight
+
+Before preparing launch copy:
+
+- run the normal ad compliance review flow;
+- check for regulated verticals: medical, finance, credit, employment,
+  housing, legal, social issues/politics;
+- compare claims against offer proof and Skool/site surfaces when present;
+- stop on unsupported guarantees, "cures/treats/heals" claims, impossible
+  outcomes, or provider-specific disallowed phrases.
+
+## Check Mode
+
+Use check mode when the operator asks "how are the ads doing" or "should we
+continue/kill this launch."
+
+Because live provider metrics are not yet a supported mutation/read adapter by
+default, use one of these sources:
+
+1. `mb status --json --peek` and relationship/outcome health.
+2. Existing push outcome/review files.
+3. Operator-provided Ads/GTM/Stripe screenshots or CSV exports.
+4. Read-only provider context only when `mb connect` and the current runtime
+   prove it is ready.
+
+Output a concise continue/change/stop recommendation and write findings to the
+push review or outcome file when the operator approves.
+
+## Approval Boundary
+
+Do not:
+
+- upload campaigns;
+- publish GTM containers;
+- change budgets;
+- start spend;
+- upload conversions;
+- ask for OAuth secrets, API keys, customer records, or raw account exports in
+  chat.
+
+Do:
+
+- prepare the plan;
+- cite exact manual steps;
+- record approval requirements;
+- checkpoint approved artifacts.

--- a/.claude/skills/mb-site/SKILL.md
+++ b/.claude/skills/mb-site/SKILL.md
@@ -98,7 +98,7 @@ Ask the operator. Do not assume.
 > **What are you doing?**
 >
 > **A. New site from scratch.** Pick a shape.
-> - **Lander** (1 page, all-in-one). V1 stub; use minisite for single-page-feel use cases. Load [`references/lander-build.md`](references/lander-build.md).
+> - **Lander** (1 page, all-in-one). Use for focused one-off offer tests, retargeting, or paid-traffic landers. Load [`references/lander-build.md`](references/lander-build.md).
 > - **Minisite** (~4-6 pages, static HTML). V1 default for paid-ad lander tests, single-offer first deploys, payment, lead-form, and booking funnels. Load [`references/minisite-build.md`](references/minisite-build.md).
 > - **Website** (full site, usually with build step). Legacy Next.js templates work today. Load [`references/website-build.md`](references/website-build.md).
 >
@@ -152,6 +152,7 @@ If the operator cannot articulate the shape, ask: "What goal are you trying to h
 **Generation + design**
 
 - [`references/minisite-generation-system.md`](references/minisite-generation-system.md) - load-bearing system prompt for minisite generation.
+- [`references/lander-generation-system.md`](references/lander-generation-system.md) - one-page lander generation profile.
 - [`references/review.md`](references/review.md) - dial-gated quality gates.
 - [`references/anti-patterns.md`](references/anti-patterns.md) - AI tells and generation anti-patterns.
 - [`references/archetypes.md`](references/archetypes.md) - 9-archetype picker. Load picked detail lazily.

--- a/.claude/skills/mb-site/references/lander-build.md
+++ b/.claude/skills/mb-site/references/lander-build.md
@@ -1,30 +1,106 @@
-# Lander — Build Flow
+# Lander Build Flow
 
-The lander shape: 1 page, all-in-one. Hero + offer + proof + CTA + footer, all on `index.html`. Maximum focus, minimum nav.
+The lander shape is one static page for one offer and one launch push. It is
+for focused paid-traffic, retargeting, or direct-response tests where extra
+navigation would weaken the decision.
 
-**V1 status:** the per-offer lander generation system prompt is not yet written. For single-page-feel use cases in V1, use the **minisite** shape — the home page does the brand work and links straight to Stripe checkout. See [`minisite-build.md`](minisite-build.md).
+Use the minisite shape when the offer needs multiple proof/process/FAQ pages.
 
-When per-offer lander generation lands, this file gets the same shape as `minisite-build.md`:
+## Start
 
-- `setup (lander)` — tool chain (domain, dns, pages, custom-domain), single-file project repo, Cloudflare Pages git-connected
-- `build --one-shot (lander)` — generation subagent invoked with `lander-generation-system.md` (also future) + offer/audience/reference URLs; produces `index.html` + `_headers` + `og.svg` + `favicon.svg` (no per-section subdirectories)
-- Validation: footer presence, OG render, single-page Lighthouse score
-- What's NOT (no nav, no multi-page structure, no `/start/thanks/` separate page — thanks state shown inline or via Stripe's default thanks page)
+1. Resolve the business repo and active offer using the normal `/mb-site`
+   rules.
+2. Run `mb status --json --peek` and use readiness, relationship health,
+   legacy `campaigns/` drift, provider facts, and ranked actions before
+   continuing.
+3. Create or select the canonical launch push:
 
+```yaml
 ---
-
-## Why not ship a lander generation system in V1
-
-Three reasons:
-
-1. **The minisite covers the use case.** A ~4–6 page minisite where supporting pages link from the home hero gives the same psychological "single focused funnel" feel as a 1-page lander, without losing the room for proof + how-it-works + faq.
-2. **Vagueness at single-page is harder.** Less surface area for variance — the system prompt risks producing visually identical output across runs unless we're disciplined. Minisite has more room to surprise.
-3. **Conversion data lives at the minisite tier.** Devon's first V1 run is paid Google Ads → minisite → Stripe deposit. The lander shape becomes load-bearing only when there's a real reason to compress to one page (very specific offers, retargeting flows, etc.) — that signal hasn't surfaced yet.
-
-When it does, this file gets the full shape and `/mb-site` adds a `lander-generation-system.md` peer to `minisite-generation-system.md`.
-
+type: push
+slug: YYYY-MM-DD-slug
+kind: launch
+status: planned
+health: unknown
+goal: { metric: "", target: "", by: YYYY-MM-DD }
+owner: ""
+audience: ""
+offer: core/offers/<offer>/offer.md
+promise: ""
+channels: [site]
 ---
+```
 
-## Graduating up
+4. If keyword-gate research exists, load it. If paid traffic is intended and no
+   keyword gate exists, route back to `/mb-think` keyword-gate mode before
+   building.
 
-A successful lander often pulls traffic that wants more proof / more pages → graduate to **minisite**. See [`graduation.md`](graduation.md) for the path.
+## Setup
+
+Use [site-repo-workflow.md](site-repo-workflow.md) for business-repo vs site-repo
+mode. The business repo stores the push and site records; the site repo stores
+the HTML/CSS/SVG files.
+
+Before domain, DNS, Pages, or deploy work:
+
+```bash
+mb connect doctor --json
+```
+
+If Cloudflare is not ready, offer connect-now, read-only planning, or stop and
+record the blocker.
+
+## Build
+
+Load [lander-generation-system.md](lander-generation-system.md). Generate in
+Claude Code or a foreground subagent; do not call a model from a Python atom.
+
+Inputs:
+
+- active offer and audience;
+- keyword-gate file, if present;
+- voice, proof, testimonials, visual style, and named enemies;
+- selected push path;
+- conversion endpoint or hosted form/checkout/booking link;
+- optional reference URLs for taste only.
+
+Output in the site repo:
+
+```text
+index.html
+_headers
+og.svg
+favicon.svg
+README.md
+```
+
+Render `og.png` from `og.svg` when the render tool is available. Keep both files
+in the site repo when rendered.
+
+## Paid-Traffic Check
+
+When paid traffic, Google Ads, GTM, conversion tracking, or "ready to launch" is
+in scope, load [site-measurement.md](site-measurement.md) and run:
+
+```bash
+mb site check "$SITE_REPO" --business-repo "$BUSINESS_REPO" --json
+```
+
+Report the exact readiness state. `ready` still means local checks passed, not
+permission to mutate ad accounts or spend money.
+
+## Publish
+
+Publishing is an explicit operator action. Before push/deploy:
+
+- show the changed files;
+- run any available static/site checks;
+- list provider or measurement blockers;
+- ask for approval;
+- after approval, checkpoint the business repo and commit/push the site repo
+  through the existing site workflow.
+
+## Graduation
+
+If the lander gets traffic but needs more proof, process detail, or SEO surface,
+recommend graduating to minisite. See [graduation.md](graduation.md).

--- a/.claude/skills/mb-site/references/lander-generation-system.md
+++ b/.claude/skills/mb-site/references/lander-generation-system.md
@@ -1,0 +1,79 @@
+# Lander Generation Profile
+
+Use this as the system profile for a one-page offer lander. The skill, not a
+Python LLM wrapper, gives this profile to the active Claude Code session or a
+foreground subagent.
+
+## Inputs
+
+- resolved offer and audience files;
+- keyword-gate research when present;
+- voice, proof, testimonials, visual style, and named enemies when present;
+- linked launch push path;
+- conversion endpoint choice;
+- optional taste references or existing URLs.
+
+## Files To Produce
+
+For a static Cloudflare Pages-compatible site repo:
+
+```text
+index.html
+_headers
+og.svg
+favicon.svg
+README.md
+```
+
+Render `og.png` from `og.svg` after generation when the render tool is
+available. Do not generate `og.png` directly from the model.
+
+## Page Contract
+
+One page, no nav dependency, mobile-first:
+
+- hero with keyword-aligned promise and one primary CTA;
+- recognition/problem section using audience language;
+- mechanism/process section;
+- proof or credibility section;
+- offer/logistics section;
+- FAQ or objections section;
+- final CTA;
+- privacy/terms links or clear hosted equivalents;
+- footer with the required business entity.
+
+The page can link to a hosted checkout, booking, or form, but it must not assume
+provider setup that `mb site check` or operator approval has not verified.
+
+## OG Image Rules
+
+`og.svg` is the page-as-thumbnail. It should be readable at roughly 200px wide:
+
+- hero text or tighter H1 echo, two lines max;
+- one signature visual object that fits the offer;
+- small wordmark;
+- no body copy, pricing, CTAs, logo bars, stock photos, grids, or collages;
+- include `og:image:alt` and `twitter:image:alt` in page metadata.
+
+## Paid-Traffic Readiness
+
+For paid traffic, the generated HTML must support the measurement rubric:
+
+- leave room for GTM snippet insertion without hardcoding secrets;
+- use `mb_*` dataLayer event names from
+  `docs/google-ads-gtm-conversion-rubric.md` when instrumentation is selected;
+- include privacy/consent posture in the page or linked docs;
+- run `mb site check "$SITE_REPO" --business-repo "$BUSINESS_REPO" --json`
+  before any ad launch recommendation.
+
+## Quality Gate
+
+Before calling the lander ready for operator review:
+
+- all required files exist;
+- footer/entity is present;
+- CTA links are real or explicitly marked as placeholders;
+- page has title, description, canonical URL when known, OG/Twitter metadata;
+- keyword cluster appears naturally without stuffing;
+- no unsupported provider claims or unsafe regulated claims;
+- `mb site check` state is reported when paid traffic is in scope.

--- a/.claude/skills/mb-site/references/minisite.md
+++ b/.claude/skills/mb-site/references/minisite.md
@@ -80,9 +80,9 @@ What goes on each page by default. The generation subagent has aesthetic freedom
 
 The conversion URL is the same one used everywhere on the site. Until the URL
 is wired, placeholder `https://CONVERSION-PLACEHOLDER` ships and the `/mb-site`
-walkthrough substitutes the real URL during the build phase. A future
-`/mb-start launch <offer>` orchestration would follow the same contract, but it
-is not a shipped structured mode today.
+walkthrough substitutes the real URL during the build phase. Guided
+`/mb-start launch <offer>` orchestration follows the same contract by routing
+the current step to `/mb-site`.
 
 ### How It Works (`/how-it-works/`)
 
@@ -302,8 +302,7 @@ Do not push email, phone, full name, address, CRM notes, booking notes, raw cust
 
 Current `/mb-site` walkthroughs and any future launch orchestration must verify
 these before money or state changes. Some gates branch on the chosen
-conversion-endpoint kind. `/mb-start launch <offer>` is not a shipped
-structured mode today.
+conversion-endpoint kind.
 
 ### Always-required gates
 
@@ -332,10 +331,10 @@ Failed gate = halt with a specific message and routing suggestion. No silent ski
 
 ## Candidate launch walkthrough
 
-Current shipped site work routes through `/mb-site`. A future
-`/mb-start launch <offer>` orchestration, if shipped, should walk the operator
-through six phases. Each phase has explicit Y/N gates on money-spending steps,
-resumability between phases, and clear exit criteria.
+Current shipped site work routes through `/mb-site`. Guided
+`/mb-start launch <offer>` orchestration walks the operator through the same
+phases by selecting the current skill step. Each phase has explicit Y/N gates on
+money-spending steps, resumability between phases, and clear exit criteria.
 
 ### Phase 1 — Pre-flight
 

--- a/.claude/skills/mb-start/SKILL.md
+++ b/.claude/skills/mb-start/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mb-start
-description: "Main entry point for Main Branch. Detects state and routes to the right skill. Use when: user says start/help/begin, is new/returning/lost, opens Main Branch without a task, or needs triage. Routes to /mb-setup, /mb-think, /mb-bet, /mb-ads, /mb-vsl, /mb-organic, /mb-wiki, /mb-help."
+description: "Main entry point for Main Branch. Detects state and routes to the right skill. Use when: user says start/help/begin, is new/returning/lost, opens Main Branch without a task, needs triage, or wants to launch an offer. Routes to /mb-setup, /mb-think, /mb-bet, /mb-site, /mb-ads, /mb-vsl, /mb-organic, /mb-wiki, /mb-help."
 loops: [sense, decide]
 ---
 
@@ -55,6 +55,12 @@ tokens in prose. Do not invent `ready_for_launch`; the valid readiness states
 are `missing`, `blocked`, `ready_for_preview`, `ready_for_operator_review`, and
 `ready`.
 
+**Offer launch path:** When the operator asks to launch an offer, use
+[references/launch-orchestration.md](references/launch-orchestration.md).
+The path is skill orchestration: keyword-gate with `/mb-think`, create/select a
+canonical launch push, build/check the lander with `/mb-site`, prepare or check
+ads with `/mb-ads`, and checkpoint approved artifacts.
+
 ---
 
 ## CRITICAL: Repo Selection Rules
@@ -92,9 +98,8 @@ are `missing`, `blocked`, `ready_for_preview`, `ready_for_operator_review`, and
 
 ## Numbered Options Pattern
 
-Always use numbered lists for multi-choice. User replies with just a number.
-
-Apply to: business repo selection, skill routing, any multiple choice.
+Always use numbered lists for multi-choice: business repo selection, skill
+routing, launch blockers, and provider setup.
 
 ---
 
@@ -429,25 +434,13 @@ to `/mb-think`.
 
 ---
 
-## Context Awareness
+## Context And Experience
 
 Fresh context gets a fuller load; working context routes directly; heavy context
-gets a brief warning; critical context routes to `/mb-end`. Show percentage only
-when relevant.
-
----
-
-## Adapt to Experience
-
-Read `user.experience` from `~/.config/vip/local.yaml` (defaults to `beginner`
-if missing): beginner = explain more, intermediate = balanced, advanced = route
-fast.
-
-**First-time** (no config, thin reference): Be verbose, route to /mb-setup
-**Returning** (config exists): Quick confirmation, route by intent
-**Expert** (advanced experience, clear intent): Get out of the way, route fast
-
-**Updating experience:** If user says "I know what I'm doing" or similar, offer to update their experience level in local.yaml.
+gets a brief warning; critical context routes to `/mb-end`. Read
+`user.experience` from `~/.config/vip/local.yaml`: beginner explains more,
+returning confirms quickly, expert routes fast. If the user asks for a faster
+mode, offer to update local experience.
 
 ---
 
@@ -468,7 +461,8 @@ Auto-detect user intent and route. Skills: `/mb-update`, `/mb-help`, `/mb-setup`
 | "ads", "copy", "static", "image ads", "video ads", "review", "compliance" | `/mb-ads` |
 | "vsl", "sales video", "about page video", "b2b video" | `/mb-vsl` |
 | "content", "reels", "tiktok", "organic", "carousel" | `/mb-organic` |
-| "site", "landing page", "lander", "minisite", "website", "one-pager", "spin up a site", "deploy site", "put this online", "I need a site", "publish site", "graduate my site", "add a CMS to my site", "launch offer" | `/mb-site`; `/mb-start launch <offer>` is not a shipped structured mode |
+| "launch offer", "keyword gate then build", "offer launch", "/mb-start launch <offer>" | Use [references/launch-orchestration.md](references/launch-orchestration.md), then route to `/mb-think`, `/mb-site`, and `/mb-ads` as each step becomes current |
+| "site", "landing page", "lander", "minisite", "website", "one-pager", "spin up a site", "deploy site", "put this online", "I need a site", "publish site", "graduate my site", "add a CMS to my site" | `/mb-site` |
 | "wiki", "notes", "atomic", "wikilinks", "publish wiki" | `/mb-wiki` |
 | "pull", "update Main Branch", "get latest" | `/mb-update` |
 | "done", "wrapping up", "end my day", "closing out", "call it a day", "that's it" | `/mb-end` |
@@ -492,6 +486,7 @@ If re-invoked after compaction: re-read `~/.config/vip/local.yaml` for repo + id
 - [references/readiness-assessment.md](references/readiness-assessment.md) — Step 6 readiness scoring
 - [references/tool-status-audit.md](references/tool-status-audit.md) — Step 5 provider/readiness audit
 - [references/triage-agent.md](references/triage-agent.md) — Triage agent prompts and synthesis
+- [references/launch-orchestration.md](references/launch-orchestration.md) — guided offer-launch path
 
 ---
 

--- a/.claude/skills/mb-start/references/launch-orchestration.md
+++ b/.claude/skills/mb-start/references/launch-orchestration.md
@@ -1,0 +1,73 @@
+# Offer Launch Orchestration
+
+Use this when the operator says "launch this offer," "keyword gate this offer
+then build the lander," "get a paid-traffic plan ready," or invokes
+`/mb-start launch <offer>`.
+
+This is skill orchestration, not a new `mb` CLI workflow runner. `/mb-start`
+keeps the main context lean, reads deterministic `mb` facts, and routes the
+operator through existing skills.
+
+## Required Starting Facts
+
+From the business repo:
+
+```bash
+mb status --json --peek
+mb connect plan
+```
+
+If status reports relationship-health gaps, legacy `campaigns/` drift, missing
+provider readiness, or update/repair blockers, surface those first and use the
+cited repair command.
+
+## Sequence
+
+1. **Resolve the offer.** Use the normal active-offer rules. If no offer exists,
+   route to `/mb-think` to codify the offer and audience before launch work.
+2. **Create or select a push.** Use `pushes/<YYYY-MM-DD-slug>/push.md` with
+   `type: push`, `kind: launch`, structured `goal`, `owner`, `audience`,
+   `offer`, and a short `promise`. If a matching active/planned launch push
+   exists, ask whether to continue it instead of creating a duplicate.
+3. **Keyword gate.** Route to `/mb-think` keyword-gate mode. A "kill" verdict
+   stops the default path unless the operator explicitly overrides.
+4. **Lander plan/build.** Route to `/mb-site` lander mode. If paid traffic is in
+   scope, require the site measurement checks from `/mb-site` before ads work.
+5. **Ad launch plan/check.** Route to `/mb-ads` launch-plan or check mode. This
+   prepares copy, keyword targets, negatives, policy findings, budget notes, and
+   manual provider steps. It does not mutate Google Ads/GTM/Meta accounts.
+6. **Checkpoint.** After each accepted artifact or approval record, run
+   `mb checkpoint --plan --json`, validate the message, and save only after
+   operator approval.
+
+## Beginner Output Pattern
+
+Show exactly one current step plus the next two steps:
+
+```text
+Current step: keyword gate the offer.
+Next: create/update the launch push.
+After that: build the lander and prepare ads for review.
+```
+
+Use numbered choices when blocked:
+
+1. Fix the blocker now with the exact `mb` command.
+2. Continue in read-only planning mode.
+3. Stop and save a checkpoint.
+
+## Approval Boundaries
+
+Always require explicit operator approval before:
+
+- buying domains;
+- attaching custom domains;
+- publishing/deploying site changes;
+- creating payment links or modifying Stripe;
+- publishing GTM containers;
+- mutating Google Ads or Meta Ads;
+- spending money;
+- uploading customer, conversion, or account data.
+
+If an adapter is not shipped with smoke evidence, describe the step as manual
+or plan-only and record it in the push or a push playbook.

--- a/.claude/skills/mb-think/SKILL.md
+++ b/.claude/skills/mb-think/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mb-think
-description: "Combined research, decision, and codification workflow. Use when: (1) Exploring a question before committing (2) Making a decision that needs documentation (3) User says research, decide, figure out, explore, codify, enrich, add context (4) Updating reference files based on decisions (5) User wants to add new testimonials, angles, or proof to existing files. Supports modes: full flow, research-only, decide-only, codify."
+description: "Combined research, decision, and codification workflow. Use when: (1) Exploring a question before committing (2) Making a decision that needs documentation (3) User says research, decide, figure out, explore, codify, enrich, add context, or keyword gate an offer (4) Updating reference files based on decisions (5) User wants to add new testimonials, angles, or proof to existing files. Supports modes: full flow, research-only, keyword-gate, decide-only, codify."
 loops: [sense, decide, ship]
 ---
 
@@ -135,6 +135,7 @@ Detect mode from user's natural language:
 | "research", "investigate", "what do we know about" | Research | [research-phase.md](references/research-phase.md) |
 | "what are people saying", "sentiment", "X/Twitter", "trending" | Research (Grok) | [grok-social.md](references/grok-social.md) |
 | "winning ads", "review mining", "customer language", "competitor ads", "comment mining" | Research | [winning-ad-research.md](references/winning-ad-research.md) |
+| "keyword gate", "kill or build this offer", "search demand", "buyer intent", "validate paid traffic demand" | Keyword Gate Research | [keyword-gate.md](references/keyword-gate.md) |
 | "decide", "we chose", "document decision" | Decide | [decide-phase.md](references/decide-phase.md) |
 | "codify", "apply", "update reference files" | Codify | [codify-phase.md](references/codify-phase.md) |
 | "add context", "enrich", "I have new info" | Codify | [codify-phase.md](references/codify-phase.md) |
@@ -159,6 +160,7 @@ When routing to research mode, detect research TYPE from user intent:
 | Instagram mining | Instagram handle, "mine [handle]", "competitor posts" | Apify | Manual screenshots |
 | Ad account research | "ad performance", "what's working", "check CPA", "audit my ads" | Verified Meta ad account context | Manual Ads Manager check |
 | Winning-ad research | "customer language", "competitor ads", "review mining", "script teardown", "comment mining" | WebSearch + Apify/Grok when configured | Manual exports, screenshots, pasted transcripts |
+| Keyword gate | "keyword gate", "kill or build", "search demand", "buyer intent", "paid traffic demand" | SERP/search sidecar + Keyword Planner CSV when available | WebSearch + operator-provided exports |
 | General research | Default, "research [topic]", "what do we know" | WebSearch + codebase | Always available |
 
 **Multiple types needed at once?** Spawn them as parallel Task agents in a single message. Example: user says "research what [creator] says on YouTube and what people think on X" — spawn one agent for YouTube transcript mining and another for X/Twitter sentiment simultaneously. Each saves its own research file; main conversation synthesizes when both return.
@@ -274,6 +276,7 @@ Gather from codebase, web, user input, local recordings.
 | Instagram mining | Apify or manual | `-ig-mining.md` |
 | Ad account data | Verified Meta Ads account context | `-ad-account.md` |
 | Competitor sites | Browser MCP or web fetch | `-competitor-mining.md` |
+| Keyword gate | SERP/search sidecar, planner CSV, or WebSearch | `-keyword-gate.md` |
 | Your own emails/DMs | Paste into conversation | `-internal-mining.md` |
 | Deep research | Build prompt → Gemini/GPT | `-gemini.md` or `-gpt.md` |
 | Codebase exploration | Grep, read, subagents | `-claude-code.md` |
@@ -350,6 +353,12 @@ See [references/research-phase.md](references/research-phase.md) for full workfl
 For ad, customer, review, competitor, and social-comment mining, use
 [references/winning-ad-research.md](references/winning-ad-research.md) to keep
 the research structured before handing off to `/mb-ads` or `/mb-organic`.
+
+For offer-launch demand validation, use
+[references/keyword-gate.md](references/keyword-gate.md). It writes a dated
+keyword-gate research file with a Build / Build with caution / Kill verdict,
+recommended lander cluster, ready-to-buy terms, and negative keyword seeds for
+`/mb-site` and `/mb-ads`.
 
 ---
 

--- a/.claude/skills/mb-think/references/keyword-gate.md
+++ b/.claude/skills/mb-think/references/keyword-gate.md
@@ -89,6 +89,9 @@ Frontmatter:
 ```yaml
 ---
 type: research
+date: YYYY-MM-DD
+topic: keyword gate for offer-slug
+source: claude-code
 status: completed
 entities: [offer-slug]
 linked_pushes: []

--- a/.claude/skills/mb-think/references/keyword-gate.md
+++ b/.claude/skills/mb-think/references/keyword-gate.md
@@ -1,0 +1,124 @@
+# Keyword Gate Research
+
+Use this for buyer-intent search demand validation before building or funding a
+launch push.
+
+Triggers:
+
+- "keyword gate this offer"
+- "kill or build this offer"
+- "is there search demand for this"
+- "what keywords should the lander/ad plan use"
+- "validate buyer intent before paid traffic"
+
+## Source Of Truth
+
+Start from the active offer and audience:
+
+- `core/offers/<offer>/offer.md` and `core/offers/<offer>/audience.md`, when
+  multi-offer mode is active;
+- otherwise `core/offer.md` and `core/audience.md`;
+- accumulated proof and voice files when they clarify pain, promise, and
+  forbidden claims.
+
+If a launch push already exists, link the research to it. If no push exists,
+write the research so `/mb-start` and `/mb-site` can create one later.
+
+## Tool Order
+
+Use progressive enhancement. Never block the workflow on an optional provider.
+
+1. `mb status --json --peek` and `mb connect doctor --json` for provider facts.
+2. Apify/search-sidecar SERP and autocomplete data when configured.
+3. Google Keyword Planner CSV when the operator provides a file path.
+4. Web search fallback for SERP inspection and adjacent terms.
+5. Operator-provided customer language, Ads Manager screenshots, or exports.
+
+Do not ask the operator to paste provider tokens, OAuth secrets, raw customer
+data, or account exports into chat.
+
+## Seed Terms
+
+Generate 8-15 seeds:
+
+- offer name and category;
+- problem-aware phrases from audience pain;
+- solution-aware phrases and synonyms;
+- comparison phrases: `vs`, `alternative`, `reviews`;
+- commercial phrases: `cost`, `price`, `consultant`, `service`, `software`,
+  `agency`, `near me` only when local intent is actually relevant;
+- audience qualifiers such as role, industry, stage, or geography.
+
+## Buckets
+
+Rank terms into:
+
+- `ready_to_buy`: high commercial intent, provider/service/software searches,
+  price/cost/comparison terms, or branded alternatives.
+- `comparison`: competitors, alternatives, best-of, reviews, category
+  evaluation.
+- `research`: informational searches that may inform page copy but should not
+  lead paid traffic by default.
+- `negative_seed`: free, template, PDF, definition, jobs, salary, DIY, examples,
+  and any irrelevant adjacent meanings.
+
+## Verdict
+
+Use an opinionated but overrideable verdict:
+
+- **Build:** at least three ready-to-buy terms with credible demand and a page
+  angle the offer can honestly satisfy.
+- **Build with caution:** one or two ready-to-buy terms, weak volume/CPC signal,
+  or heavy dependency on comparison/research terms.
+- **Kill:** no credible ready-to-buy terms, unclear buyer, or likely policy/
+  tracking risk that must be resolved first.
+
+Explain confidence based on source quality. Web-only or screenshot-only
+research is lower confidence than exported planner/provider data.
+
+## Output File
+
+Write:
+
+```text
+research/YYYY-MM-DD-keyword-gate-<offer-or-push>.md
+```
+
+Frontmatter:
+
+```yaml
+---
+type: research
+status: completed
+entities: [offer-slug]
+linked_pushes: []
+linked_offers:
+  - core/offers/<offer>/offer.md
+---
+```
+
+Body sections:
+
+- `## Verdict`
+- `## Source Quality`
+- `## Ready-To-Buy Terms`
+- `## Comparison Terms`
+- `## Research Terms`
+- `## Negative Keyword Seeds`
+- `## Recommended Lander Cluster`
+- `## Ad Plan Inputs`
+- `## What Changes`
+
+`Recommended Lander Cluster` should name the primary 2-4 terms for hero,
+meta/title, and section headings. `Ad Plan Inputs` should list ready-to-buy
+targets and negative seeds for `/mb-ads` launch-plan mode.
+
+## Stop Conditions
+
+Stop and ask before moving to lander/ad work when:
+
+- verdict is `Kill`;
+- search demand depends on unsupported provider mutation;
+- claims would trigger medical, financial, employment, housing, credit, or
+  other regulated policy review;
+- the offer/audience files are too thin to judge intent.

--- a/.claude/skills/mb-think/references/research-architecture.md
+++ b/.claude/skills/mb-think/references/research-architecture.md
@@ -85,6 +85,7 @@ Parse user's natural language to determine research type:
 | "research [complex topic]", "deep dive on..." | Deep research | Gemini 2.5 | Web search + synthesis |
 | "transcribe this file", user shares .mp4/.m4a | Local transcription | whisper-mcp | ffmpeg + CLI fallback |
 | "mine competitors", "what's [handle] posting" | Social mining | Apify Instagram Actor | Manual scraping guidance |
+| "keyword gate", "kill or build this offer", "search demand" | Keyword gate | Search/SERP sidecar or planner CSV | Web search + operator exports |
 | "research [specific question]" | General research | Codebase → Web → Ask user | Always works |
 
 ### 3. Progressive Disclosure

--- a/.claude/skills/mb-think/references/research-routing-quick-ref.md
+++ b/.claude/skills/mb-think/references/research-routing-quick-ref.md
@@ -15,6 +15,7 @@ Fast lookup table for routing research requests in /mb-think skill.
 | "deep dive", "comprehensive research" | Gemini Deep (Tier 2) | `GOOGLE_API_KEY` | Tier 1 or WebSearch |
 | Local file path, "transcribe recording" | whisper-mcp | `mcp__whisper__*` | CLI fallback |
 | Instagram handle, "mine competitors" | Apify Instagram | `mcp__apify__*` | Manual guidance |
+| "keyword gate", "kill or build this offer", "search demand" | Keyword gate | Search/SERP sidecar or planner CSV | WebSearch + manual exports |
 | "what do we know", "check existing" | Codebase grep | Always available | N/A |
 | General question | WebSearch | Always available | N/A |
 
@@ -54,6 +55,7 @@ if mcp__whisper__* exists: WHISPER=true
 | `-flash.md` | Gemini Flash (Tier 1) | `2026-01-26-quick-research-flash.md` |
 | `-gemini-deep.md` | Gemini Deep (Tier 2) | `2026-01-26-guarantee-psychology-gemini-deep.md` |
 | `-ig-mining.md` | Apify Instagram | `2026-01-26-competitor-content-ig-mining.md` |
+| `-keyword-gate.md` | Keyword gate | `2026-01-26-workshop-keyword-gate.md` |
 | `-local-mining.md` | whisper-mcp | `2026-01-26-sales-call-local-mining.md` |
 | `-claude-code.md` | This session | `2026-01-26-pricing-strategy-claude-code.md` |
 | `-web.md` | WebSearch fallback | `2026-01-26-industry-trends-web.md` |
@@ -107,6 +109,7 @@ if mcp__whisper__* exists: WHISPER=true
    └─> Instagram handle → route_instagram()
 
 3. Check complexity
+   ├─> Keyword demand / kill-or-build language → route_keyword_gate()
    ├─> Simple question → route_gemini_tier1()
    └─> Complex multi-step → route_gemini_tier2()
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+### Added
+
+- Added bundled skill guidance for a guided offer-launch path: `/mb-start`
+  can route an operator from active offer to keyword-gate research, canonical
+  launch push, one-page lander, provider-safe ad launch plan/check, and
+  checkpointed approval records without claiming live provider mutation. Refs
+  #89.
+
 ## [0.3.9] - 2026-05-08
 
 v0.3.9 makes the daily operating loop more inspectable. Main Branch now exposes

--- a/mb/tests/test_runtime_command_references.py
+++ b/mb/tests/test_runtime_command_references.py
@@ -12,14 +12,15 @@ MAIN_BRANCH_COMMAND_RE = re.compile(
     r"(?P<name>mb-[a-z0-9-]+|newsletter|ads|bet|end|help|organic|pull|setup|site|start|status|think|update|vsl|wiki)"
     r"(?=$|[`<\s,).:;])"
 )
-UNSHIPPED_STRUCTURED_FORMS = ("/mb-start launch",)
-UNSHIPPED_CONTEXT_MARKERS = (
-    "not a shipped",
-    "not shipped",
-    "not currently shipped",
-    "future",
-    "candidate",
-    "planned",
+GUIDED_ORCHESTRATION_FORMS = ("/mb-start launch",)
+GUIDED_ORCHESTRATION_CONTEXT_MARKERS = (
+    "guided",
+    "orchestration",
+    "route",
+    "routing",
+    "walk",
+    "skill",
+    "follows the same contract",
 )
 
 
@@ -74,19 +75,20 @@ def test_runtime_docs_reference_only_bundled_main_branch_slash_commands() -> Non
     assert failures == []
 
 
-def test_runtime_docs_mark_mb_start_launch_as_unshipped_when_mentioned() -> None:
+def test_runtime_docs_mark_mb_start_launch_as_guided_skill_orchestration() -> None:
     failures: list[str] = []
 
     for path in _scan_paths():
         rel = path.relative_to(REPO_ROOT)
         lines = path.read_text(encoding="utf-8").splitlines()
         for index, line in enumerate(lines):
-            if not any(form in line for form in UNSHIPPED_STRUCTURED_FORMS):
+            if not any(form in line for form in GUIDED_ORCHESTRATION_FORMS):
                 continue
             context = _line_context(lines, index)
-            if not any(marker in context for marker in UNSHIPPED_CONTEXT_MARKERS):
+            if not any(marker in context for marker in GUIDED_ORCHESTRATION_CONTEXT_MARKERS):
                 failures.append(
-                    f"{rel}:{index + 1}: /mb-start launch must be marked unshipped/future"
+                    f"{rel}:{index + 1}: /mb-start launch must be framed as "
+                    "guided skill orchestration"
                 )
 
     assert failures == []

--- a/mb/tests/test_runtime_command_references.py
+++ b/mb/tests/test_runtime_command_references.py
@@ -16,10 +16,8 @@ GUIDED_ORCHESTRATION_FORMS = ("/mb-start launch",)
 GUIDED_ORCHESTRATION_CONTEXT_MARKERS = (
     "guided",
     "orchestration",
-    "route",
-    "routing",
-    "walk",
-    "skill",
+    "skill orchestration",
+    "guided skill",
     "follows the same contract",
 )
 

--- a/mb/tests/test_validate.py
+++ b/mb/tests/test_validate.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 
 from typer.testing import CliRunner
@@ -12,6 +13,7 @@ from mb.cli import app
 from mb.validate import run
 
 runner = CliRunner()
+REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 def _write(p: Path, body: str) -> None:
@@ -54,6 +56,29 @@ def test_validate_passes_well_formed(tmp_path: Path) -> None:
     report = run(path=str(tmp_path))
     assert report["ok"] is True
     assert all(f["ok"] for f in report["files"])
+
+
+def test_keyword_gate_documented_frontmatter_validates(tmp_path: Path) -> None:
+    guide = REPO_ROOT / ".claude" / "skills" / "mb-think" / "references" / "keyword-gate.md"
+    text = guide.read_text(encoding="utf-8")
+    match = re.search(r"Frontmatter:\n\n```yaml\n(?P<frontmatter>---\n.*?\n---)\n```", text, re.S)
+    assert match is not None
+
+    frontmatter = (
+        match.group("frontmatter")
+        .replace("YYYY-MM-DD", "2026-05-08")
+        .replace("offer-slug", "workshop")
+        .replace("core/offers/<offer>/offer.md", "core/offers/workshop/offer.md")
+    )
+    _write(
+        tmp_path / "research" / "2026-05-08-keyword-gate-workshop.md",
+        f"{frontmatter}\n\n# Keyword Gate\n",
+    )
+
+    report = run(path=str(tmp_path))
+
+    assert report["ok"] is True
+    assert all(file["ok"] for file in report["files"])
 
 
 def test_validate_flags_missing_status(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Adds guided `/mb-start launch <offer>` orchestration for the current offer-launch path.
- Adds `/mb-think` keyword-gate research guidance with Build / Build with caution / Kill verdicts and validator-backed frontmatter.
- Replaces the one-page lander stub with current `/mb-site` lander build and generation guidance tied to pushes, OG rules, measurement checks, and approval gates.
- Adds `/mb-ads` launch-plan/check guidance for provider-safe campaign plans, readiness states, policy checks, and manual approval records without claiming live provider mutation.

## Scope
- In: bundled Claude Code skill guidance, runtime command reference guardrails, keyword-gate frontmatter validation coverage, and the `[Unreleased]` changelog entry.
- Out: live Google Ads/GTM/Stripe/Cloudflare/Meta mutations, new `mb` workflow/model runners, new schema beyond existing push/playbook contracts, and non-Claude runtime support claims.

## Commits
- `e011b44` — `[update] MAIN-89 guide offer launch orchestration`.
- `2cc765a` — `[fix] MAIN-89 validate keyword gate template`.

## Release / Issues
- Release: Unreleased / next v0.3.x.
- Linear ID(s): MAIN-89.
- Closes: #89.
- Refs: #147, #273, #279, #286, #350, #357, #358.
- Follow-ups: interactive Claude Code transcript smoke for `/mb-start launch <offer>` before using this as release-bearing runtime evidence.

## Success Metric
- A noob user can move from offer idea to keyword-gated launch push, lander/ad plan, and checkpoint/status evidence through one guided `/mb-start` path while power users can still invoke `/mb-think`, `/mb-site`, and `/mb-ads` directly.

## Validation
- Level 0 docs/decision: reviewed skill and changelog diff for stale claims, provider mutation boundaries, and public/private boundary.
- Level 1 static: `scripts/check.sh` passed from repo root.
- Level 2 CLI: focused runtime reference guard passed; keyword-gate documented frontmatter now round-trips through `mb validate`.
- Level 3 package/install: not run; package entrypoints, install behavior, and bundled-data wiring were not changed.
- Level 4 fixture repo: not run; scaffold/schema behavior was not changed.
- Level 5 runtime smoke: not run; this changes skill guidance and tests, not skill discovery or runtime adapter wiring.

## Public / Private Boundary
- Kept Devon/Conductor-only coordination in `.context/`; committed files contain public OSS skill guidance, tests, and changelog only.
