### PR TITLE
[update] Expand Google Ads launch playbook rails

### DIFF
--- a/.claude/playbooks/google-ads-search-launch/SKILL.md
+++ b/.claude/playbooks/google-ads-search-launch/SKILL.md
@@ -26,7 +26,8 @@ future accepted adapter ships with approval gates and smoke evidence.
 
 ## Playbook Versus Run
 
-This file is the reusable Noontide recipe. The run belongs in the business repo:
+This file is the reusable Noontide recipe: an opinionated paid-search
+offer-validation sprint. The run belongs in the business repo:
 
 ```text
 pushes/<push>/playbooks/google-ads-launch-plan.md
@@ -37,7 +38,13 @@ Create or update that run file from
 approval record, provider-boundary record, launch checklist, review-window
 record, and outcome hook for a specific offer/push.
 
-## Opinionated Defaults
+This playbook follows the authority model in [`docs/playbooks.md`](../../../docs/playbooks.md):
+official Google Ads docs are the source of truth for platform facts, Main
+Branch owns the provider boundary and run-record shape, and this file owns the
+Noontide defaults for testing many offers quickly with tight control. If the
+operator forks a default, record the fork and reason in the run file.
+
+## Playbook Defaults And Fork Points
 
 Use [`references/noontide-approach.md`](references/noontide-approach.md) as the
 style and decision rubric.
@@ -47,15 +54,29 @@ For B2B local-services lead-form campaigns, also use
 Defaults:
 
 - one offer, one primary conversion, one review window;
+- one conversion path chosen up front: call/booking, Stripe/deposit, lead form,
+  trial, or another concrete action;
+- Maximize Conversions for the first launch window when the selected primary
+  conversion is verified; use Maximize Clicks or manual CPC only as a written
+  fork when conversion tracking is absent or intentionally delayed;
 - exact and phrase match first; broad match only with a written reason;
-- geography, schedule, negatives, and sitelinks are part of the plan, not
-  afterthoughts;
+- geography is explicit: local radius, multi-city service area, statewide,
+  national, or multi-location; do not reuse local defaults for national tests;
+- campaign settings, negatives, sitelinks, callouts, structured snippets, and
+  skipped assets are part of the plan, not afterthoughts;
+- market-intent research precedes asset writing when the offer is new, the
+  audience/search language is thin, or the geography is unfamiliar;
 - a small proof budget is only useful when CPC, conversion rate, and business
   value make the result interpretable;
 - account history is useful when it exists, but a new offer can start from
   offer/customer/keyword reasoning and lander readiness;
+- Search Partners, Display Network, AI Max, Final URL Expansion, broad match,
+  price assets, lead forms, call assets, and automated URL options default to
+  off or skipped for first proof runs unless the operator records why this run
+  should fork;
 - no spend before the operator approves the lander, conversion action, consent
-  posture, billing, budget, campaign structure, copy, and review criteria;
+  posture, billing, budget, campaign structure, copy/assets, asset
+  destinations, and review criteria;
 - post-launch judgment is `continue`, `change`, or `stop`, written as an
   outcome or push review.
 
@@ -65,7 +86,11 @@ Defaults:
 - explicit bet or success criterion for the proof run;
 - launch push, or permission to create one;
 - lander or site repo, if one exists;
-- budget cap, review window, geography, and business value of the conversion;
+- budget cap, review window, geography shape, and business value of the
+  conversion;
+- conversion path: call/booking, Stripe/deposit, lead form, trial, or other;
+- market-intent research, competitor/offer positioning, customer language,
+  objections, proof, and exclusion notes when available;
 - provider readiness from `mb status --json --peek` and `mb connect plan`;
 - measurement readiness from `mb site check` when a site repo exists;
 - sanitized account history or read-only provider facts only when already
@@ -84,20 +109,32 @@ Do not invent prior winners or require pre-offer account scraping.
 3. **Lander and conversion.** Use `/mb-site` and `mb site check` before calling
    the campaign launchable. Missing measurement can still allow copy drafting,
    but not spend approval.
-4. **Campaign plan.** Use `/mb-ads launch-plan` and load the Google Ads campaign
-   plan reference. Draft structure, keywords, negatives, copy, sitelinks,
-   budget, manual provider steps, and approval gates.
-5. **B2B local-services pass.** When the offer is B2B local services, check the
+4. **Market-intent pass.** If the offer is new, thin, or entering a new
+   geography, use `/mb-think` to research buyer/search intent, competitor
+   offers, customer language, objections, proof, and bad-fit exclusions before
+   writing assets. When 2+ lanes are needed, run them as parallel foreground
+   research agents and persist findings to `research/`. If the findings change
+   durable offer, audience, market, proof, or positioning truth, update the
+   relevant `core/` files after operator approval or record proposed core
+   updates in the run file.
+5. **Campaign plan.** Use `/mb-ads launch-plan` and load the Google Ads campaign
+   plan reference. Generate the full reviewable spec: campaign settings,
+   bidding, geography mode, ad groups, keywords, negatives, RSA headlines and
+   descriptions, display paths, sitelinks, callouts, structured snippets,
+   skipped assets, budget, manual provider steps, and approval gates.
+6. **B2B local-services pass.** When the offer is B2B local services, check the
    field notes for GA4/GTM/Ads import order, Search-only defaults, geo
    presence, Search Partners, Final URL Expansion, AI Max, negative categories,
    UI gotchas, and volume calibration.
-6. **Run record.** Write or update the push playbook run from the template.
-   Keep provider refs safe and do not store raw account exports.
-7. **Manual launch.** The operator performs Google Ads/GTM/billing/spend steps
+7. **Run record.** Write or update the push playbook run from the template.
+   Record defaults used, forks taken, asset rationale, and skipped asset
+   rationale. Record research files and any core updates made or proposed. Keep
+   provider refs safe and do not store raw account exports.
+8. **Manual launch.** The operator performs Google Ads/GTM/billing/spend steps
    manually unless a future adapter is accepted.
-8. **Review.** Use `/mb-ads check` after the review window. Write the result to
+9. **Review.** Use `/mb-ads check` after the review window. Write the result to
    the run record and link an outcome/log file.
-9. **Checkpoint.** Use `/mb-end` or `mb checkpoint` to save accepted artifacts.
+10. **Checkpoint.** Use `/mb-end` or `mb checkpoint` to save accepted artifacts.
 
 ## Current Checks
 

--- a/.claude/playbooks/google-ads-search-launch/references/noontide-approach.md
+++ b/.claude/playbooks/google-ads-search-launch/references/noontide-approach.md
@@ -3,6 +3,11 @@
 This playbook validates whether paid search can turn a concrete offer into a
 business outcome. It is not a generic "set up Google Ads" tutorial.
 
+The method is built for fast offer-validation sprints: quick brand, quick
+offer, small proof budget, and a concrete conversion signal such as a call,
+booking, Stripe/deposit payment, trial, or qualified lead. The goal is to learn
+whether market intent will convert before the operator overbuilds the offer.
+
 ## What Makes The Playbook Noontide
 
 - **Bet first.** Paid search is a proof run. The operator should know what would
@@ -10,15 +15,36 @@ business outcome. It is not a generic "set up Google Ads" tutorial.
 - **Offer before account.** Account history helps, but the offer, audience,
   promise, proof, and lander decide what the campaign should try.
 - **Conversion path before spend.** Traffic without measurement is just a bill.
+- **Research feeds core.** Paid-search discovery should not die in the campaign
+  plan. If research clarifies demand, buyer language, proof, objections,
+  pricing, conversion path, or service boundaries, update `core/` after
+  operator approval or record proposed core updates in the run file.
+- **Market intent before assets.** Headlines, descriptions, sitelinks, callouts,
+  structured snippets, and negatives come from researched demand, competitor
+  gaps, customer language, objections, and proof.
 - **Search intent over volume.** Start with high-intent terms the lander can
   honestly satisfy.
 - **Negatives protect the bet.** Bad-fit queries are a strategy problem, not
   cleanup trivia.
+- **Control before automation.** For the first proof run, prefer tight
+  geography, exact/phrase targeting, explicit URLs, and manually reviewed copy
+  over automated expansion. Fork only when the operator accepts the tradeoff.
 - **One clean review window.** The first launch should answer a bounded
   question, not become a forever campaign by accident.
 - **Manual provider authority.** Main Branch can prepare, check, and record the
   plan. The operator approves and performs provider mutation until an accepted
   adapter exists.
+
+## Source And Forks
+
+Official Google Ads documentation remains the source of truth for platform
+limits, policy, feature behavior, and UI mechanics. This playbook owns the
+Noontide defaults for one use case: validating many offers quickly with tight
+control and a small budget.
+
+Forks are expected. Record the default, the fork, and the reason in the push
+playbook when changing geography scope, conversion path, bidding, broad match,
+AI Max, Final URL Expansion, Search Partners, asset types, or review windows.
 
 ## New Offer Default
 
@@ -26,6 +52,10 @@ When the business has never advertised this offer:
 
 - skip claims about historical winners;
 - research customer intent and keyword families through `/mb-think`;
+- research the geography: local radius, multi-city, statewide, national, or
+  multi-location;
+- pick the conversion path before asset writing: call/booking,
+  Stripe/deposit, lead form, trial, or another concrete action;
 - keep the first campaign small enough to learn from;
 - document assumptions in the run record;
 - expect the first review to refine keywords, negatives, lander copy, and
@@ -70,4 +100,3 @@ At the end of the review window:
   path, or offer needs repair.
 - **Stop** when the bet is disproven, blocked by policy, or too expensive to
   learn from responsibly.
-

--- a/.claude/playbooks/google-ads-search-launch/templates/push-playbook.md
+++ b/.claude/playbooks/google-ads-search-launch/templates/push-playbook.md
@@ -80,11 +80,30 @@ linked_outcomes: []
 
 -
 
-## Lander And Conversion Readiness
+## Existing Account/Campaign Decision
 
 -
 
-## Measurement Chain
+## Readiness
+
+- Lander:
+- Conversion endpoint:
+- Sitelink destinations:
+- Measurement readiness:
+- Provider readiness:
+
+## Budget And Review Window
+
+- Budget cap:
+- Review window:
+- Expected click range:
+- Extension/widening rule:
+
+## Lander And Sitelinks
+
+-
+
+## Measurement Checklist
 
 - GA4 data stream:
 - GTM container:
@@ -116,10 +135,15 @@ linked_outcomes: []
   - Approval status:
 - Decisions needed:
 
-## Campaign Settings And Structure
+## Campaign Structure
 
 - Goal:
 - Type:
+- Ad groups:
+- Structure rationale:
+
+## Campaign Settings And Forks
+
 - Bidding:
 - Networks:
 - Geography:
@@ -132,8 +156,12 @@ linked_outcomes: []
 - Search Partners:
 - Display Network:
 - URL options:
-- Ad groups:
 - Settings rationale:
+- Forks from playbook defaults:
+  - Default:
+  - Fork:
+  - Rationale:
+  - Approved by:
 
 ## Keyword Targets
 
@@ -164,7 +192,10 @@ linked_outcomes: []
 
 ## Sitelinks
 
-- Text:
+- Repeat one block per sitelink.
+
+- Sitelink:
+  Text:
   Description 1:
   Description 2:
   Final URL:
@@ -173,17 +204,23 @@ linked_outcomes: []
 
 ## Callouts
 
-- Text:
+- Repeat one block per callout.
+
+- Callout:
+  Text:
   Rationale:
   Claim source:
 
 ## Structured Snippets
 
-- Header:
+- Repeat one block per structured snippet header.
+
+- Structured snippet:
+  Header:
   Values:
   Rationale:
 
-## Other Assets And URL Options
+## Skipped Assets And URL Options
 
 - Logo/business name:
 - Image assets:
@@ -234,14 +271,7 @@ linked_outcomes: []
 - [ ] Network, geo, AI Max, and Final URL Expansion reviewed
 - [ ] Launch/unpause approved
 
-## Budget And Review Window
-
-- Budget cap:
-- Review window:
-- Expected click range:
-- Extension/widening rule:
-
-## Review Decision
+## Review Loop
 
 - Continue/change/stop:
 - Outcome/log link:

--- a/.claude/playbooks/google-ads-search-launch/templates/push-playbook.md
+++ b/.claude/playbooks/google-ads-search-launch/templates/push-playbook.md
@@ -5,6 +5,10 @@ push: ../push.md
 platform: google-ads
 provider: google-ads
 provider_boundary: plan-only
+playbook:
+  recipe: google-ads-search-launch
+  author: Noontide
+  source: .claude/playbooks/google-ads-search-launch/SKILL.md
 trigger:
   kind: operator_launch_request
 resource:
@@ -40,6 +44,37 @@ linked_outcomes: []
 - `mb connect plan` / `mb connect doctor --json`:
 - `mb site check`:
 - Account history source:
+- Research files:
+
+## Playbook Defaults And Forks
+
+- Reusable playbook:
+  `.claude/playbooks/google-ads-search-launch/SKILL.md`
+- Conversion path:
+  - [ ] Call/booking
+  - [ ] Stripe/deposit
+  - [ ] Lead form
+  - [ ] Trial/signup
+  - [ ] Other:
+- Geography shape:
+  - [ ] Single city / radius
+  - [ ] Multi-city service area
+  - [ ] Statewide
+  - [ ] National
+  - [ ] Multi-location
+- Defaults used:
+  - [ ] Search only
+  - [ ] Exact/phrase first
+  - [ ] AI Max off
+  - [ ] Final URL Expansion off
+  - [ ] Search Partners off
+  - [ ] Explicit final URL
+  - [ ] Manual provider launch
+- Forks from playbook defaults:
+  - Default:
+  - Fork:
+  - Rationale:
+  - Approved by:
 
 ## Offer And Policy Fit
 
@@ -59,16 +94,46 @@ linked_outcomes: []
 - GA4 key event:
 - Ads imported primary conversion:
 
-## Campaign Structure
+## Market Intent Research
+
+- Buyer/search-intent clusters:
+- Competitor/alternative offers:
+- Customer language:
+- Objections:
+- Proof claims safe to use:
+- Claims to avoid:
+- Bad-fit intent to exclude:
+
+## Core Updates From Research
+
+- Research files created or used:
+- Core files read:
+- Core files updated:
+- Proposed core updates not yet applied:
+  - Target file:
+  - Proposed change:
+  - Evidence:
+  - Approval status:
+- Decisions needed:
+
+## Campaign Settings And Structure
 
 - Goal:
 - Type:
 - Bidding:
 - Networks:
-- Geo:
+- Geography:
+- Presence / interest setting:
+- Language:
+- Devices:
+- Schedule:
 - AI Max:
 - Final URL Expansion:
+- Search Partners:
+- Display Network:
+- URL options:
 - Ad groups:
+- Settings rationale:
 
 ## Keyword Targets
 
@@ -83,13 +148,53 @@ linked_outcomes: []
 - DIY/education:
 - Trust-research terms:
 
-## Ads And Assets
+## RSA Assets
 
-- RSA:
-- Pinned headline:
-- Descriptions under 90 chars:
-- Logo:
+- Final URL:
 - Display path:
+- Headlines:
+  - Text:
+    Rationale:
+    Pin:
+- Descriptions:
+  - Text:
+    Rationale:
+- Character-limit check:
+- Policy/claim check:
+
+## Sitelinks
+
+- Text:
+  Description 1:
+  Description 2:
+  Final URL:
+  Job:
+  Destination audit:
+
+## Callouts
+
+- Text:
+  Rationale:
+  Claim source:
+
+## Structured Snippets
+
+- Header:
+  Values:
+  Rationale:
+
+## Other Assets And URL Options
+
+- Logo/business name:
+- Image assets:
+- Location assets:
+- Call assets:
+- Lead form assets:
+- Price/promotion assets:
+- Tracking template:
+- Final URL suffix:
+- Custom parameters:
+- Skipped assets and rationale:
 
 ## UI Review Gotchas
 
@@ -104,6 +209,9 @@ linked_outcomes: []
 - [ ] AI Max still off
 - [ ] Dependent headline fragments avoided or pinned
 - [ ] Surface-specific logo set
+- [ ] Sitelink destinations audited
+- [ ] Callout claims verified
+- [ ] Structured snippet values supported by the offer/lander
 - [ ] Ad approval state checked before diagnosing zero impressions
 
 ## Manual Provider Steps
@@ -118,6 +226,8 @@ linked_outcomes: []
 - [ ] Campaign structure reviewed
 - [ ] Keywords and negatives reviewed
 - [ ] Ad copy/assets reviewed
+- [ ] Playbook forks reviewed
+- [ ] Skipped assets reviewed
 - [ ] Billing and budget reviewed
 - [ ] GA4 to Ads link reviewed
 - [ ] Primary conversion import reviewed

--- a/.claude/skills/mb-ads/references/google-ads-campaign-plan.md
+++ b/.claude/skills/mb-ads/references/google-ads-campaign-plan.md
@@ -35,9 +35,16 @@ Read or ask for:
 
 - active offer, audience, promise, proof, and current lander;
 - launch push at `pushes/<push>/push.md`;
+- geography shape: single-city radius, multi-city service area, statewide,
+  national, or multi-location;
+- conversion path: call/booking, Stripe/deposit, lead form, trial, or another
+  concrete action;
 - provider readiness from `mb status --json --peek` and `mb connect doctor --json`;
 - site readiness from `mb site check "$SITE_REPO" --business-repo "$BUSINESS_REPO" --json`
   when a site repo exists;
+- market-intent research: buyer/search-intent clusters, competitor offers,
+  SERP/ad examples when available, customer language, reviews, sales-call
+  notes, testimonials, objections, proof, and bad-fit exclusions;
 - Google Ads account state if the operator provides a sanitized export or an
   explicitly approved read-only provider tool is already available;
 - historical winners: search terms, keywords, CPC/CPA, conversions, landing
@@ -51,6 +58,37 @@ Read or ask for:
 Do not ask the operator to paste OAuth tokens, API keys, customer records,
 raw account exports with PII, conversion uploads, or screenshots that expose
 private account details. Ask for sanitized exports or manual answers instead.
+
+## Source And Documentation Boundary
+
+Treat official Google Ads documentation as the source of truth for platform
+facts. Before locking a plan, verify current limits, policy behavior, and
+feature mechanics against official docs when a claim is load-bearing.
+
+Useful official starting points:
+
+- Responsive Search Ads and asset limits:
+  <https://support.google.com/google-ads/answer/7684791>
+- RSA pinning and field limits:
+  <https://support.google.com/google-ads/answer/12159014>
+- Search ad effectiveness guidance:
+  <https://support.google.com/google-ads/answer/6167122>
+- Google Ads assets overview:
+  <https://support.google.com/google-ads/answer/7331111>
+- Structured snippet assets:
+  <https://support.google.com/google-ads/answer/6280012>
+- Location targeting:
+  <https://support.google.com/google-ads/answer/2453995>
+- Preventing clicks outside targeted locations:
+  <https://support.google.com/google-ads/answer/9376662>
+- AI Max for Search campaigns:
+  <https://support.google.com/google-ads/answer/15913066>
+- Final URL Expansion in Search:
+  <https://support.google.com/google-ads/answer/16230205>
+
+The official docs may recommend more automation than the Noontide
+offer-validation playbook uses by default. When this playbook chooses more
+control, label it as playbook opinion and record any fork in the run record.
 
 ## Prerequisite Setup And CLI Boundary
 
@@ -105,7 +143,95 @@ restricted classification, stop and present options:
 Do not frame policy work as "bypassing" a provider. Frame it as accurate
 classification, clean claims, and operator-approved compliance.
 
-### 2. Existing Campaign Versus New Campaign
+### 2. Execution Contract For Launch Plans
+
+`/mb-ads launch-plan` must generate the reviewable launch spec, not merely tell
+the operator what to think about. After intake and research, produce concrete
+draft values for:
+
+- campaign settings: goal, bid strategy, network toggles, geography mode,
+  language, devices, schedule, URL options, and fork rationale;
+- ad group structure, exact/phrase keywords, and launch negative keywords;
+- Responsive Search Ad headlines, descriptions, display paths, pins, and
+  rationale;
+- sitelinks with description lines, final URLs, jobs, and destination audits;
+- callouts, structured snippets, optional assets, skipped assets, and skip
+  rationale;
+- manual provider steps, approval gates, budget cap, review window, and
+  continue/change/stop criteria.
+
+If there is not enough evidence to draft one of those fields, output an explicit
+`needs operator input` line instead of leaving the field implicit.
+
+Use existing Main Branch skills as execution primitives:
+
+- `/mb-think` for parallel market, competitor, customer-language, proof, and
+  conversion-path research;
+- `/mb-site` for lander, headline, proof, conversion endpoint, and measurement
+  readiness when the destination is weak or missing;
+- `/mb-ads launch-plan` for final Google Ads settings and asset generation;
+- `/mb-ads check` for post-review-window judgment.
+
+For Google Search, do not reuse social/static-ad copy generation blindly. Use
+the same specificity and variety discipline, but adapt every asset to RSA
+character limits, standalone rendering, query intent, policy review, and
+destination-page proof.
+
+### 3. Research-To-Ad-Spec Pass
+
+For a new offer, thin offer, new geography, or first run in a market, do not
+write assets from vibes. Route through `/mb-think` or an equivalent research
+pass before finalizing campaign settings and copy.
+
+Research in parallel when the runtime supports it:
+
+- **Market/search intent:** buyer-intent terms, problem-aware terms, category
+  terms, geo modifiers, high-friction phrases, and obvious bad-fit searches.
+- **Competitor and offer positioning:** direct competitors, alternative offers,
+  pricing or deposit norms, service area promises, guarantees, proof, and gaps.
+- **Customer language and objections:** reviews, sales-call notes, testimonials,
+  support tickets, forums, community posts, or operator notes that reveal how
+  buyers describe the pain and decision.
+- **Conversion-path fit:** whether this offer should validate through a call,
+  booking, Stripe/deposit payment, checkout, lead form, trial, or manual
+  qualification.
+
+Persist durable findings to `research/` when the pass produces new business
+truth. The campaign plan should cite the research files or operator-provided
+facts it used.
+
+Paid-search research is allowed to change the core, not just the ad plan. When
+the research discovers durable truth, route it deliberately:
+
+- update `core/offer.md` or `core/offers/<offer>/offer.md` when the offer,
+  pricing, promise, guarantee, mechanism, conversion path, or service boundary
+  changes;
+- update `core/audience.md` or `core/offers/<offer>/audience.md` when search
+  language, pains, objections, buyer stage, bad-fit audiences, or decision
+  criteria become clearer;
+- update `core/proof/` or `core/offers/<offer>/proof/` when a claim, proof
+  angle, testimonial, or typicality caveat becomes reusable;
+- update `core/content-strategy.md` or a strategy file when the research changes
+  channel cadence, content pillars, market thesis, or launch sequencing;
+- write a `decisions/` record when the operator accepts a durable tradeoff,
+  such as call-first versus deposit-first validation.
+
+Do not silently rewrite core truth while drafting ads. Present proposed core
+changes with evidence and apply them only when the operator approves, unless
+the operator already asked for the skill to update core as part of the run.
+If approval is pending, record the proposed updates in the push playbook.
+
+Minimum output before asset writing:
+
+- primary intent clusters;
+- excluded intent clusters;
+- geography assumption and service boundary;
+- conversion path and business value;
+- strongest proof claims that are safe to advertise;
+- claims to avoid because they are unproven, policy-sensitive, or bad-fit;
+- landing pages and sitelink destinations to use or avoid.
+
+### 4. Existing Campaign Versus New Campaign
 
 Prefer an existing campaign when all are true:
 
@@ -125,7 +251,77 @@ group, keep the campaign paused until at least one new asset is approved, and
 record the old asset status as audit context. After a clean review window, the
 operator can delete stale assets manually.
 
-### 3. Campaign Structure
+### 5. Geography And Conversion Path
+
+Campaign settings depend on geography and conversion path.
+
+For local or radius tests:
+
+- use presence targeting by default, not presence-or-interest;
+- include city/service-area language only when the business can serve it;
+- keep keywords, negatives, and sitelinks local enough to protect the proof
+  budget;
+- expect lower absolute volume and define the extension/widening rule before
+  launch.
+
+For multi-city or statewide tests:
+
+- split campaigns or ad groups when geography changes intent, CPC, proof,
+  licensing, or service capacity;
+- keep location names in copy only where true and useful;
+- record whether the operator wants one shared proof budget or separate
+  geography budgets.
+
+For national tests:
+
+- do not reuse local-radius assumptions;
+- segment by intent, offer tier, audience, or conversion path before segmenting
+  by geography;
+- require a stronger negative strategy and a clearer budget ceiling because
+  national reach can burn proof budgets quickly.
+
+For multi-location businesses:
+
+- decide whether each location needs its own campaign, location asset, landing
+  page, phone number, booking path, or review bar;
+- do not point all sitelinks at generic pages if the query implies a specific
+  location.
+
+For call/booking conversion paths, verify booking friction, calendar capacity,
+phone/call handling, and whether calls are actually desired. For
+Stripe/deposit paths, verify price, refund terms, checkout link, confirmation
+event, and whether the deposit is the real proof signal. For lead forms, verify
+privacy and regulated-category posture before using provider-hosted forms.
+
+### 6. Campaign Settings Defaults
+
+For the Noontide first proof window, default to:
+
+- campaign type: Search;
+- networks: Search Network only, Search Partners off, Display Network off;
+- bid strategy: Maximize Conversions when the selected primary conversion is
+  verified;
+- targeting: presence only for local, regulated, licensed, or service-area
+  campaigns; presence-or-interest only as a recorded fork for national,
+  location-independent, or travel-like intent;
+- AI Max: off;
+- Final URL Expansion: off;
+- keyword expansion: exact and phrase first, broad match off;
+- final URL: explicit operator-approved destination URL;
+- URL options: empty unless the measurement plan needs final URL suffix,
+  custom parameters, or a tracking template.
+
+These are playbook defaults for small-budget offer validation, not universal
+Google Ads doctrine. If the operator chooses Search Partners, broad match, AI
+Max, Final URL Expansion, provider-hosted lead forms, price assets, or automated
+URL options, record the fork, reason, risk, and review condition in the run
+record.
+
+Do not default to Target CPA or Target ROAS on a cold proof run. Mention them
+as later optimization moves only after the account has enough recent conversion
+volume and clean value tracking to make the constraint meaningful.
+
+### 7. Campaign Structure
 
 Draft only the structure that fits the evidence. Common search structures:
 
@@ -143,7 +339,13 @@ Each ad group should have:
 - policy-safe headlines/descriptions;
 - explicit manual review notes.
 
-### 4. Keywords And Negative Strategy
+For Noontide offer-validation runs, default to Search only, explicit final URL,
+no AI Max, no Final URL Expansion, and no broad match for the first proof
+window unless the operator records a fork. This is not a universal Google Ads
+rule; it is a playbook choice for small-budget tests where query, copy, and URL
+control matter more than reach.
+
+### 8. Keywords And Negative Strategy
 
 Use account history first when available. Keep:
 
@@ -165,7 +367,102 @@ If a shared negative list exists, tell the operator to attach it to the campaign
 manually. Do not paste a large account-specific negative export into public
 docs or committed examples.
 
-### 5. Lander And Conversion Prerequisites
+### 9. Ad Assets
+
+Assets should be a researched spec, not a loose copy batch.
+
+For Responsive Search Ads:
+
+- draft 12-15 headlines and 4 descriptions per ad group when enough evidence
+  exists; if evidence is thin, draft fewer only with `needs operator input`
+  lines for missing proof or offer facts;
+- organize headline angles before writing them:
+  - keyword/search intent;
+  - value or problem relief;
+  - proof, trust, or risk reversal;
+  - geography or availability when relevant;
+  - CTA or conversion path;
+  - brand/identity when useful;
+- prioritize unique intent/proof angles over repetitive variants;
+- check current character limits against official docs before the operator
+  pastes them;
+- write every unpinned headline as a standalone coherent claim because assets
+  can appear in different combinations;
+- pin only mandatory claims, disclaimers, or identity lines, and record why
+  because pinning reduces combination flexibility;
+- include at least one keyword/intent phrase where it fits naturally;
+- separate offer clarity, proof, objection handling, geography, and CTA angles;
+- remove or rewrite any claim the lander cannot support.
+
+For display paths:
+
+- choose paths that reinforce the offer or intent, such as `evaluation`,
+  `quote`, `deposit`, `booking`, or the service category;
+- avoid paths that imply unsupported claims, policy-sensitive language, or a
+  different conversion path than the final URL.
+
+For sitelinks:
+
+- use only pages that are safe, live, fast, and aligned with the ad promise;
+- audit every sitelink destination, not just the final URL;
+- prefer fewer clean sitelinks over more risky ones;
+- record each sitelink's job: book, proof, pricing, process, location, FAQ,
+  comparison, or objection handling;
+- for local offers, include location/service-area pages only when they match
+  real service capacity;
+- for national offers, avoid local-looking sitelinks unless the campaign is
+  intentionally segmented.
+
+For callouts:
+
+- use short verified claims: service speed, guarantee boundaries, licensing,
+  pricing posture, audience fit, proof, support model, or risk reversal;
+- do not use callouts for unverified superlatives or claims the operator would
+  not defend in review.
+
+For structured snippets:
+
+- use a header and values that honestly describe categories, services,
+  programs, brands, styles, destinations, or other platform-supported groupings;
+- skip snippets when the values would be vague, repetitive, policy-sensitive,
+  or unsupported by the lander.
+
+For other assets and options:
+
+- use logo/business-name/image assets only when brand assets are correct for
+  this offer and not inherited from a mismatched prior account;
+- use location assets only when physical/local presence is real and helpful;
+- use call assets only when calls are desired, staffed, and measured;
+- use price or promotion assets only when price/promo is central to the offer
+  and policy-safe in the category;
+- avoid provider-hosted lead forms for sensitive or regulated categories unless
+  privacy, consent, and data handling have been explicitly approved;
+- leave tracking templates, final URL suffixes, and custom parameters empty
+  unless the measurement plan requires them; auto-tagging plus GA4/GTM may be
+  enough for many proof runs.
+
+Record skipped assets with reasons. "Skipped" is useful evidence, not a gap.
+
+### 10. Generated Asset Quality Gates
+
+Before the plan is ready for operator approval, self-review the generated spec:
+
+- every RSA asset fits character limits or is marked for rewrite;
+- no two headlines say the same thing with different adjectives;
+- every proof or superlative claim has a source in the lander, research, or
+  operator-provided facts;
+- every unpinned headline can render alone without becoming fragmentary or
+  misleading;
+- every sitelink URL is live, relevant, mobile-safe enough to review, and has a
+  plausible conversion or trust job;
+- every callout is factual and short;
+- every structured snippet uses a supported header and honest values;
+- every skipped asset has a reason;
+- Search Partners, Display Network, AI Max, Final URL Expansion, broad match,
+  and URL automation are still off unless the run record shows an approved
+  fork.
+
+### 11. Lander And Conversion Prerequisites
 
 Before recommending launch:
 
@@ -181,7 +478,7 @@ Before recommending launch:
 Use the `mb site check` readiness state. Never invent `ready_for_launch`, and
 never treat `ready` as permission to spend.
 
-### 6. Budget And Review Window
+### 12. Budget And Review Window
 
 Capture:
 
@@ -196,7 +493,13 @@ If the account has stale conversion history, recommend conservative bidding
 until recent conversion data exists. Do not switch to automated bidding because
 it sounds sophisticated; tie it to evidence and volume.
 
-### 7. Approval Gates
+For this playbook, Maximize Conversions is the default automated bid strategy
+only after the primary conversion is verified. That is different from enabling
+AI Max, broad match, Search Partners, Display expansion, or URL automation.
+Keep those separate in the plan so the operator can approve bidding without
+accidentally approving broader automation.
+
+### 13. Approval Gates
 
 The plan must show separate approvals for:
 
@@ -221,10 +524,17 @@ For `pushes/<push>/ads.md` or the campaign-plan playbook body, include:
 - `## Existing Account/Campaign Decision`
 - `## Readiness`
 - `## Budget And Review Window`
