### PR TITLE
[update] Refresh reusable playbook topology

### DIFF
--- a/.claude/playbooks/google-ads-search-launch/SKILL.md
+++ b/.claude/playbooks/google-ads-search-launch/SKILL.md
@@ -2,15 +2,20 @@
 name: google-ads-search-launch
 tier: playbook
 calls: [start, think, site, ads, end]
-status: skeleton
-description: "Reusable Noontide playbook for validating an offer with a tightly scoped Google Ads Search launch, a paid-traffic lander, explicit approval gates, and a capped review window."
+status: draft
+description: "Reusable Noontide draft playbook for validating an offer with a tightly scoped Google Ads Search launch, a paid-traffic lander, explicit approval gates, and a capped review window."
 ---
 
 # google-ads-search-launch
 
-This is a reusable operating playbook, not a one-off ad checklist. Use it when
-the operator wants to test whether a real offer can turn paid search intent into
-leads, calls, bookings, deposits, trials, or another concrete business outcome.
+This is a reusable draft operating playbook, not a one-off ad checklist. Use it
+with manual operator judgment when the operator wants to test whether a real
+offer can turn paid search intent into leads, calls, bookings, deposits, trials,
+or another concrete business outcome.
+
+It is usable today as a manual recipe and run-record template. It is not a
+single executable orchestrator, does not automate Google Ads/GTM, and is still
+collecting evidence from operator runs.
 
 The playbook's job is to turn one offer into one paid-search proof run:
 

--- a/.claude/playbooks/ship-bet/SKILL.md
+++ b/.claude/playbooks/ship-bet/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ship-bet
 tier: playbook
-calls: [skill-brief-draft, skill-concept, skill-review, site, ads]
+calls: [start, think, skill-brief-draft, skill-concept, skill-review, site, ads, end]
 status: skeleton
 description: "Reusable skeleton playbook. Walks the operator from a proposed bet or offer to a launch push, landing page, first ad creative, review evidence, and checkpoint. Not yet a single executable orchestrator."
 ---
@@ -80,8 +80,11 @@ that folder is legacy compatibility read only.
 
 ## Cross-references
 
+- [start/SKILL.md](../../skills/mb-start/SKILL.md)
+- [think/SKILL.md](../../skills/mb-think/SKILL.md)
 - [skill-brief-draft/SKILL.md](../../skills/mb-skill-brief-draft/SKILL.md)
 - [skill-concept/SKILL.md](../../skills/mb-skill-concept/SKILL.md)
 - [skill-review/SKILL.md](../../skills/mb-skill-review/SKILL.md)
 - [site/SKILL.md](../../skills/mb-site/SKILL.md)
 - [ads/SKILL.md](../../skills/mb-ads/SKILL.md)
+- [end/SKILL.md](../../skills/mb-end/SKILL.md)

--- a/.claude/playbooks/ship-bet/SKILL.md
+++ b/.claude/playbooks/ship-bet/SKILL.md
@@ -3,45 +3,80 @@ name: ship-bet
 tier: playbook
 calls: [skill-brief-draft, skill-concept, skill-review, site, ads]
 status: skeleton
-description: "Skeleton playbook (v0.1). Walks the operator from a half-formed bet to a shipped landing page + first ad creative. v0.2 implementation lands real orchestration."
+description: "Reusable skeleton playbook. Walks the operator from a proposed bet or offer to a launch push, landing page, first ad creative, review evidence, and checkpoint. Not yet a single executable orchestrator."
 ---
 
 # ship-bet (skeleton)
 
-A playbook that takes one bet from `core/offers/<slug>/offer.md` (status: `proposed`) to a published landing page + first ad creative inside one flow.
+This is a reusable operating recipe, not a one-off run file. Use it when the
+operator wants to turn one proposed bet or offer into a launch push with a
+landing page, first ad creative, review evidence, and a saved checkpoint.
 
-**v0.1 status: skeleton.** This file documents the intended depth-3 chain. Real orchestration (single progress surface, retry on stage failure, cross-skill data passing) lands in v0.2.
+**Current status: skeleton.** This file documents the intended chain and
+artifact routing. It is not yet executable as one coherent workflow with a
+single progress surface, retry-on-failure, or cross-skill data passing. Run each
+step through the named skills and `mb` commands today.
 
