### PR TITLE
[update] Strengthen /mb-start business router

### DIFF
--- a/.claude/skills/mb-start/SKILL.md
+++ b/.claude/skills/mb-start/SKILL.md
@@ -1,27 +1,31 @@
 ---
 name: mb-start
-description: "Main entry point for Main Branch. Detects state and routes to the right skill. Use when: user says start/help/begin, is new/returning/lost, opens Main Branch without a task, needs triage, wants to launch an offer, or asks where a sales video/VSL belongs. Routes to /mb-setup, /mb-think, /mb-bet, /mb-site, /mb-ads, /mb-organic, /mb-wiki, /mb-help, with /mb-vsl preserved as a compatibility router."
+description: "Main Branch business router. Detects repo facts, save/sync state, updates, readiness, and live operator intent, then routes to the right skill or CLI contract. Use when the user starts/returns, asks what to do, needs setup, bookkeeping/books, provider setup, save/checkpoint/sync help, repair/update guidance, launch routing, or help."
 loops: [sense, decide]
 ---
 
 # Start
 
-Single entry point for Main Branch. Detect user state, context level, experience — route to the right skill.
+Single entry point for Main Branch. Detect business state, current intent, save/sync posture, and the smallest useful next route.
 
 **Recommended workflow:** Start Claude in your business repo, run `/mb-start`. It handles everything. Claude Code discovers Main Branch through project-local `.claude/skills/mb-*` bridge links; `additionalDirectories` grants file access to the engine.
 
-## Output destinations and operator vocabulary
+## Router and language contract
 
-This skill routes to other skills; it does not write coordinated work itself.
-When summarizing repo state, count records under `pushes/` (current) and
-flag `campaigns/` separately as legacy compatibility — `mb status` and
-`mb doctor` already do this. If `core/vocabulary.md` defines display words
-(e.g. `terms.push.singular: drop`), speak the operator's word in
-conversation while still referring to engine paths in any commands.
+This skill routes; it is not the worker for coordinated output. Use
+[references/router-and-language.md](references/router-and-language.md) as the
+business router before presenting a menu.
 
-If the repo has legacy `campaigns/` records, surface the doctor warning
-and recommend `mb migrate campaigns --plan` as a triage option before
-routing the operator into a skill that creates new push work.
+Business language comes first. Say saved checkpoint, unsaved local work, catch
+up, sync, reconcile, shared repo, workspace, and provider readiness. Keep raw
+git terms, checkpoint ids, branch names, `origin`, `ahead`, `behind`, `rebase`,
+and `commit` out of the first response unless the user asks for technical detail
+or the exact command must be shown.
+
+When summarizing repo state, count records under `pushes/` (current) and flag
+`campaigns/` separately as legacy compatibility. If `core/vocabulary.md` defines
+display words, speak the operator's word in conversation while still using
+engine paths in commands.
 
 **Status facts first:** Once the business repo path is known, run
 `mb status --json --peek` before asking setup or routing questions. Treat that
@@ -31,11 +35,11 @@ integrations, GitHub issue/proposal facts, bets, dirty git, since-last-check, an
 the status report says a section is unavailable.
 
 **Continuity facts:** Use `since_last_check.journal`, top-level `journal`,
-dirty-git, GitHub activity, and `checkpoint` from status to explain "where we
-left off." Do not run raw `git log` unless status says journal facts are
-unavailable. If the operator asks to save progress, run `mb checkpoint --plan
---json`, validate with `mb checkpoint --validate "..." --json`, then after
-approval run `mb checkpoint --message "..." --yes`.
+GitHub activity, and `checkpoint` from status to explain "where we left off."
+Do not run raw `git log` unless status says journal facts are unavailable. If
+the operator asks to save progress, run `mb checkpoint --plan --json`, validate
+with `mb checkpoint --validate "..." --json`, then after approval run
+`mb checkpoint --message "..." --yes`.
 
 **Provider facts first:** When setup or routing depends on GitHub, Cloudflare,
 Google/Workspace, Meta Ads, or Apify, read the status `integrations` facts
@@ -65,6 +69,12 @@ ads with `/mb-ads`, and checkpoint approved artifacts.
 decision, load `.claude/reference/business-primitives/offer-bet-push-proof.md`
 and `.claude/reference/business-primitives/setup-patterns.md`; route by business
 meaning before suggesting file moves.
+
+**Books/finance routing:** When the user mentions bookkeeping, books, finance,
+accounting, ledgers, statements, P&L, chart of accounts, tax, payroll, hledger,
+or a private admin repo for numbers, run `mb books check --repo "$REPO_PATH"
+--json` before drafting files. Keep raw private finance records out of the
+team-safe business repo; use the books contract and `storage_mode`.
 
 **Slug/destructive-operation guardrails:** Load
 `.claude/reference/business-primitives/slug-conventions.md` before naming
@@ -136,13 +146,15 @@ before taking action.
 2. Run `mb status --json --peek`; status facts gate updates, repair, readiness,
    onboarding, ranked actions, and continuity.
 3. Use status-cited repair/update commands before routing into output work.
-4. Resume onboarding from status facts; in rich repos, read existing `core/`
+4. Route live intent through [references/router-and-language.md](references/router-and-language.md)
+   before showing a generic menu.
+5. Resume onboarding from status facts; in rich repos, read existing `core/`
    before asking bounded missing-profile questions.
-5. Resolve multi-offer context without reusing numbered choices or silently
+6. Resolve multi-offer context without reusing numbered choices or silently
    writing local state.
-6. Present one clear route set or infer intent: `/mb-think`, `/mb-bet`,
+7. Present one clear route set or infer intent: `/mb-think`, `/mb-bet`,
    `/mb-ads`, `/mb-organic`, `/mb-site`, `/mb-wiki`, `/mb-help`, or
-   `/mb-end`. Treat `/mb-vsl` as compatibility routing only.
+   `/mb-end`. `/mb-vsl` is a compatibility router only.
 
 ---
 
@@ -176,12 +188,12 @@ points at that section as unavailable, degraded, or needing repair.
 Use the `update` section from `mb status --json --peek`. **Do NOT silently
 swallow required updates.** Users on stale code get broken features.
 
-For normal users, updating is not a menu of package-manager commands. Do the
-update through the Main Branch product path: route to `/mb-update` when the user
-asked about updating, or run `mb update --repo . --json` yourself during
-`/mb-start` when status says the update is required. Only mention
-`pipx upgrade mainbranch` as a bootstrap fallback when `mb update` is
-unavailable or the installed version is `0.1.x`.
+For normal users, updating is not a package-manager menu. Strongly recommend a
+recommended update, and run or route to the cited command when the update is
+required. Name installed/latest versions and version distance when status gives
+them; use status or release highlights if present, but do not invent release
+notes. See [references/router-and-language.md](references/router-and-language.md)
+for the update posture.
 
 If `update.severity` is `required` or the top ranked action is an update action,
 run the cited command. When status does not cite a narrower command, use:
