### PR TITLE
[add] mb books check — first safe books surface (MAIN-321)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,12 +19,19 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   `core/finance/books.md` exists and parses its `storage_mode`, detects
   whether `core/finance/chart-of-accounts.md` exists, verifies the
   configured storage mode's ignore rule (`.mb/private/` for solo-local
-  mode), and flags tracked files with ledger-shaped extensions
+  mode), and warns when tracked files with ledger-shaped extensions
   (`.journal`, `.hledger`, `.ledger`, `.beancount`) or statement-shaped
-  extensions (`.csv`, `.ofx`, `.qfx`, `.qbo`, `.qif`) as likely Class B
-  leaks. Opt in with `--fixture` to validate a packaged fake hledger
-  fixture by shelling out to `hledger -f <fixture> check`; if hledger is
-  not installed, the check prints a clean informational finding and the
+  extensions (`.csv`, `.ofx`, `.qfx`, `.qbo`, `.qif`) appear in the
+  business repo (likely Class B leak). The unsafe-path finding is
+  `warn`, not a hard fail, because non-finance CSVs are legitimate;
+  files carrying an explicit fixture marker (`MB-FIXTURE`,
+  `SAMPLE FIXTURE`, or `NOT A REAL LEDGER`, case-insensitive, in the
+  first 1024 bytes) are exempted. Unknown or typo'd `storage_mode`
+  values fail closed — they are treated as `solo-local` for vault
+  enforcement so a misconfigured policy cannot silently allow a leak.
+  Opt in with `--fixture` to validate a packaged fake hledger fixture
+  by shelling out to `hledger -f <fixture> check`; if hledger is not
+  installed, the check prints a clean informational finding and the
   base install keeps working. `--json` emits the standard Main Branch
   result envelope; every finding carries `audience` and
   `operator_summary` per the operator-facing GitOps contract from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,26 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ### Added
 
+- Shipped the first `mb books` surface, `mb books check`, implementing the
+  contract from `decisions/2026-05-11-mb-books-foundation.md`. The command
+  is read-only and never reads real ledger contents. It detects whether
+  `core/finance/books.md` exists and parses its `storage_mode`, detects
+  whether `core/finance/chart-of-accounts.md` exists, verifies the
+  configured storage mode's ignore rule (`.mb/private/` for solo-local
+  mode), and flags tracked files with ledger-shaped extensions
+  (`.journal`, `.hledger`, `.ledger`, `.beancount`) or statement-shaped
+  extensions (`.csv`, `.ofx`, `.qfx`, `.qbo`, `.qif`) as likely Class B
+  leaks. Opt in with `--fixture` to validate a packaged fake hledger
+  fixture by shelling out to `hledger -f <fixture> check`; if hledger is
+  not installed, the check prints a clean informational finding and the
+  base install keeps working. `--json` emits the standard Main Branch
+  result envelope; every finding carries `audience` and
+  `operator_summary` per the operator-facing GitOps contract from
+  MAIN-310. Sibling `mb books status` and `mb books doctor` shapes
+  remain deferred. The fake fixture from
+  `docs/examples/books/acme-fixture.journal` is mirrored into
+  `mb/mb/_data/books/acme-fixture.journal` so it is reachable from the
+  installed wheel. Refs MAIN-321, #486.
 - Accepted decision
   `decisions/2026-05-11-mb-books-foundation.md` choosing **hledger** as
   the bookkeeping engine for `mb books`. The hledger journal is the

--- a/docs/books.md
+++ b/docs/books.md
@@ -211,11 +211,17 @@ mb books check [REPO] [--fixture] [--fixture-path PATH] [--json]
 - detects whether `core/finance/chart-of-accounts.md` exists;
 - verifies the configured storage mode's ignore rule (`.mb/private/`
   for `solo-local`) so the vault stays out of the business repo's
-  tracked history;
-- warns or errors when ledger-shaped files (`.journal`, `.hledger`,
+  tracked history. Unknown or typo'd `storage_mode` values fail
+  closed — they are treated as `solo-local` for vault enforcement so
+  a misconfigured policy cannot silently allow a leak;
+- warns when ledger-shaped files (`.journal`, `.hledger`,
   `.ledger`, `.beancount`) or statement-shaped files (`.csv`,
   `.ofx`, `.qfx`, `.qbo`, `.qif`) are tracked in the business repo
-  (likely Class B leak);
+  (likely Class B leak). This is `warn`, not a hard fail, because
+  non-finance CSVs (audience research, content exports) are
+  legitimate. Files carrying an explicit fixture marker in their
+  first 1024 bytes — `MB-FIXTURE`, `SAMPLE FIXTURE`, or
+  `NOT A REAL LEDGER`, case-insensitive — are exempted;
 - with `--fixture`, validates a fake hledger journal fixture by
   shelling out to `hledger -f <fixture> check` — uses the bundled
   fake fixture by default, or any path passed via `--fixture-path`;
@@ -227,9 +233,9 @@ mb books check [REPO] [--fixture] [--fixture-path PATH] [--json]
 
 Exit codes:
 
-- `0` — checks passed (info or warn states allowed);
-- `1` — at least one error finding (e.g. ledger file committed,
-  missing vault ignore rule with the vault already present).
+- `0` — no error findings (info or warn states allowed);
+- `1` — at least one error finding (e.g. broken policy frontmatter,
+  or `.mb/private/` exists without a matching ignore rule).
 
 It does **not**:
 

--- a/docs/books.md
+++ b/docs/books.md
@@ -6,8 +6,9 @@ operator-facing companion to
 
 ## The Short Version
 
-- Main Branch will eventually have an `mb books` command group. The
-  first surface (`mb books check`) is planned, not shipped.
+- Main Branch ships `mb books check`, the first surface in the `mb books`
+  command group. It validates bookkeeping safety without reading any
+  real ledger contents.
 - **Main Branch uses hledger as the bookkeeping engine for `mb books`.**
   The hledger journal is the only authoritative ledger.
 - hledger is **optional** for base `mb` installs, but it is the chosen
@@ -184,8 +185,9 @@ Telling them apart should be easy:
   transactions, maybe one balance assertion);
 - a header comment names the file as a sample.
 
-When `mb books check` ships, it will treat anything that looks like a
-real ledger committed under `core/finance/` as a defect, not a feature.
+`mb books check` treats anything that looks like a real ledger or
+statement export committed in the business repo (including under
+`core/finance/`) as a defect, not a feature.
 
 ## Optional Local Viewer
 
@@ -196,24 +198,40 @@ There is no `mb` command for it.
 
 ## What `mb books` Does Today
 
-`mb books` is not a shipped command group yet. When the first surface
-lands, it will be `mb books check`, and it will:
+The shipped surface is:
 
-- detect whether `core/finance/books.md` exists and parses (including
-  the storage mode);
-- detect whether `core/finance/chart-of-accounts.md` exists and
-  follows the documented convention;
-- verify the configured storage mode's ignore rules are present (so
-  the vault stays out of the business repo's tracked history);
-- warn when files that look like real ledgers or statement exports
-  are committed in the business repo (likely Class B leak);
-- when an operator opts in and hledger is installed, validate a fake
-  `.journal` fixture by shelling out to `hledger ... -O json` and
-  reading the structured output;
-- print exact repair commands when something is off;
-- emit a JSON envelope with `--json` for scripts and skills.
+```bash
+mb books check [REPO] [--fixture] [--fixture-path PATH] [--json]
+```
 
