### PR TITLE
[add] mb status / graph / doctor expose repo topology facts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,17 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   `type: repo_topology` records, including topology role/lifecycle/visibility
   vocabularies, safe repo-link checks, and finance/legal/provider-boundary
   warnings. Refs #416.
+- Exposed repo topology facts in `mb status --json`, `mb graph --json`, and
+  `mb doctor repair --plan --json` through a shared role-neutral
+  `mb.topology` reader. Status gains an additive `topology` section and a
+  business-readable "Business map" line; graph gains `repo` nodes and
+  deterministic hub/child relationship edges (with `linked_playbook_runs`
+  resolving to push playbook run files and `INDEX_VERSION` bumped to 2);
+  doctor gains a preview-only `topology-drift` section that warns on unsafe
+  metadata, descriptor/registry handle mismatch, descriptor/role mismatch,
+  or orphaned child descriptors without renaming, deleting, or rewriting
+  any repos. Public-safe topology payload and local-machine facts
+  (e.g. clone path) stay in separate fields. Refs #418.
 
 ### Changed
 

--- a/mb/mb/doctor.py
+++ b/mb/mb/doctor.py
@@ -1157,19 +1157,21 @@ def _topology_drift_state(repo: Path) -> dict[str, Any]:
     warnings = int(summary.get("warnings", 0) or 0)
     errors = int(summary.get("errors", 0) or 0)
 
-    warn_codes = sorted(
-        {
-            str(finding.get("code") or "")
-            for finding in findings
-            if finding.get("severity") == "warn" and finding.get("code")
-        }
-    )
+    codes_by_severity: dict[str, list[str]] = {}
+    for finding in findings:
+        severity = str(finding.get("severity") or "info")
+        code = str(finding.get("code") or "")
+        if not code:
+            continue
+        codes_by_severity.setdefault(severity, []).append(code)
+    warn_codes = sorted(set(codes_by_severity.get("warn", [])))
+    error_codes = sorted(set(codes_by_severity.get("error", [])))
 
     if errors:
         state = "error"
         section_summary = (
-            f"{errors} topology drift error(s): {', '.join(warn_codes)}"
-            if warn_codes
+            f"{errors} topology drift error(s): {', '.join(error_codes)}"
+            if error_codes
             else f"{errors} topology drift error(s)"
         )
     elif warnings:

--- a/mb/mb/doctor.py
+++ b/mb/mb/doctor.py
@@ -28,6 +28,7 @@ from mb import graph as graph_mod
 from mb import migrate as migrate_mod
 from mb import migration_lint
 from mb import onboard as onboard_mod
+from mb import topology as topology_mod
 from mb import validate as validate_mod
 from mb.engine import install_mode, link_status
 from mb.freshness import format_update_alert, package_update_status, version_key
@@ -1122,6 +1123,91 @@ def _migration_drift_from_checks(
     }
 
 
+def _topology_drift_state(repo: Path) -> dict[str, Any]:
+    """Surface repo topology drift evidence for ``mb doctor repair --plan``.
+
+    Reads the topology view via :func:`mb.topology.collect` and maps its
+    findings into the doctor section vocabulary (``ok``/``info``/``warn``/
+    ``error``). Preview-only: this helper never renames, deletes, or rewrites
+    topology files or descriptors.
+    """
+    payload = topology_mod.collect(str(repo))
+    findings = payload.get("findings") or []
+    summary = payload.get("summary") or {}
+
+    severity_to_state = {"info": "info", "warn": "warn", "error": "error"}
+    checks: list[dict[str, Any]] = []
+    for finding in findings:
+        severity = str(finding.get("severity") or "info")
+        checks.append(
+            {
+                "name": str(finding.get("code") or ""),
+                "state": severity_to_state.get(severity, "info"),
+                "summary": str(finding.get("summary") or ""),
+                "path": str(finding.get("path") or ""),
+                "detail": str(finding.get("detail") or ""),
+                "repair_command": str(finding.get("repair_command") or ""),
+                "safe_to_share": True,
+            }
+        )
+
+    registry_found = bool(summary.get("registry_found"))
+    registry_ok = bool(summary.get("registry_ok"))
+    descriptor_found = bool(summary.get("descriptor_found"))
+    warnings = int(summary.get("warnings", 0) or 0)
+    errors = int(summary.get("errors", 0) or 0)
+
+    warn_codes = sorted(
+        {
+            str(finding.get("code") or "")
+            for finding in findings
+            if finding.get("severity") == "warn" and finding.get("code")
+        }
+    )
+
+    if errors:
+        state = "error"
+        section_summary = (
+            f"{errors} topology drift error(s): {', '.join(warn_codes)}"
+            if warn_codes
+            else f"{errors} topology drift error(s)"
+        )
+    elif warnings:
+        state = "warn"
+        section_summary = (
+            f"{warnings} topology drift warning(s): {', '.join(warn_codes)}"
+            if warn_codes
+            else f"{warnings} topology drift warning(s)"
+        )
+    elif not registry_found and not descriptor_found:
+        state = "info"
+        section_summary = "no topology registry yet (optional)"
+    elif registry_found and registry_ok:
+        state = "ok"
+        section_summary = "topology registry parses; no drift detected"
+    else:
+        state = "info"
+        section_summary = "no topology registry yet (optional)"
+
+    return {
+        "state": state,
+        "summary": section_summary,
+        "checks": checks,
+        "findings": findings,
+        "child_repo_count": int(summary.get("child_repo_count", 0) or 0),
+        "restricted_repo_count": int(summary.get("restricted_repo_count", 0) or 0),
+        "summary_payload": {
+            "registry_found": registry_found,
+            "registry_ok": registry_ok,
+            "descriptor_found": descriptor_found,
+            "child_repo_count": int(summary.get("child_repo_count", 0) or 0),
+            "restricted_repo_count": int(summary.get("restricted_repo_count", 0) or 0),
+            "warnings": warnings,
+            "errors": errors,
+        },
+    }
+
+
 def _validation_summary(
     repo: Path,
     *,
@@ -1561,6 +1647,35 @@ def repair_plan(
                 for item in migration_drift["findings"]
             ],
             actions=drift_actions,
+        )
+    )
+
+    topology_drift = _topology_drift_state(target)
+    topology_actions: list[dict[str, Any]] = []
+    if topology_drift["state"] in {"warn", "error"}:
+        action = _action(
+            id="topology-drift-review",
+            title="Review repo topology drift",
+            state=topology_drift["state"],
+            mode="manual",
+            command="mb status --json --peek && mb validate --json",
+            safe_to_apply=False,
+            reason=(
+                "topology drift names hub/child mismatches, unsafe metadata, "
+                "or orphaned descriptors; doctor surfaces evidence but does "
+                "not rename, delete, or rewrite repos or descriptors"
+            ),
+        )
+        actions.append(action)
+        topology_actions.append(action)
+    sections.append(
+        _section(
+            "topology-drift",
+            "Repo Topology Drift",
+            topology_drift["state"],
+            topology_drift["summary"],
+            checks=topology_drift["checks"],
+            actions=topology_actions,
         )
     )
 

--- a/mb/mb/graph.py
+++ b/mb/mb/graph.py
@@ -14,8 +14,9 @@ import yaml
 
 from mb import pushes as pushes_mod
 from mb import relationships
+from mb import topology as topology_mod
 
-INDEX_VERSION = 1
+INDEX_VERSION = 2
 EdgeKey = tuple[str, str, str, tuple[tuple[str, str], ...]]
 
 LINK_FIELDS = relationships.RELATIONSHIP_FIELDS
@@ -119,6 +120,10 @@ def _external_id(ref: str) -> str:
 
 def _entity_id(entity_type: str, value: str) -> str:
     return f"{entity_type}:{_slug(value)}"
+
+
+def _repo_node_id(slug: str) -> str:
+    return f"repo:{_slug(slug)}"
 
 
 def _slug(value: str) -> str:
@@ -345,6 +350,227 @@ def _iter_provider_refs(frontmatter: dict[str, Any]) -> list[tuple[str, list[str
     return found
 
 
+_TOPOLOGY_REGISTRY_PATH = "core/operations/repo-topology.md"
+
+# Relationship values that semantically point from this entry back to its parent.
+_TOPOLOGY_PARENT_DIRECTED_RELATIONSHIPS: tuple[str, ...] = (
+    "execution_vehicle_for",
+    "graduated_from",
+    "supersedes",
+    "archived_from",
+    "source_for",
+    "reports_to",
+)
+
+_TOPOLOGY_LINKED_FIELD_EDGE_TYPES: dict[str, str] = {
+    "linked_offers": "linked_offers",
+    "linked_pushes": "linked_pushes",
+    "linked_bets": "linked_bets",
+    "linked_decisions": "linked_decisions",
+    "linked_research": "linked_research",
+    "linked_documents": "linked_documents",
+    "linked_docs": "linked_documents",
+    "linked_logs": "linked_logs",
+    "linked_outcomes": "linked_outcomes",
+    "linked_playbook_runs": "linked_playbook_run",
+}
+
+
+def _add_topology_pass(
+    *,
+    repo: Path,
+    nodes: dict[str, dict[str, Any]],
+    edges: list[dict[str, Any]],
+    seen_edges: set[EdgeKey],
+) -> None:
+    registry = topology_mod.read_registry(repo)
+    if not registry.get("ok"):
+        return
+    repos = registry.get("repos") or []
+    by_slug: dict[str, dict[str, Any]] = {}
+    for entry in repos:
+        slug = entry.get("slug") or ""
+        if slug:
+            by_slug[slug] = entry
+
+    # Add a repo node per entry.
+    for entry in repos:
+        slug = entry.get("slug") or ""
+        if not slug:
+            continue
+        node_id = _repo_node_id(slug)
+        label = (
+            entry.get("display_name")
+            or entry.get("slug")
+            or entry.get("remote_full_name")
+            or "(repo)"
+        )
+        _add_node(
+            nodes,
+            {
+                "id": node_id,
+                "type": "repo",
+                "label": label,
+                "metadata": {
+                    "slug": entry.get("slug", ""),
+                    "role": entry.get("role", ""),
+                    "lifecycle": entry.get("lifecycle", ""),
+                    "visibility": entry.get("visibility", ""),
+                    "github_owner": entry.get("github_owner", ""),
+                    "repo_name": entry.get("repo_name", ""),
+                    "remote_full_name": entry.get("remote_full_name", ""),
+                    "domain": entry.get("domain", ""),
+                    "is_hub": bool(entry.get("is_hub")),
+                    "safe_to_share": True,
+                },
+            },
+        )
+
+    # Edges between repo nodes based on relationship semantics.
+    for entry in repos:
+        slug = entry.get("slug") or ""
+        if not slug:
+            continue
+        relationships_list = list(entry.get("relationships") or [])
+        parent_slug = entry.get("parent") or ""
+        source_id = _repo_node_id(slug)
+
+        # child_of-style edge: explicit child_of relationship OR a non-empty
+        # parent slug that exists in the registry.
+        if ("child_of" in relationships_list or parent_slug) and parent_slug in by_slug:
+            _add_edge(
+                edges,
+                seen_edges,
+                source=source_id,
+                target=_repo_node_id(parent_slug),
+                edge_type="child_of",
+                evidence={
+                    "kind": "topology_registry",
+                    "field": "child_of",
+                    "path": _TOPOLOGY_REGISTRY_PATH,
+                },
+            )
+
+        # hub_for fan-out: hub points to each child whose parent == hub slug.
+        if "hub_for" in relationships_list:
+            for child_entry in repos:
+                child_slug = child_entry.get("slug") or ""
+                if not child_slug or child_slug == slug:
+                    continue
+                if (child_entry.get("parent") or "") != slug:
+                    continue
+                _add_edge(
+                    edges,
+                    seen_edges,
+                    source=source_id,
+                    target=_repo_node_id(child_slug),
+                    edge_type="hub_for",
+                    evidence={
+                        "kind": "topology_registry",
+                        "field": "hub_for",
+                        "path": _TOPOLOGY_REGISTRY_PATH,
+                    },
+                )
+
+        # Other parent-directed relationships emit an edge from this entry to
+        # its parent slug, typed by the relationship name.
+        for rel in relationships_list:
+            if rel not in _TOPOLOGY_PARENT_DIRECTED_RELATIONSHIPS:
+                continue
+            if not parent_slug or parent_slug not in by_slug:
+                continue
+            _add_edge(
+                edges,
+                seen_edges,
+                source=source_id,
+                target=_repo_node_id(parent_slug),
+                edge_type=rel,
+                evidence={
+                    "kind": "topology_registry",
+                    "field": rel,
+                    "path": _TOPOLOGY_REGISTRY_PATH,
+                },
+            )
+
+        # Linked-* fields → file or missing nodes.
+        registry_anchor = repo / "core" / "operations" / "repo-topology.md"
+        for field, edge_type in _TOPOLOGY_LINKED_FIELD_EDGE_TYPES.items():
+            for ref in entry.get(field) or []:
+                if not isinstance(ref, str) or not ref.strip():
+                    continue
+                clean_ref = ref.strip()
+                resolved: Path | None = None
+                if relationships.is_local_markdown_ref(clean_ref):
+                    resolved = relationships.resolve_markdown_link(repo, registry_anchor, clean_ref)
+                if resolved is not None and resolved.exists() and resolved.is_file():
+                    target_id = _file_id(resolved, repo)
+                    if target_id not in nodes:
+                        _add_node(
+                            nodes,
+                            {
+                                "id": target_id,
+                                "type": "file",
+                                "label": resolved.relative_to(repo).as_posix(),
+                                "path": resolved.relative_to(repo).as_posix(),
+                                "metadata": {},
+                            },
+                        )
+                else:
+                    target_id = f"missing:{_slug(clean_ref)}"
+                    _add_node(
+                        nodes,
+                        {
+                            "id": target_id,
+                            "type": "missing",
+                            "label": clean_ref,
+                            "metadata": {"ref": clean_ref},
+                        },
+                    )
+                _add_edge(
+                    edges,
+                    seen_edges,
+                    source=source_id,
+                    target=target_id,
+                    edge_type=edge_type,
+                    evidence={
+                        "kind": "topology_registry",
+                        "field": field,
+                        "path": _TOPOLOGY_REGISTRY_PATH,
+                    },
+                )
+
+        # uses_provider → provider nodes (no raw values).
+        for provider in entry.get("uses_provider") or []:
+            if not isinstance(provider, str) or not provider.strip():
+                continue
+            provider_id = f"provider:{_slug(provider)}"
+            _add_node(
+                nodes,
+                {
+                    "id": provider_id,
+                    "type": "provider",
+                    "label": _label_from_value(provider),
+                    "metadata": {
+                        "provider": provider,
+                        "ref_kinds": [],
+                        "exposes_raw_values": False,
+                    },
+                },
+            )
+            _add_edge(
+                edges,
+                seen_edges,
+                source=source_id,
+                target=provider_id,
+                edge_type="uses_provider",
+                evidence={
+                    "kind": "topology_registry",
+                    "field": "uses_provider",
+                    "path": _TOPOLOGY_REGISTRY_PATH,
+                },
+            )
+
+
 def build_index(path: str) -> dict[str, Any]:
     """Build the machine-readable repo graph index."""
     repo = Path(path).resolve()
@@ -524,6 +750,8 @@ def build_index(path: str) -> dict[str, Any]:
                 evidence={"kind": "entity", "field": source, "path": source_rel},
             )
 
+    _add_topology_pass(repo=repo, nodes=nodes, edges=edges, seen_edges=seen_edges)
+
     sorted_nodes = sorted(nodes.values(), key=_node_sort_key)
     sorted_edges = sorted(edges, key=_edge_sort_key)
     push_facts = pushes_mod.facts(repo)
@@ -545,6 +773,12 @@ def build_index(path: str) -> dict[str, Any]:
             "push_count": push_facts["count"],
             "canonical_push_count": push_facts["canonical_count"],
             "legacy_campaign_count": push_facts["legacy_campaign_count"],
+            "repos": sum(1 for node in sorted_nodes if node["type"] == "repo"),
+            "repo_relationships": sum(
+                1
+                for edge in sorted_edges
+                if edge.get("evidence", {}).get("kind") == "topology_registry"
+            ),
         },
         "pushes": push_facts["records"],
         "active_pushes": push_facts["active"],

--- a/mb/mb/status.py
+++ b/mb/mb/status.py
@@ -19,6 +19,7 @@ from mb import onboard as onboard_mod
 from mb import pushes as pushes_mod
 from mb import ranker as ranker_mod
 from mb import site as site_mod
+from mb import topology as topology_mod
 from mb.engine import install_mode, link_status
 from mb.freshness import format_update_alert, package_update_status
 
@@ -1539,6 +1540,10 @@ def run(
     update = package_update_status(repo_path)
     github = _github(repo_path, git)
     brain = _brain(repo_path)
+    topology_payload = topology_mod.collect(
+        str(repo_path),
+        git_remote=str(git.get("remote") or ""),
+    )
     push_report = brain["pushes"]
     marker = _read_last_seen_marker(repo_path)
     report: dict[str, Any] = {
@@ -1581,6 +1586,21 @@ def run(
         generated_at=generated_at,
     )
     report["drift"] = _drift(report)
+    report["topology"] = {
+        "schema": topology_payload["schema"],
+        "safe_to_share": True,
+        "summary": topology_payload["summary"],
+        "registry": topology_payload["registry"],
+        "descriptor": topology_payload["descriptor"],
+        "current_repo": topology_payload["current_repo"],
+        "child_counts": topology_payload["child_counts"],
+        "restricted_repos": topology_payload["restricted_repos"],
+        "findings": topology_payload["findings"],
+        "local": {
+            "repo_path": str(repo_path),
+            "safe_to_share": False,
+        },
+    }
     report["readiness"] = _readiness(report)
     report["ranked_actions"] = ranker_mod.rank_status_report(report)
     report["ok"] = report["readiness"]["level"] != "not_ready"
@@ -1704,6 +1724,39 @@ def render_human(
         f"[bold]Repo[/bold] {repo_mark} Main Branch repo  branch: {branch}  state: {dirty}"
     )
     console.print(f"[bold]Install[/bold] {report['install']['detail']}")
+
+    topology = report.get("topology") or {}
+    topology_summary = topology.get("summary") or {}
+    topology_registry = topology.get("registry") or {}
+    topology_current = topology.get("current_repo") or {}
+    topology_counts = topology.get("child_counts") or {}
+    if not topology_summary.get("registry_found"):
+        console.print("[bold]Business map[/bold] no core/operations/repo-topology.md yet")
+    elif not topology_summary.get("registry_ok"):
+        console.print("[bold]Business map[/bold] [yellow]registry present but unparsable[/yellow]")
+    else:
+        display_name = topology_registry.get("business_display_name") or "(no display name)"
+        total_children = topology_counts.get("total", 0)
+        restricted = topology_summary.get("restricted_repo_count", 0)
+        suffix = f", restricted {restricted}" if restricted else ""
+        console.print(
+            f"[bold]Business map[/bold] {display_name} — {total_children} child repo(s){suffix}"
+        )
+    if topology_current.get("matched"):
+        identifier = topology_current.get("slug") or topology_current.get("remote_full_name") or "?"
+        role = topology_current.get("role") or "?"
+        console.print(f"  this repo: {role} ({identifier})")
+    if verbose:
+        topology_findings = topology.get("findings") or []
+        shown = 0
+        for finding in topology_findings:
+            severity = finding.get("severity", "")
+            if severity not in {"warn", "error"}:
+                continue
+            console.print(f"  - {severity}: {finding.get('summary', '')}")
+            shown += 1
+            if shown >= 3:
+                break
 
     claude = runtime["claude_code"]
     skills = runtime["skill_wiring"]

--- a/mb/mb/topology.py
+++ b/mb/mb/topology.py
@@ -1,0 +1,1010 @@
+"""``mb topology`` — shared reader for repo topology registry and child descriptors.
+
+This module is the single role-neutral source of normalized topology facts that
+``mb status``, ``mb graph``, and ``mb doctor repair --plan`` consume. It reads
+``core/operations/repo-topology.md`` and ``.mainbranch/repo.json`` (or the
+legacy ``.mainbranch/source.json``) and reports public-safe topology metadata
+separately from local-machine facts.
+
+Schema validation lives in :mod:`mb.validate`. This module reads what the
+validator already accepts, normalizes it for downstream consumers, and reports
+drift evidence without copying private content, renaming repos, or rewriting
+files.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from mb import github_activity
+
+REGISTRY_RELATIVE_PATH = Path("core/operations/repo-topology.md")
+CHILD_REPO_RELATIVE_PATH = Path(".mainbranch") / "repo.json"
+LEGACY_SITE_RELATIVE_PATH = Path(".mainbranch") / "source.json"
+CHILD_REPO_SCHEMA = "mb.child_repo.v0"
+
+TOPOLOGY_ROLES = frozenset(
+    {
+        "business",
+        "site",
+        "offer",
+        "product",
+        "client",
+        "finance",
+        "legal",
+        "ops",
+        "integration_sidecar",
+        "experiment",
+        "archive",
+    }
+)
+TOPOLOGY_LIFECYCLES = frozenset({"proposed", "active", "paused", "superseded", "archived"})
+TOPOLOGY_VISIBILITIES = frozenset({"public", "team_private", "restricted", "local_only"})
+TOPOLOGY_RELATIONSHIPS = frozenset(
+    {
+        "hub_for",
+        "child_of",
+        "execution_vehicle_for",
+        "graduated_from",
+        "supersedes",
+        "archived_from",
+        "source_for",
+        "reports_to",
+        "uses_provider",
+    }
+)
+
+LINKED_FIELDS: tuple[str, ...] = (
+    "linked_offers",
+    "linked_pushes",
+    "linked_bets",
+    "linked_decisions",
+    "linked_research",
+    "linked_documents",
+    "linked_docs",
+    "linked_logs",
+    "linked_outcomes",
+    "linked_playbook_runs",
+)
+
+LOCAL_ABSOLUTE_PATH_RE = re.compile(r"^(?:/|~[/\\]|[A-Za-z]:[/\\])")
+SECRET_KEY_RE = re.compile(
+    r"(api[_-]?key|access[_-]?token|refresh[_-]?token|bearer|credential|"
+    r"client[_-]?secret|password|private[_-]?key|session|cookie|secret)",
+    re.IGNORECASE,
+)
+UNSAFE_KEY_RE = re.compile(
+    r"(ledger|bank|payroll|tax|contract|legal[_-]?advice|dispute|customer|member|"
+    r"account[_-]?number|raw[_-]?(?:data|export|cache|metric)|provider[_-]?cache|"
+    r"local[_-]?path|absolute[_-]?path)",
+    re.IGNORECASE,
+)
+KNOWN_TOPOLOGY_KEYS = frozenset(
+    {
+        "slug",
+        "display_name",
+        "role",
+        "lifecycle",
+        "status",
+        "visibility",
+        "purpose",
+        "github_owner",
+        "repo_name",
+        "remote",
+        "domain",
+        "parent",
+        "relationship",
+        "uses_provider",
+        *LINKED_FIELDS,
+        "linked_playbooks",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Reading helpers
+# ---------------------------------------------------------------------------
+
+
+def _read_text(path: Path) -> str | None:
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+
+
+def _split_frontmatter(text: str) -> tuple[dict[str, Any], str]:
+    if not text.startswith("---"):
+        return {}, text
+    try:
+        end = text.index("\n---", 3)
+    except ValueError:
+        return {}, text
+    try:
+        data = yaml.safe_load(text[3:end].lstrip("\n")) or {}
+    except yaml.YAMLError:
+        return {}, text
+    body = text[end + len("\n---") :]
+    if not isinstance(data, dict):
+        return {}, body
+    return data, body
+
+
+def _string(value: Any) -> str:
+    return str(value).strip() if isinstance(value, str) else ""
+
+
+def _string_list(value: Any) -> list[str]:
+    if isinstance(value, str):
+        text = value.strip()
+        return [text] if text else []
+    if not isinstance(value, list):
+        return []
+    out: list[str] = []
+    for item in value:
+        text = _string(item)
+        if text:
+            out.append(text)
+    return out
+
+
+def normalize_remote(value: Any) -> str:
+    """Normalize a remote handle to ``owner/repo`` or empty string.
+
+    Accepts ``github:owner/repo``, ``https://github.com/owner/repo(.git)``,
+    ``git@github.com:owner/repo(.git)``, and bare ``owner/repo`` strings.
+    """
+    text = _string(value)
+    if not text:
+        return ""
+    if text.startswith("github:"):
+        text = text.removeprefix("github:").strip()
+    name = github_activity.repo_full_name(text)
+    if name:
+        return name
+    if "/" in text and "://" not in text and "@" not in text and " " not in text:
+        candidate = text.removesuffix(".git").strip("/")
+        parts = candidate.split("/")
+        if len(parts) == 2 and parts[0] and parts[1]:
+            return f"{parts[0]}/{parts[1]}"
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# Registry reader
+# ---------------------------------------------------------------------------
+
+
+def _normalize_repo_entry(entry: dict[str, Any]) -> dict[str, Any]:
+    relationships = _string_list(entry.get("relationship"))
+    linked = {field: _string_list(entry.get(field)) for field in LINKED_FIELDS}
+    blueprint_refs = _string_list(entry.get("linked_playbooks"))
+    uses_provider = _string_list(entry.get("uses_provider"))
+    remote = _string(entry.get("remote"))
+    extras = sorted(
+        str(key) for key in entry if isinstance(key, str) and key not in KNOWN_TOPOLOGY_KEYS
+    )
+    role = _string(entry.get("role"))
+    is_hub = role == "business" or "hub_for" in relationships
+    domain = _string(entry.get("domain"))
+    return {
+        "slug": _string(entry.get("slug")),
+        "display_name": _string(entry.get("display_name")),
+        "role": role,
+        "lifecycle": _string(entry.get("lifecycle")),
+        "visibility": _string(entry.get("visibility")),
+        "purpose": _string(entry.get("purpose")),
+        "github_owner": _string(entry.get("github_owner")),
+        "repo_name": _string(entry.get("repo_name")),
+        "remote": remote,
+        "remote_full_name": normalize_remote(remote)
+        or (
+            f"{_string(entry.get('github_owner'))}/{_string(entry.get('repo_name'))}"
+            if entry.get("github_owner") and entry.get("repo_name")
+            else ""
+        ),
+        "domain": domain,
+        "parent": _string(entry.get("parent")),
+        "relationships": relationships,
+        **linked,
+        "linked_playbook_blueprints": blueprint_refs,
+        "uses_provider": uses_provider,
+        "is_hub": is_hub,
+        "extra_keys": extras,
+    }
+
+
+def read_registry(repo: Path) -> dict[str, Any]:
+    """Read ``core/operations/repo-topology.md`` and normalize repo entries.
+
+    Returns a stable dict whether or not the registry exists. Public-safe; never
+    contains absolute machine paths.
+    """
+    rel = REGISTRY_RELATIVE_PATH.as_posix()
+    path = repo / REGISTRY_RELATIVE_PATH
+    if not path.exists():
+        return {
+            "found": False,
+            "path": rel,
+            "ok": False,
+            "error": "missing",
+            "schema": "",
+            "status": "",
+            "home": "",
+            "home_full_name": "",
+            "business_display_name": "",
+            "repos": [],
+        }
+    text = _read_text(path)
+    if text is None:
+        return {
+            "found": True,
+            "path": rel,
+            "ok": False,
+            "error": "unreadable",
+            "schema": "",
+            "status": "",
+            "home": "",
+            "home_full_name": "",
+            "business_display_name": "",
+            "repos": [],
+        }
+    fm, _ = _split_frontmatter(text)
+    if not fm:
+        return {
+            "found": True,
+            "path": rel,
+            "ok": False,
+            "error": "missing or unparsable frontmatter",
+            "schema": "",
+            "status": "",
+            "home": "",
+            "home_full_name": "",
+            "business_display_name": "",
+            "repos": [],
+        }
+    if fm.get("type") != "repo_topology":
+        return {
+            "found": True,
+            "path": rel,
+            "ok": False,
+            "error": "type is not 'repo_topology'",
+            "schema": _string(fm.get("schema")),
+            "status": _string(fm.get("status")),
+            "home": _string(fm.get("home")),
+            "home_full_name": normalize_remote(fm.get("home")),
+            "business_display_name": _string(fm.get("business_display_name")),
+            "repos": [],
+        }
+    raw_repos = fm.get("repos")
+    if not isinstance(raw_repos, list) or not raw_repos:
+        return {
+            "found": True,
+            "path": rel,
+            "ok": False,
+            "error": "repos must be a non-empty list of mappings",
+            "schema": _string(fm.get("schema")),
+            "status": _string(fm.get("status")),
+            "home": _string(fm.get("home")),
+            "home_full_name": normalize_remote(fm.get("home")),
+            "business_display_name": _string(fm.get("business_display_name")),
+            "repos": [],
+        }
+    repos: list[dict[str, Any]] = []
+    for entry in raw_repos:
+        if not isinstance(entry, dict):
+            continue
+        repos.append(_normalize_repo_entry(entry))
+    return {
+        "found": True,
+        "path": rel,
+        "ok": True,
+        "error": "",
+        "schema": _string(fm.get("schema")),
+        "status": _string(fm.get("status")),
+        "home": _string(fm.get("home")),
+        "home_full_name": normalize_remote(fm.get("home")),
+        "business_display_name": _string(fm.get("business_display_name")),
+        "repos": repos,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Child descriptor reader
+# ---------------------------------------------------------------------------
+
+
+def _read_json(path: Path) -> tuple[dict[str, Any], str]:
+    if not path.exists():
+        return {}, "missing"
+    try:
+        parsed = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return {}, f"invalid JSON: {exc}"
+    if not isinstance(parsed, dict):
+        return {}, "not a JSON object"
+    return parsed, ""
+
+
+def _empty_descriptor() -> dict[str, Any]:
+    return {
+        "found": False,
+        "kind": "",
+        "path": "",
+        "ok": False,
+        "error": "missing",
+        "schema": "",
+        "role": "",
+        "display_name": "",
+        "github_owner": "",
+        "repo_name": "",
+        "remote_full_name": "",
+        "safe_purpose": "",
+        "parent": {
+            "display_name": "",
+            "github_owner": "",
+            "repo_name": "",
+            "remote": "",
+            "remote_full_name": "",
+            "local_checkout_relative": "",
+        },
+        "linked": {"offers": [], "pushes": [], "bets": [], "decisions": []},
+        "return_to_hub_command": "",
+        "safe_to_share": True,
+        "legacy_business_repo_present": False,
+    }
+
+
+def _normalize_repo_json(payload: dict[str, Any], rel: str) -> dict[str, Any]:
+    parent = payload.get("parent")
+    parent_data: dict[str, Any] = parent if isinstance(parent, dict) else {}
+    linked = payload.get("linked")
+    linked_data: dict[str, Any] = linked if isinstance(linked, dict) else {}
+    schema = _string(payload.get("schema")) or CHILD_REPO_SCHEMA
+    error = ""
+    if schema != CHILD_REPO_SCHEMA:
+        error = f"unsupported schema {schema!r}"
+    parent_remote = _string(parent_data.get("remote"))
+    parent_remote_full = normalize_remote(parent_remote) or (
+        f"{_string(parent_data.get('github_owner'))}/{_string(parent_data.get('repo_name'))}"
+        if parent_data.get("github_owner") and parent_data.get("repo_name")
+        else ""
+    )
+    local_checkout_raw = _string(parent_data.get("local_checkout"))
+    if local_checkout_raw and LOCAL_ABSOLUTE_PATH_RE.match(local_checkout_raw):
+        # never expose absolute path; preserve presence flag instead
+        local_checkout = ""
+    else:
+        local_checkout = local_checkout_raw
+    role = _string(payload.get("role"))
+    return {
+        "found": True,
+        "kind": "repo_json",
+        "path": rel,
+        "ok": not error,
+        "error": error,
+        "schema": schema,
+        "role": role,
+        "display_name": _string(payload.get("display_name")),
+        "github_owner": _string(payload.get("github_owner")),
+        "repo_name": _string(payload.get("repo_name")),
+        "remote_full_name": (
+            f"{_string(payload.get('github_owner'))}/{_string(payload.get('repo_name'))}"
+            if payload.get("github_owner") and payload.get("repo_name")
+            else ""
+        ),
+        "safe_purpose": _string(payload.get("safe_purpose")),
+        "parent": {
+            "display_name": _string(parent_data.get("display_name")),
+            "github_owner": _string(parent_data.get("github_owner")),
+            "repo_name": _string(parent_data.get("repo_name")),
+            "remote": parent_remote,
+            "remote_full_name": parent_remote_full,
+            "local_checkout_relative": local_checkout,
+        },
+        "linked": {
+            "offers": _string_list(linked_data.get("offers")),
+            "pushes": _string_list(linked_data.get("pushes")),
+            "bets": _string_list(linked_data.get("bets")),
+            "decisions": _string_list(linked_data.get("decisions")),
+        },
+        "return_to_hub_command": _string(payload.get("return_to_hub_command")),
+        "safe_to_share": bool(payload.get("safe_to_share", True)),
+        "legacy_business_repo_present": False,
+    }
+
+
+def _normalize_legacy_source(payload: dict[str, Any], rel: str) -> dict[str, Any]:
+    business_repo = _string(payload.get("business_repo"))
+    legacy_absolute = bool(business_repo) and bool(LOCAL_ABSOLUTE_PATH_RE.match(business_repo))
+    return {
+        "found": True,
+        "kind": "legacy_source",
+        "path": rel,
+        "ok": True,
+        "error": "",
+        "schema": "legacy.site_source",
+        "role": "site",
+        "display_name": "",
+        "github_owner": "",
+        "repo_name": "",
+        "remote_full_name": "",
+        "safe_purpose": "",
+        "parent": {
+            "display_name": "",
+            "github_owner": "",
+            "repo_name": "",
+            "remote": "",
+            "remote_full_name": "",
+            "local_checkout_relative": "",
+        },
+        "linked": {
+            "offers": [_string(payload.get("offer_path"))]
+            if _string(payload.get("offer_path"))
+            else [],
+            "pushes": [_string(payload.get("campaign_path"))]
+            if _string(payload.get("campaign_path"))
+            else [],
+            "bets": [],
+            "decisions": [],
+        },
+        "return_to_hub_command": "",
+        "safe_to_share": bool(payload.get("safe_to_share", True)),
+        "legacy_business_repo_present": legacy_absolute,
+    }
+
+
+def read_child_descriptor(repo: Path) -> dict[str, Any]:
+    """Read ``.mainbranch/repo.json`` (preferred) or ``.mainbranch/source.json``.
+
+    Returns a normalized dict with public-safe fields. Absolute local paths from
+    legacy ``source.json`` are never copied into the public payload; their
+    presence is recorded via ``legacy_business_repo_present`` only.
+    """
+    repo_json = repo / CHILD_REPO_RELATIVE_PATH
+    source_json = repo / LEGACY_SITE_RELATIVE_PATH
+    if repo_json.exists():
+        payload, error = _read_json(repo_json)
+        if error:
+            empty = _empty_descriptor()
+            empty["found"] = True
+            empty["kind"] = "repo_json"
+            empty["path"] = CHILD_REPO_RELATIVE_PATH.as_posix()
+            empty["error"] = error
+            return empty
+        return _normalize_repo_json(payload, CHILD_REPO_RELATIVE_PATH.as_posix())
+    if source_json.exists():
+        payload, error = _read_json(source_json)
+        if error:
+            empty = _empty_descriptor()
+            empty["found"] = True
+            empty["kind"] = "legacy_source"
+            empty["path"] = LEGACY_SITE_RELATIVE_PATH.as_posix()
+            empty["error"] = error
+            return empty
+        return _normalize_legacy_source(payload, LEGACY_SITE_RELATIVE_PATH.as_posix())
+    return _empty_descriptor()
+
+
+# ---------------------------------------------------------------------------
+# Current-repo view, counts, summaries
+# ---------------------------------------------------------------------------
+
+
+def current_repo_view(
+    *,
+    registry: dict[str, Any],
+    descriptor: dict[str, Any],
+    git_remote: str = "",
+) -> dict[str, Any]:
+    """Resolve which topology entry corresponds to the current repo.
+
+    Match priority: registry remote (normalized) → registry github_owner/repo_name
+    → descriptor github_owner/repo_name. Returns role-neutral facts only.
+    """
+    git_full = normalize_remote(git_remote)
+    matched_entry: dict[str, Any] | None = None
+    match_source = "none"
+
+    if registry.get("ok") and git_full:
+        for entry in registry.get("repos", []):
+            if entry.get("remote_full_name") == git_full:
+                matched_entry = entry
+                match_source = "registry_remote"
+                break
+
+    if matched_entry is None and registry.get("ok") and descriptor.get("found"):
+        owner = descriptor.get("github_owner") or descriptor.get("parent", {}).get("github_owner")
+        repo_name = descriptor.get("repo_name")
+        if owner and repo_name:
+            target = f"{owner}/{repo_name}"
+            for entry in registry.get("repos", []):
+                if entry.get("remote_full_name") == target:
+                    matched_entry = entry
+                    match_source = "registry_owner_repo"
+                    break
+
+    if matched_entry is not None:
+        parent_slug = matched_entry.get("parent") or ""
+        parent_full = ""
+        for entry in registry.get("repos", []):
+            if entry.get("slug") == parent_slug:
+                parent_full = entry.get("remote_full_name") or ""
+                break
+        return {
+            "matched": True,
+            "match_source": match_source,
+            "slug": matched_entry.get("slug", ""),
+            "role": matched_entry.get("role", ""),
+            "lifecycle": matched_entry.get("lifecycle", ""),
+            "visibility": matched_entry.get("visibility", ""),
+            "display_name": matched_entry.get("display_name", ""),
+            "github_owner": matched_entry.get("github_owner", ""),
+            "repo_name": matched_entry.get("repo_name", ""),
+            "remote_full_name": matched_entry.get("remote_full_name", ""),
+            "domain": matched_entry.get("domain", ""),
+            "parent_slug": parent_slug,
+            "parent_remote_full_name": parent_full,
+            "is_hub": bool(matched_entry.get("is_hub")),
+            "registry_role_matches_descriptor": _registry_role_matches_descriptor(
+                matched_entry, descriptor
+            ),
+        }
+
+    if descriptor.get("found"):
+        return {
+            "matched": False,
+            "match_source": "descriptor",
+            "slug": "",
+            "role": descriptor.get("role", ""),
+            "lifecycle": "",
+            "visibility": "",
+            "display_name": descriptor.get("display_name", ""),
+            "github_owner": descriptor.get("github_owner", ""),
+            "repo_name": descriptor.get("repo_name", ""),
+            "remote_full_name": descriptor.get("remote_full_name", ""),
+            "domain": "",
+            "parent_slug": "",
+            "parent_remote_full_name": descriptor.get("parent", {}).get("remote_full_name", ""),
+            "is_hub": False,
+            "registry_role_matches_descriptor": None,
+        }
+
+    return {
+        "matched": False,
+        "match_source": "none",
+        "slug": "",
+        "role": "",
+        "lifecycle": "",
+        "visibility": "",
+        "display_name": "",
+        "github_owner": "",
+        "repo_name": "",
+        "remote_full_name": git_full,
+        "domain": "",
+        "parent_slug": "",
+        "parent_remote_full_name": "",
+        "is_hub": False,
+        "registry_role_matches_descriptor": None,
+    }
+
+
+def _registry_role_matches_descriptor(
+    entry: dict[str, Any], descriptor: dict[str, Any]
+) -> bool | None:
+    if not descriptor.get("found"):
+        return None
+    desc_role = _string(descriptor.get("role"))
+    if not desc_role:
+        return None
+    return entry.get("role") == desc_role
+
+
+def child_role_counts(
+    registry: dict[str, Any],
+    *,
+    exclude_slug: str = "",
+) -> dict[str, Any]:
+    """Count child repos by role and lifecycle.
+
+    The hub itself (``role == "business"`` or ``slug == exclude_slug``) is
+    excluded so child counts describe operating surfaces, not the hub.
+    """
+    by_role: dict[str, dict[str, int]] = {}
+    by_lifecycle: dict[str, int] = {}
+    total = 0
+    if not registry.get("ok"):
+        return {"by_role": {}, "by_lifecycle": {}, "total": 0}
+    for entry in registry.get("repos", []):
+        slug = entry.get("slug", "")
+        if slug == exclude_slug:
+            continue
+        if entry.get("role") == "business":
+            continue
+        role = entry.get("role") or "unknown"
+        lifecycle = entry.get("lifecycle") or "unknown"
+        bucket = by_role.setdefault(role, {})
+        bucket[lifecycle] = bucket.get(lifecycle, 0) + 1
+        by_lifecycle[lifecycle] = by_lifecycle.get(lifecycle, 0) + 1
+        total += 1
+    return {"by_role": by_role, "by_lifecycle": by_lifecycle, "total": total}
+
+
+def restricted_repo_summary(registry: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return safe boundary notes for non-public repos.
+
+    Restricted/team-private/local-only repos are expected business boundaries,
+    not warnings. Drift findings are emitted separately when the entry contains
+    unsafe metadata.
+    """
+    notes: list[dict[str, Any]] = []
+    if not registry.get("ok"):
+        return notes
+    for entry in registry.get("repos", []):
+        visibility = entry.get("visibility", "")
+        if visibility in {"public", ""}:
+            continue
+        notes.append(
+            {
+                "slug": entry.get("slug", ""),
+                "display_name": entry.get("display_name", ""),
+                "role": entry.get("role", ""),
+                "visibility": visibility,
+                "lifecycle": entry.get("lifecycle", ""),
+                "purpose": entry.get("purpose", ""),
+                "parent": entry.get("parent", ""),
+                "safe_to_share": True,
+            }
+        )
+    return notes
+
+
+# ---------------------------------------------------------------------------
+# Drift findings
+# ---------------------------------------------------------------------------
+
+
+def _has_unsafe_keys(entry: dict[str, Any]) -> list[str]:
+    hits: list[str] = []
+    for key in entry.get("extra_keys", []):
+        if SECRET_KEY_RE.search(key) or UNSAFE_KEY_RE.search(key):
+            hits.append(str(key))
+    return sorted(set(hits))
+
+
+def _has_absolute_path_value(entry: dict[str, Any]) -> bool:
+    for field in ("purpose", "remote", "domain"):
+        value = entry.get(field, "")
+        if isinstance(value, str) and LOCAL_ABSOLUTE_PATH_RE.match(value):
+            return True
+    return False
+
+
+def drift_findings(
+    *,
+    registry: dict[str, Any],
+    descriptor: dict[str, Any],
+    current_view: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """Emit deterministic, public-safe drift findings.
+
+    Findings are advisory: the doctor section formats them as preview-only
+    actions. The reader never renames, deletes, or rewrites files.
+    """
+    findings: list[dict[str, Any]] = []
+
+    registry_found = bool(registry.get("found"))
+    registry_ok = bool(registry.get("ok"))
+
+    if not registry_found:
+        # Missing registry alone is informational; only escalates if a child
+        # descriptor points to a hub that cannot be matched.
+        if descriptor.get("found") and descriptor.get("parent", {}).get("remote_full_name"):
+            findings.append(
+                {
+                    "code": "topology_descriptor_orphan",
+                    "severity": "warn",
+                    "summary": (
+                        "child descriptor points to a hub but no "
+                        "core/operations/repo-topology.md is present in this repo"
+                    ),
+                    "detail": (
+                        "Open the hub repo and add the topology registry, or "
+                        "remove the parent reference from the child descriptor"
+                    ),
+                    "repair_command": "mb status --json --peek",
+                    "path": descriptor.get("path", ""),
+                    "safe_to_share": True,
+                }
+            )
+        else:
+            findings.append(
+                {
+                    "code": "topology_registry_missing",
+                    "severity": "info",
+                    "summary": "no core/operations/repo-topology.md yet",
+                    "detail": (
+                        "topology is optional; add a registry when multiple "
+                        "repos need a shared business map"
+                    ),
+                    "repair_command": "",
+                    "path": REGISTRY_RELATIVE_PATH.as_posix(),
+                    "safe_to_share": True,
+                }
+            )
+        if descriptor.get("found") and not descriptor.get("ok"):
+            findings.append(
+                {
+                    "code": "topology_descriptor_unparsable",
+                    "severity": "warn",
+                    "summary": "child descriptor present but could not be parsed",
+                    "detail": str(descriptor.get("error") or ""),
+                    "repair_command": "",
+                    "path": descriptor.get("path", ""),
+                    "safe_to_share": True,
+                }
+            )
+        if descriptor.get("legacy_business_repo_present"):
+            findings.append(
+                {
+                    "code": "topology_legacy_source_local_path",
+                    "severity": "warn",
+                    "summary": (
+                        "legacy .mainbranch/source.json contains an absolute "
+                        "business_repo path; review before sharing"
+                    ),
+                    "detail": (
+                        "absolute paths are not copied into shareable topology "
+                        "output; migrate to .mainbranch/repo.json when convenient"
+                    ),
+                    "repair_command": "",
+                    "path": descriptor.get("path", ""),
+                    "safe_to_share": True,
+                }
+            )
+        return findings
+
+    if not registry_ok:
+        findings.append(
+            {
+                "code": "topology_registry_unparsable",
+                "severity": "warn",
+                "summary": (
+                    f"core/operations/repo-topology.md present but unusable: "
+                    f"{registry.get('error') or 'unknown error'}"
+                ),
+                "detail": "run `mb validate --json` for the schema-level reasons",
+                "repair_command": "mb validate --json",
+                "path": registry.get("path", ""),
+                "safe_to_share": True,
+            }
+        )
+        return findings
+
+    # Registry exists and is parsable — check entry-level evidence.
+    repos = registry.get("repos", [])
+    slugs = {entry.get("slug") for entry in repos if entry.get("slug")}
+
+    for entry in repos:
+        prefix = f"repos[{entry.get('slug') or '?'}]"
+        unsafe_keys = _has_unsafe_keys(entry)
+        if unsafe_keys:
+            findings.append(
+                {
+                    "code": "topology_repo_unsafe_keys",
+                    "severity": "warn",
+                    "summary": (f"{prefix} contains keys that look sensitive or machine-specific"),
+                    "detail": (
+                        f"unexpected keys: {', '.join(unsafe_keys)}; keep finance, "
+                        "legal, customer, provider-cache, credential, and local-path "
+                        "details out of the topology registry"
+                    ),
+                    "repair_command": "mb validate --json",
+                    "path": registry.get("path", ""),
+                    "safe_to_share": True,
+                }
+            )
+        if _has_absolute_path_value(entry):
+            findings.append(
+                {
+                    "code": "topology_repo_absolute_path",
+                    "severity": "warn",
+                    "summary": (f"{prefix} has a value that looks like a local absolute path"),
+                    "detail": (
+                        "keep durable topology on GitHub handles and business "
+                        "relationships, not machine-specific paths"
+                    ),
+                    "repair_command": "mb validate --json",
+                    "path": registry.get("path", ""),
+                    "safe_to_share": True,
+                }
+            )
+        if entry.get("linked_playbook_blueprints"):
+            findings.append(
+                {
+                    "code": "topology_playbook_blueprint_reference",
+                    "severity": "info",
+                    "summary": (
+                        f"{prefix} uses linked_playbooks; reusable playbook "
+                        "blueprints belong in engine/package capability, not "
+                        "business repo topology"
+                    ),
+                    "detail": (
+                        "use linked_playbook_runs to link a specific "
+                        "pushes/<push>/playbooks/<playbook>.md run record"
+                    ),
+                    "repair_command": "",
+                    "path": registry.get("path", ""),
+                    "safe_to_share": True,
+                }
+            )
+        parent = entry.get("parent")
+        if parent and parent not in slugs:
+            findings.append(
+                {
+                    "code": "topology_parent_slug_unmatched",
+                    "severity": "warn",
+                    "summary": (
+                        f"{prefix}.parent={parent!r} does not match any repo slug in the registry"
+                    ),
+                    "detail": ("parent slugs should reference another entry in repos[]"),
+                    "repair_command": "mb validate --json",
+                    "path": registry.get("path", ""),
+                    "safe_to_share": True,
+                }
+            )
+
+    # Descriptor cross-checks.
+    if descriptor.get("found") and descriptor.get("ok"):
+        desc_owner = descriptor.get("github_owner")
+        desc_repo = descriptor.get("repo_name")
+        desc_full = f"{desc_owner}/{desc_repo}" if desc_owner and desc_repo else ""
+        parent = descriptor.get("parent", {})
+        parent_full = parent.get("remote_full_name") or ""
+
+        # Descriptor parent should resolve to a registry entry by handle.
+        if parent_full:
+            handles = {entry.get("remote_full_name") for entry in repos}
+            if parent_full not in handles:
+                findings.append(
+                    {
+                        "code": "topology_descriptor_parent_unmatched",
+                        "severity": "warn",
+                        "summary": (
+                            "child descriptor parent does not match any "
+                            "GitHub handle in the registry"
+                        ),
+                        "detail": (
+                            "the descriptor names a hub repo that this "
+                            "topology registry does not list"
+                        ),
+                        "repair_command": "",
+                        "path": descriptor.get("path", ""),
+                        "safe_to_share": True,
+                    }
+                )
+        # Descriptor role should match registry entry for the same handle.
+        if desc_full and current_view.get("matched"):
+            mismatch = current_view.get("registry_role_matches_descriptor")
+            if mismatch is False:
+                findings.append(
+                    {
+                        "code": "topology_descriptor_role_mismatch",
+                        "severity": "warn",
+                        "summary": (
+                            "child descriptor role does not match the role "
+                            "recorded for this repo in the hub topology"
+                        ),
+                        "detail": (
+                            f"descriptor role={descriptor.get('role')!r}, "
+                            f"registry role={current_view.get('role')!r}"
+                        ),
+                        "repair_command": "",
+                        "path": descriptor.get("path", ""),
+                        "safe_to_share": True,
+                    }
+                )
+        if descriptor.get("legacy_business_repo_present"):
+            findings.append(
+                {
+                    "code": "topology_legacy_source_local_path",
+                    "severity": "warn",
+                    "summary": (
+                        "legacy .mainbranch/source.json contains an absolute business_repo path"
+                    ),
+                    "detail": (
+                        "absolute paths are not copied into shareable topology "
+                        "output; migrate to .mainbranch/repo.json when convenient"
+                    ),
+                    "repair_command": "",
+                    "path": descriptor.get("path", ""),
+                    "safe_to_share": True,
+                }
+            )
+    elif descriptor.get("found") and not descriptor.get("ok"):
+        findings.append(
+            {
+                "code": "topology_descriptor_unparsable",
+                "severity": "warn",
+                "summary": "child descriptor present but could not be parsed",
+                "detail": str(descriptor.get("error") or ""),
+                "repair_command": "",
+                "path": descriptor.get("path", ""),
+                "safe_to_share": True,
+            }
+        )
+
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Top-level view used by status / graph / doctor
+# ---------------------------------------------------------------------------
+
+
+def collect(
+    repo: str | Path,
+    *,
+    git_remote: str = "",
+) -> dict[str, Any]:
+    """Build the public-safe topology view for a repo.
+
+    Local-machine facts (e.g. absolute clone path) belong to callers, not this
+    payload. The returned dict can be embedded in JSON intended for any consumer
+    that already has access to the hub repo.
+    """
+    repo_path = Path(repo).resolve()
+    registry = read_registry(repo_path)
+    descriptor = read_child_descriptor(repo_path)
+    view = current_repo_view(
+        registry=registry,
+        descriptor=descriptor,
+        git_remote=git_remote,
+    )
+    exclude_slug = str(view.get("slug") or "") if view.get("matched") and view.get("is_hub") else ""
+    counts = child_role_counts(registry, exclude_slug=exclude_slug)
+    boundary_notes = restricted_repo_summary(registry)
+    findings = drift_findings(
+        registry=registry,
+        descriptor=descriptor,
+        current_view=view,
+    )
+    summary = {
+        "registry_found": bool(registry.get("found")),
+        "registry_ok": bool(registry.get("ok")),
+        "descriptor_found": bool(descriptor.get("found")),
+        "descriptor_kind": descriptor.get("kind", ""),
+        "current_repo_matched": bool(view.get("matched")),
+        "child_repo_count": counts.get("total", 0),
+        "restricted_repo_count": len(boundary_notes),
+        "findings": len(findings),
+        "warnings": sum(1 for f in findings if f.get("severity") == "warn"),
+        "errors": sum(1 for f in findings if f.get("severity") == "error"),
+    }
+    return {
+        "schema": "mb.topology.view.v0",
+        "summary": summary,
+        "registry": {
+            "found": registry.get("found"),
+            "ok": registry.get("ok"),
+            "path": registry.get("path"),
+            "error": registry.get("error"),
+            "schema": registry.get("schema"),
+            "status": registry.get("status"),
+            "home": registry.get("home"),
+            "home_full_name": registry.get("home_full_name"),
+            "business_display_name": registry.get("business_display_name"),
+            "repos": registry.get("repos", []),
+        },
+        "descriptor": descriptor,
+        "current_repo": view,
+        "child_counts": counts,
+        "restricted_repos": boundary_notes,
+        "findings": findings,
+        "safe_to_share": True,
+    }

--- a/mb/mb/topology.py
+++ b/mb/mb/topology.py
@@ -519,7 +519,11 @@ def current_repo_view(
                 break
 
     if matched_entry is None and registry.get("ok") and descriptor.get("found"):
-        owner = descriptor.get("github_owner") or descriptor.get("parent", {}).get("github_owner")
+        # Only match by descriptor handle when the descriptor itself names its
+        # owner/repo. Falling back to the parent's owner combined with the
+        # child's repo name would silently false-match unrelated registry
+        # entries when a child repo lives in a different GitHub org.
+        owner = descriptor.get("github_owner")
         repo_name = descriptor.get("repo_name")
         if owner and repo_name:
             target = f"{owner}/{repo_name}"

--- a/mb/tests/fixtures/status/schema-v1-basic.json
+++ b/mb/tests/fixtures/status/schema-v1-basic.json
@@ -32,6 +32,7 @@
     "schema",
     "schema_version",
     "since_last_check",
+    "topology",
     "update"
   ],
   "section_keys": {

--- a/mb/tests/test_doctor.py
+++ b/mb/tests/test_doctor.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any
 
 from typer.testing import CliRunner
 
@@ -855,3 +856,178 @@ def test_doctor_legacy_symlink_keeps_current_active_engine_root(
     assert result["repairable"] == 0
     assert result["findings"][0]["state"] == "info"
     assert result["findings"][0]["safe_to_repair"] is False
+
+
+# ---------------------------------------------------------------------------
+# Topology drift section (MAIN-289)
+# ---------------------------------------------------------------------------
+
+
+_VALID_TOPOLOGY_REGISTRY = """\
+---
+type: repo_topology
+status: active
+schema: mb.repo_topology.v0
+home: github:example-co/example
+business_display_name: Example Business
+repos:
+  - slug: example
+    display_name: Example Business
+    role: business
+    lifecycle: active
+    github_owner: example-co
+    repo_name: example
+    remote: github:example-co/example
+    visibility: team_private
+    relationship: hub_for
+  - slug: workshop-site
+    display_name: Workshop site
+    role: site
+    lifecycle: active
+    relationship: execution_vehicle_for
+    parent: example
+    github_owner: example-co
+    repo_name: workshop-site
+    remote: github:example-co/workshop-site
+    visibility: public
+---
+# Topology
+"""
+
+
+def _write_registry(repo: Path, body: str) -> None:
+    path = repo / "core" / "operations" / "repo-topology.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+
+
+def _write_child_descriptor(repo: Path, payload: dict[str, Any]) -> None:
+    path = repo / ".mainbranch" / "repo.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _topology_section(payload: dict[str, Any]) -> dict[str, Any]:
+    return next(section for section in payload["sections"] if section["id"] == "topology-drift")
+
+
+def test_doctor_topology_drift_section_info_when_no_registry(tmp_path: Path) -> None:
+    repo = tmp_path / "no-topology"
+    repo.mkdir()
+
+    payload = doctor_mod.repair_plan(repo=str(repo))
+
+    section = _topology_section(payload)
+    assert section["state"] == "info"
+    assert "optional" in section["summary"].lower() or "no topology" in section["summary"].lower()
+    action_ids = {action["id"] for action in payload["actions"]}
+    assert "topology-drift-review" not in action_ids
+
+
+def test_doctor_topology_drift_section_ok_when_registry_clean(tmp_path: Path) -> None:
+    repo = tmp_path / "clean-topology"
+    repo.mkdir()
+    _write_registry(repo, _VALID_TOPOLOGY_REGISTRY)
+
+    payload = doctor_mod.repair_plan(repo=str(repo))
+
+    section = _topology_section(payload)
+    assert section["state"] == "ok"
+    assert "no drift detected" in section["summary"].lower()
+    action_ids = {action["id"] for action in payload["actions"]}
+    assert "topology-drift-review" not in action_ids
+
+
+def test_doctor_topology_drift_section_warn_when_descriptor_orphan(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "orphan-descriptor"
+    repo.mkdir()
+    _write_child_descriptor(
+        repo,
+        {
+            "schema": "mb.child_repo.v0",
+            "role": "site",
+            "display_name": "Workshop site",
+            "github_owner": "example-co",
+            "repo_name": "workshop-site",
+            "parent": {
+                "display_name": "Example Business",
+                "github_owner": "example-co",
+                "repo_name": "example",
+                "remote": "github:example-co/example",
+            },
+        },
+    )
+
+    payload = doctor_mod.repair_plan(repo=str(repo))
+
+    section = _topology_section(payload)
+    assert section["state"] == "warn"
+    actions = {action["id"]: action for action in payload["actions"]}
+    assert "topology-drift-review" in actions
+    review = actions["topology-drift-review"]
+    assert review["mode"] == "manual"
+    assert review["safe_to_apply"] is False
+
+
+def test_doctor_topology_drift_section_warn_on_descriptor_role_mismatch(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "role-mismatch"
+    repo.mkdir()
+    _write_registry(repo, _VALID_TOPOLOGY_REGISTRY)
+    # Descriptor handle matches workshop-site (registry role: site) but
+    # claims role=product, triggering topology_descriptor_role_mismatch.
+    _write_child_descriptor(
+        repo,
+        {
+            "schema": "mb.child_repo.v0",
+            "role": "product",
+            "display_name": "Workshop site",
+            "github_owner": "example-co",
+            "repo_name": "workshop-site",
+            "parent": {
+                "display_name": "Example Business",
+                "github_owner": "example-co",
+                "repo_name": "example",
+                "remote": "github:example-co/example",
+            },
+        },
+    )
+
+    payload = doctor_mod.repair_plan(repo=str(repo))
+
+    section = _topology_section(payload)
+    assert section["state"] == "warn"
+    check_codes = {str(check.get("name")) for check in section.get("checks", [])}
+    assert "topology_descriptor_role_mismatch" in check_codes
+
+
+def test_doctor_topology_drift_preview_only(tmp_path: Path) -> None:
+    repo = tmp_path / "preview-only"
+    repo.mkdir()
+    _write_child_descriptor(
+        repo,
+        {
+            "schema": "mb.child_repo.v0",
+            "role": "site",
+            "display_name": "Workshop site",
+            "github_owner": "example-co",
+            "repo_name": "workshop-site",
+            "parent": {
+                "display_name": "Example Business",
+                "github_owner": "example-co",
+                "repo_name": "example",
+                "remote": "github:example-co/example",
+            },
+        },
+    )
+
+    payload = doctor_mod.repair_plan(repo=str(repo))
+
+    actions = {action["id"]: action for action in payload["actions"]}
+    review = actions["topology-drift-review"]
+    assert review["safe_to_apply"] is False
+    assert review["mode"] == "manual"
+    assert "does not rename" in review["reason"].lower()

--- a/mb/tests/test_graph.py
+++ b/mb/tests/test_graph.py
@@ -301,7 +301,7 @@ def test_graph_json_cli_emits_machine_readable_index(tmp_path: Path) -> None:
 
     assert result.exit_code == 0
     index = json.loads(result.stdout)
-    assert index["version"] == 1
+    assert index["version"] == 2
     assert index["summary"]["files"] == 1
     assert any(node["id"] == "company:acme" for node in index["nodes"])
 
@@ -355,3 +355,176 @@ def test_duplicate_entity_mentions_are_deduped(tmp_path: Path) -> None:
     ]
 
     assert len(channel_edges) == 1
+
+
+# ---------------------------------------------------------------------------
+# Topology integration (MAIN-289)
+# ---------------------------------------------------------------------------
+
+
+_TOPOLOGY_REGISTRY_BODY = """---
+type: repo_topology
+status: active
+schema: mb.repo_topology.v0
+home: github:example-co/example
+business_display_name: Example Business
+repos:
+  - slug: example
+    display_name: Example Business
+    role: business
+    lifecycle: active
+    github_owner: example-co
+    repo_name: example
+    remote: github:example-co/example
+    visibility: team_private
+    relationship: hub_for
+  - slug: workshop-site
+    display_name: Workshop site
+    role: site
+    lifecycle: active
+    relationship: execution_vehicle_for
+    parent: example
+    github_owner: example-co
+    repo_name: workshop-site
+    remote: github:example-co/workshop-site
+    visibility: public
+    linked_offers:
+      - core/offers/workshop/offer.md
+    linked_playbook_runs:
+      - pushes/2026-05-20-workshop-launch/playbooks/launch.md
+  - slug: finance
+    display_name: Finance source
+    role: finance
+    lifecycle: active
+    relationship: reports_to
+    parent: example
+    visibility: restricted
+---
+# Topology
+"""
+
+
+def _write_topology_registry(repo: Path, body: str = _TOPOLOGY_REGISTRY_BODY) -> Path:
+    operations = repo / "core" / "operations"
+    operations.mkdir(parents=True, exist_ok=True)
+    registry = operations / "repo-topology.md"
+    registry.write_text(body, encoding="utf-8")
+    return registry
+
+
+def test_graph_index_version_is_two(tmp_path: Path) -> None:
+    index = build_index(path=str(tmp_path))
+    assert index["version"] == 2
+
+
+def test_graph_includes_repo_nodes_from_topology(tmp_path: Path) -> None:
+    _write_topology_registry(tmp_path)
+
+    index = build_index(path=str(tmp_path))
+    nodes_by_id = {node["id"]: node for node in index["nodes"]}
+
+    for slug in ("example", "workshop-site", "finance"):
+        node = nodes_by_id.get(f"repo:{slug}")
+        assert node is not None, f"missing repo node for {slug}"
+        assert node["type"] == "repo"
+
+    assert nodes_by_id["repo:example"]["metadata"]["role"] == "business"
+    assert nodes_by_id["repo:example"]["metadata"]["visibility"] == "team_private"
+    assert nodes_by_id["repo:workshop-site"]["metadata"]["role"] == "site"
+    assert nodes_by_id["repo:workshop-site"]["metadata"]["visibility"] == "public"
+    assert nodes_by_id["repo:finance"]["metadata"]["role"] == "finance"
+    assert nodes_by_id["repo:finance"]["metadata"]["visibility"] == "restricted"
+
+    assert index["summary"]["repos"] == 3
+
+
+def test_graph_emits_deterministic_topology_edges(tmp_path: Path) -> None:
+    _write_topology_registry(tmp_path)
+    offer_path = tmp_path / "core" / "offers" / "workshop" / "offer.md"
+    offer_path.parent.mkdir(parents=True, exist_ok=True)
+    offer_path.write_text(
+        "---\ntitle: Workshop offer\n---\n",
+        encoding="utf-8",
+    )
+    playbook_path = tmp_path / "pushes" / "2026-05-20-workshop-launch" / "playbooks" / "launch.md"
+    playbook_path.parent.mkdir(parents=True, exist_ok=True)
+    playbook_path.write_text(
+        "---\ntitle: Launch playbook\n---\n",
+        encoding="utf-8",
+    )
+
+    index = build_index(path=str(tmp_path))
+    triples = {(edge["source"], edge["target"], edge["type"]) for edge in index["edges"]}
+
+    assert (
+        "repo:workshop-site",
+        "repo:example",
+        "execution_vehicle_for",
+    ) in triples
+    assert ("repo:finance", "repo:example", "reports_to") in triples
+    assert ("repo:example", "repo:workshop-site", "hub_for") in triples
+    assert ("repo:example", "repo:finance", "hub_for") in triples
+    assert (
+        "repo:workshop-site",
+        "file:core/offers/workshop/offer.md",
+        "linked_offers",
+    ) in triples
+    assert (
+        "repo:workshop-site",
+        "file:pushes/2026-05-20-workshop-launch/playbooks/launch.md",
+        "linked_playbook_run",
+    ) in triples
+
+    assert index["summary"]["repo_relationships"] >= 6
+
+
+def test_graph_resolves_missing_playbook_run_target(tmp_path: Path) -> None:
+    _write_topology_registry(tmp_path)
+    offer_path = tmp_path / "core" / "offers" / "workshop" / "offer.md"
+    offer_path.parent.mkdir(parents=True, exist_ok=True)
+    offer_path.write_text(
+        "---\ntitle: Workshop offer\n---\n",
+        encoding="utf-8",
+    )
+
+    index = build_index(path=str(tmp_path))
+    missing_edges = [
+        edge
+        for edge in index["edges"]
+        if edge["source"] == "repo:workshop-site"
+        and edge["type"] == "linked_playbook_run"
+        and str(edge["target"]).startswith("missing:")
+    ]
+    assert len(missing_edges) == 1
+
+
+def test_graph_skips_linked_playbooks_blueprint_field(tmp_path: Path) -> None:
+    body = """---
+type: repo_topology
+status: active
+schema: mb.repo_topology.v0
+home: github:example-co/example
+business_display_name: Example Business
+repos:
+  - slug: example
+    display_name: Example Business
+    role: business
+    lifecycle: active
+    github_owner: example-co
+    repo_name: example
+    remote: github:example-co/example
+    visibility: team_private
+    relationship: hub_for
+    linked_playbooks:
+      - core/playbooks/launch-checklist.md
+---
+# Topology
+"""
+    _write_topology_registry(tmp_path, body)
+
+    index = build_index(path=str(tmp_path))
+    node_ids = {node["id"] for node in index["nodes"]}
+    edge_types = {edge["type"] for edge in index["edges"]}
+
+    assert not any(node_id.startswith("engine_playbook:") for node_id in node_ids)
+    assert "linked_playbook" not in edge_types

--- a/mb/tests/test_status.py
+++ b/mb/tests/test_status.py
@@ -1435,3 +1435,98 @@ def test_status_renderer_falls_back_to_readiness_actions_for_legacy_reports(caps
 
     output = capsys.readouterr().out
     assert "Run `claude` in this repo, then `/mb-start`." in output
+
+
+_VALID_TOPOLOGY_REGISTRY = """\
+---
+type: repo_topology
+status: active
+schema: mb.repo_topology.v0
+home: github:example-co/example
+business_display_name: Example Business
+repos:
+  - slug: example
+    display_name: Example Business
+    role: business
+    lifecycle: active
+    github_owner: example-co
+    repo_name: example
+    remote: github:example-co/example
+    visibility: team_private
+    relationship: hub_for
+    purpose: Hub repo for company strategy and decisions.
+  - slug: workshop-site
+    display_name: Workshop site
+    role: site
+    lifecycle: active
+    relationship: execution_vehicle_for
+    parent: example
+    github_owner: example-co
+    repo_name: workshop-site
+    remote: github:example-co/workshop-site
+    visibility: public
+---
+# Topology
+"""
+
+
+def test_status_exposes_topology_section_when_registry_missing(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+    # Ensure no topology registry exists.
+    registry_path = repo / "core" / "operations" / "repo-topology.md"
+    if registry_path.exists():
+        registry_path.unlink()
+
+    report = status_mod.run(path=str(repo), update_marker=False)
+    topology = report["topology"]
+
+    assert topology["schema"] == "mb.topology.view.v0"
+    assert topology["safe_to_share"] is True
+    assert topology["summary"]["registry_found"] is False
+    assert topology["summary"]["warnings"] == 0
+    assert topology["current_repo"]["matched"] is False
+    assert topology["registry"]["found"] is False
+    assert topology["registry"]["ok"] is False
+    assert topology["local"]["repo_path"] == str(repo.resolve())
+    assert topology["local"]["safe_to_share"] is False
+
+
+def test_status_exposes_topology_section_with_valid_registry(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+    registry_path = repo / "core" / "operations" / "repo-topology.md"
+    registry_path.parent.mkdir(parents=True, exist_ok=True)
+    registry_path.write_text(_VALID_TOPOLOGY_REGISTRY, encoding="utf-8")
+
+    report = status_mod.run(path=str(repo), update_marker=False)
+    topology = report["topology"]
+
+    assert topology["summary"]["registry_ok"] is True
+    assert topology["summary"]["child_repo_count"] >= 1
+    # The hub itself should match by github_owner/repo_name fall-through (no
+    # remote configured in tmp git), or fall through to descriptor. Either way
+    # the registry recorded the hub role for this owner/repo pair.
+    registry_repos = topology["registry"]["repos"]
+    business_entries = [entry for entry in registry_repos if entry.get("role") == "business"]
+    assert business_entries, "expected at least one business role entry"
+
+    public_payload = json.dumps({key: topology[key] for key in topology if key != "local"})
+    assert "/Users/" not in public_payload
+    assert str(repo.resolve()) not in public_payload
+
+
+def test_status_human_output_mentions_business_map(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+
+    quiet = runner.invoke(app, ["status", str(repo)])
+    assert quiet.exit_code == 0
+    assert "Business map" in quiet.stdout
+
+    loud = runner.invoke(app, ["status", str(repo), "--verbose"])
+    assert loud.exit_code == 0
+    assert "Business map" in loud.stdout

--- a/mb/tests/test_topology.py
+++ b/mb/tests/test_topology.py
@@ -256,6 +256,37 @@ def test_current_repo_view_matches_by_remote(tmp_path: Path) -> None:
     assert view["is_hub"] is True
 
 
+def test_current_repo_view_does_not_false_match_across_github_orgs(
+    tmp_path: Path,
+) -> None:
+    """Descriptor without its own github_owner must not borrow the parent's
+    owner to compose a registry handle — a child in a different org would
+    otherwise silently match an unrelated registry entry.
+    """
+    _write_registry(tmp_path, _valid_registry())
+    _write_repo_json(
+        tmp_path,
+        {
+            "schema": topology.CHILD_REPO_SCHEMA,
+            "role": "site",
+            "display_name": "Cross-org site",
+            "repo_name": "workshop-site",
+            # descriptor's own github_owner deliberately omitted; the child
+            # really lives under a different GitHub org.
+            "parent": {
+                "github_owner": "example-co",
+                "repo_name": "example",
+                "remote": "github:example-co/example",
+            },
+        },
+    )
+    registry = topology.read_registry(tmp_path)
+    descriptor = topology.read_child_descriptor(tmp_path)
+    view = topology.current_repo_view(registry=registry, descriptor=descriptor, git_remote="")
+    assert view["matched"] is False
+    assert view["match_source"] == "descriptor"
+
+
 def test_current_repo_view_falls_back_to_descriptor(tmp_path: Path) -> None:
     _write_repo_json(
         tmp_path,

--- a/mb/tests/test_topology.py
+++ b/mb/tests/test_topology.py
@@ -1,0 +1,514 @@
+"""Tests for ``mb.topology`` reader (issue #418)."""
+
+from __future__ import annotations
+
+import json
+import textwrap
+from pathlib import Path
+
+from mb import topology
+
+
+def _write_registry(repo: Path, body: str) -> Path:
+    path = repo / "core" / "operations" / "repo-topology.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def _valid_registry(extra_repos: str = "") -> str:
+    base = textwrap.dedent(
+        """\
+        ---
+        type: repo_topology
+        status: active
+        schema: mb.repo_topology.v0
+        home: github:example-co/example
+        business_display_name: Example Business
+        repos:
+          - slug: example
+            display_name: Example Business
+            role: business
+            lifecycle: active
+            github_owner: example-co
+            repo_name: example
+            remote: github:example-co/example
+            visibility: team_private
+            relationship: hub_for
+            purpose: Hub repo for company strategy and decisions.
+          - slug: workshop-site
+            display_name: Workshop site
+            role: site
+            lifecycle: active
+            relationship: execution_vehicle_for
+            parent: example
+            github_owner: example-co
+            repo_name: workshop-site
+            remote: github:example-co/workshop-site
+            visibility: public
+            domain: workshop.example.com
+            linked_offers:
+              - core/offers/workshop/offer.md
+            linked_pushes:
+              - pushes/2026-05-20-workshop-launch/push.md
+            linked_playbook_runs:
+              - pushes/2026-05-20-workshop-launch/playbooks/launch.md
+          - slug: finance
+            display_name: Finance source
+            role: finance
+            lifecycle: active
+            relationship: reports_to
+            parent: example
+            visibility: restricted
+            purpose: Private bookkeeping; hub stores approved summaries only.
+        """
+    )
+    if extra_repos:
+        # Ensure the extra block sits at the same indent as the existing
+        # ``repos:`` list (2 spaces).
+        indented = "\n".join(
+            ("  " + line) if line.strip() else line for line in extra_repos.splitlines()
+        )
+        base = base.rstrip() + "\n" + indented + "\n"
+    return base + "---\n# Topology\n"
+
+
+# ---------------------------------------------------------------------------
+# normalize_remote
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_remote_accepts_common_handle_forms() -> None:
+    assert topology.normalize_remote("github:example-co/example") == "example-co/example"
+    assert (
+        topology.normalize_remote("https://github.com/example-co/example.git")
+        == "example-co/example"
+    )
+    assert (
+        topology.normalize_remote("git@github.com:example-co/example.git") == "example-co/example"
+    )
+    assert topology.normalize_remote("example-co/example") == "example-co/example"
+    assert topology.normalize_remote("") == ""
+    assert topology.normalize_remote("not a remote") == ""
+
+
+# ---------------------------------------------------------------------------
+# read_registry
+# ---------------------------------------------------------------------------
+
+
+def test_read_registry_missing(tmp_path: Path) -> None:
+    result = topology.read_registry(tmp_path)
+    assert result["found"] is False
+    assert result["ok"] is False
+    assert result["error"] == "missing"
+    assert result["repos"] == []
+
+
+def test_read_registry_valid(tmp_path: Path) -> None:
+    _write_registry(tmp_path, _valid_registry())
+    result = topology.read_registry(tmp_path)
+    assert result["found"] is True
+    assert result["ok"] is True
+    assert result["business_display_name"] == "Example Business"
+    assert result["home_full_name"] == "example-co/example"
+    slugs = [entry["slug"] for entry in result["repos"]]
+    assert slugs == ["example", "workshop-site", "finance"]
+    hub = result["repos"][0]
+    assert hub["is_hub"] is True
+    assert hub["remote_full_name"] == "example-co/example"
+    site = result["repos"][1]
+    assert "execution_vehicle_for" in site["relationships"]
+    assert site["linked_offers"] == ["core/offers/workshop/offer.md"]
+    assert site["linked_playbook_runs"] == ["pushes/2026-05-20-workshop-launch/playbooks/launch.md"]
+
+
+def test_read_registry_unparsable(tmp_path: Path) -> None:
+    _write_registry(tmp_path, "---\ntype: not_topology\n---\n# noop\n")
+    result = topology.read_registry(tmp_path)
+    assert result["found"] is True
+    assert result["ok"] is False
+    assert "type" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# read_child_descriptor
+# ---------------------------------------------------------------------------
+
+
+def _write_repo_json(repo: Path, payload: dict[str, object]) -> Path:
+    target = repo / ".mainbranch" / "repo.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(payload), encoding="utf-8")
+    return target
+
+
+def _write_legacy_source(repo: Path, payload: dict[str, object]) -> Path:
+    target = repo / ".mainbranch" / "source.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(payload), encoding="utf-8")
+    return target
+
+
+def test_read_child_descriptor_repo_json(tmp_path: Path) -> None:
+    _write_repo_json(
+        tmp_path,
+        {
+            "schema": topology.CHILD_REPO_SCHEMA,
+            "role": "site",
+            "display_name": "Workshop site",
+            "github_owner": "example-co",
+            "repo_name": "workshop-site",
+            "parent": {
+                "display_name": "Example Business",
+                "github_owner": "example-co",
+                "repo_name": "example",
+                "remote": "github:example-co/example",
+                "local_checkout": "../example",
+            },
+            "linked": {"offers": ["core/offers/workshop/offer.md"]},
+        },
+    )
+    result = topology.read_child_descriptor(tmp_path)
+    assert result["found"] is True
+    assert result["kind"] == "repo_json"
+    assert result["ok"] is True
+    assert result["role"] == "site"
+    assert result["parent"]["remote_full_name"] == "example-co/example"
+    assert result["parent"]["local_checkout_relative"] == "../example"
+    assert result["legacy_business_repo_present"] is False
+
+
+def test_read_child_descriptor_repo_json_drops_absolute_local_checkout(
+    tmp_path: Path,
+) -> None:
+    _write_repo_json(
+        tmp_path,
+        {
+            "schema": topology.CHILD_REPO_SCHEMA,
+            "role": "site",
+            "display_name": "Workshop site",
+            "github_owner": "example-co",
+            "repo_name": "workshop-site",
+            "parent": {
+                "github_owner": "example-co",
+                "repo_name": "example",
+                "local_checkout": "/Users/someone/Documents/GitHub/example-co/example",
+            },
+        },
+    )
+    result = topology.read_child_descriptor(tmp_path)
+    assert result["parent"]["local_checkout_relative"] == ""
+
+
+def test_read_child_descriptor_legacy_source_flags_absolute_business_repo(
+    tmp_path: Path,
+) -> None:
+    _write_legacy_source(
+        tmp_path,
+        {
+            "business_repo": "/Users/someone/Documents/GitHub/example-co/example",
+            "offer_path": "core/offers/workshop/offer.md",
+            "campaign_path": "pushes/2026-05-20-workshop-launch/push.md",
+        },
+    )
+    result = topology.read_child_descriptor(tmp_path)
+    assert result["found"] is True
+    assert result["kind"] == "legacy_source"
+    assert result["legacy_business_repo_present"] is True
+    # absolute path is never copied into the public payload
+    assert "/Users/" not in json.dumps(result)
+
+
+def test_read_child_descriptor_missing(tmp_path: Path) -> None:
+    result = topology.read_child_descriptor(tmp_path)
+    assert result["found"] is False
+    assert result["ok"] is False
+
+
+def test_read_child_descriptor_invalid_json(tmp_path: Path) -> None:
+    path = tmp_path / ".mainbranch" / "repo.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{not json", encoding="utf-8")
+    result = topology.read_child_descriptor(tmp_path)
+    assert result["found"] is True
+    assert result["ok"] is False
+    assert result["error"].startswith("invalid JSON")
+
+
+# ---------------------------------------------------------------------------
+# current_repo_view + counts + boundary notes
+# ---------------------------------------------------------------------------
+
+
+def test_current_repo_view_matches_by_remote(tmp_path: Path) -> None:
+    _write_registry(tmp_path, _valid_registry())
+    registry = topology.read_registry(tmp_path)
+    descriptor = topology.read_child_descriptor(tmp_path)
+    view = topology.current_repo_view(
+        registry=registry,
+        descriptor=descriptor,
+        git_remote="git@github.com:example-co/example.git",
+    )
+    assert view["matched"] is True
+    assert view["match_source"] == "registry_remote"
+    assert view["slug"] == "example"
+    assert view["is_hub"] is True
+
+
+def test_current_repo_view_falls_back_to_descriptor(tmp_path: Path) -> None:
+    _write_repo_json(
+        tmp_path,
+        {
+            "schema": topology.CHILD_REPO_SCHEMA,
+            "role": "site",
+            "display_name": "Workshop site",
+            "github_owner": "example-co",
+            "repo_name": "workshop-site",
+            "parent": {
+                "github_owner": "example-co",
+                "repo_name": "example",
+                "remote": "github:example-co/example",
+            },
+        },
+    )
+    registry = topology.read_registry(tmp_path)
+    descriptor = topology.read_child_descriptor(tmp_path)
+    view = topology.current_repo_view(
+        registry=registry,
+        descriptor=descriptor,
+        git_remote="",
+    )
+    assert view["matched"] is False
+    assert view["match_source"] == "descriptor"
+    assert view["role"] == "site"
+
+
+def test_child_role_counts_excludes_hub(tmp_path: Path) -> None:
+    _write_registry(tmp_path, _valid_registry())
+    registry = topology.read_registry(tmp_path)
+    counts = topology.child_role_counts(registry, exclude_slug="example")
+    assert counts["total"] == 2
+    assert counts["by_role"]["site"]["active"] == 1
+    assert counts["by_role"]["finance"]["active"] == 1
+    assert counts["by_lifecycle"]["active"] == 2
+
+
+def test_restricted_repo_summary_excludes_public(tmp_path: Path) -> None:
+    _write_registry(tmp_path, _valid_registry())
+    registry = topology.read_registry(tmp_path)
+    notes = topology.restricted_repo_summary(registry)
+    visibilities = sorted(note["visibility"] for note in notes)
+    assert "public" not in visibilities
+    assert "team_private" in visibilities
+    assert "restricted" in visibilities
+    # boundary notes must not leak unsafe metadata
+    payload = json.dumps(notes)
+    assert "/Users/" not in payload
+
+
+# ---------------------------------------------------------------------------
+# drift_findings
+# ---------------------------------------------------------------------------
+
+
+def test_drift_findings_missing_registry_is_info_when_no_descriptor(
+    tmp_path: Path,
+) -> None:
+    registry = topology.read_registry(tmp_path)
+    descriptor = topology.read_child_descriptor(tmp_path)
+    view = topology.current_repo_view(registry=registry, descriptor=descriptor, git_remote="")
+    findings = topology.drift_findings(registry=registry, descriptor=descriptor, current_view=view)
+    assert len(findings) == 1
+    assert findings[0]["code"] == "topology_registry_missing"
+    assert findings[0]["severity"] == "info"
+
+
+def test_drift_findings_missing_registry_with_descriptor_warns(
+    tmp_path: Path,
+) -> None:
+    _write_repo_json(
+        tmp_path,
+        {
+            "schema": topology.CHILD_REPO_SCHEMA,
+            "role": "site",
+            "display_name": "Workshop site",
+            "github_owner": "example-co",
+            "repo_name": "workshop-site",
+            "parent": {
+                "github_owner": "example-co",
+                "repo_name": "example",
+                "remote": "github:example-co/example",
+            },
+        },
+    )
+    registry = topology.read_registry(tmp_path)
+    descriptor = topology.read_child_descriptor(tmp_path)
+    view = topology.current_repo_view(registry=registry, descriptor=descriptor, git_remote="")
+    findings = topology.drift_findings(registry=registry, descriptor=descriptor, current_view=view)
+    codes = {f["code"] for f in findings}
+    assert "topology_descriptor_orphan" in codes
+
+
+def test_drift_findings_descriptor_parent_unmatched(tmp_path: Path) -> None:
+    _write_registry(tmp_path, _valid_registry())
+    _write_repo_json(
+        tmp_path,
+        {
+            "schema": topology.CHILD_REPO_SCHEMA,
+            "role": "site",
+            "display_name": "Workshop site",
+            "github_owner": "example-co",
+            "repo_name": "workshop-site",
+            "parent": {
+                "github_owner": "other-org",
+                "repo_name": "other-hub",
+                "remote": "github:other-org/other-hub",
+            },
+        },
+    )
+    registry = topology.read_registry(tmp_path)
+    descriptor = topology.read_child_descriptor(tmp_path)
+    view = topology.current_repo_view(registry=registry, descriptor=descriptor, git_remote="")
+    findings = topology.drift_findings(registry=registry, descriptor=descriptor, current_view=view)
+    codes = {f["code"] for f in findings}
+    assert "topology_descriptor_parent_unmatched" in codes
+
+
+def test_drift_findings_descriptor_role_mismatch(tmp_path: Path) -> None:
+    _write_registry(tmp_path, _valid_registry())
+    _write_repo_json(
+        tmp_path,
+        {
+            "schema": topology.CHILD_REPO_SCHEMA,
+            "role": "product",
+            "display_name": "Workshop site",
+            "github_owner": "example-co",
+            "repo_name": "workshop-site",
+            "parent": {
+                "github_owner": "example-co",
+                "repo_name": "example",
+                "remote": "github:example-co/example",
+            },
+        },
+    )
+    registry = topology.read_registry(tmp_path)
+    descriptor = topology.read_child_descriptor(tmp_path)
+    view = topology.current_repo_view(
+        registry=registry,
+        descriptor=descriptor,
+        git_remote="git@github.com:example-co/workshop-site.git",
+    )
+    findings = topology.drift_findings(registry=registry, descriptor=descriptor, current_view=view)
+    codes = {f["code"] for f in findings}
+    assert "topology_descriptor_role_mismatch" in codes
+
+
+def test_drift_findings_unsafe_keys_warn(tmp_path: Path) -> None:
+    extra = textwrap.dedent(
+        """\
+        - slug: legal
+          display_name: Legal source
+          role: legal
+          lifecycle: active
+          visibility: restricted
+          relationship: reports_to
+          parent: example
+          ledger_path: /private/legal/ledger
+          api_key: should-not-be-here
+        """
+    )
+    _write_registry(tmp_path, _valid_registry(extra_repos=extra))
+    registry = topology.read_registry(tmp_path)
+    descriptor = topology.read_child_descriptor(tmp_path)
+    view = topology.current_repo_view(registry=registry, descriptor=descriptor, git_remote="")
+    findings = topology.drift_findings(registry=registry, descriptor=descriptor, current_view=view)
+    codes = {f["code"] for f in findings}
+    assert "topology_repo_unsafe_keys" in codes
+
+
+def test_drift_findings_restricted_with_safe_metadata_does_not_warn(
+    tmp_path: Path,
+) -> None:
+    _write_registry(tmp_path, _valid_registry())
+    registry = topology.read_registry(tmp_path)
+    descriptor = topology.read_child_descriptor(tmp_path)
+    view = topology.current_repo_view(registry=registry, descriptor=descriptor, git_remote="")
+    findings = topology.drift_findings(registry=registry, descriptor=descriptor, current_view=view)
+    # finance entry is restricted but has only safe fields, so no warning
+    codes = {f["code"] for f in findings}
+    assert "topology_repo_unsafe_keys" not in codes
+    assert "topology_repo_absolute_path" not in codes
+
+
+def test_drift_findings_legacy_source_absolute_path(tmp_path: Path) -> None:
+    _write_registry(tmp_path, _valid_registry())
+    _write_legacy_source(
+        tmp_path,
+        {
+            "business_repo": "/Users/someone/Documents/GitHub/example-co/example",
+            "offer_path": "core/offers/workshop/offer.md",
+            "campaign_path": "pushes/2026-05-20-workshop-launch/push.md",
+        },
+    )
+    registry = topology.read_registry(tmp_path)
+    descriptor = topology.read_child_descriptor(tmp_path)
+    view = topology.current_repo_view(registry=registry, descriptor=descriptor, git_remote="")
+    findings = topology.drift_findings(registry=registry, descriptor=descriptor, current_view=view)
+    codes = {f["code"] for f in findings}
+    assert "topology_legacy_source_local_path" in codes
+
+
+def test_drift_findings_blueprint_reference_is_info(tmp_path: Path) -> None:
+    extra = textwrap.dedent(
+        """\
+        - slug: docs-site
+          display_name: Docs site
+          role: site
+          lifecycle: active
+          relationship: execution_vehicle_for
+          parent: example
+          github_owner: example-co
+          repo_name: docs-site
+          remote: github:example-co/docs-site
+          visibility: public
+          linked_playbooks:
+            - .claude/playbooks/launch/launch.md
+        """
+    )
+    _write_registry(tmp_path, _valid_registry(extra_repos=extra))
+    registry = topology.read_registry(tmp_path)
+    descriptor = topology.read_child_descriptor(tmp_path)
+    view = topology.current_repo_view(registry=registry, descriptor=descriptor, git_remote="")
+    findings = topology.drift_findings(registry=registry, descriptor=descriptor, current_view=view)
+    codes = {f["code"]: f for f in findings}
+    assert "topology_playbook_blueprint_reference" in codes
+    assert codes["topology_playbook_blueprint_reference"]["severity"] == "info"
+
+
+# ---------------------------------------------------------------------------
+# collect (top-level)
+# ---------------------------------------------------------------------------
+
+
+def test_collect_returns_safe_payload(tmp_path: Path) -> None:
+    _write_registry(tmp_path, _valid_registry())
+    payload = topology.collect(tmp_path, git_remote="git@github.com:example-co/example.git")
+    assert payload["schema"] == "mb.topology.view.v0"
+    assert payload["safe_to_share"] is True
+    assert payload["summary"]["registry_ok"] is True
+    assert payload["summary"]["current_repo_matched"] is True
+    assert payload["summary"]["child_repo_count"] == 2
+    assert payload["current_repo"]["slug"] == "example"
+    # public-safe payload must not embed any absolute paths
+    assert "/Users/" not in json.dumps(payload)
+
+
+def test_collect_handles_missing_registry(tmp_path: Path) -> None:
+    payload = topology.collect(tmp_path)
+    assert payload["summary"]["registry_found"] is False
+    assert payload["summary"]["registry_ok"] is False
+    assert payload["current_repo"]["matched"] is False
+    assert payload["restricted_repos"] == []
+    # missing registry alone is informational, not a warning
+    assert payload["summary"]["warnings"] == 0


### PR DESCRIPTION
## Summary
- `mb status --json` gains an additive `topology` section sourced from a shared role-neutral `mb.topology` reader, plus a "Business map" line in human output.
- `mb graph --json` emits `repo` nodes and deterministic hub/child relationship edges; `linked_playbook_runs` resolve to push playbook run files; `INDEX_VERSION` bumps to 2.
- `mb doctor repair --plan --json` gains a preview-only `topology-drift` section with a manual-only review action; missing registry stays informational, restricted finance/legal/client repos remain expected boundaries.
- Public-safe topology payload and local-machine facts (e.g. clone path) are isolated into separate fields. Legacy `.mainbranch/source.json` absolute `business_repo` paths are recorded as a flag rather than copied into shareable output.

## Scope
- In: `mb status` topology section + Business map render; `mb graph` repo nodes + relationship edges + `linked_*` resolution; `mb doctor repair --plan` topology-drift section; shared `mb.topology` reader for `core/operations/repo-topology.md` and `.mainbranch/repo.json` (legacy `source.json` supported); CHANGELOG.
- Out: dashboard UI/server, schema validation changes (already shipped in #416), generated `CLAUDE.md` / onboarding changes, any auto-rename / auto-delete / descriptor rewrite.

## Commits
- 9188a40 — [add] MAIN-289 topology reader for status/graph/doctor
- 544d50e — [add] MAIN-289 status topology section and Business map render
- 6b510f3 — [add] MAIN-289 graph repo nodes and hub/child topology edges
- 63045ac — [add] MAIN-289 doctor topology drift preview section
- 0084215 — [update] CHANGELOG note for MAIN-289 topology surfaces
- 2894370 — [fix] MAIN-289 review nits in topology reader and doctor section

## Release / Issues
- Release: not pinned; tracks the v0-3 topology arc seeded by `decisions/2026-05-08-business-repo-topology-map.md`.
- Linear ID(s): MAIN-289.
- Closes: #418
- Refs: #406, #416, #417
- Follow-ups: dashboard UI/server consumption of the new topology JSON; engine playbook blueprint graph semantics if/when reusable engine playbooks need first-class graph nodes.

## Success Metric
Operators (and future dashboards) can read deterministic repo topology facts from `mb status --json`, `mb graph --json`, and `mb doctor repair --plan --json` — including business display name, GitHub owner/repo, current repo role, parent hub, child counts by role/lifecycle, restricted boundary notes, and drift findings — without leaking absolute local paths or fabricating engine-playbook graph semantics, and without doctor renaming, deleting, or rewriting any repos.

## Validation
- Level 0 docs/decision: Refs the accepted `decisions/2026-05-08-business-repo-topology-map.md`.
- Level 1 static: `ruff format` + `ruff check` clean; `mypy` clean.
- Level 2 CLI: 464 pytest tests pass (was 396 before this branch); coverage 82.25%; bundled skill validation 17/17. New tests: 24 reader (test_topology.py, including cross-org false-match guard), 3 status, 5 graph, 5 doctor.
- Level 3 package/install: not exercised; no first-run / install / skill discovery surface touched, so package smoke is not required.
- Level 4 fixture repo: not exercised; no `mb onboard` / `mb init` / generated CLAUDE.md changes.
- Level 5 runtime smoke: not exercised; no slash-skill or `/mb-start` discovery changes.
- Default local gate: `scripts/check.sh` from repo root — `All checks passed!`.

## Public / Private Boundary
The topology view payload is partitioned: public-safe metadata sits at the top level (`safe_to_share: true`), and local-machine facts are isolated into `topology.local` (`safe_to_share: false`). Tests assert `/Users/` does not appear in either descriptor or `collect()` output. Legacy `.mainbranch/source.json` absolute `business_repo` paths are recorded as a `legacy_business_repo_present` flag and never copied into shareable output. Restricted/team-private/local-only repos render as boundary notes; warnings fire only on unsafe metadata, absolute paths, secret/raw-data key names, or descriptor/registry mismatch. Doctor section is preview-only (`mode="manual"`, `safe_to_apply=False`) and never renames, deletes, or rewrites topology files or descriptors. No private Devon/Conductor/runtime details introduced.