### PR TITLE
[add] Data-source registry: type: data_source + linked_data_sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,19 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   Refs #468.
 - Opened follow-up implementation issues for data-source registry and scheduled
   data sync. Refs #470, #471.
+- Added the first record type in a future registry of portable business
+  facts: `type: data_source` records at `data/<provider>/source.md`.
+  `mb validate` recognizes the schema and checks provider id, owner,
+  privacy enum, cadence (warning), freshness date, storage mapping,
+  reports list, useful-query shape, and secret leakage. `mb graph` and
+  `mb validate --cross-refs` understand the new typed relationship
+  `linked_data_sources`. `mb suggest links` carries the typed field hint
+  when the candidate is a registry record. Documented in
+  `docs/data-source-registry.md` with an accepted decision and sanitized
+  Google Ads and Stripe fixture examples. The doc frames `data_source` as
+  the first record type and leaves room for sibling types
+  (`provider_config`, `secret_handle`, `integration_account`) without
+  binding them to SQL/storage assumptions. Refs #470.
 
 ### Changed
 

--- a/decisions/2026-05-11-data-source-registry.md
+++ b/decisions/2026-05-11-data-source-registry.md
@@ -1,0 +1,93 @@
+---
+type: decision
+date: 2026-05-11
+status: accepted
+topic: First registry shape for portable business data sources
+linked_issues:
+  - https://github.com/noontide-co/mainbranch/issues/470
+linked_decisions:
+  - decisions/2026-05-11-connecting-notes-data-and-history.md
+  - decisions/2026-05-09-obsidian-first-class-viewer.md
+linked_docs:
+  - docs/data-source-registry.md
+  - docs/business-connections.md
+tags: [docs, data, graph]
+---
+
+# Data-source registry for portable business metrics
+
+## Decision
+
+A data-source record is a small markdown file with frontmatter at
+`data/<provider>/source.md`. It is the readable handle Main Branch trusts
+when decisions, pushes, playbooks, outcomes, bets, research, and reports
+reference structured data such as Google Ads, Stripe, email, CRM, or
+analytics.
+
+- `type: data_source` is the official primitive marker.
+- `provider`, `owner`, and `privacy` are required. `cadence`, `freshness`,
+  `storage`, `reports`, `useful_queries`, and `tags` are advisory.
+- `linked_data_sources` is the typed frontmatter field other records use to
+  reference a registry entry.
+- `mb validate` recognizes the schema, checks enum and date shape, rejects
+  secret-shaped frontmatter, and warns when the provider id does not match
+  the folder name. `mb graph` emits `linked_data_sources` edges and exposes
+  the relationship in the registry payload. `mb suggest links` continues to
+  rank the record as `link_report_or_data_metadata` and carries
+  `field: linked_data_sources` so agents know the typed option exists.
+- Obsidian, GitHub, and other markdown viewers can browse the record and
+  the linked reports. They are not the data store.
+
+## Why
+
+`docs/business-connections.md` already says decisions, pushes, playbooks,
+and outcomes should usually link reports or data metadata, not giant raw
+files. Without an official record shape, every mention is a fresh guess
+about where the numbers live, what they mean, who owns them, and how fresh
+they are. A small contract makes those mentions inspectable.
+
+The contract intentionally stays small. SQLite is the default for ongoing
+local data because it is portable, queryable, and inspectable. CSV is the
+default for snapshots. The numbers stay in those structured files; markdown
+stays the meaning.
+
+## Future-safe framing
+
+`type: data_source` is the **first** record type in the registry, not the
+whole registry forever. Sibling record types are plausible later:
+
+- `provider_config` for facts like GitHub org base permission, repo-creation
+  policy, or team membership;
+- `secret_handle` for non-secret pointers into a keychain or vault;
+- `integration_account` for the named account or workspace an integration
+  is wired to.
+
+For this slice the contract stays narrow: `storage`, `useful_queries`, and
+SQL-flavored examples apply to data-source records, not every future
+registry record. Privacy is the read-side visibility axis; mutation /
+blast-radius questions (for example, `mutation_risk`, `approval_required`)
+are deliberately deferred to whichever record type first needs them.
+
+Cross-link field naming for sibling record types
+(`linked_provider_configs`, `linked_integration_accounts`, or a generic
+`linked_records`) is intentionally left open. Decide it the first time a
+sibling record ships.
+
+## Out of scope
+
+- Scheduled provider sync (`MAIN-315`).
+- Provider mutation and Google Ads automation (`MAIN-229`).
+- A `mb doctor` stale-data-record check. Add it as a follow-up once the
+  contract has been in use.
+- `mb onboard` scaffolding of `data/`. The stub at
+  `mb/mb/_data/stubs/data-source.md` can be copied on request; first-run
+  flow does not change in this slice.
+- Sibling registry record types (`provider_config`, `secret_handle`,
+  `integration_account`) and the cross-link fields they would need.
+
+## Validation
+
+- `scripts/check.sh` from repo root.
+- Targeted: `mb/tests/test_validate.py`, `mb/tests/test_suggest.py`,
+  `mb/tests/test_graph.py` cover the new schema, suggestion shape, and
+  graph edge.

--- a/decisions/2026-05-11-data-source-registry.md
+++ b/decisions/2026-05-11-data-source-registry.md
@@ -51,6 +51,14 @@ local data because it is portable, queryable, and inspectable. CSV is the
 default for snapshots. The numbers stay in those structured files; markdown
 stays the meaning.
 
+The shape is portable and runtime-agnostic. The records are files in the
+repo, so they travel with Git regardless of host (local-only, personal
+GitHub, a free GitHub org, or a self-hosted Git server). The schema is a
+mechanical check, so `mb validate` runs it locally today and the same
+`scripts/check.sh` rule can run in CI when a repo opts into pre-merge
+automation. Agents read the validation output and explain mechanical fixes
+versus operator judgment; they do not own the rule.
+
 ## Future-safe framing
 
 `type: data_source` is the **first** record type in the registry, not the

--- a/docs/business-connections.md
+++ b/docs/business-connections.md
@@ -245,11 +245,14 @@ what matters before changing frontmatter, inline links, tags, or metadata.
 
 Implementation follow-ups:
 
