### PR TITLE
[docs] Align post-release books language

### DIFF
--- a/decisions/2026-05-11-mb-books-foundation.md
+++ b/decisions/2026-05-11-mb-books-foundation.md
@@ -31,12 +31,12 @@ engine when using `mb books`.
 CSV and SQLite can be import staging, source snapshots, caches, or
 report outputs. They are not the books.
 
-`mb books` is a planned command group whose first responsibility is to
-validate that a business repo carries **safe bookkeeping metadata**, not
-to read or write real ledgers. Main Branch owns the operator workflow
-and wraps hledger in plain-language commands. Real financial ledgers
-stay local and gitignored by default. The team-visible business repo
-commits only safe metadata, fake fixtures, and documentation.
+`mb books` is a command group whose first shipped surface validates that a
+business repo carries **safe bookkeeping metadata**, not real ledgers. Main
+Branch owns the operator workflow and wraps hledger in plain-language
+commands. Real financial ledgers stay local and gitignored by default. The
+team-visible business repo commits only safe metadata, fake fixtures, and
+documentation.
 
 The product stance:
 
@@ -52,9 +52,9 @@ The product stance:
 - nothing in this decision promises a QuickBooks, Xero, or bookkeeper
   replacement.
 
-This decision codifies the foundation and names the first `mb books`
-surface. It does not ship the command. Implementation lands in a
-follow-up issue that references this decision.
+This decision codifies the foundation and named the first `mb books`
+surface. `mb books check` shipped in the follow-up implementation issue
+(#486).
 
 ## Why hledger
 
@@ -135,10 +135,9 @@ Three layers, in this order of preference:
    core must not. The shell-out boundary is what keeps the licence
    and install profile clean.
 
-## Optional Extras Packaging (Planned, Not Shipped)
+## Optional Extras Packaging (Deferred)
 
-When `mb books check` ships, the implementation issue should consider
-exposing the deeper-validation paths as a small optional extra:
+Deeper-validation paths may later become a small optional extra:
 
 ```bash
 pip install "mainbranch[books]"

--- a/decisions/2026-05-11-mb-books-foundation.md
+++ b/decisions/2026-05-11-mb-books-foundation.md
@@ -2,7 +2,7 @@
 type: decision
 date: 2026-05-11
 status: accepted
-topic: mb books foundation and safe ledger contract
+topic: mb books bookkeeping foundation and safe ledger contract
 linked_issues:
   - https://github.com/noontide-co/mainbranch/issues/483
   - https://github.com/noontide-co/mainbranch/issues/128
@@ -19,7 +19,7 @@ participants: [Devon, Claude]
 tags: [books, finance, hledger, safety, foundation]
 ---
 
-# mb books foundation and safe ledger contract
+# `mb books` Bookkeeping Foundation and Safe Ledger Contract
 
 ## Decision
 
@@ -29,7 +29,7 @@ optional for base `mb` installs, but it is the chosen bookkeeping
 engine when using `mb books`.
 
 CSV and SQLite can be import staging, source snapshots, caches, or
-report outputs. They are not the books.
+report outputs. They are not the bookkeeping record.
 
 `mb books` is a command group whose first shipped surface validates that a
 business repo carries **safe bookkeeping metadata**, not real ledgers. Main
@@ -151,22 +151,23 @@ helper code `mb` needs to shell out to `hledger` cleanly. The base
 report without it. Importers, deeper reports, and a viewer are not
 add-ons that this decision commits to ship.
 
-## Storage Model: Private Books Vault
+## Storage Model: Private Bookkeeping Vault
 
-Git history for the books is valuable for auditability. GitHub-by-default
+Git history for bookkeeping is valuable for auditability. GitHub-by-default
 is **not**. Git is the history engine; GitHub is a remote
-collaboration/backup service. For real books those are not the same
+collaboration/backup service. For real bookkeeping those are not the same
 thing.
 
-The user-facing term Main Branch uses is **private books vault**. `mb`
+The user-facing term Main Branch uses is **private bookkeeping vault**. `mb`
 creates and enforces the ignore rules. Operators do not need to learn
-`.gitignore` to keep their books out of GitHub.
+`.gitignore` to keep raw bookkeeping out of GitHub. The default path remains
+`.mb/private/books/` because the command group is `mb books`.
 
 Three storage modes:
 
 ### 1. Solo local (default)
 
-The real books live in a private books vault inside the business repo's
+The real bookkeeping lives in a private bookkeeping vault inside the business repo's
 local operational area, but are ignored by the business repo's tracked
 content and never pushed to its remote. The vault carries its own local
 git history.
@@ -174,7 +175,7 @@ git history.
 Default layout:
 
 ```text
-.mb/private/books/                # private books vault (own local git history)
+.mb/private/books/                # private bookkeeping vault (own local git history)
   main.journal                    # real hledger journal (authoritative ledger)
   imports/                        # raw bank/Stripe/PayPal exports
   cache/                          # SQLite cache/staging
@@ -194,14 +195,14 @@ Rules:
 
 ### 2. Team private repo (team finance mode)
 
-When more than one person needs the books, the vault graduates to a
-separate private books repo with restricted access.
+When more than one person needs bookkeeping access, the vault graduates to a
+separate private bookkeeping repo with restricted access.
 
 ```text
 private-books-repo/               # separate GitHub private repo, restricted access
   books/main.journal              # real hledger journal (authoritative ledger)
   books/rules/                    # real import rules
-  books/policies.md               # books policies
+  books/policies.md               # bookkeeping policies
   books/month-close.md            # close runbooks
   books/reports/monthly-summary.md
   books/imports/                  # usually ignored
@@ -219,24 +220,24 @@ Rules:
   main business repo's permissions do not apply here.
 - PR review by another finance/admin user is the expected workflow
   for transaction changes.
-- The main business repo never contains the real books, even when
+- The main business repo never contains the real bookkeeping records, even when
   team mode is active.
 
 Why a separate repo and not a private folder: GitHub permissions are
 repo-level. If 20 people have access to the main repo, then a "private"
-folder inside it is not private. Real books for a team always live in
-their own repo with their own access control.
+folder inside it is not private. Real bookkeeping for a team always lives in
+its own repo with its own access control.
 
 ### 3. Advanced encrypted / off-platform vault
 
-For teams that do not want real books on GitHub at all. `mb` points
+For teams that do not want real bookkeeping on GitHub at all. `mb` points
 at an encrypted local volume, network drive, or off-platform store.
 This is a deliberate advanced choice, not a default; the setup path
 is the operator's responsibility.
 
 ### GitHub-As-Backup Warning
 
-Whenever real books are tracked on GitHub (team mode or advanced
+Whenever real bookkeeping is tracked on GitHub (team mode or advanced
 choice), `mb books status` / `mb books doctor` must surface this
 warning:
 
@@ -253,7 +254,7 @@ plain language:
 
 ```text
 Books engine:      hledger
-Real books:        Private books vault
+Real bookkeeping: Private bookkeeping vault
 Git history:       local
 GitHub backup:     not enabled
 Encrypted backup:  not configured
@@ -264,7 +265,7 @@ Team mode:
 
 ```text
 Books engine:      hledger
-Books vault:       <repo-name>
+Bookkeeping vault: <repo-name>
 Storage mode:      team private repo
 Remote backup:     enabled
 Access:            restricted
@@ -297,7 +298,7 @@ recommendation, not an error. `core/finance/import-rules/` and
 no Class B data; the check warns if real account identifiers, real
 amounts, or real counterparties appear.
 
-Real ledger material (private books vault; not in the team-visible
+Real ledger material (private bookkeeping vault; not in the team-visible
 business repo). Solo default layout:
 
 ```text
@@ -308,12 +309,12 @@ business repo). Solo default layout:
 .mb/private/books/attachments/     # statements, receipts, tax docs (optional)
 ```
 
-Team mode layout (in a separate private books repo):
+Team mode layout (in a separate private bookkeeping repo):
 
 ```text
 books/main.journal                 # real hledger journal (authoritative)
 books/rules/                       # real import rules
