### PR TITLE
[update] Align /mb-setup checkpoint guidance

### DIFF
--- a/.claude/skills/mb-setup/SKILL.md
+++ b/.claude/skills/mb-setup/SKILL.md
@@ -401,7 +401,7 @@ If conversation compacts mid-setup:
 
 When an existing user wants to add another offer (says "I want to add another offer", "I have a second product", or similar), follow the migration guide.
 
-See **[references/migration-multi-offer.md](references/migration-multi-offer.md)** for the complete migration flow: detection, naming, atomic execution, brand-level offer.md creation, product-ladder.md, and commit.
+See **[references/migration-multi-offer.md](references/migration-multi-offer.md)** for the complete migration flow: detection, naming, atomic execution, brand-level offer.md creation, product-ladder.md, and the saved checkpoint.
 
 ---
 

--- a/.claude/skills/mb-setup/SKILL.md
+++ b/.claude/skills/mb-setup/SKILL.md
@@ -316,23 +316,18 @@ Simple human-readable overview:
 - How to use the repo with Main Branch
 - Quick stats
 
-### 9. Initial Commit
+### 9. Initial Saved Checkpoint
 
 ```bash
-git add -A
-git commit -m "$(cat <<'EOF'
-[init] Bootstrap business repo with Main Branch structure
-
-- Created core/ (soul, offer, audience, voice)
-- Created core/offers/ (per-offer specifics)
-- Created core/proof/ (testimonials, angles)
-- Created core/operations/ ([business-type] specific)
-- Drafted CLAUDE.md and README.md
-
-Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
-EOF
-)"
+mb checkpoint --plan --json
+mb checkpoint --validate "[added] initial business repo foundation" --json
+mb checkpoint --message "[added] initial business repo foundation" --yes
 ```
+
+Summarize the plan first, including changed surfaces/files and any blockers.
+Save only after operator approval. Use `mb checkpoint --plan`'s proposed
+subject when it is good; otherwise use a business-readable checkpoint subject
+from `references/git-workflow.md`.
 
 ### 10. Report Gaps
 
@@ -358,9 +353,16 @@ Ask user for missing pieces or note for later.
 
 ---
 
-## Git Workflow
+## Save And Review Workflow
 
-Format: `[type] Brief description` with Co-Authored-By line. Types: `[init]`, `[add]`, `[update]`, `[fix]`, `[refactor]`, `[docs]`. See `references/git-workflow.md` for full guide.
+Use `mb checkpoint --plan`, `mb checkpoint --validate`, and
+`mb checkpoint --message ... --yes` for business-repo saves. Use lower-case,
+past-tense checkpoint verbs such as `[added]`, `[updated]`, `[decided]`,
+`[connected]`, `[ran]`, or `[fixed]`. Pull requests are proposals or review conversations.
+The planned `mb publish --plan` command and packaged publish
+skill are not shipped yet, so do not promise them.
+
+See `references/git-workflow.md` for the full guide.
 
 ---
 
@@ -372,7 +374,7 @@ Format: `[type] Brief description` with Co-Authored-By line. Types: `[init]`, `[
 - **Context Gathering:** `references/context-gathering.md` — Checklists by business type, completeness criteria
 - **Templates:** `references/templates.md` — All file templates
 - **CLAUDE.md Guide:** `references/claude-md-guide.md` — How to draft a good CLAUDE.md
-- **Git Workflow:** `references/git-workflow.md` — Commit messages and CLI usage
+- **Save and Review Workflow:** `references/git-workflow.md` — Checkpoint-first saves, sync language, and proposal/review guidance
 - **Repo Scaffolding:** `references/repo-scaffolding.md` — API keys, config.yaml, .gitignore
 - **Multi-Offer Migration:** `references/migration-multi-offer.md` — Single to multi-offer migration
 

--- a/.claude/skills/mb-setup/references/git-workflow.md
+++ b/.claude/skills/mb-setup/references/git-workflow.md
@@ -1,252 +1,131 @@
-# Git Workflow
+# Save And Review Workflow
 
-GitHub CLI best practices for Main Branch repos.
+Use this reference when `/mb-setup` needs to explain how business-repo work is
+saved, synced, or shared for review.
+
+Main Branch uses git underneath, but the operator should hear business language
+first:
+
+| Technical layer | Operator language |
+| --- | --- |
+| tracked history | saved checkpoints |
+| changed files | unsaved local work |
+| remote update | shared repo update |
+| pull request | proposal / review conversation |
+| branch or worktree | workspace |
 
 ---
 
-## Always Use Git
+## Setup Saves
 
-Every Main Branch business repo should be version controlled. Git provides:
+During setup, use `mb checkpoint` for business-repo saves. Do not ask the
+operator to stage files or write raw save commands.
 
-- History of all changes
-- Ability to revert mistakes
-- Collaboration with team members
-- Backup of your business knowledge
-
----
-
-## Initial Setup
+After the operator approves the created or changed files:
 
 ```bash