-## Intended flow (v0.2 implementation)
+## Playbook Versus Run
+
+This file is the reusable engine recipe under `.claude/playbooks/ship-bet/`.
+The concrete run belongs in the business repo:
+
+```text
+pushes/<YYYY-MM-DD-slug>/push.md
+pushes/<YYYY-MM-DD-slug>/playbooks/ship-bet.md
+```
+
+Create or select the push first. Use a push playbook run record when the run
+needs approval state, provider readiness, forks from the recipe, manual steps,
+review evidence, or outcome links. Do not write new work under `campaigns/`;
+that folder is legacy compatibility read only.
+
+## Intended Flow
 
 ```
-1. /mb-think codify    — confirm offer is named in core/offers/<slug>/
-2. skill-brief-draft  — draft minisite brief from offer + audience + voice
-3. skill-review     — Seven Sweeps + Expert Panel against the brief
-4. /mb-site build      — generate, deploy to Cloudflare Pages
-5. skill-concept    — N variations on localhost, operator picks one
-6. /mb-site publish    — push picked concept; auto-deploy
-7. /mb-ads generate    — first ad creative from the brief
-8. /mb-ads review      — compliance + lens check
-9. log/             — write playbook-run summary
+1. /mb-start          — read repo health, active bets, pushes, provider state
+2. /mb-think codify   — confirm bet, offer, audience, proof, and success bar
+3. pushes/            — create or select the launch push record
+4. skill-brief-draft  — draft minisite brief from offer + audience + voice
+5. skill-review       — Seven Sweeps + Expert Panel against the brief
+6. /mb-site build     — generate or update the landing page/site record
+7. skill-concept      — N variations on localhost, operator picks one
+8. /mb-site publish   — publish only after operator approval and readiness
+9. /mb-ads generate   — first ad creative from the brief
+10. /mb-ads review    — compliance + lens check
+11. push playbook     — record forks, approvals, review evidence, outcomes
+12. /mb-end           — checkpoint accepted artifacts
 ```
 
 ## Inputs
 
-- An offer slug with `status: proposed` in `core/offers/<slug>/`
-- A `dial` pick (convert | story | brand)
+- A bet or proposed offer to ship.
+- `core/offers/<slug>/offer.md` or the operator's approval to create/update it.
+- Audience, proof, voice, and conversion-path context.
+- A launch push, or permission to create one.
+- A `dial` pick when the creative path needs one: `convert`, `story`, or
+  `brand`.
+- Provider and site readiness facts from `mb status --json --peek`,
+  `mb connect plan`, and `mb site check` when a site repo exists.
 
 ## Outputs
 
-- A published Cloudflare Pages site
-- A first ad creative draft in `campaigns/<slug>/`
-- A playbook-run entry in `log/YYYY-MM-DD-shipbet-<slug>.md`
+- A launch push at `pushes/<YYYY-MM-DD-slug>/push.md`.
+- Optional run record at `pushes/<YYYY-MM-DD-slug>/playbooks/ship-bet.md`.
+- A site record under the push or a linked child site repo update.
+- First ad creative under `pushes/<YYYY-MM-DD-slug>/ads/`.
+- Review notes, outcome links, or a weekly/session log entry when the operator
+  approves them.
+- A checkpoint plan and operator-approved checkpoint for accepted artifacts.
 
-## v0.1 caveats
+## Skeleton Caveats
 
-- Each step runs as its own /command today; no single progress surface
-- No retry-on-failure; operator restarts the failed step
-- Data passing between steps is via files in the consumer repo
+- Each step runs as its own command today.
+- No retry-on-failure exists; the operator restarts the failed step.
+- Data passing between steps is via files in the business repo.
+- Provider mutation remains manual or provider-native unless a future accepted
+  adapter ships with approval gates and smoke evidence.
 
 ## Cross-references
 

--- a/.claude/playbooks/weekly-review/SKILL.md
+++ b/.claude/playbooks/weekly-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: weekly-review
 tier: playbook
-calls: [think, end]
+calls: [start, think, end]
 status: skeleton
 description: "Reusable skeleton playbook. Walks the operator through a weekly review across bets, offers, pushes, playbook runs, outcomes, decisions, logs, and checkpoints. Not yet a single executable orchestrator."
 ---
@@ -108,5 +108,6 @@ read only.
 
 ## Cross-references
 
+- [start/SKILL.md](../../skills/mb-start/SKILL.md)
 - [think/SKILL.md](../../skills/mb-think/SKILL.md)
 - [end/SKILL.md](../../skills/mb-end/SKILL.md)

