### PR TITLE
[docs] Refresh public story around shipped v0.3.12 substrate

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,62 +4,128 @@
 [![PyPI version](https://img.shields.io/pypi/v/mainbranch?style=flat&label=PyPI)](https://pypi.org/project/mainbranch/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-**Durable operating memory for AI-assisted businesses. Ship growth and ops work from files you own.**
+<p align="center">
+  <a href="#quickstart"><strong>Quickstart</strong></a> &middot;
+  <a href="docs/ETHOS.md"><strong>Ethos</strong></a> &middot;
+  <a href="docs/ROADMAP.md"><strong>Roadmap</strong></a> &middot;
+  <a href="docs/BEGINNER-SETUP.md"><strong>Beginner setup</strong></a> &middot;
+  <a href="https://skool.com/main"><strong>Community</strong></a>
+</p>
 
 ---
 
-## Why
+## What is Main Branch?
 
-Every SaaS tool gets better with every model update — and raises its prices. Your stuff should get better on your own computer.
+# Durable operating memory for AI-assisted businesses
 
-You already feel it. Your offer lives in Notion. Your voice lives in a thousand Loom transcripts. Your audience research is in three Google Docs you can't find. Every chat session with your AI starts from zero — you re-paste, re-explain, re-describe, and the output is still generic. One of our members called it *building on quicksand*. That's the right word.
+**You don't need to know git. You don't need to know terminals. You just need a folder.**
 
-You're renting your business. Not just the dashboards — the operational memory itself.
+Main Branch is a folder on your computer that holds your business — offer, audience, voice, decisions, research, bets, launches, meeting notes, fulfillment context, lessons. The agent reads that folder before it answers, so the work it gives you sounds like your business instead of generic AI output. The system saves itself between sessions, so you stop re-explaining who you are every time you open Claude.
 
-The open-source gap closed in 2025. The tools to own your stack exist now. Almost nobody has carved time to migrate, because there is no coherent environment that ties it together.
+Open source. Lives on your machine. Twenty bucks a month for the agent. That's it.
 
-Main Branch is that environment. Your offer, audience, voice, decisions, research, bets, pushes (launches, drops, challenges, promos — whatever your business calls them), meeting notes, fulfillment context, and operating lessons live as markdown files in a git repo you own. The `mb` CLI scaffolds, validates, repairs, graphs, and checkpoints it. The bundled skills read those files and help ship work from what your business already knows.
-
-The unusual part today is the safety net underneath:
-
-- `mb doctor repair --plan` walks you through cleaning up a stale repo.
-- Drift checks in `mb validate` and `mb doctor` flag old folders, settings, and broken links from earlier setups.
-- `mb checkpoint` saves business-readable progress during long agent runs.
-- `mb issue draft` / `mb issue open` turn errors and confusing steps into privacy-safe GitHub issues.
-- Releases run against real fixture repos before they ship.
-
-**Direction, not promises.** Mobile thought capture, team views, finance/fulfillment roll-ups, broader Ops/bookkeeping surfaces, an optional local dashboard, and any future hosted or model-invocation surface are eventual targets in [docs/ROADMAP.md](docs/ROADMAP.md), not current behavior.
-
-Every bet you ship leaves a lesson. The lessons update your offer, your audience, your voice. Your business gets smarter every week — without you having to remember. The agent recommends; you make the call.
-
-We run our own businesses on this. Inside our Skool community you watch us do it live: shipping offers through `mb`, running real ad accounts, and building the agency on top of it.
-
-Own the work. Rent only the rails.
+|        | Step             | What happens                                                                 |
+| ------ | ---------------- | ---------------------------------------------------------------------------- |
+| **01** | Open the folder  | One business, one folder. Your offer, voice, audience, and history live here.|
+| **02** | Talk to the agent| It reads the folder before it speaks. No re-pasting. No re-explaining.       |
+| **03** | The work ships   | Drafts, ad copy, landing pages, decisions. You approve. It saves itself.     |
 
 ---
 
-## What it is
-
-Main Branch is the `mb` CLI plus MIT-licensed agent workflows for running a local-first business operating repo. It's built for operators and small teams running real businesses: solo founders, small agencies, course creators, productized services, indie SaaS, and small ecom teams. Today the workflows ship for Claude Code. Codex, Cursor, OpenClaw, Hermes, and local runtimes are compatibility targets, not supported adapters yet.
-
-The repo is the operating memory: offer, audience, voice, research, decisions, bets, pushes, logs, documents, meeting summaries, fulfillment notes, safe finance summaries, and provider refs. The CLI is the deterministic control plane: setup, status, validation, graph, provider readiness, updates, repair, drift detection, and checkpoints. The skills are the judgment layer: research, decide, write, review, ship, and reflect. Agent recommends; operator decides what gets shipped, spent, published, or saved.
-
-Main Branch is opinionated about rails. The point is not to connect every SaaS tool a business has accumulated. The point is to choose boring, inspectable paths: GitHub for durable work threads, proposals, and shipped history; Cloudflare for sites and DNS; provider paths such as Google/Workspace and official ads only where smoke-tested; planned optional rails such as Postiz for social scheduling and Beancount-style plain-text finance; and optional sidecars for enrichment. Those paths should be wrapped in deterministic commands agents can call without wasting tokens guessing provider setup.
-
-Read the product frame in [docs/ETHOS.md](docs/ETHOS.md), the four operator loops (Sense → Decide → Ship → Reflect) and the four channels (Paid, Organic, Pages, Ops) in [docs/OPERATOR-LOOPS.md](docs/OPERATOR-LOOPS.md), and the release direction in [docs/ROADMAP.md](docs/ROADMAP.md).
-Reusable operating recipes and per-push run records are described in
-[docs/playbooks.md](docs/playbooks.md).
-Workspace, repo, dashboard, finance/legal, and team-log boundaries are defined
-in
-[decisions/2026-05-04-workspace-repo-sensitive-data-boundaries.md](decisions/2026-05-04-workspace-repo-sensitive-data-boundaries.md).
-Markdown/link conventions for GitHub and Obsidian live in
-[docs/markdown-link-conventions.md](docs/markdown-link-conventions.md).
-Dependency, integration, sidecar, and provider-adapter choices are recorded in
-[docs/DEPENDENCY-CHOICES.md](docs/DEPENDENCY-CHOICES.md).
+<div align="center">
+  <em>Works with</em> <strong>Claude Code today</strong>. Codex, Cursor, OpenClaw, Hermes, and local runtimes are compatibility targets, not supported yet — see <a href="docs/compatibility.md">compatibility</a>.
+</div>
 
 ---
 
-## Quick start
+## Main Branch is right for you if
+
+- You're a solo founder, small agency owner, course creator, productized-services operator, indie SaaS founder, or small ecom team
+- Your offer lives in Notion, your voice lives in Loom transcripts, your research lives in three Google Docs you can't find
+- Every chat session with your AI starts from zero and the output sounds generic
+- You're paying for SaaS dashboards that get more expensive without getting smarter
+- You want the work to live somewhere you own — not on someone else's server
+- You want a system that gets better the longer you use it, instead of starting fresh every Monday
+
+---
+
+## What stops you isn't what you think
+
+| What stops you                                          | What's actually true                                                              |
+| ------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| "I'm not technical enough. I don't know git, terminals, or any of that." | If you can move a file into a folder, the system handles the rest.       |
+| "I'll set it up wrong and not know."                    | The system tells you the next command. It can't get lost.                         |
+| "I'd mess it up and lose everything."                   | Every change is saved and rewindable. Git remembers. Mistakes don't stick.        |
+| "I need a clear plan before I start."                   | Start with the folder. The system explains itself in plain English as you go.     |
+| "I need someone to sit down and walk me through it."    | Type `/mb-start` in Claude. The agent explains. You go at your own pace.          |
+| "I won't keep up with the maintenance."                 | When something falls out of date, the system tells you the exact next step.       |
+
+---
+
+## What changes vs. just AI
+
+| Just AI                                                 | Main Branch + Claude                                                              |
+| ------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| Every chat starts from zero. You re-paste your context. | The agent reads your folder before it answers.                                    |
+| Output sounds like every other AI.                      | Output sounds like you — because the agent reads your voice files first.          |
+| Important decisions live in chat that disappears.       | Decisions live as plain notes you can read on a Tuesday.                          |
+| You build the system yourself: prompts, files, glue.    | The rails are built. Your business folder plugs in.                               |
+| $30/mo subscription. Gets more expensive every year.    | $20/mo Claude + a folder you own forever. Your stuff still works without us.      |
+
+---
+
+## What you can do today
+
+- Research a topic and turn it into a decision the system remembers
+- Open, run, close, and narrate business bets so the lessons stick around
+- Plan and run launches, drops, challenges, and promos as repeatable playbooks
+- Generate ad copy, video scripts, organic content (Reels, TikTok, carousels), and VSLs in your voice
+- Draft and ship landing pages on Cloudflare from your core files and research
+- Capture meeting transcripts, source material, and fulfillment notes into durable docs
+- Save readable progress points during long agent runs so the next session starts where this one stopped
+- Clean up stale folders, broken links, and old settings before they break a session
+- Turn errors and confusing steps into clean public GitHub issues without leaking your business data
+- Close sessions intentionally with a crystallize moment that updates your durable memory
+
+You don't run any of these commands yourself. You ask the agent. It runs them.
+
+---
+
+## What's underneath
+
+Main Branch v0.3 has three layers:
+
+- **Your folder is canonical memory.** Offer, audience, voice, decisions, research, bets, launches, logs, documents, links to other repos. Plain markdown files you can read on any computer.
+- **The CLI is the safety net.** Scaffolds the folder, validates the shape, draws the relationship graph, briefs you on what's changed, walks through repairs, saves readable checkpoints, and checks that connected providers (GitHub, Cloudflare, ads accounts) are wired up safely. The agent runs it. You don't have to learn it.
+- **The skills are the judgment layer.** The agent reads your folder, asks you the right questions, drafts work, reviews it, and routes the artifacts back into files.
+
+Agent recommends. You decide what gets shipped, spent, published, or saved.
+
+The longer-arc operating-system model — where multiple business repos, GitHub teams, structured data, and runtime adapters compose into a full team operating system — is direction, not the v0.3 shape. See [`decisions/2026-05-02-github-native-business-os.md`](decisions/2026-05-02-github-native-business-os.md).
+
+---
+
+## What Main Branch is not
+
+|                                  |                                                                                                |
+| -------------------------------- | ---------------------------------------------------------------------------------------------- |
+| **Not a chat app.**              | The chat surface is Claude Code. Main Branch gives the chat something durable to read from.    |
+| **Not a SaaS dashboard.**        | Your business doesn't live on our servers. It lives in your folder.                            |
+| **Not a connect-every-tool hub.**| We pick boring, inspectable rails: GitHub, Cloudflare, official ads paths. Curated, not sprawl.|
+| **Not a model host.**            | We don't run models. We hand the agent the right context so the model you already use is sharper.|
+| **Not magic.**                   | The work is still real. The foundation is just the right one to build on.                      |
+
+---
+
+## Direction, not promises
+
+The current package is the daily operating loop: open the folder, ground the agent, get a ranked next action, ship the work, save a readable checkpoint. Next direction tightens the same loop, expands curated provider rails, and prepares an optional local dashboard that reads from your folder instead of replacing it.
+
+Mobile thought capture, team views, finance/fulfillment roll-ups, broader Ops/bookkeeping, an optional dashboard, and any future hosted/model-invocation surface are eventual targets in [docs/ROADMAP.md](docs/ROADMAP.md), not current behavior.
+
+---
+
+## Quickstart
 
 ```bash
 pipx install mainbranch
@@ -69,7 +135,7 @@ claude
 /mb-start
 ```
 
-That's it. `mb onboard` guides the human setup, creates or connects your business repo, wires Claude Code to the bundled skills, and shows the exact next commands. `mb init` still exists as the quiet scriptable primitive underneath it. `/mb-start` then reads the deterministic status facts, checks whether the repo needs repair or an update, and routes you to setup, thinking, shipping, or closing work.
+That's it. `mb onboard` creates the folder, wires Claude Code, and shows the next step. `/mb-start` reads the folder and tells you what to do.
 
 After the first session, the daily flow is:
 
@@ -79,445 +145,31 @@ claude
 /mb-start
 ```
 
-`/mb-start` reads `mb status --json --peek` internally, so you do not need to
-run `mb status` first. Use `mb status` when you want the same deterministic
-briefing in the terminal without opening Claude Code. If you want `mb` to check
-handoff readiness and open Claude Code for you, run `mb start --launch` from
-the business repo.
+You'll need a Claude Pro ($20/mo) or Max subscription. Install Claude Code from [claude.ai](https://claude.ai). Step-by-step beginner walkthrough: [docs/BEGINNER-SETUP.md](docs/BEGINNER-SETUP.md).
 
-The normal day should feel like business work, not GitHub administration:
-
-1. Start in the business repo.
-2. Let `/mb-start` ground Claude in `mb` facts: repo health, status, updates,
-   graph links, provider readiness, and recent activity.
-3. Dump thoughts or pick a next action. Claude should route that input into the
-   right Main Branch primitive: a bet, research note, decision, push, playbook,
-   outcome, log entry, or checkpoint.
-4. Use the skills for judgment-heavy work and `mb` for deterministic checks,
-   repair, validation, graph/status facts, provider readiness, and commits.
-5. Close with `/mb-end` or `mb checkpoint` guidance so the lesson, decision,
-   artifact, or saved work lands in git before the next session.
-
-Under the hood, Main Branch uses issues, branches, pull requests, commits,
-graph links, provider refs, and local connection state to preserve and inspect
-progress. You can inspect those details when you want them, but the default
-language stays closer to the business: bets, goals, offers, pushes, playbooks,
-outcomes, and checkpoints.
-
-You'll need a Claude Pro ($20/mo) or Max subscription. Install Claude Code itself from [claude.ai](https://claude.ai) — see [docs/BEGINNER-SETUP.md](docs/BEGINNER-SETUP.md) for a step-by-step.
-
-Tested on macOS and Linux. Windows is experimental and not part of the CI
-release gate; see [docs/compatibility.md](docs/compatibility.md). Power users
-on Windows should use WSL2 for the closest supported path.
-
-**New to Claude Code, git, or terminal?** Read [docs/BEGINNER-SETUP.md](docs/BEGINNER-SETUP.md) — it covers everything step-by-step, including common errors.
-
-**Contributors** who want to hack on skills can clone the engine repo directly:
-
-```bash
-git clone https://github.com/noontide-co/mainbranch.git
-```
-
----
-
-## What you can do
-
-Once set up, you can:
-
-- Research topics and document decisions
-- Open, update, close, and narrate business bets
-- Plan and run pushes (launches, drops, challenges, promos) with reusable playbooks and per-push run records
-- Generate batches of ad copy in your voice
-- Create video scripts for Meta ads
-- Generate organic content — Reels, TikTok, carousels — from your core files and research
-- Write VSL scripts for your community
-- Review ads for compliance before you run them
-- Build and deploy Cloudflare-backed landing pages from your core files and research when the repo is connected and readiness checks pass
-- Capture meeting transcripts, source material, and fulfillment notes into durable docs, logs, research, or decisions
-- Save business-readable git checkpoints during long agent runs with `mb checkpoint`
-- Reconcile stale repo state with `mb doctor repair --plan` / `--apply`, including migration drift across legacy folders, frontmatter, and skill wiring
-- Turn errors and confusing steps into privacy-safe GitHub issues with `mb issue draft` / `mb issue open`
-- Close sessions intentionally with crystallize moments
-
-All of this happens through simple slash commands and `mb` subcommands. No custom prompt engineering required for supported workflows.
-
----
-
-## How it works
-
-Main Branch v0.3 has three layers:
-
-- **Your repo is canonical memory.** It holds the durable business truth:
-  core files, research, decisions, bets, pushes, logs, documents, and links to
-  child repos.
-- **`mb` is the deterministic control plane.** It scaffolds, validates, graphs,
-  briefs, repairs (including migration drift), checkpoints, updates, and
-  checks provider readiness — and exposes JSON contracts that skills and future
-  callers read instead of guessing.
-- **Skills are the judgment layer.** Claude Code reads repo truth, asks the
-  operator questions, drafts work, reviews it, and routes artifacts back into
-  files.
-
-The CLI and skills are meant to work together. Skills should call `mb` for
-facts instead of guessing at repo health, provider setup, or update state. The
-CLI should stay deterministic and scriptable instead of becoming a chat client
-or model host.
-
-The longer-arc operating-system model — `mb` as control plane, GitHub as the
-team layer, graph/structured data as the intelligence layer, agent runtimes as
-execution — is direction, not the v0.3 shape. See
-[`decisions/2026-05-02-github-native-business-os.md`](decisions/2026-05-02-github-native-business-os.md).
-
-You create a separate folder for YOUR business. That's where your offer,
-audience, voice, proof, operations, research, decisions, bets, pushes, logs, and
-documents live. The engine reads those files. Then it helps produce work and
-records what changed so the next session starts from the same memory.
-
-After running `mb init`, your business repo looks like this:
-
-```
-my-business/
-├── CLAUDE.md
-├── .gitignore
-├── .github/
-│   └── CODEOWNERS
-├── .mb/
-│   └── schema_version
-├── .claude/
-│   ├── settings.local.json    (gitignored — wires Claude Code to bundled skills)
-│   └── skills/                (gitignored — bridge symlinks)
-├── core/
-│   ├── vocabulary.md
-│   ├── offers/
-│   ├── proof/
-│   ├── brand/
-│   ├── strategy/
-│   ├── operations/
-│   └── finance/
-├── research/
-├── decisions/
-├── bets/
-├── log/
-├── pushes/
-├── campaigns/                 # legacy compatibility read only
-└── documents/
-```
-
-You fill in the durable business files inside `core/`. Claude reads them when generating.
-Old repos may still have `campaigns/`; `mb` reads it for compatibility, but
-new coordinated work belongs in `pushes/`.
-
-As a business grows, related work can graduate into child repos: sites,
-products/offers, client fulfillment repos, private finance repos, or ops repos.
-The business repo stays the hub. Hub topology belongs in
-`core/operations/repo-topology.md` when present; child repos can point back with
-safe `.mainbranch/repo.json` descriptors while existing site repos keep
-`.mainbranch/source.json` compatibility. Future dashboard work should map those
-repos and their pushes, bets, commits, issues, PRs, checkpoints, provider-safe
-summaries, and active decisions. The dashboard is the map, not the source of
-truth.
-
-### Connected accounts live with the business repo
-
-Your business repo carries the boundaries for connected accounts. A repo for
-one business can point at one Stripe account, Google Ads customer, ad pixel set,
-and MCP server set; a different business repo should point at different ones.
-Switching repos should switch the tools that can spend money, publish, email,
-or mutate customer accounts.
-
-The repo should keep useful non-secret identifiers where agents can inspect
-them: Stripe account/product/price IDs in offer or finance notes, Google Ads
-customer and campaign IDs (provider's term for their object) in
-`pushes/<push>/push.md` `provider_refs:`, ad pixel IDs beside the site or
-push files they belong to, and MCP server names/scopes in `CLAUDE.md` or
-local setup notes. Do not commit API keys, OAuth refresh tokens,
-service-account JSON, webhook secrets, MCP tokens, or bearer tokens. Keep
-secrets in a runtime's local config, the OS keychain, 1Password, `.env`, or
-`.claude/settings.local.json`, and keep those files gitignored.
-
----
-
-## The `mb` CLI
-
-The CLI surface for the engine. Built for Claude Code first; runtime-agnostic by design. Most workflows still happen via slash-prompt skills inside Claude Code today — the `mb` CLI is the scaffolder, validator, grapher, updater, and future adapter layer around them.
-
-| Command | What it does |
-|---|---|
-| `mb onboard` | Human setup flow: create or connect a business repo, explain how the pieces fit together, wire Claude Code skills, and show the next `/mb-start` step. |
-| `mb onboard status` | Show durable onboarding progress from `.mb/onboarding.json`, including missing core-reference inputs and the next recommended action. |
-| `mb init` | Set up a fresh business repo (business folders, CLAUDE.md, git init). |
-| `mb status` | Show the local-first briefing in the terminal without opening Claude Code: ranked next actions, since-last-check changes, drift, repo health, runtime wiring, recent decisions/research/bets/git activity, and GitHub tasks/proposals when `gh` is authenticated. Use `--json` for the v1 status schema, `--verbose` for detail, and `--peek` for non-mutating reads. |
-| `mb doctor` | Check the environment — repo shape, frontmatter sanity, settings on disk. Use `mb doctor repair --plan` / `--apply` for guided repo reconciliation; add `--include-migration` only after reviewing the migration preview. |
-| `mb connect` | Register provider credentials, test provider health, and inspect repair-safe integration status without committing secrets. |
-| `mb site check` | Check local paid-traffic measurement readiness for a site repo: GTM installation, Main Branch dataLayer events, consent posture, Google Ads plan metadata, and operator-review gates. |
-| `mb issue draft` | Create a local, privacy-scrubbed GitHub issue draft under `.mb/issue-drafts/` for bugs, feature gaps, or questions. |
-| `mb issue open` | Submit a reviewed issue draft with `gh issue create`, or print a browser/manual fallback when GitHub CLI is unavailable. |
-| `mb validate` | Frontmatter shape check across `core/`, `research/`, `decisions/`, `bets/`, `log/`, `pushes/` (and legacy `campaigns/` as compatibility), `documents/`. Pass/fail per file. |
-| `mb graph` | Build a repo graph index from frontmatter links, wikilinks, and entity tags. Emits Graphviz DOT by default, `--json` for agents/dashboards, and `--open` to render a PNG view. |
-| `mb similar-bets` | Find similar past bets and offer outcomes from repo truth so new work can learn from old attempts. |
-| `mb checkpoint` | Plan or save a business-readable git checkpoint during long agent runs. |
-| `mb think <topic>` | Print the `/mb-think` invocation hint. Run inside Claude Code for the full flow. |
-| `mb resolve <key>` | Resolve a reference key from the curated library, local core files, or bundled stubs. |
-| `mb educational <topic>` | Print a beginner education topic such as `daily-owner-loop`, `why-mainbranch-not-saas`, `github-vs-gdocs`, `provider-readiness`, `cloudflare-pages`, or `stripe`; also powers longer "tell me more" context from setup and doctor prompts. |
-| `mb skill list` | List the skills bundled with this engine. |
-| `mb skill path <name>` | Print the on-disk path to a bundled skill. |
-| `mb skill validate <name>` | Validate one bundled skill's frontmatter, local references, and 500-line gate. Use `--all --json` for CI. |
-| `mb skill link --repo .` | Repair Claude Code skill discovery in a business repo and back up stale or broken Main Branch personal symlinks. |
-| `mb skill repair --repo .` | Detect personal Claude Code skills that shadow Main Branch and explain safe repair. Use `--apply` only for stale Main Branch symlinks or broken links with Main Branch skill names. |
-
-Full list: `mb --help`.
-
-Use `mb validate` for file and frontmatter contract checks. Use `mb doctor`
-and `mb doctor repair --plan` for repo-shape, migration, runtime wiring,
-settings, and stale-guidance drift that should be repaired without treating
-every legacy compatibility file as a hard schema failure.
-
-Machine-readable command output follows the additive
-[JSON output contract](docs/json-output-contract.md): high-value `--json`
-surfaces expose shared `result_envelope_version`, `result_schema`,
-`mb_command`, `ok`, `result_status`, `errors`, `warnings`, and `actions`
-metadata while preserving their command-specific payload keys.
-
-### Provider Connections
-
-`mb connect` is the local-first foundation for supported, planned, and optional
-provider rails such as GitHub, Cloudflare, Google, Meta, Postiz, Apify,
-Beancount, and transcription providers.
-Use `mb connect plan` when you are not sure what to connect first; it explains
-GitHub, Cloudflare, Google/Workspace, Meta Ads, and Apify as numbered business
-choices with the current readiness state and exact next command.
-
-Beginner education topics explain why these rails exist before asking you to
-configure them:
-
-```bash
-mb educational daily-owner-loop
-mb educational why-mainbranch-not-saas
-mb educational provider-readiness
-mb educational cloudflare-pages
-mb educational beancount
-mb educational cal-com
-mb educational stripe
-mb educational forgejo
-mb educational cursor
-```
-
-Common provider-readiness commands:
-
-```bash
-mb connect plan
-mb connect list
-printf '%s' "$CLOUDFLARE_API_TOKEN" | mb connect cloudflare --token-stdin --metadata token_type=account --metadata account_id=...
-mb connect test cloudflare
-mb connect doctor
-mb connect status --json
-mb educational provider-readiness
-```
-
-Secrets are stored outside the business repo, using the macOS Keychain when
-available and a local `~/.mainbranch/secrets/connect.json` fallback otherwise.
-The business repo only receives non-sensitive, gitignored metadata in
-`.mb/connect.yaml`, such as the provider id, account label, credential backend,
-account-token type, and last check time.
-Stored credentials start as `unvalidated` until `mb connect test <provider>`
-runs the safest available check. Providers with a safe API probe validate
-against the provider; providers without one record that local credential
-presence was confirmed and that no automated probe exists yet. A secret ref
-alone is never reported as healthy.
-`mb connect status --json` and `mb connect doctor --json` include safe repair
-fields such as `state`, `summary`, `repair`, `repair_command`, and
-`safe_to_share` for onboarding agents. Skills and future dashboards should read
-those JSON commands or `.mb/connect.yaml`; they should never ask users to commit
-tokens.
-`--from-env` is explicit: `mb connect` does not silently import general-purpose
-environment variables.
-
----
-
-## Skills
-
-Skills are pre-built workflows you invoke with slash prompts. Instead of figuring out how to prompt Claude, you type `/mb-ads` and Claude knows exactly what to do — reads your business files, then generates output that matches your voice.
-
-The supported Claude Code contract is project-local skill discovery through the
-business repo's `.claude/skills/mb-*` bridge links. Plain `/mb-start` is the
-daily entrypoint; extra text after it is treated as normal instruction, not a
-stable `$ARGUMENTS` command API. See
-[docs/claude-code-invocation-contract.md](docs/claude-code-invocation-contract.md).
-
-Some skills ship growth work. Others maintain operating memory. `/mb-start`,
-`/mb-status`, `/mb-think`, `/mb-bet`, `/mb-end`, `mb checkpoint`, `mb graph`,
-and `mb connect` are as important as the content skills because they keep the
-repo understandable, current, and safe to operate from.
-
-**Core daily loop**
-
-| Skill | What it does |
-|---|---|
-| `/mb-start` | Main entry point — figures out what you need and routes you there |
-| `/mb-status` | Thin Claude Code wrapper over `mb status --json --peek` for daily briefing facts and ranked next actions |
-| `/mb-setup` | Set up your business repo (run this first if you're new) |
-| `/mb-think` | Research, make decisions, add context, transcribe local recordings, update durable business files |
-| `/mb-bet` | Open, update, close, list, and narrate business bets |
-| `/mb-end` | Close session — summary, crystallize, approved checkpoint guidance |
-| `/mb-help` | Get answers, troubleshoot, learn the system |
-| `/mb-update` | Update Main Branch — delegates install-mode refresh to `mb update` and summarizes what's new |
-
-**Channel skills (Paid, Organic, Pages)**
-
-| Skill | What it does |
-|---|---|
-| `/mb-ads` | Create ad copy (static or video) and review for compliance |
-| `/mb-vsl` | Write video sales letter scripts (Skool or B2B) |
-| `/mb-organic` | Generate organic content — Reels, TikTok, carousels |
-| `/mb-site` | Generate and deploy landing pages from your core files and research |
-
-**Specialty**
-
-| Skill | What it does |
-|---|---|
-| `/mb-wiki` | Personal/atomic-notes wiki workflow — optional, not part of the core daily loop |
-
-`/mb-pull` is kept as a legacy alias for `/mb-update` so older muscle memory
-still works; new docs and the live rotation teach `/mb-update`.
-
----
-
-## Honest Current State
-
-- **Built for Claude Code today.** `mb` is runtime-agnostic by design, but Claude Code is the only first-class runtime currently supported end to end.
-- **The terminal front door is live.** Bare `mb`, `mb onboard`, `mb status`, `mb start`, and `mb update` are in the public package.
-- **Owner-safe repair is shipped.** `mb doctor repair --plan`, migration drift checks across `mb validate` and `mb doctor`, and skill-link/wiring repair handle stale repos, broken settings, and old layouts without asking a non-developer to reason through git plumbing.
-- **Business-readable git saves are shipped.** `mb checkpoint` plans and saves readable commits at meaningful boundaries during long agent runs. The repo also surfaces topology facts (`mb status --json`, `mb graph --json`, `mb doctor repair --plan --json`) for agents and future dashboards to read.
-- **Privacy-safe friction capture is shipped.** `mb issue draft` / `mb issue open` turn errors and confusing steps into reviewed, scrubbed GitHub issues without leaking business data.
-- **Releases run against fixture repos.** Package-visible releases run print-mode and runtime simulations against materialized fixture repos before they ship. See [docs/release-simulations.md](docs/release-simulations.md).
-- **Packaged callers can use the CLI directly.** Paperclip-style routines, local scripts, and future adapters should invoke deterministic `mb` commands against an explicit business repo path and read JSON/exit codes. See [docs/compatibility.md](docs/compatibility.md).
-- **Growth is the strongest shipped wedge.** Ads, organic, VSLs, sites, bets, pushes, status, and checkpoints are the most developed public workflows.
-- **Ops is the expansion path.** Meetings, fulfillment, bookkeeping/P&L, team daily logs, repo topology, and dashboard views use the same memory model, but they are less shipped than the growth surfaces.
-- **Provider automation is curated and gated.** GitHub and Cloudflare paths are the most concrete today. Google/Workspace, Meta Ads, Google Ads/GTM, Postiz, Apify, Beancount, and transcription are wired as planned or optional provider/sidecar surfaces until each path has matching smoke evidence for the claimed surface.
-- **Schema is v1; will evolve.** Frontmatter shapes covered by `mb validate` are stable for the current major; breaking changes bump the major.
-- **Runtime compatibility is still ahead.** Codex, Cursor, OpenClaw, Hermes, and local LLMs are roadmap targets, not supported adapters yet.
-
-| Runtime | Status | Notes |
-|---|---|---|
-| Claude Code | Supported today | First-class adapter with skill wiring, repair, and smoke-tested first-run flow. |
-| Codex | Roadmap | Target runtime; no public adapter support claim yet. |
-| Cursor | Roadmap | Target runtime; no public adapter support claim yet. |
-| OpenClaw | Roadmap | First-tier compatibility target because users operate there; no adapter support claim yet. |
-| Hermes | Roadmap | Target runtime/memory surface; no public adapter support claim yet. |
-| Paperclip-adjacent orchestration | Roadmap | Target orchestration layer; should supervise shipped `mb` CLI/JSON commands without assuming Claude Code skills are present. |
-| Local runtimes | Roadmap | Long-range endpoint once adapter contracts are proven. |
-
-For the package/runtime caller contract, repo-path discovery rules, and the
-adapter/readiness map across invocation, workflow discovery, routing,
-automation, observability, and packaging, see
-[docs/compatibility.md](docs/compatibility.md).
-
-The engine v0.1.0 decision lives at [`decisions/2026-04-29-mb-vip-v0-1-0-master.md`](decisions/2026-04-29-mb-vip-v0-1-0-master.md). Some historical planning happened in private Noontide repos; public product truth now lives in this repository's decisions, docs, issues, changelog, and releases.
-
----
-
-## Roadmap
-
-The current package is the CLI + Claude Code first-run foundation plus the first daily operating surfaces: `mb status`, `/mb-status`, next-action ranking, bets, pushes, checkpoints, provider readiness, site checks, and privacy-safe issue drafting. Next work keeps tightening those loops, expands the curated provider rails, and prepares the future dashboard as a map over repo truth rather than a replacement for it. See [docs/ROADMAP.md](docs/ROADMAP.md) for the public roadmap and the current GitHub issue anchors. Direction, not promises.
-
-The proposed long-range product direction is captured in
-[`decisions/2026-05-02-github-native-business-os.md`](decisions/2026-05-02-github-native-business-os.md):
-Main Branch as a GitHub-native business operating system, with `mb` as the
-control plane, GitHub as the team layer, graph/structured data as the
-intelligence layer, and agent runtimes as execution.
-
-- **v0.3.x: Tightens the daily operating loop.** Status/ranking, `/mb-start`, `/mb-status`, doctor repair, checkpoints, pushes, provider readiness, and issue drafting keep becoming clearer and more reliable.
-- **v0.4: Bets and pushes become operating systems.** Stronger links between bets, offers, pages, ads, outcomes, fulfillment, Ops, and public narration.
-- **Longer range.** Runtime adapters, dashboard/server mode, repo topology, structured data, deeper Ops surfaces (meetings, books, P&L, compliance), and richer Paid, Organic, and Pages workflows.
-
-See [CHANGELOG.md](CHANGELOG.md) for what's in this release. Each release ships a "What this means for you" plain-English section above the technical detail.
-
----
-
-## Open source vs paid community
-
-Plain English boundary so nobody is surprised:
-
-- **Open-source (free, MIT)**: the `mb` CLI, bundled skills, schema, framework, docs, and future local dashboard surface when it ships. The engine is usable without joining the paid community.
-- **Paid community (Skool)**: Want to watch us build companies live with Main Branch? Free for 7 days, $19/mo after. The community can include live narration, calls, support, and curated examples that are not required for the open-source engine.
-
-Main Branch is usable on its own. The paid community is the live narration and support layer on top.
-
----
-
-## Updating
-
-- **Normal user path**: run `/mb-update` inside Claude Code. It figures out
-  which install you have and runs the right thing.
-- **Power user CLI path**: `mb update --repo .` from your business repo.
-- **Clone (developer mode)**: `git pull origin main` from the engine repo.
-
-`/mb-start` checks for important updates at the beginning of a session and will
-tell you when updating matters. The CHANGELOG entry for the new version
-surfaces as a banner the next time you run `/mb-start`.
+Tested on macOS and Linux. Windows is experimental — use WSL2.
 
 ---
 
 ## FAQ
 
-**Do I need to know how to code?**
-No. You invoke skills with slash prompts and answer questions.
+**Do I need to know how to code?** No. You invoke skills with slash prompts and answer questions.
 
-**What if I have multiple products under one brand?**
-Use one repo with `core/offers/` when the products share the same brand, team,
-voice, and access boundary. In a single-offer repo, `core/offer.md` is the
-offer truth. In a multi-offer repo, `core/offer.md` is the portfolio thesis and
-each offer gets `core/offers/<slug>/offer.md`. If an offer graduates into its
-own team, provider accounts, site, finance boundary, or operating history, move
-it into its own repo, keep the company repo as a hub, list the relationship in
-`core/operations/repo-topology.md` when useful, and give the child repo a safe
-`.mainbranch/repo.json` descriptor that points back to the hub.
+**What if I have multiple products under one brand?** Use one folder with `core/offers/` when products share brand, team, voice, and access. Move an offer into its own folder if it grows its own team, accounts, site, finance boundary, or operating history.
 
-**What's a bet vs. an offer?**
-A bet is a time-boxed operating hypothesis: what you'll try, why, by when, and
-how you'll know if it worked. An offer is a durable thing you sell or may sell
-repeatedly. A live idea can be both: test it in `bets/`, then update
-`core/offer.md` or `core/offers/<slug>/offer.md` only when you want durable
-sellable truth. Company-wide proof belongs in `core/proof/`; offer-specific
-proof belongs in `core/offers/<slug>/proof/`. Use standard proof files such as
-`testimonials.md`, `typicality.md`, and `angles/` inside those proof folders.
-A good bet can graduate into an offer, push, workflow, content pillar, child
-repo, or decision; a bad bet gets closed with learning instead of quietly
-deleting history.
+**What's a bet vs. an offer?** A bet is a time-boxed hypothesis: what you'll try, why, by when, how you'll know. An offer is a durable thing you sell. A good bet can graduate into an offer.
 
-**What if I have multiple separate businesses?**
-Create a separate repo for each brand, legal entity, provider-account boundary,
-or team-access boundary. If businesses truly share the same voice, team, and
-access rules, they can share a repo. If not, separate repos.
+**What if I have multiple separate businesses?** One folder per brand, legal entity, ad-account boundary, or team-access boundary.
 
-**How do I update when new skills come out?**
-Run `/mb-update` inside Claude Code. Power users can run `mb update --repo .`
-from the business repo.
+**How do I update?** Type `/mb-update` in Claude. Power users can run `mb update` from the folder.
 
-If `mb --version` still says `0.1.x`, ask Claude to help bootstrap the update.
-The fallback is `pipx upgrade mainbranch` once before using `mb update`; old
-installs now surface this as an in-product "Update required" alert on the main
-launch, doctor, status, and start surfaces. Existing business repos should then
-be repaired with `mb skill link --repo .`, `mb skill repair --repo .`, and
-`mb doctor` from the repo root. See [docs/MIGRATING.md](docs/MIGRATING.md) for
-the old-repo path.
-`/mb-pull` still works as a legacy alias, but new docs teach `/mb-update`.
+**Can Claude migrate an old setup for me?** Yes. Start Claude Code anywhere and paste the prompt in [docs/MIGRATING.md](docs/MIGRATING.md#recommended-let-claude-walk-you-through-it).
 
-**Can Claude migrate an old setup for me?**
-Yes. Start Claude Code anywhere and paste the prompt in
-[docs/MIGRATING.md](docs/MIGRATING.md#recommended-let-claude-walk-you-through-it).
-Claude should inspect first, update Main Branch through `/mb-update` or
-`mb update`, recommend one repo at a time, and ask before applying repairs or
-layout migrations.
+**Can I edit the skills?** You can. You don't need to.
 
-**Can I edit the skills?**
-You can, but you don't need to. They're designed to work out of the box.
+**What makes this different from ChatGPT?** ChatGPT resets between sessions. Main Branch is a folder Claude can re-read every session — your offer, audience, voice, decisions, research, and bets — so the output stays consistent with your business.
 
-**What makes this different from ChatGPT?**
-ChatGPT is a chat surface that resets between sessions. Main Branch is a CLI plus a skill set that reads files Claude can re-read every session — your offer, audience, voice, decisions, research, and bets — so outputs stay consistent with your business instead of restarting from zero.
-
-**I'm stuck. What do I do?**
-Type `/mb-start` again. It picks up where you left off.
+**I'm stuck.** Type `/mb-start` again.
 
 ---
 
@@ -531,26 +183,88 @@ For platform support and security reporting, see [SUPPORT.md](SUPPORT.md), [SECU
 
 **Common issues:**
 
-- "404 error" or "Repository not found" — verify the URL and your network. The repo is public; no access request needed.
-- "Claude doesn't see my files" — make sure you started Claude in your business repo folder and ran `/mb-start`.
-- "Skills aren't working" — run `mb skill link --repo .` from your business repo to repair bridge symlinks and known stale Main Branch shadows, then restart Claude. If still broken, run `mb skill repair --repo .` to inspect unresolved personal-skill conflicts or run `/mb-setup`.
+- "404" or "Repository not found" — verify the URL. The repo is public; no access request needed.
+- "Claude doesn't see my files" — make sure you started Claude in your business folder and ran `/mb-start`.
+- "Skills aren't working" — ask Claude to repair the wiring, or run `/mb-setup`.
 - "Output sounds generic" — add more detail to your core files, especially `core/voice.md`.
-- "I edited Main Branch but can't push" — that's expected for most users. Main Branch is the shared engine. Your business data goes in YOUR repo.
+- "I edited Main Branch but can't push" — that's expected. Main Branch is the shared engine. Your business data goes in YOUR folder.
 
-**Turn friction into a public issue:** run `mb issue draft bug --command "mb doctor" --what-happened "..."` from your business repo. Review the local draft under `.mb/issue-drafts/`, then run `mb issue open <draft> --yes` when it is safe to submit. See [docs/issue-drafting.md](docs/issue-drafting.md).
+Hit a real problem? Ask the agent to draft a clean public issue for you. It scrubs private context before submitting.
 
 ---
 
-## Technical details
+## Open source vs paid community
 
-Contributors should start with [AGENTS.md](AGENTS.md) and
-[CONTRIBUTING.md](CONTRIBUTING.md). Claude Code-specific repo guidance lives in
-[CLAUDE.md](CLAUDE.md). You don't need any of these to get started as a user.
+- **Open-source (MIT)**: the `mb` CLI, bundled skills, schema, framework, docs, and any future local dashboard. Usable without joining the paid community.
+- **Paid community ([Skool](https://skool.com/main))**: Watch us build companies live with Main Branch. Free for 7 days, $19/mo after. Live narration, calls, support, and curated examples — not required for the engine.
 
-All shipping decisions are dated, versioned, and committed alongside the code that implements them.
+Main Branch is usable on its own. The community is the live narration on top.
+
+---
+
+## For contributors and power users
+
+The `mb` CLI is the deterministic control plane. The agent runs it for normal users. If you want to inspect, script, or build on it, here's the surface.
+
+| Command                  | What it does |
+|---|---|
+| `mb onboard`             | Human setup flow: create or connect a business folder, wire Claude Code skills, show next steps. |
+| `mb init`                | Quiet scriptable primitive underneath `mb onboard`. |
+| `mb status`              | Local-first daily briefing: ranked next actions, since-last-check changes, drift, repo health, runtime wiring, recent activity, GitHub tasks/proposals. `--json` and `--peek` for callers. |
+| `mb doctor`              | Check environment, repo shape, frontmatter, settings. `mb doctor repair --plan` / `--apply` walks through guided reconciliation, including migration drift. |
+| `mb connect`             | Register provider credentials, test provider health, inspect repair-safe integration status without committing secrets. |
+| `mb site check`          | Local paid-traffic measurement readiness for a site folder: GTM install, dataLayer events, consent posture, Google Ads metadata, operator-review gates. |
+| `mb issue draft` / `open`| Draft a privacy-scrubbed GitHub issue locally, review it, then submit through `gh`. |
+| `mb validate`            | Frontmatter shape check across `core/`, `research/`, `decisions/`, `bets/`, `log/`, `pushes/`, `documents/`. Pass/fail per file. |
+| `mb graph`               | Build a folder graph from frontmatter links, wikilinks, and entity tags. Graphviz DOT, JSON, and PNG outputs. |
+| `mb checkpoint`          | Plan or save a business-readable git checkpoint during long agent runs. |
+| `mb skill list` / `path` / `validate` / `link` / `repair` | Manage and repair the bundled Claude Code skills. |
+| `mb update`              | Update Main Branch in place. |
+
+Full list: `mb --help`. JSON output contract: [docs/json-output-contract.md](docs/json-output-contract.md). Provider readiness: [docs/DEPENDENCY-CHOICES.md](docs/DEPENDENCY-CHOICES.md).
+
+**Skills:**
+
+| Skill | Loop |
+|---|---|
+| `/mb-start` | Daily entry point — figure out what you need and route there |
+| `/mb-status` | Daily briefing facts and ranked next actions |
+| `/mb-setup` | First-time setup |
+| `/mb-think` | Research, decide, codify |
+| `/mb-bet` | Open, update, close, narrate business bets |
+| `/mb-end` | Close the session — summary, crystallize, checkpoint guidance |
+| `/mb-help` | Get answers, troubleshoot, learn the system |
+| `/mb-update` | Update Main Branch (delegates to `mb update`) |
+| `/mb-ads` `/mb-vsl` `/mb-organic` `/mb-site` | Channel skills (Paid / Organic / Pages) |
+| `/mb-wiki` | Specialty: personal/atomic-notes wiki, not part of the core daily loop |
+
+`/mb-pull` is preserved as a legacy alias for `/mb-update`.
+
+**Reading order:**
+
+- [AGENTS.md](AGENTS.md) — shared operating contract for Codex, Claude Code, and other agents
+- [CLAUDE.md](CLAUDE.md) — Claude Code-specific guidance
+- [CONTRIBUTING.md](CONTRIBUTING.md) — branch / commit / validation discipline
+- [docs/ETHOS.md](docs/ETHOS.md) — product principles
+- [docs/OPERATOR-LOOPS.md](docs/OPERATOR-LOOPS.md) — Sense → Decide → Ship → Reflect taxonomy
+- [docs/ROADMAP.md](docs/ROADMAP.md) — release direction
+- [docs/compatibility.md](docs/compatibility.md) — runtime support matrix
+- [docs/release-simulations.md](docs/release-simulations.md) — release evidence ladder
 
 ---
 
 ## Community
 
-[skool.com/main](https://skool.com/main)
+- [Skool community](https://skool.com/main) — watch us build with Main Branch
+- [GitHub Issues](https://github.com/noontide-co/mainbranch/issues) — bugs and feature requests
+- [GitHub Discussions](https://github.com/noontide-co/mainbranch/discussions) — ideas
+
+---
+
+## License
+
+[MIT](LICENSE) © 2026 Noontide
+
+<p align="center">
+  <sub>Open source. Built for people who want to own their business memory, not rent it.</sub>
+</p>

--- a/README.md
+++ b/README.md
@@ -18,9 +18,17 @@ You're renting your business. Not just the dashboards — the operational memory
 
 The open-source gap closed in 2025. The tools to own your stack exist now. Almost nobody has carved time to migrate, because there is no coherent environment that ties it together.
 
-Main Branch is that environment. Your offer, audience, voice, decisions, research, bets, pushes (launches, drops, challenges, promos — whatever your business calls them), meeting notes, fulfillment context, and operating lessons live as markdown files in a git repo you own. The `mb` CLI scaffolds and checks it. The bundled skills read those files and help ship work from what your business already knows.
+Main Branch is that environment. Your offer, audience, voice, decisions, research, bets, pushes (launches, drops, challenges, promos — whatever your business calls them), meeting notes, fulfillment context, and operating lessons live as markdown files in a git repo you own. The `mb` CLI scaffolds, validates, repairs, graphs, and checkpoints it. The bundled skills read those files and help ship work from what your business already knows.
 
-The end state isn't sitting at a terminal all day. It's the opposite — eventually you dump thoughts from your phone, drafts get made, finance and fulfillment signals roll up, the team sees what is moving, you approve the risky actions, and the system executes the boring rails. We're not all the way there. The work is still real. But the substrate is the right one to build on.
+The unusual part today is the safety net underneath:
+
+- `mb doctor repair --plan` walks you through cleaning up a stale repo.
+- Drift checks in `mb validate` and `mb doctor` flag old folders, settings, and broken links from earlier setups.
+- `mb checkpoint` saves business-readable progress during long agent runs.
+- `mb issue draft` / `mb issue open` turn errors and confusing steps into privacy-safe GitHub issues.
+- Releases run against real fixture repos before they ship.
+
+**Direction, not promises.** Mobile thought capture, team views, finance/fulfillment roll-ups, broader Ops/bookkeeping surfaces, an optional local dashboard, and any future hosted or model-invocation surface are eventual targets in [docs/ROADMAP.md](docs/ROADMAP.md), not current behavior.
 
 Every bet you ship leaves a lesson. The lessons update your offer, your audience, your voice. Your business gets smarter every week — without you having to remember. The agent recommends; you make the call.
 
@@ -34,7 +42,7 @@ Own the work. Rent only the rails.
 
 Main Branch is the `mb` CLI plus MIT-licensed agent workflows for running a local-first business operating repo. It's built for operators and small teams running real businesses: solo founders, small agencies, course creators, productized services, indie SaaS, and small ecom teams. Today the workflows ship for Claude Code. Codex, Cursor, OpenClaw, Hermes, and local runtimes are compatibility targets, not supported adapters yet.
 
-The repo is the operating memory: offer, audience, voice, research, decisions, bets, pushes, logs, documents, meeting summaries, fulfillment notes, safe finance summaries, and provider refs. The CLI is the deterministic control plane: setup, status, validation, graph, provider readiness, updates, checkpoints, and repair. The skills are the judgment layer: research, decide, write, review, ship, and reflect.
+The repo is the operating memory: offer, audience, voice, research, decisions, bets, pushes, logs, documents, meeting summaries, fulfillment notes, safe finance summaries, and provider refs. The CLI is the deterministic control plane: setup, status, validation, graph, provider readiness, updates, repair, drift detection, and checkpoints. The skills are the judgment layer: research, decide, write, review, ship, and reflect. Agent recommends; operator decides what gets shipped, spent, published, or saved.
 
 Main Branch is opinionated about rails. The point is not to connect every SaaS tool a business has accumulated. The point is to choose boring, inspectable paths: GitHub for durable work threads, proposals, and shipped history; Cloudflare for sites and DNS; provider paths such as Google/Workspace and official ads only where smoke-tested; planned optional rails such as Postiz for social scheduling and Beancount-style plain-text finance; and optional sidecars for enrichment. Those paths should be wrapped in deterministic commands agents can call without wasting tokens guessing provider setup.
 
@@ -118,6 +126,7 @@ Once set up, you can:
 
 - Research topics and document decisions
 - Open, update, close, and narrate business bets
+- Plan and run pushes (launches, drops, challenges, promos) with reusable playbooks and per-push run records
 - Generate batches of ad copy in your voice
 - Create video scripts for Meta ads
 - Generate organic content — Reels, TikTok, carousels — from your core files and research
@@ -125,21 +134,26 @@ Once set up, you can:
 - Review ads for compliance before you run them
 - Build and deploy Cloudflare-backed landing pages from your core files and research when the repo is connected and readiness checks pass
 - Capture meeting transcripts, source material, and fulfillment notes into durable docs, logs, research, or decisions
+- Save business-readable git checkpoints during long agent runs with `mb checkpoint`
+- Reconcile stale repo state with `mb doctor repair --plan` / `--apply`, including migration drift across legacy folders, frontmatter, and skill wiring
+- Turn errors and confusing steps into privacy-safe GitHub issues with `mb issue draft` / `mb issue open`
 - Close sessions intentionally with crystallize moments
 
-All of this happens through simple slash commands. No custom prompt engineering required for supported workflows.
+All of this happens through simple slash commands and `mb` subcommands. No custom prompt engineering required for supported workflows.
 
 ---
 
 ## How it works
 
-Main Branch has three layers:
+Main Branch v0.3 has three layers:
 
 - **Your repo is canonical memory.** It holds the durable business truth:
   core files, research, decisions, bets, pushes, logs, documents, and links to
   child repos.
 - **`mb` is the deterministic control plane.** It scaffolds, validates, graphs,
-  briefs, repairs, checkpoints, updates, and checks provider readiness.
+  briefs, repairs (including migration drift), checkpoints, updates, and
+  checks provider readiness — and exposes JSON contracts that skills and future
+  callers read instead of guessing.
 - **Skills are the judgment layer.** Claude Code reads repo truth, asks the
   operator questions, drafts work, reviews it, and routes artifacts back into
   files.
@@ -148,6 +162,11 @@ The CLI and skills are meant to work together. Skills should call `mb` for
 facts instead of guessing at repo health, provider setup, or update state. The
 CLI should stay deterministic and scriptable instead of becoming a chat client
 or model host.
+
+The longer-arc operating-system model — `mb` as control plane, GitHub as the
+team layer, graph/structured data as the intelligence layer, agent runtimes as
+execution — is direction, not the v0.3 shape. See
+[`decisions/2026-05-02-github-native-business-os.md`](decisions/2026-05-02-github-native-business-os.md).
 
 You create a separate folder for YOUR business. That's where your offer,
 audience, voice, proof, operations, research, decisions, bets, pushes, logs, and
@@ -224,7 +243,7 @@ The CLI surface for the engine. Built for Claude Code first; runtime-agnostic by
 
 | Command | What it does |
 |---|---|
-| `mb onboard` | Human setup flow: create or connect a business repo, explain the substrate, wire Claude Code skills, and show the next `/mb-start` step. |
+| `mb onboard` | Human setup flow: create or connect a business repo, explain how the pieces fit together, wire Claude Code skills, and show the next `/mb-start` step. |
 | `mb onboard status` | Show durable onboarding progress from `.mb/onboarding.json`, including missing core-reference inputs and the next recommended action. |
 | `mb init` | Set up a fresh business repo (business folders, CLAUDE.md, git init). |
 | `mb status` | Show the local-first briefing in the terminal without opening Claude Code: ranked next actions, since-last-check changes, drift, repo health, runtime wiring, recent decisions/research/bets/git activity, and GitHub tasks/proposals when `gh` is authenticated. Use `--json` for the v1 status schema, `--verbose` for detail, and `--peek` for non-mutating reads. |
@@ -330,6 +349,8 @@ Some skills ship growth work. Others maintain operating memory. `/mb-start`,
 and `mb connect` are as important as the content skills because they keep the
 repo understandable, current, and safe to operate from.
 
+**Core daily loop**
+
 | Skill | What it does |
 |---|---|
 | `/mb-start` | Main entry point — figures out what you need and routes you there |
@@ -337,15 +358,27 @@ repo understandable, current, and safe to operate from.
 | `/mb-setup` | Set up your business repo (run this first if you're new) |
 | `/mb-think` | Research, make decisions, add context, transcribe local recordings, update durable business files |
 | `/mb-bet` | Open, update, close, list, and narrate business bets |
+| `/mb-end` | Close session — summary, crystallize, approved checkpoint guidance |
+| `/mb-help` | Get answers, troubleshoot, learn the system |
+| `/mb-update` | Update Main Branch — delegates install-mode refresh to `mb update` and summarizes what's new |
+
+**Channel skills (Paid, Organic, Pages)**
+
+| Skill | What it does |
+|---|---|
 | `/mb-ads` | Create ad copy (static or video) and review for compliance |
 | `/mb-vsl` | Write video sales letter scripts (Skool or B2B) |
 | `/mb-organic` | Generate organic content — Reels, TikTok, carousels |
 | `/mb-site` | Generate and deploy landing pages from your core files and research |
-| `/mb-wiki` | Personal wiki with atomic notes |
-| `/mb-end` | Close session — summary, crystallize, approved checkpoint guidance |
-| `/mb-help` | Get answers, troubleshoot, learn the system |
-| `/mb-update` | Update Main Branch — delegates install-mode refresh to `mb update` and summarizes what's new |
-| `/mb-pull` | Legacy alias for `/mb-update` |
+
+**Specialty**
+
+| Skill | What it does |
+|---|---|
+| `/mb-wiki` | Personal/atomic-notes wiki workflow — optional, not part of the core daily loop |
+
+`/mb-pull` is kept as a legacy alias for `/mb-update` so older muscle memory
+still works; new docs and the live rotation teach `/mb-update`.
 
 ---
 
@@ -353,6 +386,10 @@ repo understandable, current, and safe to operate from.
 
 - **Built for Claude Code today.** `mb` is runtime-agnostic by design, but Claude Code is the only first-class runtime currently supported end to end.
 - **The terminal front door is live.** Bare `mb`, `mb onboard`, `mb status`, `mb start`, and `mb update` are in the public package.
+- **Owner-safe repair is shipped.** `mb doctor repair --plan`, migration drift checks across `mb validate` and `mb doctor`, and skill-link/wiring repair handle stale repos, broken settings, and old layouts without asking a non-developer to reason through git plumbing.
+- **Business-readable git saves are shipped.** `mb checkpoint` plans and saves readable commits at meaningful boundaries during long agent runs. The repo also surfaces topology facts (`mb status --json`, `mb graph --json`, `mb doctor repair --plan --json`) for agents and future dashboards to read.
+- **Privacy-safe friction capture is shipped.** `mb issue draft` / `mb issue open` turn errors and confusing steps into reviewed, scrubbed GitHub issues without leaking business data.
+- **Releases run against fixture repos.** Package-visible releases run print-mode and runtime simulations against materialized fixture repos before they ship. See [docs/release-simulations.md](docs/release-simulations.md).
 - **Packaged callers can use the CLI directly.** Paperclip-style routines, local scripts, and future adapters should invoke deterministic `mb` commands against an explicit business repo path and read JSON/exit codes. See [docs/compatibility.md](docs/compatibility.md).
 - **Growth is the strongest shipped wedge.** Ads, organic, VSLs, sites, bets, pushes, status, and checkpoints are the most developed public workflows.
 - **Ops is the expansion path.** Meetings, fulfillment, bookkeeping/P&L, team daily logs, repo topology, and dashboard views use the same memory model, but they are less shipped than the growth surfaces.

--- a/docs/ETHOS.md
+++ b/docs/ETHOS.md
@@ -9,11 +9,13 @@ operating substrate:
 - the business repo is the business brain;
 - `mb` is the deterministic control plane;
 - agent-runtime skills are the judgment-heavy execution layer;
+- migration drift detection, `mb doctor repair`, `mb validate`, and `mb graph`
+  are the safety net that keeps the repo trustworthy as the engine evolves;
 - GitHub issues are durable work threads for tasks, requests, blockers, and
   follow-ups when work needs shared visibility;
 - pull requests are proposals and review conversations;
-- git history is the evolution story.
-- checkpoints make long agent runs durable before chat context is lost.
+- git history is the evolution story;
+- `mb checkpoint` makes long agent runs durable before chat context is lost;
 - dashboards, Obsidian graphs, and future team surfaces are views over the same
   files, not replacements for them.
 
@@ -103,7 +105,9 @@ operator usage becomes shared infrastructure.
 
 Issue drafting must be privacy-safe by default. Business context, customer
 data, tokens, local paths, and account details must not be sent without an
-explicit operator decision.
+explicit operator decision. `mb issue draft` and `mb issue open` are the
+shipped path: drafts land under `.mb/issue-drafts/` for review, the scrubber
+redacts common hazards, and submission is an explicit operator action.
 
 ### 7. Sidecars Are Optional
 
@@ -130,8 +134,10 @@ flows without evidence. Use the validation ladder in [AGENTS.md](../AGENTS.md):
 static checks, CLI tests, package smoke, fixture repo smoke, and runtime smoke
 when the behavior depends on a real runtime.
 
-The product should feel alive, but the substrate should stay boring enough to
-debug.
+Package-visible releases run simulations against fixture repos and review
+transcripts by hand. See [release-simulations.md](release-simulations.md).
+
+The product should feel alive; the parts underneath should stay boring.
 
 ### 10. Git Is The Hidden App
 
@@ -141,9 +147,10 @@ from them. Agents should checkpoint meaningful work throughout a run so future
 sessions can reconstruct what changed, what was decided, and what remains open
 from repo history.
 
-Checkpointing is not noisy autosave. It is durable business memory: readable
-commits at meaningful boundaries, with privacy and secret-safety gates before
-anything is recorded.
+`mb checkpoint` is the shipped surface for that loop: it plans or saves
+business-readable git commits at meaningful boundaries, with privacy and
+secret-safety gates before anything is recorded. Checkpointing is not noisy
+autosave; it is durable business memory.
 
 ## What We Are Not Building Yet
 

--- a/docs/OPERATOR-LOOPS.md
+++ b/docs/OPERATOR-LOOPS.md
@@ -72,19 +72,18 @@ reference-file reads sit here.
 
 **Current surfaces**
 
-- `mb status`
-- `mb doctor`
-- `mb graph`
+- `mb status` (with `--json` topology and "Business map" line)
+- `mb doctor` and `mb doctor repair --plan` (including migration drift and
+  topology-drift previews)
+- `mb graph` (with `repo` nodes and hub/child relationship edges)
 - `mb connect status`
 - `core/`, `research/`, `decisions/`, `pushes/`, legacy `campaigns/`, `log/`, `documents/`
 - GitHub issues, pull requests, release history
 - linked business, site, offer, finance, ops, and client repos when the team
-  chooses separate operating boundaries
+  chooses separate operating boundaries, surfaced through topology facts
 
-**Next improvements**
+**Direction**
 
-- richer repo-topology views across business, site, offer, finance, ops, and
-  client repos;
 - provider-readiness signals that become more specific as official paths are
   smoke-tested;
 - an optional local dashboard that visualizes existing repo / GitHub / provider
@@ -109,10 +108,12 @@ options. Discrete moments, not continuous activity.
 
 - `/mb-start`
 - `/mb-think`
-- GitHub issues and priorities
 - `mb status` ranked actions
+- GitHub issues and priorities
+- `mb issue draft` (frame friction or a feature gap clearly enough to commit
+  to acting on it)
 
-**Next improvements**
+**Direction**
 
 - Explicit pin, skip, and defer controls
 - Decision trees for provider choices, paid-SaaS exceptions, sensitive data,
@@ -141,10 +142,15 @@ operators ship creatives, SaaS founders ship features.
 - `/mb-vsl`
 - `/mb-organic`
 - `/mb-site`
-- `/mb-wiki`
 - `mb connect`
 - `mb checkpoint`
+- `mb doctor repair --plan` / `--apply` (Ship through Ops: cleaning up a stale
+  repo is the released artifact)
+- `mb issue open` (Ship through Ops: turning a reviewed draft into a public
+  GitHub issue)
 - `mb update`
+- `/mb-wiki` (specialty: personal/atomic-notes wiki, not part of the core daily
+  loop)
 
 **Channels — the four pillars**
 
@@ -158,13 +164,13 @@ A Ship event is `(loop, channel)`. Posting an ad = Ship through Paid.
 Sending the newsletter = Ship through Organic. Running `mb update` = Ship
 through Ops.
 
-**Next improvements**
+**Direction**
 
 - Skills leaning more heavily on CLI facts instead of duplicate checks
 - Optional provider and sidecar contracts
 - Beginner-safe connector flows for GitHub, Cloudflare, Google, Meta, Apify
-- deterministic site/CMS rails over Cloudflare, GitHub, and operator-approved
-  measurement checks
+- deeper site/CMS rails on top of `mb site check` over Cloudflare, GitHub, and
+  operator-approved measurement
 - richer Paid, Organic, Pages, and Ops surfaces (books, P&L, meetings,
   fulfillment, compliance)
 
@@ -190,9 +196,10 @@ of work.
 - `bets/` and the bet lifecycle (verdicts go here)
 - `decisions/` (when superseding a prior decision is itself a reflection)
 - `CHANGELOG.md` (release-as-retro)
-- `git` history — readable commits at meaningful boundaries
+- `mb checkpoint` and `git` history — business-readable commits at meaningful
+  boundaries
 
-**Next improvements**
+**Direction**
 
 - Bet-to-offer graduation rules
 - Status and dashboard visibility for active bets, deadlines, and outcomes

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -18,13 +18,24 @@ Main Branch already ships:
 - `mb onboard`, `mb init`, `mb status`, `mb start`, `mb update`, `mb doctor`,
   `mb graph`, `mb validate`, `mb migrate`, `mb connect`, and skill management
   commands;
+- `mb doctor repair --plan` / `--apply` and migration drift detection across
+  `mb validate` and `mb doctor` for stale generated guidance, legacy
+  active-write folders, stale Claude settings, wrong push/playbook paths, and
+  legacy bet campaign links;
 - Claude Code skill wiring with `mb-` prefixed bundled skills;
 - beginner setup, migration, repair, and update paths;
 - local-first provider metadata and secret-safe connection checks;
-- graph and status primitives for future dashboard and agent workflows;
-- privacy-safe GitHub issue drafting for user friction;
+- graph, status, and topology primitives (including repo-topology facts in
+  `mb status --json`, `mb graph --json`, and `mb doctor repair --plan --json`)
+  for future dashboard and agent workflows;
+- privacy-safe GitHub issue drafting and submission (`mb issue draft`,
+  `mb issue open`) for user friction;
+- push, reusable playbook, and per-push run-record vocabulary for coordinated
+  business work;
 - `bets/` and `/mb-bet` as the first Reflect primitive;
 - `mb checkpoint` as the first hidden GitOps save layer for long agent runs;
+- materialized release-simulation fixtures and the package-visible release
+  evidence ladder (PR smoke, pre-release candidate, release acceptance);
 - public contribution, support, security, compatibility, and agent guidance;
 - accepted workspace/repo/sensitive-data boundary guidance and
   GitHub/Obsidian-compatible markdown/link conventions for future dashboard,


### PR DESCRIPTION
## Summary
- Rewrite the README as a vision-led, business-owner-facing doc modeled on the Paperclip pattern: hero ("you don't need to know git, you don't need to know terminals, you just need a folder"), three-step "what happens", a "what stops you isn't what you think" pairs table, a "what changes vs. just AI" comparison, and a "what's underneath" three-layer summary in plain English without exposing CLI commands the customer never has to type.
- Move the `mb` CLI table and skill catalog under "For contributors and power users"; demote `/mb-wiki` to specialty and document `/mb-pull` as a legacy alias outside the core daily loop.
- Anchor the v0.3 safety net (`mb doctor repair --plan`, migration drift detection, `mb checkpoint`, `mb issue draft`/`open`, fixture-based release simulations) in `docs/ETHOS.md` principles, `docs/OPERATOR-LOOPS.md` Current surfaces, and `docs/ROADMAP.md` Shipped Foundation so the strongest shipped differentiators are visible.
- Re-label eventual surfaces (mobile capture, team views, finance roll-ups, dashboards, hosted/model-invocation) as direction in README and OPERATOR-LOOPS, with the "Next improvements" headers renamed to "Direction" so direction reads as direction, not implied current behavior.

## Scope
- In: `README.md`, `docs/ETHOS.md`, `docs/OPERATOR-LOOPS.md`, `docs/ROADMAP.md`. Docs-only public-narrative refresh.
- Out: topology/status/graph/doctor implementation (#418 / MAIN-289, already shipped), agent-routing doc cleanup (#437 / MAIN-297), runtime support claims, historical decision rewrites, and any new product promises for mobile/team-dashboard/finance/bookkeeping/automatic provider mutation.

## Commits
- b88ea14 — [update] README leads with v0.3 safety net and direction labels
- 250b890 — [update] ETHOS anchors the v0.3 safety net in principles language
- 267a5a4 — [update] OPERATOR-LOOPS marks shipped surfaces as current, not next
- 941caf9 — [update] ROADMAP credits drift detection, repair, issue submission, and release sims
- 562e040 — [update] README rewritten as vision-led, business-owner-facing doc

## Release / Issues
- Release: none (docs-only refresh, ships under v0.3.x without a new tag)
- Linear ID(s): MAIN-298
- Closes: #440
- Refs: #418, #437, #406, #410, #432, #436, #423
- Follow-ups: `docs/system-architecture.md` and `docs/philosophy.md` were not in scope; if either still over-promises mobile/team/finance state, file separately. The `b88ea14` commit predates the rewrite and could be squashed if a single clean README commit is preferred.

## Success Metric
- A new reader can distinguish shipped v0.3.12 behavior, active next-direction work, and longer-term product vision; README leads with "durable operating memory" + a folder-you-own framing instead of broad AI-OS claims; eventual-state language is explicitly marked direction; the safety-net differentiators (`mb doctor repair --plan`, drift detection, `mb checkpoint`, `mb issue draft`/`open`, release simulation/evidence ladder) are visible in public docs.

## Validation
- Level 0 docs/decision: refreshed READMEs, ETHOS, OPERATOR-LOOPS, ROADMAP per MAIN-298 acceptance criteria.
- Level 1 static: `scripts/check.sh` exit 0 after each commit.
- Level 2 CLI: n/a (docs-only).
- Level 3 package/install: n/a (no packaging/entrypoint/bundled-data changes).
- Level 4 fixture repo: n/a (no first-run/skill-discovery/install changes).
- Level 5 runtime smoke: n/a per `docs/release-simulations.md` ("a docs-only change can stop at scripts/check.sh unless it changes release process, runtime claims, or operator workflow"). Runtime claims unchanged; operator workflow unchanged.

## Public / Private Boundary
- Preserved. `substrate` removed from customer-facing README copy on Devon's tone note; kept where contributor-facing language already used it. Skool framing unchanged. No private member, finance, credential, or Conductor-local detail introduced. Cold-start brief stays in `.context/` (gitignored).