### PR TITLE
[fix] Retire legacy .vip YAML state

### DIFF
--- a/.claude/reference/domain-rubrics/multi-offer.md
+++ b/.claude/reference/domain-rubrics/multi-offer.md
@@ -78,10 +78,9 @@ offer-specific. Otherwise, brand-level `core/proof/testimonials.md` suffices.
 
 ## File Resolution Rules
 
-Skills resolve context files using a cascading lookup. Active offer state is
-repo-local operational state. If a future `mb` JSON field exposes active offer
-state, prefer it; `.vip/local.yaml` is a legacy fallback only and should not be
-written silently.
+Skills resolve context files using a cascading lookup. Active offer choice is
+session-scoped unless a current `mb` JSON field exposes explicit active-offer
+state. `.vip/local.yaml` is legacy audit input, not canonical routing state.
 
 ### Always Core (Never Per-Offer)
 
@@ -118,8 +117,9 @@ resolve_context(file_type):
   if file_type in [content-strategy]:
     return core/content-strategy.md
 
-  # Offer-aware -- check active offer first
-  current_offer = read a future mb JSON active-offer field if present, otherwise .vip/local.yaml as legacy fallback
+  # Offer-aware -- check explicit active offer first
+  current_offer = read a future mb JSON active-offer field if present,
+                  otherwise ask the user/session
 
   if current_offer AND exists core/offers/{current_offer}/{file_type}.md:
     return core/offers/{current_offer}/{file_type}.md
@@ -132,28 +132,27 @@ resolve_context(file_type):
 
 ## Session Offer Context
 
-Current repos should treat offer choice as session-scoped until the operator
-confirms persistence. If a deterministic `mb` command or status JSON field
-exposes active offer state, use that. Existing repos may still have legacy
-`.vip/local.yaml`:
-
-```yaml
-current_offer: community    # Legacy active offer fallback
-```
+Current repos should treat offer choice as session-scoped until an explicit
+Main Branch session-state contract exists and the operator confirms
+persistence. If a deterministic `mb` command or status JSON field exposes active
+offer state, use that. Existing repos may still have legacy `.vip/local.yaml`,
+but skills should not silently route from it.
 
 **Rules:**
 - Repo-local session state is local operational state, not durable business
   truth.
-- `/mb-start` may read `.vip/local.yaml` as a legacy fallback, but must ask
-  before writing or changing it.
+- `/mb-start` should use `mb doctor repair --plan --json` to audit legacy
+  `.vip` files and ask the operator which offer to use when routing is unclear.
+- Skills must not write or change `.vip/local.yaml`.
 - If active offer state is missing or null: brand-level mode reads from
   `core/`.
 - Skills should never fail because active offer state is missing. They fall
   back to brand-level behavior or ask which offer the current work targets.
 
 **The `.vip/` folder** is legacy local state/config. Never commit session state.
-Current doctor guidance surfaces stale `.vip/local.yaml` so the operator can
-review it instead of letting skills silently update it.
+Current doctor guidance surfaces stale `.vip/local.yaml` and `.vip/config.yaml`
+so the operator can review key families instead of letting skills silently use
+or update them.
 
 ---
 

--- a/.claude/skills/mb-ads/SKILL.md
+++ b/.claude/skills/mb-ads/SKILL.md
@@ -298,11 +298,13 @@ These patterns that work in standard ads will get rejected in Employment:
 
 Before loading reference files, resolve the active offer:
 
-1. If a future `mb` JSON field exposes active offer state, use it; otherwise read `.vip/local.yaml` only as a legacy fallback
-2. If set: load `core/offers/[current_offer]/offer.md` as the active offer
-3. If not set AND `core/offers/` exists: ask which offer
-4. If no `core/offers/` folder: use `core/offer.md` (single-offer mode)
-5. Legacy fallback: if the repo does not have `core/`, read the old
+1. If a future `mb` JSON field exposes active offer state, use it.
+2. Do not treat `.vip/local.yaml` as canonical active-offer state. If legacy
+   state exists, confirm the offer with the user instead of silently routing.
+3. If an offer is selected and `core/offers/[offer]/offer.md` exists, load it as the active offer.
+4. If no offer is selected AND `core/offers/` exists: ask which offer.
+5. If no `core/offers/` folder: use `core/offer.md` (single-offer mode)
+6. Legacy fallback: if the repo does not have `core/`, read the old
    `reference/core/` and `reference/offers/` paths.
 
 In current repos, `reference/core` and `reference/offers` are compatibility
@@ -315,7 +317,7 @@ paths.
 **Accumulate files** (load both): `testimonials.md` (offer-specific + brand-level)
 
 **Offer argument:** `/mb-ads [mode] [offer] [campaign]` — e.g., `/mb-ads static community january-launch`
-If offer specified, overrides session `current_offer` for this run.
+If offer specified, it selects the offer for this run only.
 
 ---
 
@@ -431,7 +433,7 @@ Before saving any batch, verify:
 
 If context was compacted mid-task, check:
 
-1. **Which offer?** Use a future `mb` JSON active-offer field if present; otherwise read `.vip/local.yaml` only as a legacy fallback, to restore offer context
+1. **Which offer?** Use a future `mb` JSON active-offer field if present; otherwise ask the user to restore offer context. Do not silently route from `.vip/local.yaml`.
 2. **What entry point?** Full pipeline, copy only, hook library, video scripts, review, account check
 3. **What stage?** Planning angles, writing hooks, generating prompts, reviewing, pulling account data
 4. **What's done?** Check `pushes/` (and legacy `campaigns/` on unmigrated repos) for partial work

--- a/.claude/skills/mb-ads/references/preflight-algorithm.md
+++ b/.claude/skills/mb-ads/references/preflight-algorithm.md
@@ -40,8 +40,10 @@ Score each file 0-3 based on line count + section presence.
 
 Use canonical path resolution for offer and audience files (multi-offer aware):
 
-1. If a future `mb` JSON field exposes active offer state, use it; otherwise read `.vip/local.yaml` only as a legacy fallback
-2. If `current_offer` is set and `core/offers/{current_offer}/offer.md` exists, score that file
+1. If a future `mb` JSON field exposes active offer state, use it. Otherwise
+   ask the user which offer this work is for; do not silently route from
+   `.vip/local.yaml`.
+2. If an offer is selected and `core/offers/{offer}/offer.md` exists, score that file
 3. Otherwise fall back to `core/offer.md`
 4. Same resolution for `audience.md`
 5. Legacy fallback: if `core/` is absent, read old `reference/core/` and

--- a/.claude/skills/mb-end/SKILL.md
+++ b/.claude/skills/mb-end/SKILL.md
@@ -55,7 +55,7 @@ A quick `/mb-end` (user says "just commit and close") can be steps 1-3 and 6. Bu
 
 ## Step 1: Find the Business Repo
 
-**CWD-first:** If `core/` or legacy `reference/core/` exists in CWD, you're already in the business repo — use it. Otherwise, read `~/.config/vip/local.yaml` for `default_repo` as fallback.
+**CWD-first:** If `core/` or legacy `reference/core/` exists in CWD, you're already in the business repo — use it. Otherwise, read `~/.config/vip/local.yaml` for `default_repo` only as a legacy machine-local fallback.
 
 **If no repo found:** Skip to a simple close. No business repo means no git activity to scan.
 
@@ -114,7 +114,7 @@ For the full bash (vip script resolution + fallback strict status counter), expe
 
 Present a brief, warm summary. Not a report -- a reflection.
 
-**Offer context:** If a future `mb` JSON active-offer field or legacy `.vip/local.yaml` identifies an active offer, include in summary:
+**Offer context:** If a future `mb` JSON active-offer field or explicit session context identifies an active offer, include in summary:
 "Worked on: **[offer]**"
 
 **Format (adapt to what actually happened):**
