### PR TITLE
[add] Expose operator vocabulary facts in mb status / mb start

### DIFF
--- a/.claude/skills/mb-status/SKILL.md
+++ b/.claude/skills/mb-status/SKILL.md
@@ -21,13 +21,16 @@ mb status --json --peek
 
 3. Treat the JSON as the source of truth for setup, update, drift, GitHub,
    onboarding, integrations, bets, journal activity, since-last-check,
-   readiness, and ranked actions.
+   readiness, vocabulary, and ranked actions.
 4. Summarize the top `ranked_actions` first. For each one, include:
    - title
    - command or slash command
    - reason
    - cited signal summaries
 5. Then summarize only the sections that matter for the operator's question.
+   If `vocabulary.terms.push` defines display words, use them in
+   operator-facing prose without changing canonical paths, frontmatter, JSON
+   keys, validator rules, or command names.
    Do not re-run shell probes that duplicate status facts.
    For "what changed?" or "what happened since last time?", answer from
    `since_last_check.journal` first, then top-level `journal` for recent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,11 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   CLI refactor. No CLI behaviour change in this slice. Updated the
   bookkeeping row in `docs/dependency-choices.md` to reflect the
   hledger choice. Refs MAIN-320, #483, #128.
+- Added deterministic operator vocabulary facts from optional
+  `core/vocabulary.md` to `mb status --json --peek` and `mb start --json`.
+  The new `vocabulary` block exposes bounded display terms while keeping
+  canonical folders, frontmatter types, validators, JSON keys, and command
+  names unchanged. Refs MAIN-281, #407.
 - Added `audience` and `operator_summary` fields to findings emitted by
   `mb doctor` (every repair action), `mb validate` (each validation category
   in `validation_categories`, plus `top_audience` and `top_operator_summary`

--- a/mb/mb/_data/templates/AGENTS.md.tmpl
+++ b/mb/mb/_data/templates/AGENTS.md.tmpl
@@ -37,6 +37,11 @@ playbooks, outcomes, decisions, next actions, and saved checkpoints. Treat git,
 branches, pull requests, provider refs, and local wiring as the hidden memory
 layer unless the operator asks for the plumbing.
 
+Use the `vocabulary` block from `mb status --json --peek` when present. If
+`core/vocabulary.md` says this business calls pushes drops, launches,
+challenges, or promos, use that word in operator-facing prose while preserving
+canonical paths, frontmatter, JSON keys, validator rules, and command names.
+
 ## Codex Start Workflow
 
 This is the Codex-native port of `/mb-start`. It is a workflow, not a slash
@@ -48,7 +53,8 @@ command.
    ask for the business repo path instead of guessing.
 2. Use the status JSON as the source of truth for
    readiness, drift, onboarding, update severity, GitHub facts, provider
-   readiness, recent work, ranked actions, bets, pushes, and checkpoint state.
+   readiness, recent work, ranked actions, bets, pushes, vocabulary, and
+   checkpoint state.
 3. Run `mb start --json` when you need runtime handoff, repo-boundary, or
    adapter-readiness facts.
 4. Run `mb doctor repair --plan` before recommending setup or repair. Quote the

--- a/mb/mb/codex.py
+++ b/mb/mb/codex.py
@@ -61,6 +61,11 @@ playbooks, outcomes, decisions, next actions, and saved checkpoints. Treat git,
 branches, pull requests, provider refs, and local wiring as the hidden memory
 layer unless the operator asks for the plumbing.
 
+Use the `vocabulary` block from `mb status --json --peek` when present. If
+`core/vocabulary.md` says this business calls pushes drops, launches,
+challenges, or promos, use that word in operator-facing prose while preserving
+canonical paths, frontmatter, JSON keys, validator rules, and command names.
+
 ## Codex Start Workflow
 
 This is the Codex-native port of `/mb-start`. It is a workflow, not a slash
@@ -72,7 +77,8 @@ command.
    ask for the business repo path instead of guessing.
 2. Use the status JSON as the source of truth for
    readiness, drift, onboarding, update severity, GitHub facts, provider
-   readiness, recent work, ranked actions, bets, pushes, and checkpoint state.
+   readiness, recent work, ranked actions, bets, pushes, vocabulary, and
+   checkpoint state.
 3. Run `mb start --json` when you need runtime handoff, repo-boundary, or
    adapter-readiness facts.
 4. Run `mb doctor repair --plan` before recommending setup or repair. Quote the

--- a/mb/mb/start.py
+++ b/mb/mb/start.py
@@ -13,6 +13,7 @@ from typing import Any
 from mb import checkpoint as checkpoint_mod
 from mb import codex as codex_mod
 from mb import journal as journal_mod
+from mb import vocabulary
 from mb.engine import install_mode, link_status
 from mb.freshness import format_update_alert, package_update_status
 from mb.status import _looks_like_mainbranch_repo, push_facts
@@ -268,6 +269,7 @@ def run(repo: str = ".", launch: bool = False) -> dict[str, Any]:
     checkpoint = checkpoint_mod.status(repo_path)
     journal = journal_mod.collect(repo_path, limit=8, since="14 days ago")
     push_report = push_facts(repo_path)
+    vocabulary_report = vocabulary.facts(repo_path)
     checks = _build_checks(repo_shape, git, claude_path, wiring, codex, update)
     hard_failures = _hard_failures(checks)
     handoff_ready = not hard_failures
@@ -322,6 +324,7 @@ def run(repo: str = ".", launch: bool = False) -> dict[str, Any]:
         "campaign_count": push_report["legacy_campaign_count"],
         "deprecated_campaign_keys": True,
         "push_compatibility": push_report["compatibility"],
+        "vocabulary": vocabulary_report,
         "git": git,
         "runtime": {
             "name": "claude-code",

--- a/mb/mb/status.py
+++ b/mb/mb/status.py
@@ -12,7 +12,7 @@ from typing import Any
 
 import yaml
 
-from mb import __version__, github_activity, relationships
+from mb import __version__, github_activity, relationships, vocabulary
 from mb import codex as codex_mod
 from mb import connect as connect_mod
 from mb import journal as journal_mod
@@ -2071,6 +2071,7 @@ def run(
         "campaign_count": push_report["legacy_campaign_count"],
         "deprecated_campaign_keys": True,
         "push_compatibility": push_report["compatibility"],
+        "vocabulary": vocabulary.facts(repo_path),
         "onboarding": onboard_mod.onboarding_status(repo_path),
         "integrations": connect_mod.status_all(repo_path, github=github.get("context")),
         "measurement": _measurement(repo_path),
@@ -2313,9 +2314,12 @@ def render_human(
             console.print(f"  next: {measurement['repair']}")
 
     counts = brain["counts"]
+    vocabulary_terms = report.get("vocabulary", {}).get("terms", {})
+    push_terms = vocabulary_terms.get("push", {}) if isinstance(vocabulary_terms, dict) else {}
+    push_plural = str(push_terms.get("plural") or "pushes")
     pushes_count = counts.get("pushes", 0)
     campaigns_count = counts.get("campaigns", 0)
-    pushes_segment = f"pushes {pushes_count}"
+    pushes_segment = f"{push_plural} {pushes_count}"
     if campaigns_count:
         pushes_segment += f" (legacy campaigns {campaigns_count})"
     console.print(

--- a/mb/mb/status.py
+++ b/mb/mb/status.py
@@ -2314,7 +2314,10 @@ def render_human(
             console.print(f"  next: {measurement['repair']}")
 
     counts = brain["counts"]
-    vocabulary_terms = report.get("vocabulary", {}).get("terms", {})
+    vocabulary_report = report.get("vocabulary") or {}
+    vocabulary_terms = (
+        vocabulary_report.get("terms", {}) if isinstance(vocabulary_report, dict) else {}
+    )
     push_terms = vocabulary_terms.get("push", {}) if isinstance(vocabulary_terms, dict) else {}
     push_plural = str(push_terms.get("plural") or "pushes")
     pushes_count = counts.get("pushes", 0)
@@ -2329,6 +2332,19 @@ def render_human(
         f"bets {counts['bets']}  {pushes_segment}  "
         f"log {counts['log']}  documents {counts['documents']}"
     )
+
+    if isinstance(vocabulary_report, dict):
+        vocabulary_errors = vocabulary_report.get("errors") or []
+        vocabulary_warnings = vocabulary_report.get("warnings") or []
+        if vocabulary_report.get("ok") is False or vocabulary_errors:
+            path = vocabulary_report.get("path") or "core/vocabulary.md"
+            detail = vocabulary_errors[0] if vocabulary_errors else "malformed"
+            console.print(
+                f"[yellow]Vocabulary[/yellow] {path}: {detail} (using default push/pushes)"
+            )
+        elif vocabulary_warnings:
+            path = vocabulary_report.get("path") or "core/vocabulary.md"
+            console.print(f"[yellow]Vocabulary[/yellow] {path}: {vocabulary_warnings[0]}")
 
     if verbose and brain["recent_decisions"]:
         console.print("\n[bold]Recent decisions[/bold]")

--- a/mb/mb/vocabulary.py
+++ b/mb/mb/vocabulary.py
@@ -100,7 +100,7 @@ def _summary(terms: dict[str, Any]) -> str:
     push = push_value if isinstance(push_value, dict) else {}
     singular = str(push.get("singular") or "push")
     plural = str(push.get("plural") or "pushes")
-    if singular == "push" and plural == "pushes":
+    if terms == DEFAULT_TERMS:
         return "Using default vocabulary: push/pushes."
     return f"Using operator vocabulary: {singular}/{plural}."
 

--- a/mb/mb/vocabulary.py
+++ b/mb/mb/vocabulary.py
@@ -1,0 +1,161 @@
+"""Operator-owned display vocabulary for business repo facts."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+VOCABULARY_RELATIVE_PATH = Path("core") / "vocabulary.md"
+DEFAULT_TERMS: dict[str, Any] = {
+    "push": {"singular": "push", "plural": "pushes"},
+    "statuses": {},
+    "channels": {},
+    "kinds": {},
+}
+TERM_KEYS = ("push", "statuses", "channels", "kinds")
+PUSH_TERM_KEYS = ("singular", "plural")
+
+
+def _defaults() -> dict[str, Any]:
+    return deepcopy(DEFAULT_TERMS)
+
+
+def _read_frontmatter(path: Path) -> tuple[dict[str, Any] | None, str | None]:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return None, f"unreadable: {exc}"
+    if not text.startswith("---"):
+        return None, "missing YAML frontmatter"
+    try:
+        end = text.index("\n---", 3)
+    except ValueError:
+        return None, "unterminated YAML frontmatter"
+    try:
+        data = yaml.safe_load(text[3:end].lstrip("\n")) or {}
+    except yaml.YAMLError as exc:
+        return None, f"YAML error: {exc}"
+    if not isinstance(data, dict):
+        return None, "frontmatter must be a mapping"
+    return data, None
+
+
+def _string_map(value: Any, key: str, warnings: list[str]) -> dict[str, str]:
+    if value in (None, ""):
+        return {}
+    if not isinstance(value, dict):
+        warnings.append(f"terms.{key} must be a mapping of canonical keys to display words")
+        return {}
+    cleaned: dict[str, str] = {}
+    for raw_name, raw_display in sorted(value.items(), key=lambda item: str(item[0])):
+        name = str(raw_name).strip() if raw_name is not None else ""
+        if not name:
+            warnings.append(f"terms.{key} contains an empty key")
+            continue
+        if not isinstance(raw_display, str) or not raw_display.strip():
+            warnings.append(f"terms.{key}.{name} must be a non-empty string")
+            continue
+        cleaned[name] = raw_display.strip()
+    return cleaned
+
+
+def _parse_terms(raw_terms: Any) -> tuple[dict[str, Any], list[str]]:
+    terms = _defaults()
+    warnings: list[str] = []
+    if raw_terms in (None, ""):
+        return terms, warnings
+    if not isinstance(raw_terms, dict):
+        warnings.append("terms must be a mapping")
+        return terms, warnings
+
+    for key in sorted(str(item) for item in raw_terms if str(item) not in TERM_KEYS):
+        warnings.append(f"terms.{key} is not recognized and was ignored")
+
+    raw_push = raw_terms.get("push")
+    if raw_push not in (None, ""):
+        if not isinstance(raw_push, dict):
+            warnings.append("terms.push must be a mapping with singular/plural display words")
+        else:
+            for key in sorted(str(item) for item in raw_push if str(item) not in PUSH_TERM_KEYS):
+                warnings.append(f"terms.push.{key} is not recognized and was ignored")
+            for key in PUSH_TERM_KEYS:
+                value = raw_push.get(key)
+                if value in (None, ""):
+                    continue
+                if not isinstance(value, str) or not value.strip():
+                    warnings.append(f"terms.push.{key} must be a non-empty string")
+                    continue
+                terms["push"][key] = value.strip()
+
+    for key in ("statuses", "channels", "kinds"):
+        terms[key] = _string_map(raw_terms.get(key), key, warnings)
+    return terms, warnings
+
+
+def _summary(terms: dict[str, Any]) -> str:
+    push_value = terms.get("push")
+    push = push_value if isinstance(push_value, dict) else {}
+    singular = str(push.get("singular") or "push")
+    plural = str(push.get("plural") or "pushes")
+    if singular == "push" and plural == "pushes":
+        return "Using default vocabulary: push/pushes."
+    return f"Using operator vocabulary: {singular}/{plural}."
+
+
+def facts(repo: str | Path) -> dict[str, Any]:
+    """Return deterministic operator vocabulary facts for runtime grounding."""
+    repo_path = Path(repo)
+    path = repo_path / VOCABULARY_RELATIVE_PATH
+    if not path.exists():
+        terms = _defaults()
+        return {
+            "path": VOCABULARY_RELATIVE_PATH.as_posix(),
+            "exists": False,
+            "ok": True,
+            "source": "defaults",
+            "type": "",
+            "status": "",
+            "terms": terms,
+            "warnings": [],
+            "errors": [],
+            "summary": _summary(terms),
+        }
+
+    frontmatter, error = _read_frontmatter(path)
+    if error is not None:
+        terms = _defaults()
+        return {
+            "path": VOCABULARY_RELATIVE_PATH.as_posix(),
+            "exists": True,
+            "ok": False,
+            "source": VOCABULARY_RELATIVE_PATH.as_posix(),
+            "type": "",
+            "status": "",
+            "terms": terms,
+            "warnings": [],
+            "errors": [error],
+            "summary": _summary(terms),
+        }
+
+    assert frontmatter is not None
+    warnings: list[str] = []
+    file_type = str(frontmatter.get("type") or "")
+    if file_type and file_type != "vocabulary":
+        warnings.append("type should be 'vocabulary' for operator vocabulary files")
+    terms, term_warnings = _parse_terms(frontmatter.get("terms"))
+    warnings.extend(term_warnings)
+    return {
+        "path": VOCABULARY_RELATIVE_PATH.as_posix(),
+        "exists": True,
+        "ok": True,
+        "source": VOCABULARY_RELATIVE_PATH.as_posix(),
+        "type": file_type,
+        "status": str(frontmatter.get("status") or ""),
+        "terms": terms,
+        "warnings": warnings,
+        "errors": [],
+        "summary": _summary(terms),
+    }

--- a/mb/tests/fixtures/status/schema-v1-basic.json
+++ b/mb/tests/fixtures/status/schema-v1-basic.json
@@ -35,7 +35,8 @@
     "since_last_check",
     "topology",
     "update",
-    "validation"
+    "validation",
+    "vocabulary"
   ],
   "section_keys": {
     "repo": [
@@ -106,6 +107,18 @@
       "recent_research",
       "stale_decisions",
       "stale_research"
+    ],
+    "vocabulary": [
+      "errors",
+      "exists",
+      "ok",
+      "path",
+      "source",
+      "status",
+      "summary",
+      "terms",
+      "type",
+      "warnings"
     ],
     "onboarding": [
       "boundaries",

--- a/mb/tests/test_init.py
+++ b/mb/tests/test_init.py
@@ -76,6 +76,8 @@ def _assert_agents_md_codex_start_contract(text: str) -> None:
     assert "explicit operator approval" in text
     assert "business-owner language" in text
     assert "bets, goals, offers, pushes" in text
+    assert "`vocabulary` block from `mb status --json --peek`" in text
+    assert "canonical paths, frontmatter, JSON keys" in text
     assert "If `ranked_actions` has entries" in text
     assert "Do not pretend" in text
 

--- a/mb/tests/test_start.py
+++ b/mb/tests/test_start.py
@@ -63,6 +63,20 @@ def test_start_json_prints_ready_handoff(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(codex_mod, "_which", _with_codex)
     repo = tmp_path / "acme"
     init_run(path=str(repo), name="Acme")
+    (repo / "core" / "vocabulary.md").write_text(
+        "---\n"
+        "type: vocabulary\n"
+        "status: active\n"
+        "terms:\n"
+        "  push:\n"
+        "    singular: drop\n"
+        "    plural: drops\n"
+        "  statuses:\n"
+        "    active: live\n"
+        "---\n"
+        "# Vocabulary\n",
+        encoding="utf-8",
+    )
 
     result = runner.invoke(app, ["start", "--repo", str(repo), "--json"])
 
@@ -86,6 +100,9 @@ def test_start_json_prints_ready_handoff(tmp_path: Path, monkeypatch) -> None:
     assert report["push_count"] == 0
     assert report["deprecated_campaign_keys"] is True
     assert report["push_compatibility"]["legacy_campaigns_read"] is True
+    assert report["vocabulary"]["ok"] is True
+    assert report["vocabulary"]["terms"]["push"] == {"singular": "drop", "plural": "drops"}
+    assert report["vocabulary"]["terms"]["statuses"]["active"] == "live"
     assert "update" in report
     assert "ranked_actions" not in report
     assert report["result_status"] == "ok"

--- a/mb/tests/test_status.py
+++ b/mb/tests/test_status.py
@@ -310,6 +310,45 @@ def test_status_vocabulary_reports_malformed_file(tmp_path: Path, monkeypatch) -
     assert report["vocabulary"]["errors"] == ["missing YAML frontmatter"]
 
 
+def test_status_vocabulary_returns_defaults_when_file_missing(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+    (repo / "core" / "vocabulary.md").unlink()
+
+    report = status_mod.run(path=str(repo), update_marker=False)
+
+    vocabulary = report["vocabulary"]
+    assert vocabulary["exists"] is False
+    assert vocabulary["ok"] is True
+    assert vocabulary["source"] == "defaults"
+    assert vocabulary["terms"]["push"] == {"singular": "push", "plural": "pushes"}
+    assert vocabulary["summary"] == "Using default vocabulary: push/pushes."
+
+
+def test_status_vocabulary_summary_reflects_non_push_customizations(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+    (repo / "core" / "vocabulary.md").write_text(
+        "---\ntype: vocabulary\nterms:\n  statuses:\n    active: live\n---\n# Vocabulary\n",
+        encoding="utf-8",
+    )
+
+    report = status_mod.run(path=str(repo), update_marker=False)
+
+    vocabulary = report["vocabulary"]
+    assert vocabulary["ok"] is True
+    assert vocabulary["terms"]["push"] == {"singular": "push", "plural": "pushes"}
+    assert vocabulary["summary"] == "Using operator vocabulary: push/pushes."
+
+
 def test_status_drift_does_not_warn_for_codex_instructions_until_codex_is_present(
     tmp_path: Path,
     monkeypatch,

--- a/mb/tests/test_status.py
+++ b/mb/tests/test_status.py
@@ -151,6 +151,24 @@ def test_status_json_degrades_without_github(tmp_path: Path, monkeypatch) -> Non
     monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
     repo = tmp_path / "acme"
     init_run(path=str(repo), name="Acme")
+    (repo / "core" / "vocabulary.md").write_text(
+        "---\n"
+        "type: vocabulary\n"
+        "status: active\n"
+        "terms:\n"
+        "  push:\n"
+        "    singular: drop\n"
+        "    plural: drops\n"
+        "  statuses:\n"
+        "    active: live\n"
+        "  channels:\n"
+        "    paid: paid traffic\n"
+        "  kinds:\n"
+        "    launch: launch\n"
+        "---\n"
+        "# Vocabulary\n",
+        encoding="utf-8",
+    )
     (repo / "decisions" / "2026-05-01-pricing.md").write_text(
         "---\ndate: 2026-05-01\nstatus: accepted\n---\n\n# Pricing\n",
         encoding="utf-8",
@@ -175,6 +193,12 @@ def test_status_json_degrades_without_github(tmp_path: Path, monkeypatch) -> Non
     assert report["brain"]["counts"]["decisions"] == 1
     assert report["brain"]["counts"]["bets"] == 0
     assert report["brain"]["recent_research"][0]["title"] == "Market"
+    assert report["vocabulary"]["ok"] is True
+    assert report["vocabulary"]["path"] == "core/vocabulary.md"
+    assert report["vocabulary"]["terms"]["push"] == {"singular": "drop", "plural": "drops"}
+    assert report["vocabulary"]["terms"]["statuses"]["active"] == "live"
+    assert report["vocabulary"]["terms"]["channels"]["paid"] == "paid traffic"
+    assert report["vocabulary"]["terms"]["kinds"]["launch"] == "launch"
     assert report["since_last_check"]["first_run"] is True
     assert report["marker_update"]["ok"] is True
     assert (repo / ".mb" / "last-status-seen.json").is_file()
@@ -210,6 +234,7 @@ def test_status_schema_v1_matches_golden_fixture(tmp_path: Path, monkeypatch) ->
                 "git_activity",
                 "journal",
                 "brain",
+                "vocabulary",
                 "onboarding",
                 "integrations",
                 "measurement",
@@ -231,6 +256,58 @@ def test_status_schema_v1_matches_golden_fixture(tmp_path: Path, monkeypatch) ->
     )
 
     assert actual == expected
+
+
+def test_status_vocabulary_falls_back_with_warnings_for_unknown_terms(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+    (repo / "core" / "vocabulary.md").write_text(
+        "---\n"
+        "type: vocabulary\n"
+        "terms:\n"
+        "  push:\n"
+        "    singular: challenge\n"
+        "    plural: challenges\n"
+        "    folder: challenges\n"
+        "  paths:\n"
+        "    pushes: challenges\n"
+        "  statuses:\n"
+        "    active: running\n"
+        "    completed: wrapped\n"
+        "---\n"
+        "# Vocabulary\n",
+        encoding="utf-8",
+    )
+
+    report = status_mod.run(path=str(repo), update_marker=False)
+
+    vocabulary = report["vocabulary"]
+    assert vocabulary["ok"] is True
+    assert vocabulary["terms"]["push"] == {"singular": "challenge", "plural": "challenges"}
+    assert vocabulary["terms"]["statuses"] == {"active": "running", "completed": "wrapped"}
+    assert "paths" not in vocabulary["terms"]
+    assert any("terms.paths is not recognized" in warning for warning in vocabulary["warnings"])
+    assert any(
+        "terms.push.folder is not recognized" in warning for warning in vocabulary["warnings"]
+    )
+
+
+def test_status_vocabulary_reports_malformed_file(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+    (repo / "core" / "vocabulary.md").write_text("# Vocabulary\n", encoding="utf-8")
+
+    report = status_mod.run(path=str(repo), update_marker=False)
+
+    assert report["vocabulary"]["ok"] is False
+    assert report["vocabulary"]["exists"] is True
+    assert report["vocabulary"]["terms"]["push"] == {"singular": "push", "plural": "pushes"}
+    assert report["vocabulary"]["errors"] == ["missing YAML frontmatter"]
 
 
 def test_status_drift_does_not_warn_for_codex_instructions_until_codex_is_present(


### PR DESCRIPTION
## Summary
- Adds deterministic operator vocabulary facts from optional `core/vocabulary.md` to `mb status --json --peek` and `mb start --json`, preserving canonical paths/frontmatter/JSON keys/validators/command names.
- Teaches the generated Codex repo instructions (AGENTS.md template) and the `/mb-status` skill to use operator vocabulary in user-facing prose only.
- `mb status` human render swaps in the operator plural for the Brain line, and surfaces a yellow Vocabulary warning when `core/vocabulary.md` is malformed.

## Scope
- In: parser for `core/vocabulary.md` (`mb/mb/vocabulary.py`), additive `vocabulary` block on status/start JSON, schema fixture update, Codex/mb-status prose, focused tests.
- Out: path-config / folder renaming, custom validator enums, broad skill copy rewrites, dashboard UI.

## Commits
- a96917f — [add] Expose operator vocabulary facts
- 49522be — [fix] Surface vocabulary load failures and tighten summary

## Release / Issues
- Release: unreleased (CHANGELOG `[Unreleased]` updated)
- Linear ID(s): MAIN-281
- Closes: #407
- Refs:
- Follow-ups: none

## Success Metric
Operator-facing skills can call pushes "drops/launches/challenges" while every canonical engine name, schema field, validator rule, and command stays unchanged, and a malformed `core/vocabulary.md` is visible in the default `mb status` surface.

## Validation
- Level 0 docs/decision: CHANGELOG updated; skill/template prose changes covered by `test_init.py` assertions.
- Level 1 static: `scripts/check.sh` passes (format, lint, mypy, full pytest, skill validation).
- Level 2 CLI: new tests in `test_status.py`/`test_start.py` cover JSON shape, defaults branch, malformed file, unknown-key warnings, and the non-push-only summary case.
- Level 3 package/install: not required; no packaging/install behavior changed.
- Level 4 fixture repo: status schema-v1 fixture updated and asserted via `test_status_schema_v1_matches_golden_fixture`.
- Level 5 runtime smoke: not run; no skill discovery/invocation wiring changed.

## Public / Private Boundary
No private Devon/Conductor/runtime details introduced. All changes are public OSS-safe.