### PR TITLE
[update] Dogfood mb books check after hledger cleanup

### DIFF
--- a/.claude/skills/mb-site/references/archetypes/dark-hero.md
+++ b/.claude/skills/mb-site/references/archetypes/dark-hero.md
@@ -53,7 +53,7 @@ The Dark Hero shows the broken rule and the alternative side-by-side. The verdic
 ## Example brand applications
 
 - **Forgejo** vs. closed-source Git forges: rule = "you ship a forge as a SaaS"; broken rule = self-hostable, AGPL, federation-first.
-- **Beancount** vs. consumer accounting: rule = "users want a GUI"; broken rule = plain-text ledgers in version control.
+- **hledger** vs. consumer accounting: rule = "users want a GUI"; broken rule = plain-text books plus repo-backed summaries.
 - **Cal.com** vs. closed-source scheduling: rule = "scheduling is a SaaS"; broken rule = open source, self-hostable, API-first.
 - **A landing-page builder** that ships pages as static HTML with no JS: rule = "modern sites are React apps"; broken rule = `<html>` files served from a CDN.
 - **A consultancy** that posts every client deliverable to a public GitHub repo (with consent): rule = "deliverables are confidential"; broken rule = the work itself is the marketing.

--- a/.claude/skills/mb-site/references/archetypes/david-goliath.md
+++ b/.claude/skills/mb-site/references/archetypes/david-goliath.md
@@ -6,7 +6,7 @@ Small, righteous, vastly outmatched — but armed with one specific advantage. T
 
 - Indie products against incumbents.
 - Challenger brands.
-- Tools built explicitly *against* a market default (Forgejo vs. GitHub, Beancount vs. QuickBooks, Cal.com vs. Calendly, Cloudflare Pages vs. Vercel).
+- Tools built explicitly *against* a market default (Forgejo vs. GitHub, hledger vs. QuickBooks, Cal.com vs. Calendly, Cloudflare Pages vs. Vercel).
 - Operators who already feel small and want an artifact to fight back with.
 
 Do **not** invoke when you're not actually small. If you're the incumbent, picking David is dishonest and the audience clocks it.

--- a/.claude/skills/mb-skill-brief-draft/references/archetypes/dark-hero.md
+++ b/.claude/skills/mb-skill-brief-draft/references/archetypes/dark-hero.md
@@ -53,7 +53,7 @@ The Dark Hero shows the broken rule and the alternative side-by-side. The verdic
 ## Example brand applications
 
 - **Forgejo** vs. closed-source Git forges: rule = "you ship a forge as a SaaS"; broken rule = self-hostable, AGPL, federation-first.
-- **Beancount** vs. consumer accounting: rule = "users want a GUI"; broken rule = plain-text ledgers in version control.
+- **hledger** vs. consumer accounting: rule = "users want a GUI"; broken rule = plain-text books plus repo-backed summaries.
 - **Cal.com** vs. closed-source scheduling: rule = "scheduling is a SaaS"; broken rule = open source, self-hostable, API-first.
 - **A landing-page builder** that ships pages as static HTML with no JS: rule = "modern sites are React apps"; broken rule = `<html>` files served from a CDN.
 - **A consultancy** that posts every client deliverable to a public GitHub repo (with consent): rule = "deliverables are confidential"; broken rule = the work itself is the marketing.

--- a/.claude/skills/mb-skill-brief-draft/references/archetypes/david-goliath.md
+++ b/.claude/skills/mb-skill-brief-draft/references/archetypes/david-goliath.md
@@ -6,7 +6,7 @@ Small, righteous, vastly outmatched — but armed with one specific advantage. T
 
 - Indie products against incumbents.
 - Challenger brands.
-- Tools built explicitly *against* a market default (Forgejo vs. GitHub, Beancount vs. QuickBooks, Cal.com vs. Calendly, Cloudflare Pages vs. Vercel).
+- Tools built explicitly *against* a market default (Forgejo vs. GitHub, hledger vs. QuickBooks, Cal.com vs. Calendly, Cloudflare Pages vs. Vercel).
 - Operators who already feel small and want an artifact to fight back with.
 
 Do **not** invoke when you're not actually small. If you're the incumbent, picking David is dishonest and the audience clocks it.

