### PR TITLE
[add] Operator-facing GitOps primitives: workflow_mode + audience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,12 +24,15 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   into business-language next steps. Schemas are additive; no version bump
   required. Refs MAIN-310, #463.
 - Added workflow awareness to `mb status`'s existing `git` block:
-  `workflow` (one of `solo-on-main`, `branch`, `worktree`, `detached`),
-  `default_branch` (detected from `origin/HEAD` with fallbacks to `main` and
-  `master`), `upstream`, `ahead`, `behind`, `worktree_root`, and an
-  operator-facing `summary` one-liner. Gives skills and agents a single
-  place to decide whether to recommend save-on-main, branch-and-PR, or
-  worktree-aware flows without their own git wrappers. Refs MAIN-310, #463.
+  `workflow_mode` (one of `solo-on-main`, `branch`, `worktree`,
+  `detached`), `default_branch` (detected from `origin/HEAD` with
+  fallbacks to `main` and `master`), `upstream`, `ahead`, `behind`,
+  `worktree_root`, and an operator-facing `summary` one-liner. Gives
+  skills and agents a single place to decide whether to recommend
+  save-on-main, branch-and-PR, or worktree-aware flows without their own
+  git wrappers. `workflow_mode` describes local git shape only — not
+  pre-repo setup state, actor permissions, or check-enforcement choices.
+  Refs MAIN-310, #463.
 - Accepted decision
   `decisions/2026-05-11-operator-facing-gitops-and-migration-planning.md`
   locking the operator-facing GitOps contract: finding classification,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,30 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ### Added
 
+- Added `audience` and `operator_summary` fields to findings emitted by
+  `mb doctor` (every repair action), `mb validate` (each validation category
+  in `validation_categories`, plus `top_audience` and `top_operator_summary`
+  at the root), and `mb status` ranked actions. `audience` classifies each
+  finding as `mechanical` (Main Branch can apply safely), `operator_decision`
+  (a human must decide), or `informational` (read-only signal). The existing
+  `safe_to_apply` boolean on doctor actions remains the safety gate;
+  `audience` is the routing signal skills and agents read to translate facts
+  into business-language next steps. Schemas are additive; no version bump
+  required. Refs MAIN-310, #463.
+- Added workflow awareness to `mb status`'s existing `git` block:
+  `workflow` (one of `solo-on-main`, `branch`, `worktree`, `detached`),
+  `default_branch` (detected from `origin/HEAD` with fallbacks to `main` and
+  `master`), `upstream`, `ahead`, `behind`, `worktree_root`, and an
+  operator-facing `summary` one-liner. Gives skills and agents a single
+  place to decide whether to recommend save-on-main, branch-and-PR, or
+  worktree-aware flows without their own git wrappers. Refs MAIN-310, #463.
+- Accepted decision
+  `decisions/2026-05-11-operator-facing-gitops-and-migration-planning.md`
+  locking the operator-facing GitOps contract: finding classification,
+  workflow awareness, the deferred `mb commit --plan` / `mb publish --plan`
+  primitives, a packaged `/mb-publish` skill, and `mb migrate plan`
+  non-standard folder scanning. Implementation lands in staged slices that
+  each cite this decision. Refs MAIN-310, #463.
 - Added `mb suggest links <file>` as a read-only command that ranks candidate
   frontmatter, inline Markdown, entity tag, data/report metadata, nearby
   context, and ignore decisions with JSON reasons for skills and future UI.