@@ -211,9 +223,14 @@ See **[references/repo-detection.md](references/repo-detection.md)** for the ful
 
 ---
 
-## Step 3: Pull Business Repo Updates
+## Step 3: Read Save/Sync State
 
-Once business repo is confirmed, pull its latest updates from `REPO_PATH`. See **[references/pull-engine-updates.md](references/pull-engine-updates.md)** "Pull Business Repo Updates" section for the pull command and the result-handling table.
+Once the business repo is confirmed, use status `git`, `checkpoint`, and
+`since_last_check` facts to explain whether work is saved locally, unsaved
+locally, synced to the shared repo, or waiting for reconciliation. Do not
+blindly pull or rebase the business repo from `/mb-start`. See
+[references/router-and-language.md](references/router-and-language.md) for the
+save/sync vocabulary.
 
 ---
 
@@ -306,27 +323,14 @@ See [tool-status-audit.md](references/tool-status-audit.md) for the full procedu
 ## Step 6: Readiness Assessment
 
 Use `readiness` and `ranked_actions` from `mb status --json --peek` before
-routing. The legacy scoring rubric below is fallback detail for gaps that status
-does not expose yet.
+routing. The reference below is fallback detail for gaps that status does not
+expose yet.
 
 See [readiness-assessment.md](references/readiness-assessment.md) for complete scoring rubric, session state checks, soul health check, skill-specific requirements, and display format.
 
-### Quick summary:
-
-1. **Score core files** (soul, offer, audience, voice, testimonials, angles) on 0-3 scale each. Composite max = 18. Multi-offer: score active offer's files, not just core.
-2. **Check continuity state** -- status journal activity, active decisions, uncodified research, and saved/unsaved work.
-3. **Soul health check** — for returning users (last commit >3 days ago), read soul.md and ask: "Is your current work feeling like pull or push?" Skip for active or first-time users.
-4. **Gate routing** based on composite score:
-
-| Score | Status | Action |
-|-------|--------|--------|
-| 0-3 | EMPTY | Route to `/mb-setup` |
-| 4-7 | MINIMAL | Block output skills, route to `/mb-think` |
-| 8-11 | THIN | Warn before output skills, suggest `/mb-think` first |
-| 12-14 | GOOD | All skills, note gaps |
-| 15-18 | FULL | All skills available |
-
-Adapt display to `user.experience` level (beginner = full breakdown, advanced = score only). See reference file for details.
+Quick summary: status readiness gates setup, repair, and output skills; fallback
+scoring only fills missing detail. Adapt display to `user.experience` level
+without making the repo feel audited or behind.
 
 ---
 
@@ -420,13 +424,12 @@ to `/mb-think`.
 
 **Show context:** Before presenting options, show: "Business: **[repo name]** | Offer: **[active offer or 'single']**"
 
