### PR TITLE
[fix] mb validate and doctor migration drift lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ### Added
 
+- Added privacy-safe business repo migration drift warnings through
+  `mb validate`, `mb doctor`, and `mb doctor repair --plan --json` for stale
+  generated guidance, legacy active-write folders, stale Claude settings,
+  wrong push/playbook paths, and legacy bet campaign links. Refs #432, #436.
 - Added the role-neutral `.mainbranch/repo.json` child repo descriptor contract
   for site, offer, product, client, finance, legal, ops, integration sidecar,
   experiment, and archive repos, while keeping existing site
@@ -24,6 +28,10 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ### Changed
 
+- `mb validate` now accepts current bets that use `linked_pushes` without
+  requiring legacy `linked_campaigns`, keeps `linked_campaigns` compatible for
+  old bets, and treats `research/README.md` as folder documentation instead of
+  a research artifact. Refs #432.
 - Updated generated business `CLAUDE.md`, `/mb-site`, and `/mb-help` guidance
   so agents distinguish hub work from child-repo work and avoid committed
   absolute paths, secrets, raw provider caches, finance/legal source data, or

--- a/docs/MIGRATING.md
+++ b/docs/MIGRATING.md
@@ -499,6 +499,22 @@ versions, leave it in place — `mb` reads it as compatibility. Run
 `mb doctor` and `mb migrate campaigns --plan` to preview the move to
 `pushes/` when you're ready.
 