--- a/decisions/2026-05-11-operator-facing-gitops-and-migration-planning.md
+++ b/decisions/2026-05-11-operator-facing-gitops-and-migration-planning.md
@@ -1,0 +1,255 @@
+---
+type: decision
+date: 2026-05-11
+status: accepted
+topic: Operator-facing GitOps and major migration planning
+linked_issues:
+  - https://github.com/noontide-co/mainbranch/issues/463
+linked_decisions:
+  - decisions/2026-05-01-mb-cli-vs-agent-workflows-boundary.md
+  - decisions/2026-05-02-github-native-business-os.md
+  - decisions/2026-05-05-operator-loops-taxonomy.md
+  - decisions/2026-05-05-operator-readable-git-history.md
+  - decisions/2026-05-06-main-branch-operating-spine.md
+  - decisions/2026-05-08-business-repo-topology-map.md
+linked_docs:
+  - AGENTS.md
+  - docs/OPERATOR-LOOPS.md
+  - docs/ROADMAP.md
+tags: [v0-3, gitops, migration, status, doctor, validate, checkpoint, publish]
+---
+
+# Operator-Facing GitOps and Major Migration Planning
+
+## Decision
+
+Main Branch separates **deterministic facts** (CLI JSON) from **operator-facing
+guidance** (skill prose) by adding three primitives to the engine and deferring
+three command surfaces to follow-up issues.
+
+Land in this slice:
+
+1. **`audience` classification** on every finding emitted by `mb doctor`,
+   `mb validate`, and `mb status` ranked actions. Values: `mechanical`,
+   `operator_decision`, `informational`.
+2. **`operator_summary`** plain-language one-liner on top-level findings, so a
+   business owner can read the next step without parsing schema language.
+3. **Workflow awareness** in `mb status` — extend the existing `git` block to
+   name the workflow mode (`solo-on-main`, `branch`, `worktree`, `detached`),
+   detect the default branch, and report ahead/behind counts so skills can
+   route save and publish guidance without their own git wrappers.
+
+Defer to follow-up issues, with contracts named here so future work can land
+without re-litigating the design:
+
+4. **`mb commit --plan` / `mb publish --plan`** — planned save and publish
+   primitives that read the workflow mode and route to the right git operation.
+5. **Packaged `/mb-publish` skill** — replaces per-session
+   `.context/attachments/PR instructions` files with a bundled skill that reads
+   `mb publish --plan` and walks the operator through it.
+6. **`mb migrate plan` non-standard folder scanner** — extends today's
+   `mb migrate` with a planner that surfaces non-standard top-level folders,
+   path substitution maps, and preservation guarantees before any move.
+
+## Why
+
+Dogfooding a Noontide business-repo migration after v0.3.10–v0.3.15 showed two
+gaps:
+
+- `mb doctor` and `mb validate` produce useful facts, but they still speak
+  schema and Git language. A business owner reads the JSON and does not know
+  which findings are safe to auto-repair and which need a human call.
+- Publishing changes is currently a per-session `.context/attachments/PR
+  instructions` file. That is a maintainer workaround. The engine should know
+  how to save and publish without a paste-in.
+
+This decision draws a single boundary: **the CLI exposes structured facts;
+runtime skills translate them into business language.** That boundary is in
+`decisions/2026-05-01-mb-cli-vs-agent-workflows-boundary.md`, but the current
+finding shapes do not carry enough information for skills to do that
+translation without re-deriving it every time. The three primitives in this
+slice give skills the routing signals they need.
+
+The deferred surfaces (commit-plan, publish-plan, migration planner) all depend
+on these primitives, so locking the primitives first lets each follow-up issue
+ship in its own PR with its own validation evidence.
+
+## Classification Taxonomy
+
+Every finding emitted by `mb doctor`, `mb validate`, and `mb status` ranked
+actions carries an `audience` field. Values are stable, additive, and small:
+
+- **`mechanical`** — Main Branch can apply the fix safely without operator
+  judgment. The repair is a renamed field, a missing mirror link, a stale
+  cache, or any change with a deterministic correct answer. Today this maps to
+  doctor actions with `safe_to_apply: true` and `mode: "write"`, validate
+  findings with categories in the deterministic-repair set, and status actions
+  whose recommended command is a `--apply`-style flag.
+- **`operator_decision`** — A human must decide. The repair is a content
+  change, a destructive move, a frontmatter shape that depends on what the
+  operator meant, or a workflow choice. Today this maps to doctor actions with
+  `safe_to_apply: false`, validate findings with operator-judgment categories
+  (status enum, missing slug, missing reverse link, broken cross-ref), and
+  status actions that recommend writing or editing repo files.
+- **`informational`** — The finding is a signal, not a fix. Used for read-only
+  checks, ranked actions that surface state without recommending mutation, and
+  doctor actions with `mode: "read"`.
+
+The existing `safe_to_apply` boolean on doctor actions stays as the safety
+gate. `audience` is the routing primitive for skills and agents; it is not a
+new safety mechanism.
+
+### Mapping rules (this slice)
+
+- `mb doctor` actions
+  - `mode == "read"` → `informational`
+  - `mode == "write"` and `safe_to_apply` → `mechanical`
+  - `mode == "write"` and not `safe_to_apply` → `operator_decision`
+- `mb validate` finding categories
+  - `missing_related_link_mirror`, `migration_drift` → `mechanical`
+  - `yaml_error`, `schema_shape_error`, `no_frontmatter` → `operator_decision`
+    (the file is broken; a human reads and fixes)
+  - `missing_slug`, `missing_required_key`, `status_enum_mismatch`,
+    `enum_mismatch`, `missing_cross_ref_target`, `missing_reverse_link` →
+    `operator_decision`
+  - `other_error`, `other_warning` → `operator_decision`
+- `mb status` ranked actions inherit `audience` from their underlying signal
+  when present; otherwise they default to `operator_decision` (status's job is
+  to prompt judgment, not silently repair).
+
+These rules live in code, not docs. Skills and agents should read the
+`audience` field, not re-derive from `safe_to_apply` or category names.
+
+## Operator-Facing Summary
+
+`operator_summary` is a plain-language one-liner on top-level findings:
+
+- `mb doctor` repair sections grow an `operator_summary` per section.
+- `mb validate` validation categories already carry a `repair` string;
+  `operator_summary` is added alongside as the human-facing phrasing, and
+  `repair` remains the action-oriented phrasing (the two can be the same
+  string when no separate operator framing is useful).
+- `mb status` ranked actions grow an `operator_summary` field built from their
+  existing `reason` plus a verb prefix.
+
+The summary is in plain business language, never references schema field
+names, and never assumes the operator knows what Git or YAML is.
+
+## Workflow Awareness in `mb status`
+
+`mb status`'s `git` block today emits:
+
+```text
+git.available, git.inside_work_tree, git.branch, git.commit,
+git.dirty, git.dirty_count, git.dirty_files, git.remote, git.error
+```
+
+This slice adds, in the same block, as additive optional fields:
+
+- **`workflow`** — string, one of:
+  - `solo-on-main` — current branch is the default branch and there is no
+    branch-and-PR workflow expected today.
+  - `branch` — current branch is not the default branch, and the repo is a
+    plain clone or main worktree.
+  - `worktree` — current checkout is a linked git worktree (Conductor
+    workspaces, manual `git worktree add`).
+  - `detached` — `HEAD` is detached. No save or publish operations should be
+    proposed without operator action.
+- **`default_branch`** — string, the repo's default branch when known.
+  Detected via `git symbolic-ref refs/remotes/origin/HEAD`, falling back to
+  `main` and then `master` for repos without a remote.
+- **`ahead`** — integer count of commits ahead of the upstream, or `null` when
+  unknown (no upstream tracking).
+- **`behind`** — integer count of commits behind the upstream, or `null`.
+- **`upstream`** — string name of the upstream ref, or empty.
+- **`worktree_root`** — absolute path of the worktree root when `workflow` is
+  `worktree`; empty otherwise.
+- **`summary`** — short operator-facing one-liner describing the workflow
+  state ("On main with no pending changes", "On branch `<name>` with N
+  uncommitted files", "In a worktree off `main`, branch `<name>`").
+
+All additions are additive. `STATUS_SCHEMA_VERSION` stays at `"1.0"`. Consumers
+that do not read the new fields keep working.
+
+## Deferred Surfaces (Contracts Locked Here, Implementation in Follow-Ups)
+
+### `mb commit --plan` / `mb publish --plan`
+
+A planned save and publish layer that reads `git.workflow` and routes:
+
+- `solo-on-main` and `worktree` → `mb commit --plan` produces concern-clustered
+  commit groups (using `mb checkpoint --plan` machinery) and recommends
+  `git push` when the operator confirms.
+- `branch` and `worktree` with a non-default branch → `mb publish --plan`
+  produces the commit groups plus a PR plan: title, body skeleton built from
+  the branch's commit log, closing-issues parsed from commit messages, base
+  branch, and the `gh pr create` command the operator can run.
+
+Both commands emit structured JSON with the same shape as `mb checkpoint
+--plan` today, plus a top-level `audience` and `operator_summary`. They write
+nothing without `--yes`. They are read-only by default.
+
+Follow-up issue: track separately. Validation evidence required: fixture repo
+covering each workflow mode, plus a CLI smoke that exercises plan-only.
+
+### Packaged `/mb-publish` skill
+
+Replaces the per-session `.context/attachments/PR instructions` files. The
+skill calls `mb publish --plan --json`, renders the plan in business language,
+asks the operator to confirm, and shells out to `git push` and `gh pr create`.
+The skill never reimplements PR-body generation; it reads the plan.
+
+Follow-up issue: track separately. Validation: runtime smoke from a fresh
+business repo on a feature branch.
+
+### `mb migrate plan`
+
+Extends today's `mb migrate` with a planner mode that scans non-standard
+top-level folders (`outputs/`, `reference/`, `briefs/`, `content/`, `staging/`,
+`skills/`, `ops/`, and any custom folder not covered by the topology map),
+produces a path substitution map showing where each tree would land in the
+current topology, preserves git history via `git mv`, and refuses to apply
+ambiguous moves without operator confirmation. Each move carries an
+`audience` field (`mechanical` for a topology-recognized rename;
+`operator_decision` for an ambiguous move).
+
+Follow-up issue: track separately. Validation: fixture repo with at least one
+non-standard folder and a snapshot test of the plan output.
+
+## Consequences
+
+- `mb status`, `mb doctor`, and `mb validate` JSON gains additive fields.
+  Tests assert presence and shape; tests do not assert absence of other fields,
+  to keep this slice composable with future work.
+- Skills can route on `audience` and render `operator_summary` without their
+  own git wrappers or schema-to-prose translation.
+- Future work (`mb commit --plan`, `mb publish --plan`, `/mb-publish`,
+  `mb migrate plan`) lands in its own issue and PR. Each one cites this
+  decision as the contract.
+- Per-session `.context/attachments/PR instructions` files become unnecessary
+  once `/mb-publish` ships. Until then, they remain a maintainer-only
+  workaround and should not be referenced from public docs.
+- `docs/ROADMAP.md` v0.3 line gains a sub-bullet for this work; the deferred
+  surfaces land under v0.3 or v0.4 depending on sequencing.
+
+## Review Trigger
+
+Revisit if any of these turn out to be wrong:
+
+- A finding category needs a fourth `audience` value (for example, a "blocked"
+  state where the system cannot classify safety). If so, extend the enum;
+  do not silently expand existing values.
+- The workflow detection logic misclassifies a real repo Devon or a public
+  contributor uses. Update the detection rules in `mb/mb/status.py` and the
+  fixture set.
+- A skill needs information the `operator_summary` field cannot carry. Add a
+  second field (`operator_explanation`?) rather than overloading
+  `operator_summary`.
+
+## Related links
+
+- [GitOps issue #463](https://github.com/noontide-co/mainbranch/issues/463)
+- [CLI vs agent workflows boundary](2026-05-01-mb-cli-vs-agent-workflows-boundary.md)
+- [Operator loops taxonomy](2026-05-05-operator-loops-taxonomy.md)
+- [Operator-readable git history](2026-05-05-operator-readable-git-history.md)
+- [Business repo topology map](2026-05-08-business-repo-topology-map.md)

--- a/decisions/2026-05-11-operator-facing-gitops-and-migration-planning.md
+++ b/decisions/2026-05-11-operator-facing-gitops-and-migration-planning.md
@@ -171,6 +171,32 @@ This slice adds, in the same block, as additive optional fields:
 All additions are additive. `STATUS_SCHEMA_VERSION` stays at `"1.0"`. Consumers
 that do not read the new fields keep working.
 
+### Boundary: what `workflow` does and does not describe
+
+`workflow` describes the local git checkout shape for an **existing** repo.
+It does **not** describe:
+
+- **Pre-repo setup state.** `/mb-setup`, `mb init`, and `mb onboard` can run
+  before `.git` exists, before an `origin` remote is set, or before the
+  remote has established a default branch. Those states are not workflow
+  modes; they are setup states and live under the setup/onboard surface.
+- **Actor permissions.** An external contributor with no push access looks
+  identical to an owner working on a feature branch locally. `workflow` is
+  about the local git shape; the actor's GitHub permission role (owner,
+  member, contributor, viewer) is a separate axis and should be modeled
+  separately when publish-time concerns require it.
+
+Follow-up `mb publish --plan` work should treat `actor_role` and
+`publish_path` (for example `direct_push` vs `pull_request`) as distinct
+fields, not overloads of `workflow`. A repo can be `ahead: 3` and still
+fail to push because the user lacks write access. That check sits upstream
+of ahead/behind and should be modeled where it can be detected (via `gh`
+when available) and classified `operator_decision` because membership and
+permissions need a human or admin action.
+
+These boundaries are recorded here so the deferred surfaces below do not
+have to rediscover them.
+
 ## Deferred Surfaces (Contracts Locked Here, Implementation in Follow-Ups)
 
 ### `mb commit --plan` / `mb publish --plan`
@@ -184,6 +210,16 @@ A planned save and publish layer that reads `git.workflow` and routes:
   produces the commit groups plus a PR plan: title, body skeleton built from
   the branch's commit log, closing-issues parsed from commit messages, base
   branch, and the `gh pr create` command the operator can run.
+
+`mb publish --plan` must also surface a separate `actor_role` and
+`publish_path` axis so a `branch` workflow without push access falls back to
+"open a PR from a fork" rather than failing at push time. Permission checks
+should use `gh api user/memberships/orgs/<org>` and
+`gh repo view <owner>/<repo> --json viewerPermission` when `gh` is available,
+and classify failures as `operator_decision` (membership/permission requires
+a human or admin action). Pre-repo state (no `.git`, no `origin`, no default
+branch) is out of scope for `mb publish --plan`; it belongs to the
+setup/onboard surface.
 
 Both commands emit structured JSON with the same shape as `mb checkpoint
 --plan` today, plus a top-level `audience` and `operator_summary`. They write

--- a/decisions/2026-05-11-operator-facing-gitops-and-migration-planning.md
+++ b/decisions/2026-05-11-operator-facing-gitops-and-migration-planning.md
@@ -124,16 +124,27 @@ These rules live in code, not docs. Skills and agents should read the
 
 `operator_summary` is a plain-language one-liner on top-level findings:
 
-- `mb doctor` repair sections grow an `operator_summary` per section.
+- `mb doctor` actions grow an `operator_summary` field. When no explicit
+  copy is supplied, it falls back to `reason` (or `title`) so the field is
+  always populated.
 - `mb validate` validation categories already carry a `repair` string;
   `operator_summary` is added alongside as the human-facing phrasing, and
   `repair` remains the action-oriented phrasing (the two can be the same
   string when no separate operator framing is useful).
-- `mb status` ranked actions grow an `operator_summary` field built from their
-  existing `reason` plus a verb prefix.
+- `mb status` ranked actions grow an `operator_summary` field built from
+  their existing `reason` (with `title` as the next fallback).
 
-The summary is in plain business language, never references schema field
-names, and never assumes the operator knows what Git or YAML is.
+The intent is plain business language with no schema field names or git
+jargon. This rollout is **progressive**: in this slice, validation
+categories carry the carefully written
+`VALIDATION_CATEGORY_OPERATOR_SUMMARY` copy, while doctor actions and
+status ranked actions fall back to the existing `reason`/`title` strings
+until each callsite is updated with explicit operator-facing copy. Skills
+should rely on the field being present and parseable today; they should
+not yet assume every value reads as plain business language. Follow-up
+work — and any future audit of doctor/ranker callsites — should pass
+explicit `operator_summary=` strings where the legacy `reason` still
+leaks schema or git terms.
 
 ## Workflow Awareness in `mb status`
 
@@ -165,8 +176,13 @@ This slice adds, in the same block, as additive optional fields:
 - **`worktree_root`** — absolute path of the worktree root when `workflow` is
   `worktree`; empty otherwise.
 - **`summary`** — short operator-facing one-liner describing the workflow
-  state ("On main with no pending changes", "On branch `<name>` with N
-  uncommitted files", "In a worktree off `main`, branch `<name>`").
+  state. The implementation emits forms like
+  `"On main with no uncommitted changes."`,
+  `"On branch \`feature/x\` with 3 uncommitted files ahead by 2."`,
+  `"In a worktree on \`feature/x\` with 1 uncommitted file."`,
+  and `"HEAD is detached. Check out a branch before saving."`. The exact
+  wording lives in `_build_git_summary` in `mb/mb/status.py`; this doc
+  describes the contract, not the surface phrasing.
 
 All additions are additive. `STATUS_SCHEMA_VERSION` stays at `"1.0"`. Consumers
 that do not read the new fields keep working.

--- a/decisions/2026-05-11-operator-facing-gitops-and-migration-planning.md
+++ b/decisions/2026-05-11-operator-facing-gitops-and-migration-planning.md
@@ -146,7 +146,7 @@ git.dirty, git.dirty_count, git.dirty_files, git.remote, git.error
 
 This slice adds, in the same block, as additive optional fields:
 
-- **`workflow`** — string, one of:
+- **`workflow_mode`** — string, one of:
   - `solo-on-main` — current branch is the default branch and there is no
     branch-and-PR workflow expected today.
   - `branch` — current branch is not the default branch, and the repo is a
@@ -171,28 +171,29 @@ This slice adds, in the same block, as additive optional fields:
 All additions are additive. `STATUS_SCHEMA_VERSION` stays at `"1.0"`. Consumers
 that do not read the new fields keep working.
 
-### Boundary: what `workflow` does and does not describe
+### Boundary: what `workflow_mode` does and does not describe
 
-`workflow` describes the local git checkout shape for an **existing** repo.
-It does **not** describe:
+`workflow_mode` describes the local git checkout shape for an **existing**
+repo. It does **not** describe:
 
 - **Pre-repo setup state.** `/mb-setup`, `mb init`, and `mb onboard` can run
   before `.git` exists, before an `origin` remote is set, or before the
   remote has established a default branch. Those states are not workflow
   modes; they are setup states and live under the setup/onboard surface.
 - **Actor permissions.** An external contributor with no push access looks
-  identical to an owner working on a feature branch locally. `workflow` is
-  about the local git shape; the actor's GitHub permission role (owner,
-  member, contributor, viewer) is a separate axis and should be modeled
-  separately when publish-time concerns require it.
-
-Follow-up `mb publish --plan` work should treat `actor_role` and
-`publish_path` (for example `direct_push` vs `pull_request`) as distinct
-fields, not overloads of `workflow`. A repo can be `ahead: 3` and still
-fail to push because the user lacks write access. That check sits upstream
-of ahead/behind and should be modeled where it can be detected (via `gh`
-when available) and classified `operator_decision` because membership and
-permissions need a human or admin action.
+  identical to an owner working on a feature branch locally. `workflow_mode`
+  is about the local git shape; the actor's GitHub permission role (owner,
+  member, contributor, viewer) is a separate axis and belongs to publish
+  and checks-model work, not here.
+- **Where the repo lives.** Local-only vs personal GitHub vs free GitHub org
+  vs paid org vs self-hosted Git (Forgejo/Gitea) is a setup-rubric question
+  for `/mb-setup` and `docs/DEPENDENCY-CHOICES.md`. `workflow_mode` is read
+  from the repo that already exists; it does not recommend where the next
+  repo should be created.
+- **Checks and review enforcement.** Whether a check is required, whether
+  it runs in GitHub Actions, and whether branch protection gates merges are
+  questions for a separate checks-and-review-model decision. `workflow_mode`
+  is local shape only.
 
 These boundaries are recorded here so the deferred surfaces below do not
 have to rediscover them.
