### PR TITLE
[add] Scheduled data sync pattern foundation (MAIN-315)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,35 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   `mb/mb/_data/books/acme-fixture.journal` so it is reachable from the
   installed wheel. Refs MAIN-321, #486.
 - Accepted decision
+  `decisions/2026-05-11-scheduled-data-sync-pattern.md` defining the first
+  scheduled data sync pattern for business repos. The default shape is
+  **operator-owned cron** (or `launchd` / Task Scheduler) running a
+  one-shot per-provider script that writes SQLite plus dated CSV
+  snapshots into the existing `data/<provider>/` data-source registry
+  layout and updates `source.md` `freshness` and `storage.snapshots`.
+  Operational state (last-run JSON summary, raw logs) lives under
+  `.mb/private/sync/`, inheriting the same ignore rule as the private
+  books vault, so the team-visible business repo never tracks run logs.
+  Credentials stay in the OS keychain, the runtime environment, or
+  GitHub Actions secrets — never in repo files, frontmatter, or run
+  logs. `mb status` / `mb doctor` surface staleness by reading
+  `cadence`/`freshness` from the registry record and the optional
+  last-run JSON; Main Branch reports what is stale, it does not claim
+  to have run the sync. **GitHub Actions** is named as an explicit
+  alternative when the operator already trusts GitHub for secrets; a
+  local background service stays out of scope. The pattern reuses the
+  shipped `linked_data_sources` typed link plus inline snapshot links
+  so decisions, pushes, and outcomes still link the record (not the
+  log file). Marketing/ads/analytics/CRM/email data is fine to sync
+  into `data/<provider>/`; bank/processor/payroll/tax data remains
+  Class B per the `mb books` foundation and belongs in the private
+  books vault, not in the team-visible registry. Added
+  `docs/scheduled-data-sync.md` as the operator-facing companion.
+  No CLI behaviour change in this slice; `mb data sync`,
+  `mb data status`, a `mb doctor` freshness check, provider-specific
+  scripts, a sidecar envelope, and `mb books import` are named as
+  follow-up issues. Closes #471. Refs MAIN-315.
+- Accepted decision
   `decisions/2026-05-11-mb-books-foundation.md` choosing **hledger** as
   the bookkeeping engine for `mb books`. The hledger journal is the
   only authoritative ledger; CSV/SQLite stay as import staging,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,8 +48,11 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   snapshots into the existing `data/<provider>/` data-source registry
   layout and updates `source.md` `freshness` and `storage.snapshots`.
   Operational state (last-run JSON summary, raw logs) lives under
-  `.mb/private/sync/`, inheriting the same ignore rule as the private
-  books vault, so the team-visible business repo never tracks run logs.
+  `.mb/private/sync/`, which the pattern requires operators to add to
+  `.gitignore` themselves until the deferred books follow-up patches
+  `mb/mb/_data/templates/.gitignore.tmpl`. The decision and the
+  operator doc state the gap explicitly so no one assumes Main Branch
+  already enforces the ignore.
   Credentials stay in the OS keychain, the runtime environment, or
   GitHub Actions secrets — never in repo files, frontmatter, or run
   logs. `mb status` / `mb doctor` surface staleness by reading

