### PR TITLE
[update] Prepare 0.3.15 release

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mainbranch",
-  "version": "0.3.14",
+  "version": "0.3.15",
   "description": "Main Branch Claude Code skills for running a business from markdown files in git.",
   "author": {
     "name": "Noontide"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,28 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+## [0.3.15] - 2026-05-09
+
+v0.3.15 ships the migration and repair hardening that landed after v0.3.14 as
+an installable patch release. Large validation reports now group findings by
+repair category, `mb status` and `mb doctor repair --plan` surface the top
+repair cluster, legacy `outputs/` directories get archive-oriented migration
+guidance, and onboarding recognizes canonical `core/proof/` evidence without
+requiring compatibility shims.
+
+### What this means for you (plain English)
+
+- **Repair lists are easier to act on.** `mb validate`, `mb status`, and
+  `mb doctor repair --plan` now show validation categories and top repair
+  guidance so a messy migrated repo points at the biggest useful fix first.
+- **Migration advice is less destructive.** Old top-level `outputs/` folders
+  are treated as historical generated work that should be archived or reviewed
+  by hand, not bulk-promoted into pushes or legacy campaigns.
+- **Daily startup sees current repo shapes.** `mb onboard` recognizes populated
+  `core/proof/` directories, relationship health accepts push-side
+  `linked_bets`, and proposed topology rename records can exist without
+  weakening validation for live repo entries.
+
 ### Added
 
 - Added validation category summaries to `mb validate --json`, `mb status`,

--- a/mb/mb/__init__.py
+++ b/mb/mb/__init__.py
@@ -7,6 +7,6 @@ file stays a thin dispatcher.
 
 from __future__ import annotations
 
-__version__ = "0.3.14"
+__version__ = "0.3.15"
 
 __all__ = ["__version__"]

--- a/mb/pyproject.toml
+++ b/mb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mainbranch"
-version = "0.3.14"
+version = "0.3.15"
 description = "Main Branch engine umbrella - scaffolds, validates, and graphs business-as-files repos. Claude Code first, runtime-agnostic by design."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- Prepares Main Branch 0.3.15 as the installable patch release for the migration and repair hardening that landed after 0.3.14.
- Bumps package and Claude plugin version surfaces to 0.3.15.
- Moves the accumulated unreleased CLI/workflow notes into a dated 0.3.15 changelog section.

## Scope
- In: version bump, Claude plugin manifest version, and public changelog release notes.
- Out: new product behavior beyond the already-merged MAIN-308 hardening work.

## Commits
- 15cd303 — [update] Prepare 0.3.15 release

## Release / Issues
- Release: 0.3.15 / oe-v0.3.15
- Linear ID(s): MAIN-308
- Closes: none
- Refs: #460, #462
- Follow-ups: none for this release prep PR.

## Success Metric
- A published GitHub release `oe-v0.3.15` builds and publishes `mainbranch==0.3.15`, and a fresh PyPI install reports `mb 0.3.15` with bundled skills available.

## Validation
- Level 0 docs/decision: `CHANGELOG.md` has a 0.3.15 section dated 2026-05-09; public/private boundary checked in release notes.
- Level 1 static: `scripts/check.sh` passed from repo root: format, ruff, mypy, 485 pytest tests, and `mb skill validate` for 17/17 bundled skills.
- Level 2 CLI: wheel-installed CLI ran `mb --version`, `mb skill list`, `mb doctor`, `mb status`, `mb start --json`, and `mb validate` against a fresh fixture repo.
- Level 3 package/install: `(cd mb && python3 -m build)` produced `mainbranch-0.3.15` sdist and wheel; clean venv installed `mb/dist/mainbranch-0.3.15-py3-none-any.whl` and reported `mb 0.3.15`.
- Level 4 fixture repo: wheel install smoke created `/tmp/mainbranch-release-0315-business`; onboarding, skill wiring, doctor, status, start JSON, and validate all completed successfully.
- Level 5 runtime smoke: deterministic wheel dogfood harness passed with evidence in `.context/release-0.3.15-dogfood`; short `claude -p` `pr_smoke` proxy was attempted and stopped at the explicit `$0.25` budget cap after capturing fixture facts, with zero permission denials and no repo-boundary mutations. Interactive Claude Code TUI smoke was not run because the release simulation suite was intentionally thinned per operator direction.

## Public / Private Boundary
- Release notes stay generic and public; local dogfood evidence remains in gitignored `.context/`.