@@ -201,7 +202,7 @@ have to rediscover them.
 
 ### `mb commit --plan` / `mb publish --plan`
 
-A planned save and publish layer that reads `git.workflow` and routes:
+A planned save and publish layer that reads `git.workflow_mode` and routes:
 
 - `solo-on-main` and `worktree` → `mb commit --plan` produces concern-clustered
   commit groups (using `mb checkpoint --plan` machinery) and recommends
@@ -211,15 +212,13 @@ A planned save and publish layer that reads `git.workflow` and routes:
   the branch's commit log, closing-issues parsed from commit messages, base
   branch, and the `gh pr create` command the operator can run.
 
-`mb publish --plan` must also surface a separate `actor_role` and
-`publish_path` axis so a `branch` workflow without push access falls back to
-"open a PR from a fork" rather than failing at push time. Permission checks
-should use `gh api user/memberships/orgs/<org>` and
-`gh repo view <owner>/<repo> --json viewerPermission` when `gh` is available,
-and classify failures as `operator_decision` (membership/permission requires
-a human or admin action). Pre-repo state (no `.git`, no `origin`, no default
-branch) is out of scope for `mb publish --plan`; it belongs to the
-setup/onboard surface.
+`mb publish --plan` will surface `actor_role` and `publish_path` (for example
+`direct_push` vs `pull_request`) as distinct axes from `workflow_mode`, so a
+`branch` workflow without push access can plan a fork-and-PR path rather than
+failing at push time. The exact shape of those axes — including whether and
+how `mb publish --plan` reads required-status-check state, GitHub branch
+protection, or org membership — belongs to a separate decision on the
+checks-and-review model for business repos, not this one.
 
 Both commands emit structured JSON with the same shape as `mb checkpoint
 --plan` today, plus a top-level `audience` and `operator_summary`. They write
@@ -251,6 +250,46 @@ ambiguous moves without operator confirmation. Each move carries an
 
 Follow-up issue: track separately. Validation: fixture repo with at least one
 non-standard folder and a snapshot test of the plan output.