--- a/.claude/skills/mb-skill-review/references/archetypes/dark-hero.md
+++ b/.claude/skills/mb-skill-review/references/archetypes/dark-hero.md
@@ -53,7 +53,7 @@ The Dark Hero shows the broken rule and the alternative side-by-side. The verdic
 ## Example brand applications
 
 - **Forgejo** vs. closed-source Git forges: rule = "you ship a forge as a SaaS"; broken rule = self-hostable, AGPL, federation-first.
-- **Beancount** vs. consumer accounting: rule = "users want a GUI"; broken rule = plain-text ledgers in version control.
+- **hledger** vs. consumer accounting: rule = "users want a GUI"; broken rule = plain-text books plus repo-backed summaries.
 - **Cal.com** vs. closed-source scheduling: rule = "scheduling is a SaaS"; broken rule = open source, self-hostable, API-first.
 - **A landing-page builder** that ships pages as static HTML with no JS: rule = "modern sites are React apps"; broken rule = `<html>` files served from a CDN.
 - **A consultancy** that posts every client deliverable to a public GitHub repo (with consent): rule = "deliverables are confidential"; broken rule = the work itself is the marketing.

--- a/.claude/skills/mb-skill-review/references/archetypes/david-goliath.md
+++ b/.claude/skills/mb-skill-review/references/archetypes/david-goliath.md
@@ -6,7 +6,7 @@ Small, righteous, vastly outmatched — but armed with one specific advantage. T
 
 - Indie products against incumbents.
 - Challenger brands.
-- Tools built explicitly *against* a market default (Forgejo vs. GitHub, Beancount vs. QuickBooks, Cal.com vs. Calendly, Cloudflare Pages vs. Vercel).
+- Tools built explicitly *against* a market default (Forgejo vs. GitHub, hledger vs. QuickBooks, Cal.com vs. Calendly, Cloudflare Pages vs. Vercel).
 - Operators who already feel small and want an artifact to fight back with.
 
 Do **not** invoke when you're not actually small. If you're the incumbent, picking David is dishonest and the audience clocks it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   foundation decision. Default generated `.gitignore` files now protect
   `.mb/private/`, `*.journal`, `*.hledger`, and `*.ledger` alongside the
   defensive `*.beancount` pattern.
+- Dogfooded `mb books check` through the installed package and a fresh business
+  repo after the hledger cleanup, recorded the evidence in
+  [`docs/reports/2026-05-12-books-check-dogfood.md`](docs/reports/2026-05-12-books-check-dogfood.md),
+  and updated bundled skill archetype examples that still used Beancount as an
+  active bookkeeping example.
 - Repositioned VSLs as reusable conversion knowledge inside `/mb-think`,
   `/mb-site`, `/mb-ads`, and `/mb-organic` workflows instead of a standalone
   business primitive. `/mb-vsl` remains as a compatibility router for existing

