### PR TITLE
[update] Prepare 0.3.17 release

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mainbranch",
-  "version": "0.3.16",
+  "version": "0.3.17",
   "description": "Main Branch Claude Code skills for running a business from markdown files in git.",
   "author": {
     "name": "Noontide"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+## [0.3.17] - 2026-05-12
+
+v0.3.17 is a release-tightening patch after the first `mb books` release. It
+aligns the active bookkeeping surface on hledger, proves `mb books check`
+through an installed-package dogfood run, routes VSL knowledge through the
+broader conversion workflows, and hardens the release process with supply-chain
+gates plus post-release simulation-audit coverage.
+
 ### Changed
 
 - Replaced the active Beancount-era `mb connect` and `mb educational`

--- a/mb/mb/__init__.py
+++ b/mb/mb/__init__.py
@@ -7,6 +7,6 @@ file stays a thin dispatcher.
 
 from __future__ import annotations
 
-__version__ = "0.3.16"
+__version__ = "0.3.17"
 
 __all__ = ["__version__"]

--- a/mb/pyproject.toml
+++ b/mb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mainbranch"
-version = "0.3.16"
+version = "0.3.17"
 description = "Main Branch engine umbrella - scaffolds, validates, and graphs business-as-files repos. Claude Code first, runtime-agnostic by design."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Prepares the `0.3.17` release by moving the current changelog entries into a dated section and bumping every package/plugin version site from `0.3.16` to `0.3.17`.

## Linked issue

Closes #505

Linear: MAIN-329

## Why

The work merged after `oe-v0.3.16` is ready for a patch release: hledger bookkeeping cleanup, installed-package `mb books check` dogfood, VSL conversion-workflow routing, supply-chain gate hardening, Linear release-action pinning, and the post-release simulation-audit coverage. This PR keeps release prep release-only so tag/publish can happen after review.

## Commits by concern

- `5446ffe [update] Prepare 0.3.17 release`
  - bumps `mb/pyproject.toml`, `mb/mb/__init__.py`, and `.claude-plugin/plugin.json` to `0.3.17`;
  - adds the dated `0.3.17` changelog section and summary.

- [ ] Each commit body bullet-lists the changes in that commit — not used on this single release-prep commit; the PR body carries the concern details.
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`

## Validation

Pre-push gate from repo root:

```bash
scripts/check.sh
```

- [x] Level 1 static: `scripts/check.sh` — runtime: repo Python 3.13.7 — exit: 0 — log: `.context/release-evidence/0.3.17/check.out`; `557 passed in 179.11s`, coverage `82.81%`, `mb skill validate` passed with 17/17 skills.
- [x] Level 2 CLI contract: covered by `scripts/check.sh` for this release metadata diff — runtime: repo Python 3.13.7 — exit: 0 — log: `.context/release-evidence/0.3.17/check.out`.
- [x] Level 3 package/install smoke: `(cd mb && python3 -m build)` — runtime: `python3` — exit: 0 — log: `.context/release-evidence/0.3.17/build.out`; built `mainbranch-0.3.17-py3-none-any.whl` and `mainbranch-0.3.17.tar.gz`.
- [x] Level 3 package/install smoke: fresh venv install of `mb/dist/mainbranch-0.3.17-py3-none-any.whl`, then `mb --version`, `mb skill list`, and packaged release simulation manifest load — runtime: `/tmp/mainbranch-0.3.17-smoke/bin/mb` and `/tmp/mainbranch-0.3.17-smoke/bin/python` — exit: 0 — log: `.context/release-evidence/0.3.17/package-smoke.out`; `mb --version` reported `mb 0.3.17`, skills listed, and `bookkeeping_safety_handoff` was present.
- [ ] Level 4 fixture repo — not required for this release metadata diff; no init/onboard/status/start/update behavior changed on this branch.
- [ ] Level 5 runtime smoke / dogfood harness / simulation-tier — not run on this PR; release acceptance simulation/TUI evidence remains a pre-tag gate before publishing package-visible release claims.
- [x] SKILL.md ≤500 lines (if any skill touched) — runtime: `scripts/check.sh` / `mb skill validate` — exit: 0 — log: `.context/release-evidence/0.3.17/check.out`; all 17 bundled skills passed.
- [ ] Package-visible release gate evidence before tag/publish — release-prep evidence is complete here; pre-tag release acceptance simulations, GitHub Release, PyPI publish, fresh PyPI install, installed `mb --version`, and first-run/runtime smoke remain pending after this PR merges.
- [x] Supply-chain review — N/A for this diff; no workflows, dependency files, or permissions blocks changed.

## Success metric

All release metadata agrees on `0.3.17`, the changelog has a dated `0.3.17` section, and the built wheel installs as `mb 0.3.17` before tag/publish.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [ ] N/A — change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [x] No
- [ ] Yes — migration note below

## Public / private boundary

This PR commits only public release metadata. No private runtime logs, raw transcripts, local maintainer notes, secrets, customer/member data, or private repo paths were committed; validation artifacts remain in gitignored `.context/release-evidence/0.3.17/`.
