### PR TITLE
[docs] Clean stale future-tense language after recent shipped work (MAIN-318)

### DIFF
--- a/.claude/skills/mb-wiki/references/hosting-recommendation.md
+++ b/.claude/skills/mb-wiki/references/hosting-recommendation.md
@@ -22,7 +22,6 @@ Cloudflare Pages is free, fast, and we've done the work to make setup smooth. Ot
 Other static site hosts work fine:
 - **Vercel** — Good, 100GB/mo bandwidth limit
 - **Netlify** — Good, 100GB/mo bandwidth limit
-- **GitHub Pages** — Free but requires public repo (or Pro plan)
 - **Self-hosted** — Full control, more setup work
 
 If you prefer these, the `/mb-wiki` skill can still help with content management. You'll just handle deployment yourself.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,8 +52,8 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   when to use typed frontmatter links, inline Markdown links, entity tags,
   data/report references, GitHub history links, nearby context, or no link.
   Refs #468.
-- Opened follow-up implementation issues for data-source registry and scheduled
-  data sync. Refs #470, #471.
+- Opened a follow-up implementation issue for scheduled provider data sync.
+  Refs #471.
 - Added the first record type in a future registry of portable business
   facts: `type: data_source` records at `data/<provider>/source.md`.
   `mb validate` recognizes the schema and checks provider id, owner,
@@ -74,6 +74,18 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   guidance, and softened user-facing "canonical" language toward "source of
   truth", "official", "current", or "the version `mb` trusts" where precision
   allows. Refs #468.
