### PR TITLE
[update] Refresh agent-facing routing docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,10 +48,12 @@ primitives in business language first: tasks, proposals, saved checkpoints,
 relationship health, provider readiness, and outcomes.
 
 When working on this loop, check the current GitHub issues instead of copying a
-stale plan into docs. As of 2026-05-07, the public coordination anchors are the
-runtime dogfood harness (#364), generated business `CLAUDE.md` CLI-first
-bootstrap (#353), graph/status relationship health (#357 and #358), and push
-playbook schema (#350). Verify issue state before treating any anchor as active.
+stale plan into docs. Issue anchors change quickly. For daily-loop guardrail
+work, verify the live issue state around generated repo guidance, migration
+lint, topology/status/graph facts, child repo descriptors, reusable playbooks,
+runtime dogfood, and provider readiness before treating any anchor as active.
+If docs need examples, describe the topic and link the active issue only after
+checking GitHub.
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -248,6 +248,11 @@ The CLI surface for the engine. Built for Claude Code first; runtime-agnostic by
 
 Full list: `mb --help`.
 
+Use `mb validate` for file and frontmatter contract checks. Use `mb doctor`
+and `mb doctor repair --plan` for repo-shape, migration, runtime wiring,
+settings, and stale-guidance drift that should be repaired without treating
+every legacy compatibility file as a hard schema failure.
+
 Machine-readable command output follows the additive
 [JSON output contract](docs/json-output-contract.md): high-value `--json`
 surfaces expose shared `result_envelope_version`, `result_schema`,

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -84,10 +84,11 @@ The work clusters into a few durable buckets:
   improves the public engine.
 
 Current public implementation anchors are GitHub issues, not promises in this
-roadmap. As of 2026-05-07, check the active issues for the Claude runtime
-dogfood harness (#364), generated business `CLAUDE.md` CLI-first bootstrap
-(#353), graph/status relationship health (#357 and #358), and push playbook
-schema (#350). Verify their state on GitHub before using them as current scope.
+roadmap. Check live issues before using any anchor as current scope. For this
+phase, the durable topic cluster is generated repo guidance, migration lint,
+topology/status/graph facts, child repo descriptors, reusable playbooks,
+runtime dogfood, provider readiness, and issue/friction capture. Link specific
+issue numbers only after verifying their state on GitHub.
 
 Anti-scope for v0.3.x:
 


### PR DESCRIPTION
## Summary
- Refreshes public agent-facing routing docs so contributors verify live issue state instead of following stale dated anchors.
- Clarifies the current guardrail topic cluster: generated repo guidance, migration lint, topology/status/graph facts, child repo descriptors, reusable playbooks, runtime dogfood, and provider readiness.
- Documents the `mb validate` vs `mb doctor repair --plan` split so legacy compatibility files are not treated as hard schema failures.

## Scope
- In: `AGENTS.md`, `README.md`, and `docs/ROADMAP.md` routing guidance for agents and contributors.
- Out: implementation for #432, #436, or #418; business-repo file moves; private/local Conductor preference text.

## Commits
- `fad9170` — `[update] Refresh agent doc routing`.

## Release / Issues
- Release: next v0.3.x guardrail release.
- Linear ID(s): MAIN-297 context.
- Closes: none.
- Refs: #437, #432, #436, #418.
- Follow-ups: merge the private companion branch `dmthepm/mb-routing-prefs` in `devon-homelab` for local Conductor preference routing.

## Success Metric
- Future Main Branch agents start from current routing principles and live GitHub issue state instead of stale May 7 issue anchors, and users can distinguish validation failures from migration/doctor repair guidance.

## Validation
- Level 0 docs/decision: reviewed public/private boundary and kept private Conductor/local workflow details out of public docs.
- Level 1 static: `scripts/check.sh` passed with 416 tests and bundled skill validation.
- Level 2 CLI: not applicable; no command behavior changed.
- Level 3 package/install: not applicable; no packaging, entrypoint, or bundled-data copy logic changed.
- Level 4 fixture repo: not applicable; no first-run or repo-shape implementation changed.
- Level 5 runtime smoke: not run; this changes public routing guidance, not runtime discovery or invocation.

## Public / Private Boundary
- Public docs stay generic and issue-topic based. Devon-specific Conductor/local launch preference edits were split to the private `devon-homelab` branch `dmthepm/mb-routing-prefs`.