+
+## Out of Scope (Belongs to Other Decisions)
+
+Two adjacent product questions came up while scoping this work. They are
+explicitly **not** this decision's job. Naming them here so a future agent
+does not try to resolve them inside the operator-facing GitOps surface.
+
+### Repo home and GitHub org setup rubric
+
+Where a business repo should live — local-only, personal GitHub, free
+GitHub organization, paid GitHub Team, or self-hosted Git such as
+Forgejo/Gitea — is a setup-rubric question. It belongs to `/mb-setup` and
+`docs/DEPENDENCY-CHOICES.md`, not here. GitHub organizations can be free;
+paid plans are optional and only needed for advanced team controls,
+support, or higher private-repo collaboration limits. Setup guidance
+should default to "personal GitHub or free GitHub org" and avoid
+implying a paywall.
+
+`workflow_mode` reads the local git shape of a repo that already exists.
+It does not recommend where the next repo should be created.
+
+### Checks and review model for business repos
+
+What runs locally vs in GitHub Actions, which checks are required vs
+informational vs warnings, whether branch protection gates merges, and
+how `mb publish --plan` should read GitHub check or required-status-check
+state is a separate product decision. The split is roughly:
+
+- `mb` defines and runs the rules locally;
+- agents use `mb` output to explain and repair;
+- GitHub Actions can run the same rules on PRs when the repo lives on
+  GitHub;
+- GitHub branch protection is optional for solo users, recommended for
+  team/org repos;
+- dashboards and Obsidian display state, they do not own enforcement.
+
+That model deserves its own decision and is out of scope here. The
+`audience` taxonomy (`mechanical`, `operator_decision`, `informational`)
+is reusable by that future decision; this slice should not pre-bake the
+enforcement rules.
 
 ## Consequences
 

--- a/mb/mb/doctor.py
+++ b/mb/mb/doctor.py
@@ -86,6 +86,8 @@ def _derive_audience(mode: str, safe_to_apply: bool) -> str:
     """
     if mode == "read":
         return "informational"
+    if mode == "manual":
+        return "operator_decision"
     if safe_to_apply:
         return "mechanical"
     return "operator_decision"

--- a/mb/mb/doctor.py
+++ b/mb/mb/doctor.py
@@ -74,6 +74,21 @@ REFERENCE_COMPAT_LINKS = {
     "reference/offers": "../core/offers",
 }
 STATE_ORDER = {"ok": 0, "info": 1, "warn": 2, "error": 3}
+AUDIENCE_VALUES = frozenset({"mechanical", "operator_decision", "informational"})
+
+
+def _derive_audience(mode: str, safe_to_apply: bool) -> str:
+    """Classify a repair action for operator-facing routing.
+
+    See ``decisions/2026-05-11-operator-facing-gitops-and-migration-planning.md``
+    for the contract. ``audience`` is a routing signal; ``safe_to_apply`` is the
+    safety gate and stays authoritative.
+    """
+    if mode == "read":
+        return "informational"
+    if safe_to_apply:
+        return "mechanical"
+    return "operator_decision"
 
 
 def _which(name: str) -> str:
@@ -188,7 +203,12 @@ def _action(
     writes: list[str] | None = None,
     applied: bool = False,
     result: dict[str, Any] | None = None,
+    audience: str | None = None,
+    operator_summary: str = "",
 ) -> dict[str, Any]:
+    resolved_audience = audience if audience in AUDIENCE_VALUES else _derive_audience(
+        mode, safe_to_apply
+    )
     return {
         "id": id,
         "title": title,
@@ -197,6 +217,8 @@ def _action(
         "command": command,
         "safe_to_apply": safe_to_apply,
         "reason": reason,
+        "audience": resolved_audience,
+        "operator_summary": operator_summary or reason or title,
         "writes": writes or [],
         "applied": applied,
         "result": result or {},

--- a/mb/mb/doctor.py
+++ b/mb/mb/doctor.py
@@ -208,8 +208,8 @@ def _action(
     audience: str | None = None,
     operator_summary: str = "",
 ) -> dict[str, Any]:
-    resolved_audience = audience if audience in AUDIENCE_VALUES else _derive_audience(
-        mode, safe_to_apply
+    resolved_audience = (
+        audience if audience in AUDIENCE_VALUES else _derive_audience(mode, safe_to_apply)
     )
     return {
         "id": id,

--- a/mb/mb/ranker.py
+++ b/mb/mb/ranker.py
@@ -561,6 +561,8 @@ def _action(
     reason: str,
     signals: list[dict[str, Any]],
     confidence: str | None = None,
+    audience: str = "operator_decision",
+    operator_summary: str = "",
 ) -> dict[str, Any]:
     action_confidence = confidence or _confidence(score, signals)
     safe_to_share = all(bool(signal.get("safe_to_share")) for signal in signals)
@@ -573,6 +575,8 @@ def _action(
         "score": score,
         "confidence": action_confidence,
         "reason": reason,
+        "audience": audience,
+        "operator_summary": operator_summary or reason or title,
         "signals": signals,
         "safe_to_share": safe_to_share,
     }

--- a/mb/mb/status.py
+++ b/mb/mb/status.py
@@ -168,21 +168,21 @@ def _classify_workflow(
 
 def _build_git_summary(
     *,
-    workflow: str,
+    workflow_mode: str,
     branch: str,
     default_branch: str,
     dirty_count: int,
     ahead: int | None,
     behind: int | None,
 ) -> str:
-    if workflow == "detached":
+    if workflow_mode == "detached":
         return "HEAD is detached. Check out a branch before saving."
-    if not workflow:
+    if not workflow_mode:
         return ""
 
-    if workflow == "solo-on-main":
+    if workflow_mode == "solo-on-main":
         label = f"On {branch or default_branch or 'main'}"
-    elif workflow == "worktree":
+    elif workflow_mode == "worktree":
         label = f"In a worktree on `{branch}`" if branch else "In a worktree"
     else:
         label = f"On branch `{branch}`"
@@ -236,7 +236,7 @@ def _git_info(repo: Path) -> dict[str, Any]:
             worktree_root = toplevel["stdout"].strip()
 
     default_branch = _detect_default_branch(repo)
-    workflow = _classify_workflow(
+    workflow_mode = _classify_workflow(
         branch=branch_name,
         is_linked_worktree=is_linked_worktree,
         default_branch=default_branch,
@@ -263,7 +263,7 @@ def _git_info(repo: Path) -> dict[str, Any]:
                     behind = int(parts[1])
 
     summary = _build_git_summary(
-        workflow=workflow,
+        workflow_mode=workflow_mode,
         branch=branch_name,
         default_branch=default_branch,
         dirty_count=len(dirty_lines),
@@ -280,7 +280,7 @@ def _git_info(repo: Path) -> dict[str, Any]:
         "dirty_count": len(dirty_lines),
         "dirty_files": dirty_lines[:10],
         "remote": remote["stdout"].strip() if remote["ok"] else "",
-        "workflow_mode": workflow,
+        "workflow_mode": workflow_mode,
         "default_branch": default_branch,
         "upstream": upstream_ref,
         "ahead": ahead,

--- a/mb/mb/status.py
+++ b/mb/mb/status.py
@@ -149,13 +149,14 @@ def _detect_default_branch(repo: Path) -> str:
 
 def _classify_workflow(
     *,
-    inside_worktree: bool,
     branch: str,
     is_linked_worktree: bool,
     default_branch: str,
 ) -> str:
-    if not inside_worktree:
-        return ""
+    """Classify an in-worktree checkout. Callers must ensure they are inside a
+    git work tree before calling — `_git_info` short-circuits the non-worktree
+    case before reaching this helper.
+    """
     if not branch:
         return "detached"
     if is_linked_worktree:
@@ -236,7 +237,6 @@ def _git_info(repo: Path) -> dict[str, Any]:
 
     default_branch = _detect_default_branch(repo)
     workflow = _classify_workflow(
-        inside_worktree=True,
         branch=branch_name,
         is_linked_worktree=is_linked_worktree,
         default_branch=default_branch,

--- a/mb/mb/status.py
+++ b/mb/mb/status.py
@@ -224,11 +224,15 @@ def _git_info(repo: Path) -> dict[str, Any]:
 
     git_dir = _run_command(["git", "rev-parse", "--git-dir"], cwd=repo)
     common_dir = _run_command(["git", "rev-parse", "--git-common-dir"], cwd=repo)
-    is_linked_worktree = (
-        git_dir["ok"]
-        and common_dir["ok"]
-        and git_dir["stdout"].strip() != common_dir["stdout"].strip()
-    )
+    # Linked worktrees report git-dir under .git/worktrees/<name>/ while
+    # git-common-dir points at the shared .git directory. Git can emit either
+    # path as relative or absolute depending on context, so resolve both
+    # against `repo` before comparing instead of doing raw string inequality.
+    is_linked_worktree = False
+    if git_dir["ok"] and common_dir["ok"]:
+        git_dir_path = (repo / git_dir["stdout"].strip()).resolve()
+        common_dir_path = (repo / common_dir["stdout"].strip()).resolve()
+        is_linked_worktree = git_dir_path != common_dir_path
     worktree_root = ""
     if is_linked_worktree:
         toplevel = _run_command(["git", "rev-parse", "--show-toplevel"], cwd=repo)

--- a/mb/mb/status.py
+++ b/mb/mb/status.py
@@ -125,6 +125,80 @@ def _looks_like_mainbranch_repo(repo: Path) -> dict[str, Any]:
     }
 
 
+def _detect_default_branch(repo: Path) -> str:
+    """Return the repo's default branch, falling back to common names."""
+    symbolic = _run_command(
+        ["git", "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"],
+        cwd=repo,
+    )
+    if symbolic["ok"]:
+        raw = symbolic["stdout"].strip()
+        if raw.startswith("origin/"):
+            return raw[len("origin/") :]
+        if raw:
+            return raw
+    for candidate in ("main", "master"):
+        exists = _run_command(
+            ["git", "show-ref", "--verify", "--quiet", f"refs/heads/{candidate}"],
+            cwd=repo,
+        )
+        if exists["ok"]:
+            return candidate
+    return ""
+
+
+def _classify_workflow(
+    *,
+    inside_worktree: bool,
+    branch: str,
+    is_linked_worktree: bool,
+    default_branch: str,
+) -> str:
+    if not inside_worktree:
+        return ""
+    if not branch:
+        return "detached"
+    if is_linked_worktree:
+        return "worktree"
+    if default_branch and branch == default_branch:
+        return "solo-on-main"
+    return "branch"
+
+
+def _build_git_summary(
+    *,
+    workflow: str,
+    branch: str,
+    default_branch: str,
+    dirty_count: int,
+    ahead: int | None,
+    behind: int | None,
+) -> str:
+    if workflow == "detached":
+        return "HEAD is detached. Check out a branch before saving."
+    if not workflow:
+        return ""
+
+    if workflow == "solo-on-main":
+        label = f"On {branch or default_branch or 'main'}"
+    elif workflow == "worktree":
+        label = f"In a worktree on `{branch}`" if branch else "In a worktree"
+    else:
+        label = f"On branch `{branch}`"
+
+    parts: list[str] = [label]
+    if dirty_count:
+        plural = "" if dirty_count == 1 else "s"
+        parts.append(f"with {dirty_count} uncommitted file{plural}")
+    else:
+        parts.append("with no uncommitted changes")
+    if ahead:
+        parts.append(f"ahead by {ahead}")
+    if behind:
+        parts.append(f"behind by {behind}")
+    return " ".join(parts) + "."
+
+
 def _git_info(repo: Path) -> dict[str, Any]:
     if not _which("git"):
         return {"available": False, "inside_work_tree": False, "error": "git not on PATH"}