-# If starting fresh
-git init
-git add -A
-git commit -m "[init] Bootstrap business repo with Main Branch structure"
+mb checkpoint --plan --json
+mb checkpoint --validate "[added] initial business repo foundation" --json
+mb checkpoint --message "[added] initial business repo foundation" --yes
+```
 
-# Connect to GitHub (optional but recommended)
+Use the subject proposed by `mb checkpoint --plan` when it is good. If you need
+to choose, use lower-case, past-tense business verbs:
+
+- `[added]` for new durable context or setup files;
+- `[updated]` for changed business context;
+- `[decided]` for accepted setup decisions;
+- `[connected]` for provider readiness that is now usable;
+- `[ran]` for setup maintenance, migrations, imports, or checks;
+- `[fixed]` for repaired wiring, links, or setup state.
+
+Avoid engine-contributor subjects such as `[add]`, `[update]`, `[fix]`, or
+`[refactor]` in business repos. Those are for this engine repository, not the
+operator's business history.
+
+Do not add AI attribution trailers by default. Add an `Agent:` trailer only when
+it changes how future readers should interpret generated copy, generated site
+code, synthetic research, or compliance review.
+
+---
+
+## Common Setup Moments
+
+Initial setup:
+
+```bash
+mb checkpoint --plan --json
+mb checkpoint --validate "[added] initial business repo foundation" --json
+mb checkpoint --message "[added] initial business repo foundation" --yes
+```
+
+After a context batch changes core files:
+
+```bash
+mb checkpoint --plan --json
+mb checkpoint --validate "[updated] core business context" --json
+mb checkpoint --message "[updated] core business context" --yes
+```
+
+After a provider becomes usable:
+
+```bash
+mb checkpoint --plan --json
+mb checkpoint --validate "[connected] GitHub" --json
+mb checkpoint --message "[connected] GitHub" --yes
+```
+
+After a multi-offer restructure:
+
+```bash
+mb checkpoint --plan --json
+mb checkpoint --validate "[updated] offer structure" --json
+mb checkpoint --message "[updated] offer structure" --yes
+```
+
+If `mb checkpoint --plan` reports blockers, stop and explain the blocker in
+plain language before trying to save.
+
+---
+
+## Sync And Review
+
+If the operator asks to sync saved work, first read the current facts:
+
+```bash
+mb status --json --peek
+```
+
+Use the `git.summary`, `git.workflow_mode`, `git.ahead`, and `git.behind` facts
+to explain whether work is:
+
+- saved locally but not synced;
+- waiting to catch up with the shared repo;
+- waiting for local and shared saved work to be reconciled;
+- ready to share as a proposal/review conversation.
+
+The planned `mb publish --plan` command and packaged publish skill are not
+shipped yet. Do not promise them. If the operator needs a proposal today, use
+the available GitHub tooling only after explaining the path and getting
+approval.
+
+---
+
+## GitHub Setup
+
+GitHub is optional but recommended for shared backup, tasks, and proposals.
+Check readiness from the business repo:
+
+```bash
+mb connect doctor --json
+```
+
+Creating a private GitHub repo is a setup/provider step, not a substitute for
+checkpointing approved business changes. Prefer private visibility unless the
+repo is intentionally public:
+
+```bash
 gh repo create [business-name] --private --source=. --push
 ```
 
----
-
-## Commit Message Format
-
-Always use this format:
-
-```
-[type] Brief description (50 chars max)
-
-- Detail 1
-- Detail 2
-- Detail 3
-
-Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
-```
-
-### Types
-
-| Type | Use For |
-|------|---------|
-| `[init]` | Initial repo setup |
-| `[add]` | New files, features, content |
-| `[update]` | Changes to existing files |
-| `[fix]` | Bug fixes, corrections |
-| `[refactor]` | Restructuring without changing behavior |
-| `[docs]` | Documentation only changes |
-| `[remove]` | Deleting files |
-| `[research]` | Adding research files |
-| `[decision]` | Adding decision files |
-
-### Examples
-
-**Initial setup:**
-```
-[init] Bootstrap business repo with Main Branch structure
-
-- Created core/ (soul, offer, audience, voice)
-- Created core/proof/ (testimonials, angles)
-- Created core/operations/products/
-- Drafted CLAUDE.md and README.md
-
-Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
-```
-
-**Adding content:**
-```
-[add] Customer testimonials from Q4 reviews
-
-- Added 12 new testimonials to proof/testimonials.md
-- Created 2 new angles: gift-giving.md, comfort-fit.md
-- Updated audience.md with new customer language
-
-Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
-```
-
-**Research:**
-```
-[research] Pinterest strategy analysis
-
-- Added research/2026-01-15-pinterest-strategy-gemini.md
-- Key finding: CTR below benchmark, needs content diversification
-
-Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
-```
-
-**Decision:**
-```
-[decision] Adopt lunar email calendar
-
-- Added decisions/2026-01-15-lunar-email-strategy.md
-- Decided: New/Full moon timing for campaigns
-- Rejected: Traditional sale calendar
-
-Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
-```
-
----
-
-## Using HEREDOC for Commits
-
-Always use HEREDOC for multi-line commit messages to ensure proper formatting:
-
-```bash
-git commit -m "$(cat <<'EOF'
-[type] Brief description
-
-- Detail 1
-- Detail 2
-
-Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
-EOF
-)"
-```
-
-**Why HEREDOC?**
-- Preserves line breaks
-- Handles special characters
-- Works reliably across systems
-
----
-
-## Staging Best Practices
-
-```bash
-# Stage everything
-git add -A
-
-# Stage specific files
-git add core/offer.md core/audience.md
-
-# Stage by folder
-git add core/proof/
-
-# Check what's staged
-git status
-```
-
----
-
-## Common Workflows
-
-### After Context Dump Session
-
-```bash
-git add -A
-git status  # Review changes
-git commit -m "$(cat <<'EOF'
-[update] Incorporate new business context
-
-- Updated offer.md with new pricing
-- Added 5 testimonials from customer calls
-- Created mechanism.md angle
-
-Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
-EOF
-)"
-```
-
-### After Research Session
-
-```bash
-git add research/
-git commit -m "$(cat <<'EOF'
-[research] Competitor analysis for Q1
-
-- Added research/2026-01-20-competitor-analysis-gemini.md
-- Analyzed 5 competitors' positioning
-- Identified gap in [specific area]
-
-Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
-EOF
-)"
-```
-
-### After Output Generation
-
-```bash
-git add pushes/
-git commit -m "$(cat <<'EOF'
-[add] January email campaign batch
-
-- Generated 4 welcome sequence emails
-- Created 2 promotional emails for lunar drop
-- All using Devon Voice system
-
-Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
-EOF
-)"
-```
-
----
-
-## Safety Rules
-
-1. **Never force push to main** — Protect your history
-2. **Commit frequently** — Small, logical commits
-3. **Check status before commit** — Review what's staged
-4. **Use descriptive messages** — Future you will thank you
-5. **Include Co-Authored-By** — Credit AI assistance
-
----
-
-## GitHub CLI Reference
-
-```bash
-# Check GitHub readiness from the business repo
-mb connect doctor --json
-
-# Create private repo and push
-gh repo create [name] --private --source=. --push
-
-# View repo in browser
-gh repo view --web
-
-# Create pull request (if using branches)
-gh pr create --title "Title" --body "Description"
-```
-
----
-
-## .gitignore Recommendations
-
-```gitignore
-# OS files
-.DS_Store
-Thumbs.db
-
-# Editor files
-.vscode/
-.idea/
-
-# Environment
-.env
-*.env.local
-
-# Temporary
-*.tmp
-*.log
-
-# Large media (store elsewhere)
-*.mp4
-*.mov
-```
+Use `/mb-help` for beginner GitHub questions.

--- a/.claude/skills/mb-setup/references/migration-multi-offer.md
+++ b/.claude/skills/mb-setup/references/migration-multi-offer.md
@@ -50,19 +50,15 @@ If `core/offer.md` exists and no `offers/` folder: this is a migration.
 7. **Write `core/product-ladder.md`:**
    > "How do these offers relate? Is there a natural progression?"
 
-8. **Commit atomically:**
+8. **Save the restructure as a checkpoint:**
    ```bash
