### PR TITLE
[fix] Harden migration repair UX

### DIFF
--- a/.claude/reference/business-primitives/destructive-operations.md
+++ b/.claude/reference/business-primitives/destructive-operations.md
@@ -1,0 +1,25 @@
+# Destructive Operations
+
+Ask before operations that can erase context, rewrite history, mutate outside
+accounts, or make business work hard to inspect later.
+
+## Require Explicit Approval
+
+- deleting, archiving, or moving user-authored files;
+- renaming, merging, splitting, or deleting offer folders;
+- layout migrations and archive moves;
+- checkpoint creation or commits;
+- publishing, deployment, provider/account mutation, or ad spend;
+- customer/member contact;
+- changing repo topology, remotes, or access boundaries.
+
+## Default Pattern
+
+1. Show the read-only facts from `mb status`, `mb validate`, `mb doctor repair --plan`, or the relevant provider check.
+2. Name the exact files, folders, provider objects, or git action that would change.
+3. Explain the reversible path or backup if there is one.
+4. Wait for approval before applying.
+
+Prefer archive-oriented moves for historical generated work. Do not fabricate
+retroactive bets, pushes, or campaigns just to make old files fit the current
+model.

--- a/.claude/reference/business-primitives/slug-conventions.md
+++ b/.claude/reference/business-primitives/slug-conventions.md
@@ -1,0 +1,19 @@
+# Slug Conventions
+
+Use slugs as stable business handles, not temporary labels.
+
+## Rules
+
+- Use lowercase kebab-case: `community`, `done-for-you`, `hvac-local-visibility`.
+- Name the thing being sold, tested, or worked on. Prefer nouns over slogans.
+- Keep dates in dated record filenames and push folders, not in durable offer slugs.
+- Do not rename a slug just because copy, positioning, or the public name changed.
+- Rename a slug only after an accepted decision, approved migration plan, or explicit operator instruction.
+
+## Examples
+
+- Offer folder: `core/offers/community/`
+- Bet file: `bets/2026-05-09-hvac-local-visibility.md`
+- Push folder: `pushes/2026-05-09-hvac-local-visibility/`
+
+When uncertain, ask for the stable noun the operator would use in a year.

--- a/.claude/skills/mb-setup/SKILL.md
+++ b/.claude/skills/mb-setup/SKILL.md
@@ -101,7 +101,9 @@ Don't block setup on this. Continue and mention it at the end.
 **IMPORTANT:** If user has a Skool community, choose **Community/Skool** even if they also do coaching, courses, or services outside Skool. The community is the hub — other offerings feed into it.
 
 Read `.claude/reference/business-primitives/setup-patterns.md` in the Main
-Branch engine for the current setup patterns.
+Branch engine for the current setup patterns. Read
+`.claude/reference/business-primitives/slug-conventions.md` before naming
+offer folders, pushes, bets, or topology entries.
 
 ### 2.5: Offer Structure
 
@@ -112,7 +114,7 @@ After business type, determine offer structure:
 **If one:** "Single offer — clean and simple. All your details go in `core/`. Most people start here."
 
 **If multiple:** "Multiple offers under one brand. You share the same soul and voice, but each offer has its own specifics."
-- Ask: "What should we call each offer? Short slugs work best (e.g., 'community', 'newsletter', 'done-for-you')"
+- Ask: "What stable noun should name each offer? Use lowercase kebab-case slugs like `community`, `newsletter`, or `done-for-you`; do not rename later without a decision."
 - Ask: "How do these relate? Is there a natural progression — like a free tier that feeds into a paid one?" (This builds `product-ladder.md`)
 - Store offer names for Step 4 folder creation
 - Note: The multi-offer rules live at

--- a/.claude/skills/mb-start/SKILL.md
+++ b/.claude/skills/mb-start/SKILL.md
@@ -61,13 +61,17 @@ The path is skill orchestration: keyword-gate with `/mb-think`, create/select a
 canonical launch push, build/check the lander with `/mb-site`, prepare or check
 ads with `/mb-ads`, and checkpoint approved artifacts.
 
-**Primitive routing:** When an operator brings a live idea and it is unclear
-whether it is a bet, offer, push, proof, or decision, load
-`.claude/reference/business-primitives/offer-bet-push-proof.md` from the engine
-and route by business meaning before suggesting file moves. In short: offers
-are what the business may keep selling, bets are time-boxed wagers, pushes are
-coordinated execution, proof is evidence, and decisions explain durable changes.
-Ask before renaming, deleting, merging, or moving offer folders.
+**Primitive routing:** When a live idea could be a bet, offer, push, proof, or
+decision, load `.claude/reference/business-primitives/offer-bet-push-proof.md`
+and `.claude/reference/business-primitives/setup-patterns.md`; route by business
+meaning before suggesting file moves.
+
+**Slug/destructive-operation guardrails:** Load
+`.claude/reference/business-primitives/slug-conventions.md` before naming
+business objects or topology entries, and
+`.claude/reference/business-primitives/destructive-operations.md` before
+renaming, deleting, merging, archiving, migrating, publishing, mutating
+providers, spending money, changing topology, or creating checkpoints.
 
 ---
 
@@ -142,7 +146,7 @@ before taking action.
 
 ---
 
-## Step 0: Read Status Facts
+## Status Preamble: Read Status Facts
 
 After repo selection, run:
 
@@ -213,7 +217,7 @@ Once business repo is confirmed, pull its latest updates from `REPO_PATH`. See *
 
 ---
 
-## Step 3a: Resume Onboarding Progress
+## Onboarding Preamble: Resume Onboarding Progress
 
 Prefer the `onboarding` section from `mb status --json --peek`. If status is
 unavailable or the operator specifically asks for onboarding detail, run:
@@ -273,16 +277,11 @@ operator-facing pattern is:
 
 **Full research tool detection still happens in /mb-think** — deferred to when user actually needs research. This keeps /mb-start fast and avoids checking tools user might not use this session.
 
-**What /mb-start DOES check:**
-- Provider readiness from `mb status --json --peek` and `mb connect plan`
-- MCPs that a selected skill depends on when provider status says runtime tools are still unknown
-- Critical blockers (missing config, broken paths)
-
-**What /mb-start DOES NOT do here:**
-- Full research tool scan (Gemini, Grok, whisper, etc.) — /mb-think handles this
-- Full document tool scan (markitdown, pandoc, marker) — /mb-think handles this
-
-**Why defer:** Most sessions don't use all tools. Checking everything upfront wastes time and clutters the greeting. /mb-think detects tools when user's intent requires them and surfaces setup options at the right moment.
+**What /mb-start checks:** provider readiness from `mb status --json --peek`
+and `mb connect plan`, selected-skill MCPs when provider status says runtime
+tools are unknown, and critical blockers such as missing config or broken paths.
+Leave full research/document tool scans to `/mb-think`; most sessions do not
+need every tool checked upfront.
 
 If user's stated intent involves research, route to /mb-think. It will use
 `mb` provider facts first, then detect only the runtime tools needed for the
