### PR TITLE
[add] Experimental Codex CLI adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ### Added
 
+- Added the first experimental Codex CLI-first adapter slice: fresh business
+  repos now get a tracked `AGENTS.md` Codex entrypoint, `mb start --json` and
+  `mb status --json` expose Codex readiness facts, and
+  `mb doctor repair --plan` / `--apply` can report and refresh stale Codex
+  instructions. This does not claim Codex slash-command or workflow parity.
+  Refs #405.
 - Added push playbook health facts to `mb status --json --peek`, plus concise
   human and ranked-action signals when active pushes are missing run records,
   playbook approval/status is pending, completed pushes lack outcome links, or

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Open source. Lives on your machine. Bring your own Claude Code plan. That's it.
 ---
 
 <div align="center">
-  <em>Works with</em> <strong>Claude Code today</strong>. Codex, Cursor, OpenClaw, Hermes, and local runtimes are compatibility targets, not supported yet — see <a href="docs/compatibility.md">compatibility</a>.
+  <em>Works with</em> <strong>Claude Code today</strong>. Codex CLI has an experimental CLI-first adapter for power users; Cursor, OpenClaw, Hermes, and local runtimes remain compatibility targets — see <a href="docs/compatibility.md">compatibility</a>.
 </div>
 
 ---

--- a/README.md
+++ b/README.md
@@ -147,6 +147,38 @@ claude
 
 You'll need a Claude plan that includes Claude Code. Install Claude Code from [claude.ai](https://claude.ai). Step-by-step beginner walkthrough: [docs/BEGINNER-SETUP.md](docs/BEGINNER-SETUP.md).
 
+### Trying Codex CLI
+
+Codex CLI support is experimental and CLI-first. Fresh business folders include
+an `AGENTS.md` file that tells Codex how to start from Main Branch facts. Expect
+Codex to run `mb status --json --peek`, `mb start --json`, and
+`mb doctor repair --plan`, then translate those facts into a useful owner
+briefing. Do not expect Claude Code slash commands such as `/mb-start` to work
+inside Codex yet.
+
+After installing Codex CLI, test a new repo with:
+
+```bash
+mb onboard --yes --name "Codex Smoke Business" --path codex-smoke-business
+cd codex-smoke-business
+codex
+```
+
+Ask Codex to start the business day from read-only `mb` facts and to ask before
+writing files.
+
+For a read-only smoke test:
+
+```bash
+codex exec --json --ephemeral --sandbox read-only -c 'approval_policy="never"' -C . \
+  'Start this Main Branch business day. Run only read-only mb checks and do not edit files.'
+git status --short
+```
+
+The smoke passes when Codex uses the `mb` fact commands and `git status --short`
+stays clean. See [docs/compatibility.md](docs/compatibility.md) for the current
+support boundary.
+
 Tested on macOS and Linux. Windows is experimental — use WSL2.
 
 ---

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -42,8 +42,9 @@ Main Branch already ships:
   team daily log, bookkeeping, and multi-repo work;
 - initial paid-traffic site readiness checks through `mb site check`.
 
-Claude Code is the supported runtime today. Other runtimes are compatibility
-targets until adapter code and smoke evidence exist.
+Claude Code is the supported runtime today. Codex CLI has an experimental
+CLI-first adapter; other runtimes are compatibility targets until adapter code
+and smoke evidence exist.
 
 ## Current Direction: Make The Daily Loop Boring
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -14,7 +14,8 @@ This page is the public compatibility contract for that surface.
 | Install mode | `pipx install mainbranch` | Canonical public install path. |
 | Developer mode | Git clone | For contributors who want to edit the engine or skills. |
 | Agent runtime | Claude Code | First-class today. |
-| Codex, Cursor, OpenClaw, Hermes, Paperclip-adjacent orchestration, local LLMs | Roadmap | `mb` is runtime-agnostic by design, but these adapters are not supported yet. |
+| Codex CLI | Experimental CLI-first adapter | Fresh business repos include `AGENTS.md`; `mb status`, `mb start`, and `mb doctor repair` expose Codex readiness. This is not slash-command parity. |
+| Cursor, OpenClaw, Hermes, Paperclip-adjacent orchestration, local LLMs | Roadmap | `mb` is runtime-agnostic by design, but these adapters are not supported yet. |
 
 **Windows tip — try WSL2.** If you're on Windows and want a working setup today, use [Windows Subsystem for Linux 2 (WSL2)](https://learn.microsoft.com/en-us/windows/wsl/install). Inside WSL2, follow the supported Linux flow. The pipx install path works there.
 
@@ -143,7 +144,7 @@ smoke evidence exist.
 | Runtime surface | Status | Invocation | Skill/workflow discovery | Routing and automation | Observability and packaging |
 |---|---|---|---|---|---|
 | Claude Code | Supported | `mb start --repo "$repo"` prints the `claude` handoff; `mb start --launch` may launch after readiness checks. | `mb skill link --repo "$repo"` writes project-local `.claude/skills/mb-*` bridge links and `.claude/settings.local.json`. | Slash commands such as `/mb-start` and `/mb-think` own conversation and judgment; they call deterministic `mb` commands for facts. | `mb doctor`, `mb status --json`, `mb start --json`, `mb skill repair`, and runtime dogfood evidence gate release claims. Skills ship inside the Python package today. |
-| Codex | Roadmap | Can call deterministic `mb` commands as a subprocess when pointed at a business repo. | No supported Main Branch Codex adapter or workflow packaging yet. | No supported routing contract. Any use is manual or contributor experimentation. | Needs adapter docs, generated-file rules, and fresh-repo smoke before experimental/support status. |
+| Codex CLI | Experimental | Can call deterministic `mb` commands as a subprocess when pointed at a business repo. `AGENTS.md` gives Codex a CLI-first start workflow. | Fresh `mb onboard` repos include tracked `AGENTS.md`; `mb doctor repair --plan` / `--apply` can report and refresh it. No `.agents/skills` parity is claimed yet. | Codex should run `mb status --json --peek`, `mb start --json`, and `mb doctor repair --plan` before advice, translate facts into business language, and ask before writes. | `mb doctor`, `mb status --json`, and `mb start --json` expose Codex readiness. Support remains experimental until repeated fresh-repo smoke evidence covers selected workflows. |
 | Cursor | Roadmap | Can call deterministic `mb` commands from terminal/tasks when pointed at a business repo. | No supported Cursor rules/package adapter yet. | No supported Main Branch routing contract. | Needs adapter docs, install/update rules, conflict handling, and smoke evidence. |
 | OpenClaw | Roadmap | Target public runtime surface. It should call `mb` through stable CLI/JSON commands rather than clone-era paths. | No supported OpenClaw adapter yet. | Main Branch should coexist with OpenClaw as the business repo/GitHub memory layer, not replace it. | Needs explicit adapter shape, migration notes, generated-file rules, and smoke evidence. |
 | Hermes | Roadmap | Target runtime/memory surface. It may supervise or host workflows that call packaged `mb` commands. | No supported Hermes adapter yet. | Hermes-specific routing belongs in the Hermes adapter, while `mb` remains deterministic and non-conversational. | Docs may describe internal-package expectations generically, but not as the only blessed public path. Smoke evidence is required before support claims. |
@@ -158,8 +159,8 @@ support levels:
 | Surface | Claude Code | Other runtimes and orchestrators |
 |---|---|---|
 | Deterministic CLI facts (`mb status --json`, `mb validate --json`, `mb graph --json`, `mb connect status --json`) | Supported when `mb` is installed and pointed at a business repo. | Callable as packaged CLI subprocesses, but this does not make the hosting runtime supported. |