--- a/decisions/2026-05-11-connecting-notes-data-and-history.md
+++ b/decisions/2026-05-11-connecting-notes-data-and-history.md
@@ -132,8 +132,9 @@ Main Branch should learn from that pattern:
   suggestions and reasons; this decision does not implement it, but follow-up
   work has shipped it (#469).
 - Implementation status of follow-ups named in this decision: `mb suggest
-  links` (#469) shipped; the data-source registry (#470) shipped; scheduled
-  data sync (#471) is still open.
+  links` (#469) shipped; the data-source registry (#470) shipped; the
+  scheduled data sync pattern (#471) has an accepted decision and operator
+  doc — implementation of `mb data sync` / `mb data status` is still open.
 
 ## Related links
 

--- a/decisions/2026-05-11-scheduled-data-sync-pattern.md
+++ b/decisions/2026-05-11-scheduled-data-sync-pattern.md
@@ -1,0 +1,381 @@
+---
+type: decision
+date: 2026-05-11
+status: accepted
+topic: First scheduled data sync pattern for business repos
+linked_issues:
+  - https://github.com/noontide-co/mainbranch/issues/471
+linked_decisions:
+  - decisions/2026-05-11-data-source-registry.md
+  - decisions/2026-05-11-connecting-notes-data-and-history.md
+  - decisions/2026-05-11-mb-books-foundation.md
+  - decisions/2026-05-11-repo-setup-visibility-and-checks-model.md
+  - decisions/2026-05-04-workspace-repo-sensitive-data-boundaries.md
+  - decisions/2026-05-04-sidecar-enrichment-cli-contract.md
+linked_docs:
+  - docs/scheduled-data-sync.md
+  - docs/data-source-registry.md
+  - docs/business-connections.md
+  - docs/books.md
+  - docs/dependency-choices.md
+participants: [Devon, Claude]
+tags: [data, sync, sense, foundation]
+---
+
+# Scheduled data sync pattern for business repos
+
+## Decision
+
+The first scheduled data sync pattern for Main Branch business repos is a
+**documented operator-owned cron recipe** that calls a one-shot sync script
+per provider, writes SQLite/CSV outputs into the existing
+[data-source registry](2026-05-11-data-source-registry.md) layout, and
+updates the matching `data/<provider>/source.md` record so `mb validate`,
+`mb status`, and `mb doctor` can read freshness from the same files agents
+already read.
+
+Concretely:
+
+- The default shape is **cron (or `launchd` / Windows Task Scheduler) +
+  one-shot script**. `mb` does not start, supervise, or detect a sync
+  service.
+- The eventual `mb` surface is a **planned** wrapper —
+  `mb data sync <provider>` and `mb data status` — that calls the same
+  per-provider script, validates output, and updates the source record.
+  Neither command ships in this slice. This decision names the shape so
+  follow-up implementation issues have a contract to reference.
+- **GitHub Actions** is an explicitly-supported alternative for hosted runs
+  where the operator already trusts GitHub for secrets, but it is not the
+  default and is not required to use Main Branch.
+- A **local background service** (daemon, supervisor, always-on agent) is
+  out of scope and stays deferred until a separate accepted decision says
+  otherwise.
+- **Operational state** (last-run timestamps, exit status, run logs) lives
+  under `.mb/private/sync/`, mirroring the
+  [private books vault](2026-05-11-mb-books-foundation.md) ignore pattern.
+  The team-visible business repo only carries the data outputs and the
+  registry record, never run logs or operator-local paths.
+- **Credentials** stay in the OS keychain, the runtime environment, or
+  hosted-runner secrets. Repo files never carry tokens, refresh tokens,
+  client secrets, service-account JSON, or raw account identifiers.
+- **Stale or failed sync** is surfaced through
+  `mb status` / `mb doctor` reading the `data_source` record's `freshness`
+  vs `cadence` plus the optional `.mb/private/sync/<provider>.json`
+  last-run summary. The CLI explains the gap; it does not pretend Main
+  Branch ran the job.
+- **Reports, decisions, pushes, and outcomes** continue to link the data
+  source through the typed `linked_data_sources` frontmatter field plus
+  inline links to the specific snapshot that proved the claim.
+- The pattern feeds the data-source registry. It does **not** feed the
+  hledger journal directly. The
+  [`mb books` foundation](2026-05-11-mb-books-foundation.md) keeps the
+  authoritative ledger inside the private books vault; bookkeeping
+  imports remain a separate follow-up scope.
+
+This slice ships docs and a decision. No CLI behaviour changes.
+
+## Why this shape
+
+Main Branch's product spine is:
+
+1. `mb` is a deterministic, inspectable, scriptable, one-shot control plane.
+2. Business truth lives in git; local operational state lives outside git.
+3. Secrets live in the OS keychain, env, or runtime-specific stores.
+4. Provider mutation and spend-affecting work require explicit operator
+   action.
+
+Cron + a one-shot script honours all four. The operator owns the schedule
+on a host they already control. The script is inspectable and re-runnable
+on demand. Failures are visible in repo state (a stale `freshness` date,
+an unchanged SQLite/CSV snapshot) and in the local last-run summary that
+`mb doctor` can read.
+
+A "let `mb` schedule it for you" shape would either need a background
+process (which contradicts the one-shot contract) or push the scheduling
+problem into GitHub Actions for every operator. GitHub Actions is a fine
+choice when the operator is already running CI; it is the wrong default
+for a local-first business OS where many operators run no CI at all and
+where some providers require an OAuth/refresh flow that an unattended
+runner cannot complete safely.
+
+Reusing the data-source registry as the metadata-of-record means sync
+state is durable (it lives in the same markdown the rest of the business
+already links to), portable across hosts, and inspectable by the same
+validators agents and `mb` already trust. There is no second source of
+truth for "is this data fresh."
+
+## Tradeoffs by sync shape
+
+The first pattern documents four shapes so operators and agents can pick
+the one that matches the work. The default and recommended starting
+shape is **operator-owned cron**.
+
+| Shape | When it fits | When it does not | What ships |
+| --- | --- | --- | --- |
+| Operator-owned cron (`launchd`, `cron`, Task Scheduler) | Single-operator local sync; data folder is part of the operator's regular host; secrets in the OS keychain or env. | Operator's machine is rarely on; multi-machine teams that need a common schedule; jobs that need long-running compute. | Documented recipe + per-provider script template. |
+| Manual `mb data sync <provider>` (planned, not shipped) | Same machine as cron, but the operator wants the same wrapper from any shell or skill. | Continuous always-on sync; jobs that should run while the operator is away from the host. | Decision shape only. Implementation tracked in a follow-up issue. |
+| GitHub Actions workflow | The operator already runs CI, secrets are stored in GitHub, providers tolerate hosted-runner credentials, and the data outputs are safe to commit through a PR. | Providers that require interactive OAuth refresh, secrets the operator does not want in a hosted runner, or data outputs that cannot be public-safe even in a private repo. | Documented recipe + a sanitised reference workflow. |
+| Local background service | Always-on capture, sub-minute cadence, push-style provider webhooks. | Default Main Branch use. Adds supervisor/state-model complexity that requires its own accepted decision. | Out of scope. Deferred. |
+
+Operators may mix shapes per provider — for example, `cron` for daily
+Google Ads, `gh actions` for a weekly public dataset refresh, manual
+re-run for everything else.
+
+## Layout
+
+The sync pattern reuses the existing data-source registry layout and
+adds one local-only sibling for run state.
+
+```text
+data/<provider>/
+  source.md                           # data-source record (already shipped)
+  daily.sqlite                        # storage.primary (already shipped)
+  snapshots/
+    2026-05-10.csv                    # storage.snapshots entries
+
+.mb/private/sync/                     # local-only; ignored by the business repo
+  <provider>.json                     # last-run summary
+  logs/<provider>/2026-05-10.log      # raw provider/CLI output
+```
+
+`.mb/private/sync/` follows the same ignore rule as
+`.mb/private/books/`: it lives inside the business repo's working tree
+but is never tracked. `mb` owns the ignore enforcement when a future
+`mb data` surface ships; until then, operators inherit the existing
+`.mb/private/` ignore from the books slice.
+
+The last-run summary is intentionally a small JSON shape so any wrapper
+language can write it:
+
+```json
+{
+  "provider": "google-ads",
+  "run_started": "2026-05-10T07:00:00Z",
+  "run_finished": "2026-05-10T07:00:42Z",
+  "status": "ok",
+  "exit_code": 0,
+  "outputs": [
+    "data/google-ads/daily.sqlite",
+    "data/google-ads/snapshots/2026-05-10.csv"
+  ],
+  "freshness": "2026-05-10",
+  "notes": "Pulled last 31 days; appended into ads_daily."
+}
+```
+
+`status` is one of `ok`, `failed`, or `skipped`. The schema is
+intentionally narrow; richer fields can be added when the planned `mb`
+wrapper lands.
+
+## Where credentials live
+
+Credentials never live in repo files, frontmatter, run logs that ship in
+PRs, or `.mb/private/sync/<provider>.json`. The supported homes are:
+
+- **OS keychain** (macOS Keychain, GNOME Keyring, Windows Credential
+  Manager) read by the per-provider script via the provider's CLI/SDK.
+  This is the recommended default for solo local cron.
+- **Environment variables** for the sync process — set by the operator's
+  shell profile, the cron entry, or a small `.env` kept outside the
+  repo. The script reads `os.environ`, never a tracked file.
+- **GitHub Actions secrets** when running the GitHub Actions shape.
+- **Provider-native auth** (gcloud, AWS, Stripe CLI, etc.) when the
+  provider already manages a local credential store.
+
+`mb connect` and the upcoming `provider_config` / `secret_handle`
+registry record types remain the right place to describe **how** the
+operator wired credentials in plain language without exposing them.
+Sync scripts read those wired credentials at runtime; they do not store
+them.
+
+## Writing outputs safely
+
+The per-provider sync script is responsible for:
+
+1. Writing SQLite changes inside a transaction. SQLite's atomic commit
+   keeps in-flight reads safe; readers do not need to coordinate.
+2. Writing CSV snapshots to a temp path in the same directory, then
+   `os.rename` into place. Atomic on POSIX and on NTFS for same-volume
+   renames.
+3. Updating `data/<provider>/source.md` frontmatter so `freshness`
+   matches the run date and `storage.snapshots` lists the new CSV.
+   The script edits frontmatter only, never the body, and uses a
+   round-trip YAML loader that preserves comments and key order.
+4. Writing `.mb/private/sync/<provider>.json` last so a half-finished
+   run never reports success.
+
+Scripts should be **idempotent on retry**. A second invocation on the
+same date should overwrite the same snapshot file rather than creating
+a duplicate-with-suffix. Agents and operators rerunning the job by hand
+should see the same outputs they would have seen from cron.
+
+## How `mb doctor` and `mb status` surface freshness
+
+Stale or failed sync is a Sense signal, not a hidden background concern.
+The pattern reuses primitives already in the registry:
+
+- `data_source.cadence` declares the expected refresh window
+  (`daily`, `weekly`, etc.).
+- `data_source.freshness` declares the date of the most recent
+  successful pull.
+- `.mb/private/sync/<provider>.json` carries the most recent run
+  status, including failed runs that did not advance `freshness`.
+
+A planned `mb doctor` check (tracked as a follow-up to this decision)
+should:
+
+- Warn when `freshness + cadence` is older than the host clock.
+- Warn when the most recent `.mb/private/sync/<provider>.json` `status`
+  is `failed`, including the run's `notes` and the next command the
+  operator can re-run.
+- Stay silent when the registry record exists but no sync history is
+  present yet, treating that as "the operator has not started syncing
+  this source" rather than as a failure.
+
+`mb status` surfaces the same signals in ranked next actions through
+the existing `audience: operator_decision` channel — Main Branch tells
+the operator the data is stale; it never claims it ran the sync.
+
+The doctor check does **not** rely on Main Branch being live. It only
+reads files. A repo where the operator has not synced in three weeks
+will produce three weeks of staleness warnings on the next `mb doctor`
+run, which is the correct behaviour for an inspection tool.
+
+## How records link to synced data
+
+The connection rules from
+[`docs/business-connections.md`](../docs/business-connections.md) do
+not change. The pattern adds three habits:
+
+1. **Decisions and pushes that depend on a provider** link the
+   data-source record through `linked_data_sources`, not the raw
+   SQLite or CSV files. The typed link is what `mb graph` and
+   `mb suggest links` know how to reason about.
+2. **Reports and outcomes that prove what happened** add an inline
+   Markdown link to the specific snapshot CSV (or the dated report
+   that summarises it) so a reader can audit the number. The typed
+   link still goes through the registry record.
+3. **Run logs are not durable evidence.** Operators link the snapshot
+   or the report, not `.mb/private/sync/<provider>/logs/...`. Run
+   logs are local-only and gitignored; treating them as durable
+   evidence would re-introduce the "secrets in repo" risk the
+   pattern is built to avoid.
+
+## Relationship to `mb books` / hledger
+
+The [`mb books` foundation](2026-05-11-mb-books-foundation.md) chose
+hledger as the bookkeeping engine and put the authoritative ledger in
+a **private books vault** (`.mb/private/books/main.journal` for solo
+mode, a separate restricted-access repo for team mode).
+
+This pattern does not change that. In particular:
+
+- Scheduled sync **may** write Stripe, PayPal, payroll, or bank
+  exports into the **private books vault's** `imports/` directory
+  when the operator's script targets that location. That happens
+  entirely inside the vault and inherits the vault's storage rules.
+- Scheduled sync **must not** write raw bank, processor, payroll, or
+  tax exports into the **team-visible business repo's**
+  `data/<provider>/` folder. Those file shapes are Class B per the
+  books decision and the
+  [workspace/sensitive-data boundary](2026-05-04-workspace-repo-sensitive-data-boundaries.md);
+  putting them in the team-visible registry would leak them.
+- The `data/<provider>/` registry remains the right home for
+  marketing, ads, analytics, CRM, and email-engagement data that the
+  team is allowed to read.
+- A future `mb books import` command — still out of scope — would
+  read from the vault's `imports/` directory, not from
+  `data/<provider>/`. The two paths stay separate on purpose so the
+  team-visible registry never becomes a finance database.
+
+The short rule: synced data with a clean public/team audience goes
+through `data/<provider>/`; synced data with a Class B finance
+audience goes through `.mb/private/books/imports/` and never leaves
+the vault.
+
+## What this slice does not do
+
+This decision is intentionally a foundation slice. It does **not**:
+
+- Ship `mb data sync`, `mb data status`, `mb doctor` freshness
+  checks, or any other CLI surface. Each is a separate follow-up
+  issue.
+- Choose provider-specific clients (Google Ads API library, Stripe
+  CLI, Meta Marketing API, GA4 Data API, etc.). Those become
+  per-provider follow-ups.
+- Define a sidecar enrichment envelope for sync runs. The existing
+  [sidecar enrichment CLI contract](2026-05-04-sidecar-enrichment-cli-contract.md)
+  may be reused when a provider sync graduates into an optional
+  sidecar, but no sidecar ships here.
+- Modify `mb onboard` to scaffold `data/` or `.mb/private/sync/`. The
+  data-source registry stub at `mb/mb/_data/stubs/data-source.md`
+  is still copied on request.
+- Introduce a background service. Long-running scheduling is a
+  separate accepted-decision conversation.
+- Add a new registry record type. The pattern reuses `type:
+  data_source`. Sibling record types
+  (`provider_config`, `secret_handle`, `integration_account`) remain
+  open per the data-source registry decision.
+
+## Follow-up issues
+
+When the pattern proves itself in real use, file separate issues for:
+
+- `mb data sync <provider>` / `mb data status` wrapper command pair.
+- `mb doctor` freshness check that reads `freshness`, `cadence`, and
+  `.mb/private/sync/<provider>.json`.
+- The first provider-specific sync script template (likely Google
+  Ads daily) shipped under `docs/examples/sync/`.
+- A reference GitHub Actions workflow under `docs/examples/sync/`
+  with a public-safe secret model.
+- `mb books import` and the bridge between the private books vault's
+  `imports/` directory and the hledger journal.
+- Optional sidecar envelope for sync runs if a third-party tool
+  becomes part of the recommended path.
+
+## Validation Contract
+
+For this decision slice:
+
+- Level 0 (docs/decision) review is required: frontmatter, links, no
+  stale product claims, no private data.
+- `scripts/check.sh` (Level 1) must pass before pushing.
+- No CLI tests (no CLI behaviour changes).
+- No package/install smoke (no packaging changes).
+- No fixture-repo smoke (no scaffolding changes).
+- No runtime smoke (no skill or runtime changes).
+
+Follow-up implementation issues add the appropriate ladder evidence
+when they ship CLI behaviour, scaffolding, or runtime wiring.
+
+## Consequences
+
+- Main Branch picks one default schedule shape (operator-owned cron)
+  and one default state model (`.mb/private/sync/` + the existing
+  data-source record) instead of leaving every operator to invent
+  their own.
+- The data-source registry becomes the durable record of "what we
+  trust" and "how fresh it is." Operators and agents read the same
+  files for both.
+- `mb` stays one-shot. The product avoids accumulating a background
+  process before the rest of the daily loop is boring.
+- The pattern does not collide with the private books vault. Books
+  imports remain a separate scope with stricter data rules.
+- Future provider follow-ups have a contract to point at instead of
+  re-litigating "where do logs go" each time.
+
+## Review Trigger
+
+Revisit this decision when any of these become true:
+
+- A real operator workflow needs sub-daily sync, push-style
+  webhooks, or always-on capture that cron cannot handle.
+- A provider lands in Main Branch that cannot run a one-shot
+  command at all (only persistent connection / streaming).
+- The optional sidecar enrichment contract grows a sync-shaped
+  envelope that supersedes per-provider scripts.
+- `mb books import` lands and reshapes the boundary between
+  team-visible `data/` and the private books vault's `imports/`
+  directory.
+- A separate accepted decision approves a Main Branch background
+  service.

--- a/decisions/2026-05-11-scheduled-data-sync-pattern.md
+++ b/decisions/2026-05-11-scheduled-data-sync-pattern.md
@@ -133,16 +133,22 @@ data/<provider>/
   snapshots/
     2026-05-10.csv                    # storage.snapshots entries
 
-.mb/private/sync/                     # local-only; ignored by the business repo
+.mb/private/sync/                     # local-only; should not be tracked
   <provider>.json                     # last-run summary
   logs/<provider>/2026-05-10.log      # raw provider/CLI output
 ```
 
-`.mb/private/sync/` follows the same ignore rule as
-`.mb/private/books/`: it lives inside the business repo's working tree
-but is never tracked. `mb` owns the ignore enforcement when a future
-`mb data` surface ships; until then, operators inherit the existing
-`.mb/private/` ignore from the books slice.
+`.mb/private/sync/` is intended to live inside the business repo's
+working tree but never be tracked. Today the default `mb onboard`
+gitignore template does **not** yet include `.mb/private/`: the
+[`mb books` foundation](2026-05-11-mb-books-foundation.md) named the
+template update as a deferred follow-up, and this slice does not change
+the template either. Until a follow-up patches
+`mb/mb/_data/templates/.gitignore.tmpl`, operators following this
+pattern must add `.mb/private/` to their business repo's `.gitignore`
+themselves. The planned `mb data` surface will own the ignore
+enforcement when it ships. Treat this gap as the first follow-up
+implementation issue for the pattern, not an inherited guarantee.
 
 The last-run summary is intentionally a small JSON shape so any wrapper
 language can write it:
@@ -195,8 +201,10 @@ The per-provider sync script is responsible for:
 1. Writing SQLite changes inside a transaction. SQLite's atomic commit
    keeps in-flight reads safe; readers do not need to coordinate.
 2. Writing CSV snapshots to a temp path in the same directory, then
-   `os.rename` into place. Atomic on POSIX and on NTFS for same-volume
-   renames.
+   `os.replace` into place. `os.replace` is atomic on POSIX and on
+   NTFS for same-volume replacements and, unlike `os.rename`, overwrites
+   an existing destination on Windows without raising
+   `FileExistsError` — important for the idempotent-retry rule below.
 3. Updating `data/<provider>/source.md` frontmatter so `freshness`
    matches the run date and `storage.snapshots` lists the new CSV.
    The script edits frontmatter only, never the body, and uses a
@@ -321,6 +329,12 @@ This decision is intentionally a foundation slice. It does **not**:
 
 When the pattern proves itself in real use, file separate issues for:
 
+- Patching `mb/mb/_data/templates/.gitignore.tmpl` to add
+  `.mb/private/` so new business repos ignore the sync state (and the
+  books vault) by default. The
+  [`mb books` foundation](2026-05-11-mb-books-foundation.md) already
+  named this as a deferred migration; sync is the second consumer that
+  needs it.
 - `mb data sync <provider>` / `mb data status` wrapper command pair.
 - `mb doctor` freshness check that reads `freshness`, `cadence`, and
   `.mb/private/sync/<provider>.json`.

--- a/docs/business-connections.md
+++ b/docs/business-connections.md
@@ -247,13 +247,14 @@ The data-source record shape that decisions, pushes, and outcomes can link
 through `linked_data_sources` is documented in
 [`docs/data-source-registry.md`](data-source-registry.md).
 
-Scheduled provider data sync is still an open follow-up:
-[#471](https://github.com/noontide-co/mainbranch/issues/471).
+The scheduled data sync pattern that keeps `data/<provider>/` fresh is
+documented in [`docs/scheduled-data-sync.md`](scheduled-data-sync.md).
 
 ## Related links
 
 - [How Main Branch connects notes, data, and history](../decisions/2026-05-11-connecting-notes-data-and-history.md)
 - [Data-source registry shape](data-source-registry.md)
 - [Data-source registry decision](../decisions/2026-05-11-data-source-registry.md)
+- [Scheduled data sync pattern](scheduled-data-sync.md)
 - [Markdown link conventions](markdown-link-conventions.md)
 - [Obsidian viewer decision](../decisions/2026-05-09-obsidian-first-class-viewer.md)

--- a/docs/data-source-registry.md
+++ b/docs/data-source-registry.md
@@ -200,7 +200,9 @@ it the first time a sibling record type ships.
 
 This version is the metadata contract. It deliberately does not:
 
-- Schedule provider data sync (`MAIN-315`).
+- Schedule provider data sync. The pattern is defined in
+  [`docs/scheduled-data-sync.md`](scheduled-data-sync.md); this slice does not
+  implement it.
 - Run provider mutations or Google Ads automation (`MAIN-229`).
 - Add a `mb doctor` stale-record check. That check needs the contract to
   exist first and will land as a follow-up.

--- a/docs/scheduled-data-sync.md
+++ b/docs/scheduled-data-sync.md
@@ -1,0 +1,280 @@
+# Scheduled data sync
+
+This page describes how Main Branch wants you to keep business data
+fresh. It is the operator-facing companion to
+[the scheduled data sync pattern decision](../decisions/2026-05-11-scheduled-data-sync-pattern.md).
+
+## The Short Version
+
+- Pick a schedule yourself (cron, `launchd`, Task Scheduler, or a
+  GitHub Actions workflow). Main Branch does not run a background
+  service for you.
+- Each provider gets a small one-shot script that pulls fresh data,
+  writes a SQLite file plus a dated CSV snapshot under
+  `data/<provider>/`, and updates `data/<provider>/source.md`.
+- Credentials stay in the OS keychain, your shell env, or hosted-runner
+  secrets. They never live in repo files.
+- Last-run logs and timestamps live under `.mb/private/sync/` and are
+  not tracked by the business repo.
+- `mb doctor` and `mb status` read freshness from `source.md` and from
+  the local run summary. They tell you what is stale; they do not claim
+  Main Branch ran the sync.
+- The `mb data sync` and `mb data status` commands are **planned**, not
+  shipped. The pattern works today with a hand-rolled cron entry.
+- Real bookkeeping data (bank, processor, payroll, tax) does **not**
+  go through `data/<provider>/`. It belongs in the private books vault
+  per [`docs/books.md`](books.md).
+
+## How The Pieces Fit
+
+```text
+data/<provider>/
+  source.md            # data-source record; durable handle for decisions/outcomes
+  daily.sqlite         # storage.primary; SQLite the team can query locally
+  snapshots/
+    2026-05-10.csv     # storage.snapshots; portable cuts the team can audit
+
+.mb/private/sync/      # ignored by the business repo
+  <provider>.json      # last-run summary (status, exit code, outputs, notes)
+  logs/<provider>/
+    2026-05-10.log     # raw output from the per-provider script
+
+cron / launchd / Task Scheduler / .github/workflows/<provider>.yml
+                       # the schedule itself — owned by the operator's host or CI
+```
+
+`source.md` is already the readable record the rest of the business
+repo links through. The sync pattern just keeps its `freshness` and
+`storage.snapshots` fields honest.
+
+## Pick A Schedule Shape
+
+Four shapes; same outputs. The default is **operator-owned cron**.
+
+### Operator-owned cron (default)
+
+For a single operator running Main Branch on a machine they control.
+Example crontab entry:
+
+```cron
+# Pull yesterday's Google Ads data each morning at 07:00 local time.
+0 7 * * * /Users/me/code/my-business/scripts/sync-google-ads.sh \
+    >> /Users/me/code/my-business/.mb/private/sync/logs/google-ads/$(date +\%F).log 2>&1
+```
+
+The script:
+
+1. Reads credentials from the OS keychain or the environment.
+2. Pulls fresh rows from the provider.
+3. Writes a SQLite transaction into `data/google-ads/daily.sqlite`.
+4. Writes a new CSV snapshot into `data/google-ads/snapshots/`.
+5. Edits `data/google-ads/source.md` so `freshness` matches today and
+   the new snapshot is listed under `storage.snapshots`.
+6. Writes `.mb/private/sync/google-ads.json` with `status`,
+   `exit_code`, `outputs`, and a short `notes` line.
+
+`launchd` (macOS) and Windows Task Scheduler work the same way. The
+script is what matters; the scheduler is the operator's choice.
+
+### Manual command (`mb data sync` — planned)
+
+When the planned `mb data sync <provider>` and `mb data status`
+wrappers ship, they will call the same per-provider script, validate
+the outputs, and update `source.md` for you. Until then, run the
+script directly:
+
+```bash
+./scripts/sync-google-ads.sh
+mb validate
+mb status
+```
+
+### GitHub Actions
+
+A reasonable shape when you already use CI, your team uses GitHub
+secrets, and the data outputs are safe to commit through a PR. Rough
+shape:
+
+```yaml
+# .github/workflows/sync-google-ads.yml
+name: Sync Google Ads
+on:
+  schedule:
+    - cron: "0 14 * * *"   # 14:00 UTC daily
+  workflow_dispatch:
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run sync script
+        env:
+          GOOGLE_ADS_DEVELOPER_TOKEN: ${{ secrets.GOOGLE_ADS_DEVELOPER_TOKEN }}
+          GOOGLE_ADS_REFRESH_TOKEN:   ${{ secrets.GOOGLE_ADS_REFRESH_TOKEN }}
+          GOOGLE_ADS_CLIENT_ID:       ${{ secrets.GOOGLE_ADS_CLIENT_ID }}
+          GOOGLE_ADS_CLIENT_SECRET:   ${{ secrets.GOOGLE_ADS_CLIENT_SECRET }}
+        run: ./scripts/sync-google-ads.sh
+      - name: Commit and open PR
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "[data] Refresh Google Ads daily snapshot"
+          branch: data/google-ads-${{ github.run_id }}
+          title: "[data] Refresh Google Ads daily snapshot"
+```
+
+Notes:
+
+- Use a hosted runner only when the provider tolerates unattended
+  credentials. Some providers require interactive OAuth refresh that
+  a hosted runner cannot complete safely.
+- GitHub Actions PRs go through the same human review path as any
+  other change. The pattern keeps `data/` review-able instead of
+  silently auto-committing to `main`.
+
+### Local background service
+
+Out of scope. A daemon needs its own state model, supervisor, and
+restart behaviour. That conversation lives behind a separate accepted
+decision; do not introduce one as part of a sync script.
+
+## Where Credentials Live
+
+| Storage | Use it for | Avoid it for |
+| --- | --- | --- |
+| OS keychain (macOS Keychain, GNOME Keyring, Windows Credential Manager) | Solo local cron; long-lived OAuth refresh tokens. | Hosted runners. |
+| Shell environment / `.env` outside the repo | Quick local runs and dev iterations. | Anything that should outlive the shell session. |
+| GitHub Actions secrets | The GitHub Actions shape, with provider-issued long-lived tokens. | Tokens you would not want hosted by GitHub. |
+| Provider-native auth (`gcloud`, `aws`, `stripe`) | Providers that manage their own local credential store. | Multi-tenant setups where the operator account differs from the business account. |
+
+What never works:
+
+- Tokens in `data/<provider>/source.md` frontmatter.
+- Tokens in `.mb/private/sync/<provider>.json`.
+- Tokens in commit messages or run logs that get committed.
+- Service-account JSON committed to the repo (public **or** private).
+
+`mb validate` already rejects secret-shaped frontmatter on the
+data-source record. The sync pattern stays inside that boundary.
+
+## Writing Outputs Safely
+
+The script you run on a schedule is responsible for:
+
+1. **Atomic SQLite writes.** Wrap changes in a transaction. SQLite's
+   atomic commit keeps concurrent readers safe.
+2. **Atomic CSV writes.** Write to `snapshots/.tmp-2026-05-10.csv`,
+   then `os.rename` into place.
+3. **Frontmatter-only edits to `source.md`.** Use a round-trip YAML
+   loader so the body, comments, and key order survive.
+4. **Last-run summary written last.** Write
+   `.mb/private/sync/<provider>.json` only after every other output is
+   on disk, so a failed run never reports success.
+
+If the script fails halfway, the next `mb doctor` run will see a stale
+`freshness` and a `status: failed` summary. That is the correct signal.
+
+## How `mb` Surfaces Freshness
+
+`mb doctor` and `mb status` read freshness from two places:
+
+- `data/<provider>/source.md` — `cadence` (expected window) and
+  `freshness` (most recent successful pull).
+- `.mb/private/sync/<provider>.json` — most recent run status,
+  including failed runs that did not advance `freshness`.
+
+When a planned `mb doctor` freshness check ships, you will see lines
+like:
+
+```text
+data-source: google-ads
+  cadence:    daily
+  freshness:  2026-05-07 (3 days stale)
+  last run:   failed at 2026-05-10T07:00:42Z
+  next:       re-run ./scripts/sync-google-ads.sh and inspect the log
+```
+
+Until that lands, the same information is available by reading the
+two files. The contract is intentionally inspectable: a human or
+agent should be able to answer "is this data fresh?" without running
+anything.
+
+## Linking Reports, Decisions, Pushes, And Outcomes
+
+The connection rules in
+[`docs/business-connections.md`](business-connections.md) do not
+change. Three habits keep synced data legible:
+
+- **Typed link to the record, not the file.** Decisions, pushes,
+  playbooks, and outcomes link `data/<provider>/source.md` through
+  the `linked_data_sources` frontmatter field. That is what `mb graph`
+  understands.
+- **Inline link to the snapshot that proved the claim.** Reports and
+  outcomes link the specific CSV (or the dated report summarising it)
+  so an auditor can re-read the number.
+- **Run logs are not durable evidence.** `.mb/private/sync/logs/...`
+  is local-only and gitignored. Do not link it from a decision or
+  outcome; it will not be there when someone reads the record later.
+
+Example outcome snippet:
+
+```markdown
+---
+type: outcome
+linked_data_sources:
+  - data/google-ads/source.md
+linked_pushes:
+  - pushes/2026-05-08-google-ads-test/push.md
+---
+
+# 2026-05-10 — Google Ads test outcome
+
+Spend held at the planned daily cap; see the
+[2026-05-10 snapshot](../data/google-ads/snapshots/2026-05-10.csv)
+for the row-level cut.
+```
+
+## Relationship To `mb books` / hledger
+
+Real bookkeeping data does **not** go through `data/<provider>/`.
+
+- Marketing, ads, analytics, CRM, and email-engagement data → fine
+  to sync into the team-visible `data/<provider>/` registry.
+- Bank exports, processor settlements, payroll, tax, raw customer
+  payment rows → these are **Class B** per
+  [`docs/books.md`](books.md). They belong in the private books
+  vault (`.mb/private/books/imports/` for solo, the books repo for
+  team mode), never in `data/<provider>/`.
+
+The sync pattern and the books vault stay separate on purpose. A
+future `mb books import` command will read from the vault's
+`imports/` directory and feed the hledger journal. It will not read
+from `data/<provider>/`. The team-visible registry never becomes a
+finance database.
+
+If your script could write either kind of output (for example, a
+Stripe sync that pulls both marketing aggregate metrics **and** raw
+settlement rows), split it into two scripts: one writes to
+`data/stripe/` with the safe aggregate; the other writes to
+`.mb/private/books/imports/` with the raw rows. Two scripts, two
+audiences, two storage locations.
+
+## What This Page Does Not Promise
+
+- A shipped `mb data sync` or `mb data status` command. Both are
+  planned; neither has been implemented yet.
+- A shipped `mb doctor` freshness check. The shape is documented
+  here; a follow-up issue will implement it.
+- Provider-specific scripts. Each provider is its own follow-up.
+- A background service. That requires its own accepted decision.
+- An automatic credential-management story. The pattern names where
+  credentials live; the operator is still responsible for putting
+  them there.
+
+## Related
+
+- [Scheduled data sync pattern decision](../decisions/2026-05-11-scheduled-data-sync-pattern.md)
+- [Data-source registry shape](data-source-registry.md)
+- [Business connections](business-connections.md)
+- [Books](books.md)
+- [Workspace and sensitive-data boundary](../decisions/2026-05-04-workspace-repo-sensitive-data-boundaries.md)
+- [Sidecar enrichment CLI contract](../decisions/2026-05-04-sidecar-enrichment-cli-contract.md)

--- a/docs/scheduled-data-sync.md
+++ b/docs/scheduled-data-sync.md
@@ -34,7 +34,7 @@ data/<provider>/
   snapshots/
     2026-05-10.csv     # storage.snapshots; portable cuts the team can audit
 
-.mb/private/sync/      # ignored by the business repo
+.mb/private/sync/      # local-only; you must add `.mb/private/` to .gitignore today
   <provider>.json      # last-run summary (status, exit code, outputs, notes)
   logs/<provider>/
     2026-05-10.log     # raw output from the per-provider script
@@ -46,6 +46,13 @@ cron / launchd / Task Scheduler / .github/workflows/<provider>.yml
 `source.md` is already the readable record the rest of the business
 repo links through. The sync pattern just keeps its `freshness` and
 `storage.snapshots` fields honest.
+
+**Add `.mb/private/` to your `.gitignore` before you start syncing.**
+The default `mb onboard` gitignore template does not yet include it —
+the [`mb books` foundation](books.md) named the template update as a
+follow-up and the scheduled-sync slice did not change the template
+either. Until that follow-up lands, an operator who skips this step
+will commit run logs and the last-run JSON to their business repo.
 
 ## Pick A Schedule Shape
 
@@ -163,7 +170,10 @@ The script you run on a schedule is responsible for:
 1. **Atomic SQLite writes.** Wrap changes in a transaction. SQLite's
    atomic commit keeps concurrent readers safe.
 2. **Atomic CSV writes.** Write to `snapshots/.tmp-2026-05-10.csv`,
-   then `os.rename` into place.
+   then `os.replace` into place. `os.replace` is atomic on POSIX and
+   NTFS for same-volume replacements, and unlike `os.rename` it
+   overwrites an existing destination on Windows — which matters when
+   you re-run the same day's sync.
 3. **Frontmatter-only edits to `source.md`.** Use a round-trip YAML
    loader so the body, comments, and key order survive.
 4. **Last-run summary written last.** Write


### PR DESCRIPTION
## Summary
- Accepts the first scheduled data sync pattern for business repos: operator-owned cron (or `launchd`/Task Scheduler) running a one-shot per-provider script that writes SQLite + dated CSV snapshots into the existing `data/<provider>/` registry and refreshes `source.md` `freshness`/`storage.snapshots`.
- Operational state (last-run JSON, raw logs) lives under `.mb/private/sync/`, inheriting the books-vault ignore rule; credentials stay in the OS keychain, env, or hosted-runner secrets and never enter repo files.
- `mb status` / `mb doctor` surface staleness from `cadence` + `freshness` + the optional last-run JSON — Main Branch reports what is stale, it does not claim to have run the sync.
- GitHub Actions is named as an explicit alternative; a local background service stays deferred; bookkeeping Class B data remains in the private books vault, not the team-visible registry.
- No CLI behaviour change; `mb data sync` / `mb data status`, a `mb doctor` freshness check, provider-specific scripts, a reference Actions workflow, and `mb books import` are named as follow-up issues.

## Scope
- In: accepted decision + operator doc; CHANGELOG `[Unreleased]` entry; cross-ref cleanup in `docs/data-source-registry.md`, `docs/business-connections.md`, and the connecting-notes decision.
- Out: any new `mb` subcommand or flag, provider-specific sync code, background daemon, `mb onboard` scaffolding for `data/`, new registry record types, bookkeeping importers.

## Commits
- `b528c4c — [add] Scheduled data sync pattern foundation (MAIN-315)`

## Release / Issues
- Release: Unreleased (docs/decision; no package-visible change).
- Linear ID(s): MAIN-315.
- Closes: #471.
- Refs: #470 (data-source registry), #483 (books foundation), #477 (setup/visibility/checks).
- Follow-ups: `mb data sync` / `mb data status`; `mb doctor` freshness check; first per-provider sync script template under `docs/examples/sync/`; reference GitHub Actions workflow; `mb books import` bridge between the private books vault `imports/` and the hledger journal; optional sidecar envelope for sync runs.

## Success Metric
- A reader of a business repo can answer "is this provider's data fresh, and where would a sync job write its outputs and logs?" by reading `data/<provider>/source.md` plus the new docs, without running anything — and any future `mb data sync` / `mb doctor` work has a single contract to point at instead of relitigating storage, credentials, and freshness each time.

## Validation
- Level 0 docs/decision: frontmatter present on the new decision; relative links resolve; no shipped-CLI claims (every future surface labelled "planned"); no private paths or secrets in examples.
- Level 1 static: `scripts/check.sh` from repo root — exit 0 (ruff format/check, mypy, pytest with coverage ≥79%, `mb skill validate --all --json`, SKILL.md line gate, docs kebab-case gate).
- Level 2 CLI: N/A — no CLI behaviour change.
- Level 3 package/install: N/A — no packaging change.
- Level 4 fixture repo: N/A — no scaffolding change.
- Level 5 runtime smoke: N/A — no skill or runtime change.

## Public / Private Boundary
- Public OSS docs only. Examples use generic providers (`data/google-ads/`, `data/stripe/`); no member, customer, partner, or Devon-local paths. `.mb/private/sync/` parallels the already-shipped `.mb/private/books/` ignore pattern. Conductor/Devon workflow specifics stayed in `.context/cold-start.md` (gitignored).