### PR TITLE
[docs] Clarify experimental Codex runtime wording

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,10 +17,11 @@ markdown files in git.
 - A user's business repo is the durable business brain.
 - A user is not met with git speak but instead business speak.
 
-Claude Code is the first-class runtime today. Codex, Cursor, OpenClaw, Hermes,
-Paperclip-adjacent orchestration, and local runtimes are compatibility targets
-only when tested. Do not claim support before there is an adapter or smoke
-evidence.
+Claude Code is the first-class runtime today. Codex CLI has an experimental
+CLI-first adapter for power users; it is not slash-command or workflow parity.
+Cursor, OpenClaw, Hermes, Paperclip-adjacent orchestration, and local runtimes
+remain compatibility targets until tested. Do not claim support before there is
+an adapter and smoke evidence for the exact surface.
 
 The public product frame lives in `docs/ETHOS.md`, the operator loop taxonomy
 lives in `docs/OPERATOR-LOOPS.md`, and release direction lives in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,5 +66,7 @@ Bundled Claude Code skills live in `.claude/skills/`. If you edit a skill:
 - avoid private member data, private launch strategy, or machine-specific paths
   in examples.
 
-Claude Code is first-class today. Other runtimes are roadmap targets until an
-adapter and smoke evidence exist, so do not overclaim compatibility in docs.
+Claude Code is first-class today. Codex CLI has an experimental CLI-first
+adapter for power users, but no slash-command or workflow parity claim. Other
+runtimes are roadmap targets until an adapter and smoke evidence exist, so do
+not overclaim compatibility in docs.

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ The longer-arc operating-system model — where multiple business repos, GitHub 
 
 |                                  |                                                                                                |
 | -------------------------------- | ---------------------------------------------------------------------------------------------- |
-| **Not a chat app.**              | The chat surface is Claude Code. Main Branch gives the chat something durable to read from.    |
+| **Not a chat app.**              | The supported chat surface is Claude Code; Codex CLI is experimental. Main Branch gives agents durable context to read from. |
 | **Not a SaaS dashboard.**        | Your business doesn't live on our servers. It lives in your folder.                            |
 | **Not a connect-every-tool hub.**| We pick boring, inspectable rails: GitHub, Cloudflare, official ads paths. Curated, not sprawl.|
 | **Not a model host.**            | We don't run models. We hand the agent the right context so the model you already use is sharper.|

--- a/docs/DEPENDENCY-CHOICES.md
+++ b/docs/DEPENDENCY-CHOICES.md
@@ -76,7 +76,7 @@ Use this rubric before adding, promoting, replacing, or removing a dependency.
 | Can Main Branch test it? | Local tests, CI tests, read-only smoke, package smoke, fixture repo smoke, or runtime smoke as appropriate. |
 | Does it require paid access or hosted setup? | Document account requirements, OAuth/developer-app steps, billing assumptions, and no-account fallback behavior. |
 | Where do secrets live? | Credentials must stay outside tracked repos; repo metadata must be safe to share. |
-| Does it cross runtime boundaries? | Claude Code is first-class today; other runtimes need adapters and smoke evidence before support claims. |
+| Does it cross runtime boundaries? | Claude Code is first-class today; Codex CLI is experimental and CLI-first; other runtimes need adapters and smoke evidence before support claims. |
 | Can failures be explained? | `mb doctor`, `mb connect`, `mb status`, or provider docs should tell the user what failed and the next command. |
 | Does it mutate external accounts? | Spending, publishing, emailing, deploying, and customer/account mutation need explicit operator action and provider authority. |
 | What is the exit plan? | Record the replacement, fallback, deprecation path, or reason the dependency can stay optional. |


### PR DESCRIPTION
## Summary
- Tightens public/runtime docs so Claude Code remains the first-class supported runtime while Codex CLI is described as experimental and CLI-first.
- Removes stale phrasing that grouped Codex with untested roadmap-only runtimes.
- Keeps the no-slash-command/no-workflow-parity boundary intact.

## Scope
- In: AGENTS.md, CLAUDE.md, README.md, docs/DEPENDENCY-CHOICES.md wording only.
- Out: no behavior changes, no compatibility support expansion, no issue closure.

## Validation
- `scripts/check.sh` passed: formatting, ruff, mypy, 474 tests, coverage, and 17/17 skill validation.

## Public / Private Boundary
- Public-safe docs wording only; no private or local workflow details.