-| Runtime handoff (`mb start --json`, `mb start --launch`) | Supported for Claude Code handoff and launch readiness. | Roadmap. New adapters must define their own handoff metadata and smoke evidence. |
-| Lifecycle slash skills (`/mb-start`, `/mb-status`, `/mb-setup`, `/mb-update`, `/mb-end`, `/mb-help`) | Supported through Claude Code project-local skill discovery. | Roadmap. Markdown readability is not adapter support. |
+| Runtime handoff (`mb start --json`, `mb start --launch`) | Supported for Claude Code handoff and launch readiness. | Codex CLI handoff metadata is experimental and read-only: `mb start --json` reports Codex executable and `AGENTS.md` readiness. `mb` does not launch Codex. |
+| Lifecycle slash skills (`/mb-start`, `/mb-status`, `/mb-setup`, `/mb-update`, `/mb-end`, `/mb-help`) | Supported through Claude Code project-local skill discovery. | Codex has a generated `AGENTS.md` start workflow that ports `/mb-start` as instructions, not slash commands. Other lifecycle workflows remain roadmap. |
 | Production slash skills (`/mb-think`, `/mb-ads`, `/mb-vsl`, `/mb-organic`, `/mb-site`, `/mb-wiki`, `/mb-bet`) | Supported through Claude Code skills, subject to each skill's provider and workflow limits. | Roadmap. Cursor rules, Codex prompts, OpenClaw workflows, Hermes packages, Paperclip routines, or local-runtime prompts need their own adapter/package contract before public support claims. |
 | Automation routines | May call CLI commands before handing judgment work to Claude Code. | May call shipped deterministic CLI commands against an explicit repo path. Conversation, retries, routing, and model invocation belong to the runtime adapter, not `mb`. |
 
@@ -178,10 +179,11 @@ document:
 That evidence should prove the runtime reads the business repo and does not
 write runtime state, credentials, or raw account data into tracked files.
 
-For the proposed Codex staging plan, see
-[Codex Adapter Plan](../decisions/2026-05-08-codex-adapter-plan.md). It does
-not change Codex's roadmap status; it names the evidence required before any
-experimental or supported claim.
+For the Codex staging plan, see
+[Codex Adapter Plan](../decisions/2026-05-08-codex-adapter-plan.md). The current
+implementation is the first experimental CLI-first slice: generated
+`AGENTS.md`, deterministic readiness facts, and doctor repair coverage. It does
+not claim supported Codex parity.
 
 ## Recommended setup
 
@@ -245,6 +247,9 @@ mb doctor
 ## Known Limits
 
 - Claude Code is the only first-class agent runtime today.
+- Codex CLI support is experimental and CLI-first: generated `AGENTS.md` can
+  orient Codex to `mb` facts, but Main Branch does not claim Codex slash-command
+  or workflow parity.
 - Windows is experimental.
 - Skills are bundled into the installed Python package, so public users update
   skills by upgrading `mainbranch`.

--- a/mb/mb/_data/templates/AGENTS.md.tmpl
+++ b/mb/mb/_data/templates/AGENTS.md.tmpl
@@ -1,0 +1,110 @@
+# {{BUSINESS_NAME}}
+
+Main Branch business repo instructions for Codex.
+
+## Codex Operating Contract
+
+Main Branch CLI facts are the source of truth for repo health, setup, runtime
+wiring, updates, graph/status signals, provider readiness, and repair paths.
+When the operator asks to start, begin, get oriented, triage the day, or decide
+what to do next, use this Codex-native start workflow. Do not pretend Claude
+Code slash commands exist in Codex.
+
+Start in this repo. Before setup, routing, migration, update, or repair advice,
+run the read-only checks that fit the situation:
+
+```bash
+mb --version
+mb status --json --peek
+mb start --json
+mb doctor repair --plan
+```
+
+Use `mb status --json --peek` as the default daily briefing before routing the
+operator. It names readiness, drift, onboarding progress, update state, GitHub
+activity, provider signals, recent work, ranked actions, bets, pushes, and
+checkpoint state. Do not replace those facts with ad hoc shell inspection unless
+`mb` says a section is unavailable or the command itself is missing.
+
+Read-only commands can be run without asking first. Commands that write files,
+refresh local runtime wiring, update packages, migrate business files, create
+checkpoints, publish, spend money, contact customers, email, or mutate provider
+accounts require explicit operator approval before applying.
+
+Do the technical work in technical commands, then translate the result back into
+business-owner language. Speak first in terms of bets, goals, offers, pushes,
+playbooks, outcomes, decisions, next actions, and saved checkpoints. Treat git,
+branches, pull requests, provider refs, and local wiring as the hidden memory
+layer unless the operator asks for the plumbing.
+
+## Codex Start Workflow
+
+This is the Codex-native port of `/mb-start`. It is a workflow, not a slash
+command.
+
+1. Run `mb status --json --peek` from the current working directory. Use the
+   repo markers in that JSON to confirm this is the business repo. If the
+   status report says this is not a Main Branch repo or the command is missing,
+   ask for the business repo path instead of guessing.
+2. Use the status JSON as the source of truth for
+   readiness, drift, onboarding, update severity, GitHub facts, provider
+   readiness, recent work, ranked actions, bets, pushes, and checkpoint state.
+3. Run `mb start --json` when you need runtime handoff, repo-boundary, or
+   adapter-readiness facts.
+4. Run `mb doctor repair --plan` before recommending setup or repair. Quote the
+   exact repair command from the plan. Ask before any write/apply command.
+5. If status says an update is required, route to the cited `mb update` command
+   and ask before running it. After an approved update, rerun
+   `mb status --json --peek`.
+6. Resume onboarding from status facts. In rich repos, read existing `core/`
+   files before asking bounded missing-profile questions.
+7. Present one clear business route: frame a bet, think through a decision,
+   advance a push, draft a playbook, repair the repo, review provider
+   readiness, save a checkpoint, or inspect a specific offer.
+
+Use numbered lists for operator choices, with one active choice namespace per
+turn. If the operator replies with an ambiguous number, ask what they meant
+before acting.
+
+## Routing Rules
+
+- If `ranked_actions` has entries, lead with the first action, its reason, and
+  the cited signal summaries.
+- If readiness is blocked or drift has errors, handle repair before output
+  work.
+- If onboarding is incomplete, use the `onboarding.summary` and checklist from
+  status instead of inventing a setup interview.
+- If legacy `campaigns/` records exist, surface the doctor warning and suggest
+  `mb migrate campaigns --plan` before creating new coordinated work.
+- If the operator asks for publishing, spend, provider mutation, customer
+  contact, migration, checkpoint creation, or file writes, plan first and ask
+  for explicit approval.
+- If the operator brings a live idea and it is unclear where it belongs, route
+  by business meaning: offers are what the business may keep selling; bets are
+  time-boxed wagers; pushes are coordinated execution; proof is evidence; and
+  decisions explain durable changes.
+
+## Business Folders
+
+- `core/` - the business brain: offer, audience, voice, soul, proof, brand,
+  strategy, operations, finance.
+- `core/offers/` - per-offer specifics when this is a multi-offer repo.
+- `core/proof/` - testimonials, typicality, and reusable proof.
+- `research/` - dated notes from when you went looking.
+- `decisions/` - dated choices, with rationale.
+- `bets/` - operating bets with appetite, metric, target, and outcome.
+- `pushes/` - coordinated pushes such as launches, drops, challenges, promos.
+- `log/` - running activity log.
+- `documents/` - anything that does not belong above.
+
+## Connected Accounts
+
+Never commit API keys, OAuth refresh tokens, service-account JSON, webhook
+secrets, MCP tokens, or bearer tokens. Keep secrets in the runtime's local
+config, an OS keychain, 1Password, `.env`, or another gitignored local file. If
+a tool can spend money, publish, email, or mutate a customer account, verify it
+is tethered to this repo and ask for approval before using it.
+
+## Repo Owner
+
+`@{{GH_USERNAME}}`

