### PR TITLE
[add] Google Ads search launch playbook

### DIFF
--- a/.claude/playbooks/google-ads-search-launch/SKILL.md
+++ b/.claude/playbooks/google-ads-search-launch/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: google-ads-search-launch
+tier: playbook
+calls: [mb-start, mb-think, mb-site, mb-ads, mb-end]
+status: draft
+description: "Reusable Noontide playbook for validating an offer with a tightly scoped Google Ads Search launch, a paid-traffic lander, explicit approval gates, and a capped review window."
+---
+
+# google-ads-search-launch
+
+This is a reusable operating playbook, not a one-off ad checklist. Use it when
+the operator wants to test whether a real offer can turn paid search intent into
+leads, calls, bookings, deposits, trials, or another concrete business outcome.
+
+The playbook's job is to turn one offer into one paid-search proof run:
+
+1. define the bet and success criteria;
+2. prepare or verify the lander and conversion path;
+3. build a tightly scoped Google Ads Search plan;
+4. preserve manual approval gates before spend or provider mutation;
+5. record the run as a push playbook with review evidence and an outcome hook.
+
+It does not publish campaigns, change budgets, upload conversions, publish GTM,
+or mutate provider accounts. Those steps stay manual or provider-native until a
+future accepted adapter ships with approval gates and smoke evidence.
+
+## Playbook Versus Run
+
+This file is the reusable Noontide recipe. The run belongs in the business repo:
+
+```text
+pushes/<push>/playbooks/google-ads-search-launch.md
+```
+
+Create or update that run file from
+[`templates/push-playbook.md`](templates/push-playbook.md). The run file is the
+approval record, provider-boundary record, launch checklist, review-window
+record, and outcome hook for a specific offer/push.
+
+## Opinionated Defaults
+
+Use [`references/noontide-approach.md`](references/noontide-approach.md) as the
+style and decision rubric.
+For B2B local-services lead-form campaigns, also use
+[`references/b2b-local-services-field-notes.md`](references/b2b-local-services-field-notes.md).
+
+Defaults:
+
+- one offer, one primary conversion, one review window;
+- exact and phrase match first; broad match only with a written reason;
+- geography, schedule, negatives, and sitelinks are part of the plan, not
+  afterthoughts;
+- a small proof budget is only useful when CPC, conversion rate, and business
+  value make the result interpretable;
+- account history is useful when it exists, but a new offer can start from
+  offer/customer/keyword reasoning and lander readiness;
+- no spend before the operator approves the lander, conversion action, consent
+  posture, billing, budget, campaign structure, copy, and review criteria;
+- post-launch judgment is `continue`, `change`, or `stop`, written as an
+  outcome or push review.
+
+## Required Inputs
+
+- active offer and audience;
+- explicit bet or success criterion for the proof run;
+- launch push, or permission to create one;
+- lander or site repo, if one exists;
+- budget cap, review window, geography, and business value of the conversion;
+- provider readiness from `mb status --json --peek` and `mb connect plan`;
+- measurement readiness from `mb site check` when a site repo exists;
+- sanitized account history or read-only provider facts only when already
+  approved and available.
+
+If no Google Ads account history exists for this offer, say so and continue.
+Do not invent prior winners or require pre-offer account scraping.
+
+## Flow
+
+1. **Start and scope.** Use `/mb-start` facts. Identify the offer, push, bet,
+   current repo health, provider readiness, and whether this is a new offer or
+   a rescue of an existing campaign.
+2. **Bet and KPI.** Use `/mb-think` when the success criterion is vague. Press
+   for what would make the spend a win, a useful loss, or an inconclusive test.
+3. **Lander and conversion.** Use `/mb-site` and `mb site check` before calling
+   the campaign launchable. Missing measurement can still allow copy drafting,
+   but not spend approval.
+4. **Campaign plan.** Use `/mb-ads launch-plan` and load the Google Ads campaign
+   plan reference. Draft structure, keywords, negatives, copy, sitelinks,
+   budget, manual provider steps, and approval gates.
+5. **B2B local-services pass.** When the offer is B2B local services, check the
+   field notes for GA4/GTM/Ads import order, Search-only defaults, geo
+   presence, Search Partners, Final URL Expansion, AI Max, negative categories,
+   UI gotchas, and volume calibration.
+6. **Run record.** Write or update the push playbook run from the template.
+   Keep provider refs safe and do not store raw account exports.
+7. **Manual launch.** The operator performs Google Ads/GTM/billing/spend steps
+   manually unless a future adapter is accepted.
+8. **Review.** Use `/mb-ads check` after the review window. Write the result to
+   the run record and link an outcome/log file.
+9. **Checkpoint.** Use `/mb-end` or `mb checkpoint` to save accepted artifacts.
+
+## Current Checks
+
+Run these when applicable:
+
+```bash
+mb status --json --peek
+mb connect plan
+mb connect doctor --json
+mb site check "$SITE_REPO" --business-repo "$BUSINESS_REPO" --json
+mb validate
+```
+
+These checks help the agent stay grounded. They do not prove terminal Google Ads
+campaign creation is supported.
+
+## Future Surface
+
+The playbook should eventually enable deeper checks when those surfaces exist:
+
+- Google Ads read adapter or sidecar for campaigns, search terms, spend, and
+  conversions;
+- daily paid-search metrics cache tied to bets/pushes;
+- deterministic playbook checks for Search Partners, Final URL Expansion,
+  AI Max, primary conversion presence, and provider review gates;
+- playbook health in `mb status`;
+- provider-specific repair commands;
+- dashboard view that hides technical plumbing by default but can expose issues,
+  branches, PRs, provider refs, and evidence for technical operators.
+
+Until then, keep the run useful: clear inputs, clear approvals, clean manual
+steps, and a concrete review decision.