@@ -142,18 +216,77 @@ def _git_info(repo: Path) -> dict[str, Any]:
     status = _run_command(["git", "status", "--porcelain"], cwd=repo)
     remote = _run_command(["git", "config", "--get", "remote.origin.url"], cwd=repo)
 
+    branch_name = branch["stdout"].strip() if branch["ok"] else ""
     dirty_lines = (
         [line for line in status["stdout"].splitlines() if line.strip()] if status["ok"] else []
     )
+
+    git_dir = _run_command(["git", "rev-parse", "--git-dir"], cwd=repo)
+    common_dir = _run_command(["git", "rev-parse", "--git-common-dir"], cwd=repo)
+    is_linked_worktree = (
+        git_dir["ok"]
+        and common_dir["ok"]
+        and git_dir["stdout"].strip() != common_dir["stdout"].strip()
+    )
+    worktree_root = ""
+    if is_linked_worktree:
+        toplevel = _run_command(["git", "rev-parse", "--show-toplevel"], cwd=repo)
+        if toplevel["ok"]:
+            worktree_root = toplevel["stdout"].strip()
+
+    default_branch = _detect_default_branch(repo)
+    workflow = _classify_workflow(
+        inside_worktree=True,
+        branch=branch_name,
+        is_linked_worktree=is_linked_worktree,
+        default_branch=default_branch,
+    )
+
+    upstream_ref = ""
+    ahead: int | None = None
+    behind: int | None = None
+    if branch_name:
+        upstream = _run_command(
+            ["git", "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"],
+            cwd=repo,
+        )
+        if upstream["ok"]:
+            upstream_ref = upstream["stdout"].strip()
+            counts = _run_command(
+                ["git", "rev-list", "--left-right", "--count", f"HEAD...{upstream_ref}"],
+                cwd=repo,
+            )
+            if counts["ok"]:
+                parts = counts["stdout"].split()
+                if len(parts) == 2 and parts[0].isdigit() and parts[1].isdigit():
+                    ahead = int(parts[0])
+                    behind = int(parts[1])
+
+    summary = _build_git_summary(
+        workflow=workflow,
+        branch=branch_name,
+        default_branch=default_branch,
+        dirty_count=len(dirty_lines),
+        ahead=ahead,
+        behind=behind,
+    )
+
     return {
         "available": True,
         "inside_work_tree": True,
-        "branch": branch["stdout"].strip() if branch["ok"] else "",
+        "branch": branch_name,
         "commit": commit["stdout"].strip() if commit["ok"] else "",
         "dirty": bool(dirty_lines),
         "dirty_count": len(dirty_lines),
         "dirty_files": dirty_lines[:10],
         "remote": remote["stdout"].strip() if remote["ok"] else "",
+        "workflow": workflow,
+        "default_branch": default_branch,
+        "upstream": upstream_ref,
+        "ahead": ahead,
+        "behind": behind,
+        "worktree_root": worktree_root,
+        "summary": summary,
         "error": "" if status["ok"] else status["stderr"].strip(),
     }
 

--- a/mb/mb/status.py
+++ b/mb/mb/status.py
@@ -280,7 +280,7 @@ def _git_info(repo: Path) -> dict[str, Any]:
         "dirty_count": len(dirty_lines),
         "dirty_files": dirty_lines[:10],
         "remote": remote["stdout"].strip() if remote["ok"] else "",
-        "workflow": workflow,
+        "workflow_mode": workflow,
         "default_branch": default_branch,
         "upstream": upstream_ref,
         "ahead": ahead,

--- a/mb/mb/status.py
+++ b/mb/mb/status.py
@@ -132,7 +132,7 @@ def _detect_default_branch(repo: Path) -> str:
         cwd=repo,
     )
     if symbolic["ok"]:
-        raw = symbolic["stdout"].strip()
+        raw = str(symbolic["stdout"]).strip()
         if raw.startswith("origin/"):
             return raw[len("origin/") :]
         if raw:

--- a/mb/mb/validate.py
+++ b/mb/mb/validate.py
@@ -185,7 +185,9 @@ VALIDATION_CATEGORY_OPERATOR_SUMMARY: dict[str, str] = {
     "no_frontmatter": "Add the YAML header at the top of the file.",
     "yaml_error": "Fix the YAML formatting at the top before anything else can be checked.",
     "schema_shape_error": "Reshape the YAML fields so they match the expected layout.",
-    "missing_cross_ref_target": "Fix the broken link, remove it, or mark it as intentionally archived.",
+    "missing_cross_ref_target": (
+        "Fix the broken link, remove it, or mark it as intentionally archived."
+    ),
     related_links.MISSING_RELATED_LINK_MIRROR_CATEGORY: (
         "Main Branch can repair this automatically — run `mb doctor repair --plan` then `--apply`."
     ),
@@ -1178,9 +1180,7 @@ def _validation_categories(files: list[dict[str, Any]]) -> dict[str, Any]:
                         "warnings": 0,
                         "examples": [],
                         "repair": repair_text,
-                        "audience": VALIDATION_CATEGORY_AUDIENCE.get(
-                            category, "operator_decision"
-                        ),
+                        "audience": VALIDATION_CATEGORY_AUDIENCE.get(category, "operator_decision"),
                         "operator_summary": VALIDATION_CATEGORY_OPERATOR_SUMMARY.get(
                             category, repair_text
                         ),

--- a/mb/mb/validate.py
+++ b/mb/mb/validate.py
@@ -167,6 +167,36 @@ VALIDATION_CATEGORY_REPAIR: dict[str, str] = {
     ),
 }
 