@@ -354,7 +353,9 @@ active offer, note it for routing; the selected skill loads the offer file.
 ## Step 8: Offer Detection (Multi-Offer Only)
 
 Use the active-offer resolution contract in
-`.claude/reference/business-primitives/offer-bet-push-proof.md`.
+`.claude/reference/business-primitives/offer-bet-push-proof.md`; load
+`setup-patterns.md` and `slug-conventions.md` from that same directory when
+setup shape or naming is unclear.
 
 ```bash
 find "$REPO_PATH/core/offers" -mindepth 2 -maxdepth 2 -name "offer.md" 2>/dev/null

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,36 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+### Added
+
+- Added validation category summaries to `mb validate --json`, `mb status`,
+  and `mb doctor repair --plan --json` so large repair reports identify the
+  highest-leverage debt cluster first. Refs #460.
+- Added migration drift coverage for legacy top-level `outputs/` with
+  archive-oriented guidance that avoids fabricating retroactive pushes or
+  campaigns. Refs #460.
+
+### Changed
+
+- `mb validate` now accepts `--repo PATH` as an alias for the positional path,
+  push schema failures surface the required `goal` mapping shape in the first
+  pass, and proposed topology rename entries can carry a pre-rename remote
+  mismatch without weakening validation for live entries. Refs #460.
+- Relationship health now treats push-side `linked_bets` as a valid active
+  bet-to-push relationship and gives clearer reverse-link guidance for
+  bet/push and offer/push gaps. Refs #460.
+- Onboarding progress now recognizes canonical `core/proof/` content as proof
+  instead of requiring legacy single-file proof shims. Refs #460.
+- Agent guidance now centralizes slug conventions and destructive-operation
+  approval rules for setup/start routing. Refs #460.
+
+### Fixed
+
+- `mb doctor repair --include-migration` errors and help now show the required
+  `--apply --include-migration` combination, and checkpoint hook install
+  summaries distinguish newly installed hooks from already-verified hooks.
+  Refs #460.
+
 ## [0.3.14] - 2026-05-09
 
 v0.3.14 ships the first experimental Codex CLI-first adapter slice and the

--- a/mb/mb/checkpoint.py
+++ b/mb/mb/checkpoint.py
@@ -311,9 +311,9 @@ def install_commit_hook(repo: str | Path = ".") -> dict[str, Any]:
         "ok": True,
         "changed": changed,
         "summary": (
-            "installed Main Branch checkpoint commit-message hook"
+            "installed Main Branch checkpoint commit-message hook (newly installed or repaired)"
             if changed
-            else "Main Branch checkpoint commit-message hook already installed"
+            else "verified Main Branch checkpoint commit-message hook (already installed)"
         ),
         "errors": [],
     }

--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -473,6 +473,11 @@ def _doctor_repair_from_args(args: list[str], *, json_out: bool) -> None:
             )
             typer.echo("")
             typer.echo("Plan or apply guided business-repo reconciliation repairs.")
+            typer.echo("")
+            typer.echo(
+                "Migration apply is opt-in: use `--include-migration` only with `--apply` "
+                "after reviewing the plan."
+            )
             raise typer.Exit(0)
         if arg == "--repo":
             idx += 1
@@ -497,7 +502,12 @@ def _doctor_repair_from_args(args: list[str], *, json_out: bool) -> None:
         typer.echo("mb doctor repair: choose only one of --plan or --apply", err=True)
         raise typer.Exit(2)
     if include_migration and not apply_changes:
-        typer.echo("mb doctor repair: --include-migration requires --apply", err=True)
+        typer.echo(
+            "mb doctor repair: --include-migration requires --apply. "
+            "First run `mb doctor repair --plan`; after review, rerun "
+            "`mb doctor repair --apply --include-migration`.",
+            err=True,
+        )
         raise typer.Exit(2)
 
     if apply_changes:
@@ -529,6 +539,7 @@ def _doctor_help() -> None:
     typer.echo("")
     typer.echo("Repair:")
     typer.echo("  mb doctor repair [--repo PATH] [--plan | --apply] [--include-migration] [--json]")
+    typer.echo("  Note: --include-migration is valid only with --apply after plan review.")
 
 
 @app.command(
@@ -922,6 +933,11 @@ def site_check_cmd(
 @app.command("validate")
 def validate_cmd(
     path: str = typer.Argument(".", help="Repo to validate."),
+    repo: str | None = typer.Option(
+        None,
+        "--repo",
+        help="Repo to validate. Alias for the positional PATH used by older scripts.",
+    ),
     verbose: bool = typer.Option(False, "-v", "--verbose"),
     cross_refs: bool = typer.Option(
         False,
@@ -932,8 +948,9 @@ def validate_cmd(
     json_out: bool = typer.Option(False, "--json"),
 ) -> None:
     """Check frontmatter shape and optional cross-references."""
+    target = repo or path
     report = validate_mod.run(
-        path=path,
+        path=target,
         verbose=verbose,
         cross_refs=cross_refs,
         strict=strict,

--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -868,7 +868,7 @@ def status_cmd(
     ),
 ) -> None:
     """Show a cheap daily briefing for a Main Branch repo."""
-    report = status_mod.run(path=path, update_marker=not peek)
+    report = status_mod.run(path=path, update_marker=not peek, validation_cross_refs=not peek)
     if json_out:
         typer.echo(_json_payload(report, command="mb status", schema_name="mainbranch.status"))
     else:

--- a/mb/mb/doctor.py
+++ b/mb/mb/doctor.py
@@ -1232,13 +1232,19 @@ def _validation_summary(
     summary = report.get("summary", {})
     errors = int(summary.get("errors", 0) or 0)
     warnings = int(summary.get("warnings", 0) or 0)
+    categories = report.get("validation_categories") or {}
+    top_category = categories.get("top_category")
     state = "error" if errors else ("warn" if warnings else "ok")
     return {
         "ok": report["ok"],
         "state": state,
-        "summary": f"{errors} error(s), {warnings} warning(s)",
+        "summary": (
+            f"{errors} error(s), {warnings} warning(s)"
+            + (f"; top category: {top_category}" if top_category else "")
+        ),
         "report": {
             "summary": summary,
+            "validation_categories": report.get("validation_categories", {}),
             "files": len(report.get("files", [])),
             "legacy_repair": report.get("legacy_repair"),
             "cross_refs": {

--- a/mb/mb/migration_lint.py
+++ b/mb/mb/migration_lint.py
@@ -35,6 +35,11 @@ STALE_TOP_LEVEL_FOLDERS = {
         "Use `pushes/<YYYY-MM-DD-slug>/` for coordinated work and `.mb/` or OS "
         "temp for local scratch."
     ),
+    "outputs": (
+        "`outputs/` is legacy generated-work language. Move historical content to "
+        "`documents/archive/<name>/` or classify it by hand; do not bulk-promote old "
+        "generated work into `pushes/` or legacy `campaigns/`."
+    ),
 }
 
 STALE_CLAUDE_PATTERNS = (

--- a/mb/mb/onboard.py
+++ b/mb/mb/onboard.py
@@ -367,6 +367,7 @@ def _core_inputs(repo: Path) -> dict[str, bool]:
         "soul": _has_any_file([core / "soul.md", reference_core / "soul.md"]),
         "proof": _has_any_file(
             [
+                core / "proof",
                 core / "proof.md",
                 core / "testimonials.md",
                 repo / "reference" / "proof",

--- a/mb/mb/ranker.py
+++ b/mb/mb/ranker.py
@@ -16,6 +16,7 @@ WEIGHTS: dict[str, int] = {
     "overdue_bets": 90,
     "unhealthy_integrations": 85,
     "github_context_repair": 80,
+    "validation_debt": 88,
     "dirty_git": 75,
     "attention_requests": 70,
     "assigned_tasks": 65,
@@ -232,6 +233,25 @@ def _add_drift_actions(actions: list[dict[str, Any]], report: dict[str, Any]) ->
                     severity="warn",
                     score=score,
                     reason=str(drift_item.get("summary") or "A declared integration needs repair."),
+                    signals=[_drift_signal(drift_item, weight=score)],
+                )
+            )
+        elif drift_id == "validation_debt":
+            severity = str(drift_item.get("severity") or "warn")
+            if severity != "error":
+                continue
+            score = WEIGHTS["validation_debt"]
+            actions.append(
+                _action(
+                    action_id="repair_validation_debt",
+                    title="Repair validation debt",
+                    command="mb validate --cross-refs --json",
+                    severity=severity,
+                    score=score + len(_list(drift_item.get("evidence"))),
+                    reason=str(
+                        drift_item.get("summary")
+                        or "Validation findings need to be grouped and repaired."
+                    ),
                     signals=[_drift_signal(drift_item, weight=score)],
                 )
             )

--- a/mb/mb/status.py
+++ b/mb/mb/status.py
@@ -21,6 +21,7 @@ from mb import pushes as pushes_mod
 from mb import ranker as ranker_mod
 from mb import site as site_mod
 from mb import topology as topology_mod
+from mb import validate as validate_mod
 from mb.engine import install_mode, link_status
 from mb.freshness import format_update_alert, package_update_status
 
@@ -541,6 +542,16 @@ def _relationship_adjacency(edges: list[dict[str, Any]]) -> dict[str, dict[str, 
     return adjacency
 
 
+def _linked_push_paths_for_bet(
+    adjacency: dict[str, dict[str, set[str]]],
+    bet_path: str,
+    push_paths: set[str],
+) -> set[str]:
+    direct_pushes = _linked_paths(adjacency, bet_path, "push")
+    reverse_bet_links = _linked_paths(adjacency, bet_path, "bet") & push_paths
+    return direct_pushes | reverse_bet_links
+
+
 def _relationship_slug(value: str) -> str:
     lowered = value.strip().lower()
     slug = re.sub(r"[^a-z0-9]+", "-", lowered).strip("-")
@@ -916,6 +927,7 @@ def _relationship_health(
     push_report = brain.get("pushes") or {}
     pushes = [item for item in push_report.get("records", []) if isinstance(item, dict)]
     offers = _offer_summaries(repo)
+    push_paths = {str(item.get("path") or "") for item in pushes}
     current_push_paths = {
         str(item.get("path") or "")
         for item in pushes
@@ -923,7 +935,9 @@ def _relationship_health(
     }
 
     active_bets_without_push = [
-        item for item in active_bets if not _linked_paths(adjacency, str(item["path"]), "push")
+        item
+        for item in active_bets
+        if not _linked_push_paths_for_bet(adjacency, str(item["path"]), push_paths)
     ]
     closed_bets_without_outcome = [
         item for item in closed_bets if not _linked_paths(adjacency, str(item["path"]), "outcome")
@@ -992,7 +1006,10 @@ def _relationship_health(
             severity="warn",
             summary=f"{len(active_bets_without_push)} active bet(s) need a linked push.",
             records=active_bets_without_push,
-            repair="Link each active bet to the push or playbook that supports it.",
+            repair=(
+                "Link each active bet to the push that supports it, or add the reverse "
+                "`linked_bets` field on that push."
+            ),
         )
         if active_bets_without_push
         else None,
@@ -1046,7 +1063,11 @@ def _relationship_health(
                 "or linked playbook."
             ),
             records=offers_without_current_push_or_playbook,
-            repair="Connect each live offer to a current push or reusable playbook.",
+            repair=(
+                "Connect each live offer to a current push or reusable playbook. Either set "
+                "the push `offer:` to the repo-relative offer file or add `linked_pushes:` "
+                "on the offer."
+            ),
         )
         if offers_without_current_push_or_playbook
         else None,
@@ -1512,8 +1533,74 @@ def _write_last_seen_marker(repo: Path, report: dict[str, Any]) -> dict[str, Any
     }
 
 
+def _validation_status(repo: Path) -> dict[str, Any]:
+    try:
+        report = validate_mod.run(str(repo), cross_refs=True)
+    except Exception as exc:  # pragma: no cover - defensive status boundary
+        return {
+            "ok": False,
+            "state": "error",
+            "summary": {"errors": 1, "warnings": 0, "top_category": "validation_unavailable"},
+            "validation_categories": {
+                "schema_version": "1.0",
+                "total_categories": 1,
+                "top_category": "validation_unavailable",
+                "top_repair": "Run `mb validate --cross-refs --json` for the exact failure.",
+                "by_category": {
+                    "validation_unavailable": {
+                        "count": 1,
+                        "errors": 1,
+                        "warnings": 0,
+                        "examples": [{"path": "", "message": str(exc)}],
+                        "repair": "Run `mb validate --cross-refs --json` for the exact failure.",
+                    }
+                },
+                "safe_to_share": True,
+            },
+            "safe_to_share": True,
+        }
+    summary = report.get("summary") or {}
+    errors = int(summary.get("errors") or 0)
+    warnings = int(summary.get("warnings") or 0)
+    return {
+        "ok": bool(report.get("ok")),
+        "state": "error" if errors else ("warn" if warnings else "ok"),
+        "summary": summary,
+        "validation_categories": report.get("validation_categories") or {},
+        "legacy_repair": report.get("legacy_repair"),
+        "cross_refs": {
+            "enabled": bool((report.get("cross_refs") or {}).get("enabled")),
+            "warnings": len((report.get("cross_refs") or {}).get("warnings") or []),
+            "orphan_offers": len((report.get("cross_refs") or {}).get("orphan_offers") or []),
+        },
+        "migration_drift": (report.get("migration_drift") or {}).get("summary", {}),
+        "safe_to_share": True,
+    }
+
+
 def _drift(report: dict[str, Any]) -> dict[str, Any]:
     items: list[dict[str, Any]] = []
+    validation = report.get("validation") or {}
+    validation_state = str(validation.get("state") or "ok")
+    if validation_state != "ok":
+        categories = validation.get("validation_categories") or {}
+        top_category = str(categories.get("top_category") or "")
+        top_repair = str(categories.get("top_repair") or "Run `mb validate --cross-refs --json`.")
+        summary = validation.get("summary") or {}
+        items.append(
+            {
+                "id": "validation_debt",
+                "severity": "error" if validation_state == "error" else "warn",
+                "summary": (
+                    f"{summary.get('errors', 0)} validation error(s), "
+                    f"{summary.get('warnings', 0)} warning(s)"
+                    + (f"; top category: {top_category}" if top_category else "")
+                ),
+                "evidence": list((categories.get("by_category") or {}).keys())[:5],
+                "repair": top_repair,
+                "safe_to_share": True,
+            }
+        )
     stale_decisions = report["brain"].get("stale_decisions") or []
     if stale_decisions:
         items.append(
@@ -1850,6 +1937,7 @@ def run(
         brain=brain,
         generated_at=generated_at,
     )
+    report["validation"] = _validation_status(repo_path)
     report["drift"] = _drift(report)
     report["topology"] = {
         "schema": topology_payload["schema"],

--- a/mb/mb/status.py
+++ b/mb/mb/status.py
@@ -1533,10 +1533,24 @@ def _write_last_seen_marker(repo: Path, report: dict[str, Any]) -> dict[str, Any
     }
 
 
-def _validation_status(repo: Path) -> dict[str, Any]:
+def _safe_exception_message(exc: Exception) -> str:
+    message = str(exc) or exc.__class__.__name__
+    message = re.sub(
+        r"(?<![A-Za-z0-9:])(?:"
+        r"/(?:Users|home|private|tmp|var|Volumes|opt|usr/local)/[^\s\"'`<>),;]+"
+        r"|[A-Za-z]:\\[^\s\"'`<>),;]+"
+        r")",
+        "<local-path>",
+        message,
+    )
+    return message[:240] + ("..." if len(message) > 240 else "")
+
+
+def _validation_status(repo: Path, *, cross_refs: bool = True) -> dict[str, Any]:
     try:
-        report = validate_mod.run(str(repo), cross_refs=True)
+        report = validate_mod.run(str(repo), cross_refs=cross_refs)
     except Exception as exc:  # pragma: no cover - defensive status boundary
+        message = _safe_exception_message(exc)
         return {
             "ok": False,
             "state": "error",
@@ -1551,7 +1565,7 @@ def _validation_status(repo: Path) -> dict[str, Any]:
                         "count": 1,
                         "errors": 1,
                         "warnings": 0,
-                        "examples": [{"path": "", "message": str(exc)}],
+                        "examples": [{"path": "", "message": message}],
                         "repair": "Run `mb validate --cross-refs --json` for the exact failure.",
                     }
                 },
@@ -1880,6 +1894,7 @@ def run(
     path: str = ".",
     *,
     update_marker: bool = True,
+    validation_cross_refs: bool = True,
     now: datetime | None = None,
 ) -> dict[str, Any]:
     """Build a deterministic daily briefing report."""
@@ -1937,7 +1952,7 @@ def run(
         brain=brain,
         generated_at=generated_at,
     )
-    report["validation"] = _validation_status(repo_path)
+    report["validation"] = _validation_status(repo_path, cross_refs=validation_cross_refs)
     report["drift"] = _drift(report)
     report["topology"] = {
         "schema": topology_payload["schema"],

--- a/mb/mb/validate.py
+++ b/mb/mb/validate.py
@@ -131,6 +131,23 @@ SECRET_VALUE_RE = re.compile(
 
 LINK_FIELDS = relationships.RELATIONSHIP_FIELDS
 
+VALIDATION_CATEGORY_REPAIR: dict[str, str] = {
+    "missing_slug": "Add stable kebab-case `slug:` values that name the thing sold or worked on.",
+    "missing_required_key": "Add the missing required frontmatter keys for this record type.",
+    "status_enum_mismatch": "Change `status:` to one of the allowed lifecycle values.",
+    "enum_mismatch": "Change the value to one of the allowed schema values.",
+    "no_frontmatter": "Add YAML frontmatter bounded by `---` at the top of the file.",
+    "yaml_error": "Fix malformed YAML before repairing schema fields.",
+    "schema_shape_error": "Fix nested mappings and field shapes before rerunning validation.",
+    "missing_cross_ref_target": "Repair, remove, or intentionally archive broken local links.",
+    "missing_reverse_link": "Add the suggested reverse relationship field after operator approval.",
+    "migration_drift": "Run `mb doctor repair --plan --json` and review stale layout guidance.",
+    "other_error": "Review the validation message and repair the affected record.",
+    "other_warning": (
+        "Review the warning and decide whether the relationship or file shape is intentional."
+    ),
+}
+
 DECISION_STATUS_ORDER = {
     "proposed": 0,
     "running": 1,
@@ -349,6 +366,7 @@ def _check_push_frontmatter(path: Path, fm: dict[str, Any], errors: list[str]) -
         errors.append("promise must be 140 characters or fewer")
     goal = fm.get("goal")
     if "goal" not in fm:
+        errors.append("goal must be a mapping with metric, target, and by")
         return
     if not isinstance(goal, dict):
         errors.append("goal must be a mapping with metric, target, and by")
@@ -740,9 +758,17 @@ def _check_repo_topology_frontmatter(
             and isinstance(repo_name, str)
             and remote_full_name != f"{github_owner}/{repo_name}"
         ):
-            errors.append(
-                f"{prefix}.remote must match github_owner/repo_name ({github_owner}/{repo_name})"
-            )
+            if lifecycle == "proposed":
+                warnings.append(
+                    f"{prefix}.remote points to {remote_full_name!r} while "
+                    f"github_owner/repo_name is {github_owner}/{repo_name}; allowed for "
+                    "lifecycle 'proposed' rename planning, but accepted/live entries must match"
+                )
+            else:
+                errors.append(
+                    f"{prefix}.remote must match github_owner/repo_name "
+                    f"({github_owner}/{repo_name})"
+                )
 
         domain = repo_entry.get("domain")
         if domain is not None and (
@@ -934,6 +960,88 @@ def _add_migration_lint_warnings(
             },
         )
         files_by_path[rel].setdefault("warnings", []).append(message)
+
+
+def _validation_category(message: str, *, severity: str, schema: str) -> str:
+    lowered = message.lower()
+    if message == "missing key: slug":
+        return "missing_slug"
+    if message.startswith("missing key:"):
+        return "missing_required_key"
+    if lowered in {"no frontmatter", "unterminated frontmatter", "frontmatter not a mapping"}:
+        return "no_frontmatter"
+    if lowered.startswith("yaml error:"):
+        return "yaml_error"
+    if re.match(r"^[a-z_]+=", message) and " not in " in message:
+        if message.startswith("status="):
+            return "status_enum_mismatch"
+        return "enum_mismatch"
+    if (
+        " must be a mapping" in message
+        or " must be a non-empty string" in message
+        or " must be true or false" in message
+        or " must be recorded" in message
+        or " must point to " in message
+        or " must live under " in message
+        or " must match " in message
+        or " must contain " in message
+        or " must not contain " in message
+        or "frontmatter must" in message
+    ):
+        return "schema_shape_error"
+    if " target " in message and ("does not exist" in message or "does not resolve" in message):
+        return "missing_cross_ref_target"
+    if " should include linked_" in message:
+        return "missing_reverse_link"
+    if schema == "migration-drift":
+        return "migration_drift"
+    return "other_error" if severity == "error" else "other_warning"
+
+
+def _validation_categories(files: list[dict[str, Any]]) -> dict[str, Any]:
+    categories: dict[str, dict[str, Any]] = {}
+    for file_result in files:
+        path = str(file_result.get("path") or "")
+        schema = str(file_result.get("schema") or "")
+        for severity, messages in (
+            ("error", file_result.get("errors") or []),
+            ("warning", file_result.get("warnings") or []),
+        ):
+            for raw_message in messages:
+                message = str(raw_message)
+                category = _validation_category(message, severity=severity, schema=schema)
+                entry = categories.setdefault(
+                    category,
+                    {
+                        "count": 0,
+                        "errors": 0,
+                        "warnings": 0,
+                        "examples": [],
+                        "repair": VALIDATION_CATEGORY_REPAIR.get(
+                            category, VALIDATION_CATEGORY_REPAIR["other_error"]
+                        ),
+                    },
+                )
+                entry["count"] += 1
+                entry["errors" if severity == "error" else "warnings"] += 1
+                examples = entry["examples"]
+                if len(examples) < 5:
+                    examples.append({"path": path, "message": message})
+    ordered = dict(
+        sorted(
+            categories.items(),
+            key=lambda item: (-int(item[1]["count"]), item[0]),
+        )
+    )
+    top_category = next(iter(ordered), "")
+    return {
+        "schema_version": "1.0",
+        "total_categories": len(ordered),
+        "top_category": top_category,
+        "top_repair": ordered.get(top_category, {}).get("repair", ""),
+        "by_category": ordered,
+        "safe_to_share": True,
+    }
 
 
 def _check_status_transition(
@@ -1321,6 +1429,7 @@ def run(
     files = list(files_by_path.values())
     warning_count = sum(len(f.get("warnings", [])) for f in files)
     error_count = sum(len(f.get("errors", [])) for f in files)
+    categories = _validation_categories(files)
     ok = error_count == 0 and (warning_count == 0 or not strict)
     if strict:
         for file_result in files:
@@ -1334,6 +1443,8 @@ def run(
         "cross_refs": cross_ref_report,
         "legacy_repair": _legacy_frontmatter_repair(repo, error_count),
         "migration_drift": migration_drift_report,
+        "validation_categories": categories,
+        "by_category": categories["by_category"],
         "summary": {"errors": error_count, "warnings": warning_count},
     }
 
@@ -1365,6 +1476,18 @@ def render_human(report: dict[str, Any], verbose: bool = False) -> None:
                 for warning in f.get("warnings", []):
                     console.print(f"        - {warning}")
     legacy_repair = report.get("legacy_repair")
+    categories = report.get("validation_categories") or {}
+    by_category = categories.get("by_category") or {}
+    if by_category:
+        console.print("\n[bold yellow]Validation categories[/bold yellow]")
+        for name, item in list(by_category.items())[:6]:
+            console.print(
+                f"  - {name}: {item.get('count', 0)} "
+                f"({item.get('errors', 0)} error(s), {item.get('warnings', 0)} warning(s))"
+            )
+        top_repair = categories.get("top_repair")
+        if top_repair:
+            console.print(f"  next: {top_repair}")
     if legacy_repair:
         console.print("\n[bold yellow]Legacy frontmatter repair[/bold yellow]")
         console.print(f"  {legacy_repair['message']}")

--- a/mb/mb/validate.py
+++ b/mb/mb/validate.py
@@ -366,7 +366,6 @@ def _check_push_frontmatter(path: Path, fm: dict[str, Any], errors: list[str]) -
         errors.append("promise must be 140 characters or fewer")
     goal = fm.get("goal")
     if "goal" not in fm:
-        errors.append("goal must be a mapping with metric, target, and by")
         return
     if not isinstance(goal, dict):
         errors.append("goal must be a mapping with metric, target, and by")
@@ -972,8 +971,9 @@ def _validation_category(message: str, *, severity: str, schema: str) -> str:
         return "no_frontmatter"
     if lowered.startswith("yaml error:"):
         return "yaml_error"
-    if re.match(r"^[a-z_]+=", message) and " not in " in message:
-        if message.startswith("status="):
+    enum_match = re.search(r"(?:^|[.\s\]])([a-z_]+)=", message)
+    if enum_match and " not in " in message:
+        if enum_match.group(1) == "status":
             return "status_enum_mismatch"
         return "enum_mismatch"
     if (

--- a/mb/tests/fixtures/status/schema-v1-basic.json
+++ b/mb/tests/fixtures/status/schema-v1-basic.json
@@ -34,7 +34,8 @@
     "schema_version",
     "since_last_check",
     "topology",
-    "update"
+    "update",
+    "validation"
   ],
   "section_keys": {
     "repo": [
@@ -184,6 +185,16 @@
       "sections",
       "source",
       "summary"
+    ],
+    "validation": [
+      "cross_refs",
+      "legacy_repair",
+      "migration_drift",
+      "ok",
+      "safe_to_share",
+      "state",
+      "summary",
+      "validation_categories"
     ],
     "marker_update": [
       "attempted",

--- a/mb/tests/test_checkpoint.py
+++ b/mb/tests/test_checkpoint.py
@@ -239,7 +239,13 @@ def test_checkpoint_hook_status_install_and_uninstall(tmp_path: Path) -> None:
     installed = checkpoint_mod.install_commit_hook(repo)
     assert installed["ok"] is True
     assert installed["state"] == "installed"
+    assert "newly installed" in installed["summary"]
     assert Path(installed["hook"]).exists()
+
+    verified = checkpoint_mod.install_commit_hook(repo)
+    assert verified["ok"] is True
+    assert verified["changed"] is False
+    assert "already installed" in verified["summary"]
 
     uninstalled = checkpoint_mod.uninstall_commit_hook(repo)
     assert uninstalled["ok"] is True

--- a/mb/tests/test_doctor.py
+++ b/mb/tests/test_doctor.py
@@ -552,6 +552,34 @@ def test_doctor_repair_plan_reports_migration_shape_drift(tmp_path: Path) -> Non
     assert "push-record-wrong-shape" in codes
 
 
+def test_doctor_repair_plan_exposes_validation_top_category(tmp_path: Path) -> None:
+    repo = tmp_path / "validation-categories"
+    init_run(path=str(repo), name="Acme")
+    for slug in ("one", "two"):
+        offer = repo / "core" / "offers" / slug / "offer.md"
+        offer.parent.mkdir(parents=True)
+        offer.write_text("---\nstatus: running\n---\n# Offer\n", encoding="utf-8")
+
+    result = runner.invoke(app, ["doctor", "repair", "--repo", str(repo), "--plan", "--json"])
+
+    assert result.exit_code in {0, 1}
+    payload = json.loads(result.stdout)
+    section = next(section for section in payload["sections"] if section["id"] == "validation")
+    check = section["checks"][0]
+    assert "top category: missing_slug" in check["summary"]
+    assert check["report"]["validation_categories"]["by_category"]["missing_slug"]["count"] == 2
+
+
+def test_doctor_repair_include_migration_requires_apply_guidance(tmp_path: Path) -> None:
+    result = runner.invoke(
+        app,
+        ["doctor", "repair", "--repo", str(tmp_path), "--include-migration", "--plan"],
+    )
+
+    assert result.exit_code == 2
+    assert "--apply --include-migration" in result.stderr
+
+
 def test_doctor_repair_plan_reuses_migration_drift_report(
     tmp_path: Path,
     monkeypatch,

--- a/mb/tests/test_migration_lint.py
+++ b/mb/tests/test_migration_lint.py
@@ -22,6 +22,7 @@ def test_migration_lint_reports_shape_and_frontmatter_drift_privately(
         "---\nslug: spring\nstatus: active\n---\n# Private campaign body\n",
     )
     _write(tmp_path / "ops" / "handoff.md", "# Private ops body\n")
+    _write(tmp_path / "outputs" / "old-vsl.md", "# Private generated work\n")
     _write(
         tmp_path / "pushes" / "spring" / "push.md",
         (
@@ -50,11 +51,17 @@ def test_migration_lint_reports_shape_and_frontmatter_drift_privately(
     assert "legacy-reference-active-content" in codes
     assert "legacy-campaigns-active-content" in codes
     assert "legacy-top-level-ops" in codes
+    assert "legacy-top-level-outputs" in codes
     assert "push-record-wrong-shape" in codes
     assert "playbook-run-wrong-path" in codes
     assert "bet-legacy-campaign-links-only" in codes
     assert all(finding["content_included"] is False for finding in report["findings"])
     assert "Private" not in json.dumps(report)
+    outputs = next(
+        finding for finding in report["findings"] if finding["code"] == "legacy-top-level-outputs"
+    )
+    assert "documents/archive/<name>/" in outputs["message"]
+    assert "do not bulk-promote" in outputs["message"]
 
 
 def test_migration_lint_reports_stale_generated_guidance_without_file_body(

--- a/mb/tests/test_onboard.py
+++ b/mb/tests/test_onboard.py
@@ -205,6 +205,36 @@ def test_onboard_status_reports_partial_small_team_progress(tmp_path: Path, monk
     assert team_step["required"] is True
 
 
+def test_onboard_status_accepts_canonical_core_proof_directory(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(onboard_mod, "_which", _tool_path)
+    repo = tmp_path / "proof"
+    onboard_mod.run(
+        path=str(repo),
+        name="Proof Co",
+        mode="new",
+        level="power",
+        team_size="solo",
+        business_type="coaching",
+        success_stage="working",
+        desired_outcome="usable core files",
+    )
+    (repo / "core" / "offer.md").write_text("# Offer\n", encoding="utf-8")
+    (repo / "core" / "audience.md").write_text("# Audience\n", encoding="utf-8")
+    (repo / "core" / "voice.md").write_text("# Voice\n", encoding="utf-8")
+    (repo / "core" / "soul.md").write_text("# Soul\n", encoding="utf-8")
+    if (repo / "core" / "proof").is_file():
+        (repo / "core" / "proof").unlink()
+    proof = repo / "core" / "proof" / "testimonials.md"
+    proof.parent.mkdir(parents=True, exist_ok=True)
+    proof.write_text("# Testimonials\n", encoding="utf-8")
+
+    payload = onboard_mod.onboarding_status(repo)
+
+    core_step = next(step for step in payload["checklist"] if step["id"] == "core_reference")
+    assert core_step["status"] == "complete"
+    assert "proof" not in payload["summary"]["missing_inputs"]
+
+
 def test_onboard_status_unknown_team_size_is_not_larger_team(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(onboard_mod, "_which", _tool_path)
     repo = tmp_path / "unknown-team"

--- a/mb/tests/test_status.py
+++ b/mb/tests/test_status.py
@@ -15,6 +15,7 @@ from mb import codex as codex_mod
 from mb import connect as connect_mod
 from mb import graph as graph_mod
 from mb import status as status_mod
+from mb import validate as validate_mod
 from mb.cli import app
 from mb.init import run as init_run
 
@@ -539,6 +540,77 @@ def test_status_surfaces_validation_category_counts(tmp_path: Path, monkeypatch)
     )
     assert "top category: missing_slug" in validation_drift["summary"]
     assert any(action["id"] == "repair_validation_debt" for action in report["ranked_actions"])
+
+
+def test_status_peek_skips_validation_cross_refs(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+    calls: list[bool] = []
+
+    def fake_validate(
+        path: str,
+        verbose: bool = False,
+        cross_refs: bool = False,
+        strict: bool = False,
+        migration_drift_report: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        calls.append(cross_refs)
+        return {
+            "ok": True,
+            "summary": {"errors": 0, "warnings": 0},
+            "cross_refs": {
+                "enabled": cross_refs,
+                "warnings": [],
+                "orphan_offers": [],
+            },
+            "files": [],
+            "legacy_repair": None,
+            "migration_drift": {"summary": {}},
+            "validation_categories": {
+                "schema_version": "1.0",
+                "total_categories": 0,
+                "top_category": "",
+                "top_repair": "",
+                "by_category": {},
+                "safe_to_share": True,
+            },
+        }
+
+    monkeypatch.setattr(validate_mod, "run", fake_validate)
+
+    result = runner.invoke(app, ["status", str(repo), "--json", "--peek"])
+
+    assert result.exit_code == 0, result.stdout
+    assert calls == [False]
+
+
+def test_status_validation_exception_scrubs_local_paths(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+    private_path = tmp_path / "private" / "proof.md"
+
+    def fail_validate(
+        path: str,
+        verbose: bool = False,
+        cross_refs: bool = False,
+        strict: bool = False,
+        migration_drift_report: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        raise RuntimeError(f"failed while reading {private_path}")
+
+    monkeypatch.setattr(validate_mod, "run", fail_validate)
+
+    report = status_mod.run(path=str(repo), update_marker=False)
+
+    validation = report["validation"]
+    message = validation["validation_categories"]["by_category"]["validation_unavailable"][
+        "examples"
+    ][0]["message"]
+    assert str(private_path) not in message
+    assert "<local-path>" in message
+    assert validation["safe_to_share"] is True
 
 
 def test_status_relationship_health_flags_completed_and_stale_pushes(

--- a/mb/tests/test_status.py
+++ b/mb/tests/test_status.py
@@ -218,6 +218,7 @@ def test_status_schema_v1_matches_golden_fixture(tmp_path: Path, monkeypatch) ->
                 "readiness",
                 "relationship_health",
                 "playbook_health",
+                "validation",
                 "ranked_actions",
                 "marker_update",
             ]
@@ -471,6 +472,73 @@ def test_status_relationship_health_flags_active_bet_and_offer_gaps(
     assert human.exit_code == 0
     assert "Relationship health" in human.stdout
     assert "active bet(s) need a linked push" in human.stdout
+
+
+def test_status_relationship_health_accepts_push_side_bet_links(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+    (repo / "bets" / "2026-05-01-launch.md").write_text(
+        (
+            "---\n"
+            "status: open\n"
+            "opened: 2026-05-01\n"
+            "deadline: 2026-05-31\n"
+            "appetite: 2 weeks\n"
+            "hypothesis: A launch push will create calls.\n"
+            "metric: calls\n"
+            "target: 5 calls\n"
+            "result: ''\n"
+            "linked_decisions: []\n"
+            "linked_research: []\n"
+            "linked_pushes: []\n"
+            "linked_campaigns: []\n"
+            "linked_outcomes: []\n"
+            "public: true\n"
+            "channels: []\n"
+            "tags: []\n"
+            "---\n\n"
+            "# Launch bet\n"
+        ),
+        encoding="utf-8",
+    )
+    push = _write_push(repo, "2026-05-06-launch")
+    push_record = push / "push.md"
+    push_record.write_text(
+        push_record.read_text(encoding="utf-8").replace(
+            "---\n\n# Launch push\n",
+            "linked_bets:\n  - bets/2026-05-01-launch.md\n---\n\n# Launch push\n",
+        ),
+        encoding="utf-8",
+    )
+
+    report = status_mod.run(path=str(repo), update_marker=False)
+
+    assert report["relationship_health"]["summary"]["active_bets_without_push"] == 0
+
+
+def test_status_surfaces_validation_category_counts(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+    for slug in ("one", "two"):
+        offer = repo / "core" / "offers" / slug / "offer.md"
+        offer.parent.mkdir(parents=True)
+        offer.write_text("---\nstatus: running\n---\n# Offer\n", encoding="utf-8")
+
+    report = status_mod.run(path=str(repo), update_marker=False)
+
+    assert report["validation"]["validation_categories"]["top_category"] == "missing_slug"
+    assert (
+        report["validation"]["validation_categories"]["by_category"]["missing_slug"]["count"] == 2
+    )
+    validation_drift = next(
+        item for item in report["drift"]["items"] if item["id"] == "validation_debt"
+    )
+    assert "top category: missing_slug" in validation_drift["summary"]
+    assert any(action["id"] == "repair_validation_debt" for action in report["ranked_actions"])
 
 
 def test_status_relationship_health_flags_completed_and_stale_pushes(

--- a/mb/tests/test_validate.py
+++ b/mb/tests/test_validate.py
@@ -830,14 +830,31 @@ def test_validate_requires_canonical_push_schema(tmp_path: Path) -> None:
     assert "missing key: type" in bad["errors"]
     assert "missing key: kind" in bad["errors"]
     assert "missing key: goal" in bad["errors"]
-    assert "goal must be a mapping with metric, target, and by" in bad["errors"]
+    assert "goal must be a mapping with metric, target, and by" not in bad["errors"]
     assert "missing key: owner" in bad["errors"]
     assert "missing key: audience" in bad["errors"]
     assert "missing key: offer" in bad["errors"]
     assert "missing key: promise" in bad["errors"]
     categories = report["validation_categories"]["by_category"]
     assert categories["missing_required_key"]["count"] >= 1
-    assert categories["schema_shape_error"]["count"] >= 1
+    assert "schema_shape_error" not in categories
+
+
+def test_validate_categorizes_malformed_push_goal_shape(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "pushes" / "2026-05-06-bad-goal" / "push.md",
+        _push("active", slug="bad-goal").replace(
+            "goal:\n  metric: qualified calls\n  target: 10 qualified calls\n  by: 2026-05-20\n",
+            "goal: five calls\n",
+        ),
+    )
+
+    report = run(path=str(tmp_path))
+
+    bad = [file for file in report["files"] if file["path"].endswith("push.md")][0]
+    assert "missing key: goal" not in bad["errors"]
+    assert "goal must be a mapping with metric, target, and by" in bad["errors"]
+    assert report["validation_categories"]["by_category"]["schema_shape_error"]["count"] == 1
 
 
 def test_validate_categorizes_large_frontmatter_repairs(tmp_path: Path) -> None:
@@ -1342,6 +1359,7 @@ def test_validate_rejects_unknown_repo_topology_values(tmp_path: Path) -> None:
         "repos[0].lifecycle must not be 'graduated'; use a relationship instead"
     ]
     assert any("visibility='secret'" in error for error in bad["errors"])
+    assert report["validation_categories"]["by_category"]["enum_mismatch"]["count"] >= 2
 
 
 def test_validate_repo_topology_status_uses_topology_lifecycle(tmp_path: Path) -> None:

--- a/mb/tests/test_validate.py
+++ b/mb/tests/test_validate.py
@@ -676,6 +676,19 @@ def test_validate_cli_cross_refs_default_warns_strict_fails(tmp_path: Path) -> N
     assert payload["files"][0]["ok"] is False
 
 
+def test_validate_cli_accepts_repo_alias(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "decisions" / "2026-05-08-ok.md",
+        "---\ndate: 2026-05-08\nstatus: accepted\n---\n# Ok\n",
+    )
+
+    result = runner.invoke(app, ["validate", "--repo", str(tmp_path), "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["repo"] == str(tmp_path.resolve())
+
+
 def _campaign(status: str) -> str:
     return f"---\nslug: workshop-waitlist\nstatus: {status}\n---\n# Workshop waitlist\n"
 
@@ -817,10 +830,36 @@ def test_validate_requires_canonical_push_schema(tmp_path: Path) -> None:
     assert "missing key: type" in bad["errors"]
     assert "missing key: kind" in bad["errors"]
     assert "missing key: goal" in bad["errors"]
+    assert "goal must be a mapping with metric, target, and by" in bad["errors"]
     assert "missing key: owner" in bad["errors"]
     assert "missing key: audience" in bad["errors"]
     assert "missing key: offer" in bad["errors"]
     assert "missing key: promise" in bad["errors"]
+    categories = report["validation_categories"]["by_category"]
+    assert categories["missing_required_key"]["count"] >= 1
+    assert categories["schema_shape_error"]["count"] >= 1
+
+
+def test_validate_categorizes_large_frontmatter_repairs(tmp_path: Path) -> None:
+    for index in range(3):
+        _write(
+            tmp_path / "core" / "offers" / f"offer-{index}" / "offer.md",
+            "---\nstatus: running\n---\n# Offer\n",
+        )
+    _write(
+        tmp_path / "decisions" / "2026-05-08-bad.md",
+        "---\ndate: 2026-05-08\nstatus: pending\n---\n# Bad\n",
+    )
+    _write(tmp_path / "research" / "2026-05-08-no-frontmatter.md", "# No frontmatter\n")
+
+    report = run(path=str(tmp_path))
+
+    categories = report["validation_categories"]
+    assert categories["top_category"] == "missing_slug"
+    assert categories["by_category"]["missing_slug"]["count"] == 3
+    assert categories["by_category"]["status_enum_mismatch"]["count"] == 1
+    assert categories["by_category"]["no_frontmatter"]["count"] == 1
+    assert report["summary"] == {"errors": 5, "warnings": 0}
 
 
 def test_validate_requires_canonical_push_folder_shape(tmp_path: Path) -> None:
@@ -1316,6 +1355,26 @@ def test_validate_repo_topology_status_uses_topology_lifecycle(tmp_path: Path) -
     bad = [file for file in report["files"] if file["schema"] == "repo-topology"][0]
     assert report["ok"] is False
     assert any("topology status='running'" in error for error in bad["errors"])
+
+
+def test_validate_allows_proposed_topology_rename_remote_mismatch(
+    tmp_path: Path,
+) -> None:
+    _write(
+        tmp_path / "core" / "operations" / "repo-topology.md",
+        _repo_topology()
+        .replace(
+            "    lifecycle: active\n    relationship: execution_vehicle_for\n",
+            "    lifecycle: proposed\n    relationship: execution_vehicle_for\n",
+        )
+        .replace("    repo_name: workshop-site\n", "    repo_name: renamed-workshop-site\n"),
+    )
+
+    report = run(path=str(tmp_path))
+
+    topology = [file for file in report["files"] if file["schema"] == "repo-topology"][0]
+    assert not any("remote must match" in error for error in topology["errors"])
+    assert any("allowed for lifecycle 'proposed'" in warning for warning in topology["warnings"])
 
 
 def test_validate_repo_topology_warns_on_sensitive_boundary_metadata(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Groups large validation reports by repair category and surfaces top repair guidance through `mb validate`, `mb status`, and `mb doctor repair --plan`.
- Hardens migration/repair UX for legacy `outputs/`, push schema failures, proposed topology renames, reverse relationship links, checkpoint hook messaging, and canonical `core/proof/` onboarding detection.
- Adds shared slug and destructive-operation guidance for `/mb-start` and `/mb-setup`, with `CHANGELOG.md` updated under `[Unreleased]`.
- Addresses review follow-ups by avoiding missing-goal category inflation, redacting validation fallback exceptions, skipping cross-ref validation for `mb status --peek`, and categorizing dotted topology enum errors.

## Scope
- In: deterministic CLI/reporting improvements for migration, validation, status, doctor repair, onboarding proof detection, relationship health, and packaged skill guidance.
- Out: private business repo cleanup, real user-content moves, dashboard work, new runtime support claims, and exhaustive repair of every stale dogfood relationship warning.

## Commits
- `2bab67c` — `[fix] MAIN-308 harden migration repair UX`.
- `a1d685e` — `[fix] MAIN-308 address validation review follow-ups`.

## Release / Issues
- Release: next patch release.
- Linear ID(s): MAIN-308.
- Closes: #460.
- Refs: #461.
- Follow-ups: interactive Claude Code TUI smoke before release tagging if this becomes release-bearing runtime evidence.

## Success Metric
- A dogfood repo with mixed migration/validation debt gets category-level repair guidance and safe next commands without agents fabricating pushes/campaigns, missing canonical `core/proof/`, or mutating/renaming business objects without approval.

## Validation
- Level 0 docs/decision: `CHANGELOG.md`, `/mb-start`, `/mb-setup`, and shared primitive references reviewed for public-safe language.
- Level 1 static: `scripts/check.sh` passed formatting, ruff, mypy, 485 pytest tests, and 17/17 bundled skill validation after review follow-ups.
- Level 2 CLI: focused tests cover validation categories, malformed push goal categorization, `mb validate --repo`, status fallback redaction, `mb status --peek` cross-ref gating, doctor repair guidance, status validation drift, relationship health, checkpoint wording, migration lint, topology enum/rename warnings, and onboarding proof detection.
- Level 3 package/install: built wheel, installed into `/tmp/mainbranch-smoke`, then ran `mb --version`, `mb skill list`, `mb onboard --yes --json`, and `mb start --repo ... --json`; after review follow-ups, rebuilt/reinstalled into `/tmp/mainbranch-review-smoke` and verified `mb status --json --peek` plus `mb validate --repo --json`.
- Level 4 fixture repo: from the installed wheel, ran `mb onboard`, `mb doctor`, `mb status`, `mb start --json`, and `mb validate` in a fresh business repo.
- Level 5 runtime smoke: not run; this branch changes deterministic CLI/reporting and skill guidance, not slash-command discovery, and package/fixture smokes verified packaged skill wiring plus `mb-start` discoverability from `mb start` facts.

## Public / Private Boundary
- Dogfood transcript details stayed out of committed files; committed docs and tests use generic, sanitized repo/product language with no credentials, raw customer data, or private business content.
