### PR TITLE
[docs] Obsidian as first-class optional viewer + link conventions (MAIN-306)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+### Changed
+
+- Decided that Obsidian is a first-class optional viewer over the same
+  markdown files `mb` validates, not a dependency or second source of
+  truth. `mb` keeps the typed business graph and validation; Obsidian
+  owns clickable browsing, Backlinks, and Graph view. `docs/markdown-link-conventions.md`
+  is restructured around three layered rules (canonical edges in
+  frontmatter; body mirrors are note-level only; Markdown relative links
+  for interop) and documents the cross-tool section-anchor trap and
+  authoring hazards. Generated business-repo agent guidance
+  (`CLAUDE.md.tmpl`, `AGENTS.md.tmpl`) gains a brief Linking section so
+  Claude Code and Codex agents emit the body-mirror + frontmatter pair
+  consistently. No CLI behavior, frontmatter contract, or fixture
+  changes. Refs #455.
+
 ## [0.3.14] - 2026-05-09
 
 v0.3.14 ships the first experimental Codex CLI-first adapter slice and the

--- a/decisions/2026-05-09-obsidian-first-class-viewer.md
+++ b/decisions/2026-05-09-obsidian-first-class-viewer.md
@@ -1,0 +1,117 @@
+---
+type: decision
+date: 2026-05-09
+status: accepted
+topic: Obsidian as a first-class optional viewer
+linked_issues:
+  - https://github.com/noontide-co/mainbranch/issues/455
+linked_decisions:
+  - decisions/2026-05-08-business-repo-topology-map.md
+  - decisions/2026-05-06-main-branch-operating-spine.md
+linked_docs:
+  - docs/markdown-link-conventions.md
+tags: [v0-3, docs, graph, obsidian, links, viewer]
+---
+
+# Obsidian as a First-Class Optional Viewer
+
+## Decision
+
+Main Branch does not depend on Obsidian for correctness. It treats Obsidian
+as a first-class optional viewer over the same markdown files that `mb`
+validates.
+
+`mb` owns the typed business graph: repo shape, frontmatter contracts,
+cross-reference validation, relationship health, doctor repair, and
+generated guidance. Obsidian owns mature local browsing: clickable files,
+the Backlinks pane, Graph view, and link following.
+
+The viewer story is intentionally narrow. A user who opens their business
+repo as an Obsidian vault should be able to click around files, see what
+links to what, and follow relationships. That is the whole claim. Main
+Branch does not market a dashboarding layer, recommend a database plugin,
+or take a dependency on any community plugin.
+
+This decision is documentation- and convention-bearing only. It does not
+add a CLI flag, a generator, or a packaged starter. Future user-visible
+features (an Obsidian companion artifact, a portable starter, an
+"open in Obsidian" affordance, or a connection-suggestion playbook) belong
+in their own follow-up issues.
+
+## Why
+
+Operators already have plain markdown files in a local folder. Obsidian
+already browses markdown, wikilinks, Backlinks, and Graph view without
+asking Main Branch to host a dashboard or run a second source of truth.
+The cheapest useful viewer is the one the operator already knows or can
+adopt without a vendor commitment, and Obsidian is the most established
+local-first markdown graph viewer.
+
+The relevant Obsidian behavior that makes this work:
+
+- Both `[[wikilink]]` and `[markdown](path.md)` link syntaxes parse and
+  resolve. The Backlinks pane covers both equally.
+- Graph view edges come from internal links in note bodies. Folders are
+  not containers; tags can be toggled as nodes.
+- Properties (Obsidian's typed YAML frontmatter UI, GA 2023-08-31) does
+  not recognize plain repo-relative paths as links. Only quoted
+  `[[wikilink]]` values in YAML render as graph edges. So canonical
+  typed edges in `mb` frontmatter are invisible to Obsidian's graph and
+  Backlinks unless we mirror them in note bodies.
+- Section-heading link syntax does not agree across GitHub and Obsidian.
+  GitHub slugifies headings to lowercase-hyphenated anchors; Obsidian
+  uses the heading text after `#`. Heading-fragment links are brittle
+  cross-tool.
+
+These constraints decide the convention: typed edges stay canonical in
+frontmatter for `mb`, and a body-level "Related" section creates the
+note-level edges that Obsidian Graph and Backlinks render. See
+[Markdown link conventions](../docs/markdown-link-conventions.md) for
+the link-form rules.
+
+## What this is not
+
+This decision deliberately does not include the following. Each is a
+follow-up at most, never a requirement.
+
+- A dashboarding layer recommendation. Main Branch does not endorse the
+  Obsidian Bases core plugin, Dataview, Templater, Graph Link Types,
+  community Map-of-Content plugins, or any other plugin as part of the
+  viewer story. Operators may use any of these locally; nothing in
+  Main Branch should depend on them.
+- An `mb graph --obsidian` companion artifact, generated index notes,
+  or starter `.base` files. None ship with this decision.
+- A bundled `.obsidian/` folder. `mb onboard` does not create one.
+  `.obsidian/workspace.json` and `.obsidian/workspace-mobile.json`
+  contain machine-specific pane state and should never be committed
+  shared.
+- An `mb open obsidian` affordance. The `obsidian://open` URI scheme
+  and the official Obsidian CLI (v1.12+, 2026-02) are interesting future
+  integration surfaces but are not part of this decision.
+- A change to the `linked_*` frontmatter contract. Repo-relative paths
+  with `.md` extensions remain canonical. No switch to wikilink-typed
+  frontmatter.
+
+## Consequences
+
+- `docs/markdown-link-conventions.md` is the canonical place for link
+  authoring rules. It updates to cover the three-rule contract,
+  authoring hazards, and the body-mirror pattern.
+- `mb graph`, `mb validate --cross-refs`, and `mb status relationship_health`
+  remain the deterministic source of graph truth. None of their
+  contracts change because of this decision.
+- Generated business-repo agent guidance (`CLAUDE.md.tmpl`,
+  `AGENTS.md.tmpl`) gains a brief Linking section pointing operators
+  and agents at the conventions doc.
+- A future ticket may add a connection-discovery playbook that uses
+  Obsidian's outgoing-links / Backlinks queries (or the official
+  Obsidian CLI) to propose candidate edges to the operator. That work
+  sits adjacent to the existing graph-link authoring assistance ticket
+  and stays optional.
+
+## Validation
+
+- `scripts/check.sh` from repo root.
+- No CLI behavior changes; no new fixtures required.
+- `mb validate --cross-refs --strict` against the existing
+  `mb/tests/fixtures/` continues to pass.

