### PR TITLE
[add] Validate and repair Related links mirrors

### DIFF
--- a/.claude/skills/mb-ads/SKILL.md
+++ b/.claude/skills/mb-ads/SKILL.md
@@ -47,6 +47,13 @@ promise: ""
 ---
 ```
 
+If the push is tied to a bet, decision, research file, playbook, or outcome,
+add the appropriate typed frontmatter link (`linked_bets`,
+`linked_decisions`, `linked_research`, `linked_playbooks`,
+`linked_outcomes`). Mirror canonical links in `## Related links` with
+Markdown relative links, or preview `mb doctor repair --plan` and ask before
+applying the repair. Do not infer frontmatter links from body-only references.
+
 When an ad-adjacent workflow needs a resource-delivery plan, provider setup
 recipe, launch checklist, or external automation approval record, draft it as
 `pushes/<YYYY-MM-DD-slug>/playbooks/<playbook>.md` with `type: playbook`.

--- a/.claude/skills/mb-ads/SKILL.md
+++ b/.claude/skills/mb-ads/SKILL.md
@@ -50,7 +50,7 @@ promise: ""
 If the push is tied to a bet, decision, research file, playbook, or outcome,
 add the appropriate typed frontmatter link (`linked_bets`,
 `linked_decisions`, `linked_research`, `linked_playbooks`,
-`linked_outcomes`). Mirror canonical links in `## Related links` with
+`linked_outcomes`). Mirror frontmatter links in `## Related links` with
 Markdown relative links, or preview `mb doctor repair --plan` and ask before
 applying the repair. Do not infer frontmatter links from body-only references.
 

--- a/.claude/skills/mb-bet/SKILL.md
+++ b/.claude/skills/mb-bet/SKILL.md
@@ -97,6 +97,11 @@ linked_bets:
   - bets/YYYY-MM-DD-slug.md
 ```
 
+After adding or changing typed `linked_*` frontmatter, add or repair the
+body-level `## Related links` mirror with Markdown relative links. If the
+mirror is missing or stale, run `mb doctor repair --plan` and ask before
+`mb doctor repair --apply`; do not invent relationships from body links.
+
 ## Mode: new
 
 Use when the operator says they want to try, launch, test, prove, or make a bet.
@@ -141,6 +146,10 @@ Open.
 ## Narration Notes
 
 [Public-safe angles, claims to avoid, proof needed before sharing.]
+
+## Related links
+
+- [Existing linked file](../decisions/YYYY-MM-DD-example.md)
 ```
 
 ## Mode: update

--- a/.claude/skills/mb-organic/SKILL.md
+++ b/.claude/skills/mb-organic/SKILL.md
@@ -48,6 +48,13 @@ promise: ""
 ---
 ```
 
+If the push is tied to a bet, decision, research file, playbook, or outcome,
+add the appropriate typed frontmatter link (`linked_bets`,
+`linked_decisions`, `linked_research`, `linked_playbooks`,
+`linked_outcomes`). Mirror canonical links in `## Related links` with
+Markdown relative links, or preview `mb doctor repair --plan` and ask before
+applying the repair. Do not infer frontmatter links from body-only references.
+
 ---
 
 ## Triage

--- a/.claude/skills/mb-organic/SKILL.md
+++ b/.claude/skills/mb-organic/SKILL.md
@@ -51,7 +51,7 @@ promise: ""
 If the push is tied to a bet, decision, research file, playbook, or outcome,
 add the appropriate typed frontmatter link (`linked_bets`,
 `linked_decisions`, `linked_research`, `linked_playbooks`,
-`linked_outcomes`). Mirror canonical links in `## Related links` with
+`linked_outcomes`). Mirror frontmatter links in `## Related links` with
 Markdown relative links, or preview `mb doctor repair --plan` and ask before
 applying the repair. Do not infer frontmatter links from body-only references.
 

--- a/.claude/skills/mb-site/SKILL.md
+++ b/.claude/skills/mb-site/SKILL.md
@@ -55,6 +55,14 @@ promise: ""
 ---
 ```
 
+If the push or site record is tied to a bet, decision, research file,
+playbook, or outcome, add the appropriate typed frontmatter link
+(`linked_bets`, `linked_decisions`, `linked_research`,
+`linked_playbooks`, `linked_outcomes`). Mirror canonical links in
+`## Related links` with Markdown relative links, or preview
+`mb doctor repair --plan` and ask before applying the repair. Do not infer
+frontmatter links from body-only references.
+
 ## Re-Invoke Often
 
 Say `/mb-site` again after compaction, context loss, or switching focus. It reloads skill context. Do it whenever the conversation feels stale.

--- a/.claude/skills/mb-site/SKILL.md
+++ b/.claude/skills/mb-site/SKILL.md
@@ -58,7 +58,7 @@ promise: ""
 If the push or site record is tied to a bet, decision, research file,
 playbook, or outcome, add the appropriate typed frontmatter link
 (`linked_bets`, `linked_decisions`, `linked_research`,
-`linked_playbooks`, `linked_outcomes`). Mirror canonical links in
+`linked_playbooks`, `linked_outcomes`). Mirror frontmatter links in
 `## Related links` with Markdown relative links, or preview
 `mb doctor repair --plan` and ask before applying the repair. Do not infer
 frontmatter links from body-only references.

--- a/.claude/skills/mb-think/references/templates/decision-template.md
+++ b/.claude/skills/mb-think/references/templates/decision-template.md
@@ -97,6 +97,10 @@ See: [linked research files]
 ## Review Date (Optional)
 
 [When to revisit — a date or trigger. Example: "Revisit after 100 new members"]
+
+## Related links
+
+- [Research title](../research/YYYY-MM-DD-topic-source.md)
 ```
 
 ---
@@ -122,6 +126,10 @@ linked_research:
 ```
 
 This creates an audit trail: decision -> research -> findings.
+Mirror those frontmatter links in `## Related links` with Markdown
+relative links. If the mirror is missing or stale, preview `mb doctor
+repair --plan` before applying repair; do not treat body-only links as
+typed graph data.
 
 ---
 

--- a/.claude/skills/mb-think/references/templates/research-template.md
+++ b/.claude/skills/mb-think/references/templates/research-template.md
@@ -48,6 +48,11 @@ linked_pushes: []
 
 # [Topic] Research
 
+## Related links
+
+[Leave empty until `linked_decisions` or `linked_pushes` has evidence-backed
+targets, then mirror those frontmatter links with Markdown relative links.]
+
 ## Question
 
 [1-3 sentences: What you're trying to learn. Be specific.]

--- a/.claude/skills/mb-vsl/SKILL.md
+++ b/.claude/skills/mb-vsl/SKILL.md
@@ -43,7 +43,7 @@ promise: ""
 If the push is tied to a bet, decision, research file, playbook, or outcome,
 add the appropriate typed frontmatter link (`linked_bets`,
 `linked_decisions`, `linked_research`, `linked_playbooks`,
-`linked_outcomes`). Mirror canonical links in `## Related links` with
+`linked_outcomes`). Mirror frontmatter links in `## Related links` with
 Markdown relative links, or preview `mb doctor repair --plan` and ask before
 applying the repair. Do not infer frontmatter links from body-only references.
 

--- a/.claude/skills/mb-vsl/SKILL.md
+++ b/.claude/skills/mb-vsl/SKILL.md
@@ -40,6 +40,13 @@ promise: ""
 ---
 ```
 
+If the push is tied to a bet, decision, research file, playbook, or outcome,
+add the appropriate typed frontmatter link (`linked_bets`,
+`linked_decisions`, `linked_research`, `linked_playbooks`,
+`linked_outcomes`). Mirror canonical links in `## Related links` with
+Markdown relative links, or preview `mb doctor repair --plan` and ask before
+applying the repair. Do not infer frontmatter links from body-only references.
+
 ---
 
 ## Pull Latest Updates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,14 +15,14 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 - Added warning-only Related links mirror checks to `mb validate --cross-refs`
   and a safe `mb doctor repair --plan` / `--apply` path that creates or
-  updates `## Related links` body mirrors from canonical `linked_*`
+  updates `## Related links` body mirrors from frontmatter `linked_*`
   frontmatter without making body links authoritative. Refs #454.
 
 ### Changed
 
 - Clarified graph-link authoring guidance across markdown conventions,
   generated business-repo instructions, and bundled authoring skills:
-  frontmatter remains canonical, body mirrors are repairable viewer output,
+  frontmatter remains the source of truth, body mirrors are repairable viewer output,
   and agents should not invent relationships without evidence. Refs #454.
 - Decided that Obsidian is a first-class optional viewer over the same
   markdown files `mb` validates, not a dependency or second source of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,19 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+### Added
+
+- Added warning-only Related links mirror checks to `mb validate --cross-refs`
+  and a safe `mb doctor repair --plan` / `--apply` path that creates or
+  updates `## Related links` body mirrors from canonical `linked_*`
+  frontmatter without making body links authoritative. Refs #454.
+
 ### Changed
 
+- Clarified graph-link authoring guidance across markdown conventions,
+  generated business-repo instructions, and bundled authoring skills:
+  frontmatter remains canonical, body mirrors are repairable viewer output,
+  and agents should not invent relationships without evidence. Refs #454.
 - Decided that Obsidian is a first-class optional viewer over the same
   markdown files `mb` validates, not a dependency or second source of
   truth. `mb` keeps the typed business graph and validation; Obsidian

--- a/decisions/2026-05-09-obsidian-first-class-viewer.md
+++ b/decisions/2026-05-09-obsidian-first-class-viewer.md
@@ -64,12 +64,12 @@ The relevant Obsidian behavior that makes this work:
   cross-tool.
 
 These constraints decide the convention. Typed edges in frontmatter
-remain canonical. A body `## Related links` section is a viewer mirror
+remain the source of truth. A body `## Related links` section is a viewer mirror
 only — it exists so Obsidian, GitHub, and humans can browse
 relationships without `mb` changing its graph model. If frontmatter and
 body mirrors disagree, frontmatter wins. `mb validate --cross-refs` can
 warn when the mirror is out of date, and `mb doctor repair` can preview and
-apply missing mirror links from canonical frontmatter after operator
+apply missing mirror links from frontmatter after operator
 approval.
 See [Markdown link conventions](../docs/markdown-link-conventions.md)
 for the link-form rules.
@@ -94,7 +94,7 @@ follow-up at most, never a requirement.
   and the official Obsidian CLI (v1.12+, 2026-02) are interesting future
   integration surfaces but are not part of this decision.
 - A change to the `linked_*` frontmatter contract. Repo-relative paths
-  with `.md` extensions remain canonical. No switch to wikilink-typed
+  with `.md` extensions remain the source of truth. No switch to wikilink-typed
   frontmatter.
 
 ## Consequences
@@ -115,7 +115,7 @@ follow-up at most, never a requirement.
   and stays optional.
 - Body mirrors are derived browsing aids, not authoritative graph data.
   Validation and doctor repair may warn and add missing mirror links when
-  canonical frontmatter links are absent from `## Related links`, but graph
+  frontmatter links are absent from `## Related links`, but graph
   correctness remains based on structured frontmatter.
 
 ## Validation

--- a/decisions/2026-05-09-obsidian-first-class-viewer.md
+++ b/decisions/2026-05-09-obsidian-first-class-viewer.md
@@ -67,8 +67,10 @@ These constraints decide the convention. Typed edges in frontmatter
 remain canonical. A body `## Related links` section is a viewer mirror
 only — it exists so Obsidian, GitHub, and humans can browse
 relationships without `mb` changing its graph model. If frontmatter and
-body mirrors disagree, frontmatter wins; future validation or doctor
-tooling may warn when the mirror is out of date and offer to repair it.
+body mirrors disagree, frontmatter wins. `mb validate --cross-refs` can
+warn when the mirror is out of date, and `mb doctor repair` can preview and
+apply missing mirror links from canonical frontmatter after operator
+approval.
 See [Markdown link conventions](../docs/markdown-link-conventions.md)
 for the link-form rules.
 
@@ -112,9 +114,9 @@ follow-up at most, never a requirement.
   sits adjacent to the existing graph-link authoring assistance ticket
   and stays optional.
 - Body mirrors are derived browsing aids, not authoritative graph data.
-  Future validation or doctor tooling may warn when canonical frontmatter
-  links are missing from a file's body mirror, but graph correctness
-  remains based on structured frontmatter.
+  Validation and doctor repair may warn and add missing mirror links when
+  canonical frontmatter links are absent from `## Related links`, but graph
+  correctness remains based on structured frontmatter.
 
 ## Validation
 

--- a/docs/markdown-link-conventions.md
+++ b/docs/markdown-link-conventions.md
@@ -110,10 +110,10 @@ relative links at the note level:
 ```
 
 Body mirrors are a viewer aid, not a second source of truth. Frontmatter
-typed edges remain canonical for `mb graph`, `mb validate --cross-refs`,
+typed edges remain the source of truth for `mb graph`, `mb validate --cross-refs`,
 and `mb status relationship_health`. If frontmatter and the body mirror
 disagree, frontmatter wins. `mb validate --cross-refs` warns when the
-mirror is missing canonical frontmatter edges, and `mb doctor repair
+mirror is missing frontmatter edges, and `mb doctor repair
 --plan` / `mb doctor repair --apply` can add missing mirror links after
 operator approval.
 
@@ -153,7 +153,7 @@ Use the narrowest evidence-backed frontmatter field available:
   records, or operating boundaries only when the repo-topology record has
   evidence for that boundary.
 
-If the evidence is weak, leave the canonical frontmatter link out and add a
+If the evidence is weak, leave the frontmatter link out and add a
 plain body reference only if it helps the reader. Body-only links stay
 generic references; they are not typed graph data.
 
@@ -271,7 +271,7 @@ mb validate --cross-refs
 ```
 
 This checks known frontmatter link fields and warns when important
-links are missing, when canonical frontmatter links are not mirrored in
+links are missing, when frontmatter links are not mirrored in
 `## Related links`, and when wikilinks point to missing markdown files or
 match multiple files by stem. Standard Markdown relative links are
 validated as body-link edges in the same pass.

--- a/docs/markdown-link-conventions.md
+++ b/docs/markdown-link-conventions.md
@@ -15,9 +15,9 @@ for the product stance.
    viewer-specific link strings. `mb graph`, `mb validate --cross-refs`,
    and `mb status relationship_health` read frontmatter as the source of
    truth.
-2. **Body mirrors exist only to create explicit note-level edges** for
-   Obsidian Graph and Backlinks. Mirrors do not replace structured
-   frontmatter; they sit alongside it.
+2. **Body mirrors are generated or repairable viewer output** that creates
+   explicit note-level edges for Obsidian Graph and Backlinks. Mirrors do
+   not replace structured frontmatter; they sit alongside it.
 3. **When interoperability matters, use Markdown relative links** for
    body-level mirrors. Both Obsidian and GitHub render Markdown relative
    links. Wikilinks are also valid in Obsidian-only contexts but are not
@@ -112,8 +112,10 @@ relative links at the note level:
 Body mirrors are a viewer aid, not a second source of truth. Frontmatter
 typed edges remain canonical for `mb graph`, `mb validate --cross-refs`,
 and `mb status relationship_health`. If frontmatter and the body mirror
-disagree, frontmatter wins. Future doctor / validation tooling may warn
-when the mirror is missing canonical edges and offer to repair it.
+disagree, frontmatter wins. `mb validate --cross-refs` warns when the
+mirror is missing canonical frontmatter edges, and `mb doctor repair
+--plan` / `mb doctor repair --apply` can add missing mirror links after
+operator approval.
 
 The body mirror creates one stable note-to-note edge per relationship.
 Obsidian's Backlinks pane covers Markdown links and wikilinks equally;
@@ -123,6 +125,37 @@ clickable in PR review and the file viewer.
 You may add a short prose description, including the name of the target
 section. Keep the link itself note-level; do not encode section identity
 in a heading fragment (see below).
+
+Do not manually invent relationships to fill this section. First add the
+typed `linked_*` frontmatter field from evidence, then let `mb doctor
+repair --plan` preview any missing body mirror links. The repair path adds
+missing Markdown links and preserves existing human descriptions; it does
+not delete stale body-only links or update frontmatter from body links.
+
+## Authoring Common Relationships
+
+Use the narrowest evidence-backed frontmatter field available:
+
+- Active bets should link to supporting pushes, playbooks, decisions,
+  research, and outcome/log artifacts through `linked_pushes`,
+  `linked_playbooks`, `linked_decisions`, `linked_research`, and
+  `linked_outcomes`.
+- Pushes should set `offer:` to the promoted offer file and use
+  `linked_bets`, `linked_decisions`, `linked_research`, or
+  `linked_outcomes` when the push is explicitly tied to those records.
+- Completed pushes should link outcome, review, or log artifacts through
+  `linked_outcomes`.
+- Decisions should link the bets, pushes, research, issues, docs, PRDs, or
+  superseded decisions they affect through the corresponding typed fields.
+- Research and proof files should link to the offer, bet, push, decision,
+  or outcome they support when that relationship is explicit.
+- Topology entries should link child repos to offers, pushes, playbook run
+  records, or operating boundaries only when the repo-topology record has
+  evidence for that boundary.
+
+If the evidence is weak, leave the canonical frontmatter link out and add a
+plain body reference only if it helps the reader. Body-only links stay
+generic references; they are not typed graph data.
 
 ### Do not link to section anchors across tools
 
@@ -238,9 +271,10 @@ mb validate --cross-refs
 ```
 
 This checks known frontmatter link fields and warns when important
-links are missing. It also warns when wikilinks point to missing
-markdown files or match multiple files by stem. Standard Markdown
-relative links are validated as body-link edges in the same pass.
+links are missing, when canonical frontmatter links are not mirrored in
+`## Related links`, and when wikilinks point to missing markdown files or
+match multiple files by stem. Standard Markdown relative links are
+validated as body-link edges in the same pass.
 
 Use strict mode in CI or branch cleanup when warnings should fail:
 

--- a/mb/mb/_data/templates/AGENTS.md.tmpl
+++ b/mb/mb/_data/templates/AGENTS.md.tmpl
@@ -102,6 +102,8 @@ before acting.
 Typed relationships live in frontmatter as repo-relative `.md` paths
 (`linked_decisions:`, `linked_research:`, `linked_pushes:`, etc.). Those
 are the canonical edges `mb graph` and `mb validate --cross-refs` read.
+Author them only from evidence in the repo or from explicit operator
+instruction; do not invent relationships to make the graph look fuller.
 
 When a file declares typed edges in frontmatter, mirror them in a body
 `## Related links` section using **Markdown relative links** so the same
@@ -110,6 +112,10 @@ who open the repo as a vault. The body mirror is a viewer aid, not a
 second source of truth — if frontmatter and the mirror disagree,
 frontmatter wins. Keep mirror links note-level; do not link to section
 anchors, since GitHub and Obsidian disagree on heading-fragment syntax.
+If the mirror is missing or stale, preview `mb doctor repair --plan`
+and ask before applying `mb doctor repair --apply`; repair adds missing
+body links from canonical frontmatter and does not update frontmatter
+from body-only links.
 See the engine doc
 [`docs/markdown-link-conventions.md`](https://github.com/noontide-co/mainbranch/blob/main/docs/markdown-link-conventions.md)
 for the full rules.

--- a/mb/mb/_data/templates/AGENTS.md.tmpl
+++ b/mb/mb/_data/templates/AGENTS.md.tmpl
@@ -114,7 +114,7 @@ frontmatter wins. Keep mirror links note-level; do not link to section
 anchors, since GitHub and Obsidian disagree on heading-fragment syntax.
 If the mirror is missing or stale, preview `mb doctor repair --plan`
 and ask before applying `mb doctor repair --apply`; repair adds missing
-body links from canonical frontmatter and does not update frontmatter
+body links from frontmatter and does not update frontmatter
 from body-only links.
 See the engine doc
 [`docs/markdown-link-conventions.md`](https://github.com/noontide-co/mainbranch/blob/main/docs/markdown-link-conventions.md)

--- a/mb/mb/_data/templates/CLAUDE.md.tmpl
+++ b/mb/mb/_data/templates/CLAUDE.md.tmpl
@@ -168,7 +168,7 @@ frontmatter wins. Keep mirror links note-level; do not link to section
 anchors, since GitHub and Obsidian disagree on heading-fragment syntax.
 If the mirror is missing or stale, preview `mb doctor repair --plan`
 and ask before applying `mb doctor repair --apply`; repair adds missing
-body links from canonical frontmatter and does not update frontmatter
+body links from frontmatter and does not update frontmatter
 from body-only links.
 See the engine doc
 [`docs/markdown-link-conventions.md`](https://github.com/noontide-co/mainbranch/blob/main/docs/markdown-link-conventions.md)

--- a/mb/mb/_data/templates/CLAUDE.md.tmpl
+++ b/mb/mb/_data/templates/CLAUDE.md.tmpl
@@ -156,6 +156,8 @@ itself for the bounded shape.
 Typed relationships live in frontmatter as repo-relative `.md` paths
 (`linked_decisions:`, `linked_research:`, `linked_pushes:`, etc.). Those
 are the canonical edges `mb graph` and `mb validate --cross-refs` read.
+Author them only from evidence in the repo or from explicit operator
+instruction; do not invent relationships to make the graph look fuller.
 
 When a file declares typed edges in frontmatter, mirror them in a body
 `## Related links` section using **Markdown relative links** so the same
@@ -164,6 +166,10 @@ who open the repo as a vault. The body mirror is a viewer aid, not a
 second source of truth — if frontmatter and the mirror disagree,
 frontmatter wins. Keep mirror links note-level; do not link to section
 anchors, since GitHub and Obsidian disagree on heading-fragment syntax.
+If the mirror is missing or stale, preview `mb doctor repair --plan`
+and ask before applying `mb doctor repair --apply`; repair adds missing
+body links from canonical frontmatter and does not update frontmatter
+from body-only links.
 See the engine doc
 [`docs/markdown-link-conventions.md`](https://github.com/noontide-co/mainbranch/blob/main/docs/markdown-link-conventions.md)
 for the full rules.

--- a/mb/mb/doctor.py
+++ b/mb/mb/doctor.py
@@ -2064,7 +2064,7 @@ def repair_plan(
     if related_links["summary"]["missing_links"]:
         action = _action(
             id="related-links-mirror",
-            title="Mirror canonical frontmatter links into Related links",
+            title="Mirror frontmatter links into Related links",
             state="warn",
             mode="write",
             command="mb doctor repair --apply",
@@ -2080,7 +2080,9 @@ def repair_plan(
     validation_categories = (
         validation.get("report", {}).get("validation_categories", {}).get("by_category", {})
     )
-    only_related_link_warnings = set(validation_categories) == {"missing_related_link_mirror"}
+    only_related_link_warnings = set(validation_categories) == {
+        related_links_mod.MISSING_RELATED_LINK_MIRROR_CATEGORY
+    }
     if validation["state"] != "ok" and not only_related_link_warnings:
         actions.append(
             _action(
@@ -2109,10 +2111,10 @@ def repair_plan(
             "Related Links Mirrors",
             "warn" if related_links["summary"]["missing_links"] else "ok",
             (
-                f"{related_links['summary']['missing_links']} canonical link(s) missing "
+                f"{related_links['summary']['missing_links']} frontmatter link(s) missing "
                 f"from {related_links['summary']['files']} Related links section(s)"
                 if related_links["summary"]["missing_links"]
-                else "Related links mirrors match canonical frontmatter"
+                else "Related links mirrors match frontmatter"
             ),
             checks=[
                 {
@@ -2368,13 +2370,13 @@ def repair_apply(repo: str | Path = ".", *, include_migration: bool = False) -> 
         applied.append(
             _action(
                 id="related-links-mirror",
-                title="Mirrored canonical frontmatter links into Related links",
+                title="Mirrored frontmatter links into Related links",
                 state="ok" if related_links_result["ok"] else "error",
                 mode="write",
                 command="mb doctor repair --apply",
                 safe_to_apply=True,
                 reason=(
-                    "added missing Markdown body links from canonical frontmatter; "
+                    "added missing Markdown body links from frontmatter; "
                     "frontmatter remains authoritative"
                 ),
                 writes=[str(item["path"]) for item in related_links_result["changed"]],

--- a/mb/mb/doctor.py
+++ b/mb/mb/doctor.py
@@ -29,6 +29,7 @@ from mb import graph as graph_mod
 from mb import migrate as migrate_mod
 from mb import migration_lint
 from mb import onboard as onboard_mod
+from mb import related_links as related_links_mod
 from mb import topology as topology_mod
 from mb import validate as validate_mod
 from mb.engine import install_mode, link_status
@@ -2058,7 +2059,29 @@ def repair_plan(
     )
 
     validation = _validation_summary(target, migration_drift_report=migration_drift)
-    if validation["state"] != "ok":
+    related_links = related_links_mod.plan(target)
+    related_actions: list[dict[str, Any]] = []
+    if related_links["summary"]["missing_links"]:
+        action = _action(
+            id="related-links-mirror",
+            title="Mirror canonical frontmatter links into Related links",
+            state="warn",
+            mode="write",
+            command="mb doctor repair --apply",
+            safe_to_apply=True,
+            reason=(
+                "frontmatter stays canonical; doctor only adds missing body-level "
+                "Markdown links for GitHub, Obsidian, and human browsing"
+            ),
+            writes=[str(item["path"]) for item in related_links["files"]],
+        )
+        actions.append(action)
+        related_actions.append(action)
+    validation_categories = (
+        validation.get("report", {}).get("validation_categories", {}).get("by_category", {})
+    )
+    only_related_link_warnings = set(validation_categories) == {"missing_related_link_mirror"}
+    if validation["state"] != "ok" and not only_related_link_warnings:
         actions.append(
             _action(
                 id="validate-frontmatter",
@@ -2077,6 +2100,31 @@ def repair_plan(
             validation["state"],
             validation["summary"],
             checks=[{"name": "mb validate --cross-refs", **validation}],
+        )
+    )
+
+    sections.append(
+        _section(
+            "related-links",
+            "Related Links Mirrors",
+            "warn" if related_links["summary"]["missing_links"] else "ok",
+            (
+                f"{related_links['summary']['missing_links']} canonical link(s) missing "
+                f"from {related_links['summary']['files']} Related links section(s)"
+                if related_links["summary"]["missing_links"]
+                else "Related links mirrors match canonical frontmatter"
+            ),
+            checks=[
+                {
+                    "name": str(item["path"]),
+                    "state": "warn",
+                    "summary": f"{len(item['missing'])} missing mirror link(s)",
+                    "missing": item["missing"],
+                    "content_included": False,
+                }
+                for item in related_links["files"]
+            ],
+            actions=related_actions,
         )
     )
 
@@ -2152,6 +2200,7 @@ def repair_plan(
         "post_apply": {
             "structural_verification": "mb doctor repair --plan --json",
             "validation_frontmatter_debt": "mb validate --cross-refs",
+            "related_links_mirrors": "mb doctor repair --plan --json",
             "runtime_smoke_required": (
                 "Static repair does not prove Claude Code runtime behavior. "
                 "From the business repo, run `claude`, confirm `/mb-start` is discoverable, "
@@ -2174,6 +2223,7 @@ def repair_plan(
             "legacy_vip": legacy_vip,
             "legacy_claude_links": legacy_links,
             "validation": validation.get("report", {}),
+            "related_links": related_links,
             "graph": graph.get("report", {}),
             "git": git,
         },
@@ -2310,6 +2360,26 @@ def repair_apply(repo: str | Path = ".", *, include_migration: bool = False) -> 
                 writes=["AGENTS.md"],
                 applied=bool(agents["changed"]),
                 result=agents,
+            )
+        )
+
+    related_links_result = related_links_mod.apply(target)
+    if related_links_result["changed"] or related_links_result["errors"]:
+        applied.append(
+            _action(
+                id="related-links-mirror",
+                title="Mirrored canonical frontmatter links into Related links",
+                state="ok" if related_links_result["ok"] else "error",
+                mode="write",
+                command="mb doctor repair --apply",
+                safe_to_apply=True,
+                reason=(
+                    "added missing Markdown body links from canonical frontmatter; "
+                    "frontmatter remains authoritative"
+                ),
+                writes=[str(item["path"]) for item in related_links_result["changed"]],
+                applied=bool(related_links_result["changed"]),
+                result=related_links_result,
             )
         )
 

--- a/mb/mb/related_links.py
+++ b/mb/mb/related_links.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import posixpath
 import re
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -14,18 +15,27 @@ from mb import relationships
 
 RELATED_HEADING_RE = re.compile(r"^##\s+Related links\s*$", re.IGNORECASE)
 SECTION_BOUNDARY_RE = re.compile(r"^#{1,2}\s+\S")
+MISSING_RELATED_LINK_MIRROR_CATEGORY = "missing_related_link_mirror"
 
 
 @dataclass(frozen=True)
 class MirrorRef:
-    """A canonical frontmatter relationship that can be mirrored in the body."""
+    """A frontmatter relationship that can be mirrored in the body."""
 
     field: str
     target: str
     key: str
     href: str
     label: str
-    external: bool = False
+
+
+@dataclass(frozen=True)
+class MarkdownIndex:
+    """Markdown lookup tables shared across one repo scan."""
+
+    files: tuple[Path, ...]
+    by_rel: dict[str, Path]
+    by_stem: dict[str, list[Path]]
 
 
 def _coerce_refs(value: Any) -> tuple[list[str], bool]:
@@ -70,12 +80,12 @@ def _is_hidden_or_generated(path: Path, repo: Path) -> bool:
     )
 
 
-def _markdown_files(repo: Path) -> list[Path]:
-    return [
+def _markdown_files(repo: Path) -> tuple[Path, ...]:
+    return tuple(
         path
         for path in sorted(repo.rglob("*.md"))
         if path.is_file() and not _is_hidden_or_generated(path, repo)
-    ]
+    )
 
 
 def _title_from_file(path: Path) -> str:
@@ -121,13 +131,14 @@ def _section_text(body: str) -> str:
     return "".join(body.splitlines(keepends=True)[start + 1 : end])
 
 
-def _files_by_rel_and_stem(repo: Path) -> tuple[dict[str, Path], dict[str, list[Path]]]:
+def markdown_index(repo: Path, files: Iterable[Path] | None = None) -> MarkdownIndex:
     by_rel: dict[str, Path] = {}
     by_stem: dict[str, list[Path]] = {}
-    for path in _markdown_files(repo):
+    indexed_files = tuple(files) if files is not None else _markdown_files(repo)
+    for path in indexed_files:
         by_rel[path.relative_to(repo).as_posix()] = path
         by_stem.setdefault(path.stem, []).append(path)
-    return by_rel, by_stem
+    return MarkdownIndex(files=indexed_files, by_rel=by_rel, by_stem=by_stem)
 
 
 def _resolve_wikilink(
@@ -152,14 +163,20 @@ def _resolve_wikilink(
     return matches[0] if len(matches) == 1 else None
 
 
-def related_section_targets(repo: Path, source: Path, body: str) -> set[str]:
-    """Return canonical target keys already mirrored in ``## Related links``."""
+def related_section_targets(
+    repo: Path,
+    source: Path,
+    body: str,
+    *,
+    index: MarkdownIndex | None = None,
+) -> set[str]:
+    """Return repo-relative target keys already mirrored in ``## Related links``."""
 
     section = relationships.strip_markdown_code(_section_text(body))
     if not section:
         return set()
     targets: set[str] = set()
-    files_by_rel, files_by_stem = _files_by_rel_and_stem(repo)
+    lookup = index or markdown_index(repo)
     for _, raw_target in relationships.iter_markdown_links(section):
         clean = relationships.markdown_link_target(raw_target)
         if not clean:
@@ -174,15 +191,15 @@ def related_section_targets(repo: Path, source: Path, body: str) -> set[str]:
         resolved = _resolve_wikilink(
             match.group(1),
             repo=repo,
-            files_by_rel=files_by_rel,
-            files_by_stem=files_by_stem,
+            files_by_rel=lookup.by_rel,
+            files_by_stem=lookup.by_stem,
         )
         if resolved is not None:
             targets.add(resolved.relative_to(repo).as_posix())
     return targets
 
 
-def canonical_mirror_refs(repo: Path, source: Path, fm: dict[str, Any]) -> list[MirrorRef]:
+def frontmatter_mirror_refs(repo: Path, source: Path, fm: dict[str, Any]) -> list[MirrorRef]:
     """Return frontmatter relationship refs that are safe to mirror in the body."""
 
     source_rel = source.relative_to(repo).as_posix()
@@ -223,22 +240,30 @@ def canonical_mirror_refs(repo: Path, source: Path, fm: dict[str, Any]) -> list[
     return refs
 
 
-def missing_mirror_refs(repo: Path, source: Path, fm: dict[str, Any], body: str) -> list[MirrorRef]:
-    mirrored = related_section_targets(repo, source, body)
-    return [ref for ref in canonical_mirror_refs(repo, source, fm) if ref.key not in mirrored]
+def missing_mirror_refs(
+    repo: Path,
+    source: Path,
+    fm: dict[str, Any],
+    body: str,
+    *,
+    index: MarkdownIndex | None = None,
+) -> list[MirrorRef]:
+    mirrored = related_section_targets(repo, source, body, index=index)
+    return [ref for ref in frontmatter_mirror_refs(repo, source, fm) if ref.key not in mirrored]
 
 
 def plan(repo: str | Path = ".") -> dict[str, Any]:
     """Plan Related links mirror repairs without writing files."""
 
     root = Path(repo).expanduser().resolve()
+    index = markdown_index(root)
     files: list[dict[str, Any]] = []
     total_missing = 0
-    for path in _markdown_files(root):
+    for path in index.files:
         fm, body = _read_frontmatter_and_body(path)
         if fm is None:
             continue
-        missing = missing_mirror_refs(root, path, fm, body)
+        missing = missing_mirror_refs(root, path, fm, body, index=index)
         if not missing:
             continue
         total_missing += len(missing)
@@ -251,7 +276,6 @@ def plan(repo: str | Path = ".") -> dict[str, Any]:
                         "target": ref.key,
                         "href": ref.href,
                         "label": ref.label,
-                        "external": ref.external,
                         "line": f"- [{ref.label}]({ref.href})",
                     }
                     for ref in missing
@@ -290,7 +314,7 @@ def _insert_missing_lines(body: str, lines_to_add: list[str]) -> str:
 
 
 def apply(repo: str | Path = ".") -> dict[str, Any]:
-    """Apply safe Related links mirror repairs from canonical frontmatter."""
+    """Apply safe Related links mirror repairs from frontmatter."""
 
     root = Path(repo).expanduser().resolve()
     repair_plan = plan(root)

--- a/mb/mb/related_links.py
+++ b/mb/mb/related_links.py
@@ -1,0 +1,343 @@
+"""Related-links mirror helpers for validation and doctor repair."""
+
+from __future__ import annotations
+
+import posixpath
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from mb import relationships
+
+RELATED_HEADING_RE = re.compile(r"^##\s+Related links\s*$", re.IGNORECASE)
+SECTION_BOUNDARY_RE = re.compile(r"^#{1,2}\s+\S")
+
+
+@dataclass(frozen=True)
+class MirrorRef:
+    """A canonical frontmatter relationship that can be mirrored in the body."""
+
+    field: str
+    target: str
+    key: str
+    href: str
+    label: str
+    external: bool = False
+
+
+def _coerce_refs(value: Any) -> tuple[list[str], bool]:
+    if value is None:
+        return [], True
+    if isinstance(value, str):
+        return [value], True
+    if isinstance(value, list):
+        return [item for item in value if isinstance(item, str)], all(
+            isinstance(item, str) for item in value
+        )
+    return [], False
+
+
+def _read_frontmatter_and_body(path: Path) -> tuple[dict[str, Any] | None, str]:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return None, ""
+    if not text.startswith("---"):
+        return None, text
+    try:
+        end = text.index("\n---", 3)
+    except ValueError:
+        return None, text
+    try:
+        parsed = yaml.safe_load(text[3:end].lstrip("\n")) or {}
+    except yaml.YAMLError:
+        return None, text[end + len("\n---") :]
+    return parsed if isinstance(parsed, dict) else None, text[end + len("\n---") :]
+
+
+def _is_hidden_or_generated(path: Path, repo: Path) -> bool:
+    rel_parts = path.relative_to(repo).parts
+    is_bundled_data = rel_parts[:2] == ("mb", "_data") or rel_parts[:1] == ("_data",)
+    return (
+        any(
+            part.startswith(".") or part in {"__pycache__", "node_modules", ".venv", "venv"}
+            for part in rel_parts
+        )
+        or is_bundled_data
+    )
+
+
+def _markdown_files(repo: Path) -> list[Path]:
+    return [
+        path
+        for path in sorted(repo.rglob("*.md"))
+        if path.is_file() and not _is_hidden_or_generated(path, repo)
+    ]
+
+
+def _title_from_file(path: Path) -> str:
+    fm, body = _read_frontmatter_and_body(path)
+    if fm:
+        for key in ("title", "topic", "name", "slug"):
+            value = fm.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    for line in body.splitlines():
+        if line.startswith("# "):
+            return line.removeprefix("# ").strip()
+    return path.stem.replace("-", " ").strip().title() or path.name
+
+
+def _relative_href(source: Path, target: Path) -> str:
+    rel = posixpath.relpath(target.as_posix(), start=source.parent.as_posix())
+    return rel if rel != "." else target.name
+
+
+def _section_bounds(body: str) -> tuple[int, int] | None:
+    lines = body.splitlines(keepends=True)
+    start = None
+    for index, line in enumerate(lines):
+        if RELATED_HEADING_RE.match(line.strip()):
+            start = index
+            break
+    if start is None:
+        return None
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        if SECTION_BOUNDARY_RE.match(lines[index].strip()):
+            end = index
+            break
+    return start, end
+
+
+def _section_text(body: str) -> str:
+    bounds = _section_bounds(body)
+    if bounds is None:
+        return ""
+    start, end = bounds
+    return "".join(body.splitlines(keepends=True)[start + 1 : end])
+
+
+def _files_by_rel_and_stem(repo: Path) -> tuple[dict[str, Path], dict[str, list[Path]]]:
+    by_rel: dict[str, Path] = {}
+    by_stem: dict[str, list[Path]] = {}
+    for path in _markdown_files(repo):
+        by_rel[path.relative_to(repo).as_posix()] = path
+        by_stem.setdefault(path.stem, []).append(path)
+    return by_rel, by_stem
+
+
+def _resolve_wikilink(
+    target: str,
+    *,
+    repo: Path,
+    files_by_rel: dict[str, Path],
+    files_by_stem: dict[str, list[Path]],
+) -> Path | None:
+    clean = relationships.wikilink_target(target)
+    if not clean:
+        return None
+    candidates = [clean]
+    if not clean.endswith(".md"):
+        candidates.append(f"{clean}.md")
+    for candidate in candidates:
+        if candidate in files_by_rel:
+            return files_by_rel[candidate]
+    if len(Path(clean).parts) > 1:
+        return None
+    matches = files_by_stem.get(Path(clean).stem, [])
+    return matches[0] if len(matches) == 1 else None
+
+
+def related_section_targets(repo: Path, source: Path, body: str) -> set[str]:
+    """Return canonical target keys already mirrored in ``## Related links``."""
+
+    section = relationships.strip_markdown_code(_section_text(body))
+    if not section:
+        return set()
+    targets: set[str] = set()
+    files_by_rel, files_by_stem = _files_by_rel_and_stem(repo)
+    for _, raw_target in relationships.iter_markdown_links(section):
+        clean = relationships.markdown_link_target(raw_target)
+        if not clean:
+            continue
+        if relationships.is_external_ref(clean):
+            targets.add(clean)
+            continue
+        resolved = relationships.resolve_markdown_link(repo, source, clean)
+        if resolved is not None:
+            targets.add(resolved.relative_to(repo).as_posix())
+    for match in relationships.WIKILINK_RE.finditer(section):
+        resolved = _resolve_wikilink(
+            match.group(1),
+            repo=repo,
+            files_by_rel=files_by_rel,
+            files_by_stem=files_by_stem,
+        )
+        if resolved is not None:
+            targets.add(resolved.relative_to(repo).as_posix())
+    return targets
+
+
+def canonical_mirror_refs(repo: Path, source: Path, fm: dict[str, Any]) -> list[MirrorRef]:
+    """Return frontmatter relationship refs that are safe to mirror in the body."""
+
+    source_rel = source.relative_to(repo).as_posix()
+    refs: list[MirrorRef] = []
+    seen: set[tuple[str, str]] = set()
+    for field in relationships.relationship_fields_for_source(source_rel):
+        if field not in fm:
+            continue
+        raw_refs, valid_type = _coerce_refs(fm.get(field))
+        if not valid_type:
+            continue
+        for raw_ref in raw_refs:
+            clean = relationships.clean_ref(raw_ref)
+            if not clean:
+                continue
+            if relationships.is_external_ref(clean):
+                continue
+            target = (repo / clean).resolve()
+            try:
+                target.relative_to(repo)
+            except ValueError:
+                continue
+            if not target.is_file():
+                continue
+            key = target.relative_to(repo).as_posix()
+            if (field, key) in seen:
+                continue
+            seen.add((field, key))
+            refs.append(
+                MirrorRef(
+                    field=field,
+                    target=raw_ref,
+                    key=key,
+                    href=_relative_href(source, target),
+                    label=_title_from_file(target),
+                )
+            )
+    return refs
+
+
+def missing_mirror_refs(repo: Path, source: Path, fm: dict[str, Any], body: str) -> list[MirrorRef]:
+    mirrored = related_section_targets(repo, source, body)
+    return [ref for ref in canonical_mirror_refs(repo, source, fm) if ref.key not in mirrored]
+
+
+def plan(repo: str | Path = ".") -> dict[str, Any]:
+    """Plan Related links mirror repairs without writing files."""
+
+    root = Path(repo).expanduser().resolve()
+    files: list[dict[str, Any]] = []
+    total_missing = 0
+    for path in _markdown_files(root):
+        fm, body = _read_frontmatter_and_body(path)
+        if fm is None:
+            continue
+        missing = missing_mirror_refs(root, path, fm, body)
+        if not missing:
+            continue
+        total_missing += len(missing)
+        files.append(
+            {
+                "path": path.relative_to(root).as_posix(),
+                "missing": [
+                    {
+                        "field": ref.field,
+                        "target": ref.key,
+                        "href": ref.href,
+                        "label": ref.label,
+                        "external": ref.external,
+                        "line": f"- [{ref.label}]({ref.href})",
+                    }
+                    for ref in missing
+                ],
+                "has_related_links": _section_bounds(body) is not None,
+            }
+        )
+    return {
+        "ok": total_missing == 0,
+        "repo": str(root),
+        "files": files,
+        "summary": {
+            "files": len(files),
+            "missing_links": total_missing,
+        },
+        "safe_to_apply": True,
+    }
+
+
+def _insert_missing_lines(body: str, lines_to_add: list[str]) -> str:
+    bounds = _section_bounds(body)
+    addition = "\n".join(lines_to_add) + "\n"
+    if bounds is None:
+        prefix = "" if not body or body.endswith("\n") else "\n"
+        return f"{body}{prefix}\n## Related links\n\n{addition}"
+
+    lines = body.splitlines(keepends=True)
+    _start, end = bounds
+    insert_at = end
+    prefix = ""
+    if insert_at > 0 and lines[insert_at - 1].strip():
+        prefix = "\n"
+    suffix = "" if insert_at >= len(lines) or not lines[insert_at].strip() else "\n"
+    lines[insert_at:insert_at] = [prefix + addition + suffix]
+    return "".join(lines)
+
+
+def apply(repo: str | Path = ".") -> dict[str, Any]:
+    """Apply safe Related links mirror repairs from canonical frontmatter."""
+
+    root = Path(repo).expanduser().resolve()
+    repair_plan = plan(root)
+    changed: list[dict[str, Any]] = []
+    errors: list[str] = []
+    planned_by_path = {item["path"]: item for item in repair_plan["files"]}
+    for rel, item in planned_by_path.items():
+        path = root / rel
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            errors.append(f"{rel}: {exc}")
+            continue
+        body_start = 0
+        if text.startswith("---"):
+            try:
+                body_start = text.index("\n---", 3) + len("\n---")
+            except ValueError:
+                errors.append(f"{rel}: unterminated frontmatter")
+                continue
+        prefix = text[:body_start]
+        body = text[body_start:]
+        missing_lines = [str(entry["line"]) for entry in item["missing"]]
+        updated = prefix + _insert_missing_lines(body, missing_lines)
+        if updated == text:
+            continue
+        try:
+            path.write_text(updated, encoding="utf-8")
+        except OSError as exc:
+            errors.append(f"{rel}: {exc}")
+            continue
+        changed.append(
+            {
+                "path": rel,
+                "added": missing_lines,
+                "created_section": not bool(item["has_related_links"]),
+            }
+        )
+    return {
+        "ok": not errors,
+        "repo": str(root),
+        "planned": repair_plan,
+        "changed": changed,
+        "errors": errors,
+        "summary": {
+            "files_changed": len(changed),
+            "links_added": sum(len(item["added"]) for item in changed),
+            "errors": len(errors),
+        },
+    }

--- a/mb/mb/validate.py
+++ b/mb/mb/validate.py
@@ -15,7 +15,7 @@ from typing import Any
 
 import yaml
 
-from mb import github_activity, migration_lint, relationships
+from mb import github_activity, migration_lint, related_links, relationships
 from mb import pushes as pushes_mod
 
 DECISION_STATUS = {"proposed", "accepted", "rejected", "superseded", "running"}
@@ -140,6 +140,10 @@ VALIDATION_CATEGORY_REPAIR: dict[str, str] = {
     "yaml_error": "Fix malformed YAML before repairing schema fields.",
     "schema_shape_error": "Fix nested mappings and field shapes before rerunning validation.",
     "missing_cross_ref_target": "Repair, remove, or intentionally archive broken local links.",
+    "missing_related_link_mirror": (
+        "Run `mb doctor repair --plan`, review the Related links mirror action, "
+        "then `mb doctor repair --apply` after approval."
+    ),
     "missing_reverse_link": "Add the suggested reverse relationship field after operator approval.",
     "migration_drift": "Run `mb doctor repair --plan --json` and review stale layout guidance.",
     "other_error": "Review the validation message and repair the affected record.",
@@ -991,6 +995,8 @@ def _validation_category(message: str, *, severity: str, schema: str) -> str:
         return "schema_shape_error"
     if " target " in message and ("does not exist" in message or "does not resolve" in message):
         return "missing_cross_ref_target"
+    if " is not mirrored in ## Related links" in message:
+        return "missing_related_link_mirror"
     if " should include linked_" in message:
         return "missing_reverse_link"
     if schema == "migration-drift":
@@ -1189,6 +1195,21 @@ def _check_cross_refs(
         if err is not None or fm is None:
             continue
         source_rel = source.relative_to(repo).as_posix()
+        body = _read_markdown_body(source) or ""
+        for mirror_ref in related_links.missing_mirror_refs(repo, source, fm, body):
+            findings.append(
+                _finding(
+                    code="missing-related-link-mirror",
+                    source=source,
+                    repo=repo,
+                    field=mirror_ref.field,
+                    target=mirror_ref.key,
+                    message=(
+                        f"{mirror_ref.field} target {mirror_ref.key!r} "
+                        "is not mirrored in ## Related links"
+                    ),
+                )
+            )
         for field in relationships.relationship_fields_for_source(source_rel):
             if field not in fm:
                 continue
@@ -1260,10 +1281,10 @@ def _check_cross_refs(
                     )
 
     for source in markdown_files:
-        body = _read_markdown_body(source)
-        if body is None:
+        markdown_body = _read_markdown_body(source)
+        if markdown_body is None:
             continue
-        body_without_code = relationships.strip_markdown_code(body)
+        body_without_code = relationships.strip_markdown_code(markdown_body)
         for match in relationships.WIKILINK_RE.finditer(body_without_code):
             raw_target = match.group(1)
             clean_target = relationships.wikilink_target(raw_target)

--- a/mb/mb/validate.py
+++ b/mb/mb/validate.py
@@ -140,7 +140,7 @@ VALIDATION_CATEGORY_REPAIR: dict[str, str] = {
     "yaml_error": "Fix malformed YAML before repairing schema fields.",
     "schema_shape_error": "Fix nested mappings and field shapes before rerunning validation.",
     "missing_cross_ref_target": "Repair, remove, or intentionally archive broken local links.",
-    "missing_related_link_mirror": (
+    related_links.MISSING_RELATED_LINK_MIRROR_CATEGORY: (
         "Run `mb doctor repair --plan`, review the Related links mirror action, "
         "then `mb doctor repair --apply` after approval."
     ),
@@ -996,7 +996,7 @@ def _validation_category(message: str, *, severity: str, schema: str) -> str:
     if " target " in message and ("does not exist" in message or "does not resolve" in message):
         return "missing_cross_ref_target"
     if " is not mirrored in ## Related links" in message:
-        return "missing_related_link_mirror"
+        return related_links.MISSING_RELATED_LINK_MIRROR_CATEGORY
     if " should include linked_" in message:
         return "missing_reverse_link"
     if schema == "migration-drift":
@@ -1190,13 +1190,16 @@ def _check_cross_refs(
         files_by_rel[rel] = file_path
         files_by_stem.setdefault(file_path.stem, []).append(file_path)
 
+    related_index = related_links.markdown_index(repo, markdown_files)
     for source in markdown_files:
         fm, err = _read_frontmatter(source)
         if err is not None or fm is None:
             continue
         source_rel = source.relative_to(repo).as_posix()
         body = _read_markdown_body(source) or ""
-        for mirror_ref in related_links.missing_mirror_refs(repo, source, fm, body):
+        for mirror_ref in related_links.missing_mirror_refs(
+            repo, source, fm, body, index=related_index
+        ):
             findings.append(
                 _finding(
                     code="missing-related-link-mirror",

--- a/mb/tests/test_doctor.py
+++ b/mb/tests/test_doctor.py
@@ -17,6 +17,11 @@ from mb.init import run as init_run
 runner = CliRunner()
 
 
+def _write_md(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
 def test_doctor_runs_on_empty_dir(tmp_path: Path) -> None:
     report = run(path=str(tmp_path))
     assert "checks" in report
@@ -568,6 +573,83 @@ def test_doctor_repair_plan_exposes_validation_top_category(tmp_path: Path) -> N
     check = section["checks"][0]
     assert "top category: missing_slug" in check["summary"]
     assert check["report"]["validation_categories"]["by_category"]["missing_slug"]["count"] == 2
+
+
+def test_doctor_repair_plan_reports_related_links_mirror_action(tmp_path: Path) -> None:
+    repo = tmp_path / "related-links-plan"
+    init_run(path=str(repo), name="Acme")
+    _write_md(
+        repo / "research" / "2026-05-10-audience.md",
+        "---\ndate: 2026-05-10\ntopic: audience\nsource: manual\n---\n# Audience\n",
+    )
+    _write_md(
+        repo / "decisions" / "2026-05-10-audience.md",
+        (
+            "---\n"
+            "date: 2026-05-10\n"
+            "status: accepted\n"
+            "linked_research:\n"
+            "  - research/2026-05-10-audience.md\n"
+            "---\n"
+            "# Audience decision\n"
+        ),
+    )
+
+    result = runner.invoke(app, ["doctor", "repair", "--repo", str(repo), "--plan", "--json"])
+
+    assert result.exit_code in {0, 1}
+    payload = json.loads(result.stdout)
+    section = next(section for section in payload["sections"] if section["id"] == "related-links")
+    assert section["state"] == "warn"
+    assert section["checks"][0]["name"] == "decisions/2026-05-10-audience.md"
+    actions = {action["id"]: action for action in payload["actions"]}
+    action = actions["related-links-mirror"]
+    assert action["safe_to_apply"] is True
+    assert action["writes"] == ["decisions/2026-05-10-audience.md"]
+    assert "validate-frontmatter" not in actions
+
+
+def test_doctor_repair_apply_adds_related_links_without_deleting_human_links(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "related-links-apply"
+    init_run(path=str(repo), name="Acme")
+    _write_md(
+        repo / "research" / "2026-05-10-audience.md",
+        "---\ndate: 2026-05-10\ntopic: audience\nsource: manual\n---\n# Audience Notes\n",
+    )
+    decision = repo / "decisions" / "2026-05-10-audience.md"
+    _write_md(
+        decision,
+        (
+            "---\n"
+            "date: 2026-05-10\n"
+            "status: accepted\n"
+            "linked_research:\n"
+            "  - research/2026-05-10-audience.md\n"
+            "---\n"
+            "# Audience decision\n"
+            "\n"
+            "## Related links\n"
+            "\n"
+            "- [Existing manual note](../documents/manual.md) - keep this prose.\n"
+            "\n"
+            "## Consequences\n"
+            "\n"
+            "Keep the rest of the file.\n"
+        ),
+    )
+
+    result = runner.invoke(app, ["doctor", "repair", "--repo", str(repo), "--apply", "--json"])
+
+    assert result.exit_code in {0, 1}
+    payload = json.loads(result.stdout)
+    applied = {action["id"]: action for action in payload["applied_actions"]}
+    assert "related-links-mirror" in applied
+    text = decision.read_text(encoding="utf-8")
+    assert "- [Existing manual note](../documents/manual.md) - keep this prose." in text
+    assert "- [audience](../research/2026-05-10-audience.md)" in text
+    assert "## Consequences\n\nKeep the rest of the file." in text
 
 
 def test_doctor_repair_include_migration_requires_apply_guidance(tmp_path: Path) -> None:

--- a/mb/tests/test_validate.py
+++ b/mb/tests/test_validate.py
@@ -228,6 +228,10 @@ def test_cross_refs_pass_when_targets_exist(tmp_path: Path) -> None:
             "  - research/2026-04-29-topic-source.md\n"
             "---\n"
             "# ok\n"
+            "\n"
+            "## Related links\n"
+            "\n"
+            "- [Topic](../research/2026-04-29-topic-source.md)\n"
         ),
     )
     _write(
@@ -249,6 +253,60 @@ def test_source_scoped_offer_relationship_requires_source_path() -> None:
         relationships.relationship_for_field("offer", source_path="pushes/2026-05-07-demo/push.md")
         is not None
     )
+
+
+def test_cross_refs_warn_when_frontmatter_link_missing_body_mirror(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "decisions" / "2026-04-29-missing-mirror.md",
+        (
+            "---\n"
+            "date: 2026-04-29\n"
+            "status: accepted\n"
+            "linked_research:\n"
+            "  - research/2026-04-29-topic-source.md\n"
+            "---\n"
+            "# Missing mirror\n"
+        ),
+    )
+    _write(
+        tmp_path / "research" / "2026-04-29-topic-source.md",
+        "---\ndate: 2026-04-29\ntopic: topic\nsource: source\n---\n# Topic\n",
+    )
+
+    report = run(path=str(tmp_path), cross_refs=True)
+
+    assert report["ok"] is True
+    assert report["summary"]["warnings"] == 1
+    finding = report["cross_refs"]["warnings"][0]
+    assert finding["code"] == "missing-related-link-mirror"
+    assert finding["field"] == "linked_research"
+    assert finding["target"] == "research/2026-04-29-topic-source.md"
+
+
+def test_body_only_markdown_links_do_not_replace_typed_frontmatter(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "research" / "2026-04-29-topic-source.md",
+        "---\ndate: 2026-04-29\ntopic: topic\nsource: source\n---\n# Topic\n",
+    )
+    _write(
+        tmp_path / "decisions" / "2026-04-29-body-only.md",
+        (
+            "---\n"
+            "date: 2026-04-29\n"
+            "status: accepted\n"
+            "---\n"
+            "# Body only\n"
+            "\n"
+            "## Related links\n"
+            "\n"
+            "- [Topic](../research/2026-04-29-topic-source.md)\n"
+        ),
+    )
+
+    report = run(path=str(tmp_path), cross_refs=True, strict=True)
+
+    assert report["ok"] is True
+    assert report["summary"]["warnings"] == 0
 
 
 def test_cross_refs_warn_on_missing_targets_without_strict(tmp_path: Path) -> None:
@@ -533,6 +591,10 @@ def test_cross_refs_flag_status_transition_regressions(tmp_path: Path) -> None:
             "supersedes: decisions/2026-04-28-old.md\n"
             "---\n"
             "# new\n"
+            "\n"
+            "## Related links\n"
+            "\n"
+            "- [Old](2026-04-28-old.md)\n"
         ),
     )
 
@@ -586,6 +648,10 @@ def test_cross_refs_warn_when_bet_link_lacks_reverse_link(tmp_path: Path) -> Non
             "  - channel:site\n"
             "---\n"
             "# Demo bet\n"
+            "\n"
+            "## Related links\n"
+            "\n"
+            "- [Demo](../decisions/2026-05-04-demo.md)\n"
         ),
     )
     _write(
@@ -626,6 +692,10 @@ def test_cross_refs_pass_when_bet_links_are_bidirectional(tmp_path: Path) -> Non
             "tags: []\n"
             "---\n"
             "# Demo bet\n"
+            "\n"
+            "## Related links\n"
+            "\n"
+            "- [Demo](../decisions/2026-05-04-demo.md)\n"
         ),
     )
     _write(
@@ -638,6 +708,10 @@ def test_cross_refs_pass_when_bet_links_are_bidirectional(tmp_path: Path) -> Non
             "  - bets/2026-05-04-demo.md\n"
             "---\n"
             "# Demo\n"
+            "\n"
+            "## Related links\n"
+            "\n"
+            "- [Demo bet](../bets/2026-05-04-demo.md)\n"
         ),
     )
 
@@ -996,7 +1070,8 @@ def test_validate_rejects_unknown_push_kind_even_when_vocabulary_renames_it(
 def test_validate_accepts_push_playbook_schema(tmp_path: Path) -> None:
     _write(
         tmp_path / "pushes" / "2026-05-06-target" / "push.md",
-        _push("active", slug="target"),
+        _push("active", slug="target")
+        + "\n## Related links\n\n- [Workshop](../../core/offers/workshop/offer.md)\n",
     )
     _write(
         tmp_path / "pushes" / "2026-05-06-target" / "playbooks" / "resource.md",
@@ -1036,7 +1111,8 @@ def test_validate_accepts_sanitized_push_playbook_fixture() -> None:
 def test_validate_requires_push_playbook_shape(tmp_path: Path) -> None:
     _write(
         tmp_path / "pushes" / "2026-05-06-target" / "push.md",
-        _push("active", slug="target"),
+        _push("active", slug="target")
+        + "\n## Related links\n\n- [Workshop](../../core/offers/workshop/offer.md)\n",
     )
     _write(
         tmp_path / "pushes" / "2026-05-06-target" / "playbooks" / "incomplete.md",
@@ -1070,7 +1146,8 @@ def test_validate_rejects_playbook_missing_linked_push(tmp_path: Path) -> None:
 def test_validate_rejects_playbook_wrong_push_link(tmp_path: Path) -> None:
     _write(
         tmp_path / "pushes" / "2026-05-06-target" / "push.md",
-        _push("active", slug="target"),
+        _push("active", slug="target")
+        + "\n## Related links\n\n- [Workshop](../../core/offers/workshop/offer.md)\n",
     )
     _write(
         tmp_path / "pushes" / "2026-05-06-target" / "playbooks" / "resource.md",
@@ -1087,7 +1164,8 @@ def test_validate_rejects_playbook_wrong_push_link(tmp_path: Path) -> None:
 def test_validate_rejects_unknown_playbook_status(tmp_path: Path) -> None:
     _write(
         tmp_path / "pushes" / "2026-05-06-target" / "push.md",
-        _push("active", slug="target"),
+        _push("active", slug="target")
+        + "\n## Related links\n\n- [Workshop](../../core/offers/workshop/offer.md)\n",
     )
     _write(
         tmp_path / "pushes" / "2026-05-06-target" / "playbooks" / "resource.md",
@@ -1168,7 +1246,8 @@ def test_cross_refs_resolve_linked_pushes_field(tmp_path: Path) -> None:
     )
     _write(
         tmp_path / "pushes" / "2026-05-06-target" / "push.md",
-        _push("active", slug="target"),
+        _push("active", slug="target")
+        + "\n## Related links\n\n- [Workshop](../../core/offers/workshop/offer.md)\n",
     )
     _write(
         tmp_path / "decisions" / "2026-05-06-with-link.md",
@@ -1180,6 +1259,10 @@ def test_cross_refs_resolve_linked_pushes_field(tmp_path: Path) -> None:
             "  - pushes/2026-05-06-target/push.md\n"
             "---\n"
             "# decision\n"
+            "\n"
+            "## Related links\n"
+            "\n"
+            "- [Target](../pushes/2026-05-06-target/push.md)\n"
         ),
     )
 
@@ -1196,7 +1279,8 @@ def test_cross_refs_validate_push_offer_relationship(tmp_path: Path) -> None:
     )
     _write(
         tmp_path / "pushes" / "2026-05-06-target" / "push.md",
-        _push("active", slug="target"),
+        _push("active", slug="target")
+        + "\n## Related links\n\n- [Workshop](../../core/offers/workshop/offer.md)\n",
     )
 
     report = run(path=str(tmp_path), cross_refs=True, strict=True)

--- a/mb/tests/test_validate.py
+++ b/mb/tests/test_validate.py
@@ -282,6 +282,17 @@ def test_cross_refs_warn_when_frontmatter_link_missing_body_mirror(tmp_path: Pat
     assert finding["field"] == "linked_research"
     assert finding["target"] == "research/2026-04-29-topic-source.md"
 
+    strict_report = run(path=str(tmp_path), cross_refs=True, strict=True)
+    assert strict_report["ok"] is False
+    strict_finding = strict_report["cross_refs"]["warnings"][0]
+    assert strict_finding["code"] == "missing-related-link-mirror"
+    assert (
+        strict_report["validation_categories"]["by_category"]["missing_related_link_mirror"][
+            "count"
+        ]
+        == 1
+    )
+
 
 def test_body_only_markdown_links_do_not_replace_typed_frontmatter(tmp_path: Path) -> None:
     _write(
@@ -300,6 +311,34 @@ def test_body_only_markdown_links_do_not_replace_typed_frontmatter(tmp_path: Pat
             "## Related links\n"
             "\n"
             "- [Topic](../research/2026-04-29-topic-source.md)\n"
+        ),
+    )
+
+    report = run(path=str(tmp_path), cross_refs=True, strict=True)
+
+    assert report["ok"] is True
+    assert report["summary"]["warnings"] == 0
+
+
+def test_related_links_wikilink_satisfies_frontmatter_mirror(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "research" / "2026-04-29-topic-source.md",
+        "---\ndate: 2026-04-29\ntopic: topic\nsource: source\n---\n# Topic\n",
+    )
+    _write(
+        tmp_path / "decisions" / "2026-04-29-wikilink-mirror.md",
+        (
+            "---\n"
+            "date: 2026-04-29\n"
+            "status: accepted\n"
+            "linked_research:\n"
+            "  - research/2026-04-29-topic-source.md\n"
+            "---\n"
+            "# Wikilink mirror\n"
+            "\n"
+            "## Related links\n"
+            "\n"
+            "- [[research/2026-04-29-topic-source|Topic]]\n"
         ),
     )
 


### PR DESCRIPTION
## Summary
- Adds `mb validate --cross-refs` warnings when typed `linked_*` frontmatter relationships are missing from `## Related links`.
- Adds `mb doctor repair --plan` / `--apply` support to preview and add missing body mirror links without making body-only links authoritative.
- Keeps the repair path efficient by sharing one markdown lookup index per validation or repair pass, and pins strict-mode behavior with tests.
- Updates graph-link authoring docs, generated repo guidance, bundled skills, the Obsidian viewer decision, and the changelog with plainer source-of-truth language.

## Scope
- In: typed frontmatter-to-body mirror validation, approval-gated repair, strict-mode and wikilink mirror coverage, generated guidance, bundled skill guidance, and public docs.
- Out: dashboard UI, Obsidian-specific config/features, automatic relationship discovery, data-source registry, cron sync patterns, and broad language cleanup beyond this branch.

## Commits
- `334f7e0` — `[add] Related links mirror repair (MAIN-305)`
- `ccbbe53` — `[update] Clarify graph link authoring guidance (MAIN-305)`
- `49b46f3` — `[fix] Tighten Related links mirror follow-up (MAIN-305)`

## Release / Issues
- Release: next / priority:next
- Linear ID(s): MAIN-305
- Closes: #454
- Refs: MAIN-312 for the larger decision on natural language, connection choice, data files, Git history signals, and future `mb suggest links`.
- Follow-ups: MAIN-312 should carry the broader connection matrix, data-file guidance, Obsidian CLI research, and wording cleanup.

## Success Metric
- A repo with typed frontmatter links but stale/missing `## Related links` mirrors gets a visible validation warning, strict mode fails intentionally, doctor repair previews the exact body-link edits, and `--apply` adds only the missing mirror links while preserving frontmatter and human-written prose.

## Validation
- Level 0 docs/decision: updated markdown-link conventions, the Obsidian viewer decision, generated guidance templates, bundled skills, and `CHANGELOG.md`; branch-added wording now favors “source of truth” / “frontmatter links” over heavier terminology.
- Level 1 static: `scripts/check.sh` passed from repo root.
- Level 2 CLI: `pytest tests/test_validate.py tests/test_doctor.py -q` passed; focused coverage now includes strict-mode failure for missing mirrors and wikilink mirrors satisfying the check.
- Level 3 package/install: built wheel with `python3 -m build`, installed it into a temp venv, confirmed `mb --version`, and onboarded a fresh repo from the wheel.
- Level 4 fixture repo: fresh repo smoke confirmed validate warned before repair, doctor plan/apply repaired the mirror, and validate warnings dropped to zero; wheel/onboard smoke also confirmed generated AGENTS/CLAUDE guidance contains the repair language and validates cleanly.
- Level 5 runtime smoke: not run; this changes CLI validation/repair and guidance prose, not Claude Code skill discovery or invocation.

## Public / Private Boundary
- No private Devon, Conductor, credential, partner, member, or runtime-internal details were committed; local smoke paths and notes stayed out of the repo.