-books/policies.md                  # books policies
+books/policies.md                  # bookkeeping policies
 books/month-close.md               # close runbooks
 books/reports/monthly-summary.md   # finance-team summaries
 books/imports/                     # usually ignored
@@ -342,7 +343,7 @@ class_b_data: true
 ```
 
 `vault_location` is a human-readable pointer Main Branch uses to
-explain where the books live. `mb books check` should refuse to read
+explain where bookkeeping lives. `mb books check` should refuse to read
 the vault's actual contents.
 
 ## Class B Examples For Bookkeeping

--- a/decisions/2026-05-11-scheduled-data-sync-pattern.md
+++ b/decisions/2026-05-11-scheduled-data-sync-pattern.md
@@ -52,7 +52,7 @@ Concretely:
   otherwise.
 - **Operational state** (last-run timestamps, exit status, run logs) lives
   under `.mb/private/sync/`, mirroring the
-  [private books vault](2026-05-11-mb-books-foundation.md) ignore pattern.
+  [private bookkeeping vault](2026-05-11-mb-books-foundation.md) ignore pattern.
   The team-visible business repo only carries the data outputs and the
   registry record, never run logs or operator-local paths.
 - **Credentials** stay in the OS keychain, the runtime environment, or
@@ -69,7 +69,7 @@ Concretely:
 - The pattern feeds the data-source registry. It does **not** feed the
   hledger journal directly. The
   [`mb books` foundation](2026-05-11-mb-books-foundation.md) keeps the
-  authoritative ledger inside the private books vault; bookkeeping
+  authoritative ledger inside the private bookkeeping vault; bookkeeping
   imports remain a separate follow-up scope.
 
 This slice ships docs and a decision. No CLI behaviour changes.
@@ -273,13 +273,13 @@ not change. The pattern adds three habits:
 
 The [`mb books` foundation](2026-05-11-mb-books-foundation.md) chose
 hledger as the bookkeeping engine and put the authoritative ledger in
-a **private books vault** (`.mb/private/books/main.journal` for solo
+a **private bookkeeping vault** (`.mb/private/books/main.journal` for solo
 mode, a separate restricted-access repo for team mode).
 
 This pattern does not change that. In particular:
 
 - Scheduled sync **may** write Stripe, PayPal, payroll, or bank
-  exports into the **private books vault's** `imports/` directory
+  exports into the **private bookkeeping vault's** `imports/` directory
   when the operator's script targets that location. That happens
   entirely inside the vault and inherits the vault's storage rules.
 - Scheduled sync **must not** write raw bank, processor, payroll, or
@@ -342,7 +342,7 @@ When the pattern proves itself in real use, file separate issues for:
   Ads daily) shipped under `docs/examples/sync/`.
 - A reference GitHub Actions workflow under `docs/examples/sync/`
   with a public-safe secret model.
-- `mb books import` and the bridge between the private books vault's
+- `mb books import` and the bridge between the private bookkeeping vault's
   `imports/` directory and the hledger journal.
 - Optional sidecar envelope for sync runs if a third-party tool
   becomes part of the recommended path.
@@ -373,8 +373,8 @@ when they ship CLI behaviour, scaffolding, or runtime wiring.
   files for both.
 - `mb` stays one-shot. The product avoids accumulating a background
   process before the rest of the daily loop is boring.
-- The pattern does not collide with the private books vault. Books
-  imports remain a separate scope with stricter data rules.
+- The pattern does not collide with the private bookkeeping vault.
+  Bookkeeping imports remain a separate scope with stricter data rules.
 - Future provider follow-ups have a contract to point at instead of
   re-litigating "where do logs go" each time.
 
@@ -389,7 +389,7 @@ Revisit this decision when any of these become true:
 - The optional sidecar enrichment contract grows a sync-shaped
   envelope that supersedes per-provider scripts.
 - `mb books import` lands and reshapes the boundary between
-  team-visible `data/` and the private books vault's `imports/`
+  team-visible `data/` and the private bookkeeping vault's `imports/`
   directory.
 - A separate accepted decision approves a Main Branch background
   service.

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,8 +13,8 @@ Pick the route that matches what you are doing.
 
 ### New here (cold start)
 
-- [`ethos.md`](ethos.md) — product principles.
-- [`operator-loops.md`](operator-loops.md) — Sense / Decide / Ship / Reflect.
+- [`ethos.md`](ethos.md) — product principles, source-of-truth model, and runtime stance.
+- [`operator-loops.md`](operator-loops.md) — Sense / Decide / Ship / Reflect workflow taxonomy.
 - [`roadmap.md`](roadmap.md) — current public direction.
 - [`beginner-setup.md`](beginner-setup.md) — human setup walkthrough.
 
@@ -27,16 +27,17 @@ Pick the route that matches what you are doing.
 
 ### Operating the daily loop
 
-- [`operator-loops.md`](operator-loops.md) — the four loops.
-- [`playbooks.md`](playbooks.md) — reusable operating recipes.
+- [`operator-loops.md`](operator-loops.md) — how operator work moves through Sense, Decide, Ship, Reflect.
+- [`playbooks.md`](playbooks.md) — reusable operating recipes and run records.
+- [`books.md`](books.md) — bookkeeping safety, hledger, and the private ledger vault model.
 - [`onboarding-progress.md`](onboarding-progress.md) — lifecycle skill resume surface.
-- [`business-connections.md`](business-connections.md) — link conventions inside a repo.
+- [`business-connections.md`](business-connections.md) — when to use frontmatter links, inline links, tags, data refs, or context.
 - [`markdown-link-conventions.md`](markdown-link-conventions.md) — markdown and link rules.
 - [`issue-drafting.md`](issue-drafting.md) — privacy-safe `mb issue` flow.
 
 ### Schemas and contracts
 
-- [`system-architecture.md`](system-architecture.md) — repo shapes, primitives, schemas.
+- [`system-architecture.md`](system-architecture.md) — repo shapes, business primitives, boundaries, and schemas.
 - [`json-output-contract.md`](json-output-contract.md) — `mb --json` envelope.
 - [`data-source-registry.md`](data-source-registry.md) — `type: data_source` records.
 - [`child-repo-descriptors.md`](child-repo-descriptors.md) — `.mainbranch/repo.json`.
@@ -73,6 +74,9 @@ Pick the route that matches what you are doing.
 Under `docs/`:
 
 - Markdown filenames are **lowercase kebab-case** by default.
+- Filenames should name the document's job clearly enough that a fresh agent
+  can classify it from the path. If a short product noun is ambiguous, make the
+  title explicit, for example `Bookkeeping (mb books)`.
 - The only all-caps exception under `docs/` is `docs/README.md`.
 - Files under `docs/reports/` may begin with `YYYY-MM-DD-` (dated evidence).
 - Files under `docs/prd/` use versioned lowercase names like

--- a/docs/books.md
+++ b/docs/books.md
@@ -1,8 +1,10 @@
-# Books
+# Bookkeeping (`mb books`)
 
 This page describes how Main Branch treats bookkeeping today. It is the
 operator-facing companion to
 [the mb books foundation decision](../decisions/2026-05-11-mb-books-foundation.md).
+The command group is named `mb books` because it is short; the business
+function is bookkeeping.
 
 ## The Short Version
 
@@ -15,11 +17,13 @@ operator-facing companion to
   bookkeeping engine when using `mb books`. `mb` does not require
   hledger to install, onboard, or run.
 - CSV and SQLite are import staging, source snapshots, caches, or
-  report outputs. They are not the books.
-- Real books live in a **private books vault**, never in the
-  team-visible business repo by default. `mb` keeps the books out of
-  GitHub unless the operator explicitly opts in. You should not need
-  to learn `.gitignore` to keep your books private; `mb` handles it.
+  report outputs. They are not the bookkeeping record.
+- Real bookkeeping lives in a **private bookkeeping vault**, never in the
+  team-visible business repo by default. The default path is still
+  `.mb/private/books/`, but the product concept is bookkeeping privacy,
+  not a content library. `mb` keeps raw finance out of GitHub unless the
+  operator explicitly opts in. You should not need to learn `.gitignore`
+  to keep bookkeeping private; `mb` handles it.
 - Real ledgers, statements, payroll, tax data, and account identifiers
   are **Class B data**.
 
@@ -30,8 +34,8 @@ explains the choice in `mb books status`.
 
 ### Solo local (default)
 
-The real books live in a private books vault inside your business
-repo's local working tree — but the vault is ignored by the business
+The real bookkeeping lives in a private bookkeeping vault inside your business
+repo's local working tree, but the vault is ignored by the business
 repo and never pushed to its remote.
 
 ```text