-It will **not**:
+`mb books check` runs read-only checks against a business repo. It:
+
+- detects whether `core/finance/books.md` exists and parses (including
+  the `storage_mode` field);
+- detects whether `core/finance/chart-of-accounts.md` exists;
+- verifies the configured storage mode's ignore rule (`.mb/private/`
+  for `solo-local`) so the vault stays out of the business repo's
+  tracked history;
+- warns or errors when ledger-shaped files (`.journal`, `.hledger`,
+  `.ledger`, `.beancount`) or statement-shaped files (`.csv`,
+  `.ofx`, `.qfx`, `.qbo`, `.qif`) are tracked in the business repo
+  (likely Class B leak);
+- with `--fixture`, validates a fake hledger journal fixture by
+  shelling out to `hledger -f <fixture> check` — uses the bundled
+  fake fixture by default, or any path passed via `--fixture-path`;
+- if hledger is not installed, prints a clean informational finding
+  and does not break the rest of the check;
+- prints exact repair commands when something is off;
+- emits a JSON envelope with `--json` for scripts and skills, with
+  every finding carrying `audience` and `operator_summary` fields.
+
+Exit codes:
+
+- `0` — checks passed (info or warn states allowed);
+- `1` — at least one error finding (e.g. ledger file committed,
+  missing vault ignore rule with the vault already present).
+
+It does **not**:
 
 - run real imports, reconciliation, month-close, P&L, balance sheet,
   cash-flow, or tax claims;
@@ -222,11 +240,10 @@ It will **not**:
 - read the real ledger contents inside the vault;
 - mutate any file.
 
-Sibling commands planned alongside it: `mb books status` (shows the
-storage-mode summary in plain language, plus the GitHub-as-backup
-warning when appropriate) and `mb books doctor` (repairs missing
-ignore rules and missing vault scaffolding without touching real
-ledger contents).
+Sibling commands `mb books status` (storage-mode summary plus the
+GitHub-as-backup warning) and `mb books doctor` (mechanical repairs
+to ignore rules and vault scaffolding) are named in the foundation
+decision and not yet shipped.
 
 The full first-surface spec lives in
 [the mb books foundation decision](../decisions/2026-05-11-mb-books-foundation.md).
@@ -262,9 +279,10 @@ The setup path, when the time comes:
    journal contents in.
 5. Optionally add `core/finance/chart-of-accounts.md` describing your
    account-naming convention.
-6. When `mb books check` and friends ship, `mb` will create and
-   enforce the ignore rules for your storage mode, so the books vault
-   stays out of GitHub by default.
+6. Run `mb books check` to verify the policy parses and the
+   `.mb/private/` ignore rule is in place. When the sibling
+   `mb books doctor` ships, it will mechanically add missing ignore
+   rules for you.
 
 ## Related
 

--- a/mb/mb/_data/books/acme-fixture.journal
+++ b/mb/mb/_data/books/acme-fixture.journal
@@ -1,0 +1,42 @@
+; ----------------------------------------------------------------------
+; SAMPLE FIXTURE — NOT A REAL LEDGER
+; ----------------------------------------------------------------------
+; Fictional company: Acme Fixture Inc.
+; Purpose: exercise the planned `mb books check` contract.
+; Real ledgers never live in this engine repo. See docs/books.md.
+; ----------------------------------------------------------------------
+
+; Account type declarations (hledger account directive with type: tag)
+account assets:bank:checking          ; type:A
+account assets:bank:savings           ; type:A
+account liabilities:credit-card       ; type:L
+account equity:opening-balances       ; type:E
+account income:sales                  ; type:R
+account expenses:software             ; type:X
+account expenses:office:supplies      ; type:X
+
+; Opening balance
+
+2026-01-01 opening balance
+    assets:bank:checking      1000.00 USD
+    equity:opening-balances
+
+; Sample transactions (fictional)
+
+2026-01-15 acme fixture inc - sample customer payment
+    assets:bank:checking       250.00 USD
+    income:sales
+
+2026-01-20 sample SaaS subscription
+    expenses:software           49.00 USD
+    liabilities:credit-card
+
+2026-01-25 sample office supplies
+    expenses:office:supplies    18.50 USD
+    liabilities:credit-card
+
+; Balance assertion (illustrative)
+
+2026-02-01 month-end balance check
+    assets:bank:checking            0 USD = 1250.00 USD
+    equity:opening-balances

--- a/mb/mb/books.py
+++ b/mb/mb/books.py
@@ -41,9 +41,15 @@ VAULT_RELATIVE = Path(".mb/private")
 VAULT_IGNORE_ENTRIES = (".mb/private/", ".mb/private")
 
 VALID_STORAGE_MODES = frozenset({"solo-local", "team-private-repo", "advanced-vault"})
+NON_LOCAL_STORAGE_MODES = frozenset({"team-private-repo", "advanced-vault"})
 
 BUNDLED_FIXTURE_NAME = "acme-fixture.journal"
 DOCS_BOOKS_PATH = "docs/books.md"
+
+# Fixture markers an operator can put in a sample journal/CSV to opt the
+# file out of unsafe-path detection. See the foundation decision.
+FIXTURE_MARKER_TOKENS = ("mb-fixture", "sample fixture", "not a real ledger")
+FIXTURE_MARKER_BYTES = 1024
 
 
 def _max_state(states: list[str]) -> str:
@@ -160,15 +166,25 @@ def _walk_files_fallback(repo: Path) -> list[str]:
     return out
 
 
-def _path_is_engine_fixture(rel_posix: str) -> bool:
-    """Skip the engine repo's own packaged + documented fixtures.
+def _has_fixture_marker(path: Path) -> bool:
+    """Return True when ``path`` carries an explicit fixture marker.
 