--- a/decisions/2026-05-09-obsidian-first-class-viewer.md
+++ b/decisions/2026-05-09-obsidian-first-class-viewer.md
@@ -126,3 +126,9 @@ follow-up at most, never a requirement.
   confirm body-level `## Related links` entries appear as navigable
   links and produce edges in the Graph view and entries in the
   Backlinks pane. Not automated.
+
+## Related links
+
+- [Business repo topology map](2026-05-08-business-repo-topology-map.md) — prior decision this builds on.
+- [Main Branch operating spine](2026-05-06-main-branch-operating-spine.md) — durable operating model this decision sits inside.
+- [Markdown link conventions](../docs/markdown-link-conventions.md) — link-form rules this decision points operators at.

--- a/decisions/2026-05-09-obsidian-first-class-viewer.md
+++ b/decisions/2026-05-09-obsidian-first-class-viewer.md
@@ -63,11 +63,14 @@ The relevant Obsidian behavior that makes this work:
   uses the heading text after `#`. Heading-fragment links are brittle
   cross-tool.
 
-These constraints decide the convention: typed edges stay canonical in
-frontmatter for `mb`, and a body-level "Related" section creates the
-note-level edges that Obsidian Graph and Backlinks render. See
-[Markdown link conventions](../docs/markdown-link-conventions.md) for
-the link-form rules.
+These constraints decide the convention. Typed edges in frontmatter
+remain canonical. A body `## Related links` section is a viewer mirror
+only — it exists so Obsidian, GitHub, and humans can browse
+relationships without `mb` changing its graph model. If frontmatter and
+body mirrors disagree, frontmatter wins; future validation or doctor
+tooling may warn when the mirror is out of date and offer to repair it.
+See [Markdown link conventions](../docs/markdown-link-conventions.md)
+for the link-form rules.
 
 ## What this is not
 