--- a/mb/mb/codex.py
+++ b/mb/mb/codex.py
@@ -1,0 +1,307 @@
+"""Experimental Codex CLI-first adapter helpers.
+
+Codex support starts with repo instructions and deterministic ``mb`` facts.
+This module intentionally does not invoke Codex or manage model conversation.
+"""
+
+from __future__ import annotations
+
+import shlex
+import shutil
+from importlib import resources
+from pathlib import Path
+from typing import Any
+
+AGENTS_TEMPLATE = "AGENTS.md.tmpl"
+AGENTS_RELATIVE_PATH = "AGENTS.md"
+REQUIRED_FACT_COMMANDS = (
+    "mb status --json --peek",
+    "mb start --json",
+    "mb doctor repair --plan",
+)
+
+
+_DEFAULT_AGENTS = """\
+# {{BUSINESS_NAME}}
+
+Main Branch business repo instructions for Codex.
+
+## Codex Operating Contract
+
+Main Branch CLI facts are the source of truth for repo health, setup, runtime
+wiring, updates, graph/status signals, provider readiness, and repair paths.
+When the operator asks to start, begin, get oriented, triage the day, or decide
+what to do next, use this Codex-native start workflow. Do not pretend Claude
+Code slash commands exist in Codex.
+
+Start in this repo. Before setup, routing, migration, update, or repair advice,
+run the read-only checks that fit the situation:
+
+```bash
+mb --version
+mb status --json --peek
+mb start --json
+mb doctor repair --plan
+```
+
+Use `mb status --json --peek` as the default daily briefing before routing the
+operator. It names readiness, drift, onboarding progress, update state, GitHub
+activity, provider signals, recent work, ranked actions, bets, pushes, and
+checkpoint state. Do not replace those facts with ad hoc shell inspection unless
+`mb` says a section is unavailable or the command itself is missing.
+
+Read-only commands can be run without asking first. Commands that write files,
+refresh local runtime wiring, update packages, migrate business files, create
+checkpoints, publish, spend money, contact customers, email, or mutate provider
+accounts require explicit operator approval before applying.
+
+Do the technical work in technical commands, then translate the result back into
+business-owner language. Speak first in terms of bets, goals, offers, pushes,
+playbooks, outcomes, decisions, next actions, and saved checkpoints. Treat git,
+branches, pull requests, provider refs, and local wiring as the hidden memory
+layer unless the operator asks for the plumbing.
+
+## Codex Start Workflow
+
+This is the Codex-native port of `/mb-start`. It is a workflow, not a slash
+command.
+
+1. Run `mb status --json --peek` from the current working directory. Use the
+   repo markers in that JSON to confirm this is the business repo. If the
+   status report says this is not a Main Branch repo or the command is missing,
+   ask for the business repo path instead of guessing.
+2. Use the status JSON as the source of truth for
+   readiness, drift, onboarding, update severity, GitHub facts, provider
+   readiness, recent work, ranked actions, bets, pushes, and checkpoint state.
+3. Run `mb start --json` when you need runtime handoff, repo-boundary, or
+   adapter-readiness facts.
+4. Run `mb doctor repair --plan` before recommending setup or repair. Quote the
+   exact repair command from the plan. Ask before any write/apply command.
+5. If status says an update is required, route to the cited `mb update` command
+   and ask before running it. After an approved update, rerun
+   `mb status --json --peek`.
+6. Resume onboarding from status facts. In rich repos, read existing `core/`
+   files before asking bounded missing-profile questions.
+7. Present one clear business route: frame a bet, think through a decision,
+   advance a push, draft a playbook, repair the repo, review provider
+   readiness, save a checkpoint, or inspect a specific offer.
+
+Use numbered lists for operator choices, with one active choice namespace per
+turn. If the operator replies with an ambiguous number, ask what they meant
+before acting.
+
+## Routing Rules
+
+- If `ranked_actions` has entries, lead with the first action, its reason, and
+  the cited signal summaries.
+- If readiness is blocked or drift has errors, handle repair before output
+  work.
+- If onboarding is incomplete, use the `onboarding.summary` and checklist from
+  status instead of inventing a setup interview.
+- If legacy `campaigns/` records exist, surface the doctor warning and suggest
+  `mb migrate campaigns --plan` before creating new coordinated work.
+- If the operator asks for publishing, spend, provider mutation, customer
+  contact, migration, checkpoint creation, or file writes, plan first and ask
+  for explicit approval.
+- If the operator brings a live idea and it is unclear where it belongs, route
+  by business meaning: offers are what the business may keep selling; bets are
+  time-boxed wagers; pushes are coordinated execution; proof is evidence; and
+  decisions explain durable changes.
+
+## Business Folders
+
+- `core/` - the business brain: offer, audience, voice, soul, proof, brand,
+  strategy, operations, finance.
+- `core/offers/` - per-offer specifics when this is a multi-offer repo.
+- `core/proof/` - testimonials, typicality, and reusable proof.
+- `research/` - dated notes from when you went looking.
+- `decisions/` - dated choices, with rationale.
+- `bets/` - operating bets with appetite, metric, target, and outcome.
+- `pushes/` - coordinated pushes such as launches, drops, challenges, promos.
+- `log/` - running activity log.
+- `documents/` - anything that does not belong above.
+
+## Connected Accounts
+
+Never commit API keys, OAuth refresh tokens, service-account JSON, webhook
+secrets, MCP tokens, or bearer tokens. Keep secrets in the runtime's local
+config, an OS keychain, 1Password, `.env`, or another gitignored local file. If
+a tool can spend money, publish, email, or mutate a customer account, verify it
+is tethered to this repo and ask for approval before using it.
+
+## Repo Owner
+
+`@{{GH_USERNAME}}`
+"""
+
+
+def _read_template(name: str) -> str:
+    try:
+        ref = resources.files("mb").joinpath("_data").joinpath("templates").joinpath(name)
+        return ref.read_text(encoding="utf-8")
+    except (FileNotFoundError, ModuleNotFoundError, AttributeError):
+        here = Path(__file__).resolve().parent / "_data" / "templates" / name
+        if here.exists():
+            return here.read_text(encoding="utf-8")
+        return ""
+
+
+def _render(text: str, mapping: dict[str, str]) -> str:
+    out = text
+    for key, val in mapping.items():
+        out = out.replace("{{" + key + "}}", val)
+    return out
+
+
+def _which(name: str) -> str:
+    return shutil.which(name) or ""
+
+
+def _markdown_h1(path: Path) -> str:
+    try:
+        for line in path.read_text(encoding="utf-8").splitlines():
+            stripped = line.strip()
+            if stripped.startswith("# "):
+                return stripped[2:].strip()
+    except OSError:
+        return ""
+    return ""
+
+
+def _repo_owner(repo: Path) -> str:
+    codeowners = repo / ".github" / "CODEOWNERS"
+    try:
+        for raw_line in codeowners.read_text(encoding="utf-8").splitlines():
+            line = raw_line.strip()
+            if not line or line.startswith("#"):
+                continue
+            parts = line.split()
+            for part in parts[1:]:
+                if part.startswith("@"):
+                    return part.removeprefix("@")
+    except OSError:
+        pass
+    agents = repo / AGENTS_RELATIVE_PATH
+    try:
+        lines = agents.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return "your-gh-username"
+    for line in lines:
+        stripped = line.strip().strip("`")
+        if stripped.startswith("@") and " " not in stripped:
+            return stripped.removeprefix("@")
+    return "your-gh-username"
+
+
+def business_name(repo: str | Path) -> str:
+    target = Path(repo).expanduser().resolve()
+    for relative in ("CLAUDE.md", "AGENTS.md"):
+        name = _markdown_h1(target / relative)
+        if name and "instructions" not in name.lower():
+            return name
+    return target.name or "Business"
+
+
+def render_agents_md(repo: str | Path, *, name: str = "", gh_username: str = "") -> str:
+    target = Path(repo).expanduser().resolve()
+    template = _read_template(AGENTS_TEMPLATE) or _DEFAULT_AGENTS
+    mapping = {
+        "BUSINESS_NAME": name.strip() or business_name(target),
+        "GH_USERNAME": gh_username.strip() or _repo_owner(target),
+    }
+    return _render(template, mapping)
+
+
+def agents_path(repo: str | Path) -> Path:
+    return Path(repo).expanduser().resolve() / AGENTS_RELATIVE_PATH
+
+
+def executable_status() -> dict[str, Any]:
+    path = _which("codex")
+    return {
+        "found": bool(path),
+        "path": path,
+        "executable": "codex",
+        "repair": "" if path else "Install Codex CLI before using the experimental Codex adapter.",
+    }
+
+
+def instructions_status(repo: str | Path) -> dict[str, Any]:
+    target = Path(repo).expanduser().resolve()
+    path = agents_path(target)
+    expected = render_agents_md(target)
+    exists = path.is_file()
+    try:
+        text = path.read_text(encoding="utf-8") if exists else ""
+    except OSError as exc:
+        text = ""
+        read_error = str(exc)
+    else:
+        read_error = ""
+    missing_commands = [command for command in REQUIRED_FACT_COMMANDS if command not in text]
+    approval_ok = "explicit operator approval" in text
+    slash_ok = "Do not pretend Claude" in text and "slash commands exist in Codex." in text
+    current = bool(exists and text == expected)
+    fact_grounding_ok = bool(exists and not missing_commands and approval_ok and slash_ok)
+    return {
+        "ok": bool(current and fact_grounding_ok),
+        "exists": exists,
+        "current": current,
+        "fact_grounding_ok": fact_grounding_ok,
+        "path": AGENTS_RELATIVE_PATH,
+        "absolute_path": str(path),
+        "missing_fact_commands": missing_commands,
+        "approval_boundary_ok": approval_ok,
+        "codex_native_ok": slash_ok,
+        "repair": ""
+        if current and fact_grounding_ok
+        else "Run `mb doctor repair --plan`, review, then `mb doctor repair --apply`.",
+        "repair_command": "mb doctor repair --apply",
+        "read_error": read_error,
+        "safe_to_share": True,
+    }
+
+
+def readiness(repo: str | Path) -> dict[str, Any]:
+    executable = executable_status()
+    instructions = instructions_status(repo)
+    ok = bool(executable["found"] and instructions["ok"])
+    return {
+        "ok": ok,
+        "status": "ready" if ok else "needs_setup",
+        "support_level": "experimental_cli_first_adapter",
+        "executable": executable,
+        "instructions": instructions,
+        "fact_commands": list(REQUIRED_FACT_COMMANDS),
+        "repair": "" if ok else instructions["repair"] or executable["repair"],
+        "start_command": f"codex -C {shlex.quote(str(Path(repo).expanduser().resolve()))}",
+        "smoke_command": (
+            "codex exec --json --ephemeral --sandbox read-only "
+            "-c 'approval_policy=\"never\"' "
+            f"-C {shlex.quote(str(Path(repo).expanduser().resolve()))} "
+            "'Start this Main Branch business day. Run only read-only mb checks "
+            "and do not edit files.'"
+        ),
+        "safe_to_share": True,
+    }
+
+
+def write_agents_md(
+    repo: str | Path,
+    *,
+    name: str = "",
+    gh_username: str = "",
+) -> dict[str, Any]:
+    target = Path(repo).expanduser().resolve()
+    path = agents_path(target)
+    rendered = render_agents_md(target, name=name, gh_username=gh_username)
+    existing = path.read_text(encoding="utf-8") if path.exists() else ""
+    changed = existing != rendered
+    if changed:
+        path.write_text(rendered, encoding="utf-8")
+    return {
+        "ok": True,
+        "path": AGENTS_RELATIVE_PATH,
+        "changed": changed,
+        "status": instructions_status(target),
+    }