--- a/.claude/playbooks/weekly-review/SKILL.md
+++ b/.claude/playbooks/weekly-review/SKILL.md
@@ -3,41 +3,108 @@ name: weekly-review
 tier: playbook
 calls: [think, end]
 status: skeleton
-description: "Skeleton playbook (v0.1). Walks the operator through a weekly review: status updates on running offers, decisions to ship, research to commit, log entries to write. v0.2 implementation lands real orchestration."
+description: "Reusable skeleton playbook. Walks the operator through a weekly review across bets, offers, pushes, playbook runs, outcomes, decisions, logs, and checkpoints. Not yet a single executable orchestrator."
 ---
 
 # weekly-review (skeleton)
 
-A playbook that runs every Friday: surface what changed, force a status update on every running offer, commit any draft decisions or research, write the week's log entry.
+This is a reusable operating recipe, not a one-off weekly review file. Use it to
+surface what changed, decide what needs attention, record outcomes from active
+pushes and playbook runs, promote approved research or decisions, and save a
+checkpoint.
 
-**v0.1 status: skeleton.** This file documents the intent. Real orchestration in v0.2.
+**Current status: skeleton.** This file documents the intended review chain and
+artifact routing. It is not yet executable as one coherent workflow with a
+single progress surface, automatic diffs, or cross-skill data passing. Run the
+checks and skills manually today.
 
-## Intended flow (v0.2 implementation)
+## Playbook Versus Run
 
