### PR TITLE
[update] Prepare v0.3.14 release (version bump + changelog)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mainbranch",
-  "version": "0.3.13",
+  "version": "0.3.14",
   "description": "Main Branch Claude Code skills for running a business from markdown files in git.",
   "author": {
     "name": "Noontide"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,40 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+## [0.3.14] - 2026-05-09
+
+v0.3.14 ships the first experimental Codex CLI-first adapter slice and the
+push playbook health surface that landed after v0.3.13 as an installable
+patch release. Fresh business repos now get a tracked `AGENTS.md` Codex
+entrypoint; `mb status`, `mb start`, and `mb doctor repair` expose and
+refresh Codex readiness facts; and `mb status --json --peek` flags push
+playbook health gaps without rewriting your repo. Public philosophy and
+architecture docs were also realigned to the current v0.3 story so unshipped
+surfaces are not mistaken for current behavior. Claude Code remains the
+supported runtime; Codex support is experimental and gated by future dogfood
+work.
+
+### What this means for you (plain English)
+
+- **Codex gets a real first-run path.** New `mb onboard` repos include a
+  tracked `AGENTS.md` so Codex (and any other AGENTS.md-aware runtime) has a
+  documented entrypoint. `mb status --json` and `mb start --json` now expose
+  a Codex readiness section, and `mb doctor repair --plan` / `--apply` can
+  report and refresh stale Codex instructions. This is an experimental slice;
+  Claude Code is still the supported runtime.
+- **Push playbook health is visible in `mb status`.** `mb status --json
+  --peek` adds push playbook health facts plus concise human and
+  ranked-action signals when active pushes are missing run records, playbook
+  approval/status is pending, completed pushes lack outcome links, or
+  provider boundaries remain plan/manual work. Nothing is rewritten for you;
+  the gaps are surfaced so you can act.
+- **Public docs match what ships.** `docs/philosophy.md` and
+  `docs/system-architecture.md` were realigned to the v0.3 public story so
+  unshipped surfaces (mobile, team dashboard, finance/bookkeeping features,
+  provider mutation, hosted model invocation) cannot be mistaken for current
+  behavior. Durable contracts (repo shape, topology roles, push and playbook
+  frontmatter, artifact routing) are preserved.
+
 ### Added
 
 - Added the first experimental Codex CLI-first adapter slice: fresh business
@@ -23,6 +57,16 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   human and ranked-action signals when active pushes are missing run records,
   playbook approval/status is pending, completed pushes lack outcome links, or
   provider boundaries remain plan/manual work. Refs #446.
+
+### Changed
+
+- Realigned `docs/philosophy.md` and `docs/system-architecture.md` to the v0.3
+  public story: dropped speculative surface copy, collapsed sections that
+  duplicated `docs/ETHOS.md`, `docs/OPERATOR-LOOPS.md`, and `docs/ROADMAP.md`,
+  consolidated legacy/compatibility names under a single Superseded Names
+  section, and stated the no-provider-mutation invariant up front. Durable
+  contracts (business repo shape, repo topology role table, push and playbook
+  frontmatter, artifact routing, state boundaries) are preserved. Refs #444.
 
 ## [0.3.13] - 2026-05-08
 

--- a/mb/mb/__init__.py
+++ b/mb/mb/__init__.py
@@ -7,6 +7,6 @@ file stays a thin dispatcher.
 
 from __future__ import annotations
 
-__version__ = "0.3.13"
+__version__ = "0.3.14"
 
 __all__ = ["__version__"]

--- a/mb/pyproject.toml
+++ b/mb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mainbranch"
-version = "0.3.13"
+version = "0.3.14"
 description = "Main Branch engine umbrella - scaffolds, validates, and graphs business-as-files repos. Claude Code first, runtime-agnostic by design."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- Prepare the `oe-v0.3.14` patch release: bump `mainbranch` package, plugin manifest, and `mb.__version__` to `0.3.14`.
- Promote the `[Unreleased]` CHANGELOG entries into a dated `[0.3.14] - 2026-05-09` section with a plain-English summary covering the experimental Codex CLI-first adapter slice, push playbook health in `mb status`, and the v0.3 docs realignment.

## Scope
- In: `mb/pyproject.toml`, `mb/mb/__init__.py`, `.claude-plugin/plugin.json`, `CHANGELOG.md`. Release-prep only.
- Out: tagging `oe-v0.3.14`, GitHub Release creation, PyPI publish, post-publish PyPI install smoke, post-publish Codex read-only smoke, closing #405 / MAIN-279. Those are release-owner steps after merge.

## Commits
- `0987075` — `[update] Prepare v0.3.14 release (version bump + changelog)`

## Release / Issues
- Release: `oe-v0.3.14` (target)
- Linear ID(s): MAIN-307
- Closes: none in this PR (release verification closes the work)
- Refs: #457, #405, #446, #444
- Follow-ups: tag + publish workflow, fresh PyPI install smoke, Codex CLI read-only smoke (post-publish), post-release verification comment + close on #405 / MAIN-279, deeper Codex CLI + Mac app dogfood on #453 / MAIN-304.

## Success Metric
- After merge + tag, `pip install mainbranch==0.3.14` works, `mb --version` reports `0.3.14`, and a fresh `mb onboard` repo surfaces tracked `AGENTS.md`, Codex readiness in `mb status` / `mb start` / `mb doctor repair --plan`, and push playbook health signals in `mb status --json --peek`.

## Validation
- Level 0 docs/decision: CHANGELOG section dated `2026-05-09`; release-note coverage matches the three commits since `oe-v0.3.13` (Codex adapter, push playbook health, docs realignment); plain-English summary mirrors prior dated sections; no private/local details introduced.
- Level 1 static: `scripts/check.sh` clean — 474 passed, coverage 82.52%, ruff/mypy/skill validation green.
- Level 2 CLI: covered by pytest in level 1.
- Level 3 package/install: `(cd mb && python -m build)` produced `mainbranch-0.3.14-py3-none-any.whl` + sdist; fresh `python3 -m venv` + `pip install <wheel>` reported `mb 0.3.14`; `mb skill list` returned 17 skills.
- Level 4 fixture repo: `mb onboard --yes --json` created a sanitized temp repo with tracked `AGENTS.md`; `mb status --json --peek` exposed `runtime.codex_cli` + `playbook_health`; `mb start --json` exposed `runtime.codex_cli` (with `experimental_runtimes`); `mb doctor repair --plan --json` reported `codex_native_ok`.
- Level 5 runtime smoke: skipped per issue scope. Broad Claude release-simulation suite is not required because this release's runtime delta is the Codex CLI-first adapter, not Claude skill behavior. Codex Mac app smoke is deferred to #453 / MAIN-304. Post-publish Codex CLI read-only smoke + fresh PyPI install smoke are release-owner steps after tagging `oe-v0.3.14`.

## Public / Private Boundary
- Clean. Smoke ran in `/tmp/mb-0314-business` (deleted after). No Conductor, member, credential, or local-machine detail in CHANGELOG, commit message, or PR body. `.context/cold-start.md` stays gitignored.