+- Cleaned stale future-tense language across public docs and accepted
+  decisions so they describe `mb suggest links` (MAIN-313 / #473), the
+  `type: data_source` / `linked_data_sources` registry (MAIN-314 / #475),
+  and the operator-facing GitOps primitives `audience`, `operator_summary`,
+  and `mb status` workflow awareness (MAIN-310 / #476) as shipped, while
+  keeping scheduled provider data sync (#471) and the deferred
+  `mb commit --plan` / `mb publish --plan` / `/mb-publish` /
+  `mb migrate plan` surfaces as the remaining follow-ups. Also removed
+  GitHub Pages from a hosting comparison in the bundled `/mb-wiki` skill
+  reference so it does not read as a normal Main Branch fallback. Docs-only;
+  no CLI, validator, schema, or runtime behavior changes. Refs MAIN-318,
+  #478.
 - Clarified graph-link authoring guidance across markdown conventions,
   generated business-repo instructions, and bundled authoring skills:
   frontmatter remains the source of truth, body mirrors are repairable viewer output,

--- a/decisions/2026-05-11-connecting-notes-data-and-history.md
+++ b/decisions/2026-05-11-connecting-notes-data-and-history.md
@@ -128,11 +128,12 @@ Main Branch should learn from that pattern:
   wikilinks, frontmatter links, and Related links repair.
 - Generated repo guidance and bundled skills should point agents at the matrix
   before they add relationships.
-- Future implementation work should add a command shaped like
-  `mb suggest links <file>` that returns ranked suggestions and reasons, but
-  this decision does not implement that command.
-- Follow-up issues track the implementation work: `mb suggest links` (#469),
-  data-source registry (#470), and scheduled data sync (#471).
+- `mb suggest links <file>` is the read-only command that returns ranked
+  suggestions and reasons; this decision does not implement it, but follow-up
+  work has shipped it (#469).
+- Implementation status of follow-ups named in this decision: `mb suggest
+  links` (#469) shipped; the data-source registry (#470) shipped; scheduled
+  data sync (#471) is still open.
 
 ## Related links
 

--- a/decisions/2026-05-11-operator-facing-gitops-and-migration-planning.md
+++ b/decisions/2026-05-11-operator-facing-gitops-and-migration-planning.md
@@ -21,6 +21,12 @@ tags: [v0-3, gitops, migration, status, doctor, validate, checkpoint, publish]
 
 # Operator-Facing GitOps and Major Migration Planning
 
+> Implementation status (as of 2026-05-11): slice items 1–3 (`audience`
+> classification, `operator_summary`, and `mb status` workflow awareness)
+> shipped via MAIN-310 / PR #476. Items 4–6 (`mb commit --plan` /
+> `mb publish --plan`, packaged `/mb-publish` skill, `mb migrate plan`
+> non-standard folder scanner) remain open follow-ups and have not shipped.
+
 ## Decision
 
 Main Branch separates **deterministic facts** (CLI JSON) from **operator-facing

--- a/docs/business-connections.md
+++ b/docs/business-connections.md
@@ -243,11 +243,12 @@ reasons and action types:
 It does not silently invent relationships. The operator or agent should approve
 what matters before changing frontmatter, inline links, tags, or metadata.
 
-Implementation follow-ups:
+The data-source record shape that decisions, pushes, and outcomes can link
+through `linked_data_sources` is documented in
+[`docs/data-source-registry.md`](data-source-registry.md).
 
-- data-source registry shape: see [`docs/data-source-registry.md`](data-source-registry.md)
-  and [#470](https://github.com/noontide-co/mainbranch/issues/470).
-- scheduled data sync pattern: [#471](https://github.com/noontide-co/mainbranch/issues/471).
+Scheduled provider data sync is still an open follow-up:
+[#471](https://github.com/noontide-co/mainbranch/issues/471).
 
 ## Related links
 


### PR DESCRIPTION
## Summary
- Wide audit, narrow edits: public docs and accepted decisions now describe shipped work as shipped — `mb suggest links` (MAIN-313 / #473), `type: data_source` + `linked_data_sources` (MAIN-314 / #475), and the operator-facing GitOps primitives `audience` / `operator_summary` / `mb status` workflow awareness (MAIN-310 / #476).
- Scheduled provider data sync (#471) and the deferred GitOps surfaces (`mb commit --plan`, `mb publish --plan`, `/mb-publish`, `mb migrate plan`) remain visible as the still-open follow-ups.
- Removed GitHub Pages from the bundled `/mb-wiki` hosting comparison so it does not read as a normal Main Branch fallback. Cloudflare Pages remains the recommended path.
- CHANGELOG `[Unreleased]` tightened: the "follow-up implementation issues" bullet now names only the still-open scheduled-sync follow-up (#471); a new Changed entry records this cleanup pass.

## Scope
- In: stale-language audit across `README.md`, `AGENTS.md`, `CHANGELOG.md`, `docs/**`, `decisions/**`, `.claude/skills/**`, `templates/**`, `mb/mb/_data/templates/**`, with targeted edits in the five files where audit hits actually appeared.
- Out: code, validators, schemas, CLI JSON contracts, runtime behavior, package metadata, GitHub Actions, PR #476 follow-ups, new product promises (e.g. README "Shipped Foundation" list left alone).

## Commits
- b706b77 — [docs] Clean stale future-tense language after recent shipped work (MAIN-318)

## Release / Issues
- Release: none (docs-only)
- Linear ID(s): MAIN-318
- Closes: #478
- Refs: MAIN-313 / #473, MAIN-314 / #475, MAIN-310 / #476, #471
- Follow-ups: none opened — the deferred GitOps surfaces already live in `decisions/2026-05-11-operator-facing-gitops-and-migration-planning.md`, and scheduled data sync stays tracked in #471.

## Stale-language audit
- Searches run (across `README.md`, `AGENTS.md`, `CHANGELOG.md`, `docs/**`, `decisions/**`, `.claude/skills/**`, `templates/**`, `mb/mb/_data/templates/**`):
  - `substrate` — no hits.
  - `canonical` — many hits; all technical and precise (canonical loop slugs, HTML `rel=canonical`, canonical OG dimensions, canonical engine primitive, historical "campaigns/ was canonical" narration). No user-facing setup/site copy uses it confusingly.
  - `GitHub Pages` / `github pages` — 1 hit in `.claude/skills/mb-wiki/references/hosting-recommendation.md`, removed.
  - `mb suggest links` / `suggest links` — stale future-tense in `decisions/2026-05-11-connecting-notes-data-and-history.md`, fixed.
  - `type: data_source` / `linked_data_sources` — stale follow-up framing in `docs/business-connections.md`, fixed.
  - `workflow_mode` / `operator_summary` — `decisions/2026-05-11-operator-facing-gitops-and-migration-planning.md` read as forward-looking; added an implementation-status callout.
  - PR / Linear ID grep for `#473|#475|#476|MAIN-313|MAIN-314|MAIN-310|MAIN-315` — surviving `MAIN-315` references are correctly framed as out-of-scope.
- Files changed: `docs/business-connections.md`, `decisions/2026-05-11-connecting-notes-data-and-history.md`, `decisions/2026-05-11-operator-facing-gitops-and-migration-planning.md`, `.claude/skills/mb-wiki/references/hosting-recommendation.md`, `CHANGELOG.md`.
- Important hits intentionally left alone: every `canonical` in `AGENTS.md`, `CONTRIBUTING.md`, decision files, transcript-review reports, and `.claude/` references (all precise technical uses); `docs/data-source-registry.md` and `decisions/2026-05-11-data-source-registry.md` (already describe the registry as shipped); README "Shipped Foundation" list (adding new product promises was explicitly out of scope); `docs/ROADMAP.md`, `docs/OPERATOR-LOOPS.md`, `docs/DEPENDENCY-CHOICES.md`, `docs/markdown-link-conventions.md`, `README.md`, `AGENTS.md` (audit clean).
- Why no other edits were needed: every user-facing instance of `canonical` was already precise, no normal setup/site doc presents GitHub Pages as a fallback, and shipped-feature future-tense survived only in the five files now updated.

## Success Metric
- A reviewer reading public docs/decisions cannot tell the difference between "shipped" and "future" for `mb suggest links`, `type: data_source` / `linked_data_sources`, and the operator-facing GitOps primitives — because everything shipped reads as shipped and everything still pending reads as pending.

## Validation
- Level 0 docs/decision: changed files re-read; links resolve; no stale shipped-work claims left in the changed files.
- Level 1 static: `scripts/check.sh` from repo root — `exit: 0`, 17 skills passed, 0 errors, 0 warnings.
- Level 2 CLI: N/A (no CLI surface touched).
- Level 3 package/install: N/A (no packaging touched).
- Level 4 fixture repo: N/A (no first-run, onboarding, or skill-discovery touched).
- Level 5 runtime smoke: N/A (no runtime behavior touched).

## Public / Private Boundary
- All edits are public-safe: doc/decision cleanup, a bundled wiki-skill reference, and a CHANGELOG entry. No secrets, private paths, Conductor-specific details, or member data. `.context/cold-start.md` stays gitignored.