--- a/.claude/playbooks/google-ads-search-launch/SKILL.md
+++ b/.claude/playbooks/google-ads-search-launch/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: google-ads-search-launch
 tier: playbook
-calls: [mb-start, mb-think, mb-site, mb-ads, mb-end]
-status: draft
+calls: [start, think, site, ads, end]
+status: skeleton
 description: "Reusable Noontide playbook for validating an offer with a tightly scoped Google Ads Search launch, a paid-traffic lander, explicit approval gates, and a capped review window."
 ---
 
@@ -29,7 +29,7 @@ future accepted adapter ships with approval gates and smoke evidence.
 This file is the reusable Noontide recipe. The run belongs in the business repo:
 
 ```text
-pushes/<push>/playbooks/google-ads-search-launch.md
+pushes/<push>/playbooks/google-ads-launch-plan.md
 ```
 
 Create or update that run file from

--- a/.claude/playbooks/google-ads-search-launch/references/b2b-local-services-field-notes.md
+++ b/.claude/playbooks/google-ads-search-launch/references/b2b-local-services-field-notes.md
@@ -21,6 +21,27 @@ Recommended setup order:
 The primary conversion should exist before campaign publish. Otherwise
 Maximize Conversions launches without a primary conversion to optimize against.
 
+## Measurement Gotchas
+
+Validate the measurement chain before treating a campaign as launchable:
+
+- Enhanced measurement may see form starts but miss real form submits when the
+  lander prevents the default submit event, sends an async request, or redirects
+  after success. Prefer an explicit success event pushed after validation
+  passes.
+- Separate the lander event name from the GA4 event name when useful. For
+  example, the lander can push a success-specific dataLayer event that GTM maps
+  into a cleaner GA4 `form_submit` event.
+- Use GTM Preview mode before publishing. A one-character mismatch between the
+  lander event and the GTM custom-event trigger can leave the tag in "not
+  fired" state while the rest of the setup looks correct.
+- GA4 Realtime can show an event before the Admin events table is ready. If the
+  UI allows it, register the key event by exact name instead of waiting for the
+  table to populate.
+- Google Ads import paths vary by account UI. If the normal new-conversion flow
+  does not show the expected GA4 import tile, check the linked GA4 data source,
+  app-and-web metrics import setting, and the conversion data-source editor.
+
 ## Campaign Config Defaults
 
 For a first validation run:
@@ -74,6 +95,9 @@ Check these before diagnosing strategy:
 - "Could not find the entity" at publish can come from stale URL options:
   mobile URL, tracking template, final URL suffix, or custom parameters. Open
   that panel and clear all four.
+- A conversion can be imported but still show inactive until real traffic
+  produces events. Do not confuse inactive status before traffic with a broken
+  campaign when GTM Preview and GA4 Realtime already proved the event chain.
 - Search Partners and Final URL Expansion can re-enable after edits. Verify at
   final review.
 - Description copy has a 90-character hard cap. Count before paste.
@@ -112,4 +136,3 @@ Keep these human-approved:
 - campaign publish;
 - budget changes after launch;
 - audience, geography, network, AI Max, or URL-expansion changes after launch.
-