-   git add -A
-   git commit -m "[refactor] Migrate to multi-offer structure
-
-   - Moved existing offer to offers/[existing-name]/
-   - Created brand-level core/offer.md
-   - Added offers/[new-name]/
-   - Created product-ladder.md
-   - Selected an active offer for this session; local persistence requires approval
-
-   Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>"
+   mb checkpoint --plan --json
+   mb checkpoint --validate "[updated] offer structure" --json
+   mb checkpoint --message "[updated] offer structure" --yes
    ```
+
+   Summarize the changed offer files and any blockers from the checkpoint plan.
+   Save only after operator approval.
 
 9. **Confirm:**
    > "Migration complete. You now have [N] offers. `/mb-start` will ask which offer to work on each session. Run `/mb-start [offer-name]` to jump straight to one."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   and `mb books check` operator summaries around saved checkpoints, unsaved
   local work, catching up, syncing, and reconciliation instead of defaulting to
   raw commit/rebase/ahead/behind language. Refs MAIN-333, #511.
+- Aligned `/mb-setup` save and review guidance with the shipped
+  checkpoint-first business-repo contract, replacing stale raw save examples
+  and default AI attribution trailers with `mb checkpoint` planning,
+  validation, and approval language. Refs MAIN-334, #513.
 
 ## [0.3.17] - 2026-05-12
 

--- a/mb/tests/test_setup_gitops_contract.py
+++ b/mb/tests/test_setup_gitops_contract.py
@@ -1,0 +1,57 @@
+"""Product-contract guards for `/mb-setup` save and review guidance."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SETUP_SKILL = REPO_ROOT / ".claude" / "skills" / "mb-setup" / "SKILL.md"
+SETUP_REFERENCES = REPO_ROOT / ".claude" / "skills" / "mb-setup" / "references"
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _setup_gitops_text() -> str:
+    paths = [
+        SETUP_SKILL,
+        SETUP_REFERENCES / "git-workflow.md",
+        SETUP_REFERENCES / "migration-multi-offer.md",
+    ]
+    return "\n".join(_read(path) for path in paths)
+
+
+def test_mb_setup_uses_checkpoint_first_save_guidance() -> None:
+    text = _setup_gitops_text()
+
+    required_phrases = [
+        "mb checkpoint --plan --json",
+        'mb checkpoint --validate "[added] initial business repo foundation" --json',
+        'mb checkpoint --message "[added] initial business repo foundation" --yes',
+        'mb checkpoint --validate "[updated] offer structure" --json',
+        "Save only after operator approval",
+        "Pull requests are proposals or review conversations",
+        "The planned `mb publish --plan` command",
+        "packaged publish",
+        "not shipped yet",
+    ]
+    for phrase in required_phrases:
+        assert phrase in text
+
+
+def test_mb_setup_does_not_teach_stale_business_repo_save_style() -> None:
+    text = _setup_gitops_text()
+
+    stale_phrases = [
+        "Co-Authored-By",
+        "[init] Bootstrap business repo",
+        "[type] Brief description",
+        "[refactor] Migrate to multi-offer structure",
+        "Always use HEREDOC",
+    ]
+    for phrase in stale_phrases:
+        assert phrase not in text
+
+    assert "git commit" not in text
+    assert "git add" not in text

--- a/mb/tests/test_setup_gitops_contract.py
+++ b/mb/tests/test_setup_gitops_contract.py
@@ -35,6 +35,7 @@ def test_mb_setup_uses_checkpoint_first_save_guidance() -> None:
         "The planned `mb publish --plan` command",
         "packaged publish",
         "not shipped yet",
+        "and the saved checkpoint",
     ]
     for phrase in required_phrases:
         assert phrase in text
@@ -49,6 +50,7 @@ def test_mb_setup_does_not_teach_stale_business_repo_save_style() -> None:
         "[type] Brief description",
         "[refactor] Migrate to multi-offer structure",
         "Always use HEREDOC",
+        "and commit",
     ]
     for phrase in stale_phrases:
         assert phrase not in text


### PR DESCRIPTION
## Summary

`/mb-setup` now teaches checkpoint-first business-repo saves instead of stale raw Git save examples. Setup, save/sync, proposal/review, and multi-offer migration guidance now point agents through `mb checkpoint` planning, validation, and operator approval.

## Linked issue

Closes #513

## Why

The setup skill still carried older GitOps instructions that recommended raw `git add` / `git commit`, `[type]` subjects, and default `Co-Authored-By` trailers. That conflicted with the shipped business-repo contract where commits are saved checkpoints, PRs are proposals/review conversations, and unshipped publish planner surfaces must not be promised.

## Commits by concern

- [ ] Each commit body bullet-lists the changes in that commit
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`