+# Audience routing per category. See decision
+# decisions/2026-05-11-operator-facing-gitops-and-migration-planning.md.
+# Categories absent from this map default to "operator_decision".
+VALIDATION_CATEGORY_AUDIENCE: dict[str, str] = {
+    related_links.MISSING_RELATED_LINK_MIRROR_CATEGORY: "mechanical",
+    "migration_drift": "mechanical",
+}
+
+# Operator-facing summaries. Default to the existing repair string when no
+# separate plain-language framing exists.
+VALIDATION_CATEGORY_OPERATOR_SUMMARY: dict[str, str] = {
+    "missing_slug": "Name the thing this file is about so other notes can link to it.",
+    "missing_required_key": "Fill in the few required fields this kind of file expects.",
+    "status_enum_mismatch": "Pick a recognized status (for example open, accepted, shipped).",
+    "enum_mismatch": "Pick one of the allowed values for this field.",
+    "no_frontmatter": "Add the YAML header at the top of the file.",
+    "yaml_error": "Fix the YAML formatting at the top before anything else can be checked.",
+    "schema_shape_error": "Reshape the YAML fields so they match the expected layout.",
+    "missing_cross_ref_target": "Fix the broken link, remove it, or mark it as intentionally archived.",
+    related_links.MISSING_RELATED_LINK_MIRROR_CATEGORY: (
+        "Main Branch can repair this automatically — run `mb doctor repair --plan` then `--apply`."
+    ),
+    "missing_reverse_link": "Decide whether to add the reverse link the suggestion proposes.",
+    "migration_drift": (
+        "Main Branch can repair this automatically — run `mb doctor repair --plan` then `--apply`."
+    ),
+    "other_error": "Read the validation message and decide how to fix the file.",
+    "other_warning": "Decide whether the relationship or shape is intentional, or change it.",
+}
+
 DECISION_STATUS_ORDER = {
     "proposed": 0,
     "running": 1,
@@ -1137,6 +1167,9 @@ def _validation_categories(files: list[dict[str, Any]]) -> dict[str, Any]:
             for raw_message in messages:
                 message = str(raw_message)
                 category = _validation_category(message, severity=severity, schema=schema)
+                repair_text = VALIDATION_CATEGORY_REPAIR.get(
+                    category, VALIDATION_CATEGORY_REPAIR["other_error"]
+                )
                 entry = categories.setdefault(
                     category,
                     {
@@ -1144,8 +1177,12 @@ def _validation_categories(files: list[dict[str, Any]]) -> dict[str, Any]:
                         "errors": 0,
                         "warnings": 0,
                         "examples": [],
-                        "repair": VALIDATION_CATEGORY_REPAIR.get(
-                            category, VALIDATION_CATEGORY_REPAIR["other_error"]
+                        "repair": repair_text,
+                        "audience": VALIDATION_CATEGORY_AUDIENCE.get(
+                            category, "operator_decision"
+                        ),
+                        "operator_summary": VALIDATION_CATEGORY_OPERATOR_SUMMARY.get(
+                            category, repair_text
                         ),
                     },
                 )
@@ -1161,11 +1198,14 @@ def _validation_categories(files: list[dict[str, Any]]) -> dict[str, Any]:
         )
     )
     top_category = next(iter(ordered), "")
+    top_entry = ordered.get(top_category, {})
     return {
         "schema_version": "1.0",
         "total_categories": len(ordered),
         "top_category": top_category,
-        "top_repair": ordered.get(top_category, {}).get("repair", ""),
+        "top_repair": top_entry.get("repair", ""),
+        "top_audience": top_entry.get("audience", ""),
+        "top_operator_summary": top_entry.get("operator_summary", ""),
         "by_category": ordered,
         "safe_to_share": True,
     }

--- a/mb/tests/fixtures/status/schema-v1-basic.json
+++ b/mb/tests/fixtures/status/schema-v1-basic.json
@@ -65,15 +65,22 @@
       "skill_wiring"
     ],
     "git": [
+      "ahead",
       "available",
+      "behind",
       "branch",
       "commit",
+      "default_branch",
       "dirty",
       "dirty_count",
       "dirty_files",
       "error",
       "inside_work_tree",
-      "remote"
+      "remote",
+      "summary",
+      "upstream",
+      "workflow",
+      "worktree_root"
     ],
     "git_activity": [
       "available",

--- a/mb/tests/fixtures/status/schema-v1-basic.json
+++ b/mb/tests/fixtures/status/schema-v1-basic.json
@@ -79,7 +79,7 @@
       "remote",
       "summary",
       "upstream",
-      "workflow",
+      "workflow_mode",
       "worktree_root"
     ],
     "git_activity": [

--- a/mb/tests/test_doctor.py
+++ b/mb/tests/test_doctor.py
@@ -1206,3 +1206,66 @@ def test_doctor_topology_drift_preview_only(tmp_path: Path) -> None:
     assert review["safe_to_apply"] is False
     assert review["mode"] == "manual"
     assert "does not rename" in review["reason"].lower()
+
+
+def test_derive_audience_maps_mode_and_safety() -> None:
+    assert doctor_mod._derive_audience("read", True) == "informational"
+    assert doctor_mod._derive_audience("read", False) == "informational"
+    assert doctor_mod._derive_audience("write", True) == "mechanical"
+    assert doctor_mod._derive_audience("write", False) == "operator_decision"
+    assert doctor_mod._derive_audience("manual", True) == "operator_decision"
+    assert doctor_mod._derive_audience("manual", False) == "operator_decision"
+
+
+def test_doctor_action_emits_audience_and_operator_summary() -> None:
+    safe_write = doctor_mod._action(
+        id="x",
+        title="Apply mirror",
+        state="warn",
+        mode="write",
+        command="mb doctor repair --apply",
+        safe_to_apply=True,
+        reason="Restores the Related links mirror.",
+    )
+    assert safe_write["audience"] == "mechanical"
+    assert safe_write["operator_summary"] == "Restores the Related links mirror."
+
+    read_only = doctor_mod._action(
+        id="y",
+        title="Inspect",
+        state="ok",
+        mode="read",
+        command="mb doctor",
+        safe_to_apply=True,
+        reason="",
+    )
+    assert read_only["audience"] == "informational"
+    # falls back to title when reason is empty
+    assert read_only["operator_summary"] == "Inspect"
+
+    manual = doctor_mod._action(
+        id="z",
+        title="Resolve cloud paths",
+        state="error",
+        mode="manual",
+        command="open core/finance",
+        safe_to_apply=False,
+        reason="Operator must move files out of iCloud.",
+    )
+    assert manual["audience"] == "operator_decision"
+
+
+def test_doctor_action_accepts_audience_override() -> None:
+    override = doctor_mod._action(
+        id="override",
+        title="Custom",
+        state="info",
+        mode="write",
+        command="mb x",
+        safe_to_apply=True,
+        reason="Default would be mechanical.",
+        audience="informational",
+        operator_summary="Just a heads-up.",
+    )
+    assert override["audience"] == "informational"
+    assert override["operator_summary"] == "Just a heads-up."

--- a/mb/tests/test_doctor.py
+++ b/mb/tests/test_doctor.py
@@ -1269,3 +1269,21 @@ def test_doctor_action_accepts_audience_override() -> None:
     )
     assert override["audience"] == "informational"
     assert override["operator_summary"] == "Just a heads-up."
+
+
+def test_doctor_repair_plan_actions_always_carry_audience_and_summary(
+    tmp_path: Path,
+) -> None:
+    """Every action emitted by repair_plan must have a valid audience and a
+    non-empty operator_summary. Locks the contract agents read against."""
+    repo = tmp_path / "fresh"
+    repo.mkdir()
+
+    payload = doctor_mod.repair_plan(repo=str(repo))
+
+    assert payload["actions"], "expected at least one action on a fresh repo"
+    for action in payload["actions"]:
+        assert action["audience"] in doctor_mod.AUDIENCE_VALUES, (
+            f"action {action['id']} has invalid audience: {action['audience']!r}"
+        )
+        assert action["operator_summary"], f"action {action['id']} has empty operator_summary"

--- a/mb/tests/test_ranker.py
+++ b/mb/tests/test_ranker.py
@@ -124,3 +124,31 @@ def test_ranker_surfaces_playbook_health() -> None:
     assert actions[0]["id"] == "review_playbook_health"
     assert actions[0]["signals"][0]["id"] == "playbook_health.gaps"
     assert actions[0]["signals"][0]["evidence"] == ["pushes_without_playbook"]
+
+
+def test_ranker_action_carries_audience_and_operator_summary() -> None:
+    action = ranker._action(
+        action_id="any.id",
+        title="Do the thing",
+        command="mb something",
+        severity="warn",
+        score=60,
+        reason="Three pushes need attention.",
+        signals=[],
+    )
+    assert action["audience"] == "operator_decision"
+    assert action["operator_summary"] == "Three pushes need attention."
+
+    overridden = ranker._action(
+        action_id="any.id",
+        title="Do the thing",
+        command="mb something",
+        severity="info",
+        score=10,
+        reason="Heads up.",
+        signals=[],
+        audience="informational",
+        operator_summary="Just a status note.",
+    )
+    assert overridden["audience"] == "informational"
+    assert overridden["operator_summary"] == "Just a status note."

--- a/mb/tests/test_status.py
+++ b/mb/tests/test_status.py
@@ -1970,7 +1970,10 @@ def test_build_git_summary_reads_in_business_language() -> None:
     assert "detached" in detached.lower()
 
 