--- a/.claude/playbooks/google-ads-search-launch/references/b2b-local-services-field-notes.md
+++ b/.claude/playbooks/google-ads-search-launch/references/b2b-local-services-field-notes.md
@@ -1,0 +1,115 @@
+# B2B Local Services Field Notes
+
+Use this reference when the Google Ads Search launch is for a B2B local-services
+offer with a lead-form conversion and tight geography. These notes capture
+public-safe operator field learnings. Keep raw ad copy, keyword lists, negative
+lists, screenshots, and account identifiers out of public examples.
+
+## Measurement Chain
+
+Recommended setup order:
+
+1. GA4: confirm or add the lander as a data stream.
+2. GTM: use a container for the lander surface.
+3. Install the GTM snippet on the lander and ship the lander.
+4. GTM: add GA4 configuration plus the conversion-relevant events, such as
+   `form_submit` and optional `booked_call`.
+5. GA4: mark conversion-relevant events as key events.
+6. Link GA4 to Google Ads with admin access in both products.
+7. Google Ads: import the GA4 key event as a conversion and mark one primary.
+
+The primary conversion should exist before campaign publish. Otherwise
+Maximize Conversions launches without a primary conversion to optimize against.
+
+## Campaign Config Defaults
+
+For a first validation run:
+
+- Goal: Leads.
+- Campaign type: Search.
+- Bidding: Maximize Conversions until enough conversion volume exists for a
+  target CPA decision.
+- Networks: Google Search only. Search Partners off. Display Network off.
+- Geography: primary city plus tight practical radius. Use presence-only
+  targeting, not presence-or-interest.
+- Languages: English unless the offer has a reason to do otherwise.
+- Devices and schedule: all at launch unless the operator has evidence.
+- AI Max: off at campaign and ad-group levels for tightly scoped B2B proof.
+- Final URL Expansion: off.
+- Keywords: phrase and exact mirrors at launch. Broad requires a written reason.
+- Structure: one ad group is acceptable for the first signal.
+- RSAs: at least one per ad group.
+- Headline pinning: pin only the claim that must always show; write all other
+  headlines as standalone claims.
+- Logo and display path: set explicitly so unrelated account-level assets do
+  not bleed into the proof run.
+
+Re-check Search Partners, Final URL Expansion, and AI Max at review/publish.
+They can silently return in some UI flows.
+
+## Negative Categories
+
+For B2B local-services campaigns, block consumer and bad-fit intent before
+launch. Start with categories, then adapt to the niche:
+
+- consumer service intent: repair, service, install, replacement, fix,
+  "near me", broken, leaking, noisy;
+- component or equipment terms that draw DIY or consumer searches;
+- hiring and career intent: salary, jobs, hiring, careers, apprentice,
+  training, school, license, certification;
+- warranty, rebate, tax credit, and regulatory-shopping terms;
+- DIY or education terms: diy, how to, free, cheap, manual;
+- trust-research terms that indicate non-lead intent: reviews, complaints,
+  lawsuit.
+
+Phrase match is usually enough for category blocks. Use exact match when a
+shorter phrase is ambiguous.
+
+## UI Gotchas
+
+Check these before diagnosing strategy:
+
+- Bulk headline paste can land all headlines in one row and trigger a "headline
+  too long" blocker. Add one headline per row or use the UI's bulk-add path.
+- "Could not find the entity" at publish can come from stale URL options:
+  mobile URL, tracking template, final URL suffix, or custom parameters. Open
+  that panel and clear all four.
+- Search Partners and Final URL Expansion can re-enable after edits. Verify at
+  final review.
+- Description copy has a 90-character hard cap. Count before paste.
+- Dependent headline fragments can render alone if not pinned. Prefer
+  standalone headline claims.
+- Missing surface-specific logo can cause account-level fallback assets from a
+  prior brand.
+- Under-review ads can take time. Do not troubleshoot zero impressions until
+  the ad itself is approved.
+
+## Volume Calibration
+
+For a tight B2B local-services geography, low absolute volume can be normal.
+Set expectations before launch:
+
+- small validation budgets may only produce dozens of clicks in the first
+  review window;
+- form-fill conversion rates can be low on cold high-ticket traffic;
+- zero form fills in the first short window does not automatically disprove the
+  offer.
+
+Pre-commit the next move:
+
+- extend the review window at the same daily budget;
+- widen geography only if the business can serve that area;
+- change keywords, negatives, copy, or lander when click quality is poor;
+- stop when the bet is clearly disproven or no longer worth learning from.
+
+## Manual Gates
+
+Keep these human-approved:
+
+- GTM workspace publish;
+- GA4 to Google Ads link;
+- conversion import and primary conversion selection in Ads;
+- campaign publish;
+- budget changes after launch;
+- audience, geography, network, AI Max, or URL-expansion changes after launch.
+

--- a/.claude/playbooks/google-ads-search-launch/references/noontide-approach.md
+++ b/.claude/playbooks/google-ads-search-launch/references/noontide-approach.md
@@ -1,0 +1,73 @@
+# Noontide Google Ads Search Launch Approach
+
+This playbook validates whether paid search can turn a concrete offer into a
+business outcome. It is not a generic "set up Google Ads" tutorial.
+
+## What Makes The Playbook Noontide
+
+- **Bet first.** Paid search is a proof run. The operator should know what would
+  make the spend a win, useful loss, or inconclusive test.
+- **Offer before account.** Account history helps, but the offer, audience,
+  promise, proof, and lander decide what the campaign should try.
+- **Conversion path before spend.** Traffic without measurement is just a bill.
+- **Search intent over volume.** Start with high-intent terms the lander can
+  honestly satisfy.
+- **Negatives protect the bet.** Bad-fit queries are a strategy problem, not
+  cleanup trivia.
+- **One clean review window.** The first launch should answer a bounded
+  question, not become a forever campaign by accident.
+- **Manual provider authority.** Main Branch can prepare, check, and record the
+  plan. The operator approves and performs provider mutation until an accepted
+  adapter exists.
+
+## New Offer Default
+
+When the business has never advertised this offer:
+
+- skip claims about historical winners;
+- research customer intent and keyword families through `/mb-think`;
+- keep the first campaign small enough to learn from;
+- document assumptions in the run record;
+- expect the first review to refine keywords, negatives, lander copy, and
+  conversion assumptions.
+
+## Existing Account Default
+
+When the account has useful history:
+
+- inspect prior campaigns, search terms, negatives, conversion actions,
+  disapprovals, and economics if approved read-only access or sanitized exports
+  exist;
+- rescue an existing campaign when the offer, conversion, goal, budget model,
+  and geography still match;
+- create a new campaign when the offer, conversion, goal, budget model,
+  geography, or structure materially changes;
+- pause bad assets before deleting them, so the audit trail survives the first
+  review window.
+
+## Proof Budget
+
+A small proof budget is acceptable only when it can produce an interpretable
+answer. The operator should set:
+
+- budget cap;
+- expected CPC range;
+- minimum clicks or spend before review;
+- primary conversion target;
+- business value of the conversion;
+- stop/change/continue threshold.
+
+Do not present a fixed spend amount as universal. Some niches need more data;
+some can learn from a smaller test.
+
+## Review Decision
+
+At the end of the review window:
+
+- **Continue** when the economics and lead quality are promising enough to let
+  the campaign gather more data.
+- **Change** when intent exists but the campaign, negatives, lander, conversion
+  path, or offer needs repair.
+- **Stop** when the bet is disproven, blocked by policy, or too expensive to
+  learn from responsibly.
+