+- `## Market Intent Research`
+- `## Core Updates From Research`
 - `## Campaign Structure`
+- `## Campaign Settings And Forks`
 - `## Keyword Targets`
 - `## Negative Strategy`
-- `## Ads And Assets`
+- `## RSA Assets`
+- `## Sitelinks`
+- `## Callouts`
+- `## Structured Snippets`
+- `## Skipped Assets And URL Options`
 - `## Lander And Sitelinks`
 - `## Measurement Checklist`
 - `## Manual Provider Steps`

--- a/.claude/skills/mb-ads/references/launch-plan-check.md
+++ b/.claude/skills/mb-ads/references/launch-plan-check.md
@@ -54,23 +54,27 @@ pushes/<YYYY-MM-DD-slug>/ads.md
 
 Sections:
 
+- `## Source Facts`
+- `## Offer And Policy Fit`
+- `## Existing Account/Campaign Decision`
 - `## Readiness`
 - `## Budget And Review Window`
 - `## Market Intent Research`
+- `## Core Updates From Research`
 - `## Campaign Structure`
 - `## Campaign Settings And Forks`
-- `## Existing Account/Campaign Decision`
 - `## Keyword Targets`
-- `## Negative Seeds`
+- `## Negative Strategy`
 - `## RSA Assets`
 - `## Sitelinks`
 - `## Callouts`
 - `## Structured Snippets`
 - `## Skipped Assets And URL Options`