--- a/mb/mb/codex.py
+++ b/mb/mb/codex.py
@@ -241,12 +241,14 @@ def instructions_status(repo: str | Path) -> dict[str, Any]:
     missing_commands = [command for command in REQUIRED_FACT_COMMANDS if command not in text]
     approval_ok = "explicit operator approval" in text
     slash_ok = "Do not pretend Claude" in text and "slash commands exist in Codex." in text
-    current = bool(exists and text == expected)
     fact_grounding_ok = bool(exists and not missing_commands and approval_ok and slash_ok)
+    template_match = bool(exists and text == expected)
+    current = fact_grounding_ok
     return {
-        "ok": bool(current and fact_grounding_ok),
+        "ok": fact_grounding_ok,
         "exists": exists,
         "current": current,
+        "template_match": template_match,
         "fact_grounding_ok": fact_grounding_ok,
         "path": AGENTS_RELATIVE_PATH,
         "absolute_path": str(path),
@@ -254,7 +256,7 @@ def instructions_status(repo: str | Path) -> dict[str, Any]:
         "approval_boundary_ok": approval_ok,
         "codex_native_ok": slash_ok,
         "repair": ""
-        if current and fact_grounding_ok
+        if fact_grounding_ok
         else "Run `mb doctor repair --plan`, review, then `mb doctor repair --apply`.",
         "repair_command": "mb doctor repair --apply",
         "read_error": read_error,

--- a/mb/mb/doctor.py
+++ b/mb/mb/doctor.py
@@ -22,6 +22,7 @@ from typing import Any
 import yaml
 
 from mb import checkpoint as checkpoint_mod
+from mb import codex as codex_mod
 from mb import connect as connect_mod
 from mb import engine as engine_mod
 from mb import graph as graph_mod
@@ -1289,6 +1290,36 @@ def run(path: str) -> dict[str, Any]:
         }
     )
 
+    codex_readiness = codex_mod.readiness(repo)
+    codex_executable = codex_readiness["executable"]
+    codex_instructions = codex_readiness["instructions"]
+    checks.append(
+        {
+            "name": "codex-cli",
+            "ok": bool(codex_executable["found"]),
+            "detail": codex_executable["path"] or "codex not on PATH",
+            "severity": "info",
+            "repair": codex_executable["repair"],
+            "safe_to_share": True,
+        }
+    )
+    checks.append(
+        {
+            "name": "codex-agents-md",
+            "ok": bool(codex_instructions["ok"]),
+            "detail": "AGENTS.md is current and points Codex to mb facts"
+            if codex_instructions["ok"]
+            else (
+                "AGENTS.md is missing, stale, or missing required mb fact commands. "
+                "Run `mb doctor repair --plan`, review, then `mb doctor repair --apply`."
+            ),
+            "severity": "ok" if codex_instructions["ok"] else "warn",
+            "repair": codex_instructions["repair"],
+            "safe_to_share": True,
+            "status": codex_instructions,
+        }
+    )
+
     gh_context = connect_mod.github_context(repo)
     integration_status = connect_mod.status_all(repo, github=gh_context)
     checks.append(
@@ -1945,6 +1976,55 @@ def repair_plan(
         )
     )
 