--- a/.claude/playbooks/google-ads-search-launch/templates/push-playbook.md
+++ b/.claude/playbooks/google-ads-search-launch/templates/push-playbook.md
@@ -1,0 +1,131 @@
+---
+type: playbook
+status: draft
+push: ../push.md
+platform: google-ads
+provider: google-ads
+provider_boundary: plan-only
+trigger:
+  kind: operator_launch_request
+resource:
+  kind: document
+  value: docs/google-ads-gtm-conversion-rubric.md
+copy:
+  public_cta:
+  reply:
+approval:
+  required: true
+  status: needed
+  approved_by:
+  approved_at:
+state:
+  provider_refs: []
+  activated_at:
+  retired_at:
+validation:
+  dry_run: not-run
+  smoke_evidence: []
+  notes: Plan only; no Google Ads or GTM mutation has been performed.
+linked_outcomes: []
+---
+# Google Ads Search Launch
+
+## Bet And Success Criteria
+
+-
+
+## Source Facts
+
+- `mb status --json --peek`:
+- `mb connect plan` / `mb connect doctor --json`:
+- `mb site check`:
+- Account history source:
+
+## Offer And Policy Fit
+
+-
+
+## Lander And Conversion Readiness
+
+-
+
+## Measurement Chain
+
+- GA4 data stream:
+- GTM container:
+- GTM snippet installed:
+- GA4 key event:
+- Ads imported primary conversion:
+
+## Campaign Structure
+
+- Goal:
+- Type:
+- Bidding:
+- Networks:
+- Geo:
+- AI Max:
+- Final URL Expansion:
+- Ad groups:
+
+## Keyword Targets
+
+-
+
+## Negative Strategy
+
+- Consumer service intent:
+- Component/equipment terms:
+- Hiring/career:
+- Warranty/regulatory:
+- DIY/education:
+- Trust-research terms:
+
+## Ads And Assets
+
+- RSA:
+- Pinned headline:
+- Descriptions under 90 chars:
+- Logo:
+- Display path:
+
+## UI Review Gotchas
+
+- [ ] Headlines entered one per row or via bulk-add
+- [ ] Ad URL options cleared if publish errors appear
+- [ ] Search Partners still off
+- [ ] Final URL Expansion still off
+- [ ] AI Max still off
+- [ ] Dependent headline fragments avoided or pinned
+- [ ] Surface-specific logo set
+- [ ] Ad approval state checked before diagnosing zero impressions
+
+## Manual Provider Steps
+
+-
+
+## Approval Gates
+
+- [ ] Lander and sitelinks reviewed
+- [ ] Conversion action reviewed
+- [ ] Consent/privacy posture reviewed
+- [ ] Campaign structure reviewed
+- [ ] Keywords and negatives reviewed
+- [ ] Ad copy/assets reviewed
+- [ ] Billing and budget reviewed
+- [ ] GA4 to Ads link reviewed
+- [ ] Primary conversion import reviewed
+- [ ] Network, geo, AI Max, and Final URL Expansion reviewed
+- [ ] Launch/unpause approved
+
+## Budget And Review Window
+
+- Budget cap:
+- Review window:
+- Expected click range:
+- Extension/widening rule:
+
+## Review Decision
+
+- Continue/change/stop:
+- Outcome/log link:

--- a/.claude/playbooks/google-ads-search-launch/templates/push-playbook.md
+++ b/.claude/playbooks/google-ads-search-launch/templates/push-playbook.md
@@ -54,6 +54,8 @@ linked_outcomes: []
 - GA4 data stream:
 - GTM container:
 - GTM snippet installed:
+- GTM Preview verified:
+- Lander success event:
 - GA4 key event:
 - Ads imported primary conversion:
 
@@ -91,6 +93,10 @@ linked_outcomes: []
 
 ## UI Review Gotchas
 
+- [ ] Form-submit tracking uses an explicit success event when auto-detection is unreliable
+- [ ] GTM Preview shows the conversion tag firing on the expected event
+- [ ] GA4 Realtime or key-event registration confirms the event name
+- [ ] Ads imported conversion is selected as primary, even if inactive before traffic
 - [ ] Headlines entered one per row or via bulk-add
 - [ ] Ad URL options cleared if publish errors appear
 - [ ] Search Partners still off