@@ -217,7 +217,7 @@ Task(
 
 **Agent prompt construction:** Build a structured prompt containing all gathered content from 5b, plus the agent instructions. See [references/crystallize-agent.md](references/crystallize-agent.md) for the complete agent prompt template, analysis process, anti-patterns, and question design criteria.
 
-**Pass to crystallize agent:** Include active offer from a future `mb` JSON field if present, with `.vip/local.yaml` only as a legacy fallback, so the agent can analyze offer-specific core changes and ask offer-relevant questions.
+**Pass to crystallize agent:** Include active offer from a future `mb` JSON field or explicit session context if present, so the agent can analyze offer-specific core changes and ask offer-relevant questions. Do not silently restore offer context from `.vip/local.yaml`.
 
 **The agent is read-only.** It reads files and returns findings. It does not write files. The main conversation handles all file writes.
 

--- a/.claude/skills/mb-help/references/troubleshooting.md
+++ b/.claude/skills/mb-help/references/troubleshooting.md
@@ -278,9 +278,9 @@ user:
   experience: intermediate  # beginner | intermediate | advanced
 ```
 
-**Check repo config (team settings):**
+**Audit legacy repo config/state if present:**
 ```bash
-cat /path/to/your/repo/.vip/config.yaml
+mb doctor repair --repo /path/to/your/repo --plan --json
 ```
 
 **Common fixes:**
@@ -290,7 +290,7 @@ cat /path/to/your/repo/.vip/config.yaml
 | No `~/.config/vip/local.yaml` | Run `/mb-start` — it will discover your repo and can save the path |
 | Path is wrong | Run `/mb-start` and select your repo when prompted, say "yes" to save |
 | Folder was moved | Delete `~/.config/vip/local.yaml` and run `/mb-start` again |
-| No `.vip/config.yaml` in repo | Run `/mb-start` — it will offer to create config for faster startups |
+| `.vip/config.yaml` exists | Audit it with `mb doctor repair --plan --json`; do not treat it as current team settings |
 
 **Migration from old system:**
 If you have an old `~/.claude/settings.json` with `business_repo_path`, run `mb skill link --repo .`, then `mb start --json`. The current architecture uses `.claude/settings.local.json` in your business repo to load the active Main Branch engine as an additional directory.
@@ -299,19 +299,20 @@ If you have an old `~/.claude/settings.json` with `business_repo_path`, run `mb 
 
 ## Config System Explained
 
-See `mb-start/references/config-system.md` for the full canonical reference on the config system.
+See `mb-start/references/config-system.md` for the current legacy-config cleanup guidance.
 
-**Two files, different purposes:**
+**Legacy files, different purposes:**
 
 | File | Location | What's In It | Git-tracked? |
 |------|----------|--------------|--------------|
 | `local.yaml` | `~/.config/vip/` | Default repo, your name, your experience level | No (personal) |
-| `config.yaml` | `[repo]/.vip/` | Team settings, MCP requirements, skill defaults | Yes (shared) |
+| `config.yaml` | `[repo]/.vip/` | Old mixed config/state that needs audit before reuse | Maybe old repos tracked it |
 
 **Why the split?**
 - Multiple people can work on the same business repo
 - Alice can be "advanced" while Bob is "beginner"
-- Team settings (infrastructure, MCPs) travel with the repo
+- Current provider/readiness metadata should come from `mb connect`, generated
+  repo instructions, and durable business files, not `.vip/config.yaml`
 - Personal settings stay on your machine
 
 **To reset everything:**

--- a/.claude/skills/mb-organic/SKILL.md
+++ b/.claude/skills/mb-organic/SKILL.md
@@ -109,11 +109,13 @@ For the full mining methodology (Visual/Audible/Emotional framework, AI capabili
 
 Before loading reference files, resolve the active offer:
 
-1. If a future `mb` JSON field exposes active offer state, use it; otherwise read `.vip/local.yaml` only as a legacy fallback
-2. If set: load `core/offers/[current_offer]/offer.md` as the active offer
-3. If not set AND `core/offers/` exists: ask which offer
-4. If no `core/offers/` folder: use `core/offer.md` (single-offer mode)
-5. Legacy fallback: if the repo does not have `core/`, read the old
+1. If a future `mb` JSON field exposes active offer state, use it.
+2. Do not treat `.vip/local.yaml` as canonical active-offer state. If legacy
+   state exists, confirm the offer with the user instead of silently routing.
+3. If an offer is selected and `core/offers/[offer]/offer.md` exists, load it as the active offer.
+4. If no offer is selected AND `core/offers/` exists: ask which offer.
+5. If no `core/offers/` folder: use `core/offer.md` (single-offer mode)
+6. Legacy fallback: if the repo does not have `core/`, read the old
    `reference/core/` and `reference/offers/` paths.
 
 In current repos, `reference/core` and `reference/offers` are compatibility
@@ -126,7 +128,7 @@ files. Read through them only as fallback, and write once to the canonical
 **Accumulate files** (load both): `testimonials.md` (offer-specific + brand-level)
 
 **Offer argument:** `/mb-organic video [offer] "concept"` — e.g., `/mb-organic video community "morning routine"`
-If offer specified, overrides session `current_offer` for this run.
+If offer specified, it selects the offer for this run only.
 
 ---
 

--- a/.claude/skills/mb-setup/SKILL.md
+++ b/.claude/skills/mb-setup/SKILL.md
@@ -170,7 +170,6 @@ See **[references/context-gathering.md](references/context-gathering.md)** for:
 
 ```bash
 # Always create:
-mkdir -p .vip
 mkdir -p core core/offers core/finance core/brand core/proof/angles core/operations
 mkdir -p research decisions bets log pushes documents
 ```
@@ -189,9 +188,9 @@ for offer in [offer-names]; do
 done
 
 # Ask before persisting active-offer state. Offer choice can stay session-scoped.
-# If the operator explicitly approves a saved active offer and no CLI command
-# exists yet, ensure .vip/local.yaml is gitignored, then merge-write the legacy
-# fallback without overwriting unrelated keys.
+# Do not write .vip/local.yaml as the active-offer mechanism.
+# Keep the choice session-scoped unless a future mb command exposes an explicit
+# session-state contract and the operator confirms persistence.
 
 # Create product-ladder.md placeholder at core/product-ladder.md
 touch core/product-ladder.md
@@ -204,9 +203,6 @@ Full structure (single-offer):
 ├── README.md              # Human-readable overview
 ├── .env                   # Secrets (gitignored)
 ├── .gitignore             # Include .env
-│
-├── .vip/                  # Legacy local config/state
-│   └── config.yaml        # User preferences, infrastructure refs
 │
 ├── core/                  # Evergreen business brain
 │   ├── soul.md            # Why you exist
@@ -248,19 +244,18 @@ Full structure (multi-offer — adds offer folders and `product-ladder.md`):
 │       │   └── offer.md   # Offer-specific details
 │       └── course/
 │           └── offer.md
-└── .vip/
-    ├── config.yaml        # Legacy team settings
-    └── local.yaml         # Git-IGNORED session state (current_offer)
 ```
 
 ### 4a. API Key Environment, Config, and .gitignore
 
 See **[references/repo-scaffolding.md](references/repo-scaffolding.md)** for:
 - API key environment setup (`~/.config/vip/env.sh`)
-- Legacy `.vip/config.yaml` template (includes `mcps:` section for older MCP tracking)
+- Legacy `.vip` cleanup guidance
 - `.gitignore` creation
 
-Run these steps in order: create env.sh, add shell source line, create config.yaml, create .gitignore.
+Run these steps in order: create env.sh when needed, add shell source line when
+approved, and create `.gitignore`. Do not create `.vip/config.yaml` for new
+repos.
 
 ### 5. Sort Content into Files
 

--- a/.claude/skills/mb-setup/references/migration-multi-offer.md
+++ b/.claude/skills/mb-setup/references/migration-multi-offer.md
@@ -36,10 +36,8 @@ If `core/offer.md` exists and no `offers/` folder: this is a migration.
    mkdir -p core/operations
    # (product-ladder.md will be written below)
 
-   # Active offer starts as session-scoped. Ask before persisting local state.
-   # If the operator approves and no CLI command exists yet, merge-write the
-   # legacy .vip/local.yaml fallback without overwriting unrelated keys.
-   # Ensure .vip/local.yaml is gitignored before any fallback write.
+   # Active offer stays session-scoped. Do not write .vip/local.yaml as the
+   # active-offer mechanism.
    ```
 
 5. **Write new brand-level `core/offer.md`:**

--- a/.claude/skills/mb-setup/references/repo-scaffolding.md
+++ b/.claude/skills/mb-setup/references/repo-scaffolding.md
@@ -60,98 +60,21 @@ fi
 
 **Progressive disclosure:** Don't overwhelm beginners with API setup. The env.sh exists but stays empty until they need it.
 
-## Create Initial Config
+## Legacy .vip Config
 
-Create `.vip/config.yaml` with team/business settings:
+Do not create `.vip/config.yaml` for new repos. Older repos may already have it
+with mixed business facts, MCP requirements, tool snapshots, infrastructure
+refs, content defaults, skill defaults, private paths, or client context.
 
-```yaml
-# .vip/config.yaml
-# VIP configuration for this business
-# Git-tracked, shared by all collaborators
-# NOTE: User identity (name, experience) is in ~/.config/vip/local.yaml
+Audit old files with:
 
-version: 1
-
-# === SESSION (Team Defaults) ===
-session:
-  auto_load_reference: true
-  show_context_tips: true  # Context management tips for beginners
-  warn_at_context_pct: 75
-
-# === INFRASTRUCTURE ===
-# Populated when services are connected
-infrastructure:
-  railway:
-    project_id: null
-  postiz:
-    api_url: null
-    api_key_ref: null  # keychain:vip/postiz or env:POSTIZ_API_KEY
-  r2:
-    bucket: null
-    public_url: null
-
-# === MCP SERVERS ===
-# Track which MCPs this business needs
-# /mb-start verifies these are installed, prompts setup if missing
-mcps:
-  apify:
-    required_for: [organic, think]  # Handles web scraping AND YouTube transcripts
-    setup_guide: ".claude/skills/mb-organic/references/apify-setup.md"
-
-# === TOOL STATUS CACHE (self-healing) ===
-# /mb-start and /mb-think update these over time.
-# Rule: every tool entry keeps status + notes + last_checked.
-tools:
-  apify:
-    status: null
-    notes: "unknown"
-    last_checked: null
-  gemini:
-    status: null
-    notes: "unknown"
-    last_checked: null
-  grok:
-    status: null
-    notes: "unknown"
-    last_checked: null
-  whisper:
-    status: null
-    notes: "unknown"
-    last_checked: null
-  nanobanana:
-    status: null
-    notes: "unknown"
-    last_checked: null
-  markitdown:
-    status: null
-    notes: "unknown"
-    last_checked: null
-  pandoc:
-    status: null
-    notes: "unknown"
-    last_checked: null
-  marker:
-    status: null
-    notes: "unknown"
-    last_checked: null
-  meta_ads:
-    status: null
-    method: official_connector_pending
-    notes: "unknown"
-    last_checked: null
-
-# === CONTENT ===
-content:
-  default_channels: []
-  require_review: true
-
-# === SKILL PREFERENCES ===
-skills:
-  ads:
-    default_format: static
-  think:
-    auto_create_tasks: false
+```bash
+mb doctor repair --plan --json
 ```
+
+Move only still-current, non-private facts into current surfaces such as
+`core/`, `core/operations/`, generated repo instructions, or provider metadata
+managed through `mb connect`. Keep credentials and machine-specific paths local.
 
 ## Create .gitignore
 
@@ -209,6 +132,7 @@ done
 **Why per-skill entries (not `.claude/skills/`):** Users have custom skills (deck, pr-review, etc.) that ARE tracked in git. Ignoring the whole folder would hide those. We only ignore the Main Branch-linked symlinks. Old clone-based `.claude/lenses/` and `.claude/reference/` dirs are legacy link dirs; repair them with `mb doctor repair` instead of teaching them as current setup.
 
 **Why legacy `.vip/local.yaml` is git-ignored:** Older repos may have stored
-session state like `current_offer` there. Treat it as local fallback state, not
-durable business truth, and ask before writing it. The git-tracked
-`.vip/config.yaml` holds team/business settings that should be shared.
+session state like `current_offer` there. Treat it as audit input, not durable
+business truth, and do not write it as the active-offer mechanism. Older
+`.vip/config.yaml` files may have been tracked as shared settings; audit them
+with `mb doctor repair --plan --json` before reusing any values.

--- a/.claude/skills/mb-site/references/site-context.md
+++ b/.claude/skills/mb-site/references/site-context.md
@@ -36,10 +36,12 @@ to pass. Porkbun skipped is fine for the Cloudflare-registered path.
 
 Before loading business context, resolve the active offer:
 
-1. If a future `mb` JSON field exposes active offer state, use it; otherwise read `.vip/local.yaml` only as a legacy fallback.
-2. If set, load `core/offers/[current_offer]/offer.md` as the active offer.
-3. If not set and `core/offers/` exists, ask which offer this site is for.
-4. If no `core/offers/` folder exists, use `core/offer.md` for a single-offer repo.
+1. If a future `mb` JSON field exposes active offer state, use it.
+2. Do not treat `.vip/local.yaml` as canonical active-offer state. If legacy
+   state exists, confirm the offer with the user instead of silently routing.
+3. If an offer is selected and `core/offers/[offer]/offer.md` exists, load it as the active offer.
+4. If no offer is selected and `core/offers/` exists, ask which offer this site is for.
+5. If no `core/offers/` folder exists, use `core/offer.md` for a single-offer repo.
 
 Always-core files, never per-offer: `soul.md`, `voice.md`, `content-strategy.md`.
 

--- a/.claude/skills/mb-start/SKILL.md
+++ b/.claude/skills/mb-start/SKILL.md
@@ -92,7 +92,10 @@ ads with `/mb-ads`, and checkpoint approved artifacts.
 - CWD has `core/` or legacy `reference/core/` — user chose their repo by cd'ing into it
 - User explicitly ran `/mb-start [repo-name]` with a specific path
 
-**After user selects a repo:** If the selected repo is not the current `default_repo`, ask: "Want me to save [repo-name] as your default? (faster startup next time)" If yes, update `default_repo` in `~/.config/vip/local.yaml`.
+**After user selects a repo from legacy fallback config:** If the selected repo
+is not the current `default_repo`, ask: "Want me to save [repo-name] as your
+default? (faster startup next time)" If yes, merge-update `default_repo` in
+`~/.config/vip/local.yaml`. Do not create or update `.vip/config.yaml`.
 
 ---
 
@@ -188,7 +191,8 @@ The user starts Claude in their business repo. Check CWD first before falling ba
 ```
 1. test -d "core" || test -d "reference/core"  → THIS IS the business repo. Skip to config.
 2. test -f ".claude/skills/mb-start/SKILL.md"  → user is in the engine repo; migrate.
-3. Otherwise → fall back to ~/.config/vip/local.yaml.
+3. Otherwise → fall back to `~/.config/vip/local.yaml` only as legacy
+   machine-local repo memory.
 ```
 
 See **[references/repo-detection.md](references/repo-detection.md)** for the full flow: CWD detection, migration guidance for users in the engine repo, config loading, multi-repo selection, the discovery algorithm when no config exists, the canonical `REPO_PATH` variable, and the Main Branch wiring verification block.
@@ -334,7 +338,9 @@ files already exist, read enough of those files to avoid asking for facts the
 repo already contains. Keep this bounded: summarize the existing facts and ask
 only for confirmation or missing profile fields.
 
-**Multi-offer context:** If `current_offer` is set (see Step 8), note the active offer for routing. Don't load the offer file — the selected skill will.
+**Multi-offer context:** If an active offer is explicit in CLI facts or the
+current session (see Step 8), note it for routing. Don't load the offer file —
+the selected skill will.
 
 ---
 
@@ -354,11 +360,12 @@ also absent, use `reference/offers` as the fallback. In current repos,
 
 **If offers/ found:** Multi-offer mode.
 1. Check current CLI status facts first. If a future `mb` JSON field exposes
-   active-offer local state, prefer that. If not, read `.vip/local.yaml` only as
-   a legacy fallback.
-2. If a legacy active offer is set, confirm in plain language:
-   "I see legacy session state for **[offer]**. Continue with that offer, work
-   brand-level, or switch?"
+   active-offer local state, prefer that. Do not silently route from
+   `.vip/local.yaml`.
+2. If legacy active-offer state is present, do not treat it as canonical. Say:
+   "This repo has old active-offer session state. Continue with that offer,
+   work brand-level, or switch?" Avoid echoing raw `.vip` values unless the
+   user asks to inspect the file.
 3. If no active offer is set, present offers by slug/name, not numbers when
    ranked actions or routes are already numbered:
    - `community` — paid community
@@ -368,18 +375,17 @@ also absent, use `reference/offers` as the fallback. In current repos,
    persistence. Say what will happen before writing local state:
    "For this session I'll use **[offer]**. Save that as the active offer for
    future sessions too?"
-5. Only after explicit confirmation, persist with the current supported
-   repo-local state path. If no CLI command exists yet, `.vip/local.yaml` is a
-   legacy fallback; merge-write it without overwriting unrelated keys. Do not
-   use `echo > .vip/local.yaml`.
+5. Keep the selection session-scoped. Do not write `.vip/local.yaml` as the
+   active-offer mechanism. If a future `mb` command exposes an explicit
+   session-state contract, use that only after confirmation.
 
 **Shortcut:** `/mb-start [offer-name]` selects that offer for the current
 session after validating the folder exists. It does not silently persist
 session state. Ask before saving it as the future active offer.
 
 **"all" selection:** When user picks "all" or "brand-level work", use brand
-level `core/` context for this session. Ask before persisting any local state
-that clears an active offer.
+level `core/` context for this session. Ask before persisting any future local
+state that clears an active offer.
 
 ---
 
@@ -405,7 +411,7 @@ to `/mb-think`.
 
 **Respect readiness gates from Step 6.** If status is MINIMAL or EMPTY, do not offer output skills. If THIN, warn. See [readiness-assessment.md](references/readiness-assessment.md) for skill-specific requirements.
 
-**Show context:** Before presenting options, show: "Business: **[repo name]** | Offer: **[current_offer or 'single']**"
+**Show context:** Before presenting options, show: "Business: **[repo name]** | Offer: **[active offer or 'single']**"
 
 **Surface unread CHANGELOG entries before the menu**, present the triage route
 without reusing a number from recommendations or offers, and use the "while you
@@ -430,10 +436,10 @@ skip triage.
 ## Context And Experience
 
 Fresh context gets a fuller load; working context routes directly; heavy context
-gets a brief warning; critical context routes to `/mb-end`. Read
-`user.experience` from `~/.config/vip/local.yaml`: beginner explains more,
-returning confirms quickly, expert routes fast. If the user asks for a faster
-mode, offer to update local experience.
+gets a brief warning; critical context routes to `/mb-end`. If legacy
+`~/.config/vip/local.yaml` has `user.experience`, use it as a machine-local
+fallback: beginner explains more, returning confirms quickly, expert routes
+fast. If the user asks for a faster mode, offer to update local experience.
 
 ---
 
@@ -464,11 +470,10 @@ Auto-detect user intent and route. Skills: `/mb-update`, `/mb-help`, `/mb-setup`
 
 ## Recovering from Compaction
 
-If re-invoked after compaction: re-read `~/.config/vip/local.yaml` for repo +
-identity, then use status/CLI facts for active offer if available. Read
-`.vip/local.yaml` in the business repo only as a legacy fallback for
-`current_offer`. Confirm the restored context, but do not write local state
-without explicit approval.
+If re-invoked after compaction: use CWD and `mb status --json --peek` first.
+Read `~/.config/vip/local.yaml` only as legacy fallback for repo + identity.
+Treat business-repo `.vip/local.yaml` as audit input only; confirm offer
+context from the user or current CLI facts, and do not write `.vip` state.
 
 ---
 

--- a/.claude/skills/mb-start/references/config-system.md
+++ b/.claude/skills/mb-start/references/config-system.md
@@ -1,6 +1,8 @@
-# Config System
+# Legacy Config Cleanup
 
-Four-file system: Main Branch engine linkage, personal settings, team settings, and API keys — each in the right place.
+Main Branch now treats `.vip/*.yaml` as legacy cleanup/audit input. Runtime
+skills should prefer CWD-first repo detection, `mb status --json --peek`,
+`mb connect`, `mb onboard`, and current repo files over `.vip` YAML.
 
 ---
 
@@ -9,15 +11,18 @@ Four-file system: Main Branch engine linkage, personal settings, team settings, 
 | File | Location | Purpose | Git-tracked? |
 |------|----------|---------|--------------|
 | `settings.local.json` | `[repo]/.claude/` | Grants Claude Code file access to the active Main Branch engine | No (auto git-ignored by Claude Code) |
-| `local.yaml` | `~/.config/vip/` | Legacy machine-local file for user identity, engine path, and default repo | No |
+| `local.yaml` | `~/.config/vip/` | Legacy machine-local fallback for user identity, engine path, and default repo | No |
 | `env.sh` | `~/.config/vip/` | API keys for optional research tools | No |
-| `config.yaml` | `[repo]/.vip/` | Team/business settings, MCP requirements | Yes |
+| `config.yaml` | `[repo]/.vip/` | Legacy mixed repo config that must be audited before reuse | Maybe old repos tracked it |
 
 **Key split:**
 - **Settings** = "Where is Main Branch?" (per-repo, per-machine — `.claude/settings.local.json`)
-- **Local** = "Who am I? What repo do I want?" (per-person, per-machine)
+- **Local** = "Who am I? What repo do I want?" legacy fallback (per-person, per-machine)
 - **Env** = "What API keys do I have?" (per-person, sourced by shell)
-- **Repo** = "How does this business/team operate?" (shared)
+- **Repo** = current business truth in `core/`, `research/`, `decisions/`,
+  `bets/`, `pushes/`, `log/`, `documents/`, `.mb/connect.yaml`, and generated
+  repo instructions. Do not use `.vip/config.yaml` as the current shared
+  settings surface.
 
 ### .claude/settings.local.json (Main Branch linkage)
 
@@ -157,21 +162,21 @@ last_seen_version: "0.1.0"
 
 ---
 
-## Business Repo Config (Team Settings)
+## Legacy Business Repo Config Audit
 
 ```bash
-cat [repo]/.vip/config.yaml 2>/dev/null
+mb doctor repair --plan --json
 ```
 
-Key fields:
-- `session.auto_load_reference` → Load core/ automatically
-- `session.show_context_tips` → Team default for tips
-- `mcps` → Required MCP servers for this business
-- `tools` → Cached tool status (`status`, `notes`, `last_checked`) for self-healing detection in `/mb-start` and `/mb-think`
-- `infrastructure` → Shared team resources (Postiz, hosted tools, self-hosted services, etc.)
-- `skills` → Team defaults for skill behavior
+Older repos may have `[repo]/.vip/config.yaml` with mixed key families:
+business facts, MCP requirements, tool snapshots, infrastructure refs, content
+defaults, skill defaults, client repo pointers, and old reference-structure
+notes.
 
-**Note:** `user.name` and `user.experience` are NOT here — they're in local.yaml.
+Do not load it as current truth. The doctor repair plan classifies keys without
+printing raw values so private paths, provider notes, client context, and
+credentials are not copied into chat or durable files. Move only still-current,
+non-private facts into the appropriate current surface after operator review.
 
 ---
 
@@ -191,14 +196,12 @@ cat ~/.claude/settings.json 2>/dev/null | grep business_repo_path
 
 ---
 
-## Creating Missing Config
+## Missing Legacy Config
 
 If repo has `core/` or legacy `reference/core/` but no `.vip/config.yaml`:
 
-> "Your repo exists but doesn't have VIP config. Create it?
-> Benefits: faster startups, synced preferences, MCP tracking."
-
-If yes → Create `.vip/config.yaml` with defaults from `/mb-setup`.
+Do not create it. Use `mb status --json --peek`, `mb onboard status --json`,
+`mb connect plan`, and current repo files instead.
 
 ---
 
@@ -217,10 +220,9 @@ If yes → Create `.vip/config.yaml` with defaults from `/mb-setup`.
 
 | Skill | Reads | Purpose |
 |-------|-------|---------|
-| `/mb-start` | local.yaml | Find default repo, get user experience level |
-| `/mb-start` | repo config | Check MCP requirements, session preferences |
-| `/mb-help` | local.yaml | Adjust verbosity based on experience |
-| Any skill | repo config `skills.*` | Get skill-specific preferences |
+| `/mb-start` | legacy local.yaml only when CWD/config discovery fails | Find default/recent repos as fallback |
+| `/mb-start` | `mb status --json --peek`, `mb connect`, `mb onboard` | Check readiness, repairs, onboarding, provider state |
+| `/mb-help` | legacy local.yaml only as optional fallback | Adjust verbosity based on experience |
 | `/mb-ads`, `/mb-think` | local.yaml `media.*` | Resolve where non-markdown outputs go |
 
 ---
@@ -229,11 +231,11 @@ If yes → Create `.vip/config.yaml` with defaults from `/mb-setup`.
 
 | Trigger | What's Written | Where |
 |---------|----------------|-------|
-| `/mb-setup` first run | Full local.yaml + repo config | Both files |
-| User selects repo in `/mb-start` | `default_repo`, `recent_repos` | local.yaml |
+| `/mb-setup` first run | Current repo files, `.claude/settings.local.json`, skill links, `.mb/` state | Business repo |
+| User selects repo in `/mb-start` | `default_repo`, `recent_repos` only if legacy fallback is still being used and user confirms | local.yaml |
 | User says "I'm advanced" | `user.experience` | local.yaml |
-| User says "save as default" | Skill preference | repo config `skills.*` |
-| User connects infrastructure | `infrastructure.*` | repo config |
+| User says "save as default" | Prefer current skill/workflow inputs; do not write `.vip/config.yaml` |
+| User connects infrastructure | Provider metadata through `mb connect`; secrets stay local | `.mb/connect.yaml` and local secret stores |
 | User configures media path | `media.root` or `media.{type}` | local.yaml |
 
 **Rule:** Never write silently. Confirm changes that affect future sessions.
@@ -263,7 +265,7 @@ Config is always optional. Skills work without it.
 
 ```
 1. Try local.yaml → missing? → discovery
-2. Try repo config → missing? → use defaults
+2. Use `mb status --json --peek`, `mb connect`, and repo files for current facts
 3. Path invalid? → attempt recovery, then clear and rediscover
 4. Parse error? → warn, clear, rediscover
 ```

--- a/.claude/skills/mb-start/references/config-system.md
+++ b/.claude/skills/mb-start/references/config-system.md
@@ -234,7 +234,7 @@ Do not create it. Use `mb status --json --peek`, `mb onboard status --json`,
 | `/mb-setup` first run | Current repo files, `.claude/settings.local.json`, skill links, `.mb/` state | Business repo |
 | User selects repo in `/mb-start` | `default_repo`, `recent_repos` only if legacy fallback is still being used and user confirms | local.yaml |
 | User says "I'm advanced" | `user.experience` | local.yaml |
-| User says "save as default" | Prefer current skill/workflow inputs; do not write `.vip/config.yaml` |
+| User says "save as default" | Prefer current skill/workflow inputs; do not write `.vip/config.yaml` | n/a (no write) |
 | User connects infrastructure | Provider metadata through `mb connect`; secrets stay local | `.mb/connect.yaml` and local secret stores |
 | User configures media path | `media.root` or `media.{type}` | local.yaml |
 

--- a/.claude/skills/mb-start/references/mcp-preflight.md
+++ b/.claude/skills/mb-start/references/mcp-preflight.md
@@ -50,15 +50,13 @@ Required provider choices for the setup/provider loop:
 Only continue to MCP/tool presence checks when the selected skill needs runtime
 tools that `mb connect` cannot inspect directly.
 
-### 2. Read expected MCPs from config
+### 2. Treat legacy MCP config as audit input only
 
-```yaml
-# From .vip/config.yaml
-mcps:
-  apify:
-    required_for: [organic, think]  # Handles web scraping AND YouTube transcripts
-    setup_guide: ".claude/skills/mb-organic/references/apify-setup.md"
-```
+Older repos may have `mcps.*` under `.vip/config.yaml`. Do not treat that file
+as current shared team settings. If it exists, `mb doctor repair --plan --json`
+classifies the keys as provider-readiness hints without printing raw values.
+Use `mb connect plan`, `mb connect doctor --json`, and generated repo
+instructions for current provider readiness.
 
 ### 3. Check if MCP tools are available
 
@@ -148,7 +146,9 @@ which whisper-cli >/dev/null 2>&1 && echo "whisper-cli available"
 
 | What | Where | Portable? |
 |------|-------|-----------|
-| "What this business needs" | `.vip/config.yaml` | Yes (git) |
+| "What this business needs" | `mb connect` provider metadata, generated repo instructions, and durable operations notes | Yes, when non-secret and intentionally committed |
 | "What this machine has" | `~/.claude.json` | No (local) |
 
-Config documents requirements. Installation state is Claude Code's domain. See [config-system.md](config-system.md) for the full config file layout.
+Current provider metadata documents requirements. Installation state is Claude
+Code's domain. See [config-system.md](config-system.md) for legacy config
+cleanup guidance.

--- a/.claude/skills/mb-start/references/readiness-assessment.md
+++ b/.claude/skills/mb-start/references/readiness-assessment.md
@@ -49,14 +49,15 @@ When checking section markers, search for these headings (case-insensitive). The
 
 ### Multi-Offer Scoring
 
-When a future `mb` JSON active-offer field or legacy `.vip/local.yaml` has `current_offer` set:
+When a future `mb` JSON active-offer field or the operator's current session
+selects an offer:
 
 1. Score `core/soul.md` and `core/voice.md` from core (these are always brand-level).
 2. For offer and audience, resolve using the canonical path algorithm:
-   - Check `core/offers/[current_offer]/offer.md` first. If it exists, score it.
+   - Check `core/offers/[offer]/offer.md` first. If it exists, score it.
    - If it does not exist, score `core/offer.md`.
    - Same for `audience.md`.
-3. Testimonials and angles: check both `core/proof/` (brand-level) and `core/offers/[current_offer]/` if offer-specific proof exists.
+3. Testimonials and angles: check both `core/proof/` (brand-level) and `core/offers/[offer]/` if offer-specific proof exists.
 
 Legacy fallback: if the repo has no `core/`, read `reference/core/` and
 `reference/offers/`. In current repos those paths are compatibility bridges to

--- a/.claude/skills/mb-start/references/repo-detection.md
+++ b/.claude/skills/mb-start/references/repo-detection.md
@@ -17,7 +17,7 @@ CWD-first detection of the business repo, with config fallback. The user starts 
    ├── YES → User is in the engine repo (old workflow). Trigger migration guidance.
    └── NO → Continue to step 3.
 
-3. Fall back to config:
+3. Fall back to legacy machine-local config:
    Read ~/.config/vip/local.yaml → default_repo + recent_repos
    ├── Found valid repo(s)? → Present options (see below)
    └── Nothing valid? → Discovery or /mb-setup
@@ -37,16 +37,17 @@ CWD-first detection of the business repo, with config fallback. The user starts 
 
 ## Config Loading
 
-Once business repo is identified (from CWD or config), load settings:
+Once business repo is identified (from CWD or legacy config), load current
+facts through `mb`:
 
 ```
-1. Read ~/.config/vip/local.yaml
-   ├── Found? → Get legacy engine path + default_repo + recent_repos + user identity
-   └── Missing? → Acceptable if CWD is the repo; config gets created by /mb-setup
+1. Run mb status --json --peek
+   ├── OK? → Use status facts for readiness, drift, providers, onboarding, and routing
+   └── Fails? → Use mb doctor repair --plan --json for repair guidance
 
-2. Read [repo]/.vip/config.yaml
-   ├── Found? → Get team settings, MCP requirements
-   └── Missing? → Use defaults, offer to create later
+2. If legacy .vip YAML exists
+   ├── Run mb doctor repair --plan --json to audit key families
+   └── Do not treat .vip/config.yaml as current team settings
 ```
 
 ---
@@ -124,6 +125,9 @@ user:
 ```
 
 **If user.name or user.experience missing:** Ask once, save for future sessions.
+
+Do not create or update `[repo]/.vip/config.yaml` during repo detection. Older
+repos may have it; audit it with `mb doctor repair --plan --json`.
 
 ---
 

--- a/.claude/skills/mb-start/references/triage-agent.md
+++ b/.claude/skills/mb-start/references/triage-agent.md
@@ -99,7 +99,7 @@ Gather these in main and pass as structured text in each agent's prompt:
 | Unlinked research count | `grep -rl "linked_decisions: \[\]" research/ 2>/dev/null \| wc -l` | 1 line | Agent 2 |
 | Past triage file names | `ls research/*-start-triage.md 2>/dev/null` | ~5 lines | Agent 3 |
 | Past crystallize file names | `ls research/*-end-of-day-crystallize.md 2>/dev/null` | ~5 lines | Agent 3 |
-| `current_offer` | From a future `mb` JSON active-offer field if present, with `.vip/local.yaml` as legacy fallback | 1 line | All 3 agents |
+| active offer | From a future `mb` JSON active-offer field if present, otherwise explicit session/user selection | 1 line | All 3 agents |
 | Push lifecycle listing | `grep -rl "status: draft\|status: planned\|status: active" pushes/ campaigns/ 2>/dev/null` | ~10 lines | Agent 2 |
 | Primitive map | File lists grouped by the map below | ~40 lines | All 3 agents |
 
@@ -164,7 +164,7 @@ testimonials X/3, angles X/3. Composite X/18.]
 
 === CURRENT OFFER ===
 
-[current_offer from future mb JSON field, legacy fallback, or "single-offer mode"]
+[active offer from future mb JSON field, explicit session selection, or "single-offer mode"]
 
 === PRIMITIVE MAP ===
 

--- a/.claude/skills/mb-think/SKILL.md
+++ b/.claude/skills/mb-think/SKILL.md
@@ -101,11 +101,13 @@ For self-healing semantics (stale false handling, status-change messaging, true-
 
 Before loading reference files, resolve the active offer:
 
-1. If a future `mb` JSON field exposes active offer state, use it; otherwise read `.vip/local.yaml` only as a legacy fallback
-2. If set: load `core/offers/[current_offer]/offer.md` as the active offer
-3. If not set AND `core/offers/` exists: ask which offer
-4. If no `core/offers/` folder: use `core/offer.md` (single-offer mode)
-5. Legacy fallback: if the repo does not have `core/`, read the old
+1. If a future `mb` JSON field exposes active offer state, use it.
+2. Do not treat `.vip/local.yaml` as canonical active-offer state. If legacy
+   state exists, confirm the offer with the user instead of silently routing.
+3. If an offer is selected and `core/offers/[offer]/offer.md` exists, load it as the active offer.
+4. If no offer is selected AND `core/offers/` exists: ask which offer.
+5. If no `core/offers/` folder: use `core/offer.md` (single-offer mode)
+6. Legacy fallback: if the repo does not have `core/`, read the old
    `reference/core/` and `reference/offers/` paths.
 
 In current repos, `reference/core` and `reference/offers` are compatibility
@@ -246,7 +248,7 @@ ls core/content-strategy.md 2>/dev/null
 | content-strategy.md exists but empty/thin | "Your content strategy file is a skeleton. Want to fill it in? We can derive pillars from your soul.md + offer.md + audience.md." |
 | content-strategy.md missing (community biz) | "You don't have a content strategy yet. Want to build one? It'll define your pillars, platforms, and cadence." |
 | skool-surfaces.md missing (community biz with live Skool) | "Your Skool about page and pricing card copy aren't in reference yet. Want to add them? Skills check this for congruence." |
-| `core/offers/` exists | Multi-offer repo. Use a future `mb` JSON active-offer field if present; otherwise read `.vip/local.yaml` only as a legacy fallback. If not set, ask which offer this research/decision is about. |
+| `core/offers/` exists | Multi-offer repo. Use a future `mb` JSON active-offer field if present. Otherwise ask which offer this research/decision is about; do not silently route from `.vip/local.yaml`. |
 | Nothing in progress | "What are you trying to figure out?" |
 
 **The goal is reference files.** Research and decisions are waypoints. Keep asking: "What needs to happen to get this into reference?"

--- a/.claude/skills/mb-think/references/grok-setup.md
+++ b/.claude/skills/mb-think/references/grok-setup.md
@@ -6,13 +6,15 @@ Setup guide for real-time X/Twitter data using xAI's Grok API.
 
 ## Auto-Detection
 
-Tool detection is handled automatically by `/mb-think` via `.vip/config.yaml` -- see SKILL.md for details.
+Start with `mb status --json --peek` and `mb connect doctor --json` for
+provider readiness. Treat any old `.vip/config.yaml` tool status as a legacy
+snapshot, not current truth.
 
 ### Claude Code Env Var Caveat
 
 Claude Code sessions may not inherit env vars from your shell profile (`~/.zshrc`, `~/.bashrc`). If `XAI_API_KEY` isn't in the environment, the skill checks for and sources `~/.config/vip/env.sh` before giving up. If you store API keys in a different location, update the detection script in SKILL.md or export the key in `~/.config/vip/env.sh`.
 
-See `mb-start/references/config-system.md` for the full config file layout (local.yaml, env.sh, config.yaml).
+See `mb-start/references/config-system.md` for legacy config cleanup guidance.
 
 ---
 

--- a/.claude/skills/mb-think/references/recovery.md
+++ b/.claude/skills/mb-think/references/recovery.md
@@ -93,15 +93,18 @@ User can say any of these after compaction:
 
 ## Offer Context Recovery
 
-Use a future `mb` JSON active-offer field if present; otherwise read
-`.vip/local.yaml` only as a legacy fallback to restore which offer was being
-worked on.
+Use a future `mb` JSON active-offer field if present. Otherwise infer from
+recent work or ask the user; do not silently restore offer context from
+`.vip/local.yaml`.
 
-If the file doesn't exist or `current_offer` is not set, check recent `research/` and `decisions/` files for offer-specific prefixes (e.g., `research/2026-02-04-community-pricing-analysis.md`).
+Check recent `research/` and `decisions/` files for offer-specific prefixes
+(e.g., `research/2026-02-04-community-pricing-analysis.md`).
 
 Confirm with user: "Were you working on [offer]?"
 
-If the repo has `core/offers/` but no `current_offer` is recoverable, ask before proceeding: "Which offer are you working on?" Use legacy `reference/offers/` only when `core/` is absent.
+If the repo has `core/offers/` but no active offer is clear, ask before
+proceeding: "Which offer are you working on?" Use legacy `reference/offers/`
+only when `core/` is absent.
 
 ---
 

--- a/.claude/skills/mb-think/references/research-phase.md
+++ b/.claude/skills/mb-think/references/research-phase.md
@@ -13,9 +13,10 @@ When researching an offer-specific topic, load:
 - `core/offer.md` for brand-level context
 - Both may be relevant — offer-specific for details, core for brand positioning
 
-If a future `mb` JSON field exposes active offer state, use it before starting research; otherwise read
-`.vip/local.yaml` only as a legacy fallback. If `core/offers/` exists but no
-active offer is set, ask which offer this research relates to. Use legacy
+If a future `mb` JSON field exposes active offer state, use it before starting
+research. Otherwise, if `core/offers/` exists but no active offer is selected,
+ask which offer this research relates to; do not silently route from
+`.vip/local.yaml`. Use legacy
 `reference/offers/` only when `core/` is absent.
 
 ---

--- a/.claude/skills/mb-think/references/tool-status-self-healing.md
+++ b/.claude/skills/mb-think/references/tool-status-self-healing.md
@@ -42,9 +42,9 @@ Every touched entry must include:
 Do not hide state flips:
 
 - `false → true`:
-  - "Found [tool] installed and working — updated `.vip/config.yaml`."
+  - "Found [tool] installed and working. `mb connect doctor --json` has the current provider repair path if account readiness is still missing."
 - `true → false`:
-  - "Warning: [tool] was previously available but is not detected now. I updated `.vip/config.yaml` so this doesn't fail silently."
+  - "Warning: [tool] was previously available but is not detected now. Treat old `.vip/config.yaml` tool status as stale and use current `mb connect`/runtime checks."
 
 If status does not change, use normal experience-level reporting.
 
@@ -56,8 +56,8 @@ If a runtime-local tool marked `status: true` fails at use time (missing command
 or missing MCP tool):
 
 1. Re-probe that tool immediately
-2. Update config to `status: false`, set `last_checked: [today]`, add explanatory notes
-3. Warn the user in the same turn
+2. Warn the user in the same turn
+3. If the failure is provider auth/readiness, report the `mb connect doctor --json` repair command
 
 Never let a previously-true runtime-local tool fail silently. If the failure is
 provider auth/readiness, report the `mb connect doctor --json` repair command

--- a/.claude/skills/mb-think/scripts/detect-tools.sh
+++ b/.claude/skills/mb-think/scripts/detect-tools.sh
@@ -5,17 +5,15 @@
 # Why: Claude can detect tools AND update config in one step using Read/Edit tools.
 # The bash script could only report — it couldn't reliably write YAML.
 #
-# New flow (in SKILL.md):
-# 1. Read .vip/config.yaml
-# 2. Check status values (true/false/null)
-# 3. Probe unknowns using bash or tool presence checks
-# 4. Update config with Edit tool (status + last_checked timestamp)
-# 5. Report once based on user experience level
+# New flow:
+# 1. Read `mb status --json --peek` and `mb connect doctor --json`.
+# 2. Probe runtime-local tools only when the selected workflow needs them.
+# 3. Report provider/readiness repair commands from mb instead of editing
+#    legacy .vip YAML.
 #
-# See: .claude/skills/mb-think/SKILL.md "Tool Detection (Config-First)" section
+# See: .claude/skills/mb-start/references/mcp-preflight.md
 
-echo "NOTE: detect-tools.sh is deprecated. Tool detection now happens inline in /mb-think."
-echo "The skill reads config, probes unknowns, and updates config directly."
+echo "NOTE: detect-tools.sh is deprecated. Tool detection now starts with mb connect/status facts."
 echo ""
 echo "For manual checking, here's what tools exist on this machine:"
 echo ""
@@ -90,4 +88,4 @@ which marker_single >/dev/null 2>&1 \
   || echo "  ✗ marker"
 
 echo ""
-echo "To update your config, edit .vip/config.yaml directly or let /mb-think handle it."
+echo "For provider readiness, run: mb connect doctor --json"

--- a/.claude/skills/mb-vsl/SKILL.md
+++ b/.claude/skills/mb-vsl/SKILL.md
@@ -84,11 +84,13 @@ If unclear, ask: "Is this for a Skool/membership community ($47-$497/month) or a
 
 Before loading reference files, resolve the active offer:
 
-1. If a future `mb` JSON field exposes active offer state, use it; otherwise read `.vip/local.yaml` only as a legacy fallback
-2. If set: load `core/offers/[current_offer]/offer.md` as the active offer
-3. If not set AND `core/offers/` exists: ask which offer
-4. If no `core/offers/` folder: use `core/offer.md` (single-offer mode)
-5. Legacy fallback: if the repo does not have `core/`, read the old
+1. If a future `mb` JSON field exposes active offer state, use it.
+2. Do not treat `.vip/local.yaml` as canonical active-offer state. If legacy
+   state exists, confirm the offer with the user instead of silently routing.
+3. If an offer is selected and `core/offers/[offer]/offer.md` exists, load it as the active offer.
+4. If no offer is selected AND `core/offers/` exists: ask which offer.
+5. If no `core/offers/` folder: use `core/offer.md` (single-offer mode)
+6. Legacy fallback: if the repo does not have `core/`, read the old
    `reference/core/` and `reference/offers/` paths.
 
 In current repos, `reference/core` and `reference/offers` are compatibility
@@ -100,7 +102,7 @@ files, and write once to the canonical `core/` path.
 **Accumulate files** (load both): `testimonials.md` (offer-specific + brand-level)
 
 **Offer argument:** `/mb-vsl [framework] [offer]` — e.g., `/mb-vsl skool community`
-If offer specified, overrides session `current_offer` for this run. If the active offer type is known (community/membership offer), default to Skool framework; if B2B/high-ticket, default to B2B Haynes.
+If offer specified, it selects the offer for this run only. If the active offer type is known (community/membership offer), default to Skool framework; if B2B/high-ticket, default to B2B Haynes.
 
 ---
 
@@ -212,7 +214,7 @@ Just say `/mb-vsl` again and describe where you were:
 
 ### For Claude
 
-1. **Restore offer context:** Use a future `mb` JSON active-offer field if present; otherwise read `.vip/local.yaml` only as a legacy fallback. Confirm with user if multi-offer repo.
+1. **Restore offer context:** Use a future `mb` JSON active-offer field if present; otherwise ask the user to restore offer context. Do not silently route from `.vip/local.yaml`.
 
 2. **Check for in-progress scripts:**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ### Added
 
+- Added a `mb doctor repair --plan --json` audit section for legacy
+  `.vip/local.yaml` and `.vip/config.yaml` YAML state. The plan classifies key
+  families without printing raw values, separates local/session state from
+  durable business/provider facts, and keeps deletion/migration manual. Refs
+  #413.
 - Added a release-simulation fixture for the `/mb-start` ambiguous-choice
   failure where an operator replies `1` for the top recommendation in a rich
   multi-offer repo, so release review checks that offer selection cannot
@@ -24,6 +29,10 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ### Changed
 
+- Retired `.vip/config.yaml` as active path/provider/tool config in current
+  CLI and skill guidance. New setup no longer creates it, and offer-aware
+  skills ask for explicit session context instead of silently routing from
+  `.vip/local.yaml`. Refs #413.
 - Expanded `mb doctor repair --plan --json` migration guidance with an
   offer-topology section that surfaces legacy `.vip/local.yaml` active-offer
   state, offer folder/frontmatter slug drift, and multi-offer review needs

--- a/docs/MIGRATING.md
+++ b/docs/MIGRATING.md
@@ -514,16 +514,27 @@ If anything looks wrong, stop and keep the legacy layout.
 
 ## What About `.vip/config.yaml` and `~/.config/vip/local.yaml`?
 
-Keep them for now.
+Treat them as legacy cleanup surfaces, not current Main Branch truth.
 
 - `~/.config/vip/local.yaml` is machine-local memory: default repo, recent
-  repos, experience level, and last-seen changelog version.
-- `.vip/config.yaml` is repo-local configuration used by older skills and
-  future path/config work.
+  repos, experience level, and last-seen changelog version. Current repo
+  detection is CWD-first and should use this only as a legacy fallback.
+- `.vip/config.yaml` is repo-local configuration used by older skills. It may
+  contain mixed durable facts, provider hints, stale tool snapshots, private
+  paths, or client context. Do not copy values out blindly.
 
-Do not delete either file as part of a layout migration. `mb skill link` writes
-Claude Code discovery into `.claude/settings.local.json`; it does not replace
-the old config files yet.
+Preview legacy `.vip` cleanup with:
+
+```bash
+mb doctor repair --plan --json
+```
+
+That plan classifies `.vip` key families without printing raw values. Delete or
+migrate old `.vip` files only after reviewing the audit and moving any
+still-current, non-private facts to the right current surface such as `core/`,
+`core/operations/`, provider notes, or machine-local config. `mb doctor repair
+--apply` may protect `.vip/local.yaml` in `.gitignore` and untrack it, but it
+does not delete or rewrite `.vip` YAML files.
 
 ## Current Recommendation
 

--- a/mb/mb/doctor.py
+++ b/mb/mb/doctor.py
@@ -63,6 +63,7 @@ LOCAL_STATE_PATHS = (
 )
 DURABLE_MB_PATHS = (".mb/schema_version",)
 LEGACY_VIP_LOCAL_STATE_PATHS = (".vip/local.yaml",)
+LEGACY_VIP_AUDIT_PATHS = (".vip/local.yaml", ".vip/config.yaml")
 LEGACY_CLAUDE_LINK_DIRS = (".claude/lenses", ".claude/reference")
 REFERENCE_COMPAT_LINKS = {
     "reference/core": "../core",
@@ -616,10 +617,267 @@ def _read_markdown_frontmatter(path: Path) -> dict[str, Any]:
     return parsed if isinstance(parsed, dict) else {}
 
 
+def _flatten_yaml_keys(data: dict[str, Any], *, prefix: str = "") -> list[str]:
+    keys: list[str] = []
+    for key, value in data.items():
+        key_text = str(key)
+        path = f"{prefix}.{key_text}" if prefix else key_text
+        if isinstance(value, dict) and value:
+            keys.extend(_flatten_yaml_keys(value, prefix=path))
+        else:
+            keys.append(path)
+    return keys
+
+
+def _legacy_vip_key_classification(key: str) -> dict[str, str]:
+    parts = key.split(".")
+    root = parts[0] if parts else key
+
+    if key == "current_offer":
+        return {
+            "family": "current_offer",
+            "classification": "local-session-state",
+            "destination": (
+                "Use an explicit per-run offer choice, status/start routing, or a future "
+                "Main Branch session-state contract; do not treat `.vip/local.yaml` as canonical."
+            ),
+            "action": "manual_review",
+        }
+    if root in {"default_repo", "recent_repos", "user", "media", "last_seen_version", "vip_path"}:
+        return {
+            "family": f"{root}.*" if len(parts) > 1 else root,
+            "classification": "machine-local-preference",
+            "destination": (
+                "Keep only in machine-local runtime config if still useful; never move into "
+                "tracked business files."
+            ),
+            "action": "keep_local_or_delete",
+        }
+    if root == "session":
+        return {
+            "family": "session.*",
+            "classification": "machine-local-session-state",
+            "destination": "Keep as runtime-local preference/session state if retained.",
+            "action": "keep_local_or_delete",
+        }
+    if root in {"business_type", "business_name", "offer_structure", "skool_url"} or root.endswith(
+        "_url"
+    ):
+        return {
+            "family": root,
+            "classification": "durable-business-truth",
+            "destination": (
+                "Review manually and move still-current, non-private facts into `core/`, "
+                "`core/operations/`, or onboarding state."
+            ),
+            "action": "manual_move_if_current",
+        }
+    if root == "tools":
+        return {
+            "family": "tools.*",
+            "classification": "stale-runtime-snapshot",
+            "destination": "Prefer current `mb connect`, `mb status`, and runtime facts.",
+            "action": "delete_after_review",
+        }
+    if root == "mcps":
+        return {
+            "family": "mcps.*",
+            "classification": "provider-readiness-hint",
+            "destination": (
+                "Move only durable, non-secret requirements to generated `CLAUDE.md`, "
+                "`core/operations/`, or provider docs; keep credentials local."
+            ),
+            "action": "manual_review",
+        }
+    if root == "infrastructure":
+        return {
+            "family": "infrastructure.*",
+            "classification": "provider-or-infra-hint",
+            "destination": (
+                "Classify manually. Non-secret provider identifiers may belong in operation "
+                "or provider notes; secrets and account-private details stay local."
+            ),
+            "action": "manual_review",
+        }
+    if root in {"content", "skills"}:
+        return {
+            "family": f"{root}.*",
+            "classification": "legacy-skill-default",
+            "destination": "Use explicit skill inputs or documented workflow defaults, not `.vip`.",
+            "action": "manual_review",
+        }
+    if root in {"clients", "client_repos", "child_repos", "repos"}:
+        return {
+            "family": f"{root}.*",
+            "classification": "repo-topology-hint",
+            "destination": (
+                "Review manually before moving to topology docs, graph links, or provider-safe "
+                "notes; sanitize client/private paths."
+            ),
+            "action": "manual_review",
+        }
+    if root == "reference_structure":
+        return {
+            "family": "reference_structure.*",
+            "classification": "stale-legacy-layout",
+            "destination": (
+                "Use `mb doctor`, `mb migrate --check`, and current `core/` layout facts."
+            ),
+            "action": "delete_after_review",
+        }
+    if root in {"paths", "path_config"}:
+        return {
+            "family": f"{root}.*",
+            "classification": "legacy-compatibility-fallback",
+            "destination": "Prefer current repo layout and `mb` path resolution.",
+            "action": "manual_review",
+        }
+    return {
+        "family": f"{root}.*" if len(parts) > 1 else root,
+        "classification": "manual-review",
+        "destination": (
+            "Inspect manually. Do not move raw values into durable files until privacy and "
+            "current relevance are clear."
+        ),
+        "action": "manual_review",
+    }
+
+
+def _legacy_vip_audit_state(repo: Path) -> dict[str, Any]:
+    checks: list[dict[str, Any]] = []
+    for rel in LEGACY_VIP_AUDIT_PATHS:
+        path = repo / rel
+        if not path.exists() and not path.is_symlink():
+            checks.append(
+                {
+                    "name": rel,
+                    "state": "ok",
+                    "summary": "absent",
+                    "kind": "absent",
+                    "entries": [],
+                    "deletion": {
+                        "safe": False,
+                        "reason": "file is absent",
+                    },
+                }
+            )
+            continue
+        if path.is_symlink():
+            checks.append(
+                {
+                    "name": rel,
+                    "state": "warn",
+                    "summary": "legacy `.vip` YAML is a symlink; manual review required",
+                    "kind": "legacy-vip-yaml",
+                    "entries": [],
+                    "deletion": {
+                        "safe": False,
+                        "reason": "symlink target may be machine-local or private",
+                    },
+                }
+            )
+            continue
+        try:
+            raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        except (OSError, yaml.YAMLError) as exc:
+            checks.append(
+                {
+                    "name": rel,
+                    "state": "warn",
+                    "summary": "legacy `.vip` YAML exists but could not be parsed",
+                    "kind": "legacy-vip-yaml",
+                    "parse_error": type(exc).__name__,
+                    "entries": [],
+                    "deletion": {
+                        "safe": False,
+                        "reason": "parse before deleting or migrating",
+                    },
+                }
+            )
+            continue
+        if not isinstance(raw, dict):
+            checks.append(
+                {
+                    "name": rel,
+                    "state": "warn",
+                    "summary": "legacy `.vip` YAML is not a mapping; manual review required",
+                    "kind": "legacy-vip-yaml",
+                    "entries": [],
+                    "deletion": {
+                        "safe": False,
+                        "reason": "unexpected YAML shape",
+                    },
+                }
+            )
+            continue
+
+        entries = [
+            {
+                "key": key,
+                **_legacy_vip_key_classification(key),
+                "value_included": False,
+            }
+            for key in sorted(_flatten_yaml_keys(raw))
+        ]
+        actions = {str(entry["action"]) for entry in entries}
+        manual_count = sum(1 for entry in entries if str(entry["action"]).startswith("manual"))
+        local_count = sum(
+            1 for entry in entries if str(entry["classification"]).startswith("machine-local")
+        )
+        stale_count = sum(1 for entry in entries if entry["action"] == "delete_after_review")
+        safe_to_delete = bool(entries) and not any(
+            action in actions for action in {"manual_review", "manual_move_if_current"}
+        )
+        if not entries:
+            deletion = {
+                "safe": True,
+                "reason": "file has no keys; delete after confirming no runtime still expects it",
+            }
+        elif safe_to_delete:
+            deletion = {
+                "safe": True,
+                "reason": (
+                    "only local/session/stale fallback keys were found; delete after reviewing "
+                    "that no active runtime depends on them"
+                ),
+            }
+        else:
+            deletion = {
+                "safe": False,
+                "reason": (
+                    "manual-review or durable-business keys remain; classify and move only "
+                    "still-current, non-private facts first"
+                ),
+            }
+        checks.append(
+            {
+                "name": rel,
+                "state": "warn",
+                "summary": (
+                    f"{len(entries)} legacy key(s): {manual_count} manual review, "
+                    f"{local_count} local/session, {stale_count} stale/delete"
+                ),
+                "kind": "legacy-vip-yaml",
+                "entries": entries,
+                "deletion": deletion,
+            }
+        )
+    return {
+        "state": _max_state([str(item["state"]) for item in checks]),
+        "summary": (
+            "legacy `.vip` config/state needs review"
+            if any(item["state"] != "ok" for item in checks)
+            else "no legacy `.vip` config/state files found"
+        ),
+        "checks": checks,
+    }
+
+
 def _offer_topology_state(repo: Path) -> dict[str, Any]:
     """Return migration guidance for active-offer state and multi-offer drift."""
     checks: list[dict[str, Any]] = []
     offer_records: list[dict[str, Any]] = []
+    active_offers: list[str] = []
 
     for rel in LEGACY_VIP_LOCAL_STATE_PATHS:
         path = repo / rel
@@ -634,7 +892,10 @@ def _offer_topology_state(repo: Path) -> dict[str, Any]:
             )
             continue
         data = _read_yaml_mapping(path)
-        current_offer = data.get("current_offer")
+        current_offer = str(data.get("current_offer") or "").strip()
+        current_offer_present = bool(current_offer and current_offer != "null")
+        if current_offer_present:
+            active_offers.append(current_offer)
         checks.append(
             {
                 "name": rel,
@@ -644,7 +905,8 @@ def _offer_topology_state(repo: Path) -> dict[str, Any]:
                     "but do not let skills write it silently"
                 ),
                 "kind": "legacy-vip-local-state",
-                "current_offer": current_offer,
+                "current_offer_present": current_offer_present,
+                "value_included": False,
             }
         )
 
@@ -675,13 +937,6 @@ def _offer_topology_state(repo: Path) -> dict[str, Any]:
                     }
                 )
 
-    active_offers = []
-    for check in checks:
-        if check.get("kind") != "legacy-vip-local-state":
-            continue
-        current_offer = str(check.get("current_offer") or "").strip()
-        if current_offer and current_offer != "null":
-            active_offers.append(current_offer)
     existing_folders = {str(record["folder_slug"]) for record in offer_records}
     for active_offer in active_offers:
         if active_offer not in existing_folders:
@@ -690,11 +945,11 @@ def _offer_topology_state(repo: Path) -> dict[str, Any]:
                     "name": "active-offer-target",
                     "state": "warn",
                     "summary": (
-                        f"legacy active offer `{active_offer}` has no matching "
-                        f"core/offers/{active_offer}/offer.md"
+                        "legacy active-offer state has no matching per-offer file "
+                        "under core/offers/"
                     ),
                     "kind": "missing-active-offer",
-                    "current_offer": active_offer,
+                    "value_included": False,
                 }
             )
 
@@ -712,7 +967,8 @@ def _offer_topology_state(repo: Path) -> dict[str, Any]:
                     "files; confirm brand-level vs offer-specific scope before writing"
                 ),
                 "kind": "multi-offer-review",
-                "current_offer": active_offers[0],
+                "current_offer_present": True,
+                "value_included": False,
                 "brand_offer": "core/offer.md",
                 "offers": [record["path"] for record in offer_records],
             }
@@ -1133,6 +1389,7 @@ def repair_plan(
     migration = migrate_mod.check(target, include_diff=False)
     reference_state = _legacy_reference_state(target)
     offer_topology = _offer_topology_state(target)
+    legacy_vip = _legacy_vip_audit_state(target)
     legacy_campaigns_check = next(
         (check for check in doctor_report["checks"] if check["name"] == "legacy-campaigns"),
         None,
@@ -1235,6 +1492,34 @@ def repair_plan(
             ),
             checks=offer_topology["checks"],
             actions=offer_actions,
+        )
+    )
+
+    legacy_vip_actions: list[dict[str, Any]] = []
+    if legacy_vip["state"] != "ok":
+        action = _action(
+            id="legacy-vip-audit",
+            title="Review legacy .vip YAML config/state",
+            state=legacy_vip["state"],
+            mode="manual",
+            command="mb doctor repair --plan --json",
+            safe_to_apply=False,
+            reason=(
+                ".vip YAML can contain private paths, provider notes, client context, "
+                "or stale runtime snapshots; doctor classifies keys but does not copy "
+                "raw values or migrate content automatically"
+            ),
+        )
+        actions.append(action)
+        legacy_vip_actions.append(action)
+    sections.append(
+        _section(
+            "legacy-vip",
+            "Legacy .vip Config And State",
+            legacy_vip["state"],
+            legacy_vip["summary"],
+            checks=legacy_vip["checks"],
+            actions=legacy_vip_actions,
         )
     )
 
@@ -1580,6 +1865,7 @@ def repair_plan(
             "migration": migration,
             "legacy_reference": reference_state,
             "offer_topology": offer_topology,
+            "legacy_vip": legacy_vip,
             "legacy_claude_links": legacy_links,
             "validation": validation.get("report", {}),
             "graph": graph.get("report", {}),

--- a/mb/mb/resolve.py
+++ b/mb/mb/resolve.py
@@ -8,10 +8,9 @@ Resolution order for a key like ``voice``:
 If only the stub matches, ``is_stub=True`` and the caller knows to
 display the upgrade banner.
 
-``v0.1`` shipped with canonical folder names locked. Per the
-master decision, path-config flexibility is a v0.2 unlock; this module
-reads ``.vip/config.yaml``'s ``paths:`` block defensively but defaults
-to the lock.
+Legacy repos may still have ``.vip/config.yaml`` path hints, but those files
+are not canonical Main Branch state. ``mb resolve`` uses the current locked
+repo layout and leaves old ``.vip`` values to the doctor repair audit.
 """
 
 from __future__ import annotations
@@ -19,8 +18,6 @@ from __future__ import annotations
 from importlib import resources
 from pathlib import Path
 from typing import Any
-
-import yaml
 
 from mb.engine import bundled_skills as _bundled_skills
 from mb.engine import skill_path as _skill_path
@@ -41,22 +38,11 @@ def _curated_root() -> Path:
 
 
 def _read_paths_block(repo: Path) -> dict[str, str]:
-    """v0.2 unlock entry point. v0.1 returns the canonical lock."""
-    cfg = repo / ".vip" / "config.yaml"
-    if not cfg.exists():
-        return CANONICAL_PATHS
-    try:
-        data = yaml.safe_load(cfg.read_text(encoding="utf-8")) or {}
-    except yaml.YAMLError:
-        return CANONICAL_PATHS
-    block = data.get("paths") if isinstance(data, dict) else None
-    if isinstance(block, dict):
-        # v0.2: honor the override. v0.1: still lock.
-        merged = dict(CANONICAL_PATHS)
-        for k, v in block.items():
-            if isinstance(v, str):
-                merged[k] = v
-        return merged
+    """Return the current canonical path lock.
+
+    ``repo`` is accepted for API compatibility with older callers.
+    """
+    _ = repo
     return CANONICAL_PATHS
 
 

--- a/mb/tests/test_doctor.py
+++ b/mb/tests/test_doctor.py
@@ -437,7 +437,9 @@ def test_doctor_repair_plan_reports_stale_vip_local_state(tmp_path: Path) -> Non
     vip_check = next(check for check in section["checks"] if check["name"] == ".vip/local.yaml")
     assert vip_check["state"] == "warn"
     assert vip_check["kind"] == "legacy-vip-local-state"
-    assert vip_check["current_offer"] == "community"
+    assert vip_check["current_offer_present"] is True
+    assert vip_check["value_included"] is False
+    assert "community" not in json.dumps(vip_check)
     actions = {action["id"]: action for action in payload["actions"]}
     assert actions["offer-topology-review"]["mode"] == "manual"
     assert actions["offer-topology-review"]["safe_to_apply"] is False
@@ -508,6 +510,151 @@ def test_doctor_repair_plan_flags_multi_offer_session_disagreement(tmp_path: Pat
     assert "multi-offer-review" in kinds
     assert "brand-offer-slug-overlap" in kinds
     assert section["state"] == "warn"
+
+
+def test_doctor_repair_plan_audits_mixed_vip_yaml_without_values(tmp_path: Path) -> None:
+    repo = tmp_path / "legacy-vip-audit"
+    init_run(path=str(repo), name="Acme")
+    (repo / ".vip").mkdir()
+    (repo / ".vip" / "local.yaml").write_text(
+        "\n".join(
+            [
+                "current_offer: community",
+                "user:",
+                "  name: Example Operator",
+                "session:",
+                "  show_context_tips: true",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (repo / ".vip" / "config.yaml").write_text(
+        "\n".join(
+            [
+                "business_name: Example Business",
+                "business_type: community",
+                "offer_structure: multi",
+                "tools:",
+                "  apify:",
+                "    status: installed",
+                "mcps:",
+                "  google_drive:",
+                "    required_for: docs",
+                "infrastructure:",
+                "  site:",
+                "    provider: cloudflare",
+                "content:",
+                "  default_channel: newsletter",
+                "skills:",
+                "  ads:",
+                "    default_count: 5",
+                "client_repos:",
+                "  example_client: /private/path/redacted",
+                "reference_structure:",
+                "  core: reference/core",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    before_local = (repo / ".vip" / "local.yaml").read_text(encoding="utf-8")
+    before_config = (repo / ".vip" / "config.yaml").read_text(encoding="utf-8")
+    result = runner.invoke(app, ["doctor", "repair", "--repo", str(repo), "--plan", "--json"])
+
+    assert result.exit_code in {0, 1}
+    assert (repo / ".vip" / "local.yaml").read_text(encoding="utf-8") == before_local
+    assert (repo / ".vip" / "config.yaml").read_text(encoding="utf-8") == before_config
+    payload = json.loads(result.stdout)
+    assert payload["read_only"] is True
+    section = next(section for section in payload["sections"] if section["id"] == "legacy-vip")
+    assert section["state"] == "warn"
+    by_name = {check["name"]: check for check in section["checks"]}
+    local_entries = {entry["key"]: entry for entry in by_name[".vip/local.yaml"]["entries"]}
+    config_entries = {entry["key"]: entry for entry in by_name[".vip/config.yaml"]["entries"]}
+
+    assert local_entries["current_offer"]["classification"] == "local-session-state"
+    assert local_entries["user.name"]["classification"] == "machine-local-preference"
+    assert local_entries["session.show_context_tips"]["classification"] == (
+        "machine-local-session-state"
+    )
+    assert config_entries["business_name"]["classification"] == "durable-business-truth"
+    assert config_entries["tools.apify.status"]["classification"] == "stale-runtime-snapshot"
+    assert config_entries["mcps.google_drive.required_for"]["classification"] == (
+        "provider-readiness-hint"
+    )
+    assert config_entries["infrastructure.site.provider"]["classification"] == (
+        "provider-or-infra-hint"
+    )
+    assert config_entries["content.default_channel"]["classification"] == "legacy-skill-default"
+    assert config_entries["skills.ads.default_count"]["classification"] == "legacy-skill-default"
+    assert config_entries["client_repos.example_client"]["classification"] == "repo-topology-hint"
+    assert config_entries["reference_structure.core"]["classification"] == "stale-legacy-layout"
+    assert all(entry["value_included"] is False for entry in local_entries.values())
+    assert all(entry["value_included"] is False for entry in config_entries.values())
+    assert "Example Operator" not in result.stdout
+    assert "/private/path" not in result.stdout
+    actions = {action["id"]: action for action in payload["actions"]}
+    assert actions["legacy-vip-audit"]["mode"] == "manual"
+    assert actions["legacy-vip-audit"]["safe_to_apply"] is False
+
+
+def test_doctor_repair_plan_handles_malformed_vip_yaml(tmp_path: Path) -> None:
+    repo = tmp_path / "bad-vip"
+    init_run(path=str(repo), name="Acme")
+    (repo / ".vip").mkdir()
+    (repo / ".vip" / "config.yaml").write_text("tools: [unterminated\n", encoding="utf-8")
+
+    result = runner.invoke(app, ["doctor", "repair", "--repo", str(repo), "--plan", "--json"])
+
+    assert result.exit_code in {0, 1}
+    payload = json.loads(result.stdout)
+    section = next(section for section in payload["sections"] if section["id"] == "legacy-vip")
+    check = next(check for check in section["checks"] if check["name"] == ".vip/config.yaml")
+    assert check["state"] == "warn"
+    assert check["parse_error"]
+    assert check["deletion"]["safe"] is False
+
+
+def test_doctor_repair_plan_handles_non_mapping_vip_yaml(tmp_path: Path) -> None:
+    repo = tmp_path / "list-vip"
+    init_run(path=str(repo), name="Acme")
+    (repo / ".vip").mkdir()
+    (repo / ".vip" / "config.yaml").write_text("- one\n- two\n", encoding="utf-8")
+
+    result = runner.invoke(app, ["doctor", "repair", "--repo", str(repo), "--plan", "--json"])
+
+    assert result.exit_code in {0, 1}
+    payload = json.loads(result.stdout)
+    section = next(section for section in payload["sections"] if section["id"] == "legacy-vip")
+    check = next(check for check in section["checks"] if check["name"] == ".vip/config.yaml")
+    assert check["state"] == "warn"
+    assert check["entries"] == []
+    assert check["deletion"]["safe"] is False
+
+
+def test_doctor_repair_plan_flags_vip_yaml_symlink_without_reading(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "symlink-vip"
+    init_run(path=str(repo), name="Acme")
+    private = tmp_path / "private-config.yaml"
+    private.write_text("business_name: Private Business\n", encoding="utf-8")
+    (repo / ".vip").mkdir()
+    (repo / ".vip" / "config.yaml").symlink_to(private)
+
+    result = runner.invoke(app, ["doctor", "repair", "--repo", str(repo), "--plan", "--json"])
+
+    assert result.exit_code in {0, 1}
+    assert "Private Business" not in result.stdout
+    payload = json.loads(result.stdout)
+    section = next(section for section in payload["sections"] if section["id"] == "legacy-vip")
+    check = next(check for check in section["checks"] if check["name"] == ".vip/config.yaml")
+    assert check["state"] == "warn"
+    assert check["entries"] == []
+    assert check["deletion"]["safe"] is False
+    assert "symlink" in check["summary"]
 
 
 def test_doctor_repair_plan_distinguishes_read_and_write_actions(tmp_path: Path) -> None:

--- a/mb/tests/test_resolve.py
+++ b/mb/tests/test_resolve.py
@@ -19,6 +19,21 @@ def test_resolve_local_override(tmp_path: Path) -> None:
     assert out["is_stub"] is False
 
 
+def test_resolve_ignores_legacy_vip_path_overrides(tmp_path: Path) -> None:
+    repo = tmp_path / "biz"
+    (repo / ".vip").mkdir(parents=True)
+    (repo / ".vip" / "config.yaml").write_text(
+        "paths:\n  core: legacy-core\n",
+        encoding="utf-8",
+    )
+    (repo / "legacy-core").mkdir()
+    (repo / "legacy-core" / "voice.md").write_text("# Legacy voice\n", encoding="utf-8")
+
+    out = run(key="voice", repo=str(repo))
+
+    assert out["tier"] != "local"
+
+
 def test_resolve_unknown_key_returns_unresolved_or_stub(tmp_path: Path) -> None:
     repo = tmp_path / "biz"
     repo.mkdir()


### PR DESCRIPTION
## Summary
- Adds a read-only `mb doctor repair --plan --json` audit for legacy `.vip/local.yaml` and `.vip/config.yaml` key families.
- Classifies legacy `.vip` keys without echoing raw values, including local/session state, durable business facts, provider hints, stale tool snapshots, topology hints, malformed YAML, non-mapping YAML, and symlinked YAML.
- Retires `.vip/config.yaml` as active path/provider/tool config and updates bundled skill guidance so offer context is explicit/session-scoped instead of silently restored from `.vip/local.yaml`.
- Keeps `mb doctor repair --apply` limited to existing safe local-state protection rather than deleting, rewriting, or migrating `.vip` YAML.

## Scope
In:
- `mb doctor repair --plan --json` legacy `.vip` audit section for `.vip/local.yaml` and `.vip/config.yaml`.
- Privacy-safe key classification and deletion guidance without raw value output.
- `mb resolve` canonical path behavior instead of `.vip/config.yaml:paths`.
- Bundled skill and migration/help docs that previously treated `.vip` YAML as current state.
- Sanitized tests for mixed key families, malformed/non-mapping YAML, symlinks, privacy guards, and resolve behavior.

Out:
- Migrating private user repos directly.
- Deleting `.vip` files automatically.
- Designing a hosted/settings system.
- Renaming the broader non-YAML `~/.config/vip/env.sh` namespace.
- Claiming new runtime support.

## Commits
- `e074ff2` — `[fix] MAIN-286 retire legacy vip YAML state`.
- `d0e616a` — `[fix] MAIN-286 repair legacy config table`.

## Release / Issues
- Release: Next v0.3.x cleanup.
- Linear ID(s): MAIN-286.
- Closes: #413.
- Refs: none.
- Follow-ups: broader non-YAML `~/.config/vip/env.sh` / `vip_path` namespace cleanup; Claude Code fixture smoke for legacy `.vip` state when runtime access is available.

## Success Metric
- A repo with legacy `.vip/local.yaml` and `.vip/config.yaml` gets a privacy-safe doctor repair plan that classifies keys and gives manual destinations, while current skills and CLI behavior no longer treat `.vip` YAML as canonical state.

## Validation
- Level 0 docs/decision: Updated `CHANGELOG.md`, `docs/MIGRATING.md`, and bundled skill/reference guidance; scanned committed surfaces for private local evidence.
- Level 1 static: `scripts/check.sh` passed from repo root, including formatting, lint, mypy, 401 pytest tests, and bundled skill validation.
- Level 2 CLI: `cd mb && python3 -m pytest tests/test_doctor.py -q` passed with 35 tests; `cd mb && python3 -m pytest tests/test_resolve.py -q` passed with 5 tests.
- Level 3 package/install: Not run; no packaging or entrypoint behavior changed.
- Level 4 fixture repo: Manual temp-repo JSON smoke confirmed `.vip` audit reports both legacy YAML files while withholding sample private values.
- Level 5 runtime smoke: Not run; skill prose changed, but static skill validation and CLI smoke were the verified fallback.

## Public / Private Boundary
- Private Linear/local evidence stayed in `.context` and was not committed.
- Tests use sanitized placeholder values and assert raw/private sample values are not emitted in doctor repair JSON.