+    codex_status = codex_mod.readiness(target)
+    codex_instruction_status = codex_status["instructions"]
+    codex_checks = [
+        {
+            "name": "codex-cli",
+            "state": "ok" if codex_status["executable"]["found"] else "info",
+            "summary": codex_status["executable"]["path"] or "codex not on PATH",
+        },
+        {
+            "name": "AGENTS.md",
+            "state": "ok" if codex_instruction_status["ok"] else "warn",
+            "summary": (
+                "Codex instructions are current and include mb fact grounding"
+                if codex_instruction_status["ok"]
+                else "Codex instructions are missing, stale, or missing mb fact grounding"
+            ),
+            "missing_fact_commands": codex_instruction_status["missing_fact_commands"],
+            "approval_boundary_ok": codex_instruction_status["approval_boundary_ok"],
+            "codex_native_ok": codex_instruction_status["codex_native_ok"],
+        },
+    ]
+    codex_actions: list[dict[str, Any]] = []
+    if not codex_instruction_status["ok"]:
+        action = _action(
+            id="codex-agents-md",
+            title="Refresh Codex AGENTS.md instructions",
+            state="warn",
+            mode="write",
+            command="mb doctor repair --apply",
+            safe_to_apply=True,
+            reason=(
+                "AGENTS.md is the tracked Codex entrypoint; repair writes the current "
+                "CLI-first start workflow and approval boundaries"
+            ),
+            writes=["AGENTS.md"],
+        )
+        actions.append(action)
+        codex_actions.append(action)
+    sections.append(
+        _section(
+            "codex-wiring",
+            "Codex CLI Adapter",
+            _max_state([str(item["state"]) for item in codex_checks]),
+            "Experimental CLI-first adapter instructions and executable readiness",
+            checks=codex_checks,
+            actions=codex_actions,
+        )
+    )
+
     local_state = _local_state_summary(target)
     sections.append(
         _section(
@@ -2069,7 +2149,9 @@ def repair_plan(
             "runtime_smoke_required": (
                 "Static repair does not prove Claude Code runtime behavior. "
                 "From the business repo, run `claude`, confirm `/mb-start` is discoverable, "
-                "and verify it reads repo context without writing into the engine repo."
+                "and verify it reads repo context without writing into the engine repo. "
+                "For Codex, run read-only `codex exec --json --ephemeral --sandbox read-only "
+                "-c 'approval_policy=\"never\"' -C <repo>` and verify the repo stays clean."
             ),
             "git_review": [
                 "git status --short",
@@ -2204,6 +2286,24 @@ def repair_apply(repo: str | Path = ".", *, include_migration: bool = False) -> 
                 writes=[".claude/lenses/", ".claude/reference/", ".mb/backups/"],
                 applied=bool(repaired_links["moved"]),
                 result=repaired_links,
+            )
+        )
+
+    codex_instruction_status = codex_mod.instructions_status(target)
+    if not codex_instruction_status["ok"]:
+        agents = codex_mod.write_agents_md(target)
+        applied.append(
+            _action(
+                id="codex-agents-md",
+                title="Refreshed Codex AGENTS.md instructions",
+                state="ok" if agents["ok"] else "error",
+                mode="write",
+                command="mb doctor repair --apply",
+                safe_to_apply=True,
+                reason="wrote the current CLI-first Codex start workflow and approval boundaries",
+                writes=["AGENTS.md"],
+                applied=bool(agents["changed"]),
+                result=agents,
             )
         )
 

--- a/mb/mb/init.py
+++ b/mb/mb/init.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Any
 
 from mb import checkpoint as checkpoint_mod
+from mb import codex as codex_mod
 from mb.engine import link_skills
 from mb.migrate import LATEST_SCHEMA_VERSION, SCHEMA_MARKER
 
@@ -145,6 +146,14 @@ def run(path: str, name: str) -> dict[str, Any]:
     claude_tmpl = _read_template("CLAUDE.md.tmpl") or _DEFAULT_CLAUDE
     (target / "CLAUDE.md").write_text(_render(claude_tmpl, mapping), encoding="utf-8")
     created.append("CLAUDE.md")
+
+    agents_result = codex_mod.write_agents_md(
+        target,
+        name=business_name,
+        gh_username=gh_user,
+    )
+    if agents_result["changed"]:
+        created.append("AGENTS.md")
 
     vocabulary_tmpl = _read_template("core_vocabulary.md.tmpl")
     if vocabulary_tmpl:

--- a/mb/mb/start.py
+++ b/mb/mb/start.py
@@ -211,24 +211,24 @@ def _build_checks(
         )
     codex_executable = codex.get("executable") or {}
     codex_instructions = codex.get("instructions") or {}
+    codex_found = bool(codex_executable.get("found"))
     checks.extend(
         [
             {
                 "name": "codex_cli",
-                "ok": bool(codex_executable.get("found")),
+                "ok": codex_found,
                 "severity": "info",
                 "detail": codex_executable.get("path") or "codex not on PATH",
-                "repair": codex_executable.get("repair") or "",
+                "repair": "",
             },
             {
                 "name": "codex_agents_md",
                 "ok": bool(codex_instructions.get("ok")),
-                "severity": "warn",
+                "severity": "warn" if codex_found else "info",
                 "detail": "AGENTS.md is present and points Codex to mb facts"
                 if codex_instructions.get("ok")
                 else "AGENTS.md is missing, stale, or missing required mb fact commands",
-                "repair": codex_instructions.get("repair")
-                or "Run `mb doctor repair --plan`, then `mb doctor repair --apply`.",
+                "repair": codex_instructions.get("repair") if codex_found else "",
             },
         ]
     )
@@ -293,6 +293,19 @@ def run(repo: str = ".", launch: bool = False) -> dict[str, Any]:
     if launch:
         ok = bool(launch_report["attempted"] and launch_report["returncode"] == 0)
 
+    codex_runtime: dict[str, Any] = {**codex}
+    codex_executable = codex.get("executable") or {}
+    if codex_executable.get("found"):
+        codex_runtime["command"] = {
+            "cwd": str(repo_path),
+            "argv": ["codex", "-C", str(repo_path)],
+            "display": _codex_display_command(repo_path),
+            "startup_prompt": (
+                "Start this Main Branch business day. Run only read-only mb checks "
+                "before advice and ask before writes."
+            ),
+        }
+
     return {
         "ok": ok,
         "handoff_ready": handoff_ready,
@@ -318,20 +331,7 @@ def run(repo: str = ".", launch: bool = False) -> dict[str, Any]:
             "skill_wiring": wiring,
             "codex_cli": codex,
         },
-        "experimental_runtimes": {
-            "codex_cli": {
-                **codex,
-                "command": {
-                    "cwd": str(repo_path),
-                    "argv": ["codex", "-C", str(repo_path)],
-                    "display": _codex_display_command(repo_path),
-                    "startup_prompt": (
-                        "Start this Main Branch business day. Run only read-only mb checks "
-                        "before advice and ask before writes."
-                    ),
-                },
-            }
-        },
+        "experimental_runtimes": {"codex_cli": codex_runtime},
         "checks": checks,
         "command": {
             "cwd": str(repo_path),

--- a/mb/mb/start.py
+++ b/mb/mb/start.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any
 
 from mb import checkpoint as checkpoint_mod
+from mb import codex as codex_mod
 from mb import journal as journal_mod
 from mb.engine import install_mode, link_status
 from mb.freshness import format_update_alert, package_update_status
@@ -101,6 +102,10 @@ def _display_command(repo: Path) -> str:
     return f"cd {shlex.quote(str(repo))} && claude"
 
 
+def _codex_display_command(repo: Path) -> str:
+    return f"codex -C {shlex.quote(str(repo))}"
+
+
 def _launch_claude(repo: Path) -> int:
     try:
         return subprocess.call(["claude"], cwd=repo)
@@ -115,6 +120,7 @@ def _build_checks(
     git: dict[str, Any],
     claude_path: str,
     wiring: dict[str, Any],
+    codex: dict[str, Any],
     update: dict[str, Any],
 ) -> list[dict[str, Any]]:
     dirty_detail = (
@@ -203,6 +209,29 @@ def _build_checks(
                 "repair": "Run `mb skill repair --repo .` for details.",
             }
         )
+    codex_executable = codex.get("executable") or {}
+    codex_instructions = codex.get("instructions") or {}
+    checks.extend(
+        [
+            {
+                "name": "codex_cli",
+                "ok": bool(codex_executable.get("found")),
+                "severity": "info",
+                "detail": codex_executable.get("path") or "codex not on PATH",
+                "repair": codex_executable.get("repair") or "",
+            },
+            {
+                "name": "codex_agents_md",
+                "ok": bool(codex_instructions.get("ok")),
+                "severity": "warn",
+                "detail": "AGENTS.md is present and points Codex to mb facts"
+                if codex_instructions.get("ok")
+                else "AGENTS.md is missing, stale, or missing required mb fact commands",
+                "repair": codex_instructions.get("repair")
+                or "Run `mb doctor repair --plan`, then `mb doctor repair --apply`.",
+            },
+        ]
+    )
     return checks
 
 
@@ -234,11 +263,12 @@ def run(repo: str = ".", launch: bool = False) -> dict[str, Any]:
     git = _git_status(repo_path)
     claude_path = _which("claude")
     wiring = link_status(repo_path)
+    codex = codex_mod.readiness(repo_path)
     update = package_update_status(repo_path)
     checkpoint = checkpoint_mod.status(repo_path)
     journal = journal_mod.collect(repo_path, limit=8, since="14 days ago")
     push_report = push_facts(repo_path)
-    checks = _build_checks(repo_shape, git, claude_path, wiring, update)
+    checks = _build_checks(repo_shape, git, claude_path, wiring, codex, update)
     hard_failures = _hard_failures(checks)
     handoff_ready = not hard_failures
 
@@ -286,6 +316,21 @@ def run(repo: str = ".", launch: bool = False) -> dict[str, Any]:
             "found": bool(claude_path),
             "path": claude_path,
             "skill_wiring": wiring,
+            "codex_cli": codex,
+        },
+        "experimental_runtimes": {
+            "codex_cli": {
+                **codex,
+                "command": {
+                    "cwd": str(repo_path),
+                    "argv": ["codex", "-C", str(repo_path)],
+                    "display": _codex_display_command(repo_path),
+                    "startup_prompt": (
+                        "Start this Main Branch business day. Run only read-only mb checks "
+                        "before advice and ask before writes."
+                    ),
+                },
+            }
         },
         "checks": checks,
         "command": {
@@ -333,6 +378,11 @@ def render_human(report: dict[str, Any]) -> None:
     console.print(
         "[bold]Runtime[/bold]  Claude Code "
         + ("[green]found[/green]" if runtime["found"] else "[red]missing[/red]")
+    )
+    codex = runtime.get("codex_cli") or {}
+    console.print(
+        "[bold]Codex[/bold]  "
+        + ("[green]ready[/green]" if codex.get("ok") else "[blue]experimental[/blue]")
     )
     console.print(
         "[bold]Skills[/bold]  /mb-start "

--- a/mb/mb/status.py
+++ b/mb/mb/status.py
@@ -1617,8 +1617,9 @@ def _drift(report: dict[str, Any]) -> dict[str, Any]:
             }
         )
     codex_cli = report["runtime"].get("codex_cli") or {}
+    codex_executable = codex_cli.get("executable") or {}
     codex_instructions = codex_cli.get("instructions") or {}
-    if not codex_instructions.get("ok"):
+    if codex_executable.get("found") and not codex_instructions.get("ok"):
         items.append(
             {
                 "id": "codex_instructions_not_ready",

--- a/mb/mb/status.py
+++ b/mb/mb/status.py
@@ -13,6 +13,7 @@ from typing import Any
 import yaml
 
 from mb import __version__, github_activity, relationships
+from mb import codex as codex_mod
 from mb import connect as connect_mod
 from mb import journal as journal_mod
 from mb import onboard as onboard_mod
@@ -106,6 +107,7 @@ def _run_command(args: list[str], cwd: Path | None = None, timeout: float = 3.0)
 
 def _looks_like_mainbranch_repo(repo: Path) -> dict[str, Any]:
     markers = {
+        "agents_md": (repo / "AGENTS.md").is_file(),
         "claude_md": (repo / "CLAUDE.md").is_file(),
         "core": (repo / "core").is_dir() or (repo / "reference" / "core").exists(),
         "research": (repo / "research").is_dir(),
@@ -1174,6 +1176,7 @@ def _summarize_pr(pr: dict[str, Any]) -> dict[str, Any]:
 def _runtime(repo: Path) -> dict[str, Any]:
     claude_path = _which("claude")
     wiring = link_status(repo)
+    codex = codex_mod.readiness(repo)
     return {
         "claude_code": {
             "found": bool(claude_path),
@@ -1186,6 +1189,7 @@ def _runtime(repo: Path) -> dict[str, Any]:
             if wiring["ok"]
             else "Run `mb skill repair --repo .`, then `mb skill link --repo .`.",
         },
+        "codex_cli": codex,
     }
 
 
@@ -1612,6 +1616,22 @@ def _drift(report: dict[str, Any]) -> dict[str, Any]:
                 "safe_to_share": True,
             }
         )
+    codex_cli = report["runtime"].get("codex_cli") or {}
+    codex_instructions = codex_cli.get("instructions") or {}
+    if not codex_instructions.get("ok"):
+        items.append(
+            {
+                "id": "codex_instructions_not_ready",
+                "severity": "warn",
+                "summary": "Codex AGENTS.md instructions are missing or stale.",
+                "evidence": [str(codex_instructions.get("path") or "AGENTS.md")],
+                "repair": str(
+                    codex_instructions.get("repair")
+                    or "Run `mb doctor repair --plan`, then `mb doctor repair --apply`."
+                ),
+                "safe_to_share": True,
+            }
+        )
     broken_integrations = [
         item
         for item in (report.get("integrations") or {}).get("providers", [])
@@ -2020,9 +2040,14 @@ def render_human(
 
     claude = runtime["claude_code"]
     skills = runtime["skill_wiring"]
+    codex = runtime.get("codex_cli") or {}
     claude_mark = "[green]found[/green]" if claude["found"] else "[yellow]missing[/yellow]"
     skill_mark = "[green]wired[/green]" if skills["ok"] else "[yellow]missing[/yellow]"
-    console.print(f"[bold]Runtime[/bold] Claude Code: {claude_mark}  skills: {skill_mark}")
+    codex_mark = "[green]ready[/green]" if codex.get("ok") else "[blue]experimental[/blue]"
+    console.print(
+        f"[bold]Runtime[/bold] Claude Code: {claude_mark}  skills: {skill_mark}  "
+        f"Codex: {codex_mark}"
+    )
 
     integration_summary = integrations["summary"]
     if integration_summary["configured"]:

--- a/mb/tests/fixtures/status/schema-v1-basic.json
+++ b/mb/tests/fixtures/status/schema-v1-basic.json
@@ -60,6 +60,7 @@
     ],
     "runtime": [
       "claude_code",
+      "codex_cli",
       "skill_wiring"
     ],
     "git": [

--- a/mb/tests/test_doctor.py
+++ b/mb/tests/test_doctor.py
@@ -292,6 +292,35 @@ def test_doctor_repair_apply_refreshes_codex_agents_md(tmp_path: Path) -> None:
     assert "mb status --json --peek" in agents_text
 
 
+def test_doctor_repair_preserves_custom_codex_agents_md_when_contract_is_current(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "biz"
+    init_run(path=str(repo), name="Acme")
+    agents = repo / "AGENTS.md"
+    agents.write_text(
+        agents.read_text(encoding="utf-8")
+        + "\n## Local Notes\n\nKeep this operator-specific note.\n",
+        encoding="utf-8",
+    )
+
+    plan_result = runner.invoke(app, ["doctor", "repair", "--repo", str(repo), "--plan", "--json"])
+    assert plan_result.exit_code in {0, 1}
+    plan = json.loads(plan_result.stdout)
+    actions = {action["id"]: action for action in plan["actions"]}
+    assert "codex-agents-md" not in actions
+
+    apply_result = runner.invoke(
+        app, ["doctor", "repair", "--repo", str(repo), "--apply", "--json"]
+    )
+    assert apply_result.exit_code in {0, 1}
+    applied = {
+        action["id"]: action for action in json.loads(apply_result.stdout)["applied_actions"]
+    }
+    assert "codex-agents-md" not in applied
+    assert "Keep this operator-specific note." in agents.read_text(encoding="utf-8")
+
+
 def test_doctor_repair_apply_installs_checkpoint_hook(tmp_path: Path) -> None:
     repo = tmp_path / "biz"
     init_run(path=str(repo), name="Acme")

--- a/mb/tests/test_doctor.py
+++ b/mb/tests/test_doctor.py
@@ -85,6 +85,8 @@ def test_doctor_skill_wiring_passes_after_init(tmp_path: Path) -> None:
     report = run(path=str(repo))
     wiring = next(c for c in report["checks"] if c["name"] == "skill-wiring")
     assert wiring["ok"] is True
+    codex_agents = next(c for c in report["checks"] if c["name"] == "codex-agents-md")
+    assert codex_agents["ok"] is True
     checkpoint_hook = next(c for c in report["checks"] if c["name"] == "checkpoint-hook")
     assert checkpoint_hook["ok"] is True
 
@@ -254,6 +256,40 @@ def test_doctor_repair_plan_reports_missing_checkpoint_hook(tmp_path: Path) -> N
     assert section["state"] == "warn"
     actions = {action["id"]: action for action in payload["actions"]}
     assert actions["checkpoint-hook-install"]["safe_to_apply"] is True
+
+
+def test_doctor_repair_plan_reports_missing_codex_agents_md(tmp_path: Path) -> None:
+    repo = tmp_path / "biz"
+    init_run(path=str(repo), name="Acme")
+    (repo / "AGENTS.md").unlink()
+
+    result = runner.invoke(app, ["doctor", "repair", "--repo", str(repo), "--plan", "--json"])
+
+    assert result.exit_code in {0, 1}
+    payload = json.loads(result.stdout)
+    section = next(section for section in payload["sections"] if section["id"] == "codex-wiring")
+    assert section["state"] == "warn"
+    agents_check = next(check for check in section["checks"] if check["name"] == "AGENTS.md")
+    assert agents_check["state"] == "warn"
+    actions = {action["id"]: action for action in payload["actions"]}
+    assert actions["codex-agents-md"]["safe_to_apply"] is True
+    assert actions["codex-agents-md"]["writes"] == ["AGENTS.md"]
+
+
+def test_doctor_repair_apply_refreshes_codex_agents_md(tmp_path: Path) -> None:
+    repo = tmp_path / "biz"
+    init_run(path=str(repo), name="Acme")
+    (repo / "AGENTS.md").write_text("# stale\n\nNo facts here.\n", encoding="utf-8")
+
+    result = runner.invoke(app, ["doctor", "repair", "--repo", str(repo), "--apply", "--json"])
+
+    assert result.exit_code in {0, 1}
+    payload = json.loads(result.stdout)
+    applied = {action["id"]: action for action in payload["applied_actions"]}
+    assert "codex-agents-md" in applied
+    agents_text = (repo / "AGENTS.md").read_text(encoding="utf-8")
+    assert "## Codex Start Workflow" in agents_text
+    assert "mb status --json --peek" in agents_text
 
 
 def test_doctor_repair_apply_installs_checkpoint_hook(tmp_path: Path) -> None:

--- a/mb/tests/test_init.py
+++ b/mb/tests/test_init.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from mb import codex as codex_mod
 from mb.init import _DEFAULT_CLAUDE, DATA_FOLDERS, _read_template, run
 
 
@@ -63,6 +64,22 @@ def _assert_claude_md_primitive_routing_contract(text: str) -> None:
     assert "domain rubric" not in text.lower()
 
 
+def _assert_agents_md_codex_start_contract(text: str) -> None:
+    assert "## Codex Operating Contract" in text
+    assert "Do not pretend Claude" in text
+    assert "slash commands exist in Codex." in text
+    assert "## Codex Start Workflow" in text
+    assert "This is the Codex-native port of `/mb-start`" in text
+    assert "mb status --json --peek" in text
+    assert "mb start --json" in text
+    assert "mb doctor repair --plan" in text
+    assert "explicit operator approval" in text
+    assert "business-owner language" in text
+    assert "bets, goals, offers, pushes" in text
+    assert "If `ranked_actions` has entries" in text
+    assert "Do not pretend" in text
+
+
 def test_default_claude_operating_contract_matches_template() -> None:
     template = _read_template("CLAUDE.md.tmpl")
     template_contract = _section(template, "## Claude operating contract", "## Folders")
@@ -95,6 +112,7 @@ def test_init_scaffolds_folders(tmp_path: Path) -> None:
     assert "terms:" in vocab
     assert "singular: push" in vocab
     assert (target / "CLAUDE.md").exists()
+    assert (target / "AGENTS.md").exists()
     assert (target / ".github" / "CODEOWNERS").exists()
     assert (target / ".gitignore").exists()
     assert (target / ".mb" / "schema_version").read_text(encoding="utf-8") == "0.2\n"
@@ -121,7 +139,9 @@ def test_init_scaffolds_folders(tmp_path: Path) -> None:
     assert ".mb/issue-drafts/" in gitignore
     assert ".vip/local.yaml" in gitignore
     claude_md = (target / "CLAUDE.md").read_text()
+    agents_md = (target / "AGENTS.md").read_text()
     assert "Acme Brewing" in claude_md
+    assert "Acme Brewing" in agents_md
     assert "## Connected accounts" in claude_md
     assert "Stripe account IDs" in claude_md
     assert "Google Ads customer IDs" in claude_md
@@ -136,6 +156,8 @@ def test_init_scaffolds_folders(tmp_path: Path) -> None:
     assert "legacy `campaigns/`" in claude_md
     _assert_claude_md_cli_first_contract(claude_md)
     _assert_claude_md_primitive_routing_contract(claude_md)
+    _assert_agents_md_codex_start_contract(agents_md)
+    assert codex_mod.instructions_status(target)["ok"] is True
 
 
 def test_init_idempotent(tmp_path: Path) -> None:

--- a/mb/tests/test_start.py
+++ b/mb/tests/test_start.py
@@ -52,6 +52,12 @@ def _with_codex(name: str) -> str:
     return shutil.which(name) or ""
 
 
+def _without_codex(name: str) -> str:
+    if name == "codex":
+        return ""
+    return shutil.which(name) or ""
+
+
 def test_start_json_prints_ready_handoff(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(start_mod, "_which", _with_claude)
     monkeypatch.setattr(codex_mod, "_which", _with_codex)
@@ -84,6 +90,25 @@ def test_start_json_prints_ready_handoff(tmp_path: Path, monkeypatch) -> None:
     assert "ranked_actions" not in report
     assert report["result_status"] == "ok"
     assert "status" not in report
+
+
+def test_start_json_omits_codex_command_when_codex_is_missing(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(start_mod, "_which", _with_claude)
+    monkeypatch.setattr(codex_mod, "_which", _without_codex)
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+
+    result = runner.invoke(app, ["start", "--repo", str(repo), "--json"])
+
+    assert result.exit_code == 0
+    report = json.loads(result.stdout)
+    codex = report["experimental_runtimes"]["codex_cli"]
+    assert codex["executable"]["found"] is False
+    assert "command" not in codex
+    assert "Install Codex CLI" not in report["next_actions"]
 
 
 def test_start_json_exposes_push_and_legacy_campaign_facts(tmp_path: Path, monkeypatch) -> None:

--- a/mb/tests/test_start.py
+++ b/mb/tests/test_start.py
@@ -12,6 +12,7 @@ from typing import Any
 
 from typer.testing import CliRunner
 
+from mb import codex as codex_mod
 from mb import start as start_mod
 from mb import status as status_mod
 from mb.cli import app
@@ -45,8 +46,15 @@ def _without_claude(name: str) -> str:
     return shutil.which(name) or ""
 
 
+def _with_codex(name: str) -> str:
+    if name == "codex":
+        return "/usr/local/bin/codex"
+    return shutil.which(name) or ""
+
+
 def test_start_json_prints_ready_handoff(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(start_mod, "_which", _with_claude)
+    monkeypatch.setattr(codex_mod, "_which", _with_codex)
     repo = tmp_path / "acme"
     init_run(path=str(repo), name="Acme")
 
@@ -57,6 +65,13 @@ def test_start_json_prints_ready_handoff(tmp_path: Path, monkeypatch) -> None:
     assert report["handoff_ready"] is True
     assert report["runtime"]["found"] is True
     assert report["runtime"]["skill_wiring"]["ok"] is True
+    assert report["runtime"]["codex_cli"]["ok"] is True
+    assert report["runtime"]["codex_cli"]["instructions"]["ok"] is True
+    assert report["experimental_runtimes"]["codex_cli"]["command"]["argv"] == [
+        "codex",
+        "-C",
+        str(repo.resolve()),
+    ]
     assert report["command"]["argv"] == ["claude"]
     assert report["command"]["display"].endswith(" && claude")
     assert report["command"]["follow_up"] == "/mb-start"

--- a/mb/tests/test_status.py
+++ b/mb/tests/test_status.py
@@ -11,6 +11,7 @@ from typing import Any
 
 from typer.testing import CliRunner
 
+from mb import codex as codex_mod
 from mb import connect as connect_mod
 from mb import graph as graph_mod
 from mb import status as status_mod
@@ -23,6 +24,18 @@ FIXTURES = Path(__file__).parent / "fixtures"
 
 def _without_github_or_claude(name: str) -> str:
     if name in {"gh", "claude"}:
+        return ""
+    return shutil.which(name) or ""
+
+
+def _with_codex(name: str) -> str:
+    if name == "codex":
+        return "/usr/local/bin/codex"
+    return shutil.which(name) or ""
+
+
+def _without_codex(name: str) -> str:
+    if name == "codex":
         return ""
     return shutil.which(name) or ""
 
@@ -216,6 +229,28 @@ def test_status_schema_v1_matches_golden_fixture(tmp_path: Path, monkeypatch) ->
     )
 
     assert actual == expected
+
+
+def test_status_drift_does_not_warn_for_codex_instructions_until_codex_is_present(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
+    monkeypatch.setattr(codex_mod, "_which", _without_codex)
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+    (repo / "AGENTS.md").unlink()
+
+    report = status_mod.run(path=str(repo), update_marker=False)
+
+    assert not any(
+        item["id"] == "codex_instructions_not_ready" for item in report["drift"]["items"]
+    )
+
+    monkeypatch.setattr(codex_mod, "_which", _with_codex)
+    report = status_mod.run(path=str(repo), update_marker=False)
+
+    assert any(item["id"] == "codex_instructions_not_ready" for item in report["drift"]["items"])
 
 
 def test_status_json_exposes_push_and_legacy_campaign_facts(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- Adds the Stage 1 experimental Codex CLI-first adapter for fresh Main Branch business repos.
- Generates tracked business-repo `AGENTS.md` instructions that port the `/mb-start` flow into Codex-native, non-slash-command guidance.
- Exposes Codex readiness through `mb status --json`, `mb start --json`, and `mb doctor`, with repair coverage for missing or incomplete `AGENTS.md`.
- Documents the current experimental support boundary and a read-only Codex smoke path for early testers.

## Scope
- In: generated/repaired `AGENTS.md`, Codex readiness facts, doctor repair path, README/compatibility/changelog updates, focused tests, package smoke, and read-only Codex smoke evidence.
- Out: full Codex support, slash-command parity, copying Claude skills into `.agents/skills`, selected workflow ports such as `mb-think`, shared workflow renderer architecture, and any path where `mb` invokes Codex.

## Commits
- `2d9b17b` — `[add] MAIN-279 experimental Codex adapter`.
- `45b5e4c` — `[docs] MAIN-279 explain Codex smoke path`.
- `1705b01` — `[fix] MAIN-279 tighten Codex readiness checks`.

## Release / Issues
- Release: next / experimental Codex adapter slice.
- Linear ID(s): MAIN-279.
- Closes: #405.
- Refs: #451, #453, #125.
- Follow-ups: package-visible Codex dogfood (#453), shared workflow architecture (#451), and selected workflow ports (#125).

## Success Metric
- A fresh business repo can be opened with Codex CLI, Codex reads `AGENTS.md`, grounds itself in `mb status --json --peek`, `mb start --json`, and `mb doctor repair --plan`, gives a useful owner start response, asks before writes, and leaves the repo clean in read-only smoke.

## Validation
- Level 0 docs/decision: README, compatibility docs, roadmap, and changelog updated to say experimental CLI-first Codex adapter, not slash-command parity.
- Level 1 static: `scripts/check.sh` passed with formatting, ruff, mypy, 474 pytest tests, and skill validation.
- Level 2 CLI: focused init/start/status/doctor tests cover generated `AGENTS.md`, Codex readiness, repair plan/apply, custom `AGENTS.md` preservation, status drift gating, and start JSON command gating.
- Level 3 package/install: built wheel and installed into `/tmp/mainbranch-smoke`; verified `mb --version`, `mb skill list`, `mb onboard`, and `mb start --json` from the installed package.
- Level 4 fixture repo: fresh business repo smoke ran `mb doctor`, `mb status --json --peek`, and `mb start --json`; `AGENTS.md` was present and Codex readiness was reported.
- Level 5 runtime smoke: `codex exec --json --ephemeral --sandbox read-only -c 'approval_policy="never"' -C <fresh-repo>` ran the required `mb` fact commands and `git status --short` stayed clean.

## Public / Private Boundary
- Public docs and code avoid private Devon/Conductor runtime details; smoke paths and local evidence stayed in temp directories and issue comments rather than committed product truth.