--- a/docs/reports/2026-05-12-books-check-dogfood.md
+++ b/docs/reports/2026-05-12-books-check-dogfood.md
@@ -1,0 +1,70 @@
+---
+title: mb books check hledger cleanup dogfood
+date: 2026-05-12
+linked_issue: https://github.com/noontide-co/mainbranch/issues/501
+release: next patch candidate after v0.3.16
+status: complete
+tags: [bookkeeping, dogfood, hledger, package-smoke]
+---
+
+# `mb books check` Hledger Cleanup Dogfood
+
+## Summary
+
+The post-v0.3.16 hledger cleanup passes the installed-package and fresh business
+repo smoke. The dogfood also found one stale active skill-reference family that
+still used Beancount as the bookkeeping example; this branch updates those
+examples to hledger.
+
+## Environment
+
+- Branch: `dmthepm/books-dogfood`
+- Package built from the branch with `python3 -m build`
+- Wheel installed into `/tmp/mainbranch-books-dogfood-venv`
+- Fresh business repo created at `/tmp/mainbranch-books-dogfood-business`
+- Installed CLI reported `mb 0.3.16`
+
+## Commands Run
+
+- `mb --version`
+- `mb skill list`
+- `mb educational hledger`
+- `mb educational beancount`
+- `mb onboard --yes --name "Books Dogfood" --path /tmp/mainbranch-books-dogfood-business --json`
+- `mb books check /tmp/mainbranch-books-dogfood-business --json`
+- `mb books check /tmp/mainbranch-books-dogfood-business`
+- `mb books check /tmp/mainbranch-books-dogfood-business --fixture --json`
+- `mb connect status --repo /tmp/mainbranch-books-dogfood-business --all --json`
+- `mb connect list --repo /tmp/mainbranch-books-dogfood-business --json`
+- `rg -n -i 'beancount' ...`
+
+## Results
+
+- Package/install smoke passed: the installed CLI ran and listed bundled skills.
+- `mb educational hledger` is present and has no Beancount references.
+- `mb educational beancount` exits with topic-not-found and suggests the current
+  topic list, including `hledger`.
+- Fresh `mb onboard --yes` created the business repo and linked packaged skills.
+- Generated `.gitignore` contains `.mb/private/`, `*.journal`, `*.hledger`,
+  `*.ledger`, and defensive `*.beancount`.
+- `mb books check` on the fresh repo exits 0 with expected info findings for
+  optional `core/finance/books.md` and `core/finance/chart-of-accounts.md`.
+- `mb books check --fixture` exits 0 and validates the bundled hledger fixture on
+  this machine.
+- `mb connect status --all --json` exposes `hledger`, not Beancount.
+- `mb connect list --json` exposes `hledger`, not Beancount.
+
+## Beancount Search Classification
+
+Remaining Beancount mentions after this branch are intentional:
+
+- release history and changelog entries;
+- the hledger-vs-Beancount research report and books foundation decision;
+- superseded dependency-choice rows;
+- defensive ignore and ledger-extension coverage for `.beancount` files;
+- tests that assert Beancount is no longer an active provider or educational
+  topic.
+
+The active bundled skill archetype examples were not in that category. They now
+use hledger for the bookkeeping example and describe the safe current product
+shape as plain-text books plus repo-backed summaries.


### PR DESCRIPTION
## Summary

Dogfoods `mb books check` after the hledger cleanup through the installed package and a fresh business repo, then records the public-safe evidence. The run found stale active skill archetype examples that still used Beancount as the bookkeeping example; this PR updates those examples to hledger.

## Linked issue

Closes #501

Refs #502 as the follow-up for tightening post-release simulation transcript audits.

## Why

After v0.3.16 shipped the first `mb books check` surface and later cleanup replaced active Beancount surfaces with hledger, the release candidate needed one real installed-package dogfood pass. This proves the fresh repo path, private books ignore rules, hledger fixture path, and provider/education surfaces agree before the next patch release.

## Commits by concern

- `16269c5 [update] Dogfood books check hledger cleanup`
  - records package/fresh-repo dogfood evidence in `docs/reports/2026-05-12-books-check-dogfood.md`;
  - updates bundled skill archetype examples from Beancount to hledger;
  - adds the dogfood note to `CHANGELOG.md`.