-**Surface unread CHANGELOG entries before the menu**, present the triage route
-without reusing a number from recommendations or offers, and use the "while you
-wait" pattern when spawning agents. See
-**[references/triage-menu.md](references/triage-menu.md)** for the full menu,
-the CHANGELOG "what's new" banner format (diff'd against `last_seen_version`),
-the random "while you wait" filler lines, and rules for when to auto-suggest or
-skip triage.
+If the user stated intent, route directly using
+[references/router-and-language.md](references/router-and-language.md). If the
+session is open-ended, surface the top ranked action, the strongest update
+recommendation, or the compact route menu without reusing numbers from offers or
+recommendations. Use [references/triage-menu.md](references/triage-menu.md) only
+when the user wants prioritization or deep triage.
 
 ---
 
@@ -451,26 +454,15 @@ fast. If the user asks for a faster mode, offer to update local experience.
 
 ## Intent Keywords
 
-Auto-detect user intent and route. Skills: `/mb-update`, `/mb-help`, `/mb-setup`, `/mb-think`, `/mb-ads`, `/mb-organic`, `/mb-site`, `/mb-wiki`, `/mb-end`; `/mb-vsl` remains a compatibility router. Some skills spawn parallel subagents automatically.
+Auto-detect user intent through
+[references/router-and-language.md](references/router-and-language.md). Key
+clusters: save/checkpoint/sync, bookkeeping/books/finance, provider/tool setup,
+repair/update/drift, decide/codify/research, bets, launches, sites, ads, organic,
+wiki, and help.
 
-| Keywords | Route To |
-|----------|----------|
-| "what should I work on", "help me prioritize", "what to do next", "figure out what to work on", "deep triage" | Triage route (see [triage-agent.md](references/triage-agent.md)) |
-| "help", "confused", "stuck", "don't understand", "how do I" | `/mb-help` |
-| "new", "first time", "get started", "set up" | `/mb-setup` |
-| "add", "update", "more context", "new testimonials", "enrich" | `/mb-think codify` |
-| "research", "decide", "figure out", "explore", "mine", "mining", "competitors", "transcribe", "analyze this VSL", "extract the pitch", "script teardown", "objection mining" | `/mb-think` |
-| "content strategy", "pillars", "platforms", "cadence", "content plan", "distribution" | `/mb-think` |
-| "soul check", "is this still right", "feeling obligated", "pull or push" | `/mb-think codify` (soul.md review) |
-| "newsletter", "email", "beehiiv", "weekly email" | `/mb-think` for content strategy, then `/mb-organic` for social repurposing |
-| "ads", "copy", "static", "image ads", "video ads", "video ad script", "paid sales video", "long-form video ad", "review", "compliance" | `/mb-ads` |
-| "write a VSL", "sales video", "about page video", "landing page video", "pitch script", "embedded video"; literal "/mb-vsl" | `/mb-site` unless paid, teardown, or repurposing intent is explicit; `/mb-vsl` is a compatibility router |
-| "content", "reels", "tiktok", "organic", "carousel", "short clips from sales video", "repurpose this VSL" | `/mb-organic` |
-| "launch offer", "keyword gate then build", "offer launch", "/mb-start launch <offer>" | Use [references/launch-orchestration.md](references/launch-orchestration.md), then route to `/mb-think`, `/mb-site`, and `/mb-ads` as each step becomes current |
-| "site", "landing page", "lander", "minisite", "website", "one-pager", "spin up a site", "deploy site", "put this online", "I need a site", "publish site", "graduate my site", "add a CMS to my site" | `/mb-site` |
-| "wiki", "notes", "atomic", "wikilinks", "publish wiki" | `/mb-wiki` |
-| "pull", "update Main Branch", "get latest" | `/mb-update` |
-| "done", "wrapping up", "end my day", "closing out", "call it a day", "that's it" | `/mb-end` |
+Generic "set up" is not enough to route. Use the noun: repo setup routes to
+`/mb-setup`, bookkeeping setup runs `mb books check`, provider setup reads
+`mb connect`, and decision/tool setup routes to `/mb-think`.
 
 ---
 
@@ -484,7 +476,8 @@ treat business `.vip/local.yaml` as audit input only, and do not write it.
 
 ## References
 
-- [references/pull-engine-updates.md](references/pull-engine-updates.md) — Step 1 + Step 3 pull scripts and failure warnings
+- [references/router-and-language.md](references/router-and-language.md) — business router, save/sync language, update posture, and intent clusters
+- [references/pull-engine-updates.md](references/pull-engine-updates.md) — Step 1 engine update handling
 - [references/repo-detection.md](references/repo-detection.md) — Step 2 full CWD detection, migration, multi-repo selection, REPO_PATH, Main Branch wiring verification
 - [references/triage-menu.md](references/triage-menu.md) — Step 10 CHANGELOG banner, menu, "while you wait" pattern, auto-suggest/skip rules
 - [references/auto-heal.md](references/auto-heal.md) — Bridge link recovery

--- a/.claude/skills/mb-start/SKILL.md
+++ b/.claude/skills/mb-start/SKILL.md
@@ -72,9 +72,10 @@ meaning before suggesting file moves.
 
 **Books/finance routing:** When the user mentions bookkeeping, books, finance,
 accounting, ledgers, statements, P&L, chart of accounts, tax, payroll, hledger,
-or a private admin repo for numbers, run `mb books check --repo "$REPO_PATH"
+or a restricted `finance` child repo, run `mb books check --repo "$REPO_PATH"
 --json` before drafting files. Keep raw private finance records out of the
-team-safe business repo; use the books contract and `storage_mode`.
+team-safe hub repo; use the books contract, `storage_mode`, and topology
+visibility (`restricted` or `local_only`) to route raw records.
 
 **Slug/destructive-operation guardrails:** Load
 `.claude/reference/business-primitives/slug-conventions.md` before naming

--- a/.claude/skills/mb-start/references/pull-engine-updates.md
+++ b/.claude/skills/mb-start/references/pull-engine-updates.md
@@ -1,6 +1,8 @@
-# Pull Engine Updates
+# Engine Updates
 
-Standard command for pulling latest Main Branch updates at the start of any skill invocation. CWD is the business repo. **Do NOT silently swallow failures.** Users on stale code get broken features.
+Standard command for checking or applying Main Branch engine updates at the
+start of a skill invocation. CWD is the business repo. **Do NOT silently swallow
+failures.** Users on stale code get broken features.
 
 `mb update` owns the install-mode mechanics. It detects pipx vs clone installs, runs the correct update command, and refreshes skill links for the business repo.
 
@@ -17,9 +19,9 @@ mb update --repo . --json 2>&1
 | Invalid JSON or missing engine root | "Couldn't find Main Branch. Run `mb skill link --repo .`, then restart Claude." |
 | JSON `"ok": false` or command failure | Show the warning below |
 
-## If Pull Fails — Show This Warning
+## If Update Fails - Show This Warning
 
-> "I wasn't able to pull the latest Main Branch updates. This means you may be running on an old version and missing new features.
+> "I wasn't able to update Main Branch. This means you may be running on an old version and missing new features.
 >
 > Common fixes:
 > 1. Run `mb update --check --repo .` to see which install path Main Branch detects
@@ -29,37 +31,3 @@ mb update --repo . --json 2>&1
 > You can continue, but some features may not work as expected."
 
 **Do not skip this warning.** A user running stale Main Branch is the #1 cause of "why doesn't X work" support questions.
-
----
-
-## Pull Business Repo Updates (start skill only)
-
-Once business repo is confirmed, pull its latest updates from `REPO_PATH`:
-
-```bash
-if git -C "$REPO_PATH" remote get-url origin >/dev/null 2>&1; then
-  git -C "$REPO_PATH" pull origin main 2>&1
-else
-  echo "NO_REMOTE"
-fi
-```
-
-### Handle the Result
-
-| Result | What to say |
-|--------|-------------|
-| "Already up to date." | Say nothing |
-| "Updating..." / files changed | "Pulled latest updates for [repo-name]." |
-| "NO_REMOTE" | Say nothing — local-only repo, no remote configured |
-| Any other error | Show the warning below |
-
-### If Pull Fails (and Repo Has a Remote)
-
-> "Couldn't pull updates for [repo-name]. You may be working on older reference files.
->
-> Try: Open GitHub Desktop → select [repo-name] → click 'Fetch origin'"
-
-### Why Both Repos
-
-- Main Branch engine → new skills, playbooks, compliance frameworks
-- Business repo → your reference files, decisions, research

--- a/.claude/skills/mb-start/references/readiness-assessment.md
+++ b/.claude/skills/mb-start/references/readiness-assessment.md
@@ -268,12 +268,12 @@ Modeled on /mb-end's crystallize pattern. For returning users, reconnection at s
 
 **Trigger conditions (ALL must be true):**
 1. `core/soul.md` exists and has substance (score 2+)
-2. Last journal event or commit was >3 days ago (returning after absence)
+2. Last status journal event or saved checkpoint was >3 days ago (returning after absence)
 3. This is not the user's first session ever (config exists with `user.name`)
 
 **Skip conditions (ANY skips this check):**
-- First-time user (no config, no commits)
-- Active user (committed within last 3 days)
+- First-time user (no repo history)
+- Active user (saved or updated work within last 3 days)
 - User explicitly stated intent already (e.g., `/mb-start ads` -- they know what they want)
 - Context window is already heavy (>70%)
 
@@ -550,7 +550,7 @@ Health flags from Section 3 appear alongside structural scores. File-level flags
 If session state items were found, append after the health display:
 
 > "**Since last session:**
-> - Last work: [topic from recent commit]
+> - Last work: [topic from recent saved checkpoint or journal event]
 > - [N] decisions still being evaluated or integrated
 > - [N] research files without decisions"
 

--- a/.claude/skills/mb-start/references/router-and-language.md
+++ b/.claude/skills/mb-start/references/router-and-language.md
@@ -1,0 +1,202 @@
+# Router and Language Contract
+
+`/mb-start` is the business router. It should feel like the operator opened the
+business and the system remembered where they are, what changed, and what kind
+of work their current words imply.
+
+Use this reference after `mb status --json --peek` is available and before
+presenting a menu.
+
+This operationalizes the repo-wide contract in `AGENTS.md`, generated business
+repo guidance in `templates/`, and `mb educational git-history-vs-cloud-sync`:
+git remains the durable memory layer, but the operator hears business language
+first.
+
+---
+
+## Routing Order
+
+1. If the user stated a live intent, route that intent before showing generic
+   ranked actions. Ranked actions are for open-ended starts such as "what should
+   I do next?", not for overriding "set up bookkeeping" or "save this."
+2. Apply hard gates first: required Main Branch update, broken repo wiring,
+   missing business repo, provider danger, private-data boundary, or destructive
+   operation.
+3. Use status facts as evidence: `ranked_actions`, `update`, `readiness`,
+   `onboarding`, `drift`, `integrations`, `github`, `brain`, `checkpoint`,
+   `since_last_check`, and `journal`.
+4. Choose the smallest useful next workflow. Do not present the full route menu
+   when a clear intent maps to one route.
+5. If two routes are plausible, ask one business question that separates them.
+   Example: "Is this bookkeeping setup, or are you trying to decide the tool?"
+
+---
+
+## First Screen Shape
+
+For a normal returning session, answer in this order:
+
+1. Working context: business name and the plain-language sync state.
+2. Update posture: strongly recommend updates when available, especially when
+   the user's stated intent touches a feature added after their installed
+   version.
+3. Where we left off: 1 to 3 business-readable facts from status, without raw
+   hashes or branch names.
+4. Current route: the inferred workflow or one compact choice list.
+
+Avoid "Something else" as the main escape hatch. Use "tell me what you came here
+to do" only after showing the likely business routes.
+
+---
+
+## Save and Sync Vocabulary
+
+Use business words first. Keep technical terms available only when they are the
+exact command, validation evidence, or the operator asks for git details.
+
+| Technical state | Default operator language |
+| --- | --- |
+| commit | saved checkpoint |
+| uncommitted changes | unsaved local work |
+| dirty files | local files with unsaved changes |
+| push | sync saved checkpoint to the shared repo |
+| pull/fetch | catch up with the shared repo |
+| rebase | reconcile local saved work with newer shared work |
+| ahead | saved locally but not synced |
+| behind | newer saved work exists in the shared repo |
+| diverged | both your local repo and the shared repo have newer saved work |
+| branch/worktree | workspace |
+| conflict | the same file changed in two places |
+| hash/SHA | checkpoint id |
+
+Do not print checkpoint ids, branch names, `origin`, `ahead`, `behind`,
+`diverged`, `rebase`, or `commit` in the first response unless they are inside a
+command the user must run or the user asked for technical detail.
+
+Good pattern:
+
+> "Your bookkeeping setup is saved locally. The shared repo also has one newer
+> saved change, so reconcile before syncing."
+
+Avoid:
+
+> "Local and origin have diverged. Run `git pull --rebase` before pushing."
+
+---
+
+## Update Posture
+
+When `status.update.severity` is `recommended` or `required`, name the installed
+and latest versions if present and say how many version steps are behind when
+the numbers are obvious.
+
+If the status report includes release highlights or ranked update actions, use
+those highlights. If not, say the user may be missing recent routing, repair,
+or skill fixes; do not invent exact release notes.
+
+Use direct language:
+
+> "Update strongly recommended: mb 0.3.15 -> 0.3.17. You are two versions behind,
+> and this session touches routing/bookkeeping behavior that has been changing.
+> Run `mb update` before we continue."
+
+If the update is required, run or route to the cited update command before
+business work.
+
+---
+
+## Intent Clusters
+
+### Save, checkpoint, wrap, sync
+
+Signals: save, saved, checkpoint, wrap up, closing out, end my day, sync,
+publish my saved work, catch up, reconcile, shared repo, newer work.
+
+Route:
+
+- If ending the session, use `/mb-end`.
+- If saving progress midstream, run `mb checkpoint --plan --json`, then validate
+  and save after approval.
+- If local/shared repo state is involved, explain it with the save/sync
+  vocabulary above. Do not prescribe a rebase in first response; say reconcile
+  unless technical detail is needed.
+
+### Bookkeeping, books, finance, accounting
+
+Signals: bookkeeping, books, finance, accounting, chart of accounts, P&L,
+ledger, bank statements, noontide-admin style private numbers, hledger,
+receipts, tax, payroll, revenue report.
+
+Route:
+
+- Run `mb books check --repo "$REPO_PATH" --json` before inventing structure.
+- Keep raw ledgers, statements, credentials, account numbers, payroll rows, tax
+  IDs, and exact private numbers out of the public/team-safe business repo.
+- Use the books contract fields, especially `storage_mode`, to decide whether
+  private details belong in a separate admin repo and only safe summaries belong
+  in the hub repo.
+- If the user is deciding tooling, route to `/mb-think` after the books check.
+- If the user is setting up the safe repo contract, draft or update the safe
+  finance files named by the books check. Do not create generic finance files
+  that bypass the contract.
+
+### Provider and tool setup
+
+Signals: connect, provider, Cloudflare, GitHub, Google, Workspace, Meta Ads,
+Stripe, hledger, Apify, Postiz, Cal.com, token, API key, deployment, DNS,
+calendar, booking.
+
+Route:
+
+- Read `status.integrations` first.
+- Run `mb connect plan` or `mb connect doctor --json` when status says a
+  provider is missing, degraded, or needed for the stated route.
+- Explain the business capability first, then the command.
+- Never ask the user to paste secrets into repo files or chat.
+
+### Repair, update, drift
+
+Signals: broken, not showing up, stale, migration, old layout, warnings, validate
+noise, repair, update, missing links, cross refs.
+
+Route:
+
+- Required update or stale skill wiring comes before output work.
+- Use `mb doctor repair --plan --json` for repo drift.
+- Use `mb validate --cross-refs` only when relationship/link health is the
+  stated task or status points there.
+
+### Decide, codify, research
+
+Signals: think, decide, figure out, explore, research, compare, tool decision,
+strategy, positioning, offer, audience, voice, soul check, vendor choice.
+
+Route to `/mb-think`, with `codify` when the task is to turn known context into
+durable repo truth.
+
+### Bets, pushes, sites, ads, organic, wiki
+
+Signals and routes:
+
+- bet, wager, deadline, metric, result, outcome: `/mb-bet`
+- launch, push, playbook, offer launch: launch orchestration, then `/mb-think`,
+  `/mb-site`, `/mb-ads`, or checkpoint as the current step requires
+- site, landing page, lander, minisite, publish: `/mb-site`
+- ads, Google Ads, Meta Ads, video ad, compliance: `/mb-ads`
+- organic, reels, TikTok, LinkedIn, carousel, repurpose: `/mb-organic`
+- wiki, notes, public knowledge base, atomic notes: `/mb-wiki`
+- confused, help, explain the system: `/mb-help`
+
+---
+
+## Dead-End Avoidance
+
+- Do not let generic "set up" override the specific noun. "Set up
+  bookkeeping" routes through books; "set up Cloudflare" routes through
+  provider checks; "set up the repo" routes to `/mb-setup`.
+- Do not turn every returning session into triage. Triage is for open-ended
+  prioritization or explicit deep review.
+- Do not show raw recent checkpoint ids as proof of continuity. Use journal
+  summaries and file/topic names.
+- Do not blindly catch up the business repo from the shared remote. First
+  explain the sync state and ask before changing local saved work.

--- a/.claude/skills/mb-start/references/router-and-language.md
+++ b/.claude/skills/mb-start/references/router-and-language.md
@@ -107,10 +107,11 @@ business work.
 
 ## Intent Clusters
 
-### Save, checkpoint, wrap, sync
+### Save, checkpoint, wrap, sync, publish
 
 Signals: save, saved, checkpoint, wrap up, closing out, end my day, sync,
-publish my saved work, catch up, reconcile, shared repo, newer work.
+publish my saved work, share for review, pull request, PR, proposal, catch up,
+reconcile, shared repo, newer work.
 
 Route:
 
@@ -120,21 +121,30 @@ Route:
 - If local/shared repo state is involved, explain it with the save/sync
   vocabulary above. Do not prescribe a rebase in first response; say reconcile
   unless technical detail is needed.
+- If the user asks to publish, open a PR, or share work for review, use status
+  `git.workflow_mode`, `git.summary`, and GitHub facts to explain whether this
+  is a saved checkpoint, a sync, or a proposal/review path. The planned
+  `mb publish --plan` and packaged publish skill are not shipped yet;
+  do not pretend they exist or load ad hoc PR-instruction attachments.
 
 ### Bookkeeping, books, finance, accounting
 
 Signals: bookkeeping, books, finance, accounting, chart of accounts, P&L,
-ledger, bank statements, noontide-admin style private numbers, hledger,
-receipts, tax, payroll, revenue report.
+ledger, bank statements, restricted finance child repo, restricted repo topology,
+hledger, receipts, tax, payroll, revenue report.
 
 Route:
 
 - Run `mb books check --repo "$REPO_PATH" --json` before inventing structure.
 - Keep raw ledgers, statements, credentials, account numbers, payroll rows, tax
   IDs, and exact private numbers out of the public/team-safe business repo.
-- Use the books contract fields, especially `storage_mode`, to decide whether
-  private details belong in a separate admin repo and only safe summaries belong
-  in the hub repo.
+- Preserve public topology terms: hub repo, child repo, hub registry
+  `core/operations/repo-topology.md`, child descriptor `.mainbranch/repo.json`,
+  role `finance`, and visibility `restricted` or `local_only`.
+- Use the books contract fields, especially `storage_mode`, and the repo
+  topology role `finance` with visibility `restricted` or `local_only` to
+  decide where raw books belong. The hub repo should keep only safe summaries,
+  decisions, and links.
 - If the user is deciding tooling, route to `/mb-think` after the books check.
 - If the user is setting up the safe repo contract, draft or update the safe
   finance files named by the books check. Do not create generic finance files

--- a/.claude/skills/mb-start/references/triage-agent.md
+++ b/.claude/skills/mb-start/references/triage-agent.md
@@ -18,7 +18,7 @@ skill directly.
 **Why not always-on:** Three parallel agents burn 50-80K tokens. Running them every session means the user hits 60%+ context before doing any actual work. /mb-end gates crystallize behind meaningful activity — /mb-start gates triage behind user choice. Agents eat the heavy context in their own windows, keeping main lean for whatever comes next.
 
 **Auto-suggest triage when:**
-- Returning user (last commit >3 days ago) and no stated intent
+- Returning user (last saved checkpoint or status journal event is older than 3 days) and no stated intent
 - Readiness is THIN (8-11) — "Triage can help you figure out the highest-leverage gap"
 - User says "what should I work on", "help me prioritize", "what to do next"
 
@@ -36,7 +36,7 @@ Before spawning agents, check these gates (modeled on /mb-end Step 5a):
 |------|-------|----------|
 | Context budget | Is main context < 50%? | Warn user: "Context is at X%. Triage uses significant tokens. Run it anyway?" |
 | Readiness tier | Is score ≥ 8 (THIN or above)? | Skip triage — not enough reference to analyze. Route to `/mb-think` |
-| Meaningful state | Does repo have commits, decisions, or research? | If brand new repo with just setup scaffolding, skip deep triage — suggest `/mb-think` instead |
+| Meaningful state | Does repo have saved checkpoints, decisions, or research? | If brand new repo with just setup scaffolding, skip deep triage — suggest `/mb-think` instead |
 
 ### Tiered Spawning
 
@@ -44,7 +44,7 @@ Not every session needs 3 agents. Match agent count to context:
 
 | Condition | Agents | Why |
 |-----------|--------|-----|
-| THIN (8-11), few commits | **1 agent** (Reference Health only) | Not enough content for pipeline or soul analysis |
+| THIN (8-11), few saved checkpoints | **1 agent** (Reference Health only) | Not enough content for pipeline or soul analysis |
 | GOOD (12-14), active repo | **2 agents** (Reference Health + Pipeline) | Soul analysis adds value when there's meaningful work history |
 | FULL (15-18), active repo | **3 agents** (all three) | Full analysis justified |
 | User says "deep triage" | **3 agents** regardless | Explicit request overrides tiering |
@@ -244,7 +244,7 @@ You are NOT a task manager. You identify patterns and bottlenecks.
 
 === GIT LOG (30 DAYS) ===
 
-[Git log output -- commits, what changed, when]
+[Status journal or git fallback output -- saved checkpoints, what changed, when]
 
 === ACTIVE DECISIONS ===
 
@@ -292,9 +292,9 @@ Analyze these dimensions:
    some research is exploratory. But research older than 14 days without a
    decision may be going stale.
 
-3. **Campaign lifecycle state:** Any campaign files with status: draft?
-   Scheduled? When was the last campaign asset published? Is there a gap
-   between core readiness and campaign generation?
+3. **Push lifecycle state:** Any current push files with status: draft,
+   planned, or active? When was the last execution artifact saved? Is there a
+   gap between core readiness and coordinated work?
 
 4. **Push recency:** When was the last batch generated? What type?
    Long gap between core updates and push generation = missed opportunity.

--- a/.claude/skills/mb-start/references/triage-menu.md
+++ b/.claude/skills/mb-start/references/triage-menu.md
@@ -77,26 +77,21 @@ and synthesis format.
 
 ## "While You Wait" Pattern
 
-Set expectations, then give them something to chew on:
+Set expectations, then keep the operator anchored in current business facts:
 
 > "Spinning up [1/2/3] analysis agents — this takes about **2-3 minutes**. They're reading your full reference, decisions, git history, and soul alignment so I can give you something actually useful.
 >
-> **Good news:** These run as sub-agents in their own context windows, so they won't eat into your session. You'll still have plenty of room for whatever comes next.
->
-> While we wait: [pick ONE at random per session]
-> - *The word 'decide' comes from Latin 'decidere' — literally 'to cut off.' Every decision is choosing what to let go of.*
-> - *Hemingway rewrote the ending of A Farewell to Arms 47 times. When asked why, he said: 'Getting the words right.'*
-> - *The best time to plant a tree was 20 years ago. The second best time is now.*
-> - *Your reference files are like compound interest — small deposits now, massive returns later.*
-> - *'If you can't explain it simply, you don't understand it well enough.' — Einstein. That's what codifying does.*
-> - *Fun fact: the average person mass-produces 50K+ words a day in their head. You're one of the few who actually filters those into something useful.*"
+> While that runs, here's the compact state I already trust:
+> - [top ranked action or stated intent]
+> - [main readiness or repair signal]
+> - [one continuity fact from journal/status]"
 
 ---
 
 ## When to Auto-Suggest / Skip Triage
 
 **Auto-suggest triage when:**
-- Returning user (last commit >3 days ago) and no stated intent
+- Returning user (last saved checkpoint or status journal event is older than 3 days) and no stated intent
 - Readiness is THIN (8-11) — "Triage can help you figure out the highest-leverage gap"
 - User says "what should I work on", "help me prioritize", "what to do next"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   progressive discovery, release-doc boundaries, and the local preference split,
   so maintainer-local preferences can stay short and private. Refs MAIN-330,
   #507.
+- Added an explicit `/mb-start` router and language contract covering live
+  intent routing, bookkeeping/books setup, provider setup, save/sync wording,
+  stronger update posture, and the rule that generic "set up" must not override
+  the user's specific business noun. Refs MAIN-333, #511.
+
+### Changed
+
+- Reframed `/mb-start`, `mb status` git summaries, `mb start` readiness repair,
+  and `mb books check` operator summaries around saved checkpoints, unsaved
+  local work, catching up, syncing, and reconciliation instead of defaulting to
+  raw commit/rebase/ahead/behind language. Refs MAIN-333, #511.
 
 ## [0.3.17] - 2026-05-12
 

--- a/mb/mb/books.py
+++ b/mb/mb/books.py
@@ -508,8 +508,9 @@ def _detect_unsafe_paths(repo: Path) -> list[dict[str, Any]]:
             ),
             repair=(
                 "Move each file into .mb/private/books/ (solo-local) or "
-                "the private books repo, then remove it from shared tracking "
-                "and save a checkpoint. Rotate the data if it is sensitive."
+                "the private books repo, then run `git rm --cached <file>` for "
+                "each leaked file and save a checkpoint. Rotate the data if it "
+                "is sensitive."
             ),
             evidence=leaks[:20],
         )

--- a/mb/mb/books.py
+++ b/mb/mb/books.py
@@ -422,10 +422,10 @@ def _check_vault_ignore_rule(repo: Path, storage_mode: str) -> list[dict[str, An
 
 
 def _detect_unsafe_paths(repo: Path) -> list[dict[str, Any]]:
-    """Flag ledger or statement files committed to the business repo.
+    """Flag ledger or statement files saved in the business repo.
 
     Per the foundation decision this is a ``warn``, not a hard fail:
-    operators may legitimately commit non-finance CSVs (research
+    operators may legitimately save non-finance CSVs (research
     exports, audience data) and may ship sample fixtures. Files
     carrying an explicit fixture marker (see ``FIXTURE_MARKER_TOKENS``)
     are exempted.
@@ -482,7 +482,7 @@ def _detect_unsafe_paths(repo: Path) -> list[dict[str, Any]]:
                 state="ok",
                 detail=f"Checked via {method}; no unmarked ledger-shaped files found.",
                 audience="informational",
-                operator_summary=("No raw ledgers or statements committed to the business repo."),
+                operator_summary=("No raw ledgers or statements saved in the business repo."),
             )
         )
         return findings
@@ -502,14 +502,14 @@ def _detect_unsafe_paths(repo: Path) -> list[dict[str, Any]]:
             ),
             audience="operator_decision",
             operator_summary=(
-                f"{len(leaks)} ledger/statement-shaped file(s) committed; "
+                f"{len(leaks)} ledger/statement-shaped file(s) saved in the business repo; "
                 "move them into the private books vault or mark them as "
                 "fixtures."
             ),
             repair=(
                 "Move each file into .mb/private/books/ (solo-local) or "
-                "the private books repo, then `git rm --cached <file>` and "
-                "commit. Rotate the data if it is sensitive."
+                "the private books repo, then remove it from shared tracking "
+                "and save a checkpoint. Rotate the data if it is sensitive."
             ),
             evidence=leaks[:20],
         )

--- a/mb/mb/start.py
+++ b/mb/mb/start.py
@@ -159,8 +159,8 @@ def _build_checks(
             "severity": "warn",
             "detail": dirty_detail,
             "repair": (
-                "Review, commit, or stash local changes before handing substantive work "
-                "to an agent."
+                "Review, save a checkpoint, or set aside local changes before handing "
+                "substantive work to an agent."
             ),
         },
         {

--- a/mb/mb/status.py
+++ b/mb/mb/status.py
@@ -176,14 +176,14 @@ def _build_git_summary(
     behind: int | None,
 ) -> str:
     if workflow_mode == "detached":
-        return "This workspace is detached. Check out a workspace before saving."
+        return "This workspace is detached. Switch back to your main workspace before saving."
     if not workflow_mode:
         return ""
 
     if workflow_mode == "solo-on-main":
         label = f"Working in the {branch or default_branch or 'main'} workspace"
     elif workflow_mode == "worktree":
-        label = "Working in a separate workspace"
+        label = "Working in a linked workspace"
     else:
         label = "Working in a separate workspace"
 

--- a/mb/mb/status.py
+++ b/mb/mb/status.py
@@ -176,7 +176,7 @@ def _build_git_summary(
     behind: int | None,
 ) -> str:
     if workflow_mode == "detached":
-        return "This workspace is detached. Switch back to your main workspace before saving."
+        return "This workspace is detached. Switch back to a named workspace before saving."
     if not workflow_mode:
         return ""
 
@@ -194,7 +194,7 @@ def _build_git_summary(
     else:
         parts.append("with no unsaved local changes")
     if ahead and behind:
-        parts.append("with local and shared saved work to reconcile")
+        parts[-1] += "; local and shared saved work need reconciliation"
     elif ahead:
         plural = "" if ahead == 1 else "s"
         parts.append(f"with {ahead} saved checkpoint{plural} waiting to sync")

--- a/mb/mb/status.py
+++ b/mb/mb/status.py
@@ -176,27 +176,31 @@ def _build_git_summary(
     behind: int | None,
 ) -> str:
     if workflow_mode == "detached":
-        return "HEAD is detached. Check out a branch before saving."
+        return "This workspace is detached. Check out a workspace before saving."
     if not workflow_mode:
         return ""
 
     if workflow_mode == "solo-on-main":
-        label = f"On {branch or default_branch or 'main'}"
+        label = f"Working in the {branch or default_branch or 'main'} workspace"
     elif workflow_mode == "worktree":
-        label = f"In a worktree on `{branch}`" if branch else "In a worktree"
+        label = "Working in a separate workspace"
     else:
-        label = f"On branch `{branch}`"
+        label = "Working in a separate workspace"
 
     parts: list[str] = [label]
     if dirty_count:
         plural = "" if dirty_count == 1 else "s"
-        parts.append(f"with {dirty_count} uncommitted file{plural}")
+        parts.append(f"with {dirty_count} unsaved local file{plural}")
     else:
-        parts.append("with no uncommitted changes")
-    if ahead:
-        parts.append(f"ahead by {ahead}")
-    if behind:
-        parts.append(f"behind by {behind}")
+        parts.append("with no unsaved local changes")
+    if ahead and behind:
+        parts.append("with local and shared saved work to reconcile")
+    elif ahead:
+        plural = "" if ahead == 1 else "s"
+        parts.append(f"with {ahead} saved checkpoint{plural} waiting to sync")
+    elif behind:
+        plural = "" if behind == 1 else "s"
+        parts.append(f"with {behind} newer shared checkpoint{plural} to catch up")
     return " ".join(parts) + "."
 
 

--- a/mb/tests/test_books.py
+++ b/mb/tests/test_books.py
@@ -114,6 +114,7 @@ def test_books_check_flags_committed_ledger_file(tmp_path: Path) -> None:
     # usable.
     assert leak["state"] == "warn"
     assert leak["audience"] == "operator_decision"
+    assert "git rm --cached <file>" in leak["repair"]
     assert "core/finance/main.journal" in leak["evidence"]
     assert report["ok"] is True
     assert report["state"] == "warn"

--- a/mb/tests/test_start_router_contract.py
+++ b/mb/tests/test_start_router_contract.py
@@ -20,6 +20,7 @@ def test_mb_start_delegates_router_detail_without_bloating_skill_body() -> None:
     assert len(start.splitlines()) <= 500
     assert "references/router-and-language.md" in start
     assert "bookkeeping setup runs `mb books check`" in start
+    assert "private admin repo" not in start.lower()
 
 
 def test_router_contract_covers_books_save_sync_and_updates() -> None:
@@ -30,13 +31,20 @@ def test_router_contract_covers_books_save_sync_and_updates() -> None:
         "unsaved local work",
         "catch up with the shared repo",
         "reconcile local saved work",
+        "proposal/review path",
+        "ad hoc PR-instruction attachments",
         "Update strongly recommended",
         'Run `mb books check --repo "$REPO_PATH" --json`',
         "`storage_mode`",
+        "hub registry",
+        "child descriptor `.mainbranch/repo.json`",
+        "topology role `finance` with visibility `restricted` or `local_only`",
         'generic "set up"',
     ]
     for phrase in required_phrases:
         assert phrase in router
+
+    assert "noontide-admin" not in router.lower()
 
 
 def test_start_router_no_longer_blindly_pulls_business_repo() -> None:

--- a/mb/tests/test_start_router_contract.py
+++ b/mb/tests/test_start_router_contract.py
@@ -1,0 +1,48 @@
+"""Product-contract guards for the `/mb-start` business router."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+START_SKILL = REPO_ROOT / ".claude" / "skills" / "mb-start" / "SKILL.md"
+ROUTER_REF = REPO_ROOT / ".claude" / "skills" / "mb-start" / "references" / "router-and-language.md"
+UPDATE_REF = REPO_ROOT / ".claude" / "skills" / "mb-start" / "references" / "pull-engine-updates.md"
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_mb_start_delegates_router_detail_without_bloating_skill_body() -> None:
+    start = _read(START_SKILL)
+
+    assert len(start.splitlines()) <= 500
+    assert "references/router-and-language.md" in start
+    assert "bookkeeping setup runs `mb books check`" in start
+
+
+def test_router_contract_covers_books_save_sync_and_updates() -> None:
+    router = _read(ROUTER_REF)
+
+    required_phrases = [
+        "saved checkpoint",
+        "unsaved local work",
+        "catch up with the shared repo",
+        "reconcile local saved work",
+        "Update strongly recommended",
+        'Run `mb books check --repo "$REPO_PATH" --json`',
+        "`storage_mode`",
+        'generic "set up"',
+    ]
+    for phrase in required_phrases:
+        assert phrase in router
+
+
+def test_start_router_no_longer_blindly_pulls_business_repo() -> None:
+    start = _read(START_SKILL)
+    update = _read(UPDATE_REF)
+
+    combined = f"{start}\n{update}"
+    assert 'git -C "$REPO_PATH" pull origin main' not in combined
+    assert "blindly pull or rebase the business repo" in start

--- a/mb/tests/test_status.py
+++ b/mb/tests/test_status.py
@@ -2072,7 +2072,7 @@ def test_build_git_summary_reads_in_business_language() -> None:
     )
     assert "separate workspace" in on_branch
     assert "3 unsaved local files" in on_branch
-    assert "local and shared saved work to reconcile" in on_branch
+    assert "local and shared saved work need reconciliation" in on_branch
 
     detached = status_mod._build_git_summary(
         workflow_mode="detached",
@@ -2083,7 +2083,7 @@ def test_build_git_summary_reads_in_business_language() -> None:
         behind=None,
     )
     assert "detached" in detached.lower()
-    assert "Switch back to your main workspace" in detached
+    assert "Switch back to a named workspace" in detached
 
 
 def test_git_info_solo_on_main_without_remote(tmp_path: Path) -> None:

--- a/mb/tests/test_status.py
+++ b/mb/tests/test_status.py
@@ -2083,6 +2083,7 @@ def test_build_git_summary_reads_in_business_language() -> None:
         behind=None,
     )
     assert "detached" in detached.lower()
+    assert "Switch back to your main workspace" in detached
 
 
 def test_git_info_solo_on_main_without_remote(tmp_path: Path) -> None:
@@ -2184,4 +2185,4 @@ def test_git_info_detects_linked_worktree(tmp_path: Path) -> None:
     assert info["branch"] == "feature/x"
     assert info["default_branch"] == "main"
     assert info["worktree_root"] == str(worktree_path.resolve())
-    assert "separate workspace" in info["summary"]
+    assert "linked workspace" in info["summary"]

--- a/mb/tests/test_status.py
+++ b/mb/tests/test_status.py
@@ -2059,8 +2059,8 @@ def test_build_git_summary_reads_in_business_language() -> None:
         ahead=None,
         behind=None,
     )
-    assert "On main" in on_main
-    assert "no uncommitted changes" in on_main
+    assert "main workspace" in on_main
+    assert "no unsaved local changes" in on_main
 
     on_branch = status_mod._build_git_summary(
         workflow_mode="branch",
@@ -2070,10 +2070,9 @@ def test_build_git_summary_reads_in_business_language() -> None:
         ahead=2,
         behind=1,
     )
-    assert "On branch `feature/x`" in on_branch
-    assert "3 uncommitted files" in on_branch
-    assert "ahead by 2" in on_branch
-    assert "behind by 1" in on_branch
+    assert "separate workspace" in on_branch
+    assert "3 unsaved local files" in on_branch
+    assert "local and shared saved work to reconcile" in on_branch
 
     detached = status_mod._build_git_summary(
         workflow_mode="detached",
@@ -2108,12 +2107,12 @@ def test_git_info_solo_on_main_without_remote(tmp_path: Path) -> None:
     assert info["behind"] is None
     assert info["summary"]
     assert "main" in info["summary"]
-    assert "uncommitted" in info["summary"]
+    assert "unsaved local" in info["summary"]
 
 
 def test_git_info_branch_without_upstream(tmp_path: Path) -> None:
     """Feature branch with no upstream should classify as branch, leave
-    ahead/behind null, and reference the branch name in the summary.
+    ahead/behind null, and use business-owner workspace language in the summary.
     Common state when an operator starts work but hasn't pushed yet."""
     repo = tmp_path / "branched"
     repo.mkdir()
@@ -2129,7 +2128,8 @@ def test_git_info_branch_without_upstream(tmp_path: Path) -> None:
     assert info["upstream"] == ""
     assert info["ahead"] is None
     assert info["behind"] is None
-    assert "feature/x" in info["summary"]
+    assert "separate workspace" in info["summary"]
+    assert "feature/x" not in info["summary"]
 
 
 def test_git_info_handles_non_git_directory(tmp_path: Path) -> None:
@@ -2167,7 +2167,7 @@ def test_status_ranked_actions_always_carry_audience_and_summary(
 
 def test_git_info_detects_linked_worktree(tmp_path: Path) -> None:
     """Conductor workspaces and `git worktree add` checkouts should report
-    workflow_mode='worktree' and a populated worktree_root."""
+    workflow_mode='worktree' internally and use operator-facing workspace copy."""
     main_repo = tmp_path / "main"
     main_repo.mkdir()
     assert _git(main_repo, "init", "-b", "main").returncode == 0
@@ -2184,4 +2184,4 @@ def test_git_info_detects_linked_worktree(tmp_path: Path) -> None:
     assert info["branch"] == "feature/x"
     assert info["default_branch"] == "main"
     assert info["worktree_root"] == str(worktree_path.resolve())
-    assert "worktree" in info["summary"].lower()
+    assert "separate workspace" in info["summary"]


### PR DESCRIPTION
## Summary

`/mb-start` now has an explicit business-router contract for live intent, save/sync language, bookkeeping/books setup, provider setup, publish/PR routing, and stronger update posture. The CLI copy that feeds startup now describes saved checkpoints, unsaved local work, syncing, catching up, and reconciliation before raw git terms.

## Linked issue

Closes #511

Follow-up opened: #513 for stale `/mb-setup` GitOps guidance and the deferred publish-planner surface.

## Why

Dogfood showed `/mb-start` had useful facts but the first-screen experience still felt like a technical status report: raw checkpoint ids, branch/sync plumbing, a generic escape hatch, and weak routing for bookkeeping-style requests. This PR connects the existing repo-wide "business language first" contract to the actual startup router and deterministic facts the runtime reads.

## Commits by concern

- [x] Each commit body bullet-lists the changes in that commit
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`

Commit list:
- `1522d5f [update] Strengthen mb-start business router`
- `c8a8950 [fix] Address mb-start router review`

## Validation

Repo gate from repo root:

```bash
scripts/check.sh
```

Focused post-review guard after the final router wording change:

```bash
cd mb && pytest tests/test_start_router_contract.py tests/test_status.py::test_build_git_summary_reads_in_business_language tests/test_status.py::test_git_info_branch_without_upstream tests/test_status.py::test_git_info_detects_linked_worktree tests/test_books.py::test_books_check_flags_committed_ledger_file -q
cd mb && python3 -m mb skill validate mb-start --json
```

Fixture repo smoke:

```bash
tmpdir="$(mktemp -d)"
repo="$tmpdir/test-business"
cd mb
python3 -m mb onboard --yes --name "Test Business" --path "$repo"
python3 -m mb doctor "$repo"
python3 -m mb status "$repo" --json --peek >/tmp/mainbranch-status-smoke.json
python3 -m mb start --repo "$repo" --json >/tmp/mainbranch-start-smoke.json
python3 -m mb validate "$repo"
```

Level 1 static: `scripts/check.sh` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: local excerpt: `79 files already formatted`; `All checks passed!`; `Success: no issues found in 78 source files`; `560 passed`; `mb skill validate --all --json` summary passed. After the final publish-router wording change, `python3 -m mb skill validate mb-start --json` passed with `mb-start` line count `494`, errors `0`, warnings `0`.
Level 2 CLI contract: focused post-review tests listed above — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: `7 passed in 0.64s`.
Level 3 package/install smoke: not required; no packaging, entrypoint, bundled-data install, or update mechanics changed.
Level 4 fixture repo: source CLI smoke listed above — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: onboard completed; doctor reported skill wiring available; `mb status --json --peek` and `mb start --json` emitted JSON; validate reported `nothing to check yet`.
Level 5 runtime smoke / dogfood harness / simulation-tier: not run; this PR changes router prose and CLI/operator copy, not slash-command discovery or runtime wiring. The motivating Claude Code dogfood evidence is captured on #510/#511.
Package-visible release gate evidence before tag/publish: not required; this is not a release/tag/publish PR.
Supply-chain review: not required; no workflows, dependency files, or permissions blocks changed.

- [x] Level 1 static: `scripts/check.sh` passes
- [x] Level 2 CLI contract: focused Typer/CliRunner tests, exit codes, `--json` behavior, TTY vs non-TTY (if CLI behavior touched)
- [ ] Level 3 package/install smoke (if packaging touched)
- [x] Level 4 fixture repo (if init/onboard/status/start/update touched)
- [ ] Level 5 runtime smoke / dogfood harness / simulation-tier (if runtime, first-run, skill discovery, or release validation touched)
- [x] SKILL.md <=500 lines (if any skill touched)
- [ ] Package-visible release gate evidence before tag/publish (if preparing a release)
- [ ] Supply-chain review (if `.github/workflows/`, `.github/dependabot.yml`, `mb/pyproject.toml` deps, or `id-token`/`permissions` blocks touched — see [docs/supply-chain-policy.md](../docs/supply-chain-policy.md))

## Success metric

A returning operator can ask `/mb-start` for bookkeeping, saving, syncing, publishing for review, provider setup, repair, launch, or open-ended prioritization and get routed through business language and deterministic `mb` facts without first seeing raw git plumbing or a generic "something else" fallback.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [ ] N/A — change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [x] No
- [ ] Yes — migration note below

## Public / private boundary

Confirmed: committed changes are public engine behavior, sanitized tests, and public docs/skill guidance only. The previous `noontide-admin` reference was removed from bundled skill prose and guarded by tests. Bookkeeping guidance now uses public topology vocabulary: hub repo, child repo, `core/operations/repo-topology.md`, `.mainbranch/repo.json`, role `finance`, and visibility `restricted` / `local_only`.
