### PR TITLE
[docs] Release-agent contract, post-release alignment, tight operator style (MAIN-323)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -42,6 +42,7 @@ Cite each level you ran with the evidence-line shape from
 Say which levels were not required and why.
 
 - [ ] Level 1 static: `scripts/check.sh` passes
+- [ ] Level 2 CLI contract: focused Typer/CliRunner tests, exit codes, `--json` behavior, TTY vs non-TTY (if CLI behavior touched)
 - [ ] Level 3 package/install smoke (if packaging touched)
 - [ ] Level 4 fixture repo (if init/onboard/status/start/update touched)
 - [ ] Level 5 runtime smoke / dogfood harness / simulation-tier (if runtime, first-run, skill discovery, or release validation touched)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -28,7 +28,7 @@ Closes #
 - [ ] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
 - [ ] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`
 
-## Test plan
+## Validation
 
 Pre-push gate from repo root:
 
@@ -36,11 +36,21 @@ Pre-push gate from repo root:
 scripts/check.sh
 ```
 
-- [ ] `scripts/check.sh` passes
-- [ ] Wheel install smoke (if packaging touched)
+Cite each level you ran with the evidence-line shape from
+[`docs/release-agent-contract.md`](../docs/release-agent-contract.md):
+`Level <N> <surface>: <command> — runtime: <python3/venv path> — exit: <code> — log: <path or excerpt>`.
+Say which levels were not required and why.
+
+- [ ] Level 1 static: `scripts/check.sh` passes
+- [ ] Level 3 package/install smoke (if packaging touched)
+- [ ] Level 4 fixture repo (if init/onboard/status/start/update touched)
+- [ ] Level 5 runtime smoke / dogfood harness / simulation-tier (if runtime, first-run, skill discovery, or release validation touched)
 - [ ] SKILL.md ≤500 lines (if any skill touched)
-- [ ] Claude runtime dogfood harness / simulation-tier / manual smoke evidence (if runtime, first-run, skill discovery, or release validation touched)
 - [ ] Package-visible release gate evidence before tag/publish (if preparing a release)
+
+## Success metric
+
+<!-- The observable condition that means this PR did its job. -->
 
 ## CHANGELOG
 
@@ -53,3 +63,8 @@ scripts/check.sh
 - [ ] Yes — migration note below
 
 <!-- If yes, describe what users must do to migrate. -->
+
+## Public / private boundary
+
+<!-- Confirm no private operator strategy, machine-specific paths, or runtime internals were committed.
+     See docs/oss-operating-checklist.md if in doubt. -->

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,9 @@ __pycache__/
 .ruff_cache/
 .pytest_cache/
 .coverage
+
+# Local operational state
+# .context/ is collaboration scratch and release-evidence; never durable truth.
+# .claude/*.lock is local Claude Code session state (pid, sessionId).
+.context/
+.claude/*.lock

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -303,6 +303,11 @@ Do not rewrite pushed history unless the maintainer explicitly asks.
 Use the lightest eval that proves the behavior. Do not ship first-run,
 runtime-discovery, update, packaging, or skill changes on unit tests alone.
 
+For release-bearing flows, the *how* of running these checks — picking one
+runtime path, capturing stdout/stderr/exit on the first run, and not
+re-running long checks to recover lost evidence — lives in
+[`docs/release-agent-contract.md`](docs/release-agent-contract.md).
+
 Level 0, docs/decision:
 
 - frontmatter where expected;
@@ -473,6 +478,14 @@ Do not describe a version as shipped until the release surfaces agree:
 draft PR, planning doc, or local branch mentions a version that has not been
 released, use "planned", "target", or "next" rather than "shipped".
 
+## Post-Release Alignment
+
+After a release ships, run the alignment sweep in
+[`docs/post-release-alignment.md`](docs/post-release-alignment.md) before
+opening the next parallel batch. That doc owns the post-release sequence,
+parallel-work lane rules, AI code review ritual, Conductor preferences
+policy, and the current product stance checklist.
+
 ## Review Focus
 
 When reviewing, lead with findings:
@@ -490,3 +503,12 @@ When reviewing, lead with findings:
 - truncated files.
 
 Verdicts should be explicit: approve, request changes, or needs discussion.
+
+## Writing Style
+
+Agent-facing docs (this file, `CLAUDE.md`, generated repo guidance, bundled
+skill prose) and PR descriptions follow the tight operator style rubric in
+[`docs/tight-operator-style.md`](docs/tight-operator-style.md): action-first,
+link instead of restate, plain business language, no narration of internal
+thought process. User-facing product copy stays warmer and is not bound to
+the rubric verbatim.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -483,7 +483,7 @@ released, use "planned", "target", or "next" rather than "shipped".
 After a release ships, run the alignment sweep in
 [`docs/post-release-alignment.md`](docs/post-release-alignment.md) before
 opening the next parallel batch. That doc owns the post-release sequence,
-parallel-work lane rules, AI code review ritual, Conductor preferences
+parallel-work lane rules, AI code review ritual, local agent preferences
 policy, and the current product stance checklist.
 
 ## Review Focus
@@ -507,8 +507,8 @@ Verdicts should be explicit: approve, request changes, or needs discussion.
 ## Writing Style
 
 Agent-facing docs (this file, `CLAUDE.md`, generated repo guidance, bundled
-skill prose) and PR descriptions follow the tight operator style rubric in
-[`docs/tight-operator-style.md`](docs/tight-operator-style.md): action-first,
+skill prose) and PR descriptions follow the agent writing style rubric in
+[`docs/agent-writing-style.md`](docs/agent-writing-style.md): action-first,
 link instead of restate, plain business language, no narration of internal
 thought process. User-facing product copy stays warmer and is not bound to
 the rubric verbatim.

--- a/docs/README.md
+++ b/docs/README.md
@@ -52,7 +52,7 @@ Pick the route that matches what you are doing.
 - [`claude-code-runtime-dogfood.md`](claude-code-runtime-dogfood.md) — manual runtime smoke runbook.
 - [`release-agent-contract.md`](release-agent-contract.md) — protocol for agents running release-bearing validation.
 - [`post-release-alignment.md`](post-release-alignment.md) — post-release sweep, parallel work lanes, AI review ritual.
-- [`tight-operator-style.md`](tight-operator-style.md) — compression rubric for agent-facing docs and reviews.
+- [`agent-writing-style.md`](agent-writing-style.md) — writing rubric for agent-facing docs and reviews.
 - [`google-ads-gtm-conversion-rubric.md`](google-ads-gtm-conversion-rubric.md) — paid-traffic conversion rubric.
 - [`philosophy.md`](philosophy.md) — long-form product writing.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -49,6 +49,9 @@ Pick the route that matches what you are doing.
 - [`oss-operating-checklist.md`](oss-operating-checklist.md) — public release / contributor checklist.
 - [`dependency-choices.md`](dependency-choices.md) — adopted rails and dependency policy.
 - [`claude-code-runtime-dogfood.md`](claude-code-runtime-dogfood.md) — manual runtime smoke runbook.
+- [`release-agent-contract.md`](release-agent-contract.md) — protocol for agents running release-bearing validation.
+- [`post-release-alignment.md`](post-release-alignment.md) — post-release sweep, parallel work lanes, AI review ritual.
+- [`tight-operator-style.md`](tight-operator-style.md) — compression rubric for agent-facing docs and reviews.
 - [`google-ads-gtm-conversion-rubric.md`](google-ads-gtm-conversion-rubric.md) — paid-traffic conversion rubric.
 - [`philosophy.md`](philosophy.md) — long-form product writing.
 

--- a/docs/agent-writing-style.md
+++ b/docs/agent-writing-style.md
@@ -1,4 +1,4 @@
-# Tight Operator Style
+# Agent Writing Style
 
 A short rubric for agent-facing docs, PR descriptions, review comments,
 issue bodies, and generated repo guidance. The goal is more signal per
@@ -16,8 +16,8 @@ Apply this rubric when writing for:
   guidance, bundled skill prose);
 - PR titles, bodies, and review comments;
 - GitHub issue bodies and comments synced from Linear;
-- Conductor preferences (which should be especially short — see
-  `docs/post-release-alignment.md` → Conductor preferences alignment).
+- local agent preferences (which should be especially short — see
+  `docs/post-release-alignment.md` -> Local Preferences Alignment).
 
 User-facing product copy (`README.md`, `docs/beginner-setup.md`, the
 `/mb-start` greeting, error messages an operator reads) keeps a warmer,
@@ -25,21 +25,16 @@ business-readable tone — it does not adopt this rubric verbatim. The
 rubric's compression discipline still helps there, but lead with
 plain-English clarity.
 
-## Not "caveman voice"
+## Style Boundary
 
-The discipline is borrowed from compression-style writing, but Main Branch
-does not adopt caveman tone publicly. Internally we call this **tight
-operator style**, not "caveman mode." User-facing copy stays normal,
-business-casual, and trustworthy.
+Main Branch keeps full sentences, clear tense, and a business-casual voice.
+The compression pattern is action-first writing: drop filler, keep one-line
+bullets tight, replace repeated background with links, and scale detail to
+the risk of the decision. User-facing copy stays warm and plain-spoken.
 
-The reference inspected when drafting this rubric was Julius Brussee's
-[`caveman`](https://github.com/JuliusBrussee/caveman) tool ("why use many
-token when few do trick"). What carried over: action-first phrasing,
-dropping filler and articles, replacing explanation paragraphs with
-short stacked statements, one-line bullets. What did not: caveman tone
-itself, dropped tense markers, and any user-facing stylization. Main
-Branch keeps full sentences and business-casual voice; only the
-compression discipline applies.
+A local compression-style writing reference was reviewed while drafting this
+rubric. The useful pattern was brevity with structure; the public rule is the
+rubric below.
 
 ## Rubric
 
@@ -73,16 +68,14 @@ For cold starts and PR reviews:
   Do not restate background.
 - Do not narrate your own thought process. State the conclusion.
 
-## What this is not
+## Guardrails
 
-- Not "be terse at the expense of judgment." Recommendations still earn
-  their reasoning when the reasoning is non-obvious or load-bearing.
-- Not a license to drop validation evidence or release evidence to save
-  words. See `docs/release-agent-contract.md`.
-- Not a tone change for user-facing product copy.
-- Not a directive to remove safety language. Public/private boundary
-  warnings, destructive-action callouts, and release-truth statements
-  stay.
+- Keep enough reasoning for non-obvious or load-bearing recommendations.
+- Keep validation evidence and release evidence. See
+  `docs/release-agent-contract.md`.
+- Keep user-facing product copy warm and plain-spoken.
+- Keep safety language when the risk is real. Public/private boundary
+  warnings, destructive-action callouts, and release-truth statements stay.
 
 ## Where it applies
 
@@ -92,7 +85,7 @@ For cold starts and PR reviews:
 - Generated `CLAUDE.md.tmpl` / `AGENTS.md.tmpl`: keep the generated
   business-repo instructions short and link back to engine docs for
   detail.
-- Conductor preferences: especially short. Protocol + read order, not a
+- Local agent preferences: especially short. Protocol + read order, not a
   parallel product spec.
 - PR bodies and review comments: see the validation-line evidence template
   in `docs/release-agent-contract.md`.

--- a/docs/oss-operating-checklist.md
+++ b/docs/oss-operating-checklist.md
@@ -112,6 +112,13 @@ that keep Main Branch usable as public infrastructure while it evolves quickly.
 - [ ] Package-visible releases answer the pre-simulation prompt checkpoint and
   run the pre-release candidate plus `release_acceptance` simulation tiers
   before tagging whenever feasible.
+- [ ] Release-bearing validation follows the
+  [release-agent operating contract](release-agent-contract.md): single
+  documented runtime, stdout+stderr+exit captured on the first run, no
+  blind reruns to recover lost evidence.
+- [ ] After a package-visible release ships, run the
+  [post-release alignment sweep](post-release-alignment.md) before opening
+  the next parallel batch.
 - [ ] Runtime or release-validation changes choose the appropriate
   [release simulation tier](release-simulations.md) and route transcript
   findings to skill prose, generated `CLAUDE.md`, CLI, docs, harness, runtime,

--- a/docs/post-release-alignment.md
+++ b/docs/post-release-alignment.md
@@ -28,8 +28,8 @@ next parallel batch:
    shipped via Linear release completion (not on merge).
 3. Align repo docs and decisions if anything shipped changed the product
    stance. Use the alignment sweep below.
-4. Align Conductor preferences if a new protocol, review habit, or
-   cold-start behavior was learned. Use the Conductor-prefs policy below.
+4. Align local agent preferences if a new protocol, review habit, or
+   cold-start behavior was learned. Use the local-preferences policy below.
 5. Start the next parallel batch.
 
 ## 2. Alignment sweep
@@ -114,15 +114,13 @@ When reviewing any PR, the reviewer (human or agent) checks:
 Quote only the changed behavior or the risky line in review comments. Do
 not restate the product stance — link the decision file or the doc.
 
-## 5. Conductor preferences alignment
+## 5. Local Preferences Alignment
 
-The Conductor preferences file lives in the maintainer's **private** repo
-(`devon-homelab/conductor/preferences.md`), not in this engine repo. Naming
-the path here is a pointer, not a content leak — the repo's GitHub
-visibility is private. This playbook does *not* own that file. It owns
-the policy that governs what should and should not be there.
+Local agent preferences live outside this public engine repo. This playbook
+does not own that private file. It owns the policy that governs what should
+and should not be there.
 
-Conductor preferences should:
+Local agent preferences should:
 
 - enforce working protocol (read AGENTS.md first; write
   `.context/cold-start.md`; name scope and non-scope before editing);
@@ -134,7 +132,7 @@ Conductor preferences should:
 - surface durable review habits learned from recent PRs (a sentence or two);
 - stay short enough to be read and followed.
 
-Conductor preferences should not:
+Local agent preferences should not:
 
 - duplicate detailed product facts that belong in `AGENTS.md`, `README.md`,
   or decision files;
@@ -147,14 +145,14 @@ Conductor preferences should not:
 After every release, ask:
 
 - Did the release teach us a new protocol, review habit, or cold-start
-  behavior that belongs in Conductor prefs? If yes, add it briefly.
+  behavior that belongs in local agent prefs? If yes, add it briefly.
   If no, leave prefs alone.
 - Did any existing preference duplicate repo docs or become stale? If yes,
   remove or compress it.
 
-If the Conductor preferences file lives in a separate repo
-(`devon-homelab` today), open a follow-up issue there for the change —
-do not block this engine's release on edits to a separate repo's file.
+If the local preferences file lives in a separate private repo, open a
+private follow-up there for the change. Do not block this engine's release on
+edits to a separate repo's file.
 
 ## 6. Current product stance checklist
 
@@ -181,7 +179,7 @@ truth lives in the linked doc or decision.
   and real links are accepted.
 - **Language**: plain business language first. Technical terms (canonical,
   schema, primitive) are fine in code comments and contributor docs, not in
-  user-facing copy. See `docs/tight-operator-style.md`.
+  user-facing copy. See `docs/agent-writing-style.md`.
 - **Runtime claims**: Claude Code is first-class. Codex CLI has an
   experimental CLI-first adapter. Other runtimes are compatibility targets
   until smoke evidence exists. See `docs/compatibility.md`.

--- a/docs/post-release-alignment.md
+++ b/docs/post-release-alignment.md
@@ -116,10 +116,11 @@ not restate the product stance — link the decision file or the doc.
 
 ## 5. Conductor preferences alignment
 
-The Conductor preferences file (Devon's local
-`devon-homelab/conductor/preferences.md`) lives outside this engine repo.
-This playbook does *not* own that file. It owns the policy that governs
-what should and should not be there.
+The Conductor preferences file lives in the maintainer's **private** repo
+(`devon-homelab/conductor/preferences.md`), not in this engine repo. Naming
+the path here is a pointer, not a content leak — the repo's GitHub
+visibility is private. This playbook does *not* own that file. It owns
+the policy that governs what should and should not be there.
 
 Conductor preferences should:
 

--- a/docs/post-release-alignment.md
+++ b/docs/post-release-alignment.md
@@ -1,0 +1,190 @@
+# Post-Release Alignment Playbook
+
+Main Branch is moving quickly with multiple concurrent branches. The repo
+needs a durable post-release habit so future cold starts, agent reviews,
+docs, decisions, and roadmap issues do not drift from the current product
+stance. This playbook is the standard sweep to run after every
+package-visible release, plus the safe pattern for running multiple
+branches in parallel.
+
+It complements the release runbook (`docs/release-simulations.md`), the
+release-agent contract (`docs/release-agent-contract.md`), the
+OSS operating checklist (`docs/oss-operating-checklist.md`), and the
+agent operating contract (`AGENTS.md`). This file owns *post-release
+alignment* and *parallel-work hygiene*. Do not duplicate product facts
+that live in those documents — link them.
+
+Tracked in MAIN-323 / #490.
+
+## 1. Post-release sequence
+
+After a release merges and publishes, the standard next steps before the
+next parallel batch:
+
+1. Merge / release ships (tag, GitHub Release, PyPI publish, Linear release
+   sync — see `docs/release-simulations.md`).
+2. Align Linear and GitHub issue state: close the release-prep issue, comment
+   release evidence on the issues whose work shipped, mark Linear issues
+   shipped via Linear release completion (not on merge).
+3. Align repo docs and decisions if anything shipped changed the product
+   stance. Use the alignment sweep below.
+4. Align Conductor preferences if a new protocol, review habit, or
+   cold-start behavior was learned. Use the Conductor-prefs policy below.
+5. Start the next parallel batch.
+
+## 2. Alignment sweep
+
+Run this after every release whose surface changed something agents,
+operators, or contributors read:
+
+- Review merged issues and PRs since the last tag (`git log oe-vX.Y.Z..main
+  --oneline`). For each surface that shipped, check it is described in
+  present tense in docs and generated guidance, not future tense.
+- Update or remove future-tense language for shipped commands, validators,
+  JSON fields, and decisions. Keep the deferred items as deferred — do not
+  promote them.
+- Update agent cold-start guidance (`AGENTS.md`, `CLAUDE.md.tmpl`,
+  `AGENTS.md.tmpl`, generated repo instructions) only if a new decision
+  changed how agents should think about the repo.
+- Check for stale assumptions: an old engine choice, a deprecated provider
+  recommendation, a removed file path, a renamed surface. Surface these as
+  follow-up issues if the cleanup is larger than a paragraph.
+- Confirm CHANGELOG, README, and roadmap language matches the facts. A
+  release is not done until the surfaces agree (see `AGENTS.md` →
+  Release Truth).
+
+Default to a small alignment PR labeled `[docs]`. If the sweep finds nothing
+worth changing, write that as a one-line comment on the release-prep issue
+and move on.
+
+## 3. Parallel work lanes
+
+Lanes that can usually run concurrently without merge chaos:
+
+- **Docs-only** (this file's lane): no CLI module, no `mb/_data/`, no
+  templates touched.
+- **Feature CLI**: one command surface owned by one branch. Do not parallel
+  two branches that both touch `mb/<module>.py`, `mb/cli.py`, or shared
+  packaged data unless the conflict surface is explicitly enumerated.
+- **Release prep**: only the four release files (`CHANGELOG.md`,
+  `mb/pyproject.toml`, `mb/mb/__init__.py`, `.claude-plugin/plugin.json`).
+  Anything else is its own branch.
+- **Noontide / business-model**: lives in the operator's business repo, not
+  in this engine. Never on the same branch as engine changes.
+- **Review-only**: comment-only PR reviews, no commits.
+
+Conflict rules:
+
+- Two branches touching the same CLI module, docs index, CHANGELOG, or a
+  generated template should not run blindly in parallel. The second branch
+  rebases on the first after merge.
+- Two branches updating the same `decisions/<date>-<name>.md` is a smell;
+  one branch should own a decision file at a time.
+- Each branch writes `.context/cold-start.md` before editing, naming what it
+  *will not* touch (the "Out" section). That is the parallel-lane contract.
+
+If a branch discovers it needs to touch a file owned by another in-flight
+branch, comment on the other branch's PR before editing. Do not silently
+race.
+
+## 4. AI code review ritual
+
+When reviewing any PR, the reviewer (human or agent) checks:
+
+- **Diff correctness**: code does what the PR claims.
+- **Decision alignment**: does the PR follow current decisions in
+  `decisions/` and the relevant PRDs? If it reopens a settled choice,
+  flag explicitly.
+- **Stale assumptions**: does the PR build on language that is now stale
+  (old engine, old file path, deprecated provider)? Block on stale
+  assumptions, not only on bugs.
+- **Issue hygiene**: does the PR use `Closes #N` only for full completion
+  and `Refs #N` for partial slices? Are Linear IDs preserved in branch and
+  commit metadata?
+- **CHANGELOG and docs**: user-visible CLI, skill, packaging, compatibility,
+  or workflow changes update `CHANGELOG.md` and any docs they invalidate.
+- **Public/private boundary**: see `docs/oss-operating-checklist.md`. No
+  secrets, no private operator strategy, no machine-specific paths in
+  committed files.
+- **Release impact**: does this PR change a packaging surface, runtime
+  claim, or first-run flow? If yes, it needs the corresponding evidence
+  from the validation ladder.
+- **Follow-ups**: does the PR leave the right follow-up issues open?
+
+Quote only the changed behavior or the risky line in review comments. Do
+not restate the product stance — link the decision file or the doc.
+
+## 5. Conductor preferences alignment
+
+The Conductor preferences file (Devon's local
+`devon-homelab/conductor/preferences.md`) lives outside this engine repo.
+This playbook does *not* own that file. It owns the policy that governs
+what should and should not be there.
+
+Conductor preferences should:
+
+- enforce working protocol (read AGENTS.md first; write
+  `.context/cold-start.md`; name scope and non-scope before editing);
+- tell agents what to read and in what order;
+- remind agents to check accepted decisions before reopening product choices;
+- remind agents during AI code review to check stale assumptions, docs and
+  changelog updates, Linear and GitHub issue hygiene, public/private
+  boundaries, and release impact;
+- surface durable review habits learned from recent PRs (a sentence or two);
+- stay short enough to be read and followed.
+
+Conductor preferences should not:
+
+- duplicate detailed product facts that belong in `AGENTS.md`, `README.md`,
+  or decision files;
+- repeat the whole product stance, folder map, or release model;
+- carry stale specifics (old engine choices, outdated provider
+  recommendations, old paths);
+- include implementation details that agents are already required to read
+  from the repo.
+
+After every release, ask:
+
+- Did the release teach us a new protocol, review habit, or cold-start
+  behavior that belongs in Conductor prefs? If yes, add it briefly.
+  If no, leave prefs alone.
+- Did any existing preference duplicate repo docs or become stale? If yes,
+  remove or compress it.
+
+If the Conductor preferences file lives in a separate repo
+(`devon-homelab` today), open a follow-up issue there for the change —
+do not block this engine's release on edits to a separate repo's file.
+
+## 6. Current product stance checklist
+
+Use this list as a quick decision-alignment scan during alignment sweeps and
+code review. Each line is intentionally a one-line pointer; the durable
+truth lives in the linked doc or decision.
+
+- **Bookkeeping engine**: hledger. Real books live in a private books vault
+  (solo-local under `.mb/private/books/` by default, or a separate
+  team-private repo). See `docs/books.md` and
+  `decisions/2026-05-11-mb-books-foundation.md`.
+- **Scheduled data sync**: operator-owned cron / `launchd` / Task Scheduler
+  running one-shot per-provider scripts, not a hidden daemon. See
+  `docs/scheduled-data-sync.md` and
+  `decisions/2026-05-11-scheduled-data-sync-pattern.md`.
+- **Repo rails**: GitHub is the repo, history, PR, and checks rail.
+  Cloudflare is the site, DNS, and deploy rail. GitHub Pages is not a
+  default Main Branch site host. See `docs/repo-visibility-rubric.md`.
+- **Display vs enforcement**: Obsidian and dashboards are display surfaces,
+  not enforcement engines. `mb` keeps the typed business graph and
+  validation. See `docs/markdown-link-conventions.md`.
+- **Affiliate/recommended-tools monetization**: belongs in Noontide first;
+  Main Branch does not add public affiliate links until policy, disclosures,
+  and real links are accepted.
+- **Language**: plain business language first. Technical terms (canonical,
+  schema, primitive) are fine in code comments and contributor docs, not in
+  user-facing copy. See `docs/tight-operator-style.md`.
+- **Runtime claims**: Claude Code is first-class. Codex CLI has an
+  experimental CLI-first adapter. Other runtimes are compatibility targets
+  until smoke evidence exists. See `docs/compatibility.md`.
+
+If a PR or issue contradicts one of these, treat the contradiction as a
+stale-assumption finding and block until reconciled or a new decision file
+lands.

--- a/docs/release-agent-contract.md
+++ b/docs/release-agent-contract.md
@@ -1,0 +1,158 @@
+# Release Agent Operating Contract
+
+This contract governs how agents (Claude Code, Codex, or any other automated
+worker) drive Main Branch release-bearing flows. It is the protocol layer that
+sits next to `docs/release-simulations.md`, `docs/claude-code-runtime-dogfood.md`,
+and the validation ladder in `AGENTS.md`. Those files describe *what* to run
+and *what evidence to keep*. This file describes *how to run it without
+wasting time, exit codes, or trust*.
+
+Surfaced from the v0.3.16 release prep (MAIN-322 / #489) where a release
+agent re-ran a 3-minute static check because the first run's output was
+filtered too aggressively to confirm the result, and bounced between
+`python`, `python3`, and bare scripts before committing to a single
+interpreter. Tracked in MAIN-323 / #490.
+
+## Scope
+
+Applies to any agent or human driver running:
+
+- `scripts/check.sh` for a release-prep PR;
+- wheel build + fresh-install smoke for a release candidate;
+- `scripts/claude-runtime-dogfood.py` at any simulation tier;
+- post-publish PyPI verification;
+- any other validation that takes more than ~10 seconds and produces output
+  worth preserving.
+
+Out of scope: short interactive probes (`mb --version`, `git status`, single
+unit tests under a second). Use judgment, but err on the side of capturing
+when in doubt.
+
+## Rules
+
+### 1. Pick the runtime up front. Do not switch mid-flow.
+
+On macOS in this workspace, the documented runtime is `python3` (with
+`python3 -m build`, `python3 -m venv`, `python3 -m pytest`). `python` may be
+absent; do not probe blindly.
+
+If a different interpreter is needed (a CI matrix, a venv binary,
+`/tmp/<smoke>/bin/python3.13`), state the path once at the top of the flow
+and reuse it. Do not alternate between `python`, `python3`, `uv`, or bare
+scripts without a written reason.
+
+If a test only passes under a different runtime than the one documented,
+that is a finding to surface, not something to paper over with silent
+switches.
+
+### 2. Capture stdout, stderr, and exit code on the first run.
+
+Pattern:
+
+```bash
+scripts/check.sh > .context/check.out 2>&1; echo $? > .context/check.exit
+```
+
+Or, if live progress is useful:
+
+```bash
+scripts/check.sh 2>&1 | tee .context/check.out
+status=${PIPESTATUS[0]}
+printf "%s\n" "$status" > .context/check.exit
+exit "$status"
+```
+
+For release-bearing flows, the convention is to put logs under
+`.context/release-evidence/<version>/` so the directory is gitignored and
+self-documenting:
+
+```bash
+mkdir -p .context/release-evidence/0.3.17
+scripts/check.sh > .context/release-evidence/0.3.17/check.out 2>&1
+echo $? > .context/release-evidence/0.3.17/check.exit
+```
+
+For background invocations (the dogfood harness), redirect both streams to
+the log file and append the exit code line at the end:
+
+```bash
+python3 scripts/claude-runtime-dogfood.py \
+  --install-mode pypi --pypi-version 0.3.17 \
+  --evidence-dir .context/release-evidence/0.3.17 \
+  --run-claude-print --simulation-tier release_acceptance \
+  --max-budget-usd 0.75 \
+  > .context/release-evidence/0.3.17/dogfood.log 2>&1
+echo "EXIT=$?" >> .context/release-evidence/0.3.17/dogfood.log
+```
+
+### 3. Read the saved log. Do not re-run to recover evidence.
+
+Before re-running any long check, check in order:
+
+1. Shell exit code from the previous run (`cat .context/check.exit` or the
+   trailing `EXIT=` line in the log).
+2. The saved log file.
+3. CI output for the same commit (`gh pr checks <N>`, `gh run view <id>`).
+4. Targeted failing test output, captured the same way.
+
+Re-run only when the previous result is genuinely unknown or a code change
+warrants a fresh run.
+
+### 4. Release PRs stay release-only.
+
+A release-prep PR commits only files that change because of the release:
+package version sites, the dated CHANGELOG section, and the plugin manifest.
+Process improvements (this file, the post-release playbook, agent rubric
+updates) belong on their own branch. Process documents drafted *during* a
+release flow are committed *after* the release ships, on a separate branch.
+
+Also: do not edit the engine repo working tree while a release-acceptance
+simulation is running against it. The dogfood harness fails the run with
+"engine repo git status changed during dogfood harness run" as a
+repo-boundary check. Either finish the sim before editing or run it from a
+clean checkout dedicated to the run.
+
+### 5. Validation-line evidence template.
+
+Each PR validation bullet should answer:
+
+```text
+- Level <N> <surface>: <command> — runtime: <python3 or venv path> — exit: <code> — log: <path or excerpt>; <one-line reason if a level was skipped>
+```
+
+Example:
+
+```text
+- Level 1 static: scripts/check.sh — runtime: /usr/bin/python3 (3.13) — exit: 0 — log: .context/release-evidence/0.3.17/check.out (546 passed).
+- Level 3 package/install: (cd mb && python3 -m build) + venv install of mainbranch-0.3.17-py3-none-any.whl — runtime: /tmp/mb-pypi-smoke/bin/python3 — exit: 0 — log: .context/release-evidence/0.3.17/install.out (full validation contract returned result_status: ok).
+- Level 5 runtime: scripts/claude-runtime-dogfood.py --install-mode pypi --pypi-version 0.3.17 --run-claude-print --simulation-tier release_acceptance --max-budget-usd 0.75 — exit: 0 — evidence: .context/release-evidence/0.3.17/ (summary.json, rubric.json, transcript excerpts).
+```
+
+If a level was not run, say which one and why in one line. "Not required for
+docs-only diff" is a valid reason. "Skipped because evidence was lost" is
+not — re-read the log instead.
+
+### 6. hledger fixture is a real check, not a soft note.
+
+`mb books check --fixture --json` has two documented modes:
+
+- base install with no hledger: returns the informational fallback finding
+  and `result_status: ok`;
+- hledger-equipped environment: shells out to `hledger -f <fixture> check`
+  and returns the real `fixture-valid` finding.
+
+For a package-visible release, the validation evidence must record both
+modes — or, if only one was run, explicitly call out the missing mode as a
+pre-tag blocker, not a soft note in the PR description.
+
+## Where this lives
+
+This file is the protocol. The simulation-tier matrix (`pr_smoke`,
+`prerelease_candidate`, `release_acceptance`) and the transcript review
+rubric live in `docs/release-simulations.md`. The runtime dogfood harness
+itself lives in `scripts/claude-runtime-dogfood.py` and is documented in
+`docs/claude-code-runtime-dogfood.md`. The validation ladder lives in
+`AGENTS.md`.
+
+If the protocol above contradicts those documents, the protocol document
+that names the surface most specifically wins; open an issue to reconcile.

--- a/docs/release-agent-contract.md
+++ b/docs/release-agent-contract.md
@@ -53,7 +53,8 @@ Pattern:
 scripts/check.sh > .context/check.out 2>&1; echo $? > .context/check.exit
 ```
 
-Or, if live progress is useful:
+Or, if live progress is useful (bash-specific; in zsh use
+`${pipestatus[1]}` — lowercase, 1-indexed):
 
 ```bash
 scripts/check.sh 2>&1 | tee .context/check.out
@@ -61,6 +62,9 @@ status=${PIPESTATUS[0]}
 printf "%s\n" "$status" > .context/check.exit
 exit "$status"
 ```
+
+If the agent's runtime shell is unknown, prefer the first pattern
+(`> file 2>&1; echo $? > file`) which works in both bash and zsh.
 
 For release-bearing flows, the convention is to put logs under
 `.context/release-evidence/<version>/` so the directory is gitignored and

--- a/docs/release-agent-contract.md
+++ b/docs/release-agent-contract.md
@@ -47,24 +47,37 @@ switches.
 
 ### 2. Capture stdout, stderr, and exit code on the first run.
 
-Pattern:
+Pattern (wrapper-safe — propagates the underlying exit code):
 
 ```bash
-scripts/check.sh > .context/check.out 2>&1; echo $? > .context/check.exit
+scripts/check.sh > .context/check.out 2>&1; rc=$?; printf "%s\n" "$rc" > .context/check.exit; exit "$rc"
 ```
+
+The trailing `exit "$rc"` matters. Without it, the chain ends with
+`printf` (or `echo`), which succeeds, so a wrapper like Codex, CI, or a
+tool call sees exit `0` even when `scripts/check.sh` actually failed.
+Drop the `exit "$rc"` only when running the line interactively in
+your own shell (where you don't want to close the session).
+
+The variable name matters too. `status` is a read-only special variable
+in zsh (it mirrors `$?`), so `status=$?` fails with `read-only variable`
+on Devon's default macOS shell. `rc` is safe in both bash and zsh; so
+is `exit_code`, `check_rc`, or any other non-reserved name. Avoid `status`,
+`pipestatus`, `path`, `home`, and other zsh special variables in agent-
+facing shell snippets.
 
 Or, if live progress is useful (bash-specific; in zsh use
 `${pipestatus[1]}` — lowercase, 1-indexed):
 
 ```bash
 scripts/check.sh 2>&1 | tee .context/check.out
-status=${PIPESTATUS[0]}
-printf "%s\n" "$status" > .context/check.exit
-exit "$status"
+rc=${PIPESTATUS[0]}
+printf "%s\n" "$rc" > .context/check.exit
+exit "$rc"
 ```
 
 If the agent's runtime shell is unknown, prefer the first pattern
-(`> file 2>&1; echo $? > file`) which works in both bash and zsh.
+(redirect + `rc=$?; printf; exit`) which works in both bash and zsh.
 
 For release-bearing flows, the convention is to put logs under
 `.context/release-evidence/<version>/` so the directory is gitignored and
@@ -73,11 +86,15 @@ self-documenting:
 ```bash
 mkdir -p .context/release-evidence/0.3.17
 scripts/check.sh > .context/release-evidence/0.3.17/check.out 2>&1
-echo $? > .context/release-evidence/0.3.17/check.exit
+rc=$?
+printf "%s\n" "$rc" > .context/release-evidence/0.3.17/check.exit
+exit "$rc"
 ```
 
 For background invocations (the dogfood harness), redirect both streams to
-the log file and append the exit code line at the end:
+the log file and append the exit code line at the end. Capture the status
+in a variable first so the trailing `EXIT=` line and the wrapper exit
+both reflect the harness's real outcome:
 
 ```bash
 python3 scripts/claude-runtime-dogfood.py \
@@ -86,7 +103,9 @@ python3 scripts/claude-runtime-dogfood.py \
   --run-claude-print --simulation-tier release_acceptance \
   --max-budget-usd 0.75 \
   > .context/release-evidence/0.3.17/dogfood.log 2>&1
-echo "EXIT=$?" >> .context/release-evidence/0.3.17/dogfood.log
+rc=$?
+printf "EXIT=%s\n" "$rc" >> .context/release-evidence/0.3.17/dogfood.log
+exit "$rc"
 ```
 
 ### 3. Read the saved log. Do not re-run to recover evidence.

--- a/docs/release-simulations.md
+++ b/docs/release-simulations.md
@@ -6,6 +6,12 @@ grounded in repo truth, use `mb` for deterministic checks, speak in business
 language, ask before durable writes, preserve repo boundaries, and close work
 with a checkpoint path?
 
+The *how* of running these simulations — single documented runtime, captured
+stdout/stderr/exit on the first run, no blind reruns to recover evidence —
+is in [`release-agent-contract.md`](release-agent-contract.md). This file
+owns the simulation tier matrix, prompt fixtures, transcript review, and
+release-acceptance gate.
+
 The packaged simulation manifest lives at
 `mb/mb/_data/release_simulations/manifest.json`. It is public-safe fixture
 truth: prompt fixtures, expected observations, transcript-review categories,

--- a/docs/tight-operator-style.md
+++ b/docs/tight-operator-style.md
@@ -32,6 +32,15 @@ does not adopt caveman tone publicly. Internally we call this **tight
 operator style**, not "caveman mode." User-facing copy stays normal,
 business-casual, and trustworthy.
 
+The reference inspected when drafting this rubric was Julius Brussee's
+[`caveman`](https://github.com/JuliusBrussee/caveman) tool ("why use many
+token when few do trick"). What carried over: action-first phrasing,
+dropping filler and articles, replacing explanation paragraphs with
+short stacked statements, one-line bullets. What did not: caveman tone
+itself, dropped tense markers, and any user-facing stylization. Main
+Branch keeps full sentences and business-casual voice; only the
+compression discipline applies.
+
 ## Rubric
 
 1. Lead with the action or decision.

--- a/docs/tight-operator-style.md
+++ b/docs/tight-operator-style.md
@@ -1,0 +1,94 @@
+# Tight Operator Style
+
+A short rubric for agent-facing docs, PR descriptions, review comments,
+issue bodies, and generated repo guidance. The goal is more signal per
+token, not terseness for its own sake. Plain business language stays;
+filler goes.
+
+Surfaced from MAIN-323 / #490 alongside the post-release alignment
+playbook.
+
+## Audience
+
+Apply this rubric when writing for:
+
+- agent-facing docs in this repo (`AGENTS.md`, `CLAUDE.md`, generated repo
+  guidance, bundled skill prose);
+- PR titles, bodies, and review comments;
+- GitHub issue bodies and comments synced from Linear;
+- Conductor preferences (which should be especially short — see
+  `docs/post-release-alignment.md` → Conductor preferences alignment).
+
+User-facing product copy (`README.md`, `docs/beginner-setup.md`, the
+`/mb-start` greeting, error messages an operator reads) keeps a warmer,
+business-readable tone — it does not adopt this rubric verbatim. The
+rubric's compression discipline still helps there, but lead with
+plain-English clarity.
+
+## Not "caveman voice"
+
+The discipline is borrowed from compression-style writing, but Main Branch
+does not adopt caveman tone publicly. Internally we call this **tight
+operator style**, not "caveman mode." User-facing copy stays normal,
+business-casual, and trustworthy.
+
+## Rubric
+
+1. Lead with the action or decision.
+2. State only the context this reader needs for this task.
+3. Link or point to source docs instead of restating them.
+4. Use plain business language; reserve schema and infrastructure terms
+   for contributor docs and code comments.
+5. Prefer short sections and concrete bullets over long paragraphs.
+6. Remove duplicate warnings unless the warning is load-bearing for this
+   specific moment.
+7. Separate facts, decisions, and open questions visually.
+8. Do not sound clever or overly technical when business language is
+   clearer.
+9. Do not hide risk to save words. If a step is destructive or
+   public-visible, say so plainly.
+10. End with the next action.
+
+## Token-saving rules
+
+For cold starts and PR reviews:
+
+- Do not paste the whole product stance when `AGENTS.md`, decisions, or
+  docs already cover it. Link.
+- Tell the agent which docs to read and what question to answer; do not
+  pre-answer the question.
+- Use one-line bullets for known facts.
+- Use `Out of scope:` instead of long warning paragraphs.
+- Use `Follow-ups:` instead of explaining every future branch.
+- In review comments, quote only the changed behavior or the risky line.
+  Do not restate background.
+- Do not narrate your own thought process. State the conclusion.
+
+## What this is not
+
+- Not "be terse at the expense of judgment." Recommendations still earn
+  their reasoning when the reasoning is non-obvious or load-bearing.
+- Not a license to drop validation evidence or release evidence to save
+  words. See `docs/release-agent-contract.md`.
+- Not a tone change for user-facing product copy.
+- Not a directive to remove safety language. Public/private boundary
+  warnings, destructive-action callouts, and release-truth statements
+  stay.
+
+## Where it applies
+
+- `AGENTS.md` and `CLAUDE.md`: contributor protocol, already aligned.
+- Bundled skill `SKILL.md` files: prefer linking `references/` over
+  inlining long prose.
+- Generated `CLAUDE.md.tmpl` / `AGENTS.md.tmpl`: keep the generated
+  business-repo instructions short and link back to engine docs for
+  detail.
+- Conductor preferences: especially short. Protocol + read order, not a
+  parallel product spec.
+- PR bodies and review comments: see the validation-line evidence template
+  in `docs/release-agent-contract.md`.
+
+If a passage you are writing fails the rubric, the usual remedy is to
+delete words, not rewrite. If after deletion the passage no longer makes
+sense without the missing context, link to the doc that carries the
+context.


### PR DESCRIPTION
## Summary
- New `docs/release-agent-contract.md` encodes the protocol release agents must follow for release-bearing validation: single documented runtime, capture stdout/stderr/exit on the first long run, no blind reruns to recover lost evidence, release-prep PRs stay release-only, validation lines in PRs include command + runtime + exit + log path. Surfaced from the v0.3.16 release flow.
- New `docs/post-release-alignment.md` defines the post-release sequence, alignment sweep, parallel work lanes, AI code review ritual, Conductor preferences policy (what belongs, what doesn't), and the current product stance one-line checklist.
- New `docs/tight-operator-style.md` adds a 10-rule compression rubric for agent-facing docs, PRs, and review comments — explicitly internal "tight operator style", not "caveman voice" in public copy.
- `AGENTS.md`, `docs/release-simulations.md`, `docs/oss-operating-checklist.md`, and `docs/README.md` gain minimal pointers to the new docs so agents discover them without the new docs duplicating existing content.

## Scope
- In: three new docs and minimal wiring touches in existing docs/index/agent contract.
- Out: CLI behavior, release versioning, Conductor preferences source file (lives in `devon-homelab`, not this engine repo), broad doc edits.

## Commits
- 24f64ce — [docs] Add release-agent operating contract (MAIN-323)
- 0542969 — [docs] Add post-release alignment playbook (MAIN-323)
- c1dde21 — [docs] Tighten agent review and Conductor guidance (MAIN-323)

## Release / Issues
- Release: not release-bearing (docs-only).
- Linear ID(s): MAIN-323
- Closes: #490
- Refs: #489 (the v0.3.16 release flow whose friction surfaced these rules)
- Follow-ups: apply the Conductor-prefs policy to `devon-homelab/conductor/preferences.md` (separate repo); add `.claude/scheduled_tasks.lock` to `.gitignore`; consider promoting the validation-line evidence template into the PR template; consider a `scripts/release-evidence.sh` that bakes in the capture pattern.

## Success Metric
- The next release-prep PR captures `scripts/check.sh` output and exit code on the first run, runs the wheel smoke once with logging, cites those logs in its validation lines, and doesn't re-run any long check to recover evidence. The next post-release also runs the alignment sweep before opening the next parallel batch.

## Validation
- Level 0 docs/decision: internal links resolve; no future-tense for shipped surfaces; no Conductor-prefs source text duplicated; new docs lead with what they own and link the others.
- Level 1 static: `scripts/check.sh > .context/check.out 2>&1; echo \$? > .context/check.exit` — runtime: `/usr/bin/python3` (3.13) — exit: 0 — 546 passed. Captured per the new contract on its own intro PR.
- Level 2 CLI: not required (docs-only).
- Level 3 package/install: not required.
- Level 4 fixture repo: not required.
- Level 5 runtime smoke: not required.

## Public / Private Boundary
- Cold-start lives in `.context/cold-start.md` (gitignored). No Conductor UI internals, no operator strategy, no machine paths in committed files. The Conductor-prefs *policy* is documented; the source file itself is not edited from this engine repo.