-- data-source registry: [#470](https://github.com/noontide-co/mainbranch/issues/470)
-- scheduled data sync pattern: [#471](https://github.com/noontide-co/mainbranch/issues/471)
+- data-source registry shape: see [`docs/data-source-registry.md`](data-source-registry.md)
+  and [#470](https://github.com/noontide-co/mainbranch/issues/470).
+- scheduled data sync pattern: [#471](https://github.com/noontide-co/mainbranch/issues/471).
 
 ## Related links
 
 - [How Main Branch connects notes, data, and history](../decisions/2026-05-11-connecting-notes-data-and-history.md)
+- [Data-source registry shape](data-source-registry.md)
+- [Data-source registry decision](../decisions/2026-05-11-data-source-registry.md)
 - [Markdown link conventions](markdown-link-conventions.md)
 - [Obsidian viewer decision](../decisions/2026-05-09-obsidian-first-class-viewer.md)

--- a/docs/data-source-registry.md
+++ b/docs/data-source-registry.md
@@ -17,6 +17,28 @@ records**, not every future registry record.
 authoring matrix for choosing typed links, inline links, entity tags,
 data/report references, GitHub history, and nearby context.
 
+## Where this fits
+
+A data-source record is portable. The shape is `markdown frontmatter +
+structured files in the same folder`, so it travels with the Git history
+wherever the repo lives — local-only, personal GitHub, a free GitHub org,
+or a self-hosted Git server. The registry does not depend on a hosted
+service to be meaningful.
+
+The schema itself is a **mechanical check**: a deterministic rule that can
+run in three places without changing shape.
+
+| Surface | Job |
+| --- | --- |
+| `mb validate` locally | Fast feedback while the operator or agent is editing the record. |
+| CI / pre-merge automation | Same `scripts/check.sh` rule can gate merges on a collaborative repo. |
+| Agents (Claude Code, Codex) | Read the validation output and explain mechanical fixes vs operator judgment. |
+
+Business-judgment checks like "this data source is stale" or "this
+decision changed a key data source without explaining why" are deliberately
+not part of this slice. They are warnings or review prompts for a later
+follow-up.
+
 ## What is a data-source record
 
 A data-source record lives at:

--- a/docs/data-source-registry.md
+++ b/docs/data-source-registry.md
@@ -1,0 +1,197 @@
+# Data-source registry
+
+Main Branch's first registry shape for structured business data. A
+data-source record is a small markdown file with frontmatter that points at
+the structured files Main Branch trusts for repeatable numbers and at the
+human-readable report(s) that explain what the numbers mean.
+
+This page is the contract for the **first record type** in the registry —
+`type: data_source`. The registry as a concept (a small markdown record
+with provider/owner/privacy frontmatter, linked from decisions and
+outcomes) may grow sibling record types later, such as `provider_config`,
+`secret_handle`, or `integration_account`. The `storage`, `useful_queries`,
+and SQL-flavored guidance on this page is **specific to data-source
+records**, not every future registry record.
+
+[docs/business-connections.md](business-connections.md) is the wider
+authoring matrix for choosing typed links, inline links, entity tags,
+data/report references, GitHub history, and nearby context.
+
+## What is a data-source record
+
+A data-source record lives at:
+
+```text
+data/<provider>/source.md
+```
+
+For example: `data/google-ads/source.md`, `data/stripe/source.md`,
+`data/email/source.md`, `data/crm/source.md`.
+
+Each provider gets one folder. The folder is where the structured files for
+that provider live (`daily.sqlite`, `snapshots/*.csv`), and `source.md` is
+the readable handle that decisions, pushes, playbooks, outcomes, and reports
+can point at.
+
+## Why a registry
+
+Markdown decisions, pushes, and outcomes already talk about Google Ads,
+Stripe, email, CRM, and analytics. Without a deterministic record, every
+mention is a fresh guess about where the numbers live, what they mean, who
+owns them, and how fresh they are. `data/<provider>/source.md` is the small
+durable record that makes those mentions inspectable.
+
+The registry does not invent a data warehouse. It is the readable index
+over portable structured files Main Branch can keep in the business repo:
+
+| Data shape | Use it for |
+| --- | --- |
+| SQLite (`storage.primary`) | The default for ongoing local queryable data: ads, email, Stripe, CRM, analytics. |
+| CSV (`storage.snapshots`) | Simple snapshots, one-time exports, audit-friendly daily cuts. |
+| Markdown reports (`reports:`) | What the numbers mean and what to do next. |
+| Provider-side dashboards | External; not the source of truth for Main Branch graphs. |
+
+Obsidian or other viewers can browse `source.md` and the reports. They are
+not the data store.
+
+## Frontmatter shape
+
+```yaml
+---
+type: data_source
+provider: google-ads
+owner: growth
+privacy: team_private
+cadence: daily
+freshness: 2026-05-10
+storage:
+  primary: data/google-ads/daily.sqlite
+  snapshots:
+    - data/google-ads/snapshots/2026-05-10.csv
+reports:
+  - reports/2026-05-10-google-ads-weekly.md
+useful_queries:
+  - name: weekly_spend_by_campaign
+    query: >-
+      SELECT campaign, SUM(cost_micros) / 1e6 AS spend
+      FROM ads_daily
+      WHERE date >= date('now', '-7 day')
+      GROUP BY campaign
+      ORDER BY spend DESC;
+    notes: Top spenders for the past 7 days; pair with weekly report.
+tags:
+  - channel/google-ads
+  - metric/spend
+---
+```
+
+### Required
+
+| Field | Shape | Notes |
+| --- | --- | --- |
+| `type` | string | Must equal `data_source`. |
+| `provider` | string | Lowercase id (`[a-z0-9][a-z0-9_-]*`). Should match the parent folder name. |
+| `owner` | string | The function or person accountable for this data (`growth`, `finance`, `ops`). |
+| `privacy` | enum | One of `public`, `team_private`, `restricted`, `local_only`. |
+
+### Advisory
+
+| Field | Shape | Notes |
+| --- | --- | --- |
+| `cadence` | enum | One of `realtime`, `hourly`, `daily`, `weekly`, `monthly`, `quarterly`, `ad_hoc`, `manual`. Warning, not error, if not recognized. |
+| `freshness` | date | `YYYY-MM-DD`. Validation will reject other shapes. |
+| `storage.primary` | path string | Usually a relative path to a SQLite file. |
+| `storage.snapshots` | list of strings | CSV snapshots or other portable cuts. |
+| `reports` | list of strings | Human-readable reports that explain the numbers. |
+| `useful_queries` | list of mappings | Each entry needs a non-empty `name` and `query`; `notes` is optional. |
+| `tags` | list | Entity tags such as `channel/google-ads`, `metric/spend`. |
+
+### Forbidden
+
+- API keys, refresh tokens, bearer tokens, client secrets, passwords,
+  session cookies, private keys.
+- Raw customer rows, PII, or platform account identifiers that should not
+  be visible to the repo audience.
+- Local absolute paths and machine-specific scratch directories.
+
+`mb validate` rejects records whose frontmatter contains keys or values
+that match common credential patterns.
+
+### Privacy vs mutation/blast-radius
+
+`privacy` describes visibility: who can read the rows or the report. It
+does **not** describe what happens when somebody changes a provider
+setting. A future `provider_config` record (for example, GitHub org base
+permission, repo-creation policy, or team membership) may need separate
+fields such as `mutation_risk` and `approval_required` to describe the
+blast radius of a change. That work is not part of this slice and is not
+modeled by `data_source` records.
+
+### Query typing for the future
+
+`useful_queries[].query` is opaque text today. Data-source records mostly
+have SQL queries against a local SQLite, so SQL is the practical default
+in examples. Future record types may carry other query kinds (`gh_api`,
+`stripe_cli`, `url`, `note`). When that need lands, add an explicit
+`useful_queries[].kind` field. Keep the field opaque rather than
+hardcoding a SQL-only assumption.
+
+## How records connect to the business
+
+Decisions, pushes, playbooks, outcomes, bets, research, and reports can
+point at a data-source record through the typed frontmatter relationship
+`linked_data_sources`:
+
+```yaml
+---
+date: 2026-05-11
+status: accepted
+linked_data_sources:
+  - data/google-ads/source.md
+---
+```
+
+`mb validate --cross-refs` checks that the target exists. `mb graph` emits
+a `linked_data_sources` edge so the relationship shows up in the business
+graph and in `mb status` proximity views.
+
+When the relationship is one sentence in a decision or outcome rather than a
+durable typed relationship, link the report inline instead:
+
+```markdown
+The [Google Ads weekly report](../reports/2026-05-10-google-ads-weekly.md)
+showed spend was capped by search volume.
+```
+
+`mb suggest links <file>` ranks both options as
+`link_report_or_data_metadata`. When the candidate is a registry record, the
+suggestion carries `field: linked_data_sources` so agents know the typed
+field is available.
+
+If the registry later grows sibling record types, the link fields should
+follow the same naming pattern (for example `linked_provider_configs`,
+`linked_integration_accounts`, or a more generic `linked_records`). That
+naming question is open and intentionally not decided in this slice — pick
+it the first time a sibling record type ships.
+
+## What this version does not do
+
+This version is the metadata contract. It deliberately does not:
+
+- Schedule provider data sync (`MAIN-315`).
+- Run provider mutations or Google Ads automation (`MAIN-229`).
+- Add a `mb doctor` stale-record check. That check needs the contract to
+  exist first and will land as a follow-up.
+- Scaffold a `data/` directory into new business repos through `mb onboard`.
+  A copy-safe stub lives at `mb/mb/_data/stubs/data-source.md`; future
+  onboarding can copy it on request.
+
+## Examples
+
+Fixture records used by the test suite:
+
+- `mb/tests/fixtures/data/google-ads/source.md` — daily ads spend.
+- `mb/tests/fixtures/data/stripe/source.md` — daily revenue and payouts.
+
+Both records keep raw account IDs, refresh tokens, and PII out of the
+repo. They are safe to read as public examples.

--- a/mb/mb/_data/stubs/data-source.md
+++ b/mb/mb/_data/stubs/data-source.md
@@ -1,0 +1,48 @@
+---
+type: data_source
+provider: example-provider
+owner: growth
+privacy: team_private
+cadence: daily
+freshness: YYYY-MM-DD
+storage:
+  primary: data/example-provider/daily.sqlite
+  snapshots:
+    - data/example-provider/snapshots/YYYY-MM-DD.csv
+reports:
+  - reports/YYYY-MM-DD-example-provider-weekly.md
+useful_queries:
+  - name: example_query
+    query: SELECT 1;
+    notes: Replace with a real query that an agent can re-run.
+tags:
+  - channel/example-provider
+---
+
+# Example provider — data source
+
+This is the starter shape for a `data/<provider>/source.md` record. Copy it
+into a real provider folder (`data/google-ads/source.md`,
+`data/stripe/source.md`, `data/crm/source.md`) and edit the frontmatter.
+
+## What this record is
+
+- The readable handle for one provider's local data.
+- A pointer to the structured files Main Branch trusts for repeatable
+  numbers (SQLite for ongoing local data, CSV for snapshots).
+- A pointer to the report(s) that explain what the numbers mean.
+
+## What this record is not
+
+- A place to store secrets, API tokens, refresh tokens, or raw account IDs.
+- A place to copy customer-identifying rows.
+- A replacement for the structured file. The numbers live in
+  `storage.primary` and `storage.snapshots`; markdown stays the meaning.
+
+## How agents should use this record
+
+- Reference it from decisions, pushes, playbooks, and outcomes via
+  `linked_data_sources` when the relationship is durable, or link the
+  weekly report inline when the sentence is about meaning.
+- Re-run the documented `useful_queries` instead of inventing new SQL when
+  a comparable answer already exists.

--- a/mb/mb/relationships.py
+++ b/mb/mb/relationships.py
@@ -112,6 +112,14 @@ RELATIONSHIPS: tuple[Relationship, ...] = (
         legacy=True,
     ),
     Relationship(
+        canonical_type="data_source",
+        fields=("linked_data_sources",),
+        description=(
+            "Connects a file to a data-source record (data/<provider>/source.md) "
+            "that describes provider, owner, privacy, cadence, storage, and reports."
+        ),
+    ),
+    Relationship(
         canonical_type="supersedes",
         fields=("supersedes",),
         description="Connects a newer artifact to the prior artifact it replaces.",

--- a/mb/mb/relationships.py
+++ b/mb/mb/relationships.py
@@ -15,6 +15,7 @@ LOCAL_REF_ROOTS = {
     "bets",
     "campaigns",
     "core",
+    "data",
     "decisions",
     "docs",
     "documents",
@@ -22,6 +23,7 @@ LOCAL_REF_ROOTS = {
     "outputs",
     "pushes",
     "reference",
+    "reports",
     "research",
 }
 

--- a/mb/mb/suggest.py
+++ b/mb/mb/suggest.py
@@ -196,6 +196,8 @@ def _field_for_target(rel_path: str) -> str | None:
         return "linked_pushes"
     if root == "core" and len(parts) > 1 and parts[1] == "offers":
         return "linked_offers"
+    if root == "data" and len(parts) >= 3 and parts[-1] == "source.md":
+        return "linked_data_sources"
     if root == "decisions":
         return "linked_decisions"
     if root in {"docs", "documents"}:
@@ -207,6 +209,14 @@ def _field_for_target(rel_path: str) -> str | None:
     if root == "research":
         return "linked_research"
     return None
+
+
+def _is_data_source_record(rel_path: str, frontmatter: dict[str, Any]) -> bool:
+    parts = Path(rel_path).parts
+    if len(parts) >= 3 and parts[0] == "data" and parts[-1] == "source.md":
+        return True
+    item_type = frontmatter.get("type")
+    return isinstance(item_type, str) and item_type == "data_source"
 
 
 def _is_data_or_report(rel_path: str, frontmatter: dict[str, Any]) -> bool:
@@ -278,14 +288,29 @@ def _candidate_suggestion(
 
     if _is_data_or_report(rel_path, target_frontmatter) and (mentioned or len(shared_tokens) >= 2):
         score = 82 if mentioned else min(70, 50 + len(shared_tokens) * 4)
+        is_source = _is_data_source_record(rel_path, target_frontmatter)
+        target_payload = (
+            _target_payload(rel_path, title=title, field="linked_data_sources")
+            if is_source
+            else _target_payload(rel_path, title=title)
+        )
+        reasons = (
+            [
+                "The candidate is a data-source registry record.",
+                "Link it as evidence metadata or via `linked_data_sources` rather than "
+                "raw data files.",
+            ]
+            if is_source
+            else [
+                "The candidate looks like a report or data note.",
+                "Connect it as evidence metadata instead of making raw data frontmatter truth.",
+            ]
+        )
         return _suggestion(
             action=ACTION_DATA,
             score=score,
-            target=_target_payload(rel_path, title=title),
-            reasons=[
-                "The candidate looks like a report or data note.",
-                "Connect it as evidence metadata instead of making raw data frontmatter truth.",
-            ],
+            target=target_payload,
+            reasons=reasons,
             evidence=evidence,
         )
 

--- a/mb/mb/suggest.py
+++ b/mb/mb/suggest.py
@@ -196,7 +196,7 @@ def _field_for_target(rel_path: str) -> str | None:
         return "linked_pushes"
     if root == "core" and len(parts) > 1 and parts[1] == "offers":
         return "linked_offers"
-    if root == "data" and len(parts) >= 3 and parts[-1] == "source.md":
+    if root == "data" and len(parts) == 3 and parts[-1] == "source.md":
         return "linked_data_sources"
     if root == "decisions":
         return "linked_decisions"
@@ -213,7 +213,7 @@ def _field_for_target(rel_path: str) -> str | None:
 
 def _is_data_source_record(rel_path: str, frontmatter: dict[str, Any]) -> bool:
     parts = Path(rel_path).parts
-    if len(parts) >= 3 and parts[0] == "data" and parts[-1] == "source.md":
+    if len(parts) == 3 and parts[0] == "data" and parts[-1] == "source.md":
         return True
     item_type = frontmatter.get("type")
     return isinstance(item_type, str) and item_type == "data_source"

--- a/mb/mb/validate.py
+++ b/mb/mb/validate.py
@@ -54,6 +54,21 @@ PLAYBOOK_APPROVAL_STATUS = {"not-required", "needed", "approved", "rejected"}
 PLAYBOOK_RESOURCE_KIND = {"url", "file", "repo", "document", "manual", "none"}
 PLAYBOOK_ACCEPTED_MUTATION_PROVIDERS: set[str] = set()
 PLAYBOOK_PROVIDER_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+DATA_SOURCE_TYPE = "data_source"
+DATA_SOURCE_PRIVACY = {"public", "team_private", "restricted", "local_only"}
+DATA_SOURCE_CADENCE = {
+    "realtime",
+    "hourly",
+    "daily",
+    "weekly",
+    "monthly",
+    "quarterly",
+    "ad_hoc",
+    "manual",
+}
+DATA_SOURCE_PROVIDER_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
+DATA_SOURCE_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
 TOPOLOGY_SCHEMA = {"mb.repo_topology.v0"}
 TOPOLOGY_STATUS = {"proposed", "active", "paused", "superseded", "archived"}
 TOPOLOGY_ROLE = {
@@ -280,6 +295,12 @@ SCHEMAS: dict[str, dict[str, Any]] = {
         "required": ["title"],
         "enums": {},
     },
+    "data-sources": {
+        "glob": "data/*/source.md",
+        "required": ["type", "provider", "owner", "privacy"],
+        "enums": {"type": {DATA_SOURCE_TYPE}, "privacy": DATA_SOURCE_PRIVACY},
+        "primitive": "data-source",
+    },
 }
 
 
@@ -329,6 +350,8 @@ def _check_one(path: Path, schema: dict[str, Any]) -> dict[str, Any]:
         _check_legacy_campaign_frontmatter(fm, errors)
     elif primitive == "repo-topology":
         _check_repo_topology_frontmatter(path, fm, errors, warnings)
+    elif primitive == "data-source":
+        _check_data_source_frontmatter(path, fm, errors, warnings)
     _check_provider_refs_shape(fm, errors)
     return {"path": str(path), "ok": not errors, "errors": errors, "warnings": warnings}
 
@@ -529,6 +552,82 @@ def _check_legacy_campaign_frontmatter(fm: dict[str, Any], errors: list[str]) ->
     record_type = fm.get("type")
     if record_type is not None and record_type not in {"campaign", "push"}:
         errors.append("type must be 'campaign' or 'push' for legacy campaign records")
+
+
+def _check_data_source_frontmatter(
+    path: Path,
+    fm: dict[str, Any],
+    errors: list[str],
+    warnings: list[str],
+) -> None:
+    if fm.get("type") != DATA_SOURCE_TYPE:
+        errors.append(f"type must be {DATA_SOURCE_TYPE!r}")
+
+    provider = fm.get("provider")
+    if isinstance(provider, str) and provider.strip():
+        provider_id = provider.strip()
+        if not DATA_SOURCE_PROVIDER_RE.fullmatch(provider_id):
+            errors.append("provider must be a lowercase id using letters, digits, '-' or '_'")
+        else:
+            folder = path.parent.name
+            if folder != provider_id:
+                warnings.append(
+                    f"provider {provider_id!r} does not match the parent folder {folder!r}; "
+                    "data records are usually data/<provider>/source.md"
+                )
+
+    _require_non_empty_string(fm, "owner", errors)
+
+    cadence = fm.get("cadence")
+    if isinstance(cadence, str) and cadence.strip() and cadence.strip() not in DATA_SOURCE_CADENCE:
+        warnings.append(
+            f"cadence={cadence!r} is not one of the conventional values "
+            f"{sorted(DATA_SOURCE_CADENCE)}; agents may not interpret it consistently"
+        )
+
+    freshness = _scalar_as_string(fm.get("freshness"))
+    if "freshness" in fm and freshness and not DATA_SOURCE_DATE_RE.fullmatch(freshness):
+        errors.append("freshness must be a YYYY-MM-DD date")
+
+    if "storage" in fm:
+        storage = fm.get("storage")
+        if not isinstance(storage, dict):
+            errors.append("storage must be a mapping with 'primary' and optional 'snapshots'")
+        else:
+            primary = storage.get("primary")
+            if primary is not None and (not isinstance(primary, str) or not primary.strip()):
+                errors.append("storage.primary must be a non-empty path string when present")
+            snapshots = storage.get("snapshots")
+            if snapshots is not None and (
+                not isinstance(snapshots, list)
+                or not all(isinstance(item, str) and item.strip() for item in snapshots)
+            ):
+                errors.append("storage.snapshots must be a list of non-empty path strings")
+
+    for ref_field in ("reports", "useful_queries"):
+        if ref_field not in fm:
+            continue
+        value = fm.get(ref_field)
+        if ref_field == "reports":
+            if not isinstance(value, list) or not all(
+                isinstance(item, str) and item.strip() for item in value
+            ):
+                errors.append("reports must be a list of non-empty path strings")
+        else:
+            if not isinstance(value, list) or not all(isinstance(item, dict) for item in value):
+                errors.append("useful_queries must be a list of mappings")
+                continue
+            for index, item in enumerate(value):
+                if not isinstance(item.get("name"), str) or not item.get("name").strip():
+                    errors.append(f"useful_queries[{index}].name must be a non-empty string")
+                if not isinstance(item.get("query"), str) or not item.get("query").strip():
+                    errors.append(f"useful_queries[{index}].query must be a non-empty string")
+
+    secret_paths = sorted(set(_iter_secret_paths(fm)))
+    if secret_paths:
+        errors.append(
+            "data-source frontmatter must not contain secrets: " + ", ".join(secret_paths)
+        )
 
 
 def _check_provider_refs_shape(fm: dict[str, Any], errors: list[str]) -> None:

--- a/mb/mb/validate.py
+++ b/mb/mb/validate.py
@@ -598,12 +598,26 @@ def _check_data_source_frontmatter(
             primary = storage.get("primary")
             if primary is not None and (not isinstance(primary, str) or not primary.strip()):
                 errors.append("storage.primary must be a non-empty path string when present")
+            elif isinstance(primary, str) and LOCAL_ABSOLUTE_PATH_RE.search(primary.strip()):
+                errors.append(
+                    "storage.primary must be a repo-relative path; "
+                    "machine-specific absolute paths are not portable"
+                )
             snapshots = storage.get("snapshots")
             if snapshots is not None and (
                 not isinstance(snapshots, list)
                 or not all(isinstance(item, str) and item.strip() for item in snapshots)
             ):
                 errors.append("storage.snapshots must be a list of non-empty path strings")
+            elif isinstance(snapshots, list):
+                for index, snapshot in enumerate(snapshots):
+                    if isinstance(snapshot, str) and LOCAL_ABSOLUTE_PATH_RE.search(
+                        snapshot.strip()
+                    ):
+                        errors.append(
+                            f"storage.snapshots[{index}] must be a repo-relative path; "
+                            "machine-specific absolute paths are not portable"
+                        )
 
     for ref_field in ("reports", "useful_queries"):
         if ref_field not in fm:
@@ -614,6 +628,13 @@ def _check_data_source_frontmatter(
                 isinstance(item, str) and item.strip() for item in value
             ):
                 errors.append("reports must be a list of non-empty path strings")
+            else:
+                for index, report in enumerate(value):
+                    if LOCAL_ABSOLUTE_PATH_RE.search(report.strip()):
+                        errors.append(
+                            f"reports[{index}] must be a repo-relative path; "
+                            "machine-specific absolute paths are not portable"
+                        )
         else:
             if not isinstance(value, list) or not all(isinstance(item, dict) for item in value):
                 errors.append("useful_queries must be a list of mappings")

--- a/mb/mb/validate.py
+++ b/mb/mb/validate.py
@@ -563,6 +563,7 @@ def _check_data_source_frontmatter(
     if fm.get("type") != DATA_SOURCE_TYPE:
         errors.append(f"type must be {DATA_SOURCE_TYPE!r}")
 
+    _require_non_empty_string(fm, "provider", errors)
     provider = fm.get("provider")
     if isinstance(provider, str) and provider.strip():
         provider_id = provider.strip()

--- a/mb/tests/fixtures/data/google-ads/source.md
+++ b/mb/tests/fixtures/data/google-ads/source.md
@@ -1,0 +1,55 @@
+---
+type: data_source
+provider: google-ads
+owner: growth
+privacy: team_private
+cadence: daily
+freshness: 2026-05-10
+storage:
+  primary: data/google-ads/daily.sqlite
+  snapshots:
+    - data/google-ads/snapshots/2026-05-10.csv
+reports:
+  - reports/2026-05-10-google-ads-weekly.md
+useful_queries:
+  - name: weekly_spend_by_campaign
+    query: >-
+      SELECT campaign, SUM(cost_micros) / 1e6 AS spend
+      FROM ads_daily
+      WHERE date >= date('now', '-7 day')
+      GROUP BY campaign
+      ORDER BY spend DESC;
+    notes: Top spenders for the past 7 days; pair with weekly report.
+tags:
+  - channel/google-ads
+  - metric/spend
+---
+
+# Google Ads — data source
+
+This record describes the local Google Ads data Main Branch trusts when
+markdown decisions, pushes, playbooks, or outcomes reference Google Ads
+numbers. The numbers themselves live in the structured files under
+`storage.primary` and `storage.snapshots`. The weekly report explains what
+the numbers mean.
+
+## What is here
+
+- `daily.sqlite` is the ongoing local table for spend, impressions, clicks,
+  and conversions.
+- Daily CSV snapshots are kept under `snapshots/` for quick inspection.
+- The latest weekly report is linked under `reports:`.
+
+## What is not here
+
+- Raw account IDs, refresh tokens, or login credentials. Those live in the
+  OS keychain or environment, never in this file.
+- Customer-identifying information.
+
+## How agents should use this record
+
+- Treat this file (not the raw SQLite) as the readable handle.
+- Prefer linking from decisions, pushes, and outcomes via
+  `linked_data_sources` or to the weekly report directly.
+- Re-run the documented `useful_queries` instead of inventing new SQL when a
+  comparable answer already exists.

--- a/mb/tests/fixtures/data/stripe/source.md
+++ b/mb/tests/fixtures/data/stripe/source.md
@@ -1,0 +1,53 @@
+---
+type: data_source
+provider: stripe
+owner: finance
+privacy: team_private
+cadence: daily
+freshness: 2026-05-10
+storage:
+  primary: data/stripe/payouts.sqlite
+  snapshots:
+    - data/stripe/snapshots/2026-05-10-payouts.csv
+reports:
+  - reports/2026-05-10-stripe-weekly.md
+useful_queries:
+  - name: gross_revenue_last_7_days
+    query: >-
+      SELECT date, SUM(amount_cents) / 100.0 AS gross
+      FROM charges
+      WHERE date >= date('now', '-7 day')
+      GROUP BY date
+      ORDER BY date;
+    notes: Daily gross revenue trend; pair with the weekly report.
+tags:
+  - channel/stripe
+  - metric/revenue
+---
+
+# Stripe — data source
+
+This record describes the local Stripe payments data Main Branch trusts
+when markdown decisions, pushes, or outcomes reference revenue, refunds,
+or payouts. The numbers live in `storage.primary`; the weekly report
+explains what they mean.
+
+## What is here
+
+- A local SQLite of charges, refunds, and payouts derived from the official
+  Stripe export.
+- Snapshot CSVs for human inspection.
+- A weekly report under `reports:` that summarizes trend and notable moves.
+
+## What is not here
+
+- API keys, webhook secrets, or customer PII. Those stay in environment or
+  keychain, never in this file.
+- Per-customer rows beyond what the public-safe weekly report needs.
+
+## How agents should use this record
+
+- Reference this file from decisions and outcomes that turn on revenue,
+  not the raw SQLite or per-row CSVs.
+- Use `linked_data_sources` for typed links, or link the weekly report when
+  the sentence is about meaning.

--- a/mb/tests/test_graph.py
+++ b/mb/tests/test_graph.py
@@ -528,3 +528,37 @@ repos:
 
     assert not any(node_id.startswith("engine_playbook:") for node_id in node_ids)
     assert "linked_playbook" not in edge_types
+
+
+def test_linked_data_sources_become_edges(tmp_path: Path) -> None:
+    data = tmp_path / "data" / "google-ads"
+    decisions = tmp_path / "decisions"
+    data.mkdir(parents=True)
+    decisions.mkdir()
+    (data / "source.md").write_text(
+        "---\n"
+        "type: data_source\n"
+        "provider: google-ads\n"
+        "owner: growth\n"
+        "privacy: team_private\n"
+        "---\n"
+        "# Google Ads data source\n",
+        encoding="utf-8",
+    )
+    (decisions / "2026-05-11-google-ads-first.md").write_text(
+        "---\n"
+        "date: 2026-05-11\n"
+        "status: accepted\n"
+        "linked_data_sources:\n"
+        "  - data/google-ads/source.md\n"
+        "---\n"
+        "# Decision\n",
+        encoding="utf-8",
+    )
+
+    index = build_index(path=str(tmp_path))
+    edge_types = {edge["type"] for edge in index["edges"]}
+
+    assert "linked_data_sources" in edge_types
+    registry = index["registry"]["relationships"]
+    assert any(entry["canonical_type"] == "data_source" for entry in registry)

--- a/mb/tests/test_suggest.py
+++ b/mb/tests/test_suggest.py
@@ -353,3 +353,53 @@ def test_suggest_links_render_human_prints_target_and_reasons(
     assert "linked_research" in captured.out
     assert "The source directly names Example Research." in captured.out
     assert "docs/business-connections.md" in captured.out
+
+
+def test_suggest_links_recognizes_data_source_registry(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "data" / "google-ads" / "source.md",
+        "---\n"
+        "type: data_source\n"
+        "provider: google-ads\n"
+        "owner: growth\n"
+        "privacy: team_private\n"
+        "cadence: daily\n"
+        "freshness: 2026-05-10\n"
+        "---\n"
+        "# Google Ads source\n"
+        "Local SQLite for Google Ads spend, impressions, clicks.\n",
+    )
+    _write(
+        tmp_path / "decisions" / "2026-05-11-google-ads-first.md",
+        "---\n"
+        "title: Google Ads First Decision\n"
+        "status: accepted\n"
+        "---\n"
+        "# Google Ads First Decision\n\n"
+        "We will run a Google Ads test; see data/google-ads/source.md for the "
+        "local Google Ads numbers we will trust.\n",
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "suggest",
+            "links",
+            "decisions/2026-05-11-google-ads-first.md",
+            "--repo",
+            str(tmp_path),
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    report = json.loads(result.stdout)
+    by_path = _actions_by_path(report)
+    source = by_path["data/google-ads/source.md"]
+    assert source["action"] == "link_report_or_data_metadata"
+    target = source["target"]
+    assert isinstance(target, dict)
+    assert target.get("field") == "linked_data_sources"
+    reasons = source["reasons"]
+    assert isinstance(reasons, list)
+    assert any("data-source registry record" in reason for reason in reasons)

--- a/mb/tests/test_validate.py
+++ b/mb/tests/test_validate.py
@@ -1795,3 +1795,65 @@ def test_validate_cross_refs_resolve_linked_data_sources(tmp_path: Path) -> None
     )
     assert decision["warnings"] == []
     assert "linked_data_sources" in report["cross_refs"]["checked_fields"]
+
+
+def test_validate_cross_refs_flags_missing_linked_data_source_target(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "decisions" / "2026-05-11-google-ads-first.md",
+        (
+            "---\n"
+            "date: 2026-05-11\n"
+            "status: accepted\n"
+            "linked_data_sources:\n"
+            "  - data/google-ads/source.md\n"
+            "---\n"
+            "# Decision\n"
+        ),
+    )
+
+    report = run(path=str(tmp_path), cross_refs=True, strict=True)
+
+    decision = next(
+        file for file in report["files"] if file["path"].endswith("google-ads-first.md")
+    )
+    assert decision["ok"] is False
+    assert any(
+        "linked_data_sources" in warning and "does not exist" in warning
+        for warning in decision["warnings"]
+    )
+    assert any(
+        finding["field"] == "linked_data_sources"
+        and finding["target"] == "data/google-ads/source.md"
+        for finding in report["cross_refs"]["warnings"]
+    )
+
+
+def test_validate_data_source_rejects_absolute_paths(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "data" / "google-ads" / "source.md",
+        (
+            "---\n"
+            "type: data_source\n"
+            "provider: google-ads\n"
+            "owner: growth\n"
+            "privacy: team_private\n"
+            "storage:\n"
+            "  primary: /Users/devon/Desktop/google-ads.sqlite\n"
+            "  snapshots:\n"
+            "    - ~/Downloads/2026-05-10.csv\n"
+            "reports:\n"
+            "  - C:\\\\Users\\\\devon\\\\report.md\n"
+            "---\n"
+            "# bad\n"
+        ),
+    )
+
+    report = run(path=str(tmp_path))
+
+    record = next(file for file in report["files"] if file["schema"] == "data-sources")
+    assert report["ok"] is False
+    assert any("storage.primary must be a repo-relative path" in err for err in record["errors"])
+    assert any(
+        "storage.snapshots[0] must be a repo-relative path" in err for err in record["errors"]
+    )
+    assert any("reports[0] must be a repo-relative path" in err for err in record["errors"])

--- a/mb/tests/test_validate.py
+++ b/mb/tests/test_validate.py
@@ -1606,3 +1606,171 @@ def test_cross_refs_flag_campaign_status_transition_regressions(tmp_path: Path) 
     ]
     assert len(transition_warnings) == 1
     assert "move backward" in transition_warnings[0]["message"]
+
+
+def _data_source(
+    *,
+    provider: str = "google-ads",
+    owner: str = "growth",
+    privacy: str = "team_private",
+    cadence: str = "daily",
+    freshness: str = "2026-05-10",
+    extra: str = "",
+) -> str:
+    return (
+        "---\n"
+        "type: data_source\n"
+        f"provider: {provider}\n"
+        f"owner: {owner}\n"
+        f"privacy: {privacy}\n"
+        f"cadence: {cadence}\n"
+        f"freshness: {freshness}\n"
+        "storage:\n"
+        f"  primary: data/{provider}/daily.sqlite\n"
+        "  snapshots:\n"
+        f"    - data/{provider}/snapshots/{freshness}.csv\n"
+        "reports:\n"
+        f"  - reports/{freshness}-{provider}-weekly.md\n"
+        f"{extra}"
+        "---\n"
+        f"# {provider} data source\n"
+    )
+
+
+def test_validate_accepts_well_formed_data_source(tmp_path: Path) -> None:
+    _write(tmp_path / "data" / "google-ads" / "source.md", _data_source())
+
+    report = run(path=str(tmp_path))
+
+    assert report["ok"] is True, report
+    record = next(file for file in report["files"] if file["schema"] == "data-sources")
+    assert record["errors"] == []
+    assert record["warnings"] == []
+
+
+def test_validate_rejects_data_source_missing_required_keys(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "data" / "google-ads" / "source.md",
+        "---\ntype: data_source\nprovider: google-ads\n---\n# bad\n",
+    )
+
+    report = run(path=str(tmp_path))
+
+    record = next(file for file in report["files"] if file["schema"] == "data-sources")
+    assert report["ok"] is False
+    assert "missing key: owner" in record["errors"]
+    assert "missing key: privacy" in record["errors"]
+
+
+def test_validate_rejects_data_source_bad_enums_and_dates(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "data" / "google-ads" / "source.md",
+        (
+            "---\n"
+            "type: data_source\n"
+            "provider: google-ads\n"
+            "owner: growth\n"
+            "privacy: world_readable\n"
+            "freshness: 2026/05/10\n"
+            "---\n"
+            "# bad\n"
+        ),
+    )
+
+    report = run(path=str(tmp_path))
+
+    record = next(file for file in report["files"] if file["schema"] == "data-sources")
+    assert report["ok"] is False
+    assert any("privacy=" in err for err in record["errors"])
+    assert "freshness must be a YYYY-MM-DD date" in record["errors"]
+
+
+def test_validate_warns_when_provider_folder_mismatches(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "data" / "googleads" / "source.md",
+        _data_source(provider="google-ads"),
+    )
+
+    report = run(path=str(tmp_path))
+
+    record = next(file for file in report["files"] if file["schema"] == "data-sources")
+    assert record["ok"] is True
+    assert any("does not match the parent folder" in w for w in record["warnings"])
+
+
+def test_validate_data_source_rejects_bad_storage_and_query_shape(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "data" / "google-ads" / "source.md",
+        (
+            "---\n"
+            "type: data_source\n"
+            "provider: google-ads\n"
+            "owner: growth\n"
+            "privacy: team_private\n"
+            "storage: data/google-ads/daily.sqlite\n"
+            "reports:\n"
+            "  - 42\n"
+            "useful_queries:\n"
+            "  - name: ''\n"
+            "    query: ''\n"
+            "---\n"
+            "# bad\n"
+        ),
+    )
+
+    report = run(path=str(tmp_path))
+
+    record = next(file for file in report["files"] if file["schema"] == "data-sources")
+    assert report["ok"] is False
+    assert any("storage must be a mapping" in err for err in record["errors"])
+    assert any("reports must be a list" in err for err in record["errors"])
+    assert any("useful_queries[0].name" in err for err in record["errors"])
+    assert any("useful_queries[0].query" in err for err in record["errors"])
+
+
+def test_validate_data_source_blocks_secret_frontmatter(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "data" / "google-ads" / "source.md",
+        (
+            "---\n"
+            "type: data_source\n"
+            "provider: google-ads\n"
+            "owner: growth\n"
+            "privacy: team_private\n"
+            "api_key: not-a-real-key\n"
+            "---\n"
+            "# bad\n"
+        ),
+    )
+
+    report = run(path=str(tmp_path))
+
+    record = next(file for file in report["files"] if file["schema"] == "data-sources")
+    assert report["ok"] is False
+    assert any("must not contain secrets" in err for err in record["errors"])
+
+
+def test_validate_cross_refs_resolve_linked_data_sources(tmp_path: Path) -> None:
+    _write(tmp_path / "data" / "google-ads" / "source.md", _data_source())
+    _write(
+        tmp_path / "decisions" / "2026-05-11-google-ads-first.md",
+        (
+            "---\n"
+            "date: 2026-05-11\n"
+            "status: accepted\n"
+            "linked_data_sources:\n"
+            "  - data/google-ads/source.md\n"
+            "---\n"
+            "# Decision\n"
+            "\n## Related links\n\n"
+            "- [Google Ads data source](../data/google-ads/source.md)\n"
+        ),
+    )
+
+    report = run(path=str(tmp_path), cross_refs=True)
+
+    decision = next(
+        file for file in report["files"] if file["path"].endswith("google-ads-first.md")
+    )
+    assert decision["warnings"] == []
+    assert "linked_data_sources" in report["cross_refs"]["checked_fields"]

--- a/mb/tests/test_validate.py
+++ b/mb/tests/test_validate.py
@@ -1662,6 +1662,27 @@ def test_validate_rejects_data_source_missing_required_keys(tmp_path: Path) -> N
     assert "missing key: privacy" in record["errors"]
 
 
+def test_validate_rejects_data_source_empty_provider(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "data" / "google-ads" / "source.md",
+        (
+            "---\n"
+            "type: data_source\n"
+            "provider: ''\n"
+            "owner: growth\n"
+            "privacy: team_private\n"
+            "---\n"
+            "# bad\n"
+        ),
+    )
+
+    report = run(path=str(tmp_path))
+
+    record = next(file for file in report["files"] if file["schema"] == "data-sources")
+    assert report["ok"] is False
+    assert "provider must be a non-empty string" in record["errors"]
+
+
 def test_validate_rejects_data_source_bad_enums_and_dates(tmp_path: Path) -> None:
     _write(
         tmp_path / "data" / "google-ads" / "source.md",


### PR DESCRIPTION
## Summary
- First registry shape for portable business data: `data/<provider>/source.md` records with `type: data_source`, owner, privacy, cadence, freshness, storage, reports, useful_queries.
- New typed relationship `linked_data_sources` so decisions, pushes, playbooks, outcomes, bets, and research can point at a data-source record and `mb graph` + `mb validate --cross-refs` understand the edge.
- `mb suggest links` keeps the existing `link_report_or_data_metadata` action and carries `field: linked_data_sources` when the candidate is a registry record.
- Documented in `docs/data-source-registry.md` (registry shape, required vs advisory fields, privacy vs mutation/blast-radius, query typing, portability) and `decisions/2026-05-11-data-source-registry.md` (frames `data_source` as the first record type, leaves room for `provider_config` / `secret_handle` / `integration_account` siblings).
- Sanitized Google Ads and Stripe fixtures plus a copy-safe stub under `mb/mb/_data/stubs/data-source.md` — no account IDs, tokens, or PII.

## Scope
- In: registry shape, validator, typed relationship, suggest-links hint, examples, decision, docs, CHANGELOG.
- Out: scheduled provider sync (#471 / MAIN-315), provider mutation / Google Ads automation (MAIN-229), `mb doctor` stale-record check, `mb onboard` scaffolding of `data/`, sibling registry types and their cross-link field names.

## Commits
- `fa7d176` — [add] Data-source registry decision and docs (MAIN-314)
- `7836e7d` — [add] data_source schema and linked_data_sources relationship (MAIN-314)
- `efe8c1c` — [add] Data-source fixtures and template stub (MAIN-314)
- `849cc91` — [add] Tests for data-source registry (MAIN-314)
- `24f9e48` — [update] Frame data-source registry as portable and runtime-agnostic (MAIN-314)

## Release / Issues
- Release: target next minor (additive; no packaging or first-run change).
- Linear ID(s): MAIN-314.
- Closes: #470.
- Refs: #468, #469 (`docs/business-connections.md` + `mb suggest links` groundwork this builds on).
- Follow-ups: `mb doctor` stale-data-record warning; sibling registry record types (`provider_config`, `secret_handle`, `integration_account`) and the `linked_*` field naming decision; optional `mb onboard` copy of the stub.

## Success Metric
A markdown decision, push, playbook, or outcome can link `data/<provider>/source.md` via `linked_data_sources`, `mb validate` passes the registry record, `mb graph` shows the edge, and `mb suggest links` ranks the registry record with the typed field hint — all without any private account data in the repo.

## Validation
- Level 0 docs/decision: `docs/data-source-registry.md`, `decisions/2026-05-11-data-source-registry.md`, `docs/business-connections.md` cross-link, CHANGELOG entry under `[Unreleased]`.
- Level 1 static: `scripts/check.sh` → exit 0 (ruff format check, ruff lint, mypy, pytest 508 passed, `mb skill validate --all --json`).
- Level 2 CLI: focused tests in `mb/tests/test_validate.py` (8 new), `mb/tests/test_suggest.py` (1 new), `mb/tests/test_graph.py` (1 new) covering happy path, shape failures, enum/date errors, folder/provider mismatch warning, secret leakage, and cross-ref resolution.
- Level 3 package/install: not required — no entrypoint, packaged data, or update-path change.
- Level 4 fixture repo: not required — `mb onboard` flow unchanged in this slice.
- Level 5 runtime smoke: not required — no skill discovery, first-run, or runtime-wiring change.

## Public / Private Boundary
All new content is generic OSS-safe. Fixtures and the stub avoid real account IDs, tokens, refresh tokens, and customer data; the validator rejects secret-shaped frontmatter. No Conductor, Devon-local, or member-specific details landed in the repo. Private design feedback from the parallel NOO-33 thread was distilled into public, future-safe language ("first record type", sibling types, privacy vs mutation/blast-radius) without leaking the source.