--- a/.claude/skills/mb-ads/references/google-ads-campaign-plan.md
+++ b/.claude/skills/mb-ads/references/google-ads-campaign-plan.md
@@ -1,0 +1,228 @@
+# Google Ads Campaign Plan Workflow
+
+Load this when the operator asks for a Google Ads campaign plan, campaign
+rescue, search launch, paid-traffic launch, or launch check. This workflow
+turns business context and account facts into a reviewable plan. It does not
+publish campaigns, change budgets, upload conversions, publish GTM, or mutate
+provider accounts.
+
+## Route
+
+Use this route:
+
+1. `/mb-think` when the offer, audience, policy fit, keywords, competitor terms,
+   or lander argument needs research before campaign work.
+2. `/mb-site` when the landing page, conversion endpoint, GTM/dataLayer events,
+   consent posture, sitelinks, or measurement readiness is missing.
+3. `/mb-ads launch-plan` when the operator needs campaign structure, keywords,
+   negatives, ad assets, budget, manual provider steps, and approvals.
+4. `/mb-ads check` when the operator asks whether to continue, change, or stop
+   after a review window.
+
+If the work is repeatable or has approval state, write a plan-only playbook at
+`pushes/<push>/playbooks/google-ads-launch-plan.md` with `type: playbook`.
+
+## Required Inputs
+
+Read or ask for:
+
+- active offer, audience, promise, proof, and current lander;
+- launch push at `pushes/<push>/push.md`;
+- provider readiness from `mb status --json --peek` and `mb connect doctor --json`;
+- site readiness from `mb site check "$SITE_REPO" --business-repo "$BUSINESS_REPO" --json`
+  when a site repo exists;
+- Google Ads account state if the operator provides a sanitized export or an
+  explicitly approved read-only provider tool is already available;
+- historical winners: search terms, keywords, CPC/CPA, conversions, landing
+  pages, and disapproval or policy history;
+- existing negative keyword lists and campaign-level exclusions;
+- budget cap, review window, geographic scope, and launch objective;
+- regulated-category risks such as healthcare, finance, credit, employment,
+  housing, legal, politics/social issues, alcohol, supplements, or claims that
+  need proof.
+
+Do not ask the operator to paste OAuth tokens, API keys, customer records,
+raw account exports with PII, conversion uploads, or screenshots that expose
+private account details. Ask for sanitized exports or manual answers instead.
+
+## Prerequisite Setup And CLI Boundary
+
+Before planning from live account facts, identify which access path actually
+exists:
+
+1. Run `mb status --json --peek` and `mb connect plan` from the business repo.
+2. If a site repo exists, run `mb site check "$SITE_REPO" --business-repo "$BUSINESS_REPO" --json`.
+3. Treat `mb connect` as the Main Branch readiness and repair surface, not as
+   proof that Google Ads campaign creation is supported from the terminal.
+4. Treat the current Google/Workspace connection as a docs/sheets/drive bridge
+   unless this release's `mb connect list` or `mb connect doctor --json`
+   explicitly reports a Google Ads provider adapter.
+5. Use live Google Ads reads only when an approved runtime tool, MCP server,
+   sidecar, or future `mb` adapter is already configured and the operator
+   approves read-only account inspection for this business.
+6. Use Google Ads UI/manual provider steps for account creation, billing,
+   OAuth consent, customer selection, campaign creation, launch/unpause, and
+   budget changes unless a shipped adapter with smoke evidence says otherwise.
+
+For a first-time or new-offer setup, prerequisite facts are:
+
+- Google account or manager account that owns the business relationship;
+- Google Ads customer selected for this business/offer boundary;
+- billing and spend owner confirmed in Google Ads;
+- Google Ads conversion action or GA4-imported conversion chosen for the
+  launch goal;
+- GTM or gtag instrumentation plan verified through `/mb-site`;
+- consent/privacy posture and policy pages reviewed;
+- account history either unavailable, intentionally ignored, or read through
+  a sanctioned source.
+
+If `mb connect` reports Google Ads as missing, planned, unsupported, or absent
+from the provider list, do not block copy/plan work. Continue in plan-only mode
+using repo facts, `mb site check`, sanitized exports, and manual Google Ads UI
+steps.
+
+## Decision Sequence
+
+### 1. Offer And Policy Fit
+
+Confirm the offer can be advertised as stated. For regulated categories, read
+provider policy before writing copy. If the offer or lander triggers a
+restricted classification, stop and present options:
+
+- rewrite the offer/lander/copy into a policy-safe form;
+- build a separate product or front door only if the operator accepts the
+  business, legal, and brand boundary;
+- pursue required certification or verification;
+- pause paid traffic and route to organic, SEO, referrals, or another channel.
+
+Do not frame policy work as "bypassing" a provider. Frame it as accurate
+classification, clean claims, and operator-approved compliance.
+
+### 2. Existing Campaign Versus New Campaign
+
+Prefer an existing campaign when all are true:
+
+- same offer or service line;
+- same conversion event;
+- same goal and budget structure;
+- useful historical search/query/negative-list data exists;
+- the problem is copy, lander, policy, or stale settings rather than a broken
+  campaign structure.
+
+Start a new campaign only when goal, product/service line, conversion event,
+budget model, geography, or structural settings materially change.
+
+When rescuing a campaign, pause bad or disapproved ads instead of immediately
+deleting them. Add new clean assets inside the existing campaign or a new ad
+group, keep the campaign paused until at least one new asset is approved, and
+record the old asset status as audit context. After a clean review window, the
+operator can delete stale assets manually.
+
+### 3. Campaign Structure
+
+Draft only the structure that fits the evidence. Common search structures:
+
+- brand defense: brand, founder, product, and close variants;
+- geo/local intent: service plus city/region terms;
+- high-intent service: ready-to-buy terms and "near me" variants;
+- competitor/alternative: only when policy-safe and not misleading;
+- proof or education: only when the lander and measurement path support it.
+
+Each ad group should have:
+
+- exact/phrase keyword targets where intent matters;
+- broad match only with a clear reason and tight negatives;
+- one lander or sitelink set;
+- policy-safe headlines/descriptions;
+- explicit manual review notes.
+
+### 4. Keywords And Negative Strategy
+
+Use account history first when available. Keep:
+
+- historical converters;
+- search terms with acceptable economics;
+- brand and geo-intent winners;
+- exact/phrase terms aligned with the lander promise.
+
+Exclude:
+
+- DIY, free, job, school, research, entertainment, definition, unrelated
+  locations, competitor terms that create policy risk, and impossible-fit
+  searches;
+- regulated terms that imply unsupported claims, prescription/order behavior,
+  guarantees, discriminatory targeting, or sensitive personal attributes;
+- any term the operator marks as a bad-fit lead.
+
+If a shared negative list exists, tell the operator to attach it to the campaign
+manually. Do not paste a large account-specific negative export into public
+docs or committed examples.
+
+### 5. Lander And Conversion Prerequisites
+
+Before recommending launch:
+
+- run `mb site check` when a site repo exists;
+- verify GTM/dataLayer event names match
+  `docs/google-ads-gtm-conversion-rubric.md`;
+- confirm the primary conversion action matches the launch goal;
+- audit every sitelink destination, not only the final URL;
+- confirm consent/privacy posture and policy pages are acceptable;
+- if conversion tracking has been dark or stale, require a manual test before
+  trusting performance data.
+
+Use the `mb site check` readiness state. Never invent `ready_for_launch`, and
+never treat `ready` as permission to spend.
+
+### 6. Budget And Review Window
+
+Capture:
+
+- daily/monthly budget cap;
+- bid strategy for the first review window;
+- launch geography and schedule;
+- review date or spend threshold;
+- continue/change/stop criteria;
+- who approves spend.
+
+If the account has stale conversion history, recommend conservative bidding
+until recent conversion data exists. Do not switch to automated bidding because
+it sounds sophisticated; tie it to evidence and volume.
+
+### 7. Approval Gates
+
+The plan must show separate approvals for:
+
+- campaign structure and keywords;
+- negative list;
+- ad copy and assets;
+- lander/sitelinks;
+- conversion action and GTM/Tag Assistant evidence;
+- consent/privacy posture;
+- budget and billing;
+- launch/unpause.
+
+Main Branch may write the plan and checklist. The operator performs provider
+actions unless a future adapter ships with approval gates and smoke evidence.
+
+## Output Shape
+
+For `pushes/<push>/ads.md` or the campaign-plan playbook body, include:
+
+- `## Source Facts`
+- `## Offer And Policy Fit`
+- `## Existing Account/Campaign Decision`
+- `## Readiness`
+- `## Budget And Review Window`
+- `## Campaign Structure`
+- `## Keyword Targets`
+- `## Negative Strategy`
+- `## Ads And Assets`
+- `## Lander And Sitelinks`
+- `## Measurement Checklist`
+- `## Manual Provider Steps`
+- `## Approval Gates`
+- `## Review Loop`
+
+Keep real account IDs, screenshots, raw exports, customer data, and private
+spend details out of public-safe committed examples.

