### PR TITLE
[add] mb suggest links command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ### Added
 
+- Added `mb suggest links <file>` as a read-only command that ranks candidate
+  frontmatter, inline Markdown, entity tag, data/report metadata, nearby
+  context, and ignore decisions with JSON reasons for skills and future UI.
+  Refs #469.
 - Added warning-only Related links mirror checks to `mb validate --cross-refs`
   and a safe `mb doctor repair --plan` / `--apply` path that creates or
   updates `## Related links` body mirrors from frontmatter `linked_*`
@@ -21,8 +25,8 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   when to use typed frontmatter links, inline Markdown links, entity tags,
   data/report references, GitHub history links, nearby context, or no link.
   Refs #468.
-- Opened follow-up implementation issues for `mb suggest links`, data-source
-  registry, and scheduled data sync. Refs #469, #470, #471.
+- Opened follow-up implementation issues for data-source registry and scheduled
+  data sync. Refs #470, #471.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ The `mb` CLI is the deterministic control plane. The agent runs it for normal us
 | `mb issue draft` / `open`| Draft a privacy-scrubbed GitHub issue locally, review it, then submit through `gh`. |
 | `mb validate`            | Frontmatter shape check across `core/`, `research/`, `decisions/`, `bets/`, `log/`, `pushes/`, `documents/`. Pass/fail per file. |
 | `mb graph`               | Build a folder graph from frontmatter links, wikilinks, and entity tags. Graphviz DOT, JSON, and PNG outputs. |
+| `mb suggest links`       | Suggest likely frontmatter, inline, tag, data, and context connections for a file without editing it. |
 | `mb checkpoint`          | Plan or save a business-readable git checkpoint during long agent runs. |
 | `mb skill list` / `path` / `validate` / `link` / `repair` | Manage and repair the bundled Claude Code skills. |
 | `mb update`              | Update Main Branch in place. |

--- a/docs/business-connections.md
+++ b/docs/business-connections.md
@@ -222,15 +222,16 @@ Main Branch should learn from that without making Obsidian required:
 - agents should show reasons before editing graph data;
 - local viewers should browse the same files `mb` validates.
 
-## Future CLI Shape
+## CLI Shape
 
-A future command should help agents choose connections:
+`mb suggest links` helps agents choose connections without editing files:
 
 ```bash
 mb suggest links decisions/2026-05-10-google-ads-first.md
 ```
 
-The output should rank suggestions with reasons and action types:
+Use `--json` for skills and future review UI. The output ranks suggestions with
+reasons and action types:
 
 - add typed frontmatter link;
 - add inline Markdown link;
@@ -239,12 +240,11 @@ The output should rank suggestions with reasons and action types:
 - leave as nearby context;
 - ignore.
 
-It should not silently invent relationships. The operator or agent should
-approve what matters.
+It does not silently invent relationships. The operator or agent should approve
+what matters before changing frontmatter, inline links, tags, or metadata.
 
 Implementation follow-ups:
 