-- `## Policy Preflight`
+- `## Lander And Sitelinks`
 - `## Measurement Checklist`
 - `## Manual Provider Steps`
-- `## Approval`
+- `## Approval Gates`
+- `## Review Loop`
 
 If the work includes repeatable provider setup, resource delivery, or approval
 state, draft a `type: playbook` file under `pushes/<push>/playbooks/` instead

--- a/.claude/skills/mb-ads/references/launch-plan-check.md
+++ b/.claude/skills/mb-ads/references/launch-plan-check.md
@@ -56,13 +56,17 @@ Sections:
 
 - `## Readiness`
 - `## Budget And Review Window`
+- `## Market Intent Research`
 - `## Campaign Structure`
+- `## Campaign Settings And Forks`
 - `## Existing Account/Campaign Decision`
 - `## Keyword Targets`
 - `## Negative Seeds`
-- `## Headlines`
-- `## Descriptions`
+- `## RSA Assets`
 - `## Sitelinks`
+- `## Callouts`
+- `## Structured Snippets`
+- `## Skipped Assets And URL Options`
 - `## Policy Preflight`
 - `## Measurement Checklist`
 - `## Manual Provider Steps`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,16 @@ interactive TUI slash-command proof.
   from the related operator repo launch notes: explicit form-success events,
   GTM Preview verification, GA4 Realtime/admin lag, and Google Ads conversion
   import UI variants. Refs #414, #422.
