### PR TITLE
[update] MAIN-340 prepare 0.3.18 release

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mainbranch",
-  "version": "0.3.17",
+  "version": "0.3.18",
   "description": "Main Branch Claude Code skills for running a business from markdown files in git.",
   "author": {
     "name": "Noontide"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+## [0.3.18] - 2026-05-12
+
+v0.3.18 is a package-visible skill and operator-loop patch. It strengthens
+agent cold-start guidance, makes `/mb-start` a stronger business router,
+aligns setup guidance around checkpoint-first saves, and moves high-impact
+bundled skills toward a CLI-first contract while retiring stale compatibility
+aliases.
+
 ### Added
 
 - Added `docs/agent-cold-start.md` as the public source for agent read order,
@@ -24,6 +32,10 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ### Changed
 
+- Added `docs/system-architecture.md` and `docs/agent-writing-style.md` to the
+  public cold-start always-read set, and tightened the release-agent contract
+  with a cheap release-file preflight before expensive validation gates. Refs
+  MAIN-340, #521.
 - Reframed `/mb-start`, `mb status` git summaries, `mb start` readiness repair,
   and `mb books check` operator summaries around saved checkpoints, unsaved
   local work, catching up, syncing, and reconciliation instead of defaulting to

--- a/docs/agent-cold-start.md
+++ b/docs/agent-cold-start.md
@@ -20,9 +20,13 @@ Read these before editing or reviewing:
 4. `docs/operator-loops.md` - Sense, Decide, Ship, Reflect taxonomy and daily
    loop language.
 5. `docs/roadmap.md` - current direction, anti-scope, and shipped foundation.
-6. `docs/oss-operating-checklist.md` - release, runtime-claim, state-model,
+6. `docs/system-architecture.md` - current CLI, skill, repo, provider,
+   runtime, graph, and release architecture boundaries.
+7. `docs/oss-operating-checklist.md` - release, runtime-claim, state-model,
    issue/PR, and public/private review checklist.
-7. `CHANGELOG.md` - read `[Unreleased]` and the latest shipped version section
+8. `docs/agent-writing-style.md` - action-first writing rubric for agent docs,
+   PR descriptions, reviews, issue comments, and local preferences.
+9. `CHANGELOG.md` - read `[Unreleased]` and the latest shipped version section
    so current tense matches release truth.
 
 Do not paste these docs into issue comments, PR bodies, or local preferences.

--- a/docs/release-agent-contract.md
+++ b/docs/release-agent-contract.md
@@ -30,6 +30,27 @@ when in doubt.
 
 ## Rules
 
+### 0. Run cheap release-file preflight before expensive gates.
+
+Before running `scripts/check.sh` on a release-prep branch, update and inspect
+every version-bearing release file in one pass:
+
+- `CHANGELOG.md` has a dated version section and `[Unreleased]` is empty or
+  contains only work intentionally left unreleased;
+- `mb/pyproject.toml` `project.version` matches the release version;
+- `mb/mb/__init__.py` `__version__` matches the release version;
+- `.claude-plugin/plugin.json` `version` matches the release version.
+
+Then run the cheapest targeted guard for those sites:
+
+```bash
+cd mb
+python3 -m pytest tests/test_smoke_coverage.py::test_claude_plugin_manifest_points_at_prefixed_skills -q
+```
+
+If this preflight fails, fix the release files before the full gate. Do not
+spend a full `scripts/check.sh` run discovering a mismatched release version.
+
 ### 1. Pick the runtime up front. Do not switch mid-flow.
 
 On macOS in this workspace, the documented runtime is `python3` (with

--- a/mb/mb/__init__.py
+++ b/mb/mb/__init__.py
@@ -7,6 +7,6 @@ file stays a thin dispatcher.
 
 from __future__ import annotations
 
-__version__ = "0.3.17"
+__version__ = "0.3.18"
 
 __all__ = ["__version__"]

--- a/mb/pyproject.toml
+++ b/mb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mainbranch"
-version = "0.3.17"
+version = "0.3.18"
 description = "Main Branch engine umbrella - scaffolds, validates, and graphs business-as-files repos. Claude Code first, runtime-agnostic by design."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Prepares `mainbranch` v0.3.18 by cutting the dated changelog section, bumping package/plugin version sites, and tightening release/cold-start guidance discovered during validation.

## Linked issue

Refs #521

## Why

The 0.3.18 release needs a single release-prep branch with version truth, package-visible validation evidence, and clearer release instructions so future agents catch version-site mismatches before expensive gates.

## Commits by concern

- [x] `5dc738f [update] MAIN-340 prepare 0.3.18 release`
- [x] Each commit body bullet-lists the changes in that commit
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`

## Validation

Pre-push gate from repo root:

```bash
scripts/check.sh
```

- [x] Level 1 static: `scripts/check.sh` — runtime: `python3` 3.13.7 — exit: 0 — log: `.agent/release-evidence/0.3.18/check-final.out`.
- [x] Level 2 CLI contract: `python3 -m pytest tests/test_smoke_coverage.py::test_claude_plugin_manifest_points_at_prefixed_skills -q` — runtime: `python3` 3.13.7 — exit: 0 — log: `.agent/release-evidence/0.3.18/release-version-preflight-final.out`.
- [x] Level 3 package/install smoke: `(cd mb && python3 -m build)` plus final wheel install, `mb --version`, and `mb skill list` — runtime: `/tmp/mainbranch-smoke-0.3.18.final.*/bin/python3` — exit: 0 — logs: `.agent/release-evidence/0.3.18/build-final.out`, `.agent/release-evidence/0.3.18/install-final.out` (`mb 0.3.18`).
- [x] Level 4 fixture repo: final installed wheel `mb onboard`, `mb doctor`, `mb status`, `mb start --json`, `mb validate`, and both hledger-present / hledger-missing `mb books check --fixture --json` modes — runtime: `/tmp/mainbranch-smoke-0.3.18.final.*/bin/mb` — exit: 0 — log: `.agent/release-evidence/0.3.18/fixture-final-smoke.out`.
- [x] Level 5 runtime smoke / dogfood harness / simulation-tier: `scripts/claude-runtime-dogfood.py --install-mode wheel --wheel mb/dist/mainbranch-0.3.18-py3-none-any.whl --run-claude-print --simulation-tier release_acceptance --max-budget-usd 0.75` — runtime: `python3` 3.13.7 / Claude Code 2.1.137 — exit: 0 — evidence: `.agent/release-evidence/0.3.18/dogfood-release-acceptance/` (11/11 heuristic checks; print-mode proxy evidence, not interactive TUI proof).
- [x] SKILL.md ≤500 lines: no skill files changed.
- [x] Package-visible release gate evidence before tag/publish: pre-simulation checkpoint, wheel release-acceptance proxy, final package/install smoke, and fixture smoke are saved under `.agent/release-evidence/0.3.18/`; post-merge GitHub Release/PyPI verification remains pending.
- [x] Supply-chain review: local checks recorded in `.agent/release-evidence/0.3.18/supply-chain-final.out`, `pypi-environment.json`, `dependabot-alerts.json`, and `dependency-prs.json`; workflow permissions are unchanged, `id-token: write` remains scoped to the publish job, the `pypi` environment has a required reviewer, and there are no open Dependabot alerts or dependency PRs.

## Success metric

`main` contains the v0.3.18 release-prep commit, the release owner can create `oe-v0.3.18` from matching changelog/package/plugin version truth, and future release agents run the cheap version preflight before the slow full gate.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [ ] N/A — change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [x] No
- [ ] Yes — migration note below

## Public / private boundary

Only public release metadata, public agent guidance, and package version sites were committed; local release evidence remains under gitignored `.agent/`, and no private operator strategy, machine-specific paths, secrets, or runtime internals were added to tracked files.