Commit list:
- `6bb8cf2 [update] Align setup checkpoint guidance`

## Validation

Pre-push gate from repo root:

```bash
scripts/check.sh
```

Level 1 static: `scripts/check.sh` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: local excerpt: `80 files already formatted`; `All checks passed!`; `Success: no issues found in 79 source files`; `562 passed`; `mb skill validate --all --json` summary passed.
Level 2 CLI contract: `pytest mb/tests/test_setup_gitops_contract.py -q` and `(cd mb && pytest tests/test_setup_gitops_contract.py -q)` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: both invocations reported `2 passed`.
Level 3 package/install smoke: not required; no packaging, entrypoint, bundled-data install, or update mechanics changed.
Level 4 fixture repo: not required; this changes bundled `/mb-setup` prose and regression tests, not `mb init`, `mb onboard`, repo shape, or CLI fixture behavior.
Level 5 runtime smoke / dogfood harness / simulation-tier: not run; this changes LLM-facing setup guidance, not skill discovery or runtime wiring. Manual behavior note: when a setup user asks to save, `/mb-setup` should summarize `mb checkpoint --plan --json`, validate the proposed subject, and save only after approval; when a user asks to publish/review, it should describe PRs as proposals/review conversations and not promise `mb publish --plan` or a packaged publish skill yet.
SKILL.md <=500 lines: `python3 -m mb skill validate mb-setup --json` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: `mb-setup` line count `447`, errors `0`, warnings `0`.
Package-visible release gate evidence before tag/publish: not required; this is not a release/tag/publish PR.
Supply-chain review: not required; no workflows, dependency files, or permissions blocks changed.