@@ -108,6 +111,10 @@ follow-up at most, never a requirement.
   Obsidian CLI) to propose candidate edges to the operator. That work
   sits adjacent to the existing graph-link authoring assistance ticket
   and stays optional.
+- Body mirrors are derived browsing aids, not authoritative graph data.
+  Future validation or doctor tooling may warn when canonical frontmatter
+  links are missing from a file's body mirror, but graph correctness
+  remains based on structured frontmatter.
 
 ## Validation
 
@@ -115,3 +122,7 @@ follow-up at most, never a requirement.
 - No CLI behavior changes; no new fixtures required.
 - `mb validate --cross-refs --strict` against the existing
   `mb/tests/fixtures/` continues to pass.
+- Manual smoke test: open a business repo root as an Obsidian vault and
+  confirm body-level `## Related links` entries appear as navigable
+  links and produce edges in the Graph view and entries in the
+  Backlinks pane. Not automated.

--- a/docs/markdown-link-conventions.md
+++ b/docs/markdown-link-conventions.md
@@ -131,17 +131,12 @@ when headings change or collide. Obsidian uses the heading text after `#`
 as the heading target. The two systems do not agree, and section-fragment
 links that look right in one tool will fail or drift in the other.
 
-Keep exact section identity in structured metadata when it matters:
-
-```yaml
-related:
-  - kind: related
-    path: docs/markdown-link-conventions.md
-    section: Body mirrors
-```
-
-The body mirror still uses a note-level link, with prose naming the
-target section:
+The canonical typed-edge fields (`linked_decisions`, `linked_research`,
+`linked_pushes`, `linked_outcomes`, `linked_docs`, `linked_issues`,
+`linked_bets`, `linked_playbooks`, etc.) point at files, not headings.
+That is intentional. If you need to point at a specific section of the
+target file, name the section in body prose rather than encoding it in
+a link fragment:
 
 ```markdown
 ## Related links

--- a/docs/markdown-link-conventions.md
+++ b/docs/markdown-link-conventions.md
@@ -102,12 +102,18 @@ body section so Obsidian Graph and Backlinks pick them up. Use Markdown
 relative links at the note level:
 
 ```markdown
-## Related
+## Related links
 
 - [Pricing model decision](../decisions/2026-05-04-pricing-model.md)
 - [Audience notes](../research/2026-05-04-audience-notes.md)
 - [Spring launch push](../pushes/2026-05-04-spring-launch/push.md)
 ```
+
+Body mirrors are a viewer aid, not a second source of truth. Frontmatter
+typed edges remain canonical for `mb graph`, `mb validate --cross-refs`,
+and `mb status relationship_health`. If frontmatter and the body mirror
+disagree, frontmatter wins. Future doctor / validation tooling may warn
+when the mirror is missing canonical edges and offer to repair it.
 
 The body mirror creates one stable note-to-note edge per relationship.
 Obsidian's Backlinks pane covers Markdown links and wikilinks equally;
@@ -138,7 +144,7 @@ The body mirror still uses a note-level link, with prose naming the
 target section:
 
 ```markdown
-## Related
+## Related links
 - [Markdown link conventions](markdown-link-conventions.md) — see the
   "Body mirrors" section.
 ```

--- a/docs/markdown-link-conventions.md
+++ b/docs/markdown-link-conventions.md
@@ -4,15 +4,24 @@ Main Branch business repos should be readable in GitHub, local editors, and
 Obsidian without becoming dependent on any markdown app.
 
 The repo is the durable source of truth. Markdown tools are views over that
-truth.
+truth. `mb` is the validator and graph engine; Obsidian is an optional
+first-class viewer over the same files. See
+[the Obsidian viewer decision](../decisions/2026-05-09-obsidian-first-class-viewer.md)
+for the product stance.
 
-## Goals
+## Three rules
 
-- GitHub links work in pull requests, issues, and the browser.
-- Obsidian can browse the same repo as a vault.
-- `mb graph` can build useful file and entity relationships.
-- `mb validate --cross-refs` can catch broken important links.
-- Agents can follow links without guessing.
+1. **Canonical relationship data lives in structured frontmatter**, not in
+   viewer-specific link strings. `mb graph`, `mb validate --cross-refs`,
+   and `mb status relationship_health` read frontmatter as the source of
+   truth.
+2. **Body mirrors exist only to create explicit note-level edges** for
+   Obsidian Graph and Backlinks. Mirrors do not replace structured
+   frontmatter; they sit alongside it.
+3. **When interoperability matters, use Markdown relative links** for
+   body-level mirrors. Both Obsidian and GitHub render Markdown relative
+   links. Wikilinks are also valid in Obsidian-only contexts but are not
+   the recommended convention for files that ship to GitHub.
 
 ## Filenames
 
@@ -26,14 +35,21 @@ pushes/2026-05-04-spring-launch/push.md
 core/offers/main-branch/offer.md
 ```
 