-    ``mb books check`` runs against business repos, not this engine
-    repo, but the gate must be conservative when an operator points it
-    at a checkout that happens to contain ``docs/examples/books/`` or
-    ``mb/mb/_data/books/``.
+    The foundation decision allows an escape hatch from unsafe-path
+    detection when a sample file is explicitly marked. Marker tokens
+    are matched case-insensitively in the first ``FIXTURE_MARKER_BYTES``
+    of the file. Operators can put them in a header comment so the
+    same fixture file can live anywhere in the business repo.
     """
-    return rel_posix.startswith(("docs/examples/books/", "mb/mb/_data/books/"))
+    try:
+        with path.open("rb") as handle:
+            head = handle.read(FIXTURE_MARKER_BYTES)
+    except OSError:
+        return False
+    try:
+        text = head.decode("utf-8", errors="ignore").lower()
+    except UnicodeDecodeError:
+        return False
+    return any(token in text for token in FIXTURE_MARKER_TOKENS)
 
 
 def _ignore_rule_present(entries: set[str]) -> bool:
@@ -245,12 +261,15 @@ def _detect_books_policy(repo: Path) -> tuple[dict[str, Any], list[dict[str, Any
                 state="warn",
                 detail=(
                     f"storage_mode={storage_mode!r} is not one of "
-                    "solo-local, team-private-repo, advanced-vault."
+                    "solo-local, team-private-repo, advanced-vault. "
+                    "Treating as solo-local for vault enforcement so a "
+                    "typo cannot silently allow a books leak."
                 ),
                 audience="operator_decision",
                 operator_summary=(
-                    f"Unknown storage_mode {storage_mode!r}. Use one of the "
-                    "three documented values."
+                    f"Unknown storage_mode {storage_mode!r}; assuming "
+                    "solo-local until corrected. Use one of the three "
+                    "documented values."
                 ),
                 repair=f"See {DOCS_BOOKS_PATH} for valid storage modes.",
             )
@@ -327,7 +346,13 @@ def _check_vault_ignore_rule(repo: Path, storage_mode: str) -> list[dict[str, An
     vault_path = repo / VAULT_RELATIVE
     vault_exists = vault_path.exists()
 
-    if storage_mode in ("", "solo-local"):
+    # Fail closed: only the two explicitly non-local modes skip the
+    # local vault ignore check. Anything else — empty, unknown,
+    # typo'd — gets solo-local enforcement so a misconfigured policy
+    # does not silently allow a leak.
+    treat_as_local = storage_mode not in NON_LOCAL_STORAGE_MODES
+
+    if treat_as_local:
         if ignored:
             findings.append(
                 _finding(
@@ -397,7 +422,14 @@ def _check_vault_ignore_rule(repo: Path, storage_mode: str) -> list[dict[str, An
 
 
 def _detect_unsafe_paths(repo: Path) -> list[dict[str, Any]]:
-    """Flag ledger or statement files committed to the business repo."""
+    """Flag ledger or statement files committed to the business repo.
+
+    Per the foundation decision this is a ``warn``, not a hard fail:
+    operators may legitimately commit non-finance CSVs (research
+    exports, audience data) and may ship sample fixtures. Files
+    carrying an explicit fixture marker (see ``FIXTURE_MARKER_TOKENS``)
+    are exempted.
+    """
     tracked, used_git = _tracked_files(repo)
     if used_git:
         candidates = tracked
@@ -407,43 +439,72 @@ def _detect_unsafe_paths(repo: Path) -> list[dict[str, Any]]:
         method = "filesystem walk"
 
     leaks: list[str] = []
+    fixtures: list[str] = []
     for rel in candidates:
         if not rel:
             continue
         if rel.startswith(".mb/private/"):
             continue
-        if _path_is_engine_fixture(rel):
-            continue
         suffix = Path(rel).suffix.lower()
-        if suffix in UNSAFE_EXTENSIONS:
-            leaks.append(rel)
+        if suffix not in UNSAFE_EXTENSIONS:
+            continue
+        absolute = repo / rel
+        if _has_fixture_marker(absolute):
+            fixtures.append(rel)
+            continue
+        leaks.append(rel)
+
+    findings: list[dict[str, Any]] = []
+    if fixtures:
+        findings.append(
+            _finding(
+                id="unsafe-paths-fixtures-detected",
+                title="Marked fixture files detected",
+                state="info",
+                detail=(
+                    "These files carry an explicit fixture marker and are "
+                    "exempted from the unsafe-path check."
+                ),
+                audience="informational",
+                operator_summary=(
+                    f"{len(fixtures)} file(s) marked as sample fixtures; "
+                    "skipping unsafe-path enforcement."
+                ),
+                evidence=fixtures[:20],
+            )
+        )
 
     if not leaks:
-        return [
+        findings.append(
             _finding(
                 id="unsafe-paths-clean",
                 title="No ledger or statement files tracked in the business repo",
                 state="ok",
-                detail=f"Checked via {method}; no ledger-shaped files found.",
+                detail=f"Checked via {method}; no unmarked ledger-shaped files found.",
                 audience="informational",
                 operator_summary=("No raw ledgers or statements committed to the business repo."),
             )
-        ]
+        )
+        return findings
 
-    return [
+    findings.append(
         _finding(
             id="unsafe-paths-detected",
             title="Ledger or statement files found in the business repo",
-            state="error",
+            state="warn",
             detail=(
                 "These files look like raw books or statement exports. "
                 "Real books belong in the private books vault, not the "
-                "team-visible business repo."
+                "team-visible business repo. If a flagged file is a sample, "
+                "add a fixture marker line (for example "
+                "'; MB-FIXTURE — sample, not a real ledger') in the first "
+                f"{FIXTURE_MARKER_BYTES} bytes."
             ),
             audience="operator_decision",
             operator_summary=(
                 f"{len(leaks)} ledger/statement-shaped file(s) committed; "
-                "move them into the private books vault."
+                "move them into the private books vault or mark them as "
+                "fixtures."
             ),
             repair=(
                 "Move each file into .mb/private/books/ (solo-local) or "
@@ -452,7 +513,8 @@ def _detect_unsafe_paths(repo: Path) -> list[dict[str, Any]]:
             ),
             evidence=leaks[:20],
         )
-    ]
+    )
+    return findings
 
 
 def _bundled_fixture_path() -> Path | None:

--- a/mb/mb/books.py
+++ b/mb/mb/books.py
@@ -1,0 +1,659 @@
+"""``mb books check`` — first safe books surface.
+
+Validates Main Branch's bookkeeping contract per
+``decisions/2026-05-11-mb-books-foundation.md``:
+
+- detects ``core/finance/books.md`` and parses its frontmatter (when
+  present);
+- detects ``core/finance/chart-of-accounts.md`` (when present);
+- verifies the configured storage mode's ignore rules so the private
+  books vault stays out of the business repo's tracked content;
+- warns when ledger-shaped or statement-shaped files appear in the
+  business repo's tracked content (likely Class B leak);
+- when ``--fixture`` is opted in and ``hledger`` is on PATH, validates a
+  bundled fake journal fixture via ``hledger -f <fixture> check`` and
+  reports the structured outcome;
+- explains a missing ``hledger`` binary as ``info`` without breaking
+  base installs.
+
+This surface only **reads** files. It never imports or writes ledger
+data. Real ledger contents under the private books vault are not read.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from importlib import resources
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+STATE_ORDER = {"ok": 0, "info": 1, "warn": 2, "error": 3}
+AUDIENCE_VALUES = frozenset({"mechanical", "operator_decision", "informational"})
+
+LEDGER_EXTENSIONS = (".journal", ".hledger", ".ledger", ".beancount")
+STATEMENT_EXTENSIONS = (".csv", ".ofx", ".qfx", ".qbo", ".qif")
+UNSAFE_EXTENSIONS = LEDGER_EXTENSIONS + STATEMENT_EXTENSIONS
+
+VAULT_RELATIVE = Path(".mb/private")
+VAULT_IGNORE_ENTRIES = (".mb/private/", ".mb/private")
+
+VALID_STORAGE_MODES = frozenset({"solo-local", "team-private-repo", "advanced-vault"})
+
+BUNDLED_FIXTURE_NAME = "acme-fixture.journal"
+DOCS_BOOKS_PATH = "docs/books.md"
+
+
+def _max_state(states: list[str]) -> str:
+    if not states:
+        return "ok"
+    return max(states, key=lambda state: STATE_ORDER.get(state, 3))
+
+
+def _finding(
+    *,
+    id: str,
+    title: str,
+    state: str,
+    detail: str,
+    audience: str,
+    operator_summary: str,
+    repair: str = "",
+    evidence: list[str] | None = None,
+) -> dict[str, Any]:
+    resolved_audience = audience if audience in AUDIENCE_VALUES else "operator_decision"
+    return {
+        "id": id,
+        "title": title,
+        "state": state,
+        "detail": detail,
+        "audience": resolved_audience,
+        "operator_summary": operator_summary or detail or title,
+        "repair": repair,
+        "evidence": evidence or [],
+    }
+
+
+def _read_frontmatter(path: Path) -> tuple[dict[str, Any], str]:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return {}, f"cannot read {path}: {exc}"
+    if not text.startswith("---"):
+        return {}, ""
+    end = text.find("\n---", 3)
+    if end == -1:
+        return {}, "frontmatter is not closed by a trailing '---' line"
+    try:
+        parsed = yaml.safe_load(text[3:end].strip()) or {}
+    except yaml.YAMLError as exc:
+        return {}, f"frontmatter does not parse as YAML: {exc}"
+    if not isinstance(parsed, dict):
+        return {}, "frontmatter is not a YAML mapping"
+    return parsed, ""
+
+
+def _gitignore_entries(repo: Path) -> set[str]:
+    gitignore = repo / ".gitignore"
+    if not gitignore.exists():
+        return set()
+    try:
+        text = gitignore.read_text(encoding="utf-8")
+    except OSError:
+        return set()
+    return {line.strip() for line in text.splitlines() if line.strip()}
+
+
+def _run_git(repo: Path, args: list[str]) -> tuple[bool, str]:
+    try:
+        proc = subprocess.run(
+            ["git", *args],
+            cwd=repo,
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.SubprocessError):
+        return False, ""
+    if proc.returncode != 0:
+        return False, proc.stdout.strip()
+    return True, proc.stdout.strip()
+
+
+def _tracked_files(repo: Path) -> tuple[list[str], bool]:
+    """Return git-tracked file paths and whether git was usable."""
+    ok, stdout = _run_git(repo, ["ls-files"])
+    if not ok:
+        return [], False
+    return [line for line in stdout.splitlines() if line], True
+
+
+def _walk_files_fallback(repo: Path) -> list[str]:
+    skip = {
+        ".git",
+        ".mb",
+        ".mainbranch",
+        ".claude",
+        "node_modules",
+        ".next",
+        ".venv",
+        ".pytest_cache",
+        ".mypy_cache",
+        ".ruff_cache",
+        "__pycache__",
+    }
+    out: list[str] = []
+    for path in repo.rglob("*"):
+        if not path.is_file():
+            continue
+        try:
+            rel = path.relative_to(repo)
+        except ValueError:
+            continue
+        parts = rel.parts
+        if any(part in skip for part in parts):
+            continue
+        out.append(rel.as_posix())
+    return out
+
+
+def _path_is_engine_fixture(rel_posix: str) -> bool:
+    """Skip the engine repo's own packaged + documented fixtures.
+
+    ``mb books check`` runs against business repos, not this engine
+    repo, but the gate must be conservative when an operator points it
+    at a checkout that happens to contain ``docs/examples/books/`` or
+    ``mb/mb/_data/books/``.
+    """
+    return rel_posix.startswith(("docs/examples/books/", "mb/mb/_data/books/"))
+
+
+def _ignore_rule_present(entries: set[str]) -> bool:
+    return any(entry in entries for entry in VAULT_IGNORE_ENTRIES)
+
+
+def _detect_books_policy(repo: Path) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    findings: list[dict[str, Any]] = []
+    path = repo / "core" / "finance" / "books.md"
+    if not path.exists():
+        findings.append(
+            _finding(
+                id="books-policy-missing",
+                title="No bookkeeping policy file",
+                state="info",
+                detail=(
+                    "core/finance/books.md is not present. Books policy is "
+                    "optional. Add it when you are ready to run real books."
+                ),
+                audience="informational",
+                operator_summary=(
+                    "No books policy yet. Add core/finance/books.md when you "
+                    "want Main Branch to track bookkeeping."
+                ),
+                repair="See docs/books.md for a starter shape.",
+            )
+        )
+        return {}, findings
+
+    fm, err = _read_frontmatter(path)
+    if err:
+        findings.append(
+            _finding(
+                id="books-policy-frontmatter-error",
+                title="Bookkeeping policy frontmatter does not parse",
+                state="error",
+                detail=err,
+                audience="operator_decision",
+                operator_summary=(
+                    "core/finance/books.md exists but its frontmatter is "
+                    "broken; Main Branch cannot read storage mode."
+                ),
+                repair=f"Fix the YAML frontmatter at {path.as_posix()}.",
+            )
+        )
+        return {}, findings
+
+    storage_mode = str(fm.get("storage_mode") or "").strip()
+    if not storage_mode:
+        findings.append(
+            _finding(
+                id="books-policy-storage-mode-missing",
+                title="Bookkeeping policy is missing storage_mode",
+                state="warn",
+                detail=(
+                    "core/finance/books.md has no storage_mode. Set it to "
+                    "solo-local, team-private-repo, or advanced-vault."
+                ),
+                audience="operator_decision",
+                operator_summary=(
+                    "Books policy needs a storage_mode so Main Branch knows "
+                    "where the real books live."
+                ),
+                repair=(
+                    "Add `storage_mode: solo-local` (default) to core/finance/books.md frontmatter."
+                ),
+            )
+        )
+    elif storage_mode not in VALID_STORAGE_MODES:
+        findings.append(
+            _finding(
+                id="books-policy-storage-mode-invalid",
+                title="Bookkeeping policy uses an unknown storage_mode",
+                state="warn",
+                detail=(
+                    f"storage_mode={storage_mode!r} is not one of "
+                    "solo-local, team-private-repo, advanced-vault."
+                ),
+                audience="operator_decision",
+                operator_summary=(
+                    f"Unknown storage_mode {storage_mode!r}. Use one of the "
+                    "three documented values."
+                ),
+                repair=f"See {DOCS_BOOKS_PATH} for valid storage modes.",
+            )
+        )
+    else:
+        findings.append(
+            _finding(
+                id="books-policy-ok",
+                title="Bookkeeping policy present",
+                state="ok",
+                detail=f"core/finance/books.md declares storage_mode={storage_mode}.",
+                audience="informational",
+                operator_summary=(f"Books policy in place; storage mode is {storage_mode}."),
+            )
+        )
+    return fm, findings
+
+
+def _detect_chart_of_accounts(repo: Path) -> list[dict[str, Any]]:
+    path = repo / "core" / "finance" / "chart-of-accounts.md"
+    if not path.exists():
+        return [
+            _finding(
+                id="chart-of-accounts-missing",
+                title="No chart of accounts",
+                state="info",
+                detail=(
+                    "core/finance/chart-of-accounts.md is not present. "
+                    "Add it when you settle on an account-naming convention."
+                ),
+                audience="informational",
+                operator_summary=(
+                    "No chart of accounts yet. Optional until you start real bookkeeping."
+                ),
+                repair="See docs/books.md for the shape.",
+            )
+        ]
+    fm, err = _read_frontmatter(path)
+    if err:
+        return [
+            _finding(
+                id="chart-of-accounts-frontmatter-error",
+                title="Chart of accounts frontmatter does not parse",
+                state="warn",
+                detail=err,
+                audience="operator_decision",
+                operator_summary=("core/finance/chart-of-accounts.md frontmatter cannot be read."),
+                repair=f"Fix the YAML frontmatter at {path.as_posix()}.",
+            )
+        ]
+    return [
+        _finding(
+            id="chart-of-accounts-ok",
+            title="Chart of accounts present",
+            state="ok",
+            detail="core/finance/chart-of-accounts.md is in place.",
+            audience="informational",
+            operator_summary="Chart of accounts is documented.",
+        )
+    ]
+
+
+def _check_vault_ignore_rule(repo: Path, storage_mode: str) -> list[dict[str, Any]]:
+    """Enforce the private books vault contract.
+
+    For ``solo-local``, ``.mb/private/`` must be ignored by the
+    business repo's ``.gitignore`` so the real books never enter
+    tracked history. For team/advanced modes the vault lives
+    elsewhere so the rule is informational.
+    """
+    findings: list[dict[str, Any]] = []
+    entries = _gitignore_entries(repo)
+    ignored = _ignore_rule_present(entries)
+    vault_path = repo / VAULT_RELATIVE
+    vault_exists = vault_path.exists()
+
+    if storage_mode in ("", "solo-local"):
+        if ignored:
+            findings.append(
+                _finding(
+                    id="vault-ignore-rule-ok",
+                    title="Private books vault ignore rule present",
+                    state="ok",
+                    detail=(
+                        ".mb/private/ is gitignored; the books vault will "
+                        "stay out of the business repo's tracked history."
+                    ),
+                    audience="informational",
+                    operator_summary=("Private books vault is properly ignored."),
+                )
+            )
+        else:
+            findings.append(
+                _finding(
+                    id="vault-ignore-rule-missing",
+                    title="Private books vault is not gitignored",
+                    state="error" if vault_exists else "warn",
+                    detail=(
+                        ".mb/private/ is not in .gitignore. The solo-local "
+                        "storage mode keeps real books in this directory; "
+                        "they must never enter tracked history."
+                    ),
+                    audience="mechanical",
+                    operator_summary=(
+                        "Add `.mb/private/` to .gitignore so the books vault stays local."
+                    ),
+                    repair=("echo '.mb/private/' >> .gitignore && git add .gitignore"),
+                )
+            )
+    else:
+        findings.append(
+            _finding(
+                id="vault-ignore-rule-skipped",
+                title="Private books vault is not local to this repo",
+                state="info",
+                detail=(
+                    f"storage_mode={storage_mode!r}; the real books live "
+                    "in a separate vault, not in this repo."
+                ),
+                audience="informational",
+                operator_summary=(
+                    "Real books live outside this repo for the configured storage mode."
+                ),
+            )
+        )
+        if vault_exists and not ignored:
+            findings.append(
+                _finding(
+                    id="vault-directory-unexpected",
+                    title=".mb/private/ exists but storage mode is not solo-local",
+                    state="warn",
+                    detail=(
+                        ".mb/private/ exists in this repo but storage_mode "
+                        f"is {storage_mode!r}. Confirm the real books "
+                        "have moved and remove the leftover directory."
+                    ),
+                    audience="operator_decision",
+                    operator_summary=(
+                        f"Leftover .mb/private/ vault under {storage_mode} mode; confirm migration."
+                    ),
+                )
+            )
+    return findings
+
+
+def _detect_unsafe_paths(repo: Path) -> list[dict[str, Any]]:
+    """Flag ledger or statement files committed to the business repo."""
+    tracked, used_git = _tracked_files(repo)
+    if used_git:
+        candidates = tracked
+        method = "git ls-files"
+    else:
+        candidates = _walk_files_fallback(repo)
+        method = "filesystem walk"
+
+    leaks: list[str] = []
+    for rel in candidates:
+        if not rel:
+            continue
+        if rel.startswith(".mb/private/"):
+            continue
+        if _path_is_engine_fixture(rel):
+            continue
+        suffix = Path(rel).suffix.lower()
+        if suffix in UNSAFE_EXTENSIONS:
+            leaks.append(rel)
+
+    if not leaks:
+        return [
+            _finding(
+                id="unsafe-paths-clean",
+                title="No ledger or statement files tracked in the business repo",
+                state="ok",
+                detail=f"Checked via {method}; no ledger-shaped files found.",
+                audience="informational",
+                operator_summary=("No raw ledgers or statements committed to the business repo."),
+            )
+        ]
+
+    return [
+        _finding(
+            id="unsafe-paths-detected",
+            title="Ledger or statement files found in the business repo",
+            state="error",
+            detail=(
+                "These files look like raw books or statement exports. "
+                "Real books belong in the private books vault, not the "
+                "team-visible business repo."
+            ),
+            audience="operator_decision",
+            operator_summary=(
+                f"{len(leaks)} ledger/statement-shaped file(s) committed; "
+                "move them into the private books vault."
+            ),
+            repair=(
+                "Move each file into .mb/private/books/ (solo-local) or "
+                "the private books repo, then `git rm --cached <file>` and "
+                "commit. Rotate the data if it is sensitive."
+            ),
+            evidence=leaks[:20],
+        )
+    ]
+
+
+def _bundled_fixture_path() -> Path | None:
+    try:
+        ref = (
+            resources.files("mb").joinpath("_data").joinpath("books").joinpath(BUNDLED_FIXTURE_NAME)
+        )
+        with resources.as_file(ref) as resolved:
+            if resolved.exists():
+                return Path(resolved)
+    except (FileNotFoundError, ModuleNotFoundError, AttributeError):
+        pass
+    fallback = Path(__file__).resolve().parent / "_data" / "books" / BUNDLED_FIXTURE_NAME
+    if fallback.exists():
+        return fallback
+    return None
+
+
+def _validate_fixture(
+    fixture: Path | None,
+) -> list[dict[str, Any]]:
+    """Optionally validate a fake hledger journal fixture."""
+    target = fixture or _bundled_fixture_path()
+    if target is None:
+        return [
+            _finding(
+                id="fixture-missing",
+                title="Books fixture not found",
+                state="warn",
+                detail=("No fixture path was given and the bundled fixture could not be located."),
+                audience="operator_decision",
+                operator_summary=("Pass --fixture <path> or reinstall Main Branch."),
+            )
+        ]
+
+    if not target.exists():
+        return [
+            _finding(
+                id="fixture-missing",
+                title="Books fixture not found",
+                state="warn",
+                detail=f"{target} does not exist.",
+                audience="operator_decision",
+                operator_summary=(f"Fixture path {target} not found; check the spelling."),
+            )
+        ]
+
+    if not shutil.which("hledger"):
+        return [
+            _finding(
+                id="hledger-missing",
+                title="hledger is not installed",
+                state="info",
+                detail=(
+                    "hledger is optional for base Main Branch installs. "
+                    "Install it to run deeper books validation."
+                ),
+                audience="informational",
+                operator_summary=(
+                    "Install hledger to validate journal fixtures. Base "
+                    "Main Branch continues to work without it."
+                ),
+                repair=(
+                    "Install hledger from the prebuilt binary at https://hledger.org/install.html"
+                ),
+            )
+        ]
+
+    try:
+        proc = subprocess.run(
+            ["hledger", "-f", str(target), "check"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.SubprocessError) as exc:
+        return [
+            _finding(
+                id="hledger-invocation-error",
+                title="hledger could not be invoked",
+                state="warn",
+                detail=str(exc),
+                audience="informational",
+                operator_summary=("Main Branch found hledger on PATH but could not run it."),
+            )
+        ]
+
+    if proc.returncode != 0:
+        return [
+            _finding(
+                id="fixture-invalid",
+                title="hledger could not validate the books fixture",
+                state="error",
+                detail=(proc.stderr.strip() or proc.stdout.strip())[:2000],
+                audience="operator_decision",
+                operator_summary=(
+                    "Books fixture failed hledger validation. Fix the "
+                    "journal or pass a different --fixture."
+                ),
+                repair=f"hledger -f {target} check",
+            )
+        ]
+
+    return [
+        _finding(
+            id="fixture-valid",
+            title="Books fixture validates with hledger",
+            state="ok",
+            detail=f"hledger -f {target} check passed.",
+            audience="informational",
+            operator_summary="Fake hledger fixture passes structural checks.",
+        )
+    ]
+
+
+def run(
+    repo: str | Path = ".",
+    *,
+    validate_fixture: bool = False,
+    fixture: str | Path | None = None,
+) -> dict[str, Any]:
+    """Run ``mb books check`` against ``repo``.
+
+    Read-only. Never mutates files. Never reads the contents of the
+    private books vault.
+    """
+    repo_path = Path(repo).resolve()
+
+    findings: list[dict[str, Any]] = []
+    fm, policy_findings = _detect_books_policy(repo_path)
+    findings.extend(policy_findings)
+    findings.extend(_detect_chart_of_accounts(repo_path))
+    storage_mode = str(fm.get("storage_mode") or "").strip()
+    findings.extend(_check_vault_ignore_rule(repo_path, storage_mode))
+    findings.extend(_detect_unsafe_paths(repo_path))
+
+    fixture_findings: list[dict[str, Any]] = []
+    if validate_fixture:
+        fixture_path = Path(fixture).resolve() if fixture else None
+        fixture_findings = _validate_fixture(fixture_path)
+        findings.extend(fixture_findings)
+
+    state = _max_state([finding["state"] for finding in findings])
+    errors = [finding["operator_summary"] for finding in findings if finding["state"] == "error"]
+    warnings = [finding["operator_summary"] for finding in findings if finding["state"] == "warn"]
+
+    summary = _summary(state, findings)
+
+    return {
+        "ok": state not in {"error"},
+        "state": state,
+        "repo": str(repo_path),
+        "storage_mode": storage_mode,
+        "fixture_validated": validate_fixture,
+        "summary": summary,
+        "findings": findings,
+        "errors": errors,
+        "warnings": warnings,
+        "safe_to_share": True,
+    }
+
+
+def _summary(state: str, findings: list[dict[str, Any]]) -> str:
+    counts = {"ok": 0, "info": 0, "warn": 0, "error": 0}
+    for finding in findings:
+        counts[finding.get("state", "info")] = counts.get(finding.get("state", "info"), 0) + 1
+    if state == "error":
+        return (
+            f"{counts['error']} error(s), {counts['warn']} warning(s); "
+            "see findings for repair commands."
+        )
+    if state == "warn":
+        return f"{counts['warn']} warning(s); see findings for repair commands."
+    if state == "info":
+        return "No errors. See info findings for optional bookkeeping setup."
+    return "Books check passed."
+
+
+def render_human(report: dict[str, Any]) -> None:
+    """Print a short human summary to stdout."""
+    import typer
+
+    typer.echo(f"mb books check — {report['summary']}")
+    if report.get("storage_mode"):
+        typer.echo(f"storage mode: {report['storage_mode']}")
+    typer.echo("")
+    for finding in report.get("findings", []):
+        marker = {
+            "ok": " ok ",
+            "info": "info",
+            "warn": "WARN",
+            "error": "FAIL",
+        }.get(finding.get("state", "info"), "    ")
+        typer.echo(f"  [{marker}] {finding['title']}")
+        if finding.get("operator_summary"):
+            typer.echo(f"         {finding['operator_summary']}")
+        if finding.get("repair"):
+            typer.echo(f"         repair: {finding['repair']}")
+        evidence = finding.get("evidence") or []
+        for item in evidence[:5]:
+            typer.echo(f"           - {item}")
+    typer.echo("")
+    typer.echo(f"See {DOCS_BOOKS_PATH} for the full books contract.")

--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -16,6 +16,7 @@ from typing import Any
 import typer
 
 from mb import __version__
+from mb import books as books_mod
 from mb import checkpoint as checkpoint_mod
 from mb import connect as connect_mod
 from mb import doctor as doctor_mod
@@ -85,6 +86,13 @@ site_app = typer.Typer(
     no_args_is_help=True,
 )
 app.add_typer(site_app, name="site")
+
+books_app = typer.Typer(
+    name="books",
+    help="Check bookkeeping safety and the private books vault contract.",
+    no_args_is_help=True,
+)
+app.add_typer(books_app, name="books")
 
 suggest_app = typer.Typer(
     name="suggest",
@@ -915,6 +923,43 @@ def start_cmd(
         typer.echo(_json_payload(report, command="mb start", schema_name="mainbranch.start.result"))
     else:
         start_mod.render_human(report)
+    raise typer.Exit(0 if report["ok"] else 1)
+
+
+@books_app.command("check")
+def books_check_cmd(
+    repo: str = typer.Argument(".", help="Business repo to check."),
+    validate_fixture: bool = typer.Option(
+        False,
+        "--fixture/--no-fixture",
+        help=(
+            "Validate a fake hledger journal fixture. Uses the bundled "
+            "sample unless --fixture-path is given."
+        ),
+    ),
+    fixture_path: str = typer.Option(
+        "",
+        "--fixture-path",
+        help="Path to a fake hledger journal fixture to validate.",
+    ),
+    json_out: bool = typer.Option(False, "--json", help="Machine-readable output."),
+) -> None:
+    """Check books safety: policy file, vault ignore rules, unsafe paths."""
+    report = books_mod.run(
+        repo=repo,
+        validate_fixture=validate_fixture or bool(fixture_path),
+        fixture=fixture_path or None,
+    )
+    if json_out:
+        typer.echo(
+            _json_payload(
+                report,
+                command="mb books check",
+                schema_name="mainbranch.books.check.result",
+            )
+        )
+    else:
+        books_mod.render_human(report)
     raise typer.Exit(0 if report["ok"] else 1)
 
 

--- a/mb/tests/test_books.py
+++ b/mb/tests/test_books.py
@@ -1,0 +1,279 @@
+"""``mb books check`` — first books safety surface."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from mb import books as books_mod
+from mb.cli import app
+
+runner = CliRunner()
+
+
+def _init_business_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "biz"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=repo, check=True)
+    return repo
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _git_add_all(repo: Path) -> None:
+    subprocess.run(["git", "add", "-A"], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "commit", "-q", "-m", "test"],
+        cwd=repo,
+        check=True,
+    )
+
+
+def _findings_by_id(report: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    return {finding["id"]: finding for finding in report["findings"]}
+
+
+def test_books_check_empty_repo_reports_recommendations(tmp_path: Path) -> None:
+    repo = _init_business_repo(tmp_path)
+    report = books_mod.run(repo=str(repo))
+    findings = _findings_by_id(report)
+    assert "books-policy-missing" in findings
+    assert findings["books-policy-missing"]["state"] == "info"
+    assert findings["books-policy-missing"]["audience"] == "informational"
+    assert findings["books-policy-missing"]["operator_summary"]
+    assert "chart-of-accounts-missing" in findings
+    # No books vault present, but solo-local default applies → warn (not error).
+    assert findings["vault-ignore-rule-missing"]["state"] == "warn"
+    assert findings["vault-ignore-rule-missing"]["audience"] == "mechanical"
+    assert "git ls-files" in findings["unsafe-paths-clean"]["detail"]
+    assert report["ok"] is True
+    assert report["state"] == "warn"
+
+
+def test_books_check_passes_with_policy_and_ignore_rule(tmp_path: Path) -> None:
+    repo = _init_business_repo(tmp_path)
+    _write(
+        repo / "core/finance/books.md",
+        """---
+type: books
+ledger: hledger
+operating_currency: USD
+storage_mode: solo-local
+vault_location: ".mb/private/books/"
+---
+
+# Books
+""",
+    )
+    _write(
+        repo / "core/finance/chart-of-accounts.md",
+        """---
+type: chart-of-accounts
+ledger: hledger
+---
+
+# Chart
+""",
+    )
+    _write(repo / ".gitignore", ".mb/private/\n")
+    _git_add_all(repo)
+
+    report = books_mod.run(repo=str(repo))
+    findings = _findings_by_id(report)
+    assert findings["books-policy-ok"]["state"] == "ok"
+    assert findings["chart-of-accounts-ok"]["state"] == "ok"
+    assert findings["vault-ignore-rule-ok"]["state"] == "ok"
+    assert findings["unsafe-paths-clean"]["state"] == "ok"
+    assert report["state"] == "ok"
+    assert report["ok"] is True
+    assert report["errors"] == []
+
+
+def test_books_check_flags_committed_ledger_file(tmp_path: Path) -> None:
+    repo = _init_business_repo(tmp_path)
+    _write(repo / "core/finance/notes.md", "# notes\n")
+    _write(repo / "core/finance/main.journal", "; leaked real journal\n")
+    _git_add_all(repo)
+
+    report = books_mod.run(repo=str(repo))
+    findings = _findings_by_id(report)
+    assert "unsafe-paths-detected" in findings
+    leak = findings["unsafe-paths-detected"]
+    assert leak["state"] == "error"
+    assert leak["audience"] == "operator_decision"
+    assert "core/finance/main.journal" in leak["evidence"]
+    assert report["ok"] is False
+    assert report["state"] == "error"
+
+
+def test_books_check_flags_committed_csv_statement(tmp_path: Path) -> None:
+    repo = _init_business_repo(tmp_path)
+    _write(repo / "imports/bank-2026-01.csv", "date,amount\n")
+    _git_add_all(repo)
+
+    report = books_mod.run(repo=str(repo))
+    findings = _findings_by_id(report)
+    assert findings["unsafe-paths-detected"]["state"] == "error"
+    assert "imports/bank-2026-01.csv" in findings["unsafe-paths-detected"]["evidence"]
+
+
+def test_books_check_team_mode_skips_local_ignore_rule(tmp_path: Path) -> None:
+    repo = _init_business_repo(tmp_path)
+    _write(
+        repo / "core/finance/books.md",
+        """---
+type: books
+ledger: hledger
+storage_mode: team-private-repo
+vault_location: "acme-private-books"
+---
+
+# Books
+""",
+    )
+    _git_add_all(repo)
+
+    report = books_mod.run(repo=str(repo))
+    findings = _findings_by_id(report)
+    assert findings["vault-ignore-rule-skipped"]["state"] == "info"
+    # No vault directory exists, so the leftover finding should not appear.
+    assert "vault-directory-unexpected" not in findings
+    assert report["ok"] is True
+
+
+def test_books_check_warns_on_unknown_storage_mode(tmp_path: Path) -> None:
+    repo = _init_business_repo(tmp_path)
+    _write(
+        repo / "core/finance/books.md",
+        """---
+type: books
+ledger: hledger
+storage_mode: not-a-real-mode
+---
+
+# Books
+""",
+    )
+    report = books_mod.run(repo=str(repo))
+    findings = _findings_by_id(report)
+    assert findings["books-policy-storage-mode-invalid"]["state"] == "warn"
+
+
+def test_books_check_warns_on_broken_frontmatter(tmp_path: Path) -> None:
+    repo = _init_business_repo(tmp_path)
+    _write(
+        repo / "core/finance/books.md",
+        "---\nstorage_mode: : : not-yaml\n---\n",
+    )
+    report = books_mod.run(repo=str(repo))
+    findings = _findings_by_id(report)
+    assert findings["books-policy-frontmatter-error"]["state"] == "error"
+    assert report["ok"] is False
+
+
+def test_books_check_fixture_handles_missing_hledger(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _init_business_repo(tmp_path)
+    monkeypatch.setattr("mb.books.shutil.which", lambda name: "")
+
+    report = books_mod.run(repo=str(repo), validate_fixture=True)
+    findings = _findings_by_id(report)
+    assert findings["hledger-missing"]["state"] == "info"
+    assert findings["hledger-missing"]["audience"] == "informational"
+    # Missing hledger must not break unrelated repo state.
+    assert report["ok"] is True
+
+
+def test_books_check_fixture_runs_when_hledger_available(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _init_business_repo(tmp_path)
+
+    monkeypatch.setattr("mb.books.shutil.which", lambda name: "/fake/hledger")
+
+    class _FakeCompleted:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    def _fake_run(*args: Any, **kwargs: Any) -> _FakeCompleted:
+        return _FakeCompleted()
+
+    monkeypatch.setattr("mb.books.subprocess.run", _fake_run)
+
+    report = books_mod.run(repo=str(repo), validate_fixture=True)
+    findings = _findings_by_id(report)
+    assert findings["fixture-valid"]["state"] == "ok"
+
+
+def test_books_check_fixture_reports_invalid(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _init_business_repo(tmp_path)
+    monkeypatch.setattr("mb.books.shutil.which", lambda name: "/fake/hledger")
+
+    class _Failed:
+        returncode = 1
+        stdout = ""
+        stderr = "balance assertion failed"
+
+    monkeypatch.setattr("mb.books.subprocess.run", lambda *a, **k: _Failed())
+
+    report = books_mod.run(repo=str(repo), validate_fixture=True)
+    findings = _findings_by_id(report)
+    assert findings["fixture-invalid"]["state"] == "error"
+    assert "balance assertion failed" in findings["fixture-invalid"]["detail"]
+    assert report["ok"] is False
+
+
+def test_books_check_cli_emits_json_envelope(tmp_path: Path) -> None:
+    repo = _init_business_repo(tmp_path)
+    result = runner.invoke(app, ["books", "check", str(repo), "--json"])
+    # warn-state run still exits 0 because no errors.
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["mb_command"] == "mb books check"
+    assert payload["result_schema"]["name"] == "mainbranch.books.check.result"
+    assert payload["result_envelope_version"] == "1.0"
+    for finding in payload["findings"]:
+        assert "audience" in finding
+        assert "operator_summary" in finding
+
+
+def test_books_check_cli_human_output_mentions_docs(tmp_path: Path) -> None:
+    repo = _init_business_repo(tmp_path)
+    result = runner.invoke(app, ["books", "check", str(repo)])
+    assert result.exit_code == 0, result.output
+    assert "docs/books.md" in result.output
+
+
+def test_books_check_cli_exits_one_on_error(tmp_path: Path) -> None:
+    repo = _init_business_repo(tmp_path)
+    _write(repo / "core/finance/main.journal", "; leak\n")
+    _git_add_all(repo)
+    result = runner.invoke(app, ["books", "check", str(repo)])
+    assert result.exit_code == 1, result.output
+    assert "FAIL" in result.output
+
+
+def test_books_check_engine_fixture_paths_are_ignored(tmp_path: Path) -> None:
+    repo = _init_business_repo(tmp_path)
+    _write(repo / "docs/examples/books/acme.journal", "; engine fixture\n")
+    _write(repo / "mb/mb/_data/books/acme-fixture.journal", "; pkg fixture\n")
+    _git_add_all(repo)
+    report = books_mod.run(repo=str(repo))
+    findings = _findings_by_id(report)
+    # Engine-fixture-shaped paths are skipped on purpose.
+    assert "unsafe-paths-detected" not in findings
+    assert findings["unsafe-paths-clean"]["state"] == "ok"

--- a/mb/tests/test_books.py
+++ b/mb/tests/test_books.py
@@ -109,11 +109,14 @@ def test_books_check_flags_committed_ledger_file(tmp_path: Path) -> None:
     findings = _findings_by_id(report)
     assert "unsafe-paths-detected" in findings
     leak = findings["unsafe-paths-detected"]
-    assert leak["state"] == "error"
+    # Per the foundation decision, unsafe-path detection warns rather
+    # than hard-fails so non-finance CSVs and marked fixtures stay
+    # usable.
+    assert leak["state"] == "warn"
     assert leak["audience"] == "operator_decision"
     assert "core/finance/main.journal" in leak["evidence"]
-    assert report["ok"] is False
-    assert report["state"] == "error"
+    assert report["ok"] is True
+    assert report["state"] == "warn"
 
 
 def test_books_check_flags_committed_csv_statement(tmp_path: Path) -> None:
@@ -123,8 +126,58 @@ def test_books_check_flags_committed_csv_statement(tmp_path: Path) -> None:
 
     report = books_mod.run(repo=str(repo))
     findings = _findings_by_id(report)
-    assert findings["unsafe-paths-detected"]["state"] == "error"
+    assert findings["unsafe-paths-detected"]["state"] == "warn"
     assert "imports/bank-2026-01.csv" in findings["unsafe-paths-detected"]["evidence"]
+
+
+def test_books_check_exempts_marked_fixture(tmp_path: Path) -> None:
+    repo = _init_business_repo(tmp_path)
+    _write(
+        repo / "docs/examples/sample.journal",
+        "; MB-FIXTURE — not a real ledger\n2026-01-01 sample\n",
+    )
+    _write(
+        repo / "research/audience-survey.csv",
+        "# MB-FIXTURE — synthetic responses\nq,a\n",
+    )
+    _git_add_all(repo)
+
+    report = books_mod.run(repo=str(repo))
+    findings = _findings_by_id(report)
+    assert "unsafe-paths-detected" not in findings
+    assert findings["unsafe-paths-fixtures-detected"]["state"] == "info"
+    assert "docs/examples/sample.journal" in findings["unsafe-paths-fixtures-detected"]["evidence"]
+    assert "research/audience-survey.csv" in findings["unsafe-paths-fixtures-detected"]["evidence"]
+
+
+def test_books_check_invalid_storage_mode_still_enforces_local_ignore(
+    tmp_path: Path,
+) -> None:
+    """Invalid storage_mode must fail closed: enforce solo-local ignore."""
+    repo = _init_business_repo(tmp_path)
+    _write(
+        repo / "core/finance/books.md",
+        """---
+type: books
+ledger: hledger
+storage_mode: solo-loca
+---
+
+# Books
+""",
+    )
+    # Vault directory exists but is not gitignored — must be flagged.
+    (repo / ".mb" / "private").mkdir(parents=True)
+    (repo / ".mb" / "private" / "main.journal").write_text("; real\n")
+
+    report = books_mod.run(repo=str(repo))
+    findings = _findings_by_id(report)
+    assert findings["books-policy-storage-mode-invalid"]["state"] == "warn"
+    # Critical: invalid mode does NOT route to skip; it routes to
+    # enforcement so the leak is caught.
+    assert "vault-ignore-rule-skipped" not in findings
+    assert findings["vault-ignore-rule-missing"]["state"] == "error"
+    assert report["ok"] is False
 
 
 def test_books_check_team_mode_skips_local_ignore_rule(tmp_path: Path) -> None:
@@ -195,26 +248,54 @@ def test_books_check_fixture_handles_missing_hledger(
     assert report["ok"] is True
 
 
+def _hledger_dispatcher(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    returncode: int,
+    stdout: str = "",
+    stderr: str = "",
+) -> list[list[str]]:
+    """Fake subprocess.run that only intercepts hledger calls.
+
+    Real git calls (used by ``_run_git`` for ``ls-files``) pass through
+    to the real ``subprocess.run`` so a regression that calls the wrong
+    binary cannot accidentally satisfy the test.
+    """
+    real_run = subprocess.run
+    seen: list[list[str]] = []
+
+    class _FakeCompleted:
+        def __init__(self) -> None:
+            self.returncode = returncode
+            self.stdout = stdout
+            self.stderr = stderr
+
+    def _dispatch(args: Any, *rest: Any, **kwargs: Any) -> Any:
+        argv = list(args) if isinstance(args, (list, tuple)) else [args]
+        seen.append(argv)
+        if argv and Path(str(argv[0])).name == "hledger":
+            return _FakeCompleted()
+        return real_run(args, *rest, **kwargs)
+
+    monkeypatch.setattr("mb.books.subprocess.run", _dispatch)
+    return seen
+
+
 def test_books_check_fixture_runs_when_hledger_available(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     repo = _init_business_repo(tmp_path)
-
     monkeypatch.setattr("mb.books.shutil.which", lambda name: "/fake/hledger")
-
-    class _FakeCompleted:
-        returncode = 0
-        stdout = ""
-        stderr = ""
-
-    def _fake_run(*args: Any, **kwargs: Any) -> _FakeCompleted:
-        return _FakeCompleted()
-
-    monkeypatch.setattr("mb.books.subprocess.run", _fake_run)
+    seen = _hledger_dispatcher(monkeypatch, returncode=0)
 
     report = books_mod.run(repo=str(repo), validate_fixture=True)
     findings = _findings_by_id(report)
     assert findings["fixture-valid"]["state"] == "ok"
+    # The real git ls-files call passed through, so the clean-paths
+    # finding came from real evidence, not from the fake.
+    assert findings["unsafe-paths-clean"]["state"] == "ok"
+    # And at least one of the recorded calls was the hledger invocation.
+    assert any(Path(str(call[0])).name == "hledger" for call in seen)
 
 
 def test_books_check_fixture_reports_invalid(
@@ -222,13 +303,7 @@ def test_books_check_fixture_reports_invalid(
 ) -> None:
     repo = _init_business_repo(tmp_path)
     monkeypatch.setattr("mb.books.shutil.which", lambda name: "/fake/hledger")
-
-    class _Failed:
-        returncode = 1
-        stdout = ""
-        stderr = "balance assertion failed"
-
-    monkeypatch.setattr("mb.books.subprocess.run", lambda *a, **k: _Failed())
+    _hledger_dispatcher(monkeypatch, returncode=1, stderr="balance assertion failed")
 
     report = books_mod.run(repo=str(repo), validate_fixture=True)
     findings = _findings_by_id(report)
@@ -259,21 +334,47 @@ def test_books_check_cli_human_output_mentions_docs(tmp_path: Path) -> None:
 
 
 def test_books_check_cli_exits_one_on_error(tmp_path: Path) -> None:
+    """A genuine error (broken policy frontmatter) still exits 1."""
     repo = _init_business_repo(tmp_path)
-    _write(repo / "core/finance/main.journal", "; leak\n")
-    _git_add_all(repo)
+    _write(
+        repo / "core/finance/books.md",
+        "---\nstorage_mode: : : not-yaml\n---\n",
+    )
     result = runner.invoke(app, ["books", "check", str(repo)])
     assert result.exit_code == 1, result.output
     assert "FAIL" in result.output
 
 
-def test_books_check_engine_fixture_paths_are_ignored(tmp_path: Path) -> None:
+def test_books_check_unsafe_paths_warn_does_not_exit_one(tmp_path: Path) -> None:
+    """Unsafe-path findings are warn, so the CLI must not exit 1 on them."""
     repo = _init_business_repo(tmp_path)
-    _write(repo / "docs/examples/books/acme.journal", "; engine fixture\n")
-    _write(repo / "mb/mb/_data/books/acme-fixture.journal", "; pkg fixture\n")
+    _write(repo / "core/finance/main.journal", "; leak\n")
     _git_add_all(repo)
-    report = books_mod.run(repo=str(repo))
-    findings = _findings_by_id(report)
-    # Engine-fixture-shaped paths are skipped on purpose.
-    assert "unsafe-paths-detected" not in findings
-    assert findings["unsafe-paths-clean"]["state"] == "ok"
+    result = runner.invoke(app, ["books", "check", str(repo)])
+    assert result.exit_code == 0, result.output
+    assert "WARN" in result.output
+
+
+def test_books_check_packaged_fixtures_carry_marker() -> None:
+    """The shipped fixtures must continue to carry an explicit marker.
+
+    If a future edit drops the SAMPLE FIXTURE header we want the test
+    suite to catch it immediately so the marker contract stays honest.
+    """
+    repo_root = Path(__file__).resolve().parents[2]
+    for rel in (
+        "docs/examples/books/acme-fixture.journal",
+        "mb/mb/_data/books/acme-fixture.journal",
+    ):
+        assert books_mod._has_fixture_marker(repo_root / rel), rel
+
+
+def test_bundled_fixture_matches_docs_fixture() -> None:
+    """The packaged journal is a byte-identical mirror of the docs copy."""
+    repo_root = Path(__file__).resolve().parents[2]
+    docs_bytes = (repo_root / "docs/examples/books/acme-fixture.journal").read_bytes()
+    pkg_bytes = (repo_root / "mb/mb/_data/books/acme-fixture.journal").read_bytes()
+    assert docs_bytes == pkg_bytes, (
+        "mb/mb/_data/books/acme-fixture.journal has drifted from "
+        "docs/examples/books/acme-fixture.journal. Re-sync them."
+    )


### PR DESCRIPTION
## Summary
- Ships `mb books check`, the first safe surface in the `mb books` command group, per the foundation decision from MAIN-320.
- Read-only checks: bookkeeping policy file + chart of accounts presence, `storage_mode` validation, `.mb/private/` ignore-rule guard, ledger/statement-shaped file detection in tracked content, opt-in `--fixture` validation that shells out to `hledger check`.
- Missing `hledger` is surfaced as a clean `info` finding; base installs continue to work without it.
- Findings carry `audience` and `operator_summary` per the operator GitOps contract from MAIN-310.
- `--json` emits the standard envelope (`mainbranch.books.check.result`).

## Scope
- In: `mb books` Typer subapp; `mb books check` command + module; packaged fake hledger fixture under `mb/mb/_data/books/`; tests; `docs/books.md` updated; CHANGELOG entry.
- Out: Mercury / provider imports, scheduled sync, month close, P&L / balance sheet / cashflow reports from real data, private books repo creation, team permission automation, the hledger decision itself, the engine-code migration named in MAIN-320 (`mb connect` provider rename, educational doc rename, init.py gitignore additions), the `mb books status` / `mb books doctor` siblings.

## Commits
- `8d84b6e` — [add] mb books command group with mb books check (MAIN-321)
- `39c7547` — [add] Tests for mb books check (MAIN-321)
- `3e8d812` — [docs] Document shipped mb books check surface (MAIN-321)

## Release / Issues
- Release: Unreleased (next package release).
- Linear ID(s): MAIN-321.
- Closes: #486.
- Refs: #483 (foundation), #128.
- Follow-ups: engine-code migration named in MAIN-320; `mb books status` and `mb books doctor` siblings.

## Success Metric
An operator in a business repo can run `mb books check` and get accurate, actionable findings about books policy, the private books vault ignore rule, and ledger/statement leaks — without hledger needing to be installed for the base check to work.

## Validation
- Level 0 docs/decision: `docs/books.md` updated from "planned" to shipped framing; CHANGELOG entry under `[Unreleased]`.
- Level 1 static: `scripts/check.sh` passes (`All checks passed!`, 542 tests, coverage 82.96%).
- Level 2 CLI: 14 focused tests in `mb/tests/test_books.py` — JSON envelope shape, exit codes, audience/operator_summary on findings, hledger-missing path, monkeypatched fixture validation, engine-fixture path skip.
- Level 3 package/install: not run — no packaging, first-run, skill discovery, or update path changes. Bundled fixture is reachable via `importlib.resources` with a dev-mode fallback.
- Level 4 fixture repo: not required — no scaffolding changes.
- Level 5 runtime smoke: not required — no skill or runtime changes.

## Public / Private Boundary
Clean. No member data, no Devon-local paths, no private launch detail. The bundled fixture is the same fictional `Acme Fixture Inc.` ledger that already ships under `docs/examples/books/`.