--- a/.claude/skills/mb-ads/references/google-ads-campaign-plan.md
+++ b/.claude/skills/mb-ads/references/google-ads-campaign-plan.md
@@ -21,6 +21,13 @@ Use this route:
 
 If the work is repeatable or has approval state, write a plan-only playbook at
 `pushes/<push>/playbooks/google-ads-launch-plan.md` with `type: playbook`.
+When the operator wants the reusable Noontide paid-search recipe, use the
+`google-ads-search-launch` playbook under `.claude/playbooks/`; that playbook
+instantiates the push playbook run record and calls this skill for campaign
+planning.
+For B2B local-services lead-form launches, load that playbook's field notes for
+GA4/GTM/Ads import order, Search-only defaults, UI gotchas, negative categories,
+and volume calibration.
 
 ## Required Inputs
 

--- a/.claude/skills/mb-ads/references/launch-plan-check.md
+++ b/.claude/skills/mb-ads/references/launch-plan-check.md
@@ -70,7 +70,11 @@ Sections:
 
 If the work includes repeatable provider setup, resource delivery, or approval
 state, draft a `type: playbook` file under `pushes/<push>/playbooks/` instead
-of hiding the plan in prose.
+of hiding the plan in prose. For a reusable Noontide Google Ads Search proof
+run, route through the `.claude/playbooks/google-ads-search-launch/` playbook
+and instantiate its push-playbook template.
+For B2B local-services lead-form campaigns, apply that playbook's field notes
+before launch review.
 
 ## Policy Preflight
 

--- a/.claude/skills/mb-ads/references/launch-plan-check.md
+++ b/.claude/skills/mb-ads/references/launch-plan-check.md
@@ -1,7 +1,9 @@
 # Launch Plan And Check Modes
 
 Use this when the operator asks to launch/check paid traffic, especially Google
-Ads traffic for a lander or minisite.
+Ads traffic for a lander or minisite. For Google Ads campaign structure,
+account-history, keyword, negative-list, policy-fit, and approval sequencing,
+load [`google-ads-campaign-plan.md`](google-ads-campaign-plan.md).
 
 This mode prepares a reviewable plan and checks recorded readiness. It does not
 mutate Google Ads, GTM, Meta Ads, Stripe, or analytics providers unless a future
@@ -15,6 +17,9 @@ From the business repo:
 - the launch push at `pushes/<push>/push.md`;
 - keyword-gate research, especially ready-to-buy terms and negative seeds;
 - site record or linked site repo;
+- existing ad account/campaign exports or read-only Google Ads facts when the
+  operator explicitly provides them, or when an approved runtime tool, sidecar,
+  MCP server, or future `mb` adapter proves read-only access for this business;
 - `docs/google-ads-gtm-conversion-rubric.md`;
 - `mb status --json --peek`;
 - `mb connect plan` or `mb connect doctor --json`;
@@ -52,6 +57,7 @@ Sections:
 - `## Readiness`
 - `## Budget And Review Window`
 - `## Campaign Structure`
+- `## Existing Account/Campaign Decision`
 - `## Keyword Targets`
 - `## Negative Seeds`
 - `## Headlines`
@@ -73,9 +79,23 @@ Before preparing launch copy:
 - run the normal ad compliance review flow;
 - check for regulated verticals: medical, finance, credit, employment,
   housing, legal, social issues/politics;
+- decide whether the request needs `/mb-think` first for offer/policy research,
+  keyword-gate work, competitor mapping, or a separate-product decision;
 - compare claims against offer proof and Skool/site surfaces when present;
 - stop on unsupported guarantees, "cures/treats/heals" claims, impossible
   outcomes, or provider-specific disallowed phrases.
