### PR TITLE
[update] Prepare v0.3.13 release (version bump + changelog)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mainbranch",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "description": "Main Branch Claude Code skills for running a business from markdown files in git.",
   "author": {
     "name": "Noontide"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,39 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+## [0.3.13] - 2026-05-08
+
+v0.3.13 ships the repo-topology substrate that landed after v0.3.12 as an
+installable patch release. `mb status`, `mb graph`, and `mb doctor` now expose
+topology facts; `mb validate` enforces the new repo descriptor and topology
+record schemas; migration drift now surfaces as actionable warnings; and
+reusable playbooks plus agent-facing routing docs were refreshed to match the
+current push topology.
+
+### What this means for you (plain English)
+
+- **`mb` can now show you your repo topology.** `mb status --json` adds a
+  `topology` section and a business-readable "Business map" line so you can
+  see hub/child relationships without hand-tracing them. `mb graph --json`
+  gains `repo` nodes and deterministic hub/child edges with playbook-run
+  resolution.
+- **Migration drift gets named, not hidden.** `mb validate` and
+  `mb doctor repair --plan --json` warn on stale generated guidance, legacy
+  active-write folders, stale Claude settings, wrong push/playbook paths, and
+  legacy bet campaign links — without rewriting anything for you.
+- **Child repos get a real, role-neutral descriptor.** The new
+  `.mainbranch/repo.json` contract covers site, offer, product, client,
+  finance, legal, ops, integration sidecar, experiment, and archive repos,
+  while keeping existing `.mainbranch/source.json` site behavior compatible.
+- **Topology records are validated before they go stale.** `mb validate`
+  reads `core/operations/repo-topology.md` `type: repo_topology` entries with
+  topology vocabularies, safe repo-link checks, and finance/legal/provider
+  boundary warnings.
+- **Reusable playbooks and routing docs match the current push model.**
+  `ship-bet` and `weekly-review` route run evidence into
+  `pushes/<push>/playbooks/`, outcomes, logs, and checkpoints; agent-facing
+  routing docs and the public substrate story have been refreshed to match.
+
 ### Added
 
 - Added privacy-safe business repo migration drift warnings through
@@ -47,12 +80,15 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   so agents distinguish hub work from child-repo work and avoid committed
   absolute paths, secrets, raw provider caches, finance/legal source data, or
   permission claims in repo descriptors. Refs #417.
-
 - Refreshed reusable playbook skeletons against the current push topology:
   `ship-bet` and `weekly-review` now route concrete run evidence to
   `pushes/<push>/playbooks/`, outcomes, logs, and checkpoints instead of legacy
   `campaigns/`, and the Google Ads Search launch playbook is labeled as a
   usable draft recipe rather than a non-executable skeleton. Refs #425.
+- Refreshed agent-facing routing docs to match the current daily loop,
+  topology vocabulary, and migration guardrails. Refs #437.
+- Refreshed the public story around the shipped v0.3.12 substrate so README,
+  docs, and roadmap language match what users can install today. Refs #440.
 
 ## [0.3.12] - 2026-05-08
 

--- a/mb/mb/__init__.py
+++ b/mb/mb/__init__.py
@@ -7,6 +7,6 @@ file stays a thin dispatcher.
 
 from __future__ import annotations
 
-__version__ = "0.3.12"
+__version__ = "0.3.13"
 
 __all__ = ["__version__"]

--- a/mb/pyproject.toml
+++ b/mb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mainbranch"
-version = "0.3.12"
+version = "0.3.13"
 description = "Main Branch engine umbrella - scaffolds, validates, and graphs business-as-files repos. Claude Code first, runtime-agnostic by design."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- Bumps the package/plugin version from 0.3.12 to 0.3.13 so the topology + validation + migration-drift work merged after v0.3.12 is installable as a patch release.
- Promotes the `[Unreleased]` CHANGELOG section into a dated `[0.3.13] - 2026-05-08` section with a "What this means for you" preamble covering topology in `mb status`/`mb graph`/`mb doctor`, repo descriptor validation, migration drift warnings, push/playbook topology refresh, and the agent-routing / public-story doc refresh.

## Scope
- In: version files (`mb/pyproject.toml`, `mb/mb/__init__.py`, `.claude-plugin/plugin.json`) and `CHANGELOG.md` only.
- Out: tagging, GitHub Release, PyPI publish, runtime/release-simulation evidence (gating step before tagging — handled post-merge by the operator running the release runbook). No new behavior, no out-of-scope items from MAIN-299 (Codex adapter, vocabulary storage, Postiz, visual-generation rails, VSL restructuring).

## Commits
- 52a92f0 — [update] Bump package version to 0.3.13
- 163ca8f — [update] Promote [Unreleased] changelog into 0.3.13 release section

## Release / Issues
- Release: oe-v0.3.13 (target — tag/publish after merge once release runbook evidence is recorded)
- Linear ID(s): MAIN-299
- Closes: (none — issue closes after the GitHub Release ships and PyPI verification is recorded)
- Refs: #443
- Follow-ups: tag `oe-v0.3.13`, run release-candidate + release-acceptance simulation tiers from `docs/release-simulations.md`, verify publish workflow, fresh PyPI install of `mainbranch==0.3.13`, first-run smoke from PyPI, then post evidence back to #443 and complete the matching Linear release.

## Success Metric
- A fresh user can `pip install mainbranch==0.3.13` and use `mb` to inspect, validate, and repair the new repo-topology substrate without needing an unreleased source checkout.

## Validation
- Level 0 docs/decision: CHANGELOG `[Unreleased]` reset; `[0.3.13]` section dated 2026-05-08 with plain-English preamble + Added/Changed sections sourced from the merged commit set (`git log oe-v0.3.12..origin/main`).
- Level 1 static: `scripts/check.sh` from repo root → All checks passed.
- Level 2 CLI: covered by the test suite inside `scripts/check.sh` (CliRunner tests for `--version`, status/graph/doctor/validate/start JSON contracts).
- Level 3 package/install: `(cd mb && python3 -m build)` → `mainbranch-0.3.13-py3-none-any.whl`; fresh `python3 -m venv /tmp/mainbranch-smoke` install → `mb --version` reports `mb 0.3.13`; `mb skill list` lists 17 skills.
- Level 4 fixture repo: `mb onboard --yes --json`, `mb status --json --peek`, `mb graph --json`, `mb doctor repair --plan --json`, `mb validate --cross-refs --json`, and `mb start --json` all return `result_status: ok` from a fresh `/tmp/mainbranch-smoke-business` onboarded repo.
- Level 5 runtime smoke: deferred to the release runbook (Claude Code dogfood + release-candidate/release-acceptance simulation tiers) which gates `oe-v0.3.13` tagging, per AGENTS.md and the MAIN-299 validation contract.

## Public / Private Boundary
- Public surfaces only (CHANGELOG, packaging metadata, plugin manifest). No Devon/Conductor/local runtime details introduced. Cold-start notes for this branch live in gitignored `.context/`.