-These examples use the current v0.x canonical folders. If future user research
-shows that folder names should change, that change should land through
-path-config and migration work, not ad hoc docs or skill examples that teach a
-different repo shape.
+These examples use the current v0.x canonical folders. If future user
+research shows that folder names should change, that change should land
+through path-config and migration work, not ad hoc docs or skill examples
+that teach a different repo shape.
 
-Avoid spaces, case-only distinctions, punctuation-heavy names, and repeated
-stems in different folders when you expect to use wikilinks. Obsidian can
-resolve `[[pricing-model]]` by filename stem only when the stem is unique.
+Avoid spaces, case-only distinctions, and punctuation-heavy names. Avoid
+characters Windows reserves in filenames: `< > : " / \ | ? *`. Avoid
+characters Obsidian rejects in link targets: `# | ^ : % [ ]`. These
+constraints intersect; staying lowercase, hyphenated, and ASCII-safe
+keeps every renderer happy.
+
+If you also use Obsidian wikilinks anywhere, prefer unique filename stems.
+Obsidian's default "Shortest path when possible" setting will let
+`[[pricing-model]]` resolve to whichever stem-matched file Obsidian finds
+first, which can collide silently across folders.
 
 ## Frontmatter Links
 
@@ -49,11 +65,11 @@ linked_pushes:
   - pushes/2026-05-04-spring-launch/push.md
 ```
 
-Do not use Obsidian wikilink syntax in frontmatter. Do not omit the extension.
-Do not use absolute local paths.
+Do not use Obsidian wikilink syntax in frontmatter. Do not omit the
+extension. Do not use absolute local paths.
 
-Legacy `linked_campaigns` frontmatter remains readable for migrated repos, but
-new records should use `linked_pushes`.
+Legacy `linked_campaigns` frontmatter remains readable for migrated repos,
+but new records should use `linked_pushes`.
 
 Allowed external references:
 
@@ -62,31 +78,92 @@ linked_issues:
   - https://github.com/noontide-co/mainbranch/issues/274
 ```
 
-Use external URLs for public issue, PR, release, or source links. Use local
-paths for files inside the same repo.
+Use external URLs for public issue, PR, release, or source links. Use
+local paths for files inside the same repo.
 
-## Body Links
+### Why frontmatter is not where viewer links go
 
-Use standard Markdown links when GitHub clickability matters:
+Obsidian's Properties feature treats YAML frontmatter as typed metadata.
+A property value containing `[[wikilink]]` syntax is rendered clickable
+and contributes to Graph view; a plain repo-relative path is stored as
+opaque text and does not become a graph edge or a Linked Mention. So
+`linked_pushes: [pushes/.../push.md]` is correct for `mb` and for GitHub
+PR review, but invisible to Obsidian's Graph and Backlinks. The body
+mirror below is how those edges become visible to Obsidian users.
+
+If you ever do put `[[...]]` in a YAML property, Obsidian requires the
+value to be quoted, e.g. `key: "[[Note]]"` or `key: ["[[Note]]"]`.
+Markdown formatting is not rendered inside text properties.
+
+## Body Mirrors
+
+When a file declares typed edges in frontmatter, mirror those edges in a
+body section so Obsidian Graph and Backlinks pick them up. Use Markdown
+relative links at the note level:
 
 ```markdown
-See [the pricing decision](../decisions/2026-05-04-pricing-model.md).
+## Related
+
+- [Pricing model decision](../decisions/2026-05-04-pricing-model.md)
+- [Audience notes](../research/2026-05-04-audience-notes.md)
+- [Spring launch push](../pushes/2026-05-04-spring-launch/push.md)
 ```
 
-Use Obsidian wikilinks when graph browsing is the main reason and the target is
-unambiguous:
+The body mirror creates one stable note-to-note edge per relationship.
+Obsidian's Backlinks pane covers Markdown links and wikilinks equally;
+Graph view treats both as edges. GitHub renders Markdown relative links
+clickable in PR review and the file viewer.
+
+You may add a short prose description, including the name of the target
+section. Keep the link itself note-level; do not encode section identity
+in a heading fragment (see below).
+
+### Do not link to section anchors across tools
+
+GitHub slugifies headings to lowercase-hyphenated anchors and changes them
+when headings change or collide. Obsidian uses the heading text after `#`
+as the heading target. The two systems do not agree, and section-fragment
+links that look right in one tool will fail or drift in the other.
+
+Keep exact section identity in structured metadata when it matters:
+
+```yaml
+related:
+  - kind: related
+    path: docs/markdown-link-conventions.md
+    section: Body mirrors
+```
+
+The body mirror still uses a note-level link, with prose naming the
+target section:
+
+```markdown
+## Related
+- [Markdown link conventions](markdown-link-conventions.md) — see the
+  "Body mirrors" section.
+```
+
+Treat heading anchors as brittle unless the heading is deliberately
+stable.
+
+## Wikilinks
+
+Wikilinks are valid in Obsidian and are accepted by `mb graph` and
+`mb validate --cross-refs` as body-link edges. Use them when the file is
+written for an Obsidian-only audience and GitHub readability is not a
+constraint.
+
+When you do use a wikilink, prefer the path form over a bare stem:
 
 ```markdown
 See [[decisions/2026-05-04-pricing-model|pricing decision]].
-See [[pricing-model]] only when that filename stem is unique.
 ```
 
-For durable docs, prefer the path form over bare stems. It is clearer to
-GitHub readers, agents, and future validation.
+Bare stems like `[[pricing-model]]` rely on Obsidian's basename resolver
+and can collide silently when two folders have the same stem.
 
-Heading anchors are less stable than file links because GitHub and Obsidian do
-not generate anchors the same way in every case. Prefer linking to the file and
-using a clear heading near the target.
+For files that mix audiences (PR reviewers on GitHub plus operators in
+Obsidian), use Markdown relative links per the rule above.
 
 ## Entity Tags
 
@@ -101,15 +178,19 @@ using a clear heading near the target.
 #metric/activation-rate
 ```
 
-Use these for durable entities that should appear in graph output. Keep values
-lowercase and hyphenated. Do not use entity tags for secrets, private customer
-names, account numbers, or legal/finance identifiers that should not be visible
-to the repo audience.
+Use these for durable entities that should appear in graph output. Keep
+values lowercase and hyphenated. Do not use entity tags for secrets,
+private customer names, account numbers, or legal/finance identifiers
+that should not be visible to the repo audience.
+
+Obsidian's native graph view can also surface tags as nodes when toggled.
+Nested tags (`#parent/child`) display as a hierarchy in Obsidian's Tags
+pane but do not draw parent-child edges in core Graph view.
 
 ## Cross-Repo Links
 
-A business repo may link to another repo, but a cross-repo link is not the same
-as access.
+A business repo may link to another repo, but a cross-repo link is not
+the same as access.
 
 Use public URLs when the target is public:
 
@@ -117,30 +198,35 @@ Use public URLs when the target is public:
 See [Main Branch issue #274](https://github.com/noontide-co/mainbranch/issues/274).
 ```
 
-Use a plain-text repo/path reference when the target may be private and the
-link should not imply broad access:
+Use a plain-text repo/path reference when the target may be private and
+the link should not imply broad access:
 
 ```markdown
 Private finance source: finance-repo/core/finance/ledger/
 ```
 
-Do not commit private local machine paths. If a local-only path is needed for
-an operator, keep it in local config, a private repo, or `.context/` rather
-than public docs.
+Do not commit private local machine paths. If a local-only path is
+needed for an operator, keep it in local config, a private repo, or
+`.context/` rather than public docs.
 
 ## Obsidian Setup
 
-Opening a business repo as an Obsidian vault should be optional:
+Opening a business repo as an Obsidian vault is optional. The viewer
+story is browsing files, following links, and reading the Backlinks pane
+and Graph view. That is the whole claim.
 
 1. Open the repo root as the vault.
-2. Keep attachments and exports in existing repo folders only when they are
-   safe for the repo audience.
-3. Do not rely on an Obsidian plugin for Main Branch correctness.
-4. Keep `.obsidian/` local unless a team intentionally agrees to commit shared
-   vault settings.
+2. Keep attachments and exports in existing repo folders only when they
+   are safe for the repo audience.
+3. Do not rely on an Obsidian plugin for Main Branch correctness. `mb`
+   validates and indexes the same files without any plugin.
+4. Keep `.obsidian/` local. `workspace.json` and `workspace-mobile.json`
+   contain machine-specific pane state and should not be committed
+   shared.
 
-Main Branch should not require Obsidian, replace Obsidian, or add Obsidian as a
-runtime dependency.
+Main Branch should not require Obsidian, replace Obsidian, or add
+Obsidian as a runtime dependency. See
+[the Obsidian viewer decision](../decisions/2026-05-09-obsidian-first-class-viewer.md).
 
 ## Validation
 
@@ -150,9 +236,10 @@ Run:
 mb validate --cross-refs
 ```
 
-This checks known frontmatter link fields and warns when important links are
-missing. It also warns when wikilinks point to missing markdown files or match
-multiple files by stem.
+This checks known frontmatter link fields and warns when important
+links are missing. It also warns when wikilinks point to missing
+markdown files or match multiple files by stem. Standard Markdown
+relative links are validated as body-link edges in the same pass.
 
 Use strict mode in CI or branch cleanup when warnings should fail:
 
@@ -160,5 +247,5 @@ Use strict mode in CI or branch cleanup when warnings should fail:
 mb validate --cross-refs --strict
 ```
 
-Validation does not prove a user can access a private cross-repo target. It only
-checks the current repo and safe external references.
+Validation does not prove a user can access a private cross-repo
+target. It only checks the current repo and safe external references.

--- a/docs/markdown-link-conventions.md
+++ b/docs/markdown-link-conventions.md
@@ -47,9 +47,9 @@ constraints intersect; staying lowercase, hyphenated, and ASCII-safe
 keeps every renderer happy.
 
 If you also use Obsidian wikilinks anywhere, prefer unique filename stems.
-Obsidian's default "Shortest path when possible" setting will let
-`[[pricing-model]]` resolve to whichever stem-matched file Obsidian finds
-first, which can collide silently across folders.
+Bare-stem links like `[[pricing-model]]` depend on Obsidian's basename
+resolver and can become ambiguous when multiple folders contain the same
+stem. Path-form wikilinks avoid that ambiguity.
 
 ## Frontmatter Links
 

--- a/mb/mb/_data/templates/AGENTS.md.tmpl
+++ b/mb/mb/_data/templates/AGENTS.md.tmpl
@@ -97,6 +97,24 @@ before acting.
 - `log/` - running activity log.
 - `documents/` - anything that does not belong above.
 
+## Linking
+
+Typed relationships live in frontmatter as repo-relative `.md` paths
+(`linked_decisions:`, `linked_research:`, `linked_pushes:`, etc.). Those
+are the canonical edges `mb graph` and `mb validate --cross-refs` read.
+
+When a file declares typed edges in frontmatter, mirror them in a body
+`## Related` section using **Markdown relative links** so the same edges
+show up in Obsidian's Graph view and Backlinks pane for operators who
+open the repo as a vault. Keep mirror links note-level; do not link to
+section anchors, since GitHub and Obsidian disagree on heading-fragment
+syntax. See the engine doc
+[`docs/markdown-link-conventions.md`](https://github.com/noontide-co/mainbranch/blob/main/docs/markdown-link-conventions.md)
+for the full rules.
+
+Obsidian is an optional viewer over the same files `mb` validates. Do
+not depend on any Obsidian plugin for repo correctness.
+
 ## Connected Accounts
 
 Never commit API keys, OAuth refresh tokens, service-account JSON, webhook

--- a/mb/mb/_data/templates/AGENTS.md.tmpl
+++ b/mb/mb/_data/templates/AGENTS.md.tmpl
@@ -104,11 +104,13 @@ Typed relationships live in frontmatter as repo-relative `.md` paths
 are the canonical edges `mb graph` and `mb validate --cross-refs` read.
 
 When a file declares typed edges in frontmatter, mirror them in a body
-`## Related` section using **Markdown relative links** so the same edges
-show up in Obsidian's Graph view and Backlinks pane for operators who
-open the repo as a vault. Keep mirror links note-level; do not link to
-section anchors, since GitHub and Obsidian disagree on heading-fragment
-syntax. See the engine doc
+`## Related links` section using **Markdown relative links** so the same
+edges show up in Obsidian's Graph view and Backlinks pane for operators
+who open the repo as a vault. The body mirror is a viewer aid, not a
+second source of truth — if frontmatter and the mirror disagree,
+frontmatter wins. Keep mirror links note-level; do not link to section
+anchors, since GitHub and Obsidian disagree on heading-fragment syntax.
+See the engine doc
 [`docs/markdown-link-conventions.md`](https://github.com/noontide-co/mainbranch/blob/main/docs/markdown-link-conventions.md)
 for the full rules.
 

--- a/mb/mb/_data/templates/CLAUDE.md.tmpl
+++ b/mb/mb/_data/templates/CLAUDE.md.tmpl
@@ -158,11 +158,13 @@ Typed relationships live in frontmatter as repo-relative `.md` paths
 are the canonical edges `mb graph` and `mb validate --cross-refs` read.
 
 When a file declares typed edges in frontmatter, mirror them in a body
-`## Related` section using **Markdown relative links** so the same edges
-show up in Obsidian's Graph view and Backlinks pane for operators who
-open the repo as a vault. Keep mirror links note-level; do not link to
-section anchors, since GitHub and Obsidian disagree on heading-fragment
-syntax. See the engine doc
+`## Related links` section using **Markdown relative links** so the same
+edges show up in Obsidian's Graph view and Backlinks pane for operators
+who open the repo as a vault. The body mirror is a viewer aid, not a
+second source of truth — if frontmatter and the mirror disagree,
+frontmatter wins. Keep mirror links note-level; do not link to section
+anchors, since GitHub and Obsidian disagree on heading-fragment syntax.
+See the engine doc
 [`docs/markdown-link-conventions.md`](https://github.com/noontide-co/mainbranch/blob/main/docs/markdown-link-conventions.md)
 for the full rules.
 

--- a/mb/mb/_data/templates/CLAUDE.md.tmpl
+++ b/mb/mb/_data/templates/CLAUDE.md.tmpl
@@ -151,6 +151,24 @@ itself for the bounded shape.
 - One owner per file via `.github/CODEOWNERS`.
 - Pull request titles use Conventional Commits.
 
+## Linking
+
+Typed relationships live in frontmatter as repo-relative `.md` paths
+(`linked_decisions:`, `linked_research:`, `linked_pushes:`, etc.). Those
+are the canonical edges `mb graph` and `mb validate --cross-refs` read.
+
+When a file declares typed edges in frontmatter, mirror them in a body
+`## Related` section using **Markdown relative links** so the same edges
+show up in Obsidian's Graph view and Backlinks pane for operators who
+open the repo as a vault. Keep mirror links note-level; do not link to
+section anchors, since GitHub and Obsidian disagree on heading-fragment
+syntax. See the engine doc
+[`docs/markdown-link-conventions.md`](https://github.com/noontide-co/mainbranch/blob/main/docs/markdown-link-conventions.md)
+for the full rules.
+
+Obsidian is an optional viewer over the same files `mb` validates. Do
+not depend on any Obsidian plugin for repo correctness.
+
 ## Connected accounts
 
 Treat this repo as the boundary for connected business tools. When you switch


### PR DESCRIPTION
## Summary
- Records the product stance that Main Branch does not depend on Obsidian for correctness; Obsidian is a first-class optional viewer over the same markdown files `mb` validates. `mb` keeps the typed business graph and validation; Obsidian owns clickable browsing, Backlinks, and Graph view.
- Restructures `docs/markdown-link-conventions.md` around three layered rules: canonical edges in frontmatter; body mirrors are note-level only; Markdown relative links for interop. Documents the cross-tool section-anchor trap and authoring hazards (Windows / Obsidian forbidden filename chars; YAML quoting if anyone puts `[[...]]` in properties).
- Adds a brief Linking section to generated business-repo agent guidance (`mb/mb/_data/templates/CLAUDE.md.tmpl` and `AGENTS.md.tmpl`) so Claude Code and Codex agents emit the body-mirror + frontmatter typed-edge pair consistently.
- Frames body mirrors as derived viewer aids (frontmatter wins on disagreement) so future `mb doctor` / `mb validate` work has a clear place to land.

## Scope
- In: decision file; link-conventions doc rewrite; generated business-repo agent guidance; CHANGELOG `[Unreleased]` entry.
- Out: `mb graph --obsidian` companion artifact; `.obsidian/` starter; Bases / Dataview / dashboard layer recommendation; `mb open obsidian` affordance; subagent connection-finding playbook. All captured as follow-up tickets.

## Commits
- `cbeb809` — [add] Decision: Obsidian as first-class optional viewer (MAIN-306, #455)
- `a899234` — [update] Link conventions: three-rule contract + Obsidian interop (MAIN-306, #455)
- `144832e` — [update] Generated business-repo agent guidance: add Linking section (MAIN-306, #455)
- `1c80bb3` — [update] Tighten body-mirror framing + rename to 'Related links' (MAIN-306, #455)
- `656d6e1` — [fix] Address review: decision follows its own rule + drop fictional schema (MAIN-306, #455)
- `40f4625` — [update] CHANGELOG [Unreleased]: Obsidian first-class viewer convention (MAIN-306, #455)
- `4314929` — Merge origin/main (catches branch up to v0.3.15)

## Release / Issues
- Release: `[Unreleased]` — internal docs / convention work, not a user-visible feature shipping moment. Future tickets carry the user-facing affordances.
- Linear ID(s): MAIN-306
- Closes: #455
- Refs: #454 (graph-link authoring assistance — body-mirror convention is what that work will lean on); #189 (local dashboard spike — non-goal here, scope shrinks if a dashboard later wants an "Open in Obsidian" affordance).
- Follow-ups: (1) `mb doctor` / `mb validate` warnings for missing body mirrors with optional repair path; (2) `mb open obsidian` via `obsidian://open` URI; (3) optional Obsidian-CLI playbook for outgoing-links / backlinks / orphan discovery (adjacent to #454). `.obsidian/`, Bases, Dataview, and starter dashboards remain deferred until real demand surfaces.

## Success Metric
An operator who opens their business repo as an Obsidian vault can click around files, follow `## Related links` body mirrors as graph edges and Backlinks pane entries, and use Obsidian as a viewer without `mb` correctness depending on Obsidian. Generated business-repo agent guidance teaches the body-mirror + frontmatter pair consistently.

## Validation
- Level 0 docs/decision: decision file recorded; link-conventions doc rewritten; CHANGELOG `[Unreleased]` updated.
- Level 1 static: `scripts/check.sh` exit 0 (lint, format, mypy, 474 pytest items, skill validation all pass).
- Level 2 CLI: no CLI behavior changes.
- Level 3 package/install: no packaging changes; `mb/mb/__init__.py` and `mb/pyproject.toml` untouched on this branch.
- Level 4 fixture repo: no fixture changes; `mb validate --cross-refs --strict` against existing `mb/tests/fixtures/` continues to pass via the test suite.
- Level 5 runtime smoke: not run. Documented as the manual companion in the decision file's Validation section: open a business repo as an Obsidian vault and confirm body-level `## Related links` entries appear as navigable links and produce edges in the Graph view and entries in the Backlinks pane. Obsidian app is installed locally but the official `obsidian` CLI (v1.12+) is not on PATH in this workspace, so a CLI-driven smoke was not run.

## Public / Private Boundary
Clean. All committed content is public-safe: no Skool/member context, no Conductor workflow leakage, no Devon-private machine paths, no secrets. The ChatGPT / Gemini / Grok / Hermes-ecosystem research artifacts that informed the decision are kept in gitignored `.context/` only and are not part of the diff.