+
+## Existing Campaign Guidance
+
+When account history exists, do not default to a new campaign. Prefer keeping an
+existing campaign when the same offer, conversion event, goal, budget structure,
+and useful search/negative history still apply. In that case, plan to pause bad
+or disapproved assets, add clean assets inside the existing campaign or ad
+group, keep the campaign paused until review approval, and record the old
+assets as audit context.
+
+Recommend a new campaign only when the goal, offer/service line, conversion
+event, budget model, geography, or campaign settings materially change.
 
 ## Check Mode
 
@@ -88,8 +108,8 @@ default, use one of these sources:
 1. `mb status --json --peek` and relationship/outcome health.
 2. Existing push outcome/review files.
 3. Operator-provided Ads/GTM/Stripe screenshots or CSV exports.
-4. Read-only provider context only when `mb connect` and the current runtime
-   prove it is ready.
+4. Read-only provider context only when an approved runtime tool, sidecar, MCP
+   server, or future `mb` adapter proves it can inspect that provider account.
 
 Output a concise continue/change/stop recommendation and write findings to the
 push review or outcome file when the operator approves.

--- a/.claude/skills/mb-start/references/launch-orchestration.md
+++ b/.claude/skills/mb-start/references/launch-orchestration.md
@@ -33,9 +33,17 @@ cited repair command.
    stops the default path unless the operator explicitly overrides.
 4. **Lander plan/build.** Route to `/mb-site` lander mode. If paid traffic is in
    scope, require the site measurement checks from `/mb-site` before ads work.
-5. **Ad launch plan/check.** Route to `/mb-ads` launch-plan or check mode. This
-   prepares copy, keyword targets, negatives, policy findings, budget notes, and
-   manual provider steps. It does not mutate Google Ads/GTM/Meta accounts.
+5. **Ad launch plan/check.** Route to `/mb-ads` launch-plan or check mode. For
+   Google Ads, the skill should load the Google Ads campaign-plan reference,
+   decide whether `/mb-think` policy/keyword research is needed, reuse useful
+   account history when the operator provides it or an approved read-only
+   provider tool exists, check whether an existing campaign should be rescued
+   instead of rebuilt, and prepare copy, keyword targets, negatives, policy
+   findings, budget notes, manual provider steps, approval gates, and
+   review-window criteria. Use `mb connect` and `mb site check` for readiness
+   facts, but do not treat them as proof that Google Ads campaign creation is
+   supported from the terminal. It does not mutate Google Ads/GTM/Meta
+   accounts.
 6. **Checkpoint.** After each accepted artifact or approval record, run
    `mb checkpoint --plan --json`, validate the message, and save only after
    operator approval.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,10 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   playbook, covering GA4/GTM/Ads import order, Search-only campaign defaults,
   UI gotchas, negative-keyword categories, manual gates, and validation-window
   calibration. Refs #422.
+- Expanded the Google Ads Search launch playbook with measurement-chain gotchas
+  from the related operator repo launch notes: explicit form-success events,
+  GTM Preview verification, GA4 Realtime/admin lag, and Google Ads conversion
+  import UI variants. Refs #414, #422.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,11 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   durable business truth, active bets, execution work, proof, legacy
   compatibility files, and linked operating-boundary repos before routing or
   spawning agents. Refs #410.
+- Added Google Ads campaign-plan guidance for `/mb-ads`, including
+  offer/policy-fit routing, existing-campaign rescue decisions, account-history
+  inputs, `mb connect`/provider-tool boundary checks, keyword and negative-list
+  planning, site/conversion readiness, approval gates, and a sanitized
+  plan-only push playbook fixture. Refs #414.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,13 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   inputs, `mb connect`/provider-tool boundary checks, keyword and negative-list
   planning, site/conversion readiness, approval gates, and a sanitized
   plan-only push playbook fixture. Refs #414.
+- Added the first reusable Google Ads Search launch playbook skeleton under
+  `.claude/playbooks/`, with Noontide's paid-search proof-run approach and a
+  push-playbook run template. Refs #414.
+- Added B2B local-services Google Ads field notes to the reusable Search launch
+  playbook, covering GA4/GTM/Ads import order, Search-only campaign defaults,
+  UI gotchas, negative-keyword categories, manual gates, and validation-window
+  calibration. Refs #422.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   durable business truth, active bets, execution work, proof, legacy
   compatibility files, and linked operating-boundary repos before routing or
   spawning agents. Refs #410.
+- Added Google Ads campaign-plan guidance for `/mb-ads`, including
+  offer/policy-fit routing, existing-campaign rescue decisions, account-history
+  inputs, `mb connect`/provider-tool boundary checks, keyword and negative-list
+  planning, site/conversion readiness, approval gates, and a sanitized
+  plan-only push playbook fixture. Refs #414.
 
 ### Changed
 

--- a/mb/tests/fixtures/pushes/2026-05-08-google-ads-launch/playbooks/google-ads-launch-plan.md
+++ b/mb/tests/fixtures/pushes/2026-05-08-google-ads-launch/playbooks/google-ads-launch-plan.md
@@ -1,0 +1,54 @@
+---
+type: playbook
+status: draft
+push: ../push.md
+platform: google-ads
+provider: google-ads
+provider_boundary: plan-only
+trigger:
+  kind: operator_launch_request
+resource:
+  kind: document
+  value: docs/google-ads-gtm-conversion-rubric.md
+copy:
+  public_cta: Prepare Google Ads materials for operator review.
+  reply: Plan only; provider changes require explicit operator approval.
+approval:
+  required: true
+  status: needed
+  approved_by:
+  approved_at:
+state:
+  provider_refs: []
+  activated_at:
+  retired_at:
+validation:
+  dry_run: not-run
+  smoke_evidence: []
+  notes: Fixture is a plan only and performs no Google Ads or GTM mutation.
+linked_outcomes: []
+---
+# Google Ads Launch Plan Playbook
+
+This sanitized fixture demonstrates a provider-safe Google Ads campaign plan.
+It records approval state, readiness evidence, manual provider steps, and review
+hooks without storing account IDs, customer data, screenshots, or secrets.
+
+## Source Facts
+
+- `mb status --json --peek` should be read before campaign planning.
+- `mb connect plan` or `mb connect doctor --json` should identify provider
+  readiness and repair commands.
+- `mb site check <site> --business-repo <business> --json` should verify local
+  paid-traffic measurement readiness when a site repo exists.
+- Live Google Ads account reads require a separately approved runtime tool,
+  sidecar, MCP server, or future `mb` adapter. This fixture does not prove
+  terminal campaign creation.
+
+## Manual Provider Steps
+
+- Select the Google account or manager account that owns the business.
+- Select the Google Ads customer for this offer boundary.
+- Confirm billing, conversion actions, consent posture, and launch budget.
+- Create, pause, unpause, or edit campaigns in Google Ads only after operator
+  approval.

--- a/mb/tests/fixtures/pushes/2026-05-08-google-ads-launch/push.md
+++ b/mb/tests/fixtures/pushes/2026-05-08-google-ads-launch/push.md
@@ -1,0 +1,18 @@
+---
+type: push
+slug: google-ads-launch
+kind: launch
+status: planned
+health: unknown
+goal:
+  metric: qualified leads
+  target: "5"
+  by: 2026-05-22
+owner: Test Operator
+audience: buyers searching for a high-intent service
+offer: mb/tests/fixtures/core/offers/workshop/offer.md
+promise: Prepare a provider-safe Google Ads launch plan for operator review.
+---
+# Google Ads Launch Push
+
+Sanitized push wrapper for a Google Ads campaign-plan playbook fixture.

--- a/mb/tests/test_validate.py
+++ b/mb/tests/test_validate.py
@@ -875,6 +875,12 @@ def test_validate_accepts_sanitized_push_playbook_fixture() -> None:
         and file["ok"]
         for file in report["files"]
     )
+    assert any(
+        file["path"] == "pushes/2026-05-08-google-ads-launch/playbooks/google-ads-launch-plan.md"
+        and file["schema"] == "push-playbooks"
+        and file["ok"]
+        for file in report["files"]
+    )
 
 
 def test_validate_requires_push_playbook_shape(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Adds a plan-only Google Ads campaign workflow for `/mb-ads`, including policy fit, account-history use, existing-campaign rescue, keyword/negative planning, site readiness, approvals, and review loops.
- Adds the reusable `.claude/playbooks/google-ads-search-launch/` playbook plus a push-playbook template for business-repo run records.
- Adds sanitized B2B local-services field notes and measurement-chain gotchas from the operator workflow without committing raw transcripts, account details, copy, keywords, or provider screenshots.
- Adds a sanitized push playbook fixture and validation assertion for the Google Ads launch-plan shape.

## Scope
- In: Google Ads planning guidance, reusable playbook recipe, run-record template, sanitized fixture/test coverage, and changelog entry.
- Out: Google Ads/GTM provider automation, campaign publishing, budget mutation, conversion uploads, billing/account setup, raw transcript or account data, and claims that terminal campaign creation is supported.

## Commits
- `6f21ca1` — `[add] MAIN-287 Google Ads campaign plan workflow`.
- `c07ddb8` — `[add] MAIN-287 Google Ads campaign plan workflow`.
- `8467dc5` — merge commit preserving the already-pushed branch history after pulling latest `main`.
- `c4f6c98` — `[add] MAIN-287 Google Ads search launch playbook`.
- `c9ad8d0` — `[update] MAIN-287 Google Ads measurement gotchas`.
- `191115e` — `[fix] MAIN-287 align Google Ads playbook run name`.

## Release / Issues
- Release: v0.3.x / next workflow tightening.
- Linear ID(s): MAIN-287, MAIN-291.
- Closes: #414.
- Refs: #422.
- Follow-ups: Google Ads provider adapter/write path, deterministic Ads config checks, playbook health in `mb status`, and sidecar-backed metrics/import review.

## Success Metric
- An agent can route a Google Ads Search launch into a public-safe reusable playbook and a validated push playbook run record, while keeping provider mutation manual until an accepted adapter exists.

## Validation
- Level 0 docs/decision: reviewed public/private boundary, naming consistency, and merged playbook topology guidance.
- Level 1 static: `scripts/check.sh` passed.
- Level 2 CLI: `cd mb && python3 -m pytest tests/test_validate.py tests/test_runtime_command_references.py -q` passed; `cd mb && python3 -m mb skill validate --all` passed.
- Level 3 package/install: not run; no packaging, entrypoint, bundled-data install, or update path changed.
- Level 4 fixture repo: not run; no scaffold/runtime repo shape changed, but the sanitized push playbook fixture is covered by validation tests.
- Level 5 runtime smoke: not run; skill discovery/invocation did not change, and this is LLM-facing playbook/reference prose.

## Public / Private Boundary
- Private transcripts, local paths, account IDs, live URLs, raw ad copy, exact keywords/negative lists, screenshots, spend details, and customer-specific context stayed out of committed files; source summaries remain in `.context/` only.
