### PR TITLE
[add] Surface push playbook health in mb status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+### Added
+
+- Added push playbook health facts to `mb status --json --peek`, plus concise
+  human and ranked-action signals when active pushes are missing run records,
+  playbook approval/status is pending, completed pushes lack outcome links, or
+  provider boundaries remain plan/manual work. Refs #446.
+
 ## [0.3.13] - 2026-05-08
 
 v0.3.13 ships the repo-topology substrate that landed after v0.3.12 as an

--- a/mb/mb/ranker.py
+++ b/mb/mb/ranker.py
@@ -20,6 +20,7 @@ WEIGHTS: dict[str, int] = {
     "attention_requests": 70,
     "assigned_tasks": 65,
     "blocked_or_stale_tasks": 60,
+    "playbook_health_gaps": 84,
     "relationship_health_gaps": 82,
     "due_bets": 58,
     "stale_decisions": 50,
@@ -50,6 +51,7 @@ def rank_status_report(
     actions: list[dict[str, Any]] = []
     _add_readiness_actions(actions, report)
     _add_drift_actions(actions, report)
+    _add_playbook_actions(actions, report)
     _add_relationship_actions(actions, report)
     _add_bet_actions(actions, report)
     _add_github_actions(actions, report)
@@ -370,6 +372,38 @@ def _add_relationship_actions(actions: list[dict[str, Any]], report: dict[str, A
                     summary="business graph has actionable relationship gaps",
                     evidence=[str(item.get("id") or "") for item in gaps[:5]],
                     weight=WEIGHTS["relationship_health_gaps"],
+                    safe_to_share=all(bool(item.get("safe_to_share", True)) for item in gaps),
+                )
+            ],
+        )
+    )
+
+
+def _add_playbook_actions(actions: list[dict[str, Any]], report: dict[str, Any]) -> None:
+    playbook_health = _dict(report.get("playbook_health"))
+    gaps = [_dict(item) for item in _list(playbook_health.get("gaps"))]
+    if not gaps:
+        return
+    warnings = [item for item in gaps if item.get("severity") == "warn"]
+    first_gap = gaps[0]
+    score = WEIGHTS["playbook_health_gaps"] + min(len(gaps) * 3, 18)
+    actions.append(
+        _action(
+            action_id="review_playbook_health",
+            title="Review push playbook health",
+            command="mb status --verbose --peek",
+            severity="warn" if warnings else "info",
+            score=score,
+            reason=str(
+                first_gap.get("summary") or f"{len(gaps)} push playbook signal(s) need review."
+            ),
+            signals=[
+                _signal(
+                    "playbook_health.gaps",
+                    severity="warn" if warnings else "info",
+                    summary="push playbook run records have actionable health signals",
+                    evidence=[str(item.get("id") or "") for item in gaps[:5]],
+                    weight=WEIGHTS["playbook_health_gaps"],
                     safe_to_share=all(bool(item.get("safe_to_share", True)) for item in gaps),
                 )
             ],

--- a/mb/mb/status.py
+++ b/mb/mb/status.py
@@ -44,6 +44,14 @@ ACTIVE_PUSH_STATUSES = {"planned", "active", "paused"}
 COMPLETED_PUSH_STATUSES = {"completed"}
 LIVE_OFFER_STATUSES = {"accepted", "graduated", "running", "scaling"}
 STALE_PUSH_DAYS = 14
+PUSH_STATUSES_EXPECTING_PLAYBOOK = {"planned", "active"}
+PLAYBOOK_STATUSES_NEEDING_ATTENTION = {"draft", "planned"}
+PLAYBOOK_APPROVAL_STATUSES_NEEDING_ATTENTION = {"needed", "rejected", ""}
+PLAYBOOK_PROVIDER_BOUNDARIES_NEEDING_ATTENTION = {
+    "plan-only",
+    "external-manual",
+    "manual-provider",
+}
 
 
 def _utc_now() -> datetime:
@@ -652,6 +660,58 @@ def _offer_summaries(repo: Path) -> list[dict[str, Any]]:
     return [_file_summary(repo, path, _read_frontmatter(path)) for path in unique_paths]
 
 
+def _coerce_string_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value] if value.strip() else []
+    if isinstance(value, list):
+        return [item for item in value if isinstance(item, str) and item.strip()]
+    return []
+
+
+def _playbook_summary(repo: Path, path: Path) -> dict[str, Any]:
+    meta = _read_frontmatter(path)
+    try:
+        rel = path.relative_to(repo).as_posix()
+    except ValueError:
+        rel = str(path)
+    push_path = ""
+    if path.parent.name == "playbooks" and path.parent.parent.name:
+        push_path = f"pushes/{path.parent.parent.name}/push.md"
+    approval_raw = meta.get("approval")
+    approval: dict[str, Any] = approval_raw if isinstance(approval_raw, dict) else {}
+    state_raw = meta.get("state")
+    state: dict[str, Any] = state_raw if isinstance(state_raw, dict) else {}
+    return {
+        "path": rel,
+        "title": _title_from_markdown(path),
+        "status": str(meta.get("status", "") or ""),
+        "push": str(meta.get("push", "") or ""),
+        "resolved_push": push_path,
+        "platform": str(meta.get("platform", "") or ""),
+        "provider": str(meta.get("provider", "") or ""),
+        "provider_boundary": str(meta.get("provider_boundary", "") or ""),
+        "approval": {
+            "required": bool(approval.get("required")),
+            "status": str(approval.get("status", "") or ""),
+            "approved_by": str(approval.get("approved_by", "") or ""),
+            "approved_at": str(approval.get("approved_at", "") or ""),
+        },
+        "linked_outcomes": _coerce_string_list(meta.get("linked_outcomes")),
+        "provider_refs_recorded": bool(state.get("provider_refs")),
+        "updated_at": datetime.fromtimestamp(path.stat().st_mtime).isoformat(timespec="seconds"),
+    }
+
+
+def _playbook_summaries(repo: Path) -> list[dict[str, Any]]:
+    return [
+        _playbook_summary(repo, path)
+        for path in sorted(repo.glob("pushes/*/playbooks/*.md"))
+        if path.is_file()
+    ]
+
+
 def _gap(
     *,
     gap_id: str,
@@ -668,6 +728,157 @@ def _gap(
         "evidence": [str(item.get("path") or item.get("source") or "") for item in records[:5]],
         "records": records[:5],
         "repair": repair,
+        "safe_to_share": True,
+    }
+
+
+def _playbook_health(
+    repo: Path,
+    *,
+    brain: dict[str, Any],
+) -> dict[str, Any]:
+    push_report = brain.get("pushes") or {}
+    pushes = [
+        item
+        for item in push_report.get("records", [])
+        if isinstance(item, dict) and item.get("source") == "canonical"
+    ]
+    playbooks = _playbook_summaries(repo)
+    playbooks_by_push: dict[str, list[dict[str, Any]]] = {}
+    for playbook in playbooks:
+        push_path = str(playbook.get("resolved_push") or "")
+        if push_path:
+            playbooks_by_push.setdefault(push_path, []).append(playbook)
+
+    pushes_without_playbook = [
+        item
+        for item in pushes
+        if str(item.get("status") or "").lower() in PUSH_STATUSES_EXPECTING_PLAYBOOK
+        and not playbooks_by_push.get(str(item.get("path") or ""))
+    ]
+    pending_status = [
+        item
+        for item in playbooks
+        if str(item.get("status") or "").lower() in PLAYBOOK_STATUSES_NEEDING_ATTENTION
+    ]
+    approval_needed = [
+        item
+        for item in playbooks
+        if bool((item.get("approval") or {}).get("required"))
+        and str((item.get("approval") or {}).get("status") or "").lower()
+        in PLAYBOOK_APPROVAL_STATUSES_NEEDING_ATTENTION
+    ]
+    completed_without_outcome: list[dict[str, Any]] = []
+    for push in pushes:
+        if str(push.get("status") or "").lower() not in COMPLETED_PUSH_STATUSES:
+            continue
+        for playbook in playbooks_by_push.get(str(push.get("path") or ""), []):
+            if not playbook.get("linked_outcomes"):
+                item = dict(playbook)
+                item["push_status"] = str(push.get("status") or "")
+                completed_without_outcome.append(item)
+    provider_boundary_attention = [
+        item
+        for item in playbooks
+        if str(item.get("provider_boundary") or "").lower()
+        in PLAYBOOK_PROVIDER_BOUNDARIES_NEEDING_ATTENTION
+        and str(item.get("status") or "").lower() not in {"canceled", "retired"}
+    ]
+
+    gaps = [
+        _gap(
+            gap_id="pushes_without_playbook",
+            severity="warn",
+            summary=(
+                f"{len(pushes_without_playbook)} active/planned push(es) need a playbook run."
+            ),
+            records=pushes_without_playbook,
+            repair="Add a run record under `pushes/<push>/playbooks/` for each active push.",
+        )
+        if pushes_without_playbook
+        else None,
+        _gap(
+            gap_id="pending_playbook_statuses",
+            severity="warn",
+            summary=f"{len(pending_status)} playbook run(s) are still draft/planned.",
+            records=pending_status,
+            repair="Review each playbook run and move it toward approved, active, or completed.",
+        )
+        if pending_status
+        else None,
+        _gap(
+            gap_id="playbook_approval_needed",
+            severity="warn",
+            summary=f"{len(approval_needed)} playbook run(s) still need approval.",
+            records=approval_needed,
+            repair="Record approval status before publishing, spending, or mutating providers.",
+        )
+        if approval_needed
+        else None,
+        _gap(
+            gap_id="completed_playbooks_without_outcome",
+            severity="warn",
+            summary=(
+                f"{len(completed_without_outcome)} completed-push playbook run(s) "
+                "need an outcome link."
+            ),
+            records=completed_without_outcome,
+            repair="Add `linked_outcomes` to the playbook after the push is reviewed.",
+        )
+        if completed_without_outcome
+        else None,
+        _gap(
+            gap_id="manual_provider_boundaries",
+            severity="info",
+            summary=(
+                f"{len(provider_boundary_attention)} playbook run(s) are still "
+                "plan/manual provider work."
+            ),
+            records=provider_boundary_attention,
+            repair=(
+                "Confirm the operator expects manual provider steps before treating this "
+                "as automation."
+            ),
+        )
+        if provider_boundary_attention
+        else None,
+    ]
+    active_gaps = [gap_item for gap_item in gaps if gap_item is not None]
+    return {
+        "ok": not active_gaps,
+        "source": "mb status playbook scan",
+        "summary": {
+            "gaps": len(active_gaps),
+            "warnings": len([item for item in active_gaps if item["severity"] == "warn"]),
+            "info": len([item for item in active_gaps if item["severity"] == "info"]),
+            "playbooks": len(playbooks),
+            "pushes_without_playbook": len(pushes_without_playbook),
+            "pending_playbook_statuses": len(pending_status),
+            "playbook_approval_needed": len(approval_needed),
+            "completed_playbooks_without_outcome": len(completed_without_outcome),
+            "manual_provider_boundaries": len(provider_boundary_attention),
+        },
+        "gaps": active_gaps,
+        "sections": {
+            "pushes": {
+                "records": len(pushes),
+                "expecting_playbook": len(
+                    [
+                        item
+                        for item in pushes
+                        if str(item.get("status") or "").lower() in PUSH_STATUSES_EXPECTING_PLAYBOOK
+                    ]
+                ),
+                "without_playbook": pushes_without_playbook[:5],
+            },
+            "playbooks": {
+                "records": playbooks[:5],
+                "pending_status": pending_status[:5],
+                "approval_needed": approval_needed[:5],
+                "completed_without_outcome": completed_without_outcome[:5],
+                "provider_boundary_attention": provider_boundary_attention[:5],
+            },
+        },
         "safe_to_share": True,
     }
 
@@ -1348,6 +1559,27 @@ def _drift(report: dict[str, Any]) -> dict[str, Any]:
                 "safe_to_share": True,
             }
         )