- [x] Level 1 static: `scripts/check.sh` passes
- [x] Level 2 CLI contract: focused Typer/CliRunner tests, exit codes, `--json` behavior, TTY vs non-TTY (if CLI behavior touched)
- [ ] Level 3 package/install smoke (if packaging touched)
- [ ] Level 4 fixture repo (if init/onboard/status/start/update touched)
- [ ] Level 5 runtime smoke / dogfood harness / simulation-tier (if runtime, first-run, skill discovery, or release validation touched)
- [x] SKILL.md ≤500 lines (if any skill touched)
- [ ] Package-visible release gate evidence before tag/publish (if preparing a release)
- [ ] Supply-chain review (if `.github/workflows/`, `.github/dependabot.yml`, `mb/pyproject.toml` deps, or `id-token`/`permissions` blocks touched — see [docs/supply-chain-policy.md](../docs/supply-chain-policy.md))

## Success metric

An agent routed into `/mb-setup` for first setup, multi-offer migration, saving, syncing, or review guidance no longer teaches raw business-repo Git commits and instead uses checkpoint-first save language plus proposal/review framing.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [ ] N/A — change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [x] No
- [ ] Yes — migration note below

## Public / private boundary

Committed changes are public bundled skill guidance, public changelog text, and sanitized regression tests only. No private operator strategy, raw business data, credentials, local machine paths, or private runtime notes were added.