-```
-1. mb validate          — confirm frontmatter is clean
-2. mb graph             — print the link graph (changes since last week)
-3. /mb-think               — for each running offer, force a status update
-4. /mb-end                 — close the session with a log entry
-5. log/                 — write weekly-review-YYYY-MM-DD.md
+This file is the reusable engine recipe under `.claude/playbooks/weekly-review/`.
+The concrete review belongs in the business repo. Use:
+
+- `log/weekly-review-YYYY-MM-DD.md` for the week-level chronology, decisions,
+  blockers, and handoff notes;
+- `pushes/<push>/playbooks/<playbook>.md` when reviewing one push playbook run's
+  approvals, forks, validation evidence, manual steps, or linked outcomes;
+- `pushes/<push>/review-log.md`, `pushes/<push>/reviews/`, or outcome/log links
+  when the review changes the push state;
+- `research/`, `core/`, `decisions/`, or `bets/` only when the operator
+  approves durable memory updates.
+
+Do not write new work under `campaigns/`; that folder is legacy compatibility
+read only.
+
+## Intended Flow
+
+```text
+1. /mb-start or mb status --json --peek
+   Read repo health, updates, provider readiness, active bets, pushes, and
+   recent activity.
+2. mb validate
+   Confirm frontmatter and links are clean enough to trust the review.
+3. mb graph
+   Inspect relationship drift across bets, offers, pushes, decisions, outcomes,
+   and legacy compatibility records.
+4. Active bets and offers
+   Identify bets needing a verdict, offers needing a status note, and proposed
+   core updates that require operator approval.
+5. Pushes and playbook runs
+   Review active or recently completed pushes, including
+   pushes/<push>/playbooks/<playbook>.md run records, provider-boundary notes,
+   validation evidence, manual steps, and linked outcomes.
+6. /mb-think
+   Codify approved lessons into research, core files, decisions, bet verdicts,
+   or proposed updates.
+7. /mb-end
+   Close with a weekly log entry and checkpoint plan.
+8. mb checkpoint
+   Save accepted artifacts after operator approval.
 ```
 
 ## Inputs
 
-- The consumer repo's full state
+- The business repo's full state
 - Optional: last week's `log/weekly-review-YYYY-MM-DD.md` for diff context
+- Active and recently completed `pushes/`
+- Push playbook run records under `pushes/<push>/playbooks/`
+- Open bet verdicts, proposed decisions, research drafts, and outcome files
 
 ## Outputs
 
-- Updated `core/offers/*/offer.md` files (status enums refreshed)
-- A weekly log entry summarizing decisions, research, and shipped work
-- Any draft decisions promoted from `proposed` to `accepted` or `rejected`
+- A weekly log entry at `log/weekly-review-YYYY-MM-DD.md`.
+- Updated bet verdicts, push reviews, playbook run records, or outcome links
+  when the operator approves the change.
+- Approved updates to `core/offers/*/offer.md`, `core/audience.md`,
+  `core/proof/`, research, or strategy files when the week changes durable
+  business truth.
+- Draft decisions promoted from `proposed` to `accepted` or `rejected` only
+  after an explicit operator decision.
+- A checkpoint plan and operator-approved checkpoint for accepted artifacts.
 
-## Status enum reminder
+## Review Boundaries
 
-`proposed | running | scaling | killed | graduated | died`
+- Preserve primitive boundaries:
+  - bets answer "what are we trying to learn?";
+  - offers answer "what do we sell repeatedly?";
+  - pushes answer "what coordinated work is shipping?";
+  - push playbooks answer "what happened in this run?";
+  - logs answer "what happened this week?"
+- Do not delete, rename, or collapse bets, offer folders, pushes, or child repos
+  during review. Link forward when work graduates, is superseded, or needs a
+  follow-up.
+- Keep provider/account data safe. Do not commit tokens, raw exports, customer
+  records, screenshots with private account details, session secrets, or local
+  absolute paths.
 
-Every running offer gets a one-line status update during the playbook. Killed and died are first-class states — graduating an offer to `died` is the capture mechanism for "given my past losses, help me decide today."
+## Skeleton Caveats
+
+- Each step runs as its own command today.
+- No automatic weekly diff or progress UI exists yet.
+- Status updates should follow the current validators for the file being edited;
+  do not invent new enum values in reusable prose.
+- Provider mutation remains manual or provider-native unless a future accepted
+  adapter ships with approval gates and smoke evidence.
 
 ## Cross-references
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   absolute paths, secrets, raw provider caches, finance/legal source data, or
   permission claims in repo descriptors. Refs #417.
 
+- Refreshed reusable playbook skeletons against the current push topology:
+  `ship-bet` and `weekly-review` now route concrete run evidence to
+  `pushes/<push>/playbooks/`, outcomes, logs, and checkpoints instead of legacy
+  `campaigns/`, and the Google Ads Search launch playbook is labeled as a
+  usable draft recipe rather than a non-executable skeleton. Refs #425.
+
 ## [0.3.12] - 2026-05-08
 
 v0.3.12 is a quick follow-up release for the Google Ads launch playbook rails

--- a/docs/playbooks.md
+++ b/docs/playbooks.md
@@ -35,7 +35,7 @@ back into the business repo's durable memory:
 
 If the operator has not approved a core edit yet, the run record should include
 a proposed-core-updates section with target files, proposed changes, evidence,
-and approval status. The push playbook remains the campaign audit trail; core
+and approval status. The push playbook remains the run audit trail; core
 remains the reusable business truth that future playbooks and skills read.
 
 ## Authority Layers


### PR DESCRIPTION
## Summary
- Refreshes the reusable `ship-bet` and `weekly-review` playbook skeletons against the current push topology.
- Routes concrete run evidence to `pushes/<push>/playbooks/`, push reviews, outcomes, logs, and checkpoints instead of legacy `campaigns/` writes.
- Labels `google-ads-search-launch` as a usable draft recipe, and tightens playbook docs from campaign audit trail to run audit trail.
- Aligns playbook `calls:` metadata and cross-references with the flows they now describe.

## Scope
- In: bundled reusable playbook prose, playbook docs, and the Unreleased changelog entry.
- Out: orchestration UI, provider automation, public playbook renames, push playbook schema changes, dashboard work, and runtime invocation changes.

## Commits
- `393e071` — `[update] Refresh reusable playbook topology`.
- `ac796b5` — `[update] Align playbook call metadata`.

## Release / Issues
- Release: v0.3.x / Unreleased.
- Linear ID(s): MAIN-292.
- Closes: #425.
- Refs: #420, #389, #424.
- Follow-ups: none.

## Success Metric
- Reusable playbooks no longer direct agents to write new work under `campaigns/`, and `ship-bet`, `weekly-review`, and `google-ads-search-launch` consistently distinguish reusable recipes from per-push run records.

## Validation
- Level 0 docs/decision: checked public-safe wording, changelog entry, and no private Devon/Conductor details in tracked files.
- Level 1 static: `cd mb && python3 -m mb skill validate --all`, `git diff --check`, and `scripts/check.sh` passed.
- Level 2 CLI: not applicable; no CLI behavior changed.
- Level 3 package/install: not applicable; no packaging, entrypoint, or bundled-data copy logic changed.
- Level 4 fixture repo: not applicable; no repo-shape, first-run, migration, or validation schema changed.
- Level 5 runtime smoke: skipped because this changes bundled playbook prose/docs, not skill discovery or runtime invocation.

## Public / Private Boundary
- Public examples remain sanitized and generic; local Conductor workflow notes stayed in `.context/` and were not committed.