+    playbook_health = report.get("playbook_health") or {}
+    playbook_summary = playbook_health.get("summary") or {}
+    if playbook_summary.get("gaps", 0):
+        top_gap = (playbook_health.get("gaps") or [{}])[0]
+        items.append(
+            {
+                "id": "playbook_health_gaps",
+                "severity": "warn" if playbook_summary.get("warnings", 0) else "info",
+                "summary": (
+                    f"{playbook_summary.get('gaps', 0)} push playbook health signal(s) need review."
+                ),
+                "evidence": [
+                    str(item.get("id") or "") for item in (playbook_health.get("gaps") or [])[:5]
+                ],
+                "repair": str(
+                    top_gap.get("repair")
+                    or "Run `mb status --verbose --peek` to inspect playbook health."
+                ),
+                "safe_to_share": True,
+            }
+        )
     onboarding_summary = (report.get("onboarding") or {}).get("summary") or {}
     if onboarding_summary.get("status") == "in_progress":
         items.append(
@@ -1482,6 +1714,16 @@ def _readiness(report: dict[str, Any]) -> dict[str, Any]:
                 or "Review relationship gaps with `mb status --verbose --peek`."
             )
         )
+    playbook_health = report.get("playbook_health") or {}
+    playbook_gaps = playbook_health.get("gaps") or []
+    if playbook_gaps:
+        first_gap = playbook_gaps[0]
+        next_actions.append(
+            str(
+                first_gap.get("repair")
+                or "Review playbook health with `mb status --verbose --peek`."
+            )
+        )
     onboarding_summary = (report.get("onboarding") or {}).get("summary") or {}
     if onboarding_summary.get("status") == "in_progress":
         next_actions.append(
@@ -1578,6 +1820,7 @@ def run(
         brain=brain,
         today=current_time.date(),
     )
+    report["playbook_health"] = _playbook_health(repo_path, brain=brain)
     report["since_last_check"] = _since_last_check(
         repo_path,
         marker=marker,
@@ -1641,6 +1884,10 @@ def render_human(
     since = report.get("since_last_check") or {}
     drift = report.get("drift") or {"summary": {"total": 0}, "items": []}
     relationship_health = report.get("relationship_health") or {
+        "summary": {"gaps": 0},
+        "gaps": [],
+    }
+    playbook_health = report.get("playbook_health") or {
         "summary": {"gaps": 0},
         "gaps": [],
     }
@@ -1711,6 +1958,18 @@ def render_human(
                 console.print(f"    next: {gap['repair']}")
     else:
         console.print("[bold]Relationship health[/bold] no actionable business-link gaps detected")
+
+    playbook_summary = playbook_health.get("summary") or {}
+    if playbook_summary.get("gaps", 0):
+        console.print(
+            "[bold]Playbook health[/bold] "
+            f"{playbook_summary.get('warnings', 0)} warning(s), "
+            f"{playbook_summary.get('info', 0)} info"
+        )
+        for gap in (playbook_health.get("gaps") or [])[:3]:
+            console.print(f"  - {gap['summary']}")
+            if verbose and gap.get("repair"):
+                console.print(f"    next: {gap['repair']}")
 
     repo_mark = (
         "[green]yes[/green]" if repo["looks_like_mainbranch_repo"] else "[yellow]no[/yellow]"

--- a/mb/mb/status.py
+++ b/mb/mb/status.py
@@ -765,6 +765,7 @@ def _playbook_health(
         item
         for item in playbooks
         if bool((item.get("approval") or {}).get("required"))
+        and str(item.get("status") or "").lower() not in {"canceled", "retired"}
         and str((item.get("approval") or {}).get("status") or "").lower()
         in PLAYBOOK_APPROVAL_STATUSES_NEEDING_ATTENTION
     ]

--- a/mb/tests/fixtures/status/schema-v1-basic.json
+++ b/mb/tests/fixtures/status/schema-v1-basic.json
@@ -21,6 +21,7 @@
     "measurement",
     "ok",
     "onboarding",
+    "playbook_health",
     "push_compatibility",
     "push_count",
     "pushes",
@@ -170,6 +171,14 @@
       "gaps",
       "ok",
       "registry_version",
+      "safe_to_share",
+      "sections",
+      "source",
+      "summary"
+    ],
+    "playbook_health": [
+      "gaps",
+      "ok",
       "safe_to_share",
       "sections",
       "source",

--- a/mb/tests/test_ranker.py
+++ b/mb/tests/test_ranker.py
@@ -104,3 +104,23 @@ def test_ranker_uses_github_status_sections() -> None:
     assert actions[0]["id"] == "review_github_attention"
     assert actions[0]["signals"][0]["evidence"] == ["#12: Review proposal"]
     assert actions[0]["safe_to_share"] is False
+
+
+def test_ranker_surfaces_playbook_health() -> None:
+    report = _base_report()
+    report["playbook_health"] = {
+        "gaps": [
+            {
+                "id": "pushes_without_playbook",
+                "severity": "warn",
+                "summary": "1 active/planned push(es) need a playbook run.",
+                "safe_to_share": True,
+            }
+        ]
+    }
+
+    actions = ranker.rank_status_report(report)
+
+    assert actions[0]["id"] == "review_playbook_health"
+    assert actions[0]["signals"][0]["id"] == "playbook_health.gaps"
+    assert actions[0]["signals"][0]["evidence"] == ["pushes_without_playbook"]

--- a/mb/tests/test_status.py
+++ b/mb/tests/test_status.py
@@ -54,6 +54,85 @@ def _commit(repo: Path, relative_path: str, content: str, subject: str, body: st
     assert result.returncode == 0, result.stderr
 
 
+def _write_push(
+    repo: Path,
+    slug: str,
+    *,
+    status: str = "active",
+    offer: str = "core/offers/coaching/offer.md",
+) -> Path:
+    push = repo / "pushes" / slug
+    push.mkdir(parents=True, exist_ok=True)
+    (push / "push.md").write_text(
+        (
+            "---\n"
+            "type: push\n"
+            f"slug: {slug[11:]}\n"
+            "kind: launch\n"
+            f"status: {status}\n"
+            "health: on-track\n"
+            "goal:\n"
+            "  metric: booked calls\n"
+            "  target: 5 booked calls\n"
+            "  by: 2026-05-20\n"
+            "owner: Operator\n"
+            "audience: founders\n"
+            f"offer: {offer}\n"
+            "promise: Ship a sanitized launch.\n"
+            "started: 2026-05-06\n"
+            "review_on: 2026-05-20\n"
+            "---\n\n"
+            "# Launch push\n"
+        ),
+        encoding="utf-8",
+    )
+    return push
+
+
+def _write_playbook(
+    push: Path,
+    *,
+    status: str = "active",
+    provider_boundary: str = "candidate-adapter",
+    approval_status: str = "approved",
+    linked_outcomes: str = "[]",
+) -> None:
+    playbooks = push / "playbooks"
+    playbooks.mkdir(parents=True, exist_ok=True)
+    (playbooks / "launch.md").write_text(
+        (
+            "---\n"
+            "type: playbook\n"
+            f"status: {status}\n"
+            "push: ../push.md\n"
+            "platform: email\n"
+            "provider: manual\n"
+            f"provider_boundary: {provider_boundary}\n"
+            "trigger:\n"
+            "  kind: operator_launch_request\n"
+            "resource:\n"
+            "  kind: document\n"
+            "  value: documents/launch.md\n"
+            "approval:\n"
+            "  required: true\n"
+            f"  status: {approval_status}\n"
+            "  approved_by: Operator\n"
+            "  approved_at: 2026-05-06\n"
+            "state:\n"
+            "  provider_refs: []\n"
+            "  activated_at:\n"
+            "  retired_at:\n"
+            "validation:\n"
+            "  dry_run: passed\n"
+            "  smoke_evidence: []\n"
+            f"linked_outcomes: {linked_outcomes}\n"
+            "---\n\n"
+            "# Launch playbook\n"
+        ),
+        encoding="utf-8",
+    )
+
+
 def test_status_json_degrades_without_github(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
     repo = tmp_path / "acme"
@@ -125,6 +204,7 @@ def test_status_schema_v1_matches_golden_fixture(tmp_path: Path, monkeypatch) ->
                 "drift",
                 "readiness",
                 "relationship_health",
+                "playbook_health",
                 "ranked_actions",
                 "marker_update",
             ]
@@ -186,6 +266,96 @@ def test_status_json_exposes_push_and_legacy_campaign_facts(tmp_path: Path, monk
         "pushes/2026-05-06-workshop/push.md",
         "campaigns/2026-05-legacy/campaign.md",
     }
+
+
+def test_status_playbook_health_accepts_healthy_active_push_playbook(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+    offer = repo / "core" / "offers" / "coaching"
+    offer.mkdir(parents=True)
+    (offer / "offer.md").write_text(
+        "---\nslug: coaching\nstatus: running\n---\n\n# Coaching\n",
+        encoding="utf-8",
+    )
+    push = _write_push(repo, "2026-05-06-launch")
+    _write_playbook(push, status="active", approval_status="approved")
+
+    report = status_mod.run(path=str(repo), update_marker=False)
+
+    health = report["playbook_health"]
+    assert health["ok"] is True
+    assert health["summary"]["playbooks"] == 1
+    assert health["summary"]["pushes_without_playbook"] == 0
+    assert health["summary"]["pending_playbook_statuses"] == 0
+    assert health["summary"]["playbook_approval_needed"] == 0
+    assert health["gaps"] == []
+
+    human = runner.invoke(app, ["status", str(repo), "--no-color", "--peek"])
+    assert human.exit_code == 0
+    assert "Playbook health" not in human.stdout
+
+
+def test_status_playbook_health_flags_active_push_without_playbook(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+    push = _write_push(repo, "2026-05-06-launch")
+
+    result = runner.invoke(app, ["status", str(repo), "--json", "--peek"])
+
+    assert result.exit_code == 0
+    report = json.loads(result.stdout)
+    health = report["playbook_health"]
+    assert health["ok"] is False
+    assert health["summary"]["pushes_without_playbook"] == 1
+    assert health["sections"]["pushes"]["without_playbook"][0]["path"] == (
+        "pushes/2026-05-06-launch/push.md"
+    )
+    assert any(item["id"] == "playbook_health_gaps" for item in report["drift"]["items"])
+    assert any(action["id"] == "review_playbook_health" for action in report["ranked_actions"])
+
+    human = runner.invoke(app, ["status", str(repo), "--no-color", "--peek"])
+
+    assert human.exit_code == 0
+    assert "Playbook health" in human.stdout
+    assert "active/planned push(es) need a playbook run" in human.stdout
+    assert push.is_dir()
+
+
+def test_status_playbook_health_flags_pending_and_completed_without_outcome(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+    planned = _write_push(repo, "2026-05-06-planned", status="planned")
+    _write_playbook(
+        planned,
+        status="draft",
+        provider_boundary="plan-only",
+        approval_status="needed",
+    )
+    completed = _write_push(repo, "2026-05-07-completed", status="completed")
+    _write_playbook(completed, status="completed", approval_status="approved")
+
+    report = status_mod.run(path=str(repo), update_marker=False)
+
+    health = report["playbook_health"]
+    assert health["summary"]["pending_playbook_statuses"] == 1
+    assert health["summary"]["playbook_approval_needed"] == 1
+    assert health["summary"]["completed_playbooks_without_outcome"] == 1
+    assert health["summary"]["manual_provider_boundaries"] == 1
+    assert health["sections"]["playbooks"]["pending_status"][0]["path"] == (
+        "pushes/2026-05-06-planned/playbooks/launch.md"
+    )
+    assert health["sections"]["playbooks"]["completed_without_outcome"][0]["path"] == (
+        "pushes/2026-05-07-completed/playbooks/launch.md"
+    )
 
 
 def test_status_relationship_health_flags_active_bet_and_offer_gaps(

--- a/mb/tests/test_status.py
+++ b/mb/tests/test_status.py
@@ -358,6 +358,28 @@ def test_status_playbook_health_flags_pending_and_completed_without_outcome(
     )
 
 
+def test_status_playbook_health_ignores_retired_playbook_approval(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+    push = _write_push(repo, "2026-05-06-launch")
+    _write_playbook(
+        push,
+        status="retired",
+        provider_boundary="plan-only",
+        approval_status="",
+    )
+
+    report = status_mod.run(path=str(repo), update_marker=False)
+
+    health = report["playbook_health"]
+    assert health["summary"]["playbook_approval_needed"] == 0
+    assert health["summary"]["manual_provider_boundaries"] == 0
+    assert health["gaps"] == []
+
+
 def test_status_relationship_health_flags_active_bet_and_offer_gaps(
     tmp_path: Path, monkeypatch
 ) -> None:


### PR DESCRIPTION
## Summary

- Adds `playbook_health` to `mb status --json --peek` for push playbook run records under `pushes/<push>/playbooks/`.
- Surfaces concise human status, drift, readiness, and ranked-action signals when playbook health needs operator attention.
- Tracks missing playbooks for active/planned pushes, draft/planned run states, approval gaps, completed pushes without outcome links, and plan/manual provider boundaries.
- Keeps `mb validate` as the hard schema authority while making `mb status` useful for daily-loop playbook health.
- Updates tests, the status schema fixture, and `CHANGELOG.md`.

## Scope

In:
- Additive status JSON and human output for push playbook health.
- Focused tests for healthy, missing, pending, completed-without-outcome, manual-boundary, and retired playbook cases.
- Ranked action and drift/readiness integration for actionable playbook signals.

Out:
- Provider account mutation or automation.
- Google Ads/GTM automation.
- Dashboard UI.
- New playbook schema design.
- First-class graph nodes for reusable engine playbook blueprints.

## Commits

- `f2e4cbb` — `[add] MAIN-301 surface playbook health in status`
- `a5bbd98` — `[fix] MAIN-301 ignore retired playbook approvals`

## Release / Issues

- Release: Unreleased; no Linear Release assigned.
- Linear ID(s): MAIN-301.
- Closes: #446.
- Refs: #350, #414, #425, #418.
- Follow-ups: None identified.

## Success Metric

- `mb status --json --peek` exposes safe, additive playbook-health facts, and human `mb status` only surfaces playbook gaps when there is an actionable daily-loop signal.

## Validation

- Level 0 docs/decision: `CHANGELOG.md` updated under `[Unreleased]`.
- Level 1 static: `scripts/check.sh` passed from repo root, including format, Ruff, mypy, and skill validation.
- Level 2 CLI: `scripts/check.sh` passed with 469 pytest tests; focused `tests/test_status.py` and `tests/test_ranker.py` cover the new status/ranker behavior.
- Level 3 package/install: Not run; packaging and bundled data were not changed.
- Level 4 fixture repo: Covered by sanitized status fixtures and temp repo tests.
- Level 5 runtime smoke: Not run; Claude Code skill discovery and runtime invocation were not changed.

## Public / Private Boundary

- No private Devon, Conductor, runtime, customer, provider account, or local machine details were committed; `.context/` remains local scratch only.
