### PR TITLE
[update] Prepare 0.3.16 release (MAIN-322)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mainbranch",
-  "version": "0.3.15",
+  "version": "0.3.16",
   "description": "Main Branch Claude Code skills for running a business from markdown files in git.",
   "author": {
     "name": "Noontide"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,54 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+## [0.3.16] - 2026-05-11
+
+v0.3.16 lands the first concrete `mb books` command surface alongside the
+hledger + private books vault foundation, accepts the scheduled data sync
+pattern for business repos, exposes operator vocabulary facts in `mb status`
+and `mb start`, and locks the operator-facing GitOps primitives (`audience` /
+`operator_summary` on findings, workflow awareness on `mb status`). Several
+docs and conventions slices land in the same release: graph link authoring
+guidance, Related links mirror validation and repair, the `mb suggest links`
+command, the first record type in the data-source registry, the business
+connections decision, and a docs architecture / language cleanup pass.
+
+### What this means for you (plain English)
+
+- **First safe books surface.** `mb books check` inspects whether your
+  finance metadata is wired up, warns if ledger or statement files look like
+  they leaked into the team-visible repo, and (with `--fixture`) round-trips
+  a packaged fake hledger journal so you can confirm hledger works on your
+  machine without ever touching real numbers.
+- **Books storage is a clear contract.** hledger is the chosen engine, and
+  real books live in a private books vault — solo-local under
+  `.mb/private/books/` by default, or a separate team-private repo —
+  never in the team-visible business repo.
+- **Scheduled data sync has a documented pattern.** The accepted pattern is
+  operator-owned cron (or `launchd` / Task Scheduler) writing into the
+  existing `data/<provider>/` registry layout, with `mb status` and
+  `mb doctor` reporting freshness from the registry record. No CLI
+  behavior change yet — the foundation is named and follow-ups are tracked.
+- **`mb status` and `mb start` know more about your repo shape.** A
+  `vocabulary` block surfaces optional `core/vocabulary.md` display terms,
+  and the `git` block now carries `workflow_mode`, `default_branch`,
+  `upstream`, `ahead`, `behind`, `worktree_root`, and a one-liner
+  `summary`. Skills and agents can decide save-on-main vs branch-and-PR
+  vs worktree-aware flows without their own git wrappers.
+- **Findings tell you who acts on them.** `mb doctor`, `mb validate`, and
+  `mb status` actions now carry `audience`
+  (`mechanical` / `operator_decision` / `informational`) plus an
+  `operator_summary` so agents can route a fact into business-language
+  next steps. `mb validate` also exposes per-category summaries and a top
+  cluster so messy migrated repos point at the biggest useful fix first.
+- **Link conventions are clearer.** `mb suggest links <file>` ranks
+  candidate relationships with JSON reasons; `mb validate --cross-refs`
+  and `mb doctor repair --plan` keep `## Related links` body mirrors in
+  sync with frontmatter without making body links authoritative; the
+  `type: data_source` record at `data/<provider>/source.md` is the first
+  portable business-facts record and ships with a `linked_data_sources`
+  typed link.
+
 ### Added
 
 - Shipped the first `mb books` surface, `mb books check`, implementing the

--- a/mb/mb/__init__.py
+++ b/mb/mb/__init__.py
@@ -7,6 +7,6 @@ file stays a thin dispatcher.
 
 from __future__ import annotations
 
-__version__ = "0.3.15"
+__version__ = "0.3.16"
 
 __all__ = ["__version__"]

--- a/mb/pyproject.toml
+++ b/mb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mainbranch"
-version = "0.3.15"
+version = "0.3.16"
 description = "Main Branch engine umbrella - scaffolds, validates, and graphs business-as-files repos. Claude Code first, runtime-agnostic by design."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- Bumps `mainbranch` and the `.claude-plugin` manifest from 0.3.15 to 0.3.16 and dates the CHANGELOG section for the release.
- Promotes the `[Unreleased]` entries into `[0.3.16] - 2026-05-11` with a plain-English "What this means for you" intro covering `mb books check`, the hledger + private books vault foundation, the accepted scheduled data sync pattern, operator vocabulary facts in `mb status` / `mb start`, the operator-facing GitOps primitives (`audience` / `operator_summary`, workflow awareness), `mb suggest links`, Related links validate/repair, and the `type: data_source` registry record.

## Scope
- In: version bump in three sites; CHANGELOG promotion; nothing else.
- Out: tagging `oe-v0.3.16`, GitHub Release, PyPI publish, post-publish verification, release-acceptance simulation tier — those belong to the publish step after merge.

## Commits
- 4c874dd — [update] Prepare 0.3.16 release (MAIN-322)

## Release / Issues
- Release: 0.3.16. Linear MAIN-322 was filed at 0.3.13 naming "0.3.14" as the target; `oe-v0.3.14` and `oe-v0.3.15` have since shipped, so the next package release is 0.3.16. The issue explicitly allowed this semver decision before the release branch starts.
- Linear ID(s): MAIN-322
- Closes: #489
- Refs: MAIN-321 / #486 / #487, MAIN-320 / #483 / #484, MAIN-315 / #471 / #488, MAIN-281 / #407 / #485, MAIN-310 / #463 / #476, MAIN-313 / #469 / #473, MAIN-314 / #470 / #475, MAIN-305 / #454 / #467, MAIN-306 / #455 / #466, MAIN-312 / #468 / #472, MAIN-317 / #477 / #481, MAIN-318 / #478 / #480, MAIN-319 / #479 / #482
- Follow-ups: tag `oe-v0.3.16`, publish to PyPI, run release-acceptance simulation against a fresh PyPI install, post evidence on #489.

## Success Metric
- A fresh user can install `mainbranch==0.3.16`, get `mb --version` → `mb 0.3.16`, run `mb onboard` and `mb status --json --peek`, see the new operator vocabulary / workflow-awareness facts, and exercise `mb books check --json` and `mb books check --fixture --json` without unreleased source checkout.

## Validation
- Level 0 docs/decision: CHANGELOG `[Unreleased]` → `[0.3.16] - 2026-05-11`; intro lists user-visible surfaces from the merged PRs in `oe-v0.3.15..main`.
- Level 1 static: `scripts/check.sh` → 546 passed, 0 failed.
- Level 2 CLI: covered by the package-test suite inside `scripts/check.sh` (typer/CliRunner, JSON envelopes, exit codes).
- Level 3 package/install: `(cd mb && python -m build)` produced `mainbranch-0.3.16-py3-none-any.whl`; fresh venv install ran the full MAIN-322 contract — `mb --version`, `mb skill list`, `mb onboard --yes --json`, `mb status --json --peek`, `mb start --json`, `mb graph --json`, `mb validate --cross-refs --json`, `mb doctor repair --plan --json`, `mb books check --json`, `mb books check --fixture --json` — all returned `result_status: ok`.
- Level 4 fixture repo: covered by the `mb onboard` + downstream commands above in the smoke venv.
- Level 5 runtime smoke: not run for this release-prep diff. Package-visible release acceptance (release simulation tier + manual transcript review) belongs to the publish step after merge per `docs/release-simulations.md`. Note: hledger is not installed in this smoke environment, so `mb books check --fixture --json` exercised the documented informational fallback path; please re-run on a hledger-equipped machine before tagging.

## Public / Private Boundary
- Cold-start lives in `.context/cold-start.md` (gitignored). Only version bumps and CHANGELOG content are committed. No private operator, Conductor, or runtime details.