-def test_git_info_exposes_workflow_on_solo_main(tmp_path: Path) -> None:
+def test_git_info_solo_on_main_without_remote(tmp_path: Path) -> None:
+    """Local repo on the default branch with no `origin` remote should still
+    classify as solo-on-main, leave ahead/behind null, and produce a clear
+    summary. Locks the contract for the most common existing-repo state."""
     repo = tmp_path / "solo"
     repo.mkdir()
     assert _git(repo, "init", "-b", "main").returncode == 0
@@ -1983,13 +1986,19 @@ def test_git_info_exposes_workflow_on_solo_main(tmp_path: Path) -> None:
     assert info["workflow_mode"] == "solo-on-main"
     assert info["default_branch"] == "main"
     assert info["dirty"] is False
-    assert info["summary"]
-    # No upstream configured; ahead/behind should be None.
+    assert info["remote"] == ""
+    assert info["upstream"] == ""
     assert info["ahead"] is None
     assert info["behind"] is None
+    assert info["summary"]
+    assert "main" in info["summary"]
+    assert "uncommitted" in info["summary"]
 
 
-def test_git_info_exposes_workflow_on_branch(tmp_path: Path) -> None:
+def test_git_info_branch_without_upstream(tmp_path: Path) -> None:
+    """Feature branch with no upstream should classify as branch, leave
+    ahead/behind null, and reference the branch name in the summary.
+    Common state when an operator starts work but hasn't pushed yet."""
     repo = tmp_path / "branched"
     repo.mkdir()
     assert _git(repo, "init", "-b", "main").returncode == 0
@@ -2001,6 +2010,9 @@ def test_git_info_exposes_workflow_on_branch(tmp_path: Path) -> None:
     assert info["branch"] == "feature/x"
     assert info["workflow_mode"] == "branch"
     assert info["default_branch"] == "main"
+    assert info["upstream"] == ""
+    assert info["ahead"] is None
+    assert info["behind"] is None
     assert "feature/x" in info["summary"]
 
 