+- Added a playbook concept guide that separates official platform rules,
+  global platform guidance, attributed playbook opinion, fork points, and
+  per-push run records. Refs #427.
+- Added playbook memory guidance so paid-search discoveries can become durable
+  `research/`, `core/`, proof, strategy, or decision updates instead of staying
+  trapped inside one campaign run record. Refs #427.
+- Added Google Ads campaign-settings and asset research rails for
+  `/mb-ads launch-plan`, including market-intent research, geography and
+  conversion-path choices, RSA rationale, sitelinks, callouts, structured
+  snippets, skipped assets, URL options, and playbook fork records. Refs #427.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ The repo is the operating memory: offer, audience, voice, research, decisions, b
 Main Branch is opinionated about rails. The point is not to connect every SaaS tool a business has accumulated. The point is to choose boring, inspectable paths: GitHub for durable work threads, proposals, and shipped history; Cloudflare for sites and DNS; provider paths such as Google/Workspace and official ads only where smoke-tested; planned optional rails such as Postiz for social scheduling and Beancount-style plain-text finance; and optional sidecars for enrichment. Those paths should be wrapped in deterministic commands agents can call without wasting tokens guessing provider setup.
 
 Read the product frame in [docs/ETHOS.md](docs/ETHOS.md), the four operator loops (Sense → Decide → Ship → Reflect) and the four channels (Paid, Organic, Pages, Ops) in [docs/OPERATOR-LOOPS.md](docs/OPERATOR-LOOPS.md), and the release direction in [docs/ROADMAP.md](docs/ROADMAP.md).
+Reusable operating recipes and per-push run records are described in
+[docs/playbooks.md](docs/playbooks.md).
 Workspace, repo, dashboard, finance/legal, and team-log boundaries are defined
 in
 [decisions/2026-05-04-workspace-repo-sensitive-data-boundaries.md](decisions/2026-05-04-workspace-repo-sensitive-data-boundaries.md).

--- a/docs/playbooks.md
+++ b/docs/playbooks.md
@@ -1,0 +1,124 @@
+# Playbooks
+
+Playbooks are attributed operating methods for repeatable business work.
+They are not platform documentation, universal best practice, or hidden
+automation authority.
+
+Main Branch uses two related meanings:
+
+- **Reusable playbook:** an engine or community recipe under
+  `.claude/playbooks/<name>/`. It describes a repeatable method, its defaults,
+  its source, and the skills or checks it calls.
+- **Push playbook:** a business repo run record under
+  `pushes/<push>/playbooks/<playbook>.md`. It records what happened for one
+  offer, push, launch, campaign, resource drop, or operating run.
+
+The reusable playbook teaches the method. The push playbook proves what the
+operator actually chose, approved, changed, and learned.
+
+## Business Memory
+
+Playbooks should not trap durable learning inside a one-off run file. When a
+run discovers something that changes the business, market, offer, audience,
+proof, positioning, or conversion path, the agent should route that learning
+back into the business repo's durable memory:
+
+- `research/` for dated evidence, synthesis, source notes, and open questions;
+- `core/offer.md` or `core/offers/<offer>/offer.md` for durable offer truth;
+- `core/audience.md` or `core/offers/<offer>/audience.md` for buyer language,
+  pains, objections, and decision criteria;
+- `core/proof/` or `core/offers/<offer>/proof/` for approved claims,
+  testimonials, proof angles, and typicality context;
+- `core/content-strategy.md` or other strategy files when the discovery changes
+  channel strategy, positioning, or launch cadence;
+- `decisions/` when the operator chooses a durable rule or tradeoff.
+
+If the operator has not approved a core edit yet, the run record should include
+a proposed-core-updates section with target files, proposed changes, evidence,
+and approval status. The push playbook remains the campaign audit trail; core
+remains the reusable business truth that future playbooks and skills read.
+
+## Authority Layers
+
+Treat playbook guidance as a stack of authority, not a flat rulebook:
+
+1. **Official platform rules.** Provider docs, policies, field limits, and
+   supported features are the source of truth for platform behavior. A Google
+   Ads playbook should link to Google Ads Help for character limits, location
+   targeting modes, policy surfaces, conversion imports, and asset types when
+   it makes factual claims.
+2. **Global platform guidance.** Main Branch can keep reusable guidance for a
+   platform: provider boundaries, privacy posture, manual approval gates,
+   common readiness checks, and durable run-record shape.
+3. **Playbook opinion.** A playbook is a method with taste. It can prefer one
+   setup over another for a specific use case, as long as it says why. For
+   example, a small-budget offer-validation Google Ads playbook can keep AI
+   Max and Final URL Expansion off because the method values query, copy, and
+   URL control more than reach during the first proof run.
+4. **Fork points.** A good playbook names where a reasonable operator might
+   diverge. The fork should capture what changed, why, who approved it, and
+   whether it changes the review bar.
+5. **Run record.** The push playbook is the concrete audit trail: inputs,
+   defaults used, forks taken, provider boundary, approval gates, evidence,
+   manual steps, and outcome links.
+
+This lets Main Branch be opinionated without pretending that every playbook
+default is universally correct.
+
+## Attribution
+
+Reusable playbooks should preserve source and authorship when the method comes
+from a person, team, community, transcript, research packet, or proven client
+workflow. Attribution helps operators evaluate fit and helps contributors
+ship real methods without flattening them into anonymous doctrine.
+
+Good attribution answers:
+
+- who authored or contributed the method;
+- what source material or operating runs informed it;
+- what type of proof exists: field notes, official docs, research synthesis,
+  repeated internal use, customer result, or draft hypothesis;
+- what is intentionally opinionated;
+- what should be revalidated against current official docs before use.
+
+Do not commit raw private transcripts, account data, customer details,
+credentials, screenshots, or exact partner/customer strategy to public
+playbooks. Summarize the reusable method and keep private source material in
+private repos or `.context/`.
+
+## Forking A Playbook
+
+Forking is normal. A playbook is useful because it gives the operator a
+starting stance, not because it removes judgment.
+
+Record a fork when the operator changes:
+
+- target audience, geography, or conversion path;
+- provider settings that affect reach, spend, or policy risk;
+- copy/creative defaults;
+- approval gates;
+- budget, review window, or success metric;
+- execution tool or provider boundary.
+
+The run record should state the default, the chosen fork, and the rationale.
+That rationale becomes future business memory and may later improve the
+reusable playbook.
+
+## Contribution Shape
+
+Third-party or community playbooks can be bundled when they are public-safe and
+fit the Main Branch state model. For example, a contributor's Dream 100 email
+strategy can be represented as an attributed reusable playbook with its own
+defaults, source notes, fork points, and run-record template. Operators can run
+it exactly, fork it, or copy its structure into their own business repo.
+
+A submitted playbook should make clear whether it is:
+
+- a skeleton: intended shape, not yet executable as one coherent workflow;
+- a draft: usable with manual operator judgment, still collecting evidence;
+- a proven method: used repeatedly enough that the defaults are durable;
+- deprecated: retained for history, not recommended for new runs.
+
+Current validation focuses on push playbook run records under `pushes/`.
+Reusable playbook taxonomy and attribution may become stricter as more
+community methods are added.

