### PR TITLE
[docs] Clarify agent cold start

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,8 @@ __pycache__/
 .coverage
 
 # Local operational state
-# .context/ is collaboration scratch and release-evidence; never durable truth.
+# Local scratch and release evidence; never durable truth.
 # .claude/*.lock is local Claude Code session state (pid, sessionId).
+.agent/
 .context/
 .claude/*.lock

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,10 +139,11 @@ Do not commit:
 - private community operations, launch plans, or partner/customer strategy;
 - untested runtime compatibility claims.
 
-Use OS temp or the runner's gitignored scratch space for throwaway build
-artifacts, scratch repos, smoke-test output, and branch-local handoff notes.
-Scratch space is not durable product truth. Durable truth belongs in code,
-tests, docs, decisions, fixtures, or GitHub issues.
+Use OS temp for throwaway scratch repos. Use `.agent/` for repo-local,
+gitignored agent logs, smoke-test evidence, and branch-local handoff notes.
+Some hosted runners may provide their own ignored scratch space; public examples
+in this repo use `.agent/`. Scratch space is not durable product truth. Durable
+truth belongs in code, tests, docs, decisions, fixtures, or GitHub issues.
 
 ## Start Protocol
 
@@ -153,10 +154,13 @@ cold-start sequence. The short version:
    `docs/operator-loops.md`, `docs/roadmap.md`,
    `docs/oss-operating-checklist.md`, and the current `CHANGELOG.md`
    `[Unreleased]` plus latest shipped section.
-2. Read the assigned GitHub issue and all comments, then call Linear MCP
-   `get_issue` for the mirrored Linear issue. The returned `gitBranchName` is
-   the branch name. GitHub is the public durable work thread for comments by
-   default; Linear-only comments are for private logs or internal team context.
+2. Read the assigned GitHub issue and all comments. Maintainer and hosted
+   agents with Linear access then call Linear MCP `get_issue` for the mirrored
+   Linear issue and use the returned `gitBranchName` as the branch name.
+   External contributors without Linear access can use a GitHub-native branch
+   name and reference the issue in the PR. GitHub is the public durable work
+   thread for comments by default; Linear-only comments are for private logs or
+   internal team context.
 3. Write a local cold-start note for substantial branches before editing.
 4. Progressively discover task-specific docs and decisions only after the work
    thread is clear: runtime docs for runtime claims, release docs for
@@ -218,17 +222,19 @@ concern-organized commits.
 
 ## Branches, Issues, and Releases
 
-GitHub issues in this repo mirror to Linear. For issue work, call Linear MCP
-`get_issue` for the mirrored Linear issue and use its `gitBranchName`; this
-normally has the shape
+GitHub issues in this repo mirror to Linear. Maintainer and hosted agents with
+Linear access should call Linear MCP `get_issue` for the mirrored Linear issue
+and use its `gitBranchName`; this normally has the shape
 `<username>/main-<number>-<full-ticket-title-lowercase-with-dashes>`. Preserve
 Linear IDs in branch names, commit messages, and PR metadata so Linear Releases
 can attach work correctly.
 
-If work truly has no issue, create the public GitHub issue first when the work
-is product-facing, then fetch the mirrored Linear issue and use its
-`gitBranchName`. For non-issue maintenance, use a short concrete branch name
-such as `<gh-username>/status-briefing` or `<gh-username>/runtime-smoke`.
+External contributors without Linear access can use a GitHub-native branch name
+such as `<gh-username>/<issue-number>-<short-title>` and reference the GitHub
+issue in the PR. If work truly has no issue, create the public GitHub issue
+first when the work is product-facing. For non-issue maintenance, use a short
+concrete branch name such as `<gh-username>/status-briefing` or
+`<gh-username>/runtime-smoke`.
 
 GitHub remains the public durable issue thread:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,39 +139,32 @@ Do not commit:
 - private community operations, launch plans, or partner/customer strategy;
 - untested runtime compatibility claims.
 
-Use OS temp for throwaway build artifacts, scratch repos, and smoke-test output.
-Use `.context/` only for repo-bound handoff notes such as `cold-start.md` or
-branch-specific collaboration state. It is gitignored and is not durable product
-truth. Durable truth belongs in code, tests, docs, decisions, fixtures, or GitHub
-issues.
+Use OS temp or the runner's gitignored scratch space for throwaway build
+artifacts, scratch repos, smoke-test output, and branch-local handoff notes.
+Scratch space is not durable product truth. Durable truth belongs in code,
+tests, docs, decisions, fixtures, or GitHub issues.
 
 ## Start Protocol
 
-Before editing:
+Use [`docs/agent-cold-start.md`](docs/agent-cold-start.md) for the full
+cold-start sequence. The short version:
 
-1. Read this file.
-2. Read `README.md`.
-3. Read `docs/ethos.md`.
-4. Read the assigned GitHub/Linear issue and all comments.
-5. If the work touches public product shape, release discipline, runtime claims,
-   contributor workflow, or public/private boundaries, apply
-   `docs/oss-operating-checklist.md`.
-6. If the work touches roadmap, priorities, workflow shape, or product framing,
-   read:
-   - `docs/operator-loops.md`
-   - `docs/roadmap.md`
-7. If the work touches v0.2 product direction, read:
-   - `decisions/2026-05-02-github-native-business-os.md`
-   - `docs/prd/v0-2-first-run-daily-briefing.md`
-   - `docs/prd/v0-2-agent-workflow-and-evals.md`
-8. If the work touches the CLI/runtime boundary, read:
-   - `decisions/2026-05-01-mb-cli-vs-agent-workflows-boundary.md`
-   - `docs/compatibility.md`
-9. If the work touches skills, inspect the relevant
-   `.claude/skills/<name>/SKILL.md` and nearby tests or fixtures.
-10. Check open PRs for overlapping files before making broad edits.
+1. Read the always-read set first: this file, `README.md`, `docs/ethos.md`,
+   `docs/operator-loops.md`, `docs/roadmap.md`,
+   `docs/oss-operating-checklist.md`, and the current `CHANGELOG.md`
+   `[Unreleased]` plus latest shipped section.
+2. Read the assigned GitHub issue and all comments, then call Linear MCP
+   `get_issue` for the mirrored Linear issue. The returned `gitBranchName` is
+   the branch name. GitHub is the public durable work thread for comments by
+   default; Linear-only comments are for private logs or internal team context.
+3. Write a local cold-start note for substantial branches before editing.
+4. Progressively discover task-specific docs and decisions only after the work
+   thread is clear: runtime docs for runtime claims, release docs for
+   release-bearing work, skill docs for skill changes, PRDs/decisions for
+   product choices, and post-release docs for post-release sweeps.
+5. Check open PRs for overlapping files before making broad edits.
 
-For substantial branches, write `.context/cold-start.md` before editing:
+For substantial branches, write a local cold-start note before editing:
 
 ```md
 # Cold Start
@@ -225,20 +218,27 @@ concern-organized commits.
 
 ## Branches, Issues, and Releases
 
-If a Linear issue exists, use Linear's official branch name when it is provided
-by the issue or task runner. Preserve Linear IDs in branch names, commit
-messages, and PR metadata so Linear Releases can attach work correctly.
+GitHub issues in this repo mirror to Linear. For issue work, call Linear MCP
+`get_issue` for the mirrored Linear issue and use its `gitBranchName`; this
+normally has the shape
+`<username>/main-<number>-<full-ticket-title-lowercase-with-dashes>`. Preserve
+Linear IDs in branch names, commit messages, and PR metadata so Linear Releases
+can attach work correctly.
 
-If no Linear issue exists, use a short concrete branch name such as
-`<gh-username>/status-briefing` or `<gh-username>/runtime-smoke`.
+If work truly has no issue, create the public GitHub issue first when the work
+is product-facing, then fetch the mirrored Linear issue and use its
+`gitBranchName`. For non-issue maintenance, use a short concrete branch name
+such as `<gh-username>/status-briefing` or `<gh-username>/runtime-smoke`.
 
 GitHub remains the public durable issue thread:
 
 - use `Closes #N` only when the PR fully completes the GitHub issue;
 - use `Refs #N` for partial slices or related context;
-- comment on issues when scope changes, blockers appear, or a branch is ready
-  for review;
-- keep target release and priority visible in `.context/cold-start.md` and PR
+- comment on GitHub issues when scope changes, blockers appear, or a branch is
+  ready for review; the GitHub comment syncs to Linear;
+- use Linear-only comments only for private logs or internal context that should
+  not appear on public GitHub;
+- keep target release and priority visible in the local cold-start note and PR
   bodies for release-bearing work.
 
 ## Linear-Hosted Agents
@@ -247,7 +247,7 @@ When launched from Linear or assigned a Linear issue:
 
 - treat the Linear issue as the task brief, but verify durable details in this
   repository before editing;
-- use the official Linear branch name if the task runner provides it;
+- use the Linear issue's `gitBranchName`;
 - preserve the Linear ID in branch, commit, and PR metadata;
 - map Linear status honestly: move to started/in progress only when coding or
   writing actually begins, and do not mark shipped until release verification

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
-### Changed
+### Added
 
 - Added `docs/agent-cold-start.md` as the public source for agent read order,
   progressive discovery, release-doc boundaries, and the local preference split,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+### Changed
+
+- Added `docs/agent-cold-start.md` as the public source for agent read order,
+  progressive discovery, release-doc boundaries, and the local preference split,
+  so maintainer-local preferences can stay short and private. Refs MAIN-330,
+  #507.
+
 ## [0.3.17] - 2026-05-12
 
 v0.3.17 is a release-tightening patch after the first `mb books` release. It

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ and provider state as the technical memory layer underneath the business loop.
   discipline, validation, and PR expectations.
 - Use `README.md`, `docs/`, `decisions/`, tests, and GitHub issues as durable
   context.
-- Keep `.context/` as local scratch only.
+- Keep local scratch files out of durable product docs and commits.
 - Run `scripts/check.sh` from the repo root before pushing code or docs that
   could affect packaged behavior.
 - If you change first-run, skill discovery, `mb init`, `mb onboard`,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,9 @@
 
 Main Branch is a public repo. Anyone can read it; not everyone is wired in to the engine cadence. The contributor flow below documents how the work happens, what gates run, and what discipline rules apply.
 
-These rules are **tool-agnostic.** Conductor users, Codex users, Cursor users, and direct CLI contributors all follow the same shape — the rules describe the work, not the editor.
+These rules are **tool-agnostic.** Codex users, Cursor users, Claude Code
+users, hosted agents, and direct CLI contributors all follow the same shape:
+the rules describe the work, not the editor.
 
 For changes that could affect public product shape, release discipline, runtime
 claims, contributor workflow, or public/private boundaries, use

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,6 +47,7 @@ Pick the route that matches what you are doing.
 
 ### Contributing to the engine
 
+- [`agent-cold-start.md`](agent-cold-start.md) — public read order and progressive discovery contract for agents.
 - [`oss-operating-checklist.md`](oss-operating-checklist.md) — public release / contributor checklist.
 - [`dependency-choices.md`](dependency-choices.md) — adopted rails and dependency policy.
 - [`supply-chain-policy.md`](supply-chain-policy.md) — PyPI publishing, GitHub Actions, dependency, and post-compromise rules.

--- a/docs/agent-cold-start.md
+++ b/docs/agent-cold-start.md
@@ -1,0 +1,128 @@
+# Agent Cold Start
+
+Use this sequence at the start of each Main Branch issue, PR review, or release
+task. The goal is fast context with the right source of truth: read the durable
+public contract first, then discover only the extra docs the task actually
+touches.
+
+This file is public agent guidance. Private maintainer workflow preferences can
+point here, but should not duplicate the product contract.
+
+## Always Read First
+
+Read these before editing or reviewing:
+
+1. `AGENTS.md` - repo operating contract, validation ladder, public/private
+   boundary, and PR expectations.
+2. `README.md` - user-facing promise, command surface, runtime support claim,
+   and beginner path.
+3. `docs/ethos.md` - product principles and state model.
+4. `docs/operator-loops.md` - Sense, Decide, Ship, Reflect taxonomy and daily
+   loop language.
+5. `docs/roadmap.md` - current direction, anti-scope, and shipped foundation.
+6. `docs/oss-operating-checklist.md` - release, runtime-claim, state-model,
+   issue/PR, and public/private review checklist.
+7. `CHANGELOG.md` - read `[Unreleased]` and the latest shipped version section
+   so current tense matches release truth.
+
+Do not paste these docs into issue comments, PR bodies, or local preferences.
+Link them and state only the decision the current task needs.
+
+## Then Read The Work Thread
+
+Read the assigned GitHub issue and comments before editing. Main Branch GitHub
+issues mirror to Linear, so call Linear MCP `get_issue` for the mirrored issue
+before naming the branch. The returned `gitBranchName` is the branch name.
+
+GitHub remains the public durable work thread. Leave public coordination
+comments on GitHub by default; the sync carries them to Linear. Use Linear-only
+comments only for private logs, local runtime notes, or internal team context
+that should not appear in public GitHub.
+
+For old, heavily commented, or previously worked issues:
+
+- read every issue comment oldest to newest;
+- read linked PRs when their diff or comments are load-bearing context;
+- read one hop of linked issues when the assigned issue depends on them;
+- inspect any named file path on current `main` before assuming shape;
+- summarize the current contract in a local cold-start note when comments
+  changed scope over time.
+
+## Write The Cold Start Note
+
+For substantial branches, write a local cold-start note before editing:
+
+- issue and Linear ID when present;
+- priority, status, target release if any;
+- operator loop: Sense, Decide, Ship, or Reflect;
+- in scope and out of scope;
+- validation plan by ladder level;
+- whether package, fixture, runtime, or release smoke is required.
+
+Local scratch space is not durable product truth. Keep durable facts in public
+docs, decisions, tests, fixtures, or GitHub issues.
+
+## Progressive Discovery
+
+After the work thread is clear, read only the extra docs that match the surface
+you are changing.
+
+| Trigger | Read |
+| --- | --- |
+| Product direction, roadmap, workflow shape, dashboard, provider choice, dependency choice, setup policy | `docs/roadmap.md`, `docs/operator-loops.md`, relevant `decisions/`, relevant PRD under `docs/prd/`, `docs/dependency-choices.md` when dependencies or provider rails are in play |
+| CLI/runtime boundary, runtime support claim, adapter behavior | `decisions/2026-05-01-mb-cli-vs-agent-workflows-boundary.md`, `docs/compatibility.md`, `docs/claude-code-runtime-dogfood.md` when Claude Code evidence matters |
+| Skills or generated runtime guidance | relevant `.claude/skills/<name>/SKILL.md`, its `references/`, generated templates under `templates/`, nearby skill validation tests or fixtures |
+| First-run, package install, skill discovery, `mb init`, `mb onboard`, `mb status`, `mb start`, `mb update` | `docs/release-simulations.md`, `docs/release-agent-contract.md`, package/install smoke contract in `AGENTS.md`, relevant CLI tests |
+| Release prep, package-visible release, supply-chain or publish workflow | `docs/release-agent-contract.md`, `docs/release-simulations.md`, `docs/supply-chain-policy.md`, current `CHANGELOG.md`, GitHub Release / PyPI / Linear release state |
+| Post-release sweep | `docs/post-release-alignment.md`, local release evidence when available, shipped PRs since the last tag |
+| Public/private boundary, support, contributor workflow, state model | `docs/oss-operating-checklist.md`, `SUPPORT.md`, `SECURITY.md`, `CONTRIBUTING.md` as relevant |
+
+Do not read every decision file by default. Use the issue, changed files,
+`AGENTS.md`, and the trigger table above to pick the few that can change the
+answer.
+
+## Branch And Issue Hygiene
+
+- Main Branch issues mirror to Linear. Fetch the mirrored Linear issue with
+  Linear MCP `get_issue` and use its `gitBranchName` for issue work.
+- The normal shape is `<username>/main-<number>-<full-ticket-title-lowercase-with-dashes>`.
+- Do not synthesize a different branch name for issue work.
+- If work truly has no issue, use a short descriptive branch and create the
+  public GitHub issue first when the work is product-facing.
+- Preserve Linear IDs in branch names, commit messages, and PR metadata when
+  available so Linear Releases can attach work.
+- Use `Closes #N` only when the PR fully resolves the GitHub issue.
+- Use `Refs #N` for setup work, partial slices, or related context.
+- Leave public status, blocker, scope, and readiness comments on GitHub by
+  default. Use Linear-only comments only for private logs or internal context.
+
+## Release Noise Boundary
+
+Most issues are not releases. Do not load release runbooks, PyPI checks, or
+release-simulation evidence unless the task touches a release-bearing surface:
+packaging, install/update, first-run, skill discovery, runtime claims, publish
+workflow, supply chain, or post-release alignment.
+
+When the task is release-bearing, use the release docs exactly. Do not compress
+away evidence capture, first-run smoke, PyPI verification, or the distinction
+between Claude Code print-mode proxy evidence and interactive TUI smoke.
+
+## Local Preference Split
+
+Local maintainer preferences should stay short and private:
+
+- workspace path and target branch;
+- issue, branch, Linear, and PR workflow habits;
+- private local repo paths and tool availability;
+- reminders learned from recent reviews that do not belong in public docs.
+
+Local preferences should not carry:
+
+- the full Main Branch product contract;
+- release truth that belongs in `CHANGELOG.md`, GitHub Releases, and PyPI;
+- runtime support claims that belong in `docs/compatibility.md`;
+- public/private policy that belongs in `docs/oss-operating-checklist.md`;
+- stale issue lists or future-tense product plans.
+
+If a preference would help any contributor, move it into this repo. If it only
+helps one maintainer's local workflow, keep it private and brief.

--- a/docs/agent-cold-start.md
+++ b/docs/agent-cold-start.md
@@ -31,8 +31,11 @@ Link them and state only the decision the current task needs.
 ## Then Read The Work Thread
 
 Read the assigned GitHub issue and comments before editing. Main Branch GitHub
-issues mirror to Linear, so call Linear MCP `get_issue` for the mirrored issue
-before naming the branch. The returned `gitBranchName` is the branch name.
+issues mirror to Linear. Maintainer and hosted agents with Linear access should
+call Linear MCP `get_issue` for the mirrored issue before naming the branch; the
+returned `gitBranchName` is the branch name. External contributors without
+Linear access can use a GitHub-native branch name and reference the issue in the
+PR.
 
 GitHub remains the public durable work thread. Leave public coordination
 comments on GitHub by default; the sync carries them to Linear. Use Linear-only
@@ -59,8 +62,11 @@ For substantial branches, write a local cold-start note before editing:
 - validation plan by ladder level;
 - whether package, fixture, runtime, or release smoke is required.
 
-Local scratch space is not durable product truth. Keep durable facts in public
-docs, decisions, tests, fixtures, or GitHub issues.
+Use `.agent/` for repo-local, gitignored agent logs, smoke-test evidence, and
+branch-local handoff notes. Some hosted runners may provide their own ignored
+scratch space; public examples in this repo use `.agent/`. Scratch space is not
+durable product truth. Keep durable facts in public docs, decisions, tests,
+fixtures, or GitHub issues.
 
 ## Progressive Discovery
 
@@ -83,10 +89,13 @@ answer.
 
 ## Branch And Issue Hygiene
 
-- Main Branch issues mirror to Linear. Fetch the mirrored Linear issue with
-  Linear MCP `get_issue` and use its `gitBranchName` for issue work.
+- Main Branch issues mirror to Linear. Maintainer and hosted agents with Linear
+  access fetch the mirrored Linear issue with Linear MCP `get_issue` and use
+  its `gitBranchName` for issue work.
 - The normal shape is `<username>/main-<number>-<full-ticket-title-lowercase-with-dashes>`.
-- Do not synthesize a different branch name for issue work.
+- External contributors without Linear access can use
+  `<gh-username>/<issue-number>-<short-title>` and reference the GitHub issue in
+  the PR.
 - If work truly has no issue, use a short descriptive branch and create the
   public GitHub issue first when the work is product-facing.
 - Preserve Linear IDs in branch names, commit messages, and PR metadata when

--- a/docs/agent-writing-style.md
+++ b/docs/agent-writing-style.md
@@ -80,6 +80,8 @@ For cold starts and PR reviews:
 ## Where it applies
 
 - `AGENTS.md` and `CLAUDE.md`: contributor protocol, already aligned.
+- `docs/agent-cold-start.md`: public read order and progressive discovery
+  contract. Keep this as the source for what agents open first.
 - Bundled skill `SKILL.md` files: prefer linking `references/` over
   inlining long prose.
 - Generated `CLAUDE.md.tmpl` / `AGENTS.md.tmpl`: keep the generated

--- a/docs/markdown-link-conventions.md
+++ b/docs/markdown-link-conventions.md
@@ -246,7 +246,7 @@ Private finance source: finance-repo/core/finance/ledger/
 
 Do not commit private local machine paths. If a local-only path is
 needed for an operator, keep it in local config, a private repo, or
-`.context/` rather than public docs.
+local scratch space rather than public docs.
 
 ## Obsidian Setup
 

--- a/docs/oss-operating-checklist.md
+++ b/docs/oss-operating-checklist.md
@@ -14,8 +14,8 @@ that keep Main Branch usable as public infrastructure while it evolves quickly.
   data, or private operating details are committed.
 - [ ] Examples and fixtures are sanitized and generic.
 - [ ] Private local preferences, agent-runner notes, launch plans, partner
-  strategy, and machine-specific paths stay in private repos or `.context/`,
-  not in durable public docs.
+  strategy, and machine-specific paths stay in private repos or local scratch
+  space, not in durable public docs.
 - [ ] If a note only makes sense to one maintainer, rewrite it generically or
   keep it private.
 
@@ -186,6 +186,7 @@ Before approval or handoff, answer these plainly:
 - Does the validation evidence match the surface that changed?
 - Is anything here private, overclaimed, or likely to mislead a future agent?
 
-Private local preferences should point to this checklist instead of duplicating
-public operating rules. Keep local workflow details private and keep durable
-product truth in this repository.
+Private local preferences should point to this checklist and
+[`agent-cold-start.md`](agent-cold-start.md) instead of duplicating public
+operating rules. Keep local workflow details private and keep durable product
+truth in this repository.

--- a/docs/playbooks.md
+++ b/docs/playbooks.md
@@ -84,7 +84,7 @@ Good attribution answers:
 Do not commit raw private transcripts, account data, customer details,
 credentials, screenshots, or exact partner/customer strategy to public
 playbooks. Summarize the reusable method and keep private source material in
-private repos or `.context/`.
+private repos or local scratch space.
 
 ## Forking A Playbook
 

--- a/docs/post-release-alignment.md
+++ b/docs/post-release-alignment.md
@@ -24,16 +24,20 @@ next parallel batch:
 1. Merge / release ships (tag, GitHub Release, PyPI publish, Linear release
    sync — see `docs/release-simulations.md`).
 2. Align Linear and GitHub issue state: close the release-prep issue, comment
-   release evidence on the issues whose work shipped, mark Linear issues
-   shipped via Linear release completion (not on merge).
+   release evidence on GitHub by default so the public thread and Linear mirror
+   agree, mark Linear issues shipped via Linear release completion (not on
+   merge).
 3. Audit release simulation transcripts when the release touched package,
    runtime, first-run, generated guidance, or operator workflow behavior. Use
    the transcript audit below.
 4. Align repo docs and decisions if anything shipped changed the product
    stance. Use the alignment sweep below.
-5. Align local agent preferences if a new protocol, review habit, or
-   cold-start behavior was learned. Use the local-preferences policy below.
-6. Start the next parallel batch.
+5. Audit agent cold-start guidance when the release taught a new protocol,
+   review habit, validation rule, or task-triggered read path. Use
+   `docs/agent-cold-start.md` as the public source of truth.
+6. Align local agent preferences only when a private local workflow reminder
+   changed. Use the local-preferences policy below.
+7. Start the next parallel batch.
 
 ## 2. Alignment sweep
 
@@ -55,6 +59,9 @@ operators, or contributors read:
 - Confirm CHANGELOG, README, and roadmap language matches the facts. A
   release is not done until the surfaces agree (see `AGENTS.md` →
   Release Truth).
+- Confirm `docs/agent-cold-start.md` still tells agents which docs are
+  always-read and which are task-triggered. Do not push release-specific
+  instructions into local preferences when they belong in public docs.
 
 Default to a small alignment PR labeled `[docs]`. If the sweep finds nothing
 worth changing, write that as a one-line comment on the release-prep issue
@@ -72,8 +79,8 @@ does the right thing?
 
 Use this sequence:
 
-1. Read the release simulation evidence under `.context/release-evidence/` or
-   the release-prep issue. Start from `summary.json`, `rubric.json`, transcript
+1. Read the local release simulation evidence or the release-prep issue. Start
+   from `summary.json`, `rubric.json`, transcript
    excerpts, and `evidence-template.md`; do not rerun simulations just to
    recover wording.
 2. Compare each run against `docs/release-simulations.md` transcript-review
@@ -86,7 +93,7 @@ Use this sequence:
 5. Keep private local runtime logs, raw transcripts, local machine details, and
    maintainer-only notes out of GitHub and public docs. If the synced Linear
    issue needs that context, add a Linear-only comment; otherwise keep it in
-   `.context/`.
+   private local scratch space.
 6. Update `docs/release-simulations.md`, the packaged simulation manifest, or
    the dogfood harness only when the audit finds a repeatable gap that should
    protect future releases.
@@ -126,7 +133,7 @@ Conflict rules:
   rebases on the first after merge.
 - Two branches updating the same `decisions/<date>-<name>.md` is a smell;
   one branch should own a decision file at a time.
-- Each branch writes `.context/cold-start.md` before editing, naming what it
+- Each branch writes a local cold-start note before editing, naming what it
   *will not* touch (the "Out" section). That is the parallel-lane contract.
 
 If a branch discovers it needs to touch a file owned by another in-flight
@@ -168,21 +175,25 @@ and should not be there.
 
 Local agent preferences should:
 
-- enforce working protocol (read AGENTS.md first; write
-  `.context/cold-start.md`; name scope and non-scope before editing);
-- tell agents what to read and in what order;
+- point agents to `docs/agent-cold-start.md` for the public read order and
+  progressive discovery contract;
+- enforce private working protocol that is local to the maintainer's
+  environment, such as workspace path, target branch, issue/branch workflow,
+  and local tool availability;
 - remind agents to check accepted decisions before reopening product choices;
 - remind agents during AI code review to check stale assumptions, docs and
-  changelog updates, Linear and GitHub issue hygiene, public/private
-  boundaries, and release impact;
-- surface durable review habits learned from recent PRs (a sentence or two);
+  changelog updates, issue hygiene, public/private boundaries, and release
+  impact;
+- surface durable private review habits learned from recent PRs in a sentence
+  or two;
 - stay short enough to be read and followed.
 
 Local agent preferences should not:
 
 - duplicate detailed product facts that belong in `AGENTS.md`, `README.md`,
-  or decision files;
-- repeat the whole product stance, folder map, or release model;
+  `docs/agent-cold-start.md`, or decision files;
+- repeat the whole product stance, folder map, release model, or validation
+  ladder;
 - carry stale specifics (old engine choices, outdated provider
   recommendations, old paths);
 - include implementation details that agents are already required to read
@@ -191,8 +202,9 @@ Local agent preferences should not:
 After every release, ask:
 
 - Did the release teach us a new protocol, review habit, or cold-start
-  behavior that belongs in local agent prefs? If yes, add it briefly.
-  If no, leave prefs alone.
+  behavior? If it helps all contributors, update public docs. If it is local
+  private workflow, add it briefly to local preferences. If neither, leave
+  preferences alone.
 - Did any existing preference duplicate repo docs or become stale? If yes,
   remove or compress it.
 

--- a/docs/prd/v0-2-agent-workflow-and-evals.md
+++ b/docs/prd/v0-2-agent-workflow-and-evals.md
@@ -96,7 +96,7 @@ the durable business brain.
 
 ## Scope
 
-Before editing, write a short scope note in `.context/cold-start.md`:
+Before editing, write a short local scope note:
 
 - issue / PR link;
 - intended release;
@@ -131,9 +131,8 @@ Preferred evidence order:
 
 ## Per-Branch Startup File
 
-Every substantial branch should create a gitignored note at
-`.context/cold-start.md` or an equivalent local scratch file. This is not the
-final artifact, but it keeps agents honest during the run.
+Every substantial branch should create a gitignored local scratch note. This is
+not the final artifact, but it keeps agents honest during the run.
 
 Suggested shape:
 
@@ -176,8 +175,8 @@ Out:
 - 
 ```
 
-The final PR should not rely on `.context/`. Anything durable belongs in docs,
-tests, decisions, or issue comments.
+The final PR should not rely on local scratch files. Anything durable belongs
+in docs, tests, decisions, or issue comments.
 
 ## PR Creation Template
 

--- a/docs/release-agent-contract.md
+++ b/docs/release-agent-contract.md
@@ -50,7 +50,8 @@ switches.
 Pattern (wrapper-safe — propagates the underlying exit code):
 
 ```bash
-scripts/check.sh > .context/check.out 2>&1; rc=$?; printf "%s\n" "$rc" > .context/check.exit; exit "$rc"
+mkdir -p .agent
+scripts/check.sh > .agent/check.out 2>&1; rc=$?; printf "%s\n" "$rc" > .agent/check.exit; exit "$rc"
 ```
 
 The trailing `exit "$rc"` matters. Without it, the chain ends with
@@ -60,8 +61,8 @@ Drop the `exit "$rc"` only when running the line interactively in
 your own shell (where you don't want to close the session).
 
 The variable name matters too. `status` is a read-only special variable
-in zsh (it mirrors `$?`), so `status=$?` fails with `read-only variable`
-on Devon's default macOS shell. `rc` is safe in both bash and zsh; so
+in zsh (it mirrors `$?`), so `status=$?` fails with `read-only variable`.
+`rc` is safe in both bash and zsh; so
 is `exit_code`, `check_rc`, or any other non-reserved name. Avoid `status`,
 `pipestatus`, `path`, `home`, and other zsh special variables in agent-
 facing shell snippets.
@@ -70,9 +71,10 @@ Or, if live progress is useful (bash-specific; in zsh use
 `${pipestatus[1]}` — lowercase, 1-indexed):
 
 ```bash
-scripts/check.sh 2>&1 | tee .context/check.out
+mkdir -p .agent
+scripts/check.sh 2>&1 | tee .agent/check.out
 rc=${PIPESTATUS[0]}
-printf "%s\n" "$rc" > .context/check.exit
+printf "%s\n" "$rc" > .agent/check.exit
 exit "$rc"
 ```
 
@@ -80,14 +82,14 @@ If the agent's runtime shell is unknown, prefer the first pattern
 (redirect + `rc=$?; printf; exit`) which works in both bash and zsh.
 
 For release-bearing flows, the convention is to put logs under
-`.context/release-evidence/<version>/` so the directory is gitignored and
+`.agent/release-evidence/<version>/` so the directory is gitignored and
 self-documenting:
 
 ```bash
-mkdir -p .context/release-evidence/0.3.17
-scripts/check.sh > .context/release-evidence/0.3.17/check.out 2>&1
+mkdir -p .agent/release-evidence/0.3.17
+scripts/check.sh > .agent/release-evidence/0.3.17/check.out 2>&1
 rc=$?
-printf "%s\n" "$rc" > .context/release-evidence/0.3.17/check.exit
+printf "%s\n" "$rc" > .agent/release-evidence/0.3.17/check.exit
 exit "$rc"
 ```
 
@@ -99,12 +101,12 @@ both reflect the harness's real outcome:
 ```bash
 python3 scripts/claude-runtime-dogfood.py \
   --install-mode pypi --pypi-version 0.3.17 \
-  --evidence-dir .context/release-evidence/0.3.17 \
+  --evidence-dir .agent/release-evidence/0.3.17 \
   --run-claude-print --simulation-tier release_acceptance \
   --max-budget-usd 0.75 \
-  > .context/release-evidence/0.3.17/dogfood.log 2>&1
+  > .agent/release-evidence/0.3.17/dogfood.log 2>&1
 rc=$?
-printf "EXIT=%s\n" "$rc" >> .context/release-evidence/0.3.17/dogfood.log
+printf "EXIT=%s\n" "$rc" >> .agent/release-evidence/0.3.17/dogfood.log
 exit "$rc"
 ```
 
@@ -112,7 +114,7 @@ exit "$rc"
 
 Before re-running any long check, check in order:
 
-1. Shell exit code from the previous run (`cat .context/check.exit` or the
+1. Shell exit code from the previous run (`cat .agent/check.exit` or the
    trailing `EXIT=` line in the log).
 2. The saved log file.
 3. CI output for the same commit (`gh pr checks <N>`, `gh run view <id>`).
@@ -146,9 +148,9 @@ Each PR validation bullet should answer:
 Example:
 
 ```text
-- Level 1 static: scripts/check.sh — runtime: /usr/bin/python3 (3.13) — exit: 0 — log: .context/release-evidence/0.3.17/check.out (546 passed).
-- Level 3 package/install: (cd mb && python3 -m build) + venv install of mainbranch-0.3.17-py3-none-any.whl — runtime: /tmp/mb-pypi-smoke/bin/python3 — exit: 0 — log: .context/release-evidence/0.3.17/install.out (full validation contract returned result_status: ok).
-- Level 5 runtime: scripts/claude-runtime-dogfood.py --install-mode pypi --pypi-version 0.3.17 --run-claude-print --simulation-tier release_acceptance --max-budget-usd 0.75 — exit: 0 — evidence: .context/release-evidence/0.3.17/ (summary.json, rubric.json, transcript excerpts).
+- Level 1 static: scripts/check.sh — runtime: /usr/bin/python3 (3.13) — exit: 0 — log: .agent/release-evidence/0.3.17/check.out (546 passed).
+- Level 3 package/install: (cd mb && python3 -m build) + venv install of mainbranch-0.3.17-py3-none-any.whl — runtime: /tmp/mb-pypi-smoke/bin/python3 — exit: 0 — log: .agent/release-evidence/0.3.17/install.out (full validation contract returned result_status: ok).
+- Level 5 runtime: scripts/claude-runtime-dogfood.py --install-mode pypi --pypi-version 0.3.17 --run-claude-print --simulation-tier release_acceptance --max-budget-usd 0.75 — exit: 0 — evidence: .agent/release-evidence/0.3.17/ (summary.json, rubric.json, transcript excerpts).
 ```
 
 If a level was not run, say which one and why in one line. "Not required for


### PR DESCRIPTION
## Summary

Adds a public agent cold-start contract and tightens the supporting docs so agents know what to read first, what to discover only when the task requires it, and how to name issue branches from Linear `gitBranchName`.

## Linked issue

Closes #507

Linear: MAIN-330

## Why

Post-release work exposed that local maintainer preferences were carrying too much product and release contract. That made agent cold starts larger than needed and blurred what belongs in public repo docs versus private local workflow notes.

This PR moves the durable guidance into public docs and keeps private/local scratch language out of public agent instructions.

## Commits by concern

- `7922857 [docs] MAIN-330 clarify agent cold start`
  - adds `docs/agent-cold-start.md` as the public read-order and progressive discovery contract;
  - updates `AGENTS.md` to point at that contract and require Linear MCP `get_issue` -> `gitBranchName` for issue branch naming;
  - tightens post-release/local preference policy so release and product truth stay in public docs;
  - replaces current public `.context` guidance with generic local scratch language and `.agent` release-evidence examples;
  - updates related docs and `[Unreleased]`.

- [ ] Each commit body bullet-lists the changes in that commit — not used on this single docs commit; the PR body carries the concern details.
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`

## Validation

Pre-push gate from repo root:

```bash
scripts/check.sh
```

- [x] Level 1 static: `scripts/check.sh` — runtime: repo Python via `scripts/check.sh` — exit: 0 — log: `.agent/checks/main-330-check.out`; `mb skill validate` passed with 17/17 skills.
- [ ] Level 2 CLI contract — not required; no CLI behavior changed.
- [ ] Level 3 package/install smoke — not required; no packaging, entrypoint, bundled data, skill discovery, or update path changed.
- [ ] Level 4 fixture repo — not required; no `mb init`, `mb onboard`, `mb status`, `mb start`, or update behavior changed.
- [ ] Level 5 runtime smoke / dogfood harness / simulation-tier — not required; no runtime invocation, first-run, skill discovery, or release validation behavior changed.
- [x] SKILL.md <=500 lines (if any skill touched) — runtime: `scripts/check.sh` / `mb skill validate` — exit: 0 — log: `.agent/checks/main-330-check.out`; all 17 bundled skills passed.
- [ ] Package-visible release gate evidence before tag/publish — not required; this is not release prep.
- [ ] Supply-chain review — not required; no workflow, Dependabot, dependency, `id-token`, or permissions changes.

## Success metric

A new agent can read the public protocol and know the always-read docs, the progressive discovery triggers, the GitHub/Linear comment split, and that Linear MCP `get_issue` -> `gitBranchName` is the branch-name source for issue work.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [ ] N/A — change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [x] No
- [ ] Yes — migration note below

## Public / private boundary

This PR removes maintainer-specific scratch-path guidance from current public instructions and keeps local workflow details out of committed product docs. No private runtime logs, raw transcripts, local machine paths, credentials, customer/member data, or private repo paths were committed.