+Current `mb validate` and `mb doctor repair --plan --json` also report
+non-destructive migration drift warnings. These warnings name stale paths and
+categories without printing file bodies:
+
+- generated `CLAUDE.md` guidance that still teaches `reference/` or
+  `campaigns/` as active write targets;
+- legacy active-looking folders such as `reference/`, `campaigns/`, `.vip/`,
+  `ops/`, `skills/`, `briefs/`, `content/`, or `staging/`;
+- push records that are not shaped as `pushes/<YYYY-MM-DD-slug>/push.md`;
+- bet frontmatter that still only links legacy `campaigns/` records.
+
+These are warnings, not destructive repairs. Use them to decide what to move,
+rewrite, or leave as compatibility. Folder docs such as `research/README.md`
+are not treated as research reports and do not need research-record
+frontmatter.
+
 Validate before merging the branch:
 
 ```bash

--- a/mb/mb/doctor.py
+++ b/mb/mb/doctor.py
@@ -1098,9 +1098,41 @@ def _repair_legacy_claude_symlinks(repo: Path, findings: list[dict[str, Any]]) -
     }
 
 
-def _validation_summary(repo: Path) -> dict[str, Any]:
+def _migration_drift_from_checks(
+    checks: list[dict[str, Any]],
+    repo: Path,
+) -> dict[str, Any] | None:
+    check = next((item for item in checks if item.get("name") == "migration-drift"), None)
+    if check is None:
+        return None
+    findings = check.get("findings", [])
+    if not isinstance(findings, list):
+        findings = []
+    summary = check.get("summary")
+    if not isinstance(summary, dict):
+        summary = {
+            "warnings": len(findings),
+            "categories": sorted({str(item.get("category")) for item in findings}),
+        }
+    return {
+        "ok": not findings,
+        "repo": str(repo),
+        "findings": findings,
+        "summary": summary,
+    }
+
+
+def _validation_summary(
+    repo: Path,
+    *,
+    migration_drift_report: dict[str, Any] | None = None,
+) -> dict[str, Any]:
     try:
-        report = validate_mod.run(str(repo), cross_refs=True)
+        report = validate_mod.run(
+            str(repo),
+            cross_refs=True,
+            migration_drift_report=migration_drift_report,
+        )
     except Exception as exc:  # pragma: no cover - defensive CLI boundary
         return {
             "ok": False,
@@ -1278,6 +1310,7 @@ def run(path: str) -> dict[str, Any]:
             ),
             "severity": "ok" if drift["ok"] else "warn",
             "findings": drift["findings"],
+            "summary": drift["summary"],
             "safe_to_share": True,
         }
     )
@@ -1407,7 +1440,9 @@ def repair_plan(
     )
 
     migration = migrate_mod.check(target, include_diff=False)
-    migration_drift = migration_lint.run(target)
+    migration_drift = _migration_drift_from_checks(
+        doctor_report["checks"], target
+    ) or migration_lint.run(target)
     reference_state = _legacy_reference_state(target)
     offer_topology = _offer_topology_state(target)
     legacy_vip = _legacy_vip_audit_state(target)
@@ -1819,7 +1854,7 @@ def repair_plan(
         )
     )
 
-    validation = _validation_summary(target)
+    validation = _validation_summary(target, migration_drift_report=migration_drift)
     if validation["state"] != "ok":
         actions.append(
             _action(

--- a/mb/mb/doctor.py
+++ b/mb/mb/doctor.py
@@ -26,6 +26,7 @@ from mb import connect as connect_mod
 from mb import engine as engine_mod
 from mb import graph as graph_mod
 from mb import migrate as migrate_mod
+from mb import migration_lint
 from mb import onboard as onboard_mod
 from mb import validate as validate_mod
 from mb.engine import install_mode, link_status
@@ -1124,6 +1125,7 @@ def _validation_summary(repo: Path) -> dict[str, Any]:
                 "warnings": len(report.get("cross_refs", {}).get("warnings", [])),
                 "orphan_offers": len(report.get("cross_refs", {}).get("orphan_offers", [])),
             },
+            "migration_drift": report.get("migration_drift", {}).get("summary", {}),
         },
     }
 
@@ -1261,6 +1263,24 @@ def run(path: str) -> dict[str, Any]:
     checks.append(_repo_layout_check(repo))
     checks.append(_schema_version_check(repo))
     checks.append(_legacy_campaigns_check(repo))
+    drift = migration_lint.run(repo)
+    checks.append(
+        {
+            "name": "migration-drift",
+            "ok": bool(drift["ok"]),
+            "detail": (
+                "no migration-shape drift found"
+                if drift["ok"]
+                else (
+                    f"{drift['summary']['warnings']} migration drift warning(s): "
+                    + ", ".join(drift["summary"]["categories"])
+                )
+            ),
+            "severity": "ok" if drift["ok"] else "warn",
+            "findings": drift["findings"],
+            "safe_to_share": True,
+        }
+    )
     checkpoint_hook = checkpoint_mod.hook_status(repo)
     hook_state = str(checkpoint_hook.get("state"))
     checks.append(
@@ -1387,6 +1407,7 @@ def repair_plan(
     )
 
     migration = migrate_mod.check(target, include_diff=False)
+    migration_drift = migration_lint.run(target)
     reference_state = _legacy_reference_state(target)
     offer_topology = _offer_topology_state(target)
     legacy_vip = _legacy_vip_audit_state(target)
@@ -1461,6 +1482,50 @@ def repair_plan(
             _max_state([str(item["state"]) for item in layout_checks]),
             f"schema {migration.get('current_version')} -> {migration.get('latest_version')}",
             checks=layout_checks,
+        )
+    )
+
+    drift_actions: list[dict[str, Any]] = []
+    if migration_drift["findings"]:
+        action = _action(
+            id="migration-drift-review",
+            title="Review business repo migration drift",
+            state="warn",
+            mode="manual",
+            command="mb doctor repair --plan --json && mb validate --json",
+            safe_to_apply=False,
+            reason=(
+                "migration drift warnings name stale paths and categories without "
+                "copying private file contents; operators should approve moves or "
+                "frontmatter repairs explicitly"
+            ),
+        )
+        actions.append(action)
+        drift_actions.append(action)
+    sections.append(
+        _section(
+            "migration-drift",
+            "Migration Drift Lint",
+            "warn" if migration_drift["findings"] else "ok",
+            (
+                f"{migration_drift['summary']['warnings']} warning(s): "
+                + ", ".join(migration_drift["summary"]["categories"])
+                if migration_drift["findings"]
+                else "no legacy active-write or stale runtime guidance drift found"
+            ),
+            checks=[
+                {
+                    "name": str(item["code"]),
+                    "state": "warn",
+                    "summary": str(item["message"]),
+                    "path": str(item["path"]),
+                    "category": str(item["category"]),
+                    "repair_command": str(item["repair_command"]),
+                    "content_included": False,
+                }
+                for item in migration_drift["findings"]
+            ],
+            actions=drift_actions,
         )
     )
 
@@ -1864,6 +1929,7 @@ def repair_plan(
         "raw": {
             "migration": migration,
             "legacy_reference": reference_state,
+            "migration_drift": migration_drift,
             "offer_topology": offer_topology,
             "legacy_vip": legacy_vip,
             "legacy_claude_links": legacy_links,

--- a/mb/mb/migration_lint.py
+++ b/mb/mb/migration_lint.py
@@ -124,6 +124,12 @@ def _read_frontmatter(path: Path) -> dict[str, Any]:
     return parsed if isinstance(parsed, dict) else {}
 
 
+def _cached_frontmatter(path: Path, cache: dict[Path, dict[str, Any]]) -> dict[str, Any]:
+    if path not in cache:
+        cache[path] = _read_frontmatter(path)
+    return cache[path]
+
+
 def _iter_markdown_files(root: Path) -> list[Path]:
     if not root.is_dir():
         return []
@@ -228,13 +234,18 @@ def _lint_vip(repo: Path, findings: list[dict[str, Any]]) -> None:
     )
 
 
-def _lint_push_shapes(repo: Path, findings: list[dict[str, Any]]) -> None:
+def _lint_push_shapes(
+    repo: Path,
+    findings: list[dict[str, Any]],
+    frontmatter_cache: dict[Path, dict[str, Any]],
+) -> None:
     pushes = repo / "pushes"
     if not pushes.is_dir():
         return
     for md in _iter_markdown_files(pushes):
         rel = md.relative_to(repo).as_posix()
         parts = md.relative_to(repo).parts
+        fm = _cached_frontmatter(md, frontmatter_cache)
         if parts[-1] == "push.md":
             if len(parts) != 3 or not pushes_mod.PUSH_FOLDER_RE.fullmatch(parts[1]):
                 findings.append(
@@ -247,7 +258,7 @@ def _lint_push_shapes(repo: Path, findings: list[dict[str, Any]]) -> None:
                     )
                 )
             continue
-        if _read_frontmatter(md).get("type") == "push":
+        if fm.get("type") == "push":
             findings.append(
                 _finding(
                     code="push-frontmatter-wrong-path",
@@ -259,9 +270,7 @@ def _lint_push_shapes(repo: Path, findings: list[dict[str, Any]]) -> None:
                     repair_command="mb doctor repair --plan --json",
                 )
             )
-        if _read_frontmatter(md).get("type") == "playbook" and (
-            len(parts) < 4 or parts[2] != "playbooks"
-        ):
+        if fm.get("type") == "playbook" and (len(parts) < 4 or parts[2] != "playbooks"):
             findings.append(
                 _finding(
                     code="playbook-run-wrong-path",
@@ -273,7 +282,11 @@ def _lint_push_shapes(repo: Path, findings: list[dict[str, Any]]) -> None:
             )
 
 
-def _lint_frontmatter(repo: Path, findings: list[dict[str, Any]]) -> None:
+def _lint_frontmatter(
+    repo: Path,
+    findings: list[dict[str, Any]],
+    frontmatter_cache: dict[Path, dict[str, Any]],
+) -> None:
     for bet in _iter_markdown_files(repo / "bets"):
         fm = _read_frontmatter(bet)
         if not fm:
@@ -293,7 +306,7 @@ def _lint_frontmatter(repo: Path, findings: list[dict[str, Any]]) -> None:
                 )
             )
     for push in _iter_markdown_files(repo / "pushes"):
-        fm = _read_frontmatter(push)
+        fm = _cached_frontmatter(push, frontmatter_cache)
         if fm and push.name == "push.md" and fm.get("type") not in {None, "push"}:
             findings.append(
                 _finding(
@@ -315,7 +328,21 @@ def _lint_claude_guidance(repo: Path, findings: list[dict[str, Any]]) -> None:
     except OSError:
         return
     for code, concept, pattern, message in STALE_CLAUDE_PATTERNS:
-        if not pattern.search(text):
+        match = pattern.search(text)
+        if match is None:
+            continue
+        context = text[max(0, match.start() - 24) : match.end() + 24].lower()
+        if (code.endswith("write-guidance") or code.endswith("core-guidance")) and any(
+            phrase in context
+            for phrase in (
+                "do not write",
+                "don't write",
+                "never write",
+                "not write",
+                "compatibility fallback",
+                "compatibility path",
+            )
+        ):
             continue
         findings.append(
             _finding(
@@ -368,12 +395,13 @@ def _lint_settings(repo: Path, findings: list[dict[str, Any]]) -> None:
 def run(repo: str | Path) -> dict[str, Any]:
     target = Path(repo).expanduser().resolve()
     findings: list[dict[str, Any]] = []
+    frontmatter_cache: dict[Path, dict[str, Any]] = {}
     _lint_reference(target, findings)
     _lint_campaigns(target, findings)
     _lint_top_level_folders(target, findings)
     _lint_vip(target, findings)
-    _lint_push_shapes(target, findings)
-    _lint_frontmatter(target, findings)
+    _lint_push_shapes(target, findings, frontmatter_cache)
+    _lint_frontmatter(target, findings, frontmatter_cache)
     _lint_claude_guidance(target, findings)
     _lint_settings(target, findings)
     categories = sorted({str(item["category"]) for item in findings})

--- a/mb/mb/migration_lint.py
+++ b/mb/mb/migration_lint.py
@@ -1,0 +1,388 @@
+"""Privacy-safe business repo migration drift lint.
+
+The lint surface warns about old active-looking repo shapes without reading or
+printing private file bodies. It is intentionally advisory: compatibility paths
+remain readable, while current agents get deterministic guidance about where
+new work belongs.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from mb import engine as engine_mod
+from mb import pushes as pushes_mod
+
+STALE_TOP_LEVEL_FOLDERS = {
+    "ops": "Use `core/operations/` for durable operations context.",
+    "skills": (
+        "Use packaged `.claude/skills/mb-*` wiring; do not treat top-level `skills/` "
+        "as current business memory."
+    ),
+    "briefs": (
+        "Use `research/`, `decisions/`, `pushes/`, `log/`, or `documents/` based on the artifact."
+    ),
+    "content": (
+        "Use `pushes/`, `documents/`, or channel-specific push/playbook records "
+        "for shipped content."
+    ),
+    "staging": (
+        "Use `pushes/<YYYY-MM-DD-slug>/` for coordinated work and `.mb/` or OS "
+        "temp for local scratch."
+    ),
+}
+
+STALE_CLAUDE_PATTERNS = (
+    (
+        "stale-claude-reference-guidance",
+        "reference/",
+        re.compile(r"(?im)^\s*[-*]\s*`?reference/`?\s+(?:-|--|\u2014)"),
+        "`reference/` is legacy compatibility. New durable business truth belongs in `core/`.",
+    ),
+    (
+        "stale-claude-reference-core-guidance",
+        "reference/core",
+        re.compile(
+            r"(?i)(?:write|add|create|new work|new truth)[^\n.]{0,80}reference/(?:core|offers)"
+        ),
+        (
+            "`reference/core` and `reference/offers` are compatibility paths. "
+            "New writes belong in `core/` and `core/offers/`."
+        ),
+    ),
+    (
+        "stale-claude-campaigns-guidance",
+        "campaigns/",
+        re.compile(r"(?im)^\s*[-*]\s*`?campaigns/`?\s+(?:-|--|\u2014)"),
+        "`campaigns/` is compatibility read. New coordinated work belongs in `pushes/`.",
+    ),
+    (
+        "stale-claude-campaign-write-guidance",
+        "campaigns/",
+        re.compile(r"(?i)(?:write|add|create|new work|new coordinated work)[^\n.]{0,80}campaigns/"),
+        "`campaigns/` is compatibility read. New coordinated work belongs in `pushes/`.",
+    ),
+)
+
+
+def _finding(
+    *,
+    code: str,
+    path: str,
+    category: str,
+    message: str,
+    repair_command: str,
+) -> dict[str, Any]:
+    return {
+        "code": code,
+        "path": path,
+        "category": category,
+        "message": message,
+        "repair_command": repair_command,
+        "safe_to_share": True,
+        "content_included": False,
+    }
+
+
+def _has_non_ignored_content(path: Path) -> bool:
+    if path.is_symlink():
+        return False
+    if path.is_file():
+        return path.name not in {".gitkeep", ".DS_Store"}
+    if not path.is_dir():
+        return False
+    for child in path.rglob("*"):
+        if (
+            child.is_file()
+            and not child.is_symlink()
+            and child.name not in {".gitkeep", ".DS_Store"}
+        ):
+            return True
+    return False
+
+
+def _read_frontmatter(path: Path) -> dict[str, Any]:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return {}
+    if not text.startswith("---"):
+        return {}
+    try:
+        end = text.index("\n---", 3)
+    except ValueError:
+        return {}
+    try:
+        parsed = yaml.safe_load(text[3:end].lstrip("\n")) or {}
+    except yaml.YAMLError:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _iter_markdown_files(root: Path) -> list[Path]:
+    if not root.is_dir():
+        return []
+    return sorted(path for path in root.rglob("*.md") if path.is_file() and not path.is_symlink())
+
+
+def _lint_reference(repo: Path, findings: list[dict[str, Any]]) -> None:
+    reference = repo / "reference"
+    if not reference.exists() or reference.is_symlink():
+        return
+    for rel in ("reference/core", "reference/offers"):
+        path = repo / rel
+        if path.exists() and not path.is_symlink() and _has_non_ignored_content(path):
+            findings.append(
+                _finding(
+                    code="legacy-reference-active-content",
+                    path=rel,
+                    category="legacy-folder",
+                    message=(
+                        f"{rel} contains real files. Main Branch can read legacy `reference/`, "
+                        "but new durable business truth belongs in `core/`."
+                    ),
+                    repair_command="mb migrate --check",
+                )
+            )
+    other_files = [
+        child.relative_to(repo).as_posix()
+        for child in reference.rglob("*")
+        if child.is_file()
+        and not child.is_symlink()
+        and child.name not in {".gitkeep", ".DS_Store"}
+        and not child.relative_to(repo)
+        .as_posix()
+        .startswith(("reference/core/", "reference/offers/"))
+    ]
+    if other_files:
+        findings.append(
+            _finding(
+                code="legacy-reference-extra-content",
+                path="reference/",
+                category="legacy-folder",
+                message=(
+                    f"reference/ contains {len(other_files)} file(s) outside compatibility links. "
+                    "Classify them before writing new work; current homes are usually `core/`, "
+                    "`research/`, `decisions/`, `pushes/`, `log/`, or `documents/`."
+                ),
+                repair_command="mb doctor repair --plan --json",
+            )
+        )
+
+
+def _lint_campaigns(repo: Path, findings: list[dict[str, Any]]) -> None:
+    campaigns = repo / "campaigns"
+    if campaigns.is_dir() and _has_non_ignored_content(campaigns):
+        findings.append(
+            _finding(
+                code="legacy-campaigns-active-content",
+                path="campaigns/",
+                category="legacy-folder",
+                message=(
+                    "`campaigns/` contains legacy content. It remains readable for "
+                    "compatibility; new coordinated work belongs in `pushes/`."
+                ),
+                repair_command="mb migrate campaigns --plan",
+            )
+        )
+
+
+def _lint_top_level_folders(repo: Path, findings: list[dict[str, Any]]) -> None:
+    for name, destination in STALE_TOP_LEVEL_FOLDERS.items():
+        path = repo / name
+        if path.is_dir() and _has_non_ignored_content(path):
+            findings.append(
+                _finding(
+                    code=f"legacy-top-level-{name}",
+                    path=f"{name}/",
+                    category="legacy-folder",
+                    message=(
+                        f"Top-level `{name}/` looks like an old active-write folder. {destination}"
+                    ),
+                    repair_command="mb doctor repair --plan --json",
+                )
+            )
+
+
+def _lint_vip(repo: Path, findings: list[dict[str, Any]]) -> None:
+    vip = repo / ".vip"
+    if not vip.is_dir() or not _has_non_ignored_content(vip):
+        return
+    findings.append(
+        _finding(
+            code="legacy-vip-config",
+            path=".vip/",
+            category="legacy-settings",
+            message=(
+                "`.vip/` contains pre-current Main Branch config or state. Treat it as "
+                "legacy audit material, not active product truth; doctor classifies keys "
+                "without printing raw values."
+            ),
+            repair_command="mb doctor repair --plan --json",
+        )
+    )
+
+
+def _lint_push_shapes(repo: Path, findings: list[dict[str, Any]]) -> None:
+    pushes = repo / "pushes"
+    if not pushes.is_dir():
+        return
+    for md in _iter_markdown_files(pushes):
+        rel = md.relative_to(repo).as_posix()
+        parts = md.relative_to(repo).parts
+        if parts[-1] == "push.md":
+            if len(parts) != 3 or not pushes_mod.PUSH_FOLDER_RE.fullmatch(parts[1]):
+                findings.append(
+                    _finding(
+                        code="push-record-wrong-shape",
+                        path=rel,
+                        category="filename",
+                        message="Push records should live at `pushes/<YYYY-MM-DD-slug>/push.md`.",
+                        repair_command="mb doctor repair --plan --json",
+                    )
+                )
+            continue
+        if _read_frontmatter(md).get("type") == "push":
+            findings.append(
+                _finding(
+                    code="push-frontmatter-wrong-path",
+                    path=rel,
+                    category="filename",
+                    message=(
+                        "A `type: push` record should be named `pushes/<YYYY-MM-DD-slug>/push.md`."
+                    ),
+                    repair_command="mb doctor repair --plan --json",
+                )
+            )
+        if _read_frontmatter(md).get("type") == "playbook" and (
+            len(parts) < 4 or parts[2] != "playbooks"
+        ):
+            findings.append(
+                _finding(
+                    code="playbook-run-wrong-path",
+                    path=rel,
+                    category="filename",
+                    message="Playbook run records should live under `pushes/<push>/playbooks/`.",
+                    repair_command="mb doctor repair --plan --json",
+                )
+            )
+
+
+def _lint_frontmatter(repo: Path, findings: list[dict[str, Any]]) -> None:
+    for bet in _iter_markdown_files(repo / "bets"):
+        fm = _read_frontmatter(bet)
+        if not fm:
+            continue
+        rel = bet.relative_to(repo).as_posix()
+        if "linked_campaigns" in fm and "linked_pushes" not in fm:
+            findings.append(
+                _finding(
+                    code="bet-legacy-campaign-links-only",
+                    path=rel,
+                    category="frontmatter",
+                    message=(
+                        "`linked_campaigns` remains readable, but current bets should also "
+                        "use `linked_pushes` for canonical push links."
+                    ),
+                    repair_command="mb validate --json",
+                )
+            )
+    for push in _iter_markdown_files(repo / "pushes"):
+        fm = _read_frontmatter(push)
+        if fm and push.name == "push.md" and fm.get("type") not in {None, "push"}:
+            findings.append(
+                _finding(
+                    code="push-record-type-mismatch",
+                    path=push.relative_to(repo).as_posix(),
+                    category="frontmatter",
+                    message="Files named `push.md` should use `type: push` frontmatter.",
+                    repair_command="mb validate --json",
+                )
+            )
+
+
+def _lint_claude_guidance(repo: Path, findings: list[dict[str, Any]]) -> None:
+    path = repo / "CLAUDE.md"
+    if not path.is_file():
+        return
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return
+    for code, concept, pattern, message in STALE_CLAUDE_PATTERNS:
+        if not pattern.search(text):
+            continue
+        findings.append(
+            _finding(
+                code=code,
+                path="CLAUDE.md",
+                category="runtime-guidance",
+                message=(
+                    f"Generated repo guidance still teaches `{concept}` as an active path. "
+                    f"{message}"
+                ),
+                repair_command="mb doctor repair --plan --json",
+            )
+        )
+
+
+def _lint_settings(repo: Path, findings: list[dict[str, Any]]) -> None:
+    path = repo / ".claude" / "settings.local.json"
+    if not path.is_file():
+        return
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return
+    dirs = data.get("permissions", {}).get("additionalDirectories", [])
+    if not isinstance(dirs, list):
+        return
+    root = engine_mod.engine_root()
+    if root is None:
+        return
+    stale = [
+        value
+        for value in dirs
+        if isinstance(value, str) and engine_mod.is_stale_engine_path(value, root)
+    ]
+    if stale:
+        findings.append(
+            _finding(
+                code="stale-claude-settings-engine-path",
+                path=".claude/settings.local.json",
+                category="runtime-settings",
+                message=(
+                    f".claude/settings.local.json has {len(stale)} stale Main Branch engine "
+                    "path(s). Refresh project-local skill wiring before trusting runtime discovery."
+                ),
+                repair_command="mb skill link --repo . --json",
+            )
+        )
+
+
+def run(repo: str | Path) -> dict[str, Any]:
+    target = Path(repo).expanduser().resolve()
+    findings: list[dict[str, Any]] = []
+    _lint_reference(target, findings)
+    _lint_campaigns(target, findings)
+    _lint_top_level_folders(target, findings)
+    _lint_vip(target, findings)
+    _lint_push_shapes(target, findings)
+    _lint_frontmatter(target, findings)
+    _lint_claude_guidance(target, findings)
+    _lint_settings(target, findings)
+    categories = sorted({str(item["category"]) for item in findings})
+    return {
+        "ok": not findings,
+        "repo": str(target),
+        "findings": findings,
+        "summary": {
+            "warnings": len(findings),
+            "categories": categories,
+        },
+    }

--- a/mb/mb/validate.py
+++ b/mb/mb/validate.py
@@ -1279,11 +1279,23 @@ def _legacy_frontmatter_repair(repo: Path, error_count: int) -> dict[str, Any] |
     }
 
 
+def _is_folder_doc(path: Path, schema_name: str) -> bool:
+    return schema_name in {
+        "research",
+        "decisions",
+        "bets",
+        "log",
+        "documents",
+        "push-playbooks",
+    } and (path.name == "README.md")
+
+
 def run(
     path: str,
     verbose: bool = False,
     cross_refs: bool = False,
     strict: bool = False,
+    migration_drift_report: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Run validation across all known schemas. Verbose adds key dumps."""
     repo = Path(path).resolve()
@@ -1291,14 +1303,15 @@ def run(
     for schema_name, schema in SCHEMAS.items():
         glob = schema["glob"]
         for f in sorted(repo.glob(glob)):
-            if schema_name == "research" and f.name == "README.md":
+            if _is_folder_doc(f, schema_name):
                 continue
             r = _check_one(f, schema)
             r["schema"] = schema_name
             r["path"] = str(f.relative_to(repo))
             files_by_path[r["path"]] = r
 
-    migration_drift_report = migration_lint.run(repo)
+    if migration_drift_report is None:
+        migration_drift_report = migration_lint.run(repo)
     _add_migration_lint_warnings(files_by_path, migration_drift_report)
 
     cross_ref_report = {"enabled": False, "checked_fields": [], "warnings": [], "orphan_offers": []}

--- a/mb/mb/validate.py
+++ b/mb/mb/validate.py
@@ -15,7 +15,7 @@ from typing import Any
 
 import yaml
 
-from mb import github_activity, relationships
+from mb import github_activity, migration_lint, relationships
 from mb import pushes as pushes_mod
 
 DECISION_STATUS = {"proposed", "accepted", "rejected", "superseded", "running"}
@@ -176,10 +176,9 @@ SCHEMAS: dict[str, dict[str, Any]] = {
     },
     "bets": {
         "glob": "bets/*.md",
-        # `linked_campaigns` stays required for backward compatibility with
-        # every committed bet. New bet writes also include `linked_pushes`
-        # (canonical, recognized in LINK_FIELDS). A follow-up PR can drop
-        # `linked_campaigns` from required once the migration apply lands.
+        # Current bets use `linked_pushes`; legacy bets may still have only
+        # `linked_campaigns`. _check_bet_frontmatter enforces that at least one
+        # campaign/push link field exists without requiring the legacy field.
         "required": [
             "status",
             "opened",
@@ -191,13 +190,13 @@ SCHEMAS: dict[str, dict[str, Any]] = {
             "result",
             "linked_decisions",
             "linked_research",
-            "linked_campaigns",
             "linked_outcomes",
             "public",
             "channels",
             "tags",
         ],
         "enums": {"status": BET_STATUS},
+        "primitive": "bet",
     },
     "log": {
         "glob": "log/*.md",
@@ -301,6 +300,8 @@ def _check_one(path: Path, schema: dict[str, Any]) -> dict[str, Any]:
     primitive = schema.get("primitive")
     if primitive == "push":
         _check_push_frontmatter(path, fm, errors)
+    elif primitive == "bet":
+        _check_bet_frontmatter(fm, errors)
     elif primitive == "playbook":
         _check_playbook_frontmatter(path, fm, errors)
     elif primitive == "legacy-campaign":
@@ -309,6 +310,11 @@ def _check_one(path: Path, schema: dict[str, Any]) -> dict[str, Any]:
         _check_repo_topology_frontmatter(path, fm, errors, warnings)
     _check_provider_refs_shape(fm, errors)
     return {"path": str(path), "ok": not errors, "errors": errors, "warnings": warnings}
+
+
+def _check_bet_frontmatter(fm: dict[str, Any], errors: list[str]) -> None:
+    if "linked_pushes" not in fm and "linked_campaigns" not in fm:
+        errors.append("missing key: linked_pushes or linked_campaigns")
 
 
 def _require_non_empty_string(fm: dict[str, Any], key: str, errors: list[str]) -> None:
@@ -907,6 +913,29 @@ def _add_file_warning(
     files_by_path[rel].setdefault("warnings", []).append(message)
 
 
+def _add_migration_lint_warnings(
+    files_by_path: dict[str, dict[str, Any]],
+    report: dict[str, Any],
+) -> None:
+    for finding in report.get("findings", []):
+        raw_path = str(finding.get("path") or "migration-drift")
+        rel = raw_path.rstrip("/") or raw_path
+        message = str(finding.get("message") or "")
+        if not message:
+            continue
+        files_by_path.setdefault(
+            rel,
+            {
+                "path": rel,
+                "ok": True,
+                "errors": [],
+                "warnings": [],
+                "schema": "migration-drift",
+            },
+        )
+        files_by_path[rel].setdefault("warnings", []).append(message)
+
+
 def _check_status_transition(
     *,
     source: Path,
@@ -1262,10 +1291,15 @@ def run(
     for schema_name, schema in SCHEMAS.items():
         glob = schema["glob"]
         for f in sorted(repo.glob(glob)):
+            if schema_name == "research" and f.name == "README.md":
+                continue
             r = _check_one(f, schema)
             r["schema"] = schema_name
             r["path"] = str(f.relative_to(repo))
             files_by_path[r["path"]] = r
+
+    migration_drift_report = migration_lint.run(repo)
+    _add_migration_lint_warnings(files_by_path, migration_drift_report)
 
     cross_ref_report = {"enabled": False, "checked_fields": [], "warnings": [], "orphan_offers": []}
     if cross_refs:
@@ -1286,6 +1320,7 @@ def run(
         "strict": strict,
         "cross_refs": cross_ref_report,
         "legacy_repair": _legacy_frontmatter_repair(repo, error_count),
+        "migration_drift": migration_drift_report,
         "summary": {"errors": error_count, "warnings": warning_count},
     }
 

--- a/mb/tests/test_doctor.py
+++ b/mb/tests/test_doctor.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typer.testing import CliRunner
 
 from mb import doctor as doctor_mod
+from mb import migration_lint
 from mb.cli import app
 from mb.doctor import _detect_cloud_paths, _repo_layout_check, run
 from mb.init import run as init_run
@@ -483,6 +484,31 @@ def test_doctor_repair_plan_reports_migration_shape_drift(tmp_path: Path) -> Non
     assert "legacy-campaigns-active-content" in codes
     assert "legacy-vip-config" in codes
     assert "push-record-wrong-shape" in codes
+
+
+def test_doctor_repair_plan_reuses_migration_drift_report(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    repo = tmp_path / "reuse-drift"
+    init_run(path=str(repo), name="Acme")
+    calls = 0
+
+    def fake_lint(path: Path) -> dict[str, object]:
+        nonlocal calls
+        calls += 1
+        return {
+            "ok": True,
+            "repo": str(path),
+            "findings": [],
+            "summary": {"warnings": 0, "categories": []},
+        }
+
+    monkeypatch.setattr(migration_lint, "run", fake_lint)
+
+    doctor_mod.repair_plan(repo)
+
+    assert calls == 1
 
 
 def test_doctor_repair_plan_exposes_reference_split_truth(tmp_path: Path) -> None:

--- a/mb/tests/test_doctor.py
+++ b/mb/tests/test_doctor.py
@@ -398,6 +398,93 @@ def test_doctor_repair_plan_exposes_legacy_campaigns_to_pushes_action(tmp_path: 
     assert legacy_check["state"] == "warn"
 
 
+def test_doctor_repair_plan_reports_stale_generated_guidance_privately(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "stale-guidance"
+    init_run(path=str(repo), name="Acme")
+    (repo / "CLAUDE.md").write_text(
+        "\n".join(
+            [
+                "# Acme",
+                "",
+                "## Folders",
+                "",
+                "- `reference/` - current business memory and active write target",
+                "- `campaigns/` - current coordinated work",
+                "",
+                "Private customer note that should never appear in lint output.",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["doctor", "repair", "--repo", str(repo), "--plan", "--json"])
+
+    assert result.exit_code in {0, 1}
+    payload = json.loads(result.stdout)
+    section = next(section for section in payload["sections"] if section["id"] == "migration-drift")
+    assert section["state"] == "warn"
+    checks = {check["name"]: check for check in section["checks"]}
+    assert "stale-claude-reference-guidance" in checks
+    assert "stale-claude-campaigns-guidance" in checks
+    assert checks["stale-claude-reference-guidance"]["content_included"] is False
+    assert "Private customer note" not in result.stdout
+    actions = {action["id"]: action for action in payload["actions"]}
+    assert actions["migration-drift-review"]["mode"] == "manual"
+    assert actions["migration-drift-review"]["safe_to_apply"] is False
+
+
+def test_doctor_repair_plan_reports_migration_shape_drift(tmp_path: Path) -> None:
+    repo = tmp_path / "shape-drift"
+    init_run(path=str(repo), name="Acme")
+    (repo / "reference" / "core").mkdir(parents=True)
+    (repo / "reference" / "core" / "offer.md").write_text("# Legacy offer\n", encoding="utf-8")
+    (repo / ".vip").mkdir()
+    (repo / ".vip" / "config.yaml").write_text(
+        "reference_structure:\n  core: reference/core\n",
+        encoding="utf-8",
+    )
+    legacy = repo / "campaigns" / "2026-04-launch"
+    legacy.mkdir(parents=True)
+    (legacy / "campaign.md").write_text(
+        "---\nslug: launch\nstatus: active\n---\n# Launch\n",
+        encoding="utf-8",
+    )
+    wrong_push = repo / "pushes" / "launch" / "push.md"
+    wrong_push.parent.mkdir(parents=True)
+    wrong_push.write_text(
+        (
+            "---\n"
+            "type: push\n"
+            "slug: launch\n"
+            "kind: launch\n"
+            "status: active\n"
+            "health: unknown\n"
+            "goal: {}\n"
+            "owner: Devon\n"
+            "audience: buyers\n"
+            "offer: offer\n"
+            "promise: promise\n"
+            "---\n"
+            "# Push\n"
+        ),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["doctor", "repair", "--repo", str(repo), "--plan", "--json"])
+
+    assert result.exit_code in {0, 1}
+    payload = json.loads(result.stdout)
+    section = next(section for section in payload["sections"] if section["id"] == "migration-drift")
+    codes = {check["name"] for check in section["checks"]}
+    assert "legacy-reference-active-content" in codes
+    assert "legacy-campaigns-active-content" in codes
+    assert "legacy-vip-config" in codes
+    assert "push-record-wrong-shape" in codes
+
+
 def test_doctor_repair_plan_exposes_reference_split_truth(tmp_path: Path) -> None:
     repo = tmp_path / "split-truth"
     (repo / "core").mkdir(parents=True)

--- a/mb/tests/test_migration_lint.py
+++ b/mb/tests/test_migration_lint.py
@@ -1,0 +1,93 @@
+"""Business repo migration drift lint."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from mb import migration_lint
+
+
+def _write(path: Path, body: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+
+
+def test_migration_lint_reports_shape_and_frontmatter_drift_privately(
+    tmp_path: Path,
+) -> None:
+    _write(tmp_path / "reference" / "core" / "offer.md", "# Private offer body\n")
+    _write(
+        tmp_path / "campaigns" / "spring" / "campaign.md",
+        "---\nslug: spring\nstatus: active\n---\n# Private campaign body\n",
+    )
+    _write(tmp_path / "ops" / "handoff.md", "# Private ops body\n")
+    _write(
+        tmp_path / "pushes" / "spring" / "push.md",
+        (
+            "---\n"
+            "type: push\n"
+            "slug: spring\n"
+            "kind: launch\n"
+            "status: active\n"
+            "health: unknown\n"
+            "---\n"
+            "# Private push body\n"
+        ),
+    )
+    _write(
+        tmp_path / "pushes" / "2026-05-08-launch" / "run.md",
+        "---\ntype: playbook\n---\n# Private playbook body\n",
+    )
+    _write(
+        tmp_path / "bets" / "2026-05-08-legacy.md",
+        ("---\nstatus: open\nlinked_campaigns: []\n---\n# Private bet body\n"),
+    )
+
+    report = migration_lint.run(tmp_path)
+
+    codes = {finding["code"] for finding in report["findings"]}
+    assert "legacy-reference-active-content" in codes
+    assert "legacy-campaigns-active-content" in codes
+    assert "legacy-top-level-ops" in codes
+    assert "push-record-wrong-shape" in codes
+    assert "playbook-run-wrong-path" in codes
+    assert "bet-legacy-campaign-links-only" in codes
+    assert all(finding["content_included"] is False for finding in report["findings"])
+    assert "Private" not in json.dumps(report)
+
+
+def test_migration_lint_reports_stale_generated_guidance_without_file_body(
+    tmp_path: Path,
+) -> None:
+    _write(
+        tmp_path / "CLAUDE.md",
+        (
+            "# Business\n\n"
+            "- `reference/` - active business memory\n"
+            "- `campaigns/` - active coordinated work\n\n"
+            "Private customer detail.\n"
+        ),
+    )
+
+    report = migration_lint.run(tmp_path)
+
+    codes = {finding["code"] for finding in report["findings"]}
+    assert "stale-claude-reference-guidance" in codes
+    assert "stale-claude-campaigns-guidance" in codes
+    assert "Private customer detail" not in json.dumps(report)
+
+
+def test_migration_lint_reports_stale_claude_settings_engine_path(
+    tmp_path: Path,
+) -> None:
+    stale_engine = tmp_path / "mb-vip"
+    _write(
+        tmp_path / ".claude" / "settings.local.json",
+        json.dumps({"permissions": {"additionalDirectories": [str(stale_engine)]}}),
+    )
+
+    report = migration_lint.run(tmp_path)
+
+    codes = {finding["code"] for finding in report["findings"]}
+    assert "stale-claude-settings-engine-path" in codes

--- a/mb/tests/test_migration_lint.py
+++ b/mb/tests/test_migration_lint.py
@@ -78,6 +78,24 @@ def test_migration_lint_reports_stale_generated_guidance_without_file_body(
     assert "Private customer detail" not in json.dumps(report)
 
 
+def test_migration_lint_does_not_flag_negated_reference_write_guidance(
+    tmp_path: Path,
+) -> None:
+    _write(
+        tmp_path / "CLAUDE.md",
+        (
+            "# Business\n\n"
+            "Do not write to reference/core; it is a compatibility path. "
+            "New truth belongs in core/.\n"
+        ),
+    )
+
+    report = migration_lint.run(tmp_path)
+
+    codes = {finding["code"] for finding in report["findings"]}
+    assert "stale-claude-reference-core-guidance" not in codes
+
+
 def test_migration_lint_reports_stale_claude_settings_engine_path(
     tmp_path: Path,
 ) -> None:
@@ -91,3 +109,32 @@ def test_migration_lint_reports_stale_claude_settings_engine_path(
 
     codes = {finding["code"] for finding in report["findings"]}
     assert "stale-claude-settings-engine-path" in codes
+
+
+def test_migration_lint_reuses_push_frontmatter_reads(tmp_path: Path, monkeypatch) -> None:
+    wrong_push = tmp_path / "pushes" / "spring" / "push.md"
+    wrong_playbook = tmp_path / "pushes" / "2026-05-08-launch" / "run.md"
+    _write(
+        wrong_push,
+        "---\ntype: push\nslug: spring\n---\n# Private push body\n",
+    )
+    _write(
+        wrong_playbook,
+        "---\ntype: playbook\n---\n# Private playbook body\n",
+    )
+    original = migration_lint._read_frontmatter
+    calls: dict[Path, int] = {}
+
+    def counted(path: Path) -> dict[str, object]:
+        calls[path] = calls.get(path, 0) + 1
+        return original(path)
+
+    monkeypatch.setattr(migration_lint, "_read_frontmatter", counted)
+
+    report = migration_lint.run(tmp_path)
+
+    codes = {finding["code"] for finding in report["findings"]}
+    assert "push-record-wrong-shape" in codes
+    assert "playbook-run-wrong-path" in codes
+    assert calls[wrong_push] == 1
+    assert calls[wrong_playbook] == 1

--- a/mb/tests/test_validate.py
+++ b/mb/tests/test_validate.py
@@ -58,6 +58,87 @@ def test_validate_passes_well_formed(tmp_path: Path) -> None:
     assert all(f["ok"] for f in report["files"])
 
 
+def test_validate_accepts_canonical_bet_linked_pushes_without_legacy_campaigns(
+    tmp_path: Path,
+) -> None:
+    _write(
+        tmp_path / "bets" / "2026-05-08-launch.md",
+        (
+            "---\n"
+            "status: open\n"
+            "opened: 2026-05-08\n"
+            "deadline: 2026-05-22\n"
+            "appetite: 2 weeks\n"
+            "hypothesis: If we ship the push, qualified calls will increase.\n"
+            "metric: qualified calls\n"
+            "target: 10 qualified calls\n"
+            "result: ''\n"
+            "linked_decisions: []\n"
+            "linked_research: []\n"
+            "linked_pushes: []\n"
+            "linked_outcomes: []\n"
+            "public: false\n"
+            "channels: []\n"
+            "tags: []\n"
+            "---\n"
+            "# Launch bet\n"
+        ),
+    )
+
+    report = run(path=str(tmp_path))
+
+    assert report["ok"] is True
+    bet = next(file for file in report["files"] if file["schema"] == "bets")
+    assert bet["errors"] == []
+
+
+def test_validate_keeps_legacy_bet_campaign_links_readable(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "bets" / "2026-05-08-legacy.md",
+        (
+            "---\n"
+            "status: open\n"
+            "opened: 2026-05-08\n"
+            "deadline: 2026-05-22\n"
+            "appetite: 2 weeks\n"
+            "hypothesis: If the legacy campaign lands, calls will increase.\n"
+            "metric: qualified calls\n"
+            "target: 10 qualified calls\n"
+            "result: ''\n"
+            "linked_decisions: []\n"
+            "linked_research: []\n"
+            "linked_campaigns: []\n"
+            "linked_outcomes: []\n"
+            "public: false\n"
+            "channels: []\n"
+            "tags: []\n"
+            "---\n"
+            "# Legacy bet\n"
+        ),
+    )
+
+    report = run(path=str(tmp_path))
+
+    assert report["ok"] is True
+    bet = next(file for file in report["files"] if file["schema"] == "bets")
+    assert bet["errors"] == []
+    assert any("linked_campaigns" in warning for warning in bet["warnings"])
+
+
+def test_validate_ignores_research_readme_folder_docs(tmp_path: Path) -> None:
+    _write(tmp_path / "research" / "README.md", "# Research\n\nFolder docs without frontmatter.\n")
+    _write(
+        tmp_path / "research" / "2026-05-08-topic-source.md",
+        "---\ndate: 2026-05-08\ntopic: topic\nsource: source\n---\n# Research\n",
+    )
+
+    report = run(path=str(tmp_path))
+
+    assert report["ok"] is True
+    paths = {file["path"] for file in report["files"]}
+    assert "research/README.md" not in paths
+
+
 def test_keyword_gate_documented_frontmatter_validates(tmp_path: Path) -> None:
     guide = REPO_ROOT / ".claude" / "skills" / "mb-think" / "references" / "keyword-gate.md"
     text = guide.read_text(encoding="utf-8")
@@ -483,7 +564,7 @@ def test_cross_refs_warn_when_bet_link_lacks_reverse_link(tmp_path: Path) -> Non
             "linked_decisions:\n"
             "  - decisions/2026-05-04-demo.md\n"
             "linked_research: []\n"
-            "linked_campaigns: []\n"
+            "linked_pushes: []\n"
             "linked_outcomes: []\n"
             "public: true\n"
             "channels:\n"
@@ -524,7 +605,7 @@ def test_cross_refs_pass_when_bet_links_are_bidirectional(tmp_path: Path) -> Non
             "linked_decisions:\n"
             "  - decisions/2026-05-04-demo.md\n"
             "linked_research: []\n"
-            "linked_campaigns: []\n"
+            "linked_pushes: []\n"
             "linked_outcomes: []\n"
             "public: true\n"
             "channels:\n"

--- a/mb/tests/test_validate.py
+++ b/mb/tests/test_validate.py
@@ -125,8 +125,16 @@ def test_validate_keeps_legacy_bet_campaign_links_readable(tmp_path: Path) -> No
     assert any("linked_campaigns" in warning for warning in bet["warnings"])
 
 
-def test_validate_ignores_research_readme_folder_docs(tmp_path: Path) -> None:
+def test_validate_ignores_folder_readme_docs(tmp_path: Path) -> None:
     _write(tmp_path / "research" / "README.md", "# Research\n\nFolder docs without frontmatter.\n")
+    _write(tmp_path / "decisions" / "README.md", "# Decisions\n\nFolder docs.\n")
+    _write(tmp_path / "bets" / "README.md", "# Bets\n\nFolder docs.\n")
+    _write(tmp_path / "log" / "README.md", "# Log\n\nFolder docs.\n")
+    _write(tmp_path / "documents" / "README.md", "# Documents\n\nFolder docs.\n")
+    _write(
+        tmp_path / "pushes" / "2026-05-08-launch" / "playbooks" / "README.md",
+        "# Playbooks\n\nFolder docs.\n",
+    )
     _write(
         tmp_path / "research" / "2026-05-08-topic-source.md",
         "---\ndate: 2026-05-08\ntopic: topic\nsource: source\n---\n# Research\n",
@@ -137,6 +145,11 @@ def test_validate_ignores_research_readme_folder_docs(tmp_path: Path) -> None:
     assert report["ok"] is True
     paths = {file["path"] for file in report["files"]}
     assert "research/README.md" not in paths
+    assert "decisions/README.md" not in paths
+    assert "bets/README.md" not in paths
+    assert "log/README.md" not in paths
+    assert "documents/README.md" not in paths
+    assert "pushes/2026-05-08-launch/playbooks/README.md" not in paths
 
 
 def test_keyword_gate_documented_frontmatter_validates(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Fixes push-era validation drift so current bets can use `linked_pushes` without requiring legacy `linked_campaigns`.
- Adds privacy-safe migration drift warnings across `mb validate`, `mb doctor`, and `mb doctor repair --plan --json`.
- Keeps legacy folders and fields readable while telling agents where new work belongs under `core/`, `bets/`, and `pushes/`.
- Treats folder `README.md` files as documentation instead of schema records.

## Scope
- In: bet link validation, folder-doc schema skips, stale generated guidance lint, stale Claude settings lint, legacy folder/path warnings, tests, changelog, and migration docs.
- Out: destructive migrations, automatic rewrites, dashboard UI, topology/child-repo/playbook follow-up scope, and new runtime support claims.

## Commits
- `0d6fe88` — `[fix] MAIN-295 MAIN-296 lint migration drift`.
- `5d391f6` — `[fix] MAIN-295 MAIN-296 address migration lint review`.

## Release / Issues
- Release: Unreleased.
- Linear ID(s): MAIN-295, MAIN-296.
- Closes: #432, #436.
- Refs: none.
- Follow-ups: none from this branch.

## Success Metric
- Upgraded business repos with canonical `pushes/`, legacy compatibility folders, stale generated guidance, and folder docs get actionable warnings without false schema failures or private content leakage.

## Validation
- Level 0 docs/decision: updated `CHANGELOG.md` and `docs/MIGRATING.md`.
- Level 1 static: `scripts/check.sh` passed, including ruff format/check and mypy.
- Level 2 CLI: focused pytest passed with `110 passed`; full gate passed with `427 passed`.
- Level 3 package/install: not run; packaging and entrypoints were not changed.
- Level 4 fixture repo: smoke covered `mb validate --json`, `mb doctor repair --plan --json`, and `mb status --json --peek` against a migrated drift fixture; warning output did not echo private body text.
- Level 5 runtime smoke: not run; this changes deterministic CLI lint and generated guidance detection, not Claude Code discovery or invocation.

## Public / Private Boundary
- Migration warnings name paths, categories, and repair commands without printing file bodies, secrets, local private details, or customer/member data.