- [ ] Each commit body bullet-lists the changes in that commit — not used on this single narrow commit; the PR body carries the concern details.
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`

## Validation

Pre-push gate from repo root:

```bash
scripts/check.sh
```

- [x] Level 1 static: `scripts/check.sh` — runtime: repo Python 3.13.7 — exit: 0 — log: `555 passed in 189.79s`; coverage `82.81%`; `mb skill validate` passed with 17/17 skills.
- [x] Level 2 CLI contract: `cd mb && pytest tests/test_books.py tests/test_connect.py tests/test_init.py tests/test_smoke_coverage.py -q` — runtime: repo Python 3.13.7 — exit: 0 — log: `70 passed in 7.86s`.
- [x] Level 3 package/install smoke: `(cd mb && python3 -m build) && python3 -m venv /tmp/mainbranch-books-dogfood-venv && /tmp/mainbranch-books-dogfood-venv/bin/pip install --quiet mb/dist/*.whl && /tmp/mainbranch-books-dogfood-venv/bin/mb --version && /tmp/mainbranch-books-dogfood-venv/bin/mb skill list` — runtime: `/tmp/mainbranch-books-dogfood-venv/bin/mb` — exit: 0 — log: installed CLI reported `mb 0.3.16` and listed bundled skills.
- [x] Level 3 package/install smoke: rebuild/reinstall after skill edits and search packaged skill archetypes — runtime: `/tmp/mainbranch-books-dogfood-venv-2/bin/mb` — exit: 0 — log: packaged archetype files now contain `hledger vs. QuickBooks` and `plain-text books plus repo-backed summaries`.
- [x] Level 4 fixture repo: `/tmp/mainbranch-books-dogfood-venv/bin/mb onboard --yes --name "Books Dogfood" --path /tmp/mainbranch-books-dogfood-business --json` — runtime: `/tmp/mainbranch-books-dogfood-venv/bin/mb` — exit: 0 — log: fresh repo created and packaged skills linked.
- [x] Level 4 fixture repo: `rg -n '^\\.mb/private/|^\\*\\.journal|^\\*\\.hledger|^\\*\\.ledger|^\\*\\.beancount' .gitignore` in `/tmp/mainbranch-books-dogfood-business` — runtime: shell/rg — exit: 0 — log: generated `.gitignore` contains `.mb/private/`, `*.journal`, `*.hledger`, `*.ledger`, and `*.beancount`.
- [x] Level 4 fixture repo: `/tmp/mainbranch-books-dogfood-venv/bin/mb books check /tmp/mainbranch-books-dogfood-business --json` — runtime: `/tmp/mainbranch-books-dogfood-venv/bin/mb` — exit: 0 — log: `ok: true`, expected optional books-policy/chart-of-accounts info findings, private vault ignore ok.
- [x] Level 4 fixture repo: `/tmp/mainbranch-books-dogfood-venv/bin/mb books check /tmp/mainbranch-books-dogfood-business --fixture --json` — runtime: `/tmp/mainbranch-books-dogfood-venv/bin/mb` — exit: 0 — log: `fixture_validated: true`; bundled hledger fixture passed on this machine.
- [x] Level 4 fixture repo: `/tmp/mainbranch-books-dogfood-venv/bin/mb connect status --repo /tmp/mainbranch-books-dogfood-business --all --json` and `mb connect list --repo /tmp/mainbranch-books-dogfood-business --json` — runtime: `/tmp/mainbranch-books-dogfood-venv/bin/mb` — exit: 0 — log: provider list exposes `hledger`, not Beancount.
- [x] SKILL.md ≤500 lines (if any skill touched) — runtime: `scripts/check.sh` / `mb skill validate` — exit: 0 — log: all bundled skills passed validation.
- [x] Package-visible release gate evidence before tag/publish (if preparing a release) — this PR is release-candidate dogfood evidence, not the tag/publish step.
- [x] Supply-chain review (if `.github/workflows/`, `.github/dependabot.yml`, `mb/pyproject.toml` deps, or `id-token`/`permissions` blocks touched — see [docs/supply-chain-policy.md](../docs/supply-chain-policy.md)) — N/A; no supply-chain files touched.
- [ ] Level 5 runtime smoke / dogfood harness / simulation-tier (if runtime, first-run, skill discovery, or release validation touched) — not required for this PR; it validates package/CLI/books behavior, not runtime slash-command discovery.

## Success metric

A reviewer can verify that the installed package and a fresh generated business repo run the current hledger-backed `mb books check` path, and no active packaged skill or provider/education surface still presents Beancount as the current bookkeeping choice.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [ ] N/A — change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [x] No
- [ ] Yes — migration note below

## Public / private boundary

This PR commits only public-safe docs, changelog text, and bundled skill reference wording. The dogfood report mentions throwaway `/tmp` smoke paths only, includes no private finance data, and keeps private runtime/local notes out of public docs.