--- a/mb/tests/test_status.py
+++ b/mb/tests/test_status.py
@@ -1902,16 +1902,6 @@ def test_status_human_output_mentions_business_map(tmp_path: Path, monkeypatch) 
 def test_classify_workflow_covers_known_states() -> None:
     assert (
         status_mod._classify_workflow(
-            inside_worktree=False,
-            branch="anything",
-            is_linked_worktree=False,
-            default_branch="main",
-        )
-        == ""
-    )
-    assert (
-        status_mod._classify_workflow(
-            inside_worktree=True,
             branch="",
             is_linked_worktree=False,
             default_branch="main",
@@ -1920,7 +1910,6 @@ def test_classify_workflow_covers_known_states() -> None:
     )
     assert (
         status_mod._classify_workflow(
-            inside_worktree=True,
             branch="main",
             is_linked_worktree=False,
             default_branch="main",
@@ -1929,7 +1918,6 @@ def test_classify_workflow_covers_known_states() -> None:
     )
     assert (
         status_mod._classify_workflow(
-            inside_worktree=True,
             branch="feature/x",
             is_linked_worktree=False,
             default_branch="main",
@@ -1938,7 +1926,6 @@ def test_classify_workflow_covers_known_states() -> None:
     )
     assert (
         status_mod._classify_workflow(
-            inside_worktree=True,
             branch="feature/x",
             is_linked_worktree=True,
             default_branch="main",
@@ -2022,3 +2009,25 @@ def test_git_info_handles_non_git_directory(tmp_path: Path) -> None:
     # Either git is missing or this is not a work tree; either way no workflow.
     assert info.get("inside_work_tree") in (False, None)
     assert "workflow_mode" not in info or info.get("workflow_mode") in ("", None)
+
+
+def test_git_info_detects_linked_worktree(tmp_path: Path) -> None:
+    """Conductor workspaces and `git worktree add` checkouts should report
+    workflow_mode='worktree' and a populated worktree_root."""
+    main_repo = tmp_path / "main"
+    main_repo.mkdir()
+    assert _git(main_repo, "init", "-b", "main").returncode == 0
+    _configure_git_user(main_repo)
+    _commit(main_repo, "README.md", "hello\n", "[add] readme")
+
+    worktree_path = tmp_path / "wt-feature"
+    add = _git(main_repo, "worktree", "add", "-b", "feature/x", str(worktree_path))
+    assert add.returncode == 0, add.stderr
+
+    info = status_mod._git_info(worktree_path)
+    assert info["inside_work_tree"] is True
+    assert info["workflow_mode"] == "worktree"
+    assert info["branch"] == "feature/x"
+    assert info["default_branch"] == "main"
+    assert info["worktree_root"] == str(worktree_path.resolve())
+    assert "worktree" in info["summary"].lower()

--- a/mb/tests/test_status.py
+++ b/mb/tests/test_status.py
@@ -1897,3 +1897,128 @@ def test_status_human_output_mentions_business_map(tmp_path: Path, monkeypatch) 
     loud = runner.invoke(app, ["status", str(repo), "--verbose"])
     assert loud.exit_code == 0
     assert "Business map" in loud.stdout
+
+
+def test_classify_workflow_covers_known_states() -> None:
+    assert (
+        status_mod._classify_workflow(
+            inside_worktree=False,
+            branch="anything",
+            is_linked_worktree=False,
+            default_branch="main",
+        )
+        == ""
+    )
+    assert (
+        status_mod._classify_workflow(
+            inside_worktree=True,
+            branch="",
+            is_linked_worktree=False,
+            default_branch="main",
+        )
+        == "detached"
+    )
+    assert (
+        status_mod._classify_workflow(
+            inside_worktree=True,
+            branch="main",
+            is_linked_worktree=False,
+            default_branch="main",
+        )
+        == "solo-on-main"
+    )
+    assert (
+        status_mod._classify_workflow(
+            inside_worktree=True,
+            branch="feature/x",
+            is_linked_worktree=False,
+            default_branch="main",
+        )
+        == "branch"
+    )
+    assert (
+        status_mod._classify_workflow(
+            inside_worktree=True,
+            branch="feature/x",
+            is_linked_worktree=True,
+            default_branch="main",
+        )
+        == "worktree"
+    )
+
+
+def test_build_git_summary_reads_in_business_language() -> None:
+    on_main = status_mod._build_git_summary(
+        workflow="solo-on-main",
+        branch="main",
+        default_branch="main",
+        dirty_count=0,
+        ahead=None,
+        behind=None,
+    )
+    assert "On main" in on_main
+    assert "no uncommitted changes" in on_main
+
+    on_branch = status_mod._build_git_summary(
+        workflow="branch",
+        branch="feature/x",
+        default_branch="main",
+        dirty_count=3,
+        ahead=2,
+        behind=1,
+    )
+    assert "On branch `feature/x`" in on_branch
+    assert "3 uncommitted files" in on_branch
+    assert "ahead by 2" in on_branch
+    assert "behind by 1" in on_branch
+
+    detached = status_mod._build_git_summary(
+        workflow="detached",
+        branch="",
+        default_branch="main",
+        dirty_count=0,
+        ahead=None,
+        behind=None,
+    )
+    assert "detached" in detached.lower()
+
+
+def test_git_info_exposes_workflow_on_solo_main(tmp_path: Path) -> None:
+    repo = tmp_path / "solo"
+    repo.mkdir()
+    assert _git(repo, "init", "-b", "main").returncode == 0
+    _configure_git_user(repo)
+    _commit(repo, "README.md", "hello\n", "[add] readme")
+
+    info = status_mod._git_info(repo)
+    assert info["inside_work_tree"] is True
+    assert info["branch"] == "main"
+    assert info["workflow"] == "solo-on-main"
+    assert info["default_branch"] == "main"
+    assert info["dirty"] is False
+    assert info["summary"]
+    # No upstream configured; ahead/behind should be None.
+    assert info["ahead"] is None
+    assert info["behind"] is None
+
+
+def test_git_info_exposes_workflow_on_branch(tmp_path: Path) -> None:
+    repo = tmp_path / "branched"
+    repo.mkdir()
+    assert _git(repo, "init", "-b", "main").returncode == 0
+    _configure_git_user(repo)
+    _commit(repo, "README.md", "hello\n", "[add] readme")
+    assert _git(repo, "checkout", "-b", "feature/x").returncode == 0
+
+    info = status_mod._git_info(repo)
+    assert info["branch"] == "feature/x"
+    assert info["workflow"] == "branch"
+    assert info["default_branch"] == "main"
+    assert "feature/x" in info["summary"]
+
+
+def test_git_info_handles_non_git_directory(tmp_path: Path) -> None:
+    info = status_mod._git_info(tmp_path)
+    # Either git is missing or this is not a work tree; either way no workflow.
+    assert info.get("inside_work_tree") in (False, None)
+    assert "workflow" not in info or info.get("workflow") in ("", None)

--- a/mb/tests/test_status.py
+++ b/mb/tests/test_status.py
@@ -2023,6 +2023,32 @@ def test_git_info_handles_non_git_directory(tmp_path: Path) -> None:
     assert "workflow_mode" not in info or info.get("workflow_mode") in ("", None)
 
 
+def test_status_ranked_actions_always_carry_audience_and_summary(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Every ranked action emitted by `mb status` must have a valid audience
+    and a non-empty operator_summary, so skills can route on the field
+    without re-deriving from schema language."""
+    monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
+    repo = tmp_path / "fresh"
+    init_run(path=str(repo), name="Fresh")
+
+    payload = status_mod.run(
+        path=str(repo),
+        now=datetime(2026, 5, 4, 12, 0, tzinfo=timezone.utc),
+        update_marker=False,
+    )
+
+    actions = payload["ranked_actions"]
+    assert actions, "expected at least one ranked action on a fresh repo"
+    valid_audiences = {"mechanical", "operator_decision", "informational"}
+    for action in actions:
+        assert action["audience"] in valid_audiences, (
+            f"action {action['id']} has invalid audience: {action['audience']!r}"
+        )
+        assert action["operator_summary"], f"action {action['id']} has empty operator_summary"
+
+
 def test_git_info_detects_linked_worktree(tmp_path: Path) -> None:
     """Conductor workspaces and `git worktree add` checkouts should report
     workflow_mode='worktree' and a populated worktree_root."""

--- a/mb/tests/test_status.py
+++ b/mb/tests/test_status.py
@@ -1936,7 +1936,7 @@ def test_classify_workflow_covers_known_states() -> None:
 
 def test_build_git_summary_reads_in_business_language() -> None:
     on_main = status_mod._build_git_summary(
-        workflow="solo-on-main",
+        workflow_mode="solo-on-main",
         branch="main",
         default_branch="main",
         dirty_count=0,
@@ -1947,7 +1947,7 @@ def test_build_git_summary_reads_in_business_language() -> None:
     assert "no uncommitted changes" in on_main
 
     on_branch = status_mod._build_git_summary(
-        workflow="branch",
+        workflow_mode="branch",
         branch="feature/x",
         default_branch="main",
         dirty_count=3,
@@ -1960,7 +1960,7 @@ def test_build_git_summary_reads_in_business_language() -> None:
     assert "behind by 1" in on_branch
 
     detached = status_mod._build_git_summary(
-        workflow="detached",
+        workflow_mode="detached",
         branch="",
         default_branch="main",
         dirty_count=0,

--- a/mb/tests/test_status.py
+++ b/mb/tests/test_status.py
@@ -1993,7 +1993,7 @@ def test_git_info_exposes_workflow_on_solo_main(tmp_path: Path) -> None:
     info = status_mod._git_info(repo)
     assert info["inside_work_tree"] is True
     assert info["branch"] == "main"
-    assert info["workflow"] == "solo-on-main"
+    assert info["workflow_mode"] == "solo-on-main"
     assert info["default_branch"] == "main"
     assert info["dirty"] is False
     assert info["summary"]
@@ -2012,7 +2012,7 @@ def test_git_info_exposes_workflow_on_branch(tmp_path: Path) -> None:
 
     info = status_mod._git_info(repo)
     assert info["branch"] == "feature/x"
-    assert info["workflow"] == "branch"
+    assert info["workflow_mode"] == "branch"
     assert info["default_branch"] == "main"
     assert "feature/x" in info["summary"]
 
@@ -2021,4 +2021,4 @@ def test_git_info_handles_non_git_directory(tmp_path: Path) -> None:
     info = status_mod._git_info(tmp_path)
     # Either git is missing or this is not a work tree; either way no workflow.
     assert info.get("inside_work_tree") in (False, None)
-    assert "workflow" not in info or info.get("workflow") in ("", None)
+    assert "workflow_mode" not in info or info.get("workflow_mode") in ("", None)

--- a/mb/tests/test_validate.py
+++ b/mb/tests/test_validate.py
@@ -1857,3 +1857,24 @@ def test_validate_data_source_rejects_absolute_paths(tmp_path: Path) -> None:
         "storage.snapshots[0] must be a repo-relative path" in err for err in record["errors"]
     )
     assert any("reports[0] must be a repo-relative path" in err for err in record["errors"])
+
+
+def test_validation_categories_carry_audience_and_operator_summary(tmp_path: Path) -> None:
+    for index in range(2):
+        _write(
+            tmp_path / "core" / "offers" / f"offer-{index}" / "offer.md",
+            "---\nstatus: running\n---\n# Offer\n",
+        )
+
+    report = run(path=str(tmp_path))
+    categories = report["validation_categories"]
+
+    assert categories["top_category"] == "missing_slug"
+    assert categories["top_audience"] == "operator_decision"
+    assert categories["top_operator_summary"]
+    assert "schema" not in categories["top_operator_summary"].lower()
+
+    entry = categories["by_category"]["missing_slug"]
+    assert entry["audience"] == "operator_decision"
+    assert entry["operator_summary"]
+    assert entry["repair"]  # legacy field still present


### PR DESCRIPTION
## Summary
- Locks the operator-facing GitOps contract for `mb status`, `mb doctor`, and `mb validate` in a decision doc and ships the first implementation slice.
- Adds workflow awareness to `mb status`'s `git` block — `workflow_mode` (`solo-on-main` | `branch` | `worktree` | `detached`), `default_branch`, `upstream`, `ahead`/`behind`, `worktree_root`, and a plain-language `summary`.
- Adds `audience` (`mechanical` | `operator_decision` | `informational`) and `operator_summary` to findings emitted by `mb doctor` actions, `mb validate` categories, and `mb status` ranked actions, so skills can render practical next steps without re-deriving them from schema language.
- Defers `mb commit --plan`, `mb publish --plan`, packaged `/mb-publish` skill, and `mb migrate plan` to follow-up issues with contracts named in the decision doc.
- Records explicit out-of-scope notes for two adjacent decisions (repo home / GitHub org setup rubric; checks-and-review model) so future work does not bleed into this slice.

## Scope
- In: decision doc; additive JSON fields on status/doctor/validate; workflow detection + summary; classification taxonomy; tests + golden fixture update; CHANGELOG.
- Out: new CLI commands; first-run/onboard changes; bundled skill prose changes; package surface changes; `workflow_mode` describing pre-repo setup state, actor permissions, repo home choice, or check enforcement (all named as separate axes in the decision doc).

## Commits
- 52f4fa9 — [add] Decision: operator-facing GitOps and migration planning
- 78ecf71 — [add] Workflow awareness in mb status git block
- 226b4a1 — [add] audience + operator_summary on doctor, validate, ranker findings
- 1e3245b — [add] Tests for workflow detection and finding classification
- 302ae93 — [docs] CHANGELOG: workflow awareness, audience classification, decision
- 42a9fc3 — [fix] Apply ruff format and mypy fixes for audience plumbing
- 2ec04e9 — [update] Decision: name pre-repo and actor-role boundaries
- f83a521 — [update] Rename workflow to workflow_mode and name out-of-scope decisions

## Release / Issues
- Release: Unreleased
- Linear ID(s): MAIN-310
- Closes:
- Refs: #463
- Follow-ups: open separate issues for `mb commit --plan` / `mb publish --plan`, packaged `/mb-publish` skill, `mb migrate plan` non-standard folder scanner, and the two adjacent decisions (repo home / GitHub org rubric; checks-and-review model).

## Success Metric
- Skills and agents can read `mb status`, `mb doctor`, and `mb validate` JSON, route on `audience`, render `operator_summary`, and route save/publish guidance off `git.workflow_mode` without their own git wrappers or schema-to-prose translation.

## Validation
- Level 0 docs/decision: `decisions/2026-05-11-operator-facing-gitops-and-migration-planning.md` accepted; CHANGELOG updated under `[Unreleased]`.
- Level 1 static: `scripts/check.sh` exits 0 (ruff format, ruff check, mypy, pytest with coverage gate, `mb skill validate --all`, SKILL.md ≤500 lines).
- Level 2 CLI: new unit tests for `_classify_workflow`, `_build_git_summary`, `_git_info` integration on solo-main and feature branch, `_derive_audience` matrix, `_action` audience/operator_summary defaults and overrides, validation category audience routing.
- Level 3 package/install: not required — no CLI surface added/removed, no first-run or packaging change.
- Level 4 fixture repo: golden status schema fixture updated for the new `git` keys; existing fixtures unchanged.
- Level 5 runtime smoke: not required — no bundled skill prose changes in this slice.

## Public / Private Boundary
- All changes are public OSS-safe. No private Noontide/Conductor/runtime details introduced. The decision doc references the `.context/attachments/PR instructions` workaround only to mark it as a maintainer-only pattern that the future packaged `/mb-publish` skill should retire.