--- a/mb/mb/_data/templates/CLAUDE.md.tmpl
+++ b/mb/mb/_data/templates/CLAUDE.md.tmpl
@@ -85,11 +85,16 @@ When deciding where an idea belongs, use business meaning first:
 - Bet: a time-boxed wager with appetite, target, evidence, and verdict.
 - Push: coordinated work that ships something to an audience.
 - Reusable playbook: an engine recipe for running a repeatable operating
-  workflow.
+  workflow. Treat its defaults as attributed method, not universal law.
 - Push playbook: this push's approval, provider-boundary, check, manual-step,
-  evidence, and outcome record.
+  evidence, fork, and outcome record.
 - Proof: evidence that a claim is true.
 - Decision: rationale for changing durable truth.
+
+Reusable playbooks can encode official platform rules, Main Branch guidance,
+and author opinion. Push playbooks record which defaults were used or forked
+for this run and why. See `docs/playbooks.md` in the Main Branch engine for
+the full model.
 
 In a single-offer repo, `core/offer.md` is the durable offer truth. In a
 multi-offer repo, `core/offer.md` is the portfolio thesis and

--- a/mb/mb/init.py
+++ b/mb/mb/init.py
@@ -288,11 +288,16 @@ When deciding where an idea belongs, use business meaning first:
 - Bet: a time-boxed wager with appetite, target, evidence, and verdict.
 - Push: coordinated work that ships something to an audience.
 - Reusable playbook: an engine recipe for running a repeatable operating
