### PR TITLE
[add] Supply-chain security gates for releases and dependencies (MAIN-324)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -41,6 +41,7 @@ scripts/check.sh
 - [ ] SKILL.md ≤500 lines (if any skill touched)
 - [ ] Claude runtime dogfood harness / simulation-tier / manual smoke evidence (if runtime, first-run, skill discovery, or release validation touched)
 - [ ] Package-visible release gate evidence before tag/publish (if preparing a release)
+- [ ] Supply-chain review (if `.github/workflows/`, `.github/dependabot.yml`, `mb/pyproject.toml` deps, or `id-token`/`permissions` blocks touched — see [docs/supply-chain-policy.md](../docs/supply-chain-policy.md))
 
 ## CHANGELOG
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -59,11 +59,10 @@ updates:
     labels:
       - "dependencies"
       - "supply-chain-review"
+    # Dependabot's github-actions cooldown schema only supports
+    # `default-days` (not the semver-*-days breakdown that pip supports).
     cooldown:
       default-days: 7
-      semver-major-days: 14
-      semver-minor-days: 7
-      semver-patch-days: 3
     groups:
       # Official actions/* tend to ship together; grouping minor/patch
       # updates keeps the supply-chain review surface to one PR per cycle.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,8 +42,13 @@ updates:
           - "typer"
           - "pyyaml"
           - "rich"
+        update-types:
+          - "patch"
+      python-extras:
+        patterns:
           - "cairosvg"
         update-types:
+          - "minor"
           - "patch"
 
   - package-ecosystem: "github-actions"
@@ -57,3 +62,24 @@ updates:
     cooldown:
       default-days: 7
       semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
+    groups:
+      # Official actions/* tend to ship together; grouping minor/patch
+      # updates keeps the supply-chain review surface to one PR per cycle.
+      github-actions-official:
+        patterns:
+          - "actions/*"
+        update-types:
+          - "minor"
+          - "patch"
+      # Third-party actions in the publish path (PyPA publisher, Linear
+      # release sync). Major bumps still open as individual PRs so the
+      # release-pipeline review is not hidden inside a group diff.
+      github-actions-release:
+        patterns:
+          - "pypa/gh-action-pypi-publish"
+          - "linear/linear-release-action"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,16 @@
 # Dependabot config — weekly sweep for Python deps and GitHub Actions.
-# pyproject.toml lives at /mb, so the pip ecosystem is rooted there.
+#
+# Policy lives in:
+#   - docs/supply-chain-policy.md
+#   - decisions/2026-05-11-supply-chain-security-gates.md
+#
+# pyproject.toml lives at /mb, so the pip ecosystem is rooted there. The
+# `cooldown` block delays freshly-published versions so Main Branch is not
+# the first consumer of a release in the short window before the ecosystem
+# detects malicious versions. It is not a guarantee — it is one layer.
+#
+# Dependency PRs are not bundled with feature work. Security updates land
+# expedited as their own PR ahead of the weekly cadence.
 version: 2
 updates:
   - package-ecosystem: "pip"
@@ -7,9 +18,42 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "supply-chain-review"
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
+    groups:
+      python-dev-tooling:
+        patterns:
+          - "ruff"
+          - "mypy"
+          - "pytest"
+          - "pytest-cov"
+          - "types-*"
+        update-types:
+          - "minor"
+          - "patch"
+      python-runtime:
+        patterns:
+          - "typer"
+          - "pyyaml"
+          - "rich"
+          - "cairosvg"
+        update-types:
+          - "patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "supply-chain-review"
+    cooldown:
+      default-days: 7
+      semver-major-days: 14

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -10,7 +10,17 @@ name: publish-pypi
 #
 # Publish release: tag `oe-vMAJOR.MINOR.PATCH` and use the Releases UI only
 # after the package-visible release gate in docs/release-simulations.md has
-# recorded release simulation and transcript-review evidence.
+# recorded release simulation and transcript-review evidence, and the
+# release-time supply-chain checks in docs/supply-chain-policy.md have run.
+#
+# Supply-chain posture (see decisions/2026-05-11-supply-chain-security-gates.md):
+#   - id-token: write is granted to exactly one job: `publish`.
+#   - Top-level permissions are contents: read; jobs widen explicitly.
+#   - The release artifact is built once in `build` and republished by
+#     `publish`; no rebuild happens in the publish environment.
+#   - The publish job is double-gated: the `pypi` environment requires a
+#     human approver, and an `if:` guard requires the release tag to match
+#     `oe-v*` so a stray release on a non-Main-Branch tag cannot publish.
 #
 # Release notes: the `extract-changelog` job parses CHANGELOG.md for the
 # section matching the release tag and updates the GitHub Release body
@@ -105,6 +115,11 @@ jobs:
     name: Publish to PyPI
     needs: [build, release-notes]
     runs-on: ubuntu-latest
+    # Defense in depth: trusted publishing + `pypi` environment approval are
+    # the primary gates. This `if:` blocks any GitHub Release whose tag does
+    # not match the Main Branch release scheme (`oe-vMAJOR.MINOR.PATCH`)
+    # from claiming an OIDC token, even if the environment is approved.
+    if: startsWith(github.event.release.tag_name, 'oe-v')
     environment:
       name: pypi
       url: https://pypi.org/p/mainbranch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,23 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+### Security
+
+- Locked Main Branch's supply-chain posture in
+  [`decisions/2026-05-11-supply-chain-security-gates.md`](decisions/2026-05-11-supply-chain-security-gates.md)
+  and documented the durable rules in
+  [`docs/supply-chain-policy.md`](docs/supply-chain-policy.md): trusted-publishing
+  OIDC only, `id-token: write` scoped to one job in `publish-pypi.yml`, `pypi`
+  GitHub Environment with a human approver, single-build artifact reused at
+  publish, dependency review in isolation, release-time supply-chain checks,
+  and a public-safe post-compromise response path.
+- `.github/workflows/publish-pypi.yml` now carries a defensive `if:` guard so
+  the `publish` job only runs when the release tag matches `oe-v*`, on top of
+  the trusted-publishing binding and the `pypi` environment approval gate.
+- `.github/dependabot.yml` now groups pip + GitHub Actions updates, labels
+  them for supply-chain review, and applies a release-age `cooldown` so
+  freshly-published versions are not proposed the same hour they land.
+
 ## [0.3.16] - 2026-05-11
 
 v0.3.16 lands the first concrete `mb books` command surface alongside the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -35,6 +35,20 @@ Include:
 - Expected impact
 - Any logs or screenshots that do not expose private business data
 
+## Supply chain
+
+Main Branch publishes to PyPI through a GitHub Actions workflow using trusted
+publishing (OIDC) gated by a GitHub Environment with a required reviewer. The
+durable policy — including the `id-token: write` boundary, dependency update
+posture, release-time supply-chain checks, and post-compromise response — is
+documented in [`docs/supply-chain-policy.md`](docs/supply-chain-policy.md) and
+locked in
+[`decisions/2026-05-11-supply-chain-security-gates.md`](decisions/2026-05-11-supply-chain-security-gates.md).
+
+If you suspect a Main Branch release, dependency update, or workflow has been
+compromised, follow the private report path below rather than opening a public
+issue.
+
 ## Scope
 
 In scope:
@@ -45,6 +59,8 @@ In scope:
   commands
 - Accidental exposure of private business data in generated files or logs
 - GitHub Actions, packaging, or release workflow issues that could affect users
+- Supply-chain issues in the published `mainbranch` package, the publish
+  workflow, or pinned GitHub Actions used by this repo
 
 Out of scope:
 

--- a/decisions/2026-05-11-supply-chain-security-gates.md
+++ b/decisions/2026-05-11-supply-chain-security-gates.md
@@ -1,0 +1,147 @@
+---
+type: decision
+date: 2026-05-11
+status: accepted
+topic: Supply-chain security gates for releases and dependencies
+linked_issues:
+  - https://github.com/noontide-co/mainbranch/issues/491
+linked_decisions:
+  - decisions/2026-05-11-repo-setup-visibility-and-checks-model.md
+  - decisions/2026-05-04-workspace-repo-sensitive-data-boundaries.md
+linked_docs:
+  - docs/supply-chain-policy.md
+  - docs/release-simulations.md
+  - docs/dependency-choices.md
+  - SECURITY.md
+tags: [security, release, supply-chain, github-actions, pypi, dependencies]
+---
+
+# Supply-Chain Security Gates For Releases And Dependencies
+
+## Decision
+
+Main Branch's supply-chain posture is small, boring, explicit, and biased
+toward deliberate human approval over clever automation. The rules below are
+the contract; the durable reference lives in
+[`docs/supply-chain-policy.md`](../docs/supply-chain-policy.md).
+
+- **PyPI publishing uses trusted publishing (OIDC) only.** No long-lived
+  PyPI API token lives in repo secrets, in maintainer dotfiles, or in any
+  GitHub Actions workflow.
+- **Publishing is gated by a GitHub Environment with required reviewers.**
+  The `pypi` environment requires at least one human approver before the
+  publish job can claim its OIDC identity. Trusted publishing without an
+  approval gate would let any successful release event publish; the gate is
+  what makes the publish step deliberate.
+- **`id-token: write` is granted to exactly one job in exactly one
+  workflow: `publish-pypi.yml` -> `publish`.** Every other job and workflow
+  uses the repo default of `contents: read` or narrower. New workflows must
+  not request `id-token: write` unless a new decision accepts the surface.
+- **The publish workflow triggers on `release: published`, not on raw tag
+  push.** The publish job carries a defensive `if:` guard so it only runs
+  when the release tag matches `oe-v*`. This prevents a stray release on a
+  non-Main-Branch tag from publishing.
+- **The release artifact is built once and published from that same
+  artifact.** The `build` job uploads the sdist/wheel, the `publish` job
+  downloads the same artifact. No rebuild happens inside the publishing
+  environment.
+- **Dependencies are pinned to documented floors and reviewed in
+  isolation.** `mb` has a small dependency surface (`typer`, `pyyaml`,
+  `rich`) declared with minimum versions in `mb/pyproject.toml`. Dependabot
+  opens grouped weekly PRs with a release-age cooldown so freshly-published
+  versions are not pulled the moment the ecosystem releases them. Dependency
+  PRs are not bundled with feature work.
+- **No hash-locked install path is required today.** `mb` is a small,
+  Typer-shaped CLI; introducing `pip-tools`, `uv`, or `poetry` lockfiles
+  would force a new dependency manager on contributors before the surface
+  earns it. This is revisable if the dependency footprint grows or if a
+  specific compromise scenario requires hash-locking.
+- **`scripts/check.sh` protects normal development. Release-only checks
+  protect users and PyPI.** Release validation runs the package-visible
+  release gate documented in
+  [`docs/release-simulations.md`](../docs/release-simulations.md) plus the
+  supply-chain checks in `docs/supply-chain-policy.md`. PR CI does not run
+  the release publish workflow.
+- **Post-compromise response has a written path.** If a dependency, a
+  release pipeline, or the PyPI account is suspected compromised,
+  `docs/supply-chain-policy.md` describes who pauses publishing, which
+  GitHub Environment approval is revoked, how to yank an affected release
+  on PyPI, and how to notify users through `SECURITY.md` and the GitHub
+  Release body.
+
+## Why
+
+Recent npm-ecosystem compromises (publishing-pipeline takeovers, malicious
+post-publish replacement of trusted packages, malicious dependency updates
+landing in the short window before ecosystem detection) reinforced lessons
+that apply to PyPI and GitHub Actions too:
+
+- Trusted publishing / OIDC reduces long-lived-token risk but does not stop
+  malicious code from running inside an authorized release workflow.
+- CI publishing removes the human second factor unless an environment
+  requires manual approval.
+- Dependency updates can land malicious versions during the short window
+  before the ecosystem detects and removes them.
+- Lockfiles, pinned versions, dependency age policies, and release-time
+  gates each plug different holes; no single control is sufficient.
+- Release workflows should be narrow, manually approved, and isolated from
+  normal PR checks.
+
+Main Branch is a small, public, single-maintainer-shaped CLI today. The
+right move is not a SLSA Level 3 build chain; it is to make the release
+path explicit, narrow, and reviewable. This decision locks the boring
+rules so the release process can grow safely without each contributor
+re-litigating the trade-offs.
+
+## Scope Locked
+
+- PyPI publishing flow (`publish-pypi.yml`).
+- Permissions and `id-token` use across all GitHub Actions workflows.
+- Dependency update policy for the `pip` and `github-actions` ecosystems
+  managed by Dependabot.
+- Package metadata and dependency declaration shape.
+- Manual approval gate via GitHub Environments.
+- Release-only supply-chain checks layered on top of the existing
+  package-visible release gate.
+- Public-safe post-compromise response guidance.
+
+## Out Of Scope
+
+- Replacing PyPI.
+- Building a private package mirror.
+- Full SLSA / Sigstore / in-toto provenance attestation.
+- npm ecosystem work (this repo ships no Node runtime surface).
+- Emergency incident response execution.
+- Hash-locked install via `pip-tools`, `uv`, or `poetry`.
+- Branch protection / ruleset configuration on `main` (recommended as a
+  follow-up; not configurable from inside the repo).
+
+## What Changes
+
+- `decisions/2026-05-11-supply-chain-security-gates.md` (this file).
+- `docs/supply-chain-policy.md` — durable policy and release runbook.
+- `.github/workflows/publish-pypi.yml` — defensive `if:` guard so the
+  publish job only runs from `oe-v*` releases; comment header documents
+  the trusted-publishing posture.
+- `.github/dependabot.yml` — release-age cooldown, grouped pip updates,
+  and explicit review labels.
+- `SECURITY.md` — link to the policy from the existing security report
+  surface.
+- `docs/oss-operating-checklist.md` — supply-chain checklist items in the
+  Release Readiness section.
+- `docs/README.md` — link the new policy from the docs index.
+- `.github/PULL_REQUEST_TEMPLATE.md` — dependency / release-pipeline
+  review checkbox.
+- `CHANGELOG.md` — `[Unreleased]` Security entry.
+
+## Follow-ups
+
+- Configure required reviewers on the `pypi` GitHub Environment. Cannot
+  be set from inside the repo; requires repo settings access.
+- Add branch protection on `main`: require CI green, require PR review,
+  block force-push, restrict who can push tags matching `oe-v*`.
+- Evaluate SHA-pinning third-party GitHub Actions with Dependabot
+  ecosystem updates; tracked as a separate slice.
+- Re-evaluate hash-locked installs (`pip-tools` / `uv`) once the
+  dependency surface grows past the current three runtime deps or after
+  any concrete compromise scenario surfaces.

--- a/docs/README.md
+++ b/docs/README.md
@@ -48,6 +48,7 @@ Pick the route that matches what you are doing.
 
 - [`oss-operating-checklist.md`](oss-operating-checklist.md) — public release / contributor checklist.
 - [`dependency-choices.md`](dependency-choices.md) — adopted rails and dependency policy.
+- [`supply-chain-policy.md`](supply-chain-policy.md) — PyPI publishing, GitHub Actions, dependency, and post-compromise rules.
 - [`claude-code-runtime-dogfood.md`](claude-code-runtime-dogfood.md) — manual runtime smoke runbook.
 - [`google-ads-gtm-conversion-rubric.md`](google-ads-gtm-conversion-rubric.md) — paid-traffic conversion rubric.
 - [`philosophy.md`](philosophy.md) — long-form product writing.

--- a/docs/oss-operating-checklist.md
+++ b/docs/oss-operating-checklist.md
@@ -135,6 +135,18 @@ that keep Main Branch usable as public infrastructure while it evolves quickly.
   matching `oe-vX.Y.Z` GitHub Release, and PyPI package state agree.
 - [ ] Planned release copy uses "planned", "target", or "next" until release
   verification proves users can install it.
+- [ ] Supply-chain posture from [`supply-chain-policy.md`](supply-chain-policy.md)
+  holds: `id-token: write` is granted to exactly one job in
+  `publish-pypi.yml`; top-level `permissions: contents: read` is preserved on
+  every workflow; the `pypi` GitHub Environment still requires a human
+  reviewer; no new long-lived PyPI token has been added.
+- [ ] Release-time supply-chain checks from
+  [`supply-chain-policy.md`](supply-chain-policy.md) run before tagging an
+  `oe-v*` release (CHANGELOG section, dependency review, workflow permissions
+  scan, Dependabot state, environment-reviewer confirmation, fresh PyPI
+  install verification).
+- [ ] Dependency upgrades are reviewed in isolation, not bundled with feature
+  work; Dependabot security advisories land as expedited dedicated PRs.
 
 ## 8. Issue / PR Discipline
 

--- a/docs/supply-chain-policy.md
+++ b/docs/supply-chain-policy.md
@@ -65,9 +65,12 @@ human approval over clever automation.
 - GitHub Actions are pinned to major-version tags
   (e.g. `actions/checkout@v6`, `pypa/gh-action-pypi-publish@release/v1`).
 - Dependabot's `github-actions` ecosystem opens weekly PRs when a pinned
-  major changes. The grouped review notes pattern in
-  [`.github/dependabot.yml`](../.github/dependabot.yml) keeps these PRs
-  reviewable.
+  major changes, with minor/patch updates grouped into a `github-actions-official`
+  PR (the `actions/*` family) and a `github-actions-release` PR (the
+  PyPA publisher and Linear release action). Major bumps still open as
+  individual PRs so the release-pipeline review is not hidden inside a
+  group diff. See
+  [`.github/dependabot.yml`](../.github/dependabot.yml).
 - Pinning to commit SHAs is preferred for higher-risk supply chains.
   Main Branch defers SHA pinning until the publish surface grows; it is
   tracked as a follow-up in

--- a/docs/supply-chain-policy.md
+++ b/docs/supply-chain-policy.md
@@ -1,0 +1,204 @@
+# Supply-Chain Policy
+
+Main Branch is a small public Python CLI that publishes to PyPI through a
+GitHub Actions workflow. The supply chain is short, and the trade-offs are
+explicit. This doc is the durable reference for the rules locked in
+[`decisions/2026-05-11-supply-chain-security-gates.md`](../decisions/2026-05-11-supply-chain-security-gates.md).
+
+The product stance is: small, boring, explicit, biased toward deliberate
+human approval over clever automation.
+
+## Current Posture
+
+### PyPI publishing
+
+- The PyPI publisher for `mainbranch` is configured as a **trusted
+  publisher** (OIDC) bound to:
+  - `owner=noontide-co`
+  - `repo=mainbranch`
+  - `workflow=publish-pypi.yml`
+  - `environment=pypi`
+- No long-lived PyPI API token lives in repo secrets, in maintainer
+  dotfiles, or in any GitHub Actions workflow.
+- The publish workflow triggers on `release: published`, not on raw tag
+  push. A release is a deliberate Releases-UI action by a maintainer.
+- The publish job carries a defensive `if:` guard so it only runs when
+  the release tag matches `oe-v*`. Defense in depth — the trusted
+  publisher binding is the primary gate.
+- The release artifact is built once in the `build` job, uploaded as an
+  artifact, then downloaded and published by the `publish` job. No
+  rebuild happens inside the publishing environment.
+
+### GitHub Environments and manual approval
+
+- The `pypi` GitHub Environment is the human approval gate. It is
+  configured in repo settings (not in YAML) to require at least one
+  reviewer before the `publish` job can claim its OIDC identity.
+- Trusted publishing without an approval gate would let any successful
+  release event publish. The environment gate is what makes the publish
+  step deliberate.
+- The reviewer must understand what is being published: which tag, which
+  build artifact, and which CHANGELOG section.
+
+### GitHub Actions permissions
+
+- Both `.github/workflows/ci.yml` and `.github/workflows/publish-pypi.yml`
+  declare `permissions: contents: read` at the top level. Every job
+  inherits the most restrictive default.
+- `id-token: write` is granted to exactly one job in exactly one
+  workflow: `publish-pypi.yml` -> `publish`. This permission is required
+  by the OIDC trusted-publishing exchange and must not appear anywhere
+  else without a new accepted decision.
+- The `release-notes` job in `publish-pypi.yml` requests `contents: write`
+  scoped to itself, only to update the GitHub Release body with the
+  CHANGELOG slice. It does not have `id-token: write` and cannot publish
+  to PyPI.
+- The `linear-release` job requests `contents: read` and uses the
+  `LINEAR_ACCESS_KEY` secret. It is gated on the `oe-v*` tag prefix and
+  only runs after `publish` succeeds.
+- New workflows or jobs must declare the minimum permissions they need
+  and document any deviation from `contents: read` in the workflow file
+  header.
+
+### Action pinning
+
+- GitHub Actions are pinned to major-version tags
+  (e.g. `actions/checkout@v6`, `pypa/gh-action-pypi-publish@release/v1`).
+- Dependabot's `github-actions` ecosystem opens weekly PRs when a pinned
+  major changes. The grouped review notes pattern in
+  [`.github/dependabot.yml`](../.github/dependabot.yml) keeps these PRs
+  reviewable.
+- Pinning to commit SHAs is preferred for higher-risk supply chains.
+  Main Branch defers SHA pinning until the publish surface grows; it is
+  tracked as a follow-up in
+  [`decisions/2026-05-11-supply-chain-security-gates.md`](../decisions/2026-05-11-supply-chain-security-gates.md).
+
+### Package metadata and dependency surface
+
+- `mb/pyproject.toml` declares three runtime dependencies: `typer`,
+  `pyyaml`, `rich`. Each has a documented floor (`>=`) and no upper
+  bound. Floors come from the lowest version known to work; upper bounds
+  would force premature compatibility breaks.
+- The dev extras (`ruff`, `mypy`, `pytest`, `pytest-cov`,
+  `types-PyYAML`) are pinned by compatibility-friendly ranges
+  (`~=`, `>=,<`).
+- Optional extras (e.g. `ogrender`) follow the same floor-only rule.
+- The base install footprint stays small on purpose. Adding a runtime
+  dependency requires the dependency rubric in
+  [`docs/dependency-choices.md`](dependency-choices.md).
+
+### Dependency update policy
+
+- Dependabot manages two ecosystems: `pip` (rooted at `/mb`) and
+  `github-actions` (rooted at `/`).
+- pip updates are grouped (security-only PRs separate from version
+  upgrades), opened weekly, capped at five open PRs per ecosystem, and
+  carry a release-age cooldown so a freshly-published version is not
+  proposed the same hour it lands on the index.
+- The cooldown gives the ecosystem time to detect malicious versions
+  before Main Branch surfaces them as proposals. It is not a guarantee.
+- Dependency PRs are reviewed for:
+  - the upstream changelog or release notes;
+  - new transitive deps introduced;
+  - any required code changes;
+  - whether the floor in `pyproject.toml` should move with the upgrade.
+- Dependency upgrades are not bundled with feature work. Mixing them
+  hides the supply-chain review surface inside a feature diff.
+- A security advisory (Dependabot security update) is treated as
+  expedited: review, validate, and merge as its own PR, ahead of the
+  weekly cadence.
+
+### No hash-locked install today
+
+- `mb` is a small Typer-shaped CLI with three runtime dependencies.
+  Introducing `pip-tools`, `uv`, or `poetry` lockfiles would force a new
+  dependency manager on contributors before the surface earns it.
+- This is revisable. If the dependency footprint grows or a specific
+  compromise scenario requires hash-locking, the decision will move and
+  this section will say so.
+
+### PR-time supply-chain review
+
+When reviewing a PR, surface these checks alongside `scripts/check.sh`:
+
+- Does this PR add a runtime dependency? If yes, does it pass the
+  dependency rubric in [`docs/dependency-choices.md`](dependency-choices.md)?
+- Does this PR change `.github/workflows/`? If yes, does it touch
+  permissions, secrets, environments, or `id-token`?
+- Does this PR change `.github/dependabot.yml`?
+- Does this PR change `mb/pyproject.toml` dependency floors?
+- Does this PR mix a dependency upgrade into a feature change?
+
+The PR template includes a "Supply-chain review" checkbox so reviewers do
+not have to remember the list from memory.
+
+## Release-Time Supply-Chain Checks
+
+The package-visible release gate in
+[`docs/release-simulations.md`](release-simulations.md) already covers
+runtime evidence. The checks below are the supply-chain layer on top of
+it. Run them before tagging an `oe-v*` release.
+
+1. Confirm `[Unreleased]` in `CHANGELOG.md` is empty or has been moved
+   to the new version section. The published release body is built from
+   the matching CHANGELOG section.
+2. Confirm no new runtime dependency landed without a dependency-rubric
+   note. `git log --oneline main..HEAD -- mb/pyproject.toml` should be
+   reviewable in one pass.
+3. Confirm no new workflow file landed with `id-token: write` or with a
+   `permissions:` block broader than `contents: read`. Search:
+   `grep -RIn "id-token\|permissions:" .github/workflows/`.
+4. Confirm Dependabot is current. No open security advisories,
+   no overdue grouped upgrades that should land in this release.
+5. Confirm the `pypi` GitHub Environment still requires a reviewer.
+   This is a settings check, not a YAML check.
+6. Tag and publish via the GitHub Releases UI. The publish workflow
+   triggers on `release: published`; the publish job blocks on the
+   `pypi` environment approval.
+7. Approve the deployment in the GitHub Actions UI only after the build
+   and release-notes jobs have completed and the artifact looks right.
+8. After publish, verify the fresh PyPI install per
+   `docs/release-simulations.md` (Release Acceptance tier).
+
+## Post-Compromise Response
+
+If a dependency, the release pipeline, or the PyPI account is suspected
+compromised:
+
+1. **Stop publishing.** Do not approve any pending `pypi` environment
+   deployment. Cancel any in-flight `publish` job. Revoke the
+   pending-publisher binding in the PyPI project settings if the
+   workflow file or repo is itself suspected.
+2. **Pause Dependabot merges.** Close any open dependency PR that
+   matches the suspected upstream package and any PR that updates the
+   suspected GitHub Action. Add a comment naming why.
+3. **Yank the affected release on PyPI** if a compromised version was
+   already published. Yanking keeps existing installs intact while
+   blocking new resolutions.
+4. **Open a private security advisory** on GitHub. Do not discuss the
+   suspected compromise in public issues or PR comments.
+5. **Notify users.** Update `SECURITY.md` if the affected version
+   range needs documenting. Add a `### Security` entry to
+   `CHANGELOG.md` and to the next GitHub Release body.
+6. **Rotate any credential that could have been exposed.** This
+   includes `LINEAR_ACCESS_KEY` and any other repo secret the
+   compromised workflow could have read.
+7. **Record what happened.** Add a dated report under
+   `docs/reports/YYYY-MM-DD-supply-chain-<short-name>.md` after the
+   advisory is public, using the sanitized public-evidence rules in
+   [`docs/release-simulations.md`](release-simulations.md).
+
+This response path is intentionally short. Full incident response
+playbooks would over-claim. Add new steps only after a real incident
+proves the gap.
+
+## Related Links
+
+- [Supply-chain security gates decision](../decisions/2026-05-11-supply-chain-security-gates.md)
+- [Repo setup, visibility, and checks model decision](../decisions/2026-05-11-repo-setup-visibility-and-checks-model.md)
+- [Workspace, repo, and sensitive-data boundaries decision](../decisions/2026-05-04-workspace-repo-sensitive-data-boundaries.md)
+- [Dependency choices](dependency-choices.md)
+- [Release simulations](release-simulations.md)
+- [Checks and review model](checks-and-review-model.md)
+- [OSS operating checklist](oss-operating-checklist.md)
+- [SECURITY.md](../SECURITY.md)


### PR DESCRIPTION
## Summary
- Lock Main Branch's supply-chain posture as a dated decision and a durable `docs/supply-chain-policy.md`: PyPI trusted publishing only, `id-token: write` scoped to one job, `pypi` GitHub Environment as the human approval gate, single-build artifact reused at publish, isolated dependency review with release-age cooldown, release-time supply-chain checks, and a public-safe post-compromise response path.
- Add defense-in-depth on the publish workflow: `if: startsWith(release tag, 'oe-v')` on the publish job so a stray release on a non-Main-Branch tag cannot claim the OIDC token, even if the environment is approved.
- Tighten Dependabot to group pip + GitHub Actions updates, label them `supply-chain-review`, and apply a release-age `cooldown` so freshly-published versions are not proposed the same hour they land.
- Surface the new policy from `SECURITY.md`, `docs/oss-operating-checklist.md`, `docs/README.md`, and the PR template; record the change under `CHANGELOG.md` `[Unreleased]` Security.

## Scope
- In: PyPI publishing flow, GitHub Actions permissions / `id-token` boundary, Dependabot policy, package metadata posture, manual approval gate, release-only supply-chain checks, post-compromise response guidance, contributor-doc surfacing.
- Out: replacing PyPI, private mirror, full SLSA/Sigstore provenance, npm tooling, hash-locked installs via `pip-tools` / `uv` / `poetry`, emergency response execution, repo-settings changes (Environment reviewers, branch protection, ruleset config).

## Commits
- `0064ab0` — [add] Supply-chain security policy and decision
- `550ef61` — [update] Tighten publish-pypi guard and dependabot review posture
- `08906a4` — [update] Surface supply-chain policy from contributor docs
- `66d33fd` — [docs] CHANGELOG: Unreleased Security entry for supply-chain gates

## Release / Issues
- Release: unscheduled (policy work; no version-bearing change).
- Linear ID(s): MAIN-324.
- Closes: #491
- Refs: —
- Follow-ups:
  - Configure required reviewers on the `pypi` GitHub Environment (repo settings; cannot be done in-repo).
  - Add `main` branch protection: require CI green, require PR review, block force-push, restrict who can push `oe-v*` tags.
  - Optionally SHA-pin third-party GitHub Actions with Dependabot ecosystem updates (separate slice).
  - Re-evaluate hash-locked installs once the runtime dependency surface grows past the current three.

## Success Metric
- A future contributor reading `docs/supply-chain-policy.md` and the decision can verify in one pass that PyPI publishing is gated by trusted publishing + the `pypi` Environment reviewer + the `oe-v*` tag guard, that `id-token: write` lives in exactly one job, and that dependency upgrades land as isolated reviewable PRs with a cooldown — without having to re-derive the rules from workflow YAML.

## Validation
- Level 0 docs/decision: frontmatter present on the decision; internal links resolve; no private/customer/member content; CHANGELOG `[Unreleased]` Security entry added.
- Level 1 static: `scripts/check.sh` passed locally (exit 0).
- Level 2 CLI: n/a — no CLI behavior changes.
- Level 3 package/install: n/a — no packaging changes.
- Level 4 fixture repo: n/a — no scaffolding changes.
- Level 5 runtime smoke: n/a — no skill prose or skill-discovery changes.

## Public / Private Boundary
- All changes are public-safe. No secrets, no member/customer data, no machine-specific paths. Private Conductor / Devon-local notes stay in `.context/cold-start.md` (gitignored).