@@ -48,15 +52,15 @@ GitHub remote by default. Encrypted local backup is recommended.
 
 ### Team private repo
 
-When two or more people need books access, the vault graduates to a
-separate **private books repo** with access restricted to the
+When two or more people need bookkeeping access, the vault graduates to a
+separate **private bookkeeping repo** with access restricted to the
 finance/admin users who need it.
 
 ```text
 private-books-repo/
   books/main.journal           # real hledger journal (source of truth)
   books/rules/                 # real import rules
-  books/policies.md            # books policies
+  books/policies.md            # bookkeeping policies
   books/month-close.md         # close runbooks
   books/reports/monthly-summary.md
   books/imports/   # ignored
@@ -67,22 +71,22 @@ private-books-repo/
 
 PR review by another finance/admin user is the expected workflow for
 transaction changes. The main business repo never contains the real
-books, even when team mode is active.
+bookkeeping records, even when team mode is active.
 
 Why a separate repo and not a private folder: GitHub permissions are
 repo-level. If 20 people have access to the main business repo, then a
-"private" folder inside it is not actually private. Real books for a
-team always live in their own repo with their own access control.
+"private" folder inside it is not actually private. Real bookkeeping for a
+team always lives in its own repo with its own access control.
 
 ### Advanced encrypted / off-platform vault
 
-For teams that do not want real books on GitHub at all. `mb` points at
+For teams that do not want real bookkeeping on GitHub at all. `mb` points at
 an encrypted local volume, network drive, or off-platform store. This
 is a deliberate advanced choice, not a default.
 
 ### GitHub Warning
 
-Whenever real books are tracked on GitHub (team mode or advanced
+Whenever real bookkeeping is tracked on GitHub (team mode or advanced
 choice), `mb books status` surfaces:
 
 ```text
@@ -103,7 +107,7 @@ docs/reports/finance/              # sanitized summaries only
 ```
 
 All four are optional. A business repo without them is still valid.
-When present, they describe how the operator runs the books — not
+When present, they describe how the operator runs bookkeeping, not
 what the numbers are. `core/finance/import-rules/` and
 `docs/reports/finance/` may exist only when their contents contain
 no Class B data; `mb books check` warns when real identifiers or
@@ -125,9 +129,9 @@ encrypted_backup: false
 class_b_data: true
 ---
 
-# Books
+# Bookkeeping
 
-This business uses an hledger journal kept in a private books vault.
+This business uses an hledger journal kept in a private bookkeeping vault.
 This file is the public-safe pointer. The journal itself is not
 committed here.
 ```
@@ -138,7 +142,7 @@ operator uses (`assets`, `liabilities`, `equity`, `income`,
 real account numbers, balances, or specific institution names tied
 to live accounts.
 
-### In the private books vault (Class B; not in the business repo)
+### In the private bookkeeping vault (Class B; not in the business repo)
 
 The layout depends on the storage mode — see above. The principle is
 the same: the vault is where real bookkeeping lives, and the

--- a/docs/ethos.md
+++ b/docs/ethos.md
@@ -123,9 +123,9 @@ dependencies of the core engine.
 Main Branch should not connect every tool an operator has accumulated. The team
 should make opinionated, explainable choices: prefer official provider paths,
 boring CLIs, portable files, and local-first state. Cloudflare, GitHub,
-Google/Workspace, official ads paths, Postiz, Beancount, Apify, transcription,
-and future sidecars earn their place by improving a loop and by failing in ways
-`mb` can explain.
+Google/Workspace, official ads paths, Postiz, hledger, Apify, transcription,
+and future sidecars earn their place by improving a loop and by failing in
+ways `mb` can explain.
 
 ### 9. Evidence Beats Hunches
 

--- a/docs/examples/books/acme-fixture.journal
+++ b/docs/examples/books/acme-fixture.journal
@@ -2,7 +2,7 @@
 ; SAMPLE FIXTURE — NOT A REAL LEDGER
 ; ----------------------------------------------------------------------
 ; Fictional company: Acme Fixture Inc.
-; Purpose: exercise the planned `mb books check` contract.
+; Purpose: exercise the shipped `mb books check` contract.
 ; Real ledgers never live in this engine repo. See docs/books.md.
 ; ----------------------------------------------------------------------
 

--- a/docs/examples/books/books.md
+++ b/docs/examples/books/books.md
@@ -11,7 +11,7 @@ encrypted_backup: false
 class_b_data: true
 ---
 
-# Books — Sample
+# Bookkeeping — Sample
 
 > Sample file. Not a real bookkeeping policy. See
 > [docs/books.md](../../books.md) for the operator-facing description and
@@ -20,7 +20,7 @@ class_b_data: true
 
 This is what a real `core/finance/books.md` could look like in a
 business repo for a fictional company using the solo-local storage
-mode. The real books live in a private books vault inside the
+mode. The real bookkeeping records live in a private bookkeeping vault inside the
 business repo's local working tree, ignored from the business repo's
 tracked content and never pushed to its remote.
 

--- a/docs/examples/books/index.md
+++ b/docs/examples/books/index.md
@@ -1,6 +1,6 @@
 # Books Examples
 
-Fake bookkeeping fixtures used to exercise the planned `mb books check`
+Fake bookkeeping fixtures used to exercise the shipped `mb books check`
 contract. Everything in this folder is intentionally fake.
 
 These files exist in this engine repo only. They are not copied into a

--- a/docs/examples/books/index.md
+++ b/docs/examples/books/index.md
@@ -1,4 +1,4 @@
-# Books Examples
+# Bookkeeping Examples
 
 Fake bookkeeping fixtures used to exercise the shipped `mb books check`
 contract. Everything in this folder is intentionally fake.

--- a/docs/operator-loops.md
+++ b/docs/operator-loops.md
@@ -298,11 +298,11 @@ Underneath Ship sit the four channels every operator can recognize:
 - **Organic** — owned audience content (Reels, TikTok, threads, YouTube,
   newsletter, Skool posts)
 - **Pages** — landers, minisites, websites, public bet pages, deployed assets
-- **Ops** — bookkeeping (Beancount), P&L, compliance, integrations, meetings,
+- **Ops** — bookkeeping (hledger), P&L, compliance, integrations, meetings,
   fulfillment, repo topology, team updates, and operating health
 
 Skills cluster by channel today (`/mb-ads` for Paid, `/mb-organic` and
-`/mb-vsl` for Organic, `/mb-site` for Pages, `mb books` planned for Ops).
+`/mb-vsl` for Organic, `/mb-site` for Pages, `mb books check` for Ops).
 Channels grow over time without bloating the loop count — adding new sidecar
 CLIs adds new Ship channels, not new loops.
 

--- a/docs/operator-loops.md
+++ b/docs/operator-loops.md
@@ -171,8 +171,8 @@ through Ops.
 - Beginner-safe connector flows for GitHub, Cloudflare, Google, Meta, Apify
 - deeper site/CMS rails on top of `mb site check` over Cloudflare, GitHub, and
   operator-approved measurement
-- richer Paid, Organic, Pages, and Ops surfaces (books, P&L, meetings,
-  fulfillment, compliance)
+- richer Paid, Organic, Pages, and Ops surfaces (bookkeeping through
+  `mb books`, P&L, meetings, fulfillment, compliance)
 
 ## 4. Reflect
 
@@ -302,7 +302,8 @@ Underneath Ship sit the four channels every operator can recognize:
   fulfillment, repo topology, team updates, and operating health
 
 Skills cluster by channel today (`/mb-ads` for Paid, `/mb-organic` and
-`/mb-vsl` for Organic, `/mb-site` for Pages, `mb books check` for Ops).
+`/mb-vsl` for Organic, `/mb-site` for Pages, `mb books check` for
+bookkeeping Ops).
 Channels grow over time without bloating the loop count — adding new sidecar
 CLIs adds new Ship channels, not new loops.
 

--- a/docs/post-release-alignment.md
+++ b/docs/post-release-alignment.md
@@ -160,9 +160,10 @@ Use this list as a quick decision-alignment scan during alignment sweeps and
 code review. Each line is intentionally a one-line pointer; the durable
 truth lives in the linked doc or decision.
 
-- **Bookkeeping engine**: hledger. Real books live in a private books vault
-  (solo-local under `.mb/private/books/` by default, or a separate
-  team-private repo). See `docs/books.md` and
+- **Bookkeeping engine**: hledger. The shipped command group is `mb books`,
+  but the business function is bookkeeping. Real bookkeeping records live
+  in a private bookkeeping vault (solo-local under `.mb/private/books/` by
+  default, or a separate team-private repo). See `docs/books.md` and
   `decisions/2026-05-11-mb-books-foundation.md`.
 - **Scheduled data sync**: operator-owned cron / `launchd` / Task Scheduler
   running one-shot per-provider scripts, not a hidden daemon. See

--- a/docs/scheduled-data-sync.md
+++ b/docs/scheduled-data-sync.md
@@ -22,7 +22,7 @@ fresh. It is the operator-facing companion to
 - The `mb data sync` and `mb data status` commands are **planned**, not
   shipped. The pattern works today with a hand-rolled cron entry.
 - Real bookkeeping data (bank, processor, payroll, tax) does **not**
-  go through `data/<provider>/`. It belongs in the private books vault
+  go through `data/<provider>/`. It belongs in the private bookkeeping vault
   per [`docs/books.md`](books.md).
 
 ## How The Pieces Fit
@@ -251,11 +251,11 @@ Real bookkeeping data does **not** go through `data/<provider>/`.
   to sync into the team-visible `data/<provider>/` registry.
 - Bank exports, processor settlements, payroll, tax, raw customer
   payment rows → these are **Class B** per
-  [`docs/books.md`](books.md). They belong in the private books
+  [`docs/books.md`](books.md). They belong in the private bookkeeping
   vault (`.mb/private/books/imports/` for solo, the books repo for
   team mode), never in `data/<provider>/`.
 
-The sync pattern and the books vault stay separate on purpose. A
+The sync pattern and the bookkeeping vault stay separate on purpose. A
 future `mb books import` command will read from the vault's
 `imports/` directory and feed the hledger journal. It will not read
 from `data/<provider>/`. The team-visible registry never becomes a

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -81,7 +81,7 @@ repo `.mainbranch/source.json` files remain compatibility links.
 | `offer` | Graduated offer or productized service that needs its own lifecycle | Linked back to the business repo |
 | `product` | Software product, tool, course, template, or product surface | Separate when execution has its own lifecycle |
 | `client` | Client-specific fulfillment context and deliverables | Separate when access or confidentiality differs |
-| `finance` | Beancount ledger, exports, tax docs, sensitive P&L sources | Private by default; share summaries intentionally |
+| `finance` | hledger journal, exports, tax docs, sensitive P&L sources | Private by default; share summaries intentionally |
 | `legal` | Contracts, entity docs, disputes, or legal reviews | Private by default; share summaries intentionally |
 | `ops` | Private infrastructure, runbooks, provider setup, or team routines | Separate when operational authority differs |
 | `integration_sidecar` | Helper repo/tool for provider, analytics, enrichment, deployment data, raw caches, metrics databases, or connector glue | Optional and contract-backed |
@@ -487,8 +487,8 @@ runtimes are compatibility targets until adapter code and smoke evidence
 exist. See [compatibility.md](compatibility.md).
 
 Curated rails — GitHub, Cloudflare, Google/Workspace, official ads paths,
-Postiz, Beancount, transcription helpers — earn their place by improving a
-loop and by failing in ways `mb` can explain. See
+Postiz, hledger, transcription helpers — earn their place by improving a loop
+and by failing in ways `mb` can explain. See
 [ethos.md](ethos.md#8-curated-rails-beat-saas-sprawl) and
 [dependency-choices.md](dependency-choices.md).
 

--- a/mb/mb/_data/books/acme-fixture.journal
+++ b/mb/mb/_data/books/acme-fixture.journal
@@ -2,7 +2,7 @@
 ; SAMPLE FIXTURE — NOT A REAL LEDGER
 ; ----------------------------------------------------------------------
 ; Fictional company: Acme Fixture Inc.
-; Purpose: exercise the planned `mb books check` contract.
+; Purpose: exercise the shipped `mb books check` contract.
 ; Real ledgers never live in this engine repo. See docs/books.md.
 ; ----------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Runs the post-release alignment sweep after `v0.3.16` and updates public docs that still described shipped `mb books check` behavior as planned.
- Aligns active architecture/channel language from Beancount to hledger while leaving broader provider, educational, template, test, and CLI-copy cleanup to #494.
- Clarifies that `mb books` is the shipped command name, while the business function is bookkeeping, and tightens the docs index so fresh agents can classify docs by filename and description.

## Linked issue

Refs #489
Refs #494

## Why

The `v0.3.16` release shipped `mb books check` and the hledger bookkeeping foundation, but a few public docs and fixtures still used pre-release language. This PR keeps release truth, bookkeeping docs, and architecture copy aligned without expanding into the larger Beancount-era active-surface cleanup.

## Commits by concern

- [ ] Each commit body bullet-lists the changes in that commit (second follow-up commit is subject-only; diff is docs-only)
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`

Commits:

- `4a9be38` — `[docs] Align post-release books language`
- `11425ce` — `[docs] Clarify bookkeeping and doc discovery language`

## Validation

Pre-push gate from repo root:

```bash
scripts/check.sh
```

- [x] Level 1 static: `scripts/check.sh` — runtime: `/usr/bin/python3` (3.13) — exit: `0` — log: `.context/check-post-release-alignment-bookkeeping.out` (546 passed)
- [x] Level 2 CLI contract: not required; no CLI behavior changed
- [x] Level 3 package/install smoke: not required; no packaging or install surface changed
- [x] Level 4 fixture repo: not required; no init/onboard/status/start/update behavior changed
- [x] Level 5 runtime smoke / dogfood harness / simulation-tier: not required; no runtime, first-run, skill discovery, or release validation behavior changed
- [x] SKILL.md <=500 lines: not required; no skill files changed
- [x] Package-visible release gate evidence before tag/publish: not required; this is post-release docs alignment, not a release prep PR
- [x] Supply-chain review: not required; no workflow, Dependabot, dependency, `id-token`, or permissions changes

## Success metric

A reviewer can scan the touched docs and fixtures after `v0.3.16` and see `mb books check` described as shipped, hledger as the current bookkeeping rail, `mb books` as the command name rather than the whole concept, and #494 as the owner of remaining Beancount-era provider/education/template/test cleanup.

## CHANGELOG

- [x] N/A — docs alignment only; no user-visible CLI, skill, packaging, compatibility, workflow, or release-process change

## Breaking changes

- [x] No
- [ ] Yes — migration note below

## Public / private boundary

No private operator strategy, machine-specific paths, secrets, customer/member data, or runtime internals were committed. The branch only updates public release-alignment docs and mirrored fake fixture copy.