-- `mb suggest links`: [#469](https://github.com/noontide-co/mainbranch/issues/469)
 - data-source registry: [#470](https://github.com/noontide-co/mainbranch/issues/470)
 - scheduled data sync pattern: [#471](https://github.com/noontide-co/mainbranch/issues/471)
 

--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -31,6 +31,7 @@ from mb import site as site_mod
 from mb import skill_validate as skill_validate_mod
 from mb import start as start_mod
 from mb import status as status_mod
+from mb import suggest as suggest_mod
 from mb import think as think_mod
 from mb import update as update_mod
 from mb import validate as validate_mod
@@ -84,6 +85,13 @@ site_app = typer.Typer(
     no_args_is_help=True,
 )
 app.add_typer(site_app, name="site")
+
+suggest_app = typer.Typer(
+    name="suggest",
+    help="Suggest read-only business repo improvements.",
+    no_args_is_help=True,
+)
+app.add_typer(suggest_app, name="suggest")
 
 CONNECT_METADATA_OPTION = typer.Option(
     [],
@@ -980,6 +988,36 @@ def graph_cmd(
         graph_mod.open_dot(dot)
     else:
         typer.echo(dot)
+
+
+@suggest_app.command("links")
+def suggest_links_cmd(
+    file: str = typer.Argument(..., help="Markdown file to inspect."),
+    repo: str = typer.Option(".", "--repo", help="Business repo to query."),
+    limit: int = typer.Option(10, "--limit", min=0, help="Maximum suggestions to return."),
+    include_ignored: bool = typer.Option(
+        False,
+        "--include-ignored",
+        help="Include candidates classified as ignore.",
+    ),
+    json_out: bool = typer.Option(False, "--json", help="Machine-readable output."),
+) -> None:
+    """Suggest likely business connections without editing files."""
+    try:
+        report = suggest_mod.suggest_links(
+            source_file=file,
+            repo=repo,
+            limit=limit,
+            include_ignored=include_ignored,
+        )
+    except ValueError as exc:
+        typer.echo(f"mb suggest links: {exc}", err=True)
+        raise typer.Exit(2) from exc
+    if json_out:
+        typer.echo(json.dumps(report, indent=2))
+    else:
+        suggest_mod.render_human(report)
+    raise typer.Exit(0 if report["ok"] else 1)
 
 
 @app.command("similar-bets")

--- a/mb/mb/related_links.py
+++ b/mb/mb/related_links.py
@@ -141,7 +141,7 @@ def markdown_index(repo: Path, files: Iterable[Path] | None = None) -> MarkdownI
     return MarkdownIndex(files=indexed_files, by_rel=by_rel, by_stem=by_stem)
 
 
-def _resolve_wikilink(
+def resolve_wikilink(
     target: str,
     *,
     repo: Path,
@@ -188,7 +188,7 @@ def related_section_targets(
         if resolved is not None:
             targets.add(resolved.relative_to(repo).as_posix())
     for match in relationships.WIKILINK_RE.finditer(section):
-        resolved = _resolve_wikilink(
+        resolved = resolve_wikilink(
             match.group(1),
             repo=repo,
             files_by_rel=lookup.by_rel,

--- a/mb/mb/suggest.py
+++ b/mb/mb/suggest.py
@@ -173,6 +173,15 @@ def _existing_body_targets(
         resolved = relationships.resolve_markdown_link(repo, source, clean)
         if resolved is not None:
             targets.add(resolved.relative_to(repo).as_posix())
+    for match in relationships.WIKILINK_RE.finditer(body_without_code):
+        resolved = related_links.resolve_wikilink(
+            match.group(1),
+            repo=repo,
+            files_by_rel=index.by_rel,
+            files_by_stem=index.by_stem,
+        )
+        if resolved is not None:
+            targets.add(resolved.relative_to(repo).as_posix())
     return targets
 
 
@@ -191,7 +200,7 @@ def _field_for_target(rel_path: str) -> str | None:
         return "linked_decisions"
     if root in {"docs", "documents"}:
         return "linked_docs"
-    if root in {"log", "outputs"} or "outcome" in rel_path:
+    if root in {"log", "outcomes", "outputs"}:
         return "linked_outcomes"
     if root == "pushes":
         return "linked_pushes"

--- a/mb/mb/suggest.py
+++ b/mb/mb/suggest.py
@@ -1,0 +1,466 @@
+"""Read-only relationship suggestions for business repo files."""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+import yaml
+from rich.console import Console
+
+from mb import graph, related_links, relationships
+
+SCHEMA_VERSION = "1.0"
+MATRIX_DOC = "docs/business-connections.md"
+
+ACTION_TYPED = "add_typed_frontmatter_link"
+ACTION_INLINE = "add_inline_markdown_link"
+ACTION_ENTITY = "add_entity_tag"
+ACTION_DATA = "link_report_or_data_metadata"
+ACTION_CONTEXT = "leave_nearby_context"
+ACTION_IGNORE = "ignore"
+
+ACTION_LABELS: dict[str, str] = {
+    ACTION_TYPED: "add typed frontmatter link",
+    ACTION_INLINE: "add inline Markdown link",
+    ACTION_ENTITY: "add entity tag",
+    ACTION_DATA: "link report or data metadata",
+    ACTION_CONTEXT: "leave as nearby context",
+    ACTION_IGNORE: "ignore",
+}
+
+STOPWORDS = {
+    "about",
+    "after",
+    "again",
+    "against",
+    "also",
+    "because",
+    "before",
+    "being",
+    "business",
+    "could",
+    "decision",
+    "decisions",
+    "does",
+    "files",
+    "from",
+    "have",
+    "into",
+    "links",
+    "main",
+    "markdown",
+    "more",
+    "needs",
+    "note",
+    "notes",
+    "only",
+    "other",
+    "repo",
+    "research",
+    "should",
+    "that",
+    "their",
+    "there",
+    "these",
+    "this",
+    "through",
+    "with",
+}
+TOKEN_RE = re.compile(r"[A-Za-z][A-Za-z0-9_-]{2,}")
+
+
+def _read_markdown(path: Path) -> tuple[dict[str, Any], str]:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return {}, ""
+    if not text.startswith("---"):
+        return {}, text
+    try:
+        end = text.index("\n---", 3)
+    except ValueError:
+        return {}, text
+    try:
+        parsed = yaml.safe_load(text[3:end].lstrip("\n")) or {}
+    except yaml.YAMLError:
+        return {}, text[end + len("\n---") :]
+    frontmatter = parsed if isinstance(parsed, dict) else {}
+    return frontmatter, text[end + len("\n---") :]
+
+
+def _tokens(text: str) -> set[str]:
+    return {
+        token.replace("_", "-").lower()
+        for token in TOKEN_RE.findall(text)
+        if token.lower() not in STOPWORDS
+    }
+
+
+def _title(path: Path, frontmatter: dict[str, Any], body: str) -> str:
+    for key in ("title", "topic", "name", "slug"):
+        value = frontmatter.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    for line in body.splitlines():
+        if line.startswith("# "):
+            return line.removeprefix("# ").strip()
+    return path.stem.replace("-", " ").strip().title() or path.name
+
+
+def _phrase_variants(repo: Path, path: Path, title: str) -> set[str]:
+    stem_words = path.stem.replace("-", " ").replace("_", " ").strip().lower()
+    variants = {
+        path.relative_to(repo).as_posix().lower(),
+        path.stem.lower(),
+        title.lower(),
+        stem_words,
+    }
+    return {variant for variant in variants if variant}
+
+
+def _mentioned(text: str, variants: set[str]) -> bool:
+    lowered = text.lower()
+    return any(variant in lowered for variant in variants if len(variant) >= 5)
+
+
+def _coerce_refs(value: Any) -> list[str]:
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, list):
+        return [item for item in value if isinstance(item, str)]
+    return []
+
+
+def _existing_frontmatter_targets(
+    repo: Path,
+    source: Path,
+    frontmatter: dict[str, Any],
+) -> set[str]:
+    source_rel = source.relative_to(repo).as_posix()
+    targets: set[str] = set()
+    for field in relationships.relationship_fields_for_source(source_rel):
+        for raw_ref in _coerce_refs(frontmatter.get(field)):
+            clean = relationships.clean_ref(raw_ref)
+            if not clean:
+                continue
+            if relationships.is_external_ref(clean):
+                targets.add(clean)
+                continue
+            target = (repo / clean).resolve()
+            try:
+                rel = target.relative_to(repo).as_posix()
+            except ValueError:
+                continue
+            targets.add(rel)
+    return targets
+
+
+def _existing_body_targets(
+    repo: Path,
+    source: Path,
+    body: str,
+    index: related_links.MarkdownIndex,
+) -> set[str]:
+    targets = related_links.related_section_targets(repo, source, body, index=index)
+    body_without_code = relationships.strip_markdown_code(body)
+    for _, raw_target in relationships.iter_markdown_links(body_without_code):
+        clean = relationships.markdown_link_target(raw_target)
+        if not clean or relationships.is_external_ref(clean):
+            continue
+        resolved = relationships.resolve_markdown_link(repo, source, clean)
+        if resolved is not None:
+            targets.add(resolved.relative_to(repo).as_posix())
+    return targets
+
+
+def _field_for_target(rel_path: str) -> str | None:
+    parts = Path(rel_path).parts
+    if not parts:
+        return None
+    root = parts[0]
+    if root == "bets":
+        return "linked_bets"
+    if root == "campaigns":
+        return "linked_pushes"
+    if root == "core" and len(parts) > 1 and parts[1] == "offers":
+        return "linked_offers"
+    if root == "decisions":
+        return "linked_decisions"
+    if root in {"docs", "documents"}:
+        return "linked_docs"
+    if root in {"log", "outputs"} or "outcome" in rel_path:
+        return "linked_outcomes"
+    if root == "pushes":
+        return "linked_pushes"
+    if root == "research":
+        return "linked_research"
+    return None
+
+
+def _is_data_or_report(rel_path: str, frontmatter: dict[str, Any]) -> bool:
+    parts = Path(rel_path).parts
+    if parts and parts[0] in {"data", "reports"}:
+        return True
+    item_type = frontmatter.get("type")
+    return isinstance(item_type, str) and item_type in {"data_source", "dataset", "report"}
+
+
+def _target_payload(rel_path: str, *, title: str, field: str | None = None) -> dict[str, Any]:
+    target: dict[str, Any] = {"path": rel_path, "title": title}
+    if field:
+        target["field"] = field
+    return target
+
+
+def _suggestion(
+    *,
+    action: str,
+    score: int,
+    target: dict[str, Any],
+    reasons: list[str],
+    evidence: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "action": action,
+        "action_label": ACTION_LABELS[action],
+        "score": score,
+        "target": target,
+        "reasons": reasons,
+        "evidence": evidence,
+    }
+
+
+def _candidate_suggestion(
+    *,
+    repo: Path,
+    source_text: str,
+    source_tokens: set[str],
+    existing_frontmatter_targets: set[str],
+    existing_body_targets: set[str],
+    target_path: Path,
+) -> dict[str, Any]:
+    rel_path = target_path.relative_to(repo).as_posix()
+    target_frontmatter, target_body = _read_markdown(target_path)
+    title = _title(target_path, target_frontmatter, target_body)
+    field = _field_for_target(rel_path)
+    mentioned = _mentioned(source_text, _phrase_variants(repo, target_path, title))
+    shared_tokens = sorted(source_tokens & _tokens(f"{rel_path}\n{title}\n{target_body[:2000]}"))[
+        :8
+    ]
+    evidence = {
+        "mentioned_by_name": mentioned,
+        "shared_terms": shared_tokens,
+    }
+
+    if _is_data_or_report(rel_path, target_frontmatter) and (mentioned or len(shared_tokens) >= 2):
+        score = 82 if mentioned else min(70, 50 + len(shared_tokens) * 4)
+        return _suggestion(
+            action=ACTION_DATA,
+            score=score,
+            target=_target_payload(rel_path, title=title),
+            reasons=[
+                "The candidate looks like a report or data note.",
+                "Connect it as evidence metadata instead of making raw data frontmatter truth.",
+            ],
+            evidence=evidence,
+        )
+
+    if field and mentioned and rel_path not in existing_frontmatter_targets:
+        return _suggestion(
+            action=ACTION_TYPED,
+            score=90,
+            target=_target_payload(rel_path, title=title, field=field),
+            reasons=[
+                f"The source directly names {title}.",
+                f"`{field}` is the matching typed frontmatter field for this file family.",
+            ],
+            evidence=evidence,
+        )
+
+    if mentioned and rel_path not in existing_body_targets:
+        return _suggestion(
+            action=ACTION_INLINE,
+            score=72,
+            target=_target_payload(rel_path, title=title),
+            reasons=[
+                "The source directly names this file, but it is not a typed "
+                "relationship candidate.",
+                "An inline Markdown link keeps the sentence helpful for human readers.",
+            ],
+            evidence=evidence,
+        )
+
+    if field and len(shared_tokens) >= 3 and rel_path not in existing_frontmatter_targets:
+        score = min(55, 25 + len(shared_tokens) * 5)
+        return _suggestion(
+            action=ACTION_CONTEXT,
+            score=score,
+            target=_target_payload(rel_path, title=title, field=field),
+            reasons=[
+                "The files share business terms, but the evidence is weak.",
+                "Leave this as nearby context unless the operator confirms a real relationship.",
+            ],
+            evidence=evidence,
+        )
+
+    return _suggestion(
+        action=ACTION_IGNORE,
+        score=0,
+        target=_target_payload(rel_path, title=title, field=field),
+        reasons=["No strong name match, typed relationship, or useful shared evidence."],
+        evidence=evidence,
+    )
+
+
+def _entity_suggestions(
+    *,
+    repo: Path,
+    source_text: str,
+    source_tokens: set[str],
+    source_path: Path,
+    files: tuple[Path, ...],
+) -> list[dict[str, Any]]:
+    existing_tags = {
+        f"#{kind}/{slug}" for kind, slug in graph.ENTITY_HASHTAG_RE.findall(source_text)
+    }
+    discovered: dict[str, set[str]] = {}
+    for path in files:
+        if path == source_path:
+            continue
+        _, body = _read_markdown(path)
+        for kind, slug in graph.ENTITY_HASHTAG_RE.findall(body):
+            tag = f"#{kind}/{slug}"
+            if tag in existing_tags:
+                continue
+            terms = _tokens(slug.replace("/", " ").replace("-", " "))
+            if terms and terms.issubset(source_tokens):
+                discovered.setdefault(tag, set()).add(path.relative_to(repo).as_posix())
+
+    suggestions: list[dict[str, Any]] = []
+    for tag, paths in sorted(discovered.items()):
+        suggestions.append(
+            _suggestion(
+                action=ACTION_ENTITY,
+                score=65,
+                target={"tag": tag},
+                reasons=[
+                    f"The source names the entity terms for `{tag}`.",
+                    "Use entity tags for recurring companies, offers, channels, "
+                    "competitors, or metrics.",
+                ],
+                evidence={"seen_in": sorted(paths)[:5]},
+            )
+        )
+    return suggestions
+
+
+def suggest_links(
+    source_file: str | Path,
+    *,
+    repo: str | Path = ".",
+    limit: int = 10,
+    include_ignored: bool = False,
+) -> dict[str, Any]:
+    """Return ranked link suggestions without editing files."""
+
+    root = Path(repo).expanduser().resolve()
+    source = Path(source_file).expanduser()
+    if not source.is_absolute():
+        source = root / source
+    source = source.resolve()
+    try:
+        source_rel = source.relative_to(root).as_posix()
+    except ValueError as exc:
+        raise ValueError(f"{source_file} is outside repo {root}") from exc
+    if not source.is_file():
+        raise ValueError(f"{source_rel} does not exist")
+    if source.suffix != ".md":
+        raise ValueError(f"{source_rel} is not a Markdown file")
+
+    index = related_links.markdown_index(root)
+    source_frontmatter, source_body = _read_markdown(source)
+    source_frontmatter_text = yaml.safe_dump(source_frontmatter, sort_keys=True)
+    source_text = f"{source_rel}\n{source_frontmatter_text}\n{source_body}"
+    source_tokens = _tokens(source_text)
+    existing_frontmatter = _existing_frontmatter_targets(root, source, source_frontmatter)
+    existing_body = _existing_body_targets(root, source, source_body, index)
+
+    ignored_count = 0
+    suggestions: list[dict[str, Any]] = []
+    for target_path in index.files:
+        if target_path == source:
+            continue
+        candidate = _candidate_suggestion(
+            repo=root,
+            source_text=source_text,
+            source_tokens=source_tokens,
+            existing_frontmatter_targets=existing_frontmatter,
+            existing_body_targets=existing_body,
+            target_path=target_path,
+        )
+        if candidate["action"] == ACTION_IGNORE:
+            ignored_count += 1
+            if not include_ignored:
+                continue
+        suggestions.append(candidate)
+
+    suggestions.extend(
+        _entity_suggestions(
+            repo=root,
+            source_text=source_text,
+            source_tokens=source_tokens,
+            source_path=source,
+            files=index.files,
+        )
+    )
+    suggestions.sort(key=lambda item: (-int(item["score"]), str(item["target"])))
+    if limit >= 0:
+        suggestions = suggestions[:limit]
+
+    counts = Counter(str(item["action"]) for item in suggestions)
+    return {
+        "ok": True,
+        "command": "mb suggest links",
+        "schema_version": SCHEMA_VERSION,
+        "repo": str(root),
+        "source": source_rel,
+        "matrix": {
+            "doc": MATRIX_DOC,
+            "actions": [{"id": action, "label": label} for action, label in ACTION_LABELS.items()],
+        },
+        "suggestions": suggestions,
+        "summary": {
+            "total": len(suggestions),
+            "by_action": dict(sorted(counts.items())),
+            "ignored_candidates": ignored_count,
+            "writes": 0,
+        },
+        "safe_to_apply": False,
+    }
+
+
+def render_human(report: dict[str, Any]) -> None:
+    """Print a compact human summary for terminal use."""
+
+    console = Console()
+    console.print(f"\n[bold]mb suggest links[/bold]  {report['source']}")
+    console.print("No files were changed.\n")
+    suggestions = report["suggestions"]
+    if not suggestions:
+        console.print("No useful link candidates found.")
+        return
+    for item in suggestions:
+        target = item["target"]
+        target_label = target.get("path") or target.get("tag") or "candidate"
+        console.print(
+            f"[bold]{item['score']:>3}[/bold]  {item['action_label']}  [cyan]{target_label}[/cyan]"
+        )
+        field = target.get("field")
+        if field:
+            console.print(f"     field: {field}")
+        for reason in item["reasons"]:
+            console.print(f"     - {reason}")
+    console.print(f"\nDecision guide: {report['matrix']['doc']}")

--- a/mb/mb/suggest.py
+++ b/mb/mb/suggest.py
@@ -236,7 +236,7 @@ def _suggestion(
 def _candidate_suggestion(
     *,
     repo: Path,
-    source_text: str,
+    source_mention_text: str,
     source_tokens: set[str],
     existing_frontmatter_targets: set[str],
     existing_body_targets: set[str],
@@ -246,7 +246,7 @@ def _candidate_suggestion(
     target_frontmatter, target_body = _read_markdown(target_path)
     title = _title(target_path, target_frontmatter, target_body)
     field = _field_for_target(rel_path)
-    mentioned = _mentioned(source_text, _phrase_variants(repo, target_path, title))
+    mentioned = _mentioned(source_mention_text, _phrase_variants(repo, target_path, title))
     shared_tokens = sorted(source_tokens & _tokens(f"{rel_path}\n{title}\n{target_body[:2000]}"))[
         :8
     ]
@@ -254,6 +254,18 @@ def _candidate_suggestion(
         "mentioned_by_name": mentioned,
         "shared_terms": shared_tokens,
     }
+
+    if rel_path in existing_frontmatter_targets or rel_path in existing_body_targets:
+        return _suggestion(
+            action=ACTION_IGNORE,
+            score=0,
+            target=_target_payload(rel_path, title=title, field=field),
+            reasons=[
+                "This target is already connected in frontmatter or the body.",
+                "Do not suggest duplicate links; use repair commands for missing mirrors.",
+            ],
+            evidence=evidence,
+        )
 
     if _is_data_or_report(rel_path, target_frontmatter) and (mentioned or len(shared_tokens) >= 2):
         score = 82 if mentioned else min(70, 50 + len(shared_tokens) * 4)
@@ -383,8 +395,9 @@ def suggest_links(
     index = related_links.markdown_index(root)
     source_frontmatter, source_body = _read_markdown(source)
     source_frontmatter_text = yaml.safe_dump(source_frontmatter, sort_keys=True)
-    source_text = f"{source_rel}\n{source_frontmatter_text}\n{source_body}"
-    source_tokens = _tokens(source_text)
+    source_index_text = f"{source_rel}\n{source_frontmatter_text}\n{source_body}"
+    source_mention_text = f"{source_rel}\n{source_body}"
+    source_tokens = _tokens(source_index_text)
     existing_frontmatter = _existing_frontmatter_targets(root, source, source_frontmatter)
     existing_body = _existing_body_targets(root, source, source_body, index)
 
@@ -395,7 +408,7 @@ def suggest_links(
             continue
         candidate = _candidate_suggestion(
             repo=root,
-            source_text=source_text,
+            source_mention_text=source_mention_text,
             source_tokens=source_tokens,
             existing_frontmatter_targets=existing_frontmatter,
             existing_body_targets=existing_body,
@@ -410,7 +423,7 @@ def suggest_links(
     suggestions.extend(
         _entity_suggestions(
             repo=root,
-            source_text=source_text,
+            source_text=source_mention_text,
             source_tokens=source_tokens,
             source_path=source,
             files=index.files,

--- a/mb/tests/test_suggest.py
+++ b/mb/tests/test_suggest.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from typer.testing import CliRunner
 
+from mb import suggest
 from mb.cli import app
 
 runner = CliRunner()
@@ -247,3 +248,108 @@ def test_suggest_links_rejects_non_markdown_source(tmp_path: Path) -> None:
 
     assert result.exit_code == 2
     assert "is not a Markdown file" in result.stderr
+
+
+def test_suggest_links_does_not_misclassify_outcome_substring(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "research" / "voice-outcome-mapping.md",
+        "---\ntitle: Voice Outcome Mapping\n---\nMapping launch voice to expected outcomes.\n",
+    )
+    _write(
+        tmp_path / "decisions" / "2026-05-11-voice-pass.md",
+        "---\n"
+        "title: Voice Pass Decision\n"
+        "status: accepted\n"
+        "---\n"
+        "# Voice Pass Decision\n\n"
+        "We will incorporate the Voice Outcome Mapping research before the launch.\n",
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "suggest",
+            "links",
+            "decisions/2026-05-11-voice-pass.md",
+            "--repo",
+            str(tmp_path),
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    report = json.loads(result.stdout)
+    by_path = _actions_by_path(report)
+    research = by_path["research/voice-outcome-mapping.md"]
+    target = research["target"]
+    assert isinstance(target, dict)
+    assert target.get("field") == "linked_research"
+
+
+def test_suggest_links_skips_targets_already_wikilinked(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "research" / "google-ads-intent.md",
+        "---\ntitle: Google Ads Intent Research\n---\n"
+        "Search intent from founders comparing launch systems.\n",
+    )
+    _write(
+        tmp_path / "docs" / "ads-overview.md",
+        "---\ntitle: Ads Overview\n---\n"
+        "# Ads Overview\n\n"
+        "See [[google-ads-intent]] for the demand signal we used.\n",
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "suggest",
+            "links",
+            "docs/ads-overview.md",
+            "--repo",
+            str(tmp_path),
+            "--include-ignored",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    report = json.loads(result.stdout)
+    by_path = _actions_by_path(report)
+    research = by_path["research/google-ads-intent.md"]
+    assert research["action"] == "ignore"
+    reasons = research["reasons"]
+    assert isinstance(reasons, list)
+    assert "already connected" in reasons[0]
+
+
+def test_suggest_links_render_human_prints_target_and_reasons(
+    tmp_path: Path, capsys: object
+) -> None:
+    report = {
+        "source": "decisions/sample.md",
+        "suggestions": [
+            {
+                "action": "add_typed_frontmatter_link",
+                "action_label": "add typed frontmatter link",
+                "score": 90,
+                "target": {
+                    "path": "research/example.md",
+                    "title": "Example Research",
+                    "field": "linked_research",
+                },
+                "reasons": ["The source directly names Example Research."],
+                "evidence": {},
+            }
+        ],
+        "matrix": {"doc": "docs/business-connections.md", "actions": []},
+    }
+
+    suggest.render_human(report)
+
+    captured = capsys.readouterr()  # type: ignore[attr-defined]
+    assert "mb suggest links" in captured.out
+    assert "decisions/sample.md" in captured.out
+    assert "research/example.md" in captured.out
+    assert "linked_research" in captured.out
+    assert "The source directly names Example Research." in captured.out
+    assert "docs/business-connections.md" in captured.out

--- a/mb/tests/test_suggest.py
+++ b/mb/tests/test_suggest.py
@@ -1,0 +1,130 @@
+"""Tests for read-only link suggestions."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from mb.cli import app
+
+runner = CliRunner()
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _actions_by_path(report: dict[str, object]) -> dict[str, dict[str, object]]:
+    suggestions = report["suggestions"]
+    assert isinstance(suggestions, list)
+    by_path: dict[str, dict[str, object]] = {}
+    for suggestion in suggestions:
+        assert isinstance(suggestion, dict)
+        target = suggestion["target"]
+        assert isinstance(target, dict)
+        path = target.get("path")
+        if isinstance(path, str):
+            by_path[path] = suggestion
+    return by_path
+
+
+def test_suggest_links_returns_ranked_json_without_writing(tmp_path: Path) -> None:
+    source = tmp_path / "decisions" / "2026-05-11-google-ads-first.md"
+    _write(
+        tmp_path / "research" / "google-ads-intent.md",
+        "---\ntitle: Google Ads Intent Research\n---\n"
+        "Search intent from founders comparing launch systems.\n"
+        "Track #channel/google-ads.\n",
+    )
+    _write(
+        tmp_path / "reports" / "google-ads-weekly.md",
+        "---\ntype: report\ntitle: Google Ads Weekly Report\n---\n"
+        "Weekly Google Ads spend and conversion notes.\n",
+    )
+    _write(
+        source,
+        "---\n"
+        "title: Google Ads First Decision\n"
+        "status: accepted\n"
+        "linked_research: []\n"
+        "---\n"
+        "# Google Ads First Decision\n\n"
+        "We chose Google Ads first because the Google Ads Intent Research and "
+        "Google Ads Weekly Report showed enough demand.\n",
+    )
+    before = source.read_text(encoding="utf-8")
+
+    result = runner.invoke(
+        app,
+        [
+            "suggest",
+            "links",
+            "decisions/2026-05-11-google-ads-first.md",
+            "--repo",
+            str(tmp_path),
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    assert source.read_text(encoding="utf-8") == before
+    report = json.loads(result.stdout)
+    assert report["ok"] is True
+    assert report["safe_to_apply"] is False
+    assert report["summary"]["writes"] == 0
+    by_path = _actions_by_path(report)
+    research = by_path["research/google-ads-intent.md"]
+    assert research["action"] == "add_typed_frontmatter_link"
+    research_target = research["target"]
+    assert isinstance(research_target, dict)
+    assert research_target["field"] == "linked_research"
+    assert by_path["reports/google-ads-weekly.md"]["action"] == "link_report_or_data_metadata"
+    assert any(
+        suggestion["action"] == "add_entity_tag"
+        and suggestion["target"] == {"tag": "#channel/google-ads"}
+        for suggestion in report["suggestions"]
+    )
+
+
+def test_suggest_links_can_include_ignored_candidates(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "decisions" / "pricing.md",
+        "---\ntitle: Pricing\nstatus: accepted\n---\n# Pricing\n\nUse annual plans.\n",
+    )
+    _write(
+        tmp_path / "research" / "unrelated.md",
+        "---\ntitle: Churn Interview\n---\n# Churn Interview\n\nSupport notes.\n",
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "suggest",
+            "links",
+            "decisions/pricing.md",
+            "--repo",
+            str(tmp_path),
+            "--include-ignored",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    report = json.loads(result.stdout)
+    assert report["suggestions"][0]["action"] == "ignore"
+    assert report["summary"]["ignored_candidates"] == 1
+
+
+def test_suggest_links_rejects_non_markdown_source(tmp_path: Path) -> None:
+    _write(tmp_path / "notes.txt", "plain text\n")
+
+    result = runner.invoke(
+        app,
+        ["suggest", "links", "notes.txt", "--repo", str(tmp_path), "--json"],
+    )
+
+    assert result.exit_code == 2
+    assert "is not a Markdown file" in result.stderr

--- a/mb/tests/test_suggest.py
+++ b/mb/tests/test_suggest.py
@@ -118,6 +118,125 @@ def test_suggest_links_can_include_ignored_candidates(tmp_path: Path) -> None:
     assert report["summary"]["ignored_candidates"] == 1
 
 
+def test_suggest_links_skips_targets_already_in_frontmatter(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "research" / "google-ads-intent.md",
+        "---\ntitle: Google Ads Intent Research\n---\n"
+        "Search intent from founders comparing launch systems.\n",
+    )
+    _write(
+        tmp_path / "decisions" / "2026-05-11-google-ads-first.md",
+        "---\n"
+        "title: Google Ads First Decision\n"
+        "status: accepted\n"
+        "linked_research:\n"
+        "  - research/google-ads-intent.md\n"
+        "---\n"
+        "# Google Ads First Decision\n\n"
+        "We weighed paid acquisition against organic for the new quarter.\n",
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "suggest",
+            "links",
+            "decisions/2026-05-11-google-ads-first.md",
+            "--repo",
+            str(tmp_path),
+            "--include-ignored",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    report = json.loads(result.stdout)
+    by_path = _actions_by_path(report)
+    research = by_path["research/google-ads-intent.md"]
+    assert research["action"] == "ignore"
+    reasons = research["reasons"]
+    assert isinstance(reasons, list)
+    assert "already connected" in reasons[0]
+
+
+def test_suggest_links_skips_targets_already_inline_linked(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "research" / "google-ads-intent.md",
+        "---\ntitle: Google Ads Intent Research\n---\n"
+        "Search intent from founders comparing launch systems.\n",
+    )
+    _write(
+        tmp_path / "docs" / "ads-overview.md",
+        "---\ntitle: Ads Overview\n---\n"
+        "# Ads Overview\n\n"
+        "See [Google Ads Intent Research](../research/google-ads-intent.md) for "
+        "the demand signal we used.\n",
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "suggest",
+            "links",
+            "docs/ads-overview.md",
+            "--repo",
+            str(tmp_path),
+            "--include-ignored",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    report = json.loads(result.stdout)
+    by_path = _actions_by_path(report)
+    research = by_path["research/google-ads-intent.md"]
+    assert research["action"] == "ignore"
+    reasons = research["reasons"]
+    assert isinstance(reasons, list)
+    assert "already connected" in reasons[0]
+
+
+def test_suggest_links_skips_report_already_linked(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "reports" / "google-ads-weekly.md",
+        "---\ntype: report\ntitle: Google Ads Weekly Report\n---\n"
+        "Weekly Google Ads spend and conversion notes.\n",
+    )
+    _write(
+        tmp_path / "decisions" / "2026-05-11-google-ads-first.md",
+        "---\n"
+        "title: Google Ads First Decision\n"
+        "status: accepted\n"
+        "---\n"
+        "# Google Ads First Decision\n\n"
+        "We chose Google Ads first; see "
+        "[Google Ads Weekly Report](../reports/google-ads-weekly.md) "
+        "for the spend and conversion trend.\n",
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "suggest",
+            "links",
+            "decisions/2026-05-11-google-ads-first.md",
+            "--repo",
+            str(tmp_path),
+            "--include-ignored",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    report = json.loads(result.stdout)
+    by_path = _actions_by_path(report)
+    report_entry = by_path["reports/google-ads-weekly.md"]
+    assert report_entry["action"] == "ignore"
+    reasons = report_entry["reasons"]
+    assert isinstance(reasons, list)
+    assert "already connected" in reasons[0]
+
+
 def test_suggest_links_rejects_non_markdown_source(tmp_path: Path) -> None:
     _write(tmp_path / "notes.txt", "plain text\n")
 


### PR DESCRIPTION
## Summary
- Adds read-only `mb suggest links <file>` that ranks candidate connections (typed frontmatter, inline Markdown, entity tag, data/report, nearby context, ignore) with reasons and evidence.
- Output is JSON-first so agents and a future review UI can explain suggestions before any file changes.
- Suppresses duplicate proposals when a target is already wired up in frontmatter or in the body.
- Reuses the connection decision matrix in `docs/business-connections.md`; the relationship registry and markdown index do the heavy lifting.

## Scope
- In: deterministic candidate suggestions, JSON + human output, docs/changelog/README updates, regression tests for the read-only + duplicate-safety contract.
- Out: applying suggestions, schema changes, data-source registry, scheduled sync, embeddings/LLM calls.

## Commits
- cae4ad5 — [add] Add mb suggest links command
- 269f99d — [fix] Suppress duplicate suggestions for already-linked targets

## Release / Issues
- Release: unscheduled (next 0.3.x slice)
- Linear ID(s): MAIN-313
- Closes: #469
- Refs: #468
- Follow-ups: #470, #471 remain open for data-source registry and scheduled sync.

## Success Metric
- An agent running `mb suggest links <file> --json` gets ranked, reason-bearing connection candidates without any file write and without duplicate proposals for already-linked targets.

## Validation
- Level 0 docs/decision: README, CHANGELOG, and `docs/business-connections.md` updated to reflect the new command and matrix framing.
- Level 1 static: `scripts/check.sh` passes (ruff format, ruff lint, mypy on 74 files).
- Level 2 CLI: 496 tests pass, including new regression coverage for frontmatter / inline / data-report duplicate suppression and the no-write contract.
- Level 3 package/install: not run; no packaging surface changed.
- Level 4 fixture repo: not run; command operates on any business repo via `--repo`.
- Level 5 runtime smoke: not run; this is a deterministic CLI surface and does not touch skill discovery, first-run, or runtime invocation.

## Public / Private Boundary
- Clean. No private Devon/Conductor/runtime details introduced; examples reuse the public `docs/business-connections.md` matrix.