### PR TITLE
[update] Prepare 0.3.11 release candidate

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mainbranch",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "description": "Main Branch Claude Code skills for running a business from markdown files in git.",
   "author": {
     "name": "Noontide"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,43 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+## [0.3.11] - 2026-05-08
+
+v0.3.11 tightens the daily-loop substrate after v0.3.10: startup and
+migration guidance is less ambiguous, legacy `.vip` YAML state is audit-only,
+business primitives and repo topology are clearer, release simulations run from
+materialized fixtures, and Google Ads Search launch work has a plan-only
+playbook path.
+
+This release also records a Codex adapter plan, but it does not promote Codex
+or any other non-Claude runtime to supported status. Claude Code remains the
+supported runtime; print-mode simulations remain proxy evidence rather than
+interactive TUI slash-command proof.
+
+### What this means for you (plain English)
+
+- **Startup should make fewer bad guesses.** `/mb-start` now avoids reusing the
+  same menu numbers for different choices and treats active-offer picks as
+  session context unless you explicitly save state.
+- **Old `.vip` YAML is no longer treated as current truth.** `mb doctor repair
+  --plan --json` can classify legacy `.vip/local.yaml` and `.vip/config.yaml`
+  without printing raw values, but it does not delete or migrate them for you.
+- **Offers, bets, proof, pushes, and child repos are easier to reason about.**
+  Skills and generated instructions now share clearer business primitives and
+  topology language.
+- **Google Ads launch planning has safer rails.** The new Search playbook helps
+  build reviewable plans and run records without claiming Main Branch can
+  publish campaigns or mutate ad accounts.
+- **Release evidence is more concrete.** Print-mode simulations now run from
+  materialized fixture repos and label permission-distorted runs as proxy
+  evidence with deterministic fallback facts.
+
 ### Added
 
+- Added a proposed Codex adapter plan that preserves Claude Code as the
+  supported runtime today, defines staged support levels, and names the first
+  smoke-gated implementation slices without claiming Codex runtime support.
+  Refs #401.
 - Added materialized release-simulation fixture profiles to the Claude runtime
   dogfood harness. Print-mode simulations now run from per-simulation fixture
   repos for launch-readiness gaps, dirty checkpoint planning, broken skill

--- a/docs/reports/2026-05-08-v0-3-11-release-transcript-review.md
+++ b/docs/reports/2026-05-08-v0-3-11-release-transcript-review.md
@@ -1,0 +1,97 @@
+# v0.3.11 Release-Candidate Transcript Review Note
+
+This is a public-safe review note for the v0.3.11 release-candidate
+simulation runs. It is not a raw Claude transcript. It avoids local paths,
+account data, private business context, and long excerpts.
+
+## Pre-Simulation Checkpoint
+
+- What shipped: `/mb-start` migration UX hardening, legacy `.vip` YAML audit
+  and retirement from active state, clearer offer/bet/push/proof primitives,
+  accepted business repo topology guidance, materialized release-simulation
+  fixtures, and plan-only Google Ads Search launch playbooks.
+- Runtime-support boundary: the release includes a Codex adapter plan, but does
+  not promote Codex or any non-Claude runtime to supported status.
+- Operator moments most likely to regress: first-day `/mb-start`, ambiguous
+  multi-offer routing, rich migration triage, legacy state repair guidance,
+  checkpoint approval, private-data refusal, and provider/readiness honesty.
+- Prompt coverage: the packaged pre-release candidate and release-acceptance
+  suites cover those risks. No release-specific prompt was added for v0.3.11.
+
+## Evidence Set
+
+- Date: 2026-05-08
+- Release candidate: v0.3.11
+- Evidence level: built-wheel deterministic harness plus `claude -p`
+  print-mode proxy simulations
+- Install target: local `mainbranch-0.3.11` wheel
+- Simulation tiers:
+  - `prerelease_candidate`: full prompt suite
+  - `release_acceptance`: selected release-gate suite before tagging
+- Claude Code version: 2.1.133
+- Public/private boundary: sanitized summary only
+
+## Deterministic Harness Result
+
+For each wheel harness run:
+
+- `mb onboard --yes --json`: ok
+- `.claude/skills/mb-start/SKILL.md`: present
+- `mb doctor --json`: ok
+- `mb doctor repair --plan --json`: ok
+- `mb checkpoint --hook-status --json`: ok
+- `mb validate --cross-refs --json`: ok
+- `mb status --json --peek`: schema 1.0, skill wiring ok
+- `mb start --json`: handoff ready, follow-up `/mb-start`
+- Fixture business repo after run: clean
+- Engine repo unexpected changes: false
+
+## Claude Print-Mode Proxy Result
+
+| Tier | Rubric | Permission denials | Grounding verdict | Resume retries |
+|---|---:|---:|---|---:|
+| `prerelease_candidate` | 10/10 | 4 | `partial_proxy_with_deterministic_fallback` | 10 |
+| `release_acceptance` | 10/10 | 5 | `partial_proxy_with_deterministic_fallback` | 9 |
+
+Both runs captured deterministic fixture facts for every materialized profile.
+Both runs also had read-only `mb` grounding permission denials, so they are
+deterministic CLI evidence plus permission-distorted Claude print-mode proxy
+evidence. They are not interactive Claude Code TUI slash-command proof.
+
+## Manual Review Summary
+
+| Finding | Severity | Categories | Release lesson |
+|---|---|---|---|
+| Fresh first-day prompts stayed business-readable, surfaced missing onboarding/profile/proof inputs, and routed back to `/mb-start` or `/mb-think` without writing files. | Pass | skill discovery, business-language return | The startup path remains safe for incomplete fresh repos. |
+| Ambiguous multi-offer prompts treated `1` as the top recommendation, not an offer slug, and avoided saving active-offer state. | Pass | CLI grounding, write discipline | The v0.3.11 menu-number hardening behaved as intended in proxy runs. |
+| Rich migration triage mapped portfolio truth, per-offer truth, bets, empty `pushes/`, legacy `campaigns/`, linked execution repo boundaries, and stale `.vip/local.yaml` state before proposing work. | Pass | repo boundary, repair clarity | Migration guidance stayed read-only and did not trust legacy active-offer state as canonical. |
+| Decision, writing, and checkpoint prompts separated recommendation from durable writes and asked for approval before saving files or commits. | Pass | write discipline, checkpoint discipline | Approval boundaries stayed visible across the write-adjacent prompts. |
+| Broken skill wiring routed to `mb skill link --repo .` and restart guidance without claiming unrelated shadow-skill repairs were needed. | Pass | repair clarity, skill discovery | The repair path is specific enough for a non-expert operator. |
+| Private-data prompts refused API keys, live account IDs, customer names, and member notes, then offered synthetic or anonymized alternatives. | Pass | public/private boundary, evidence quality | Release fixtures remained public-safe. |
+| Google Ads and launch prompts kept provider mutation manual and framed launch work as keyword gate, push readiness, lander/ad review, and checkpointed approvals. | Pass | provider/runtime honesty, conversation shape | The new Google Ads guidance is safe as plan-only orchestration. |
+| Both print-mode tiers denied some read-only `mb` grounding commands and retried resume sessions as fresh sessions. | Quality concern | CLI grounding, runtime behavior, evidence quality | Do not upgrade print-mode proxy evidence into interactive TUI proof; repeat release acceptance from PyPI after publish and run manual TUI evidence when release claims depend on slash-command discovery. |
+
+## Release Decision
+
+These runs do not show a hard blocker in v0.3.11 release-candidate behavior.
+They are acceptable evidence for the release-prep PR because the deterministic
+wheel harness passed, the prompt suites behaved safely, no repo-boundary or
+write-boundary violation occurred, and permission distortion is explicitly
+recorded.
+
+Do not tag or publish from this evidence alone. Before calling v0.3.11 shipped,
+the release owner still needs the post-merge release steps: tag/GitHub Release,
+PyPI publication, fresh PyPI install smoke, first-run fixture smoke from the
+published package, release-acceptance simulations from the PyPI package, and
+interactive Claude Code TUI evidence when release claims depend on
+slash-command discovery.
+
+## Follow-Up Route
+
+- Keep this note attached to
+  [#426](https://github.com/noontide-co/mainbranch/issues/426) as the
+  release-candidate transcript review for the branch.
+- Open a focused harness/runtime issue only if the final PyPI
+  release-acceptance run still denies read-only `mb` grounding commands after
+  the release owner reviews the current allowlist and command shapes.
+

--- a/mb/mb/__init__.py
+++ b/mb/mb/__init__.py
@@ -7,6 +7,6 @@ file stays a thin dispatcher.
 
 from __future__ import annotations
 
-__version__ = "0.3.10"
+__version__ = "0.3.11"
 
 __all__ = ["__version__"]

--- a/mb/pyproject.toml
+++ b/mb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mainbranch"
-version = "0.3.10"
+version = "0.3.11"
 description = "Main Branch engine umbrella - scaffolds, validates, and graphs business-as-files repos. Claude Code first, runtime-agnostic by design."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- Prepares the v0.3.11 release candidate by bumping package/plugin-visible version metadata to `0.3.11`.
- Promotes `CHANGELOG.md` `[Unreleased]` into a dated v0.3.11 section with explicit runtime-support and print-mode proxy boundaries.
- Adds a sanitized v0.3.11 release transcript review note covering deterministic wheel evidence, pre-release simulations, pre-tag release-acceptance simulations, and remaining post-merge release duties.

## Scope
- In: version metadata, changelog release notes, and public-safe release-candidate evidence for the current `origin/main` diff since v0.3.10.
- Out: tagging, publishing, PyPI verification, post-publish release-acceptance runs, and claiming interactive Claude Code TUI smoke from print-mode proxy evidence.

## Commits
- `40ec7c7` — `[update] MAIN-293 prepare 0.3.11 release candidate`.

## Release / Issues
- Release: 0.3.11 target.
- Linear ID(s): MAIN-293.
- Closes: none; #426 must remain open through post-merge publish and final release evidence.
- Refs: #426.
- Follow-ups: create `oe-v0.3.11`, verify publish workflow, verify PyPI, fresh PyPI install smoke, PyPI release-acceptance simulations, and interactive Claude Code TUI evidence when release claims depend on slash-command discovery.

## Success Metric
- Reviewers can verify that v0.3.11 package metadata, changelog copy, and release-candidate evidence agree before merge, without overstating non-Claude runtime support or print-mode proxy evidence.

## Validation
- Level 0 docs/decision: reviewed release notes and transcript report for public/private boundary, runtime claims, and release truth.
- Level 1 static: `scripts/check.sh` passed after final edits: format/lint/mypy, 408 tests, coverage 81.79%, and 17 bundled skills validated.
- Level 2 CLI: fresh wheel venv smoke ran `mb --version`, `mb skill list`, `mb onboard --yes --json`, `mb status --json --peek`, `mb start --json`, and `mb validate --cross-refs --json`; all completed successfully after using positional repo args for `status` and `validate`.
- Level 3 package/install: `(cd mb && python3 -m build)` built `mainbranch-0.3.11.tar.gz` and `mainbranch-0.3.11-py3-none-any.whl`; clean venv install reported `mb 0.3.11`.
- Level 4 fixture repo: deterministic wheel dogfood harness passed from the built wheel, including onboard, doctor, repair plan, checkpoint status, validate, status, start, skill wiring, and repo-boundary checks.
- Level 5 runtime smoke: `prerelease_candidate` and pre-tag `release_acceptance` Claude print-mode proxy tiers passed 10/10 heuristic checks, but were classified as `partial_proxy_with_deterministic_fallback` because read-only `mb` grounding saw permission denials; no interactive Claude Code TUI smoke was run.

## Public / Private Boundary
- Raw local evidence and transcripts stayed in `.context/`; the committed report is sanitized and contains no raw transcripts, local paths, credentials, account data, or customer/member data.
