### PR TITLE
[update] Prepare 0.3.12 follow-up release

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mainbranch",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "description": "Main Branch Claude Code skills for running a business from markdown files in git.",
   "author": {
     "name": "Noontide"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,35 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+## [0.3.12] - 2026-05-08
+
+v0.3.12 is a quick follow-up release for the Google Ads launch playbook rails
+merged after v0.3.11. It moves the post-release playbook changelog entries out
+of the already-published v0.3.11 section and ships them as their own patch.
+
+### What this means for you (plain English)
+
+- **Google Ads Search launch plans get more reviewable.** `/mb-ads
+  launch-plan` now has clearer rails for researched campaign settings, assets,
+  skipped asset rationale, approval gates, and proposed durable `core/`
+  updates without mutating Google Ads.
+- **Reusable playbooks and per-push run records are easier to separate.** The
+  docs now distinguish platform rules, attributed playbook opinion, fork
+  points, and one-off push execution records.
+
+### Added
+
+- Added a playbook concept guide that separates official platform rules,
+  global platform guidance, attributed playbook opinion, fork points, and
+  per-push run records. Refs #427.
+- Added playbook memory guidance so paid-search discoveries can become durable
+  `research/`, `core/`, proof, strategy, or decision updates instead of staying
+  trapped inside one campaign run record. Refs #427.
+- Added Google Ads campaign-settings and asset research rails for
+  `/mb-ads launch-plan`, including market-intent research, geography and
+  conversion-path choices, RSA rationale, sitelinks, callouts, structured
+  snippets, skipped assets, URL options, and playbook fork records. Refs #427.
+
 ## [0.3.11] - 2026-05-08
 
 v0.3.11 tightens the daily-loop substrate after v0.3.10: startup and
@@ -93,16 +122,6 @@ interactive TUI slash-command proof.
   from the related operator repo launch notes: explicit form-success events,
   GTM Preview verification, GA4 Realtime/admin lag, and Google Ads conversion
   import UI variants. Refs #414, #422.
-- Added a playbook concept guide that separates official platform rules,
-  global platform guidance, attributed playbook opinion, fork points, and
-  per-push run records. Refs #427.
-- Added playbook memory guidance so paid-search discoveries can become durable
-  `research/`, `core/`, proof, strategy, or decision updates instead of staying
-  trapped inside one campaign run record. Refs #427.
-- Added Google Ads campaign-settings and asset research rails for
-  `/mb-ads launch-plan`, including market-intent research, geography and
-  conversion-path choices, RSA rationale, sitelinks, callouts, structured
-  snippets, skipped assets, URL options, and playbook fork records. Refs #427.
 
 ### Changed
 

--- a/mb/mb/__init__.py
+++ b/mb/mb/__init__.py
@@ -7,6 +7,6 @@ file stays a thin dispatcher.
 
 from __future__ import annotations
 
-__version__ = "0.3.11"
+__version__ = "0.3.12"
 
 __all__ = ["__version__"]

--- a/mb/pyproject.toml
+++ b/mb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mainbranch"
-version = "0.3.11"
+version = "0.3.12"
 description = "Main Branch engine umbrella - scaffolds, validates, and graphs business-as-files repos. Claude Code first, runtime-agnostic by design."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- Prepares v0.3.12 as a quick follow-up release for the Google Ads launch playbook rails merged in #429.
- Moves the #427 changelog entries out of the already-published v0.3.11 section into a dated v0.3.12 section.
- Bumps package and Claude plugin version surfaces from 0.3.11 to 0.3.12.

## Scope
- In: release metadata, package/plugin version surfaces, and changelog placement for v0.3.12.
- Out: new product behavior, release tagging/publishing, full simulation tiers, and interactive Claude Code TUI smoke.

## Commits
- e9c02bf — [update] MAIN-294 prepare 0.3.12 follow-up release

## Release / Issues
- Release: 0.3.12 target
- Linear ID(s): MAIN-294 context
- Closes: none
- Refs: #427, #429
- Follow-ups: after merge, tag `oe-v0.3.12`, publish, and verify PyPI install.

## Success Metric
- Reviewers can merge a narrow v0.3.12 release-prep PR whose packaged version surfaces and changelog match the post-v0.3.11 Google Ads playbook work.

## Validation
- Level 0 docs/decision: `CHANGELOG.md` now has a dated 0.3.12 section and no longer attributes #427 entries to already-published 0.3.11.
- Level 1 static: `scripts/check.sh` passed, including 408 pytest tests and bundled skill validation.
- Level 2 CLI: covered by the repo gate and wheel smoke for `mb --version` / `mb skill list`.
- Level 3 package/install: `python3 -m build` passed from `mb/`; clean venv installed `mb/dist/mainbranch-0.3.12-py3-none-any.whl`, `mb --version` returned `mb 0.3.12`, and `mb skill list` succeeded.
- Level 4 fixture repo: not run for this narrow release metadata follow-up.
- Level 5 runtime smoke: intentionally skipped per operator direction for this quick follow-up release.

## Public / Private Boundary
- Only public release metadata, changelog text, and version surfaces changed; private Conductor/local workflow details stayed in `.context/` and issue coordination.