-  workflow.
+  workflow. Treat its defaults as attributed method, not universal law.
 - Push playbook: this push's approval, provider-boundary, check, manual-step,
-  evidence, and outcome record.
+  evidence, fork, and outcome record.
 - Proof: evidence that a claim is true.
 - Decision: rationale for changing durable truth.
+
+Reusable playbooks can encode official platform rules, Main Branch guidance,
+and author opinion. Push playbooks record which defaults were used or forked
+for this run and why. See `docs/playbooks.md` in the Main Branch engine for
+the full model.
 
 In a single-offer repo, `core/offer.md` is the durable offer truth. In a
 multi-offer repo, `core/offer.md` is the portfolio thesis and


### PR DESCRIPTION
## Summary
- Defines reusable playbooks versus push playbook run records, including authority layers, attribution, fork points, and research-to-core memory routing.
- Expands the Google Ads Search launch playbook into an executable Noontide offer-validation recipe with controlled first-run defaults and explicit forks.
- Teaches `/mb-ads launch-plan` to generate campaign settings, keyword/negative strategy, RSA assets, sitelinks, callouts, structured snippets, skipped assets, approval gates, and core-update proposals.
- Aligns the Google Ads push-playbook template and launch-plan references around the same validator-facing section headings.

## Scope
- In: Playbook concept docs, Google Ads Search launch playbook/reference guidance, generated business `CLAUDE.md` playbook language, changelog entry, and run-record template fields.
- Out: Google Ads API creation, GTM/GA4 mutation, budget changes, publish/unpause, billing setup, raw private transcripts, real account exports, screenshots, or live ad copy.

## Commits
- `2791320` — `[update] Expand Google Ads playbook execution rails`.
- `2e9d759` — `[fix] Align Google Ads playbook headings`.

## Release / Issues
- Release: v0.3.x / next workflow tightening.
- Linear ID(s): MAIN-294.
- Closes: #427.
- Refs: #414, #422, #424, #425.
- Follow-ups: Make playbook run records first-class in `mb validate` / `mb status` for approval gates, unresolved core-update proposals, skipped asset rationale, and provider-boundary fields.

## Success Metric
- A future `/mb-ads launch-plan` run can produce a reviewable, provider-safe Google Ads Search campaign plan that includes researched settings, assets, rationale, manual gates, and any proposed durable `core/` updates without mutating Google Ads.

## Validation
- Level 0 docs/decision: Manual public/private boundary and heading-contract review completed; follow-up review feedback reconciled.
- Level 1 static: `scripts/check.sh` passed after the review fix.
- Level 2 CLI: Included `mypy`, 408 pytest tests, and `mb skill validate --all` for 17 bundled skills through `scripts/check.sh`.
- Level 3 package/install: Not run; packaging and entrypoints were not changed.
- Level 4 fixture repo: Not run; business-repo fixture behavior was not changed.
- Level 5 runtime smoke: Not run; this changes docs, playbook templates, and skill references, not runtime discovery or provider mutation.

## Public / Private Boundary
- Kept private transcript material, account IDs, customer data, live keyword lists, screenshots, and local Conductor context out of committed files; public docs use sanitized, generic Google Ads and playbook guidance only.
