### PR TITLE
[add] Offer sharpening system

### DIFF
--- a/.claude/reference/business-primitives/offer-bet-push-proof.md
+++ b/.claude/reference/business-primitives/offer-bet-push-proof.md
@@ -70,6 +70,12 @@ it sells or may sell repeatedly. Examples: confirmed promise, pricing,
 mechanism, deliverables, guarantee, qualification rules, or checkout/fulfillment
 details.
 
+Use the offer-sharpening reference when those durable offer fields are unclear:
+`.claude/reference/conversion/offer-sharpening.md`. The sharpening rubric checks
+audience, problem/outcome, transformation, mechanism, proof, price/value logic,
+risk reversal, objections, reason to act, and next step before page, ad, video,
+or launch work scales.
+
 Create or update a **push** when there is coordinated execution: a launch,
 drop, challenge, promo, content sequence, lander, ads plan, provider setup
 playbook, or internal adoption effort.

--- a/.claude/reference/conversion/offer-sharpening.md
+++ b/.claude/reference/conversion/offer-sharpening.md
@@ -1,0 +1,154 @@
+# Offer Sharpening Reference
+
+Use this when a workflow needs to improve an offer before creating pages, ads,
+organic content, sales videos, launch plans, or readiness checks.
+
+The public guide is `docs/offer-sharpening.md`. This file is the skill-facing
+routing reference.
+
+## Product Stance
+
+- Main Branch collects and translates useful business frameworks; it is not a
+  one-style guru system.
+- Style is an operator choice. Conversion fundamentals are required.
+- A strong offer is sharp, specific, believable, and easy to act on.
+- Strong conversion does not require fake urgency, invented proof, or one
+  universal tone.
+- Direct-response pressure and calm trust-first positioning are both valid
+  when the claims are honest and the next step is clear.
+
+## Required Rubric
+
+Before scaling traffic or creating conversion assets, check:
+
+1. audience;
+2. problem or desired outcome;
+3. specific transformation;
+4. mechanism;
+5. proof and typicality;
+6. price/value logic;
+7. risk reversal;
+8. objections;
+9. honest reason to act;
+10. next step.
+
+If any item is missing, route to `/mb-think` or ask the operator before writing
+page, ad, video, or launch assets from thin context.
+
+## Style Spectrum
+
+Choose the style intentionally:
+
+- **Direct-response:** use clearer stakes, value stack, proof, risk reversal,
+  urgency, and explicit CTA. Refuse fake scarcity, invented proof, and
+  guarantees the business cannot fulfill.
+- **Calm clarity:** use plain truth, restrained copy, precision, and visible
+  next steps. Do not let taste replace proof, value, or conversion.
+- **Premium expert:** use diagnosis, selectivity, authority, and fit. Require
+  evidence for authority claims.
+- **Community-led:** use belonging, participation, peer examples, and momentum.
+  Keep the concrete buyer outcome visible.
+- **Open-source / trust-first:** use transparency, ownership, public proof, and
+  durability. Philosophy supports the offer; it does not replace the next step.
+- **High-ticket service:** use qualification, scope boundaries, proof, risk
+  reversal, and a consultative conversion path.
+- **Low-ticket productized:** use a clear deliverable, fast result, low-friction
+  purchase, and simple promise.
+- **Free lead magnet / entry offer:** deliver real public value and name the
+  bridge to deeper help. Record automation as a playbook unless a supported
+  provider path exists.
+
+## Source Files
+
+Start from current Main Branch primitives:
+
+- resolved offer: `core/offer.md` or `core/offers/<slug>/offer.md`;
+- resolved audience: `core/audience.md` or `core/offers/<slug>/audience.md`;
+- voice and style: `core/voice.md`;
+- content/distribution context: `core/content-strategy.md` when present;
+- proof: `core/proof/` and `core/offers/<slug>/proof/`;
+- current wager: `bets/YYYY-MM-DD-slug.md` when the offer is still a test;
+- coordinated work: `pushes/<YYYY-MM-DD-slug>/push.md`;
+- durable rationale: `decisions/YYYY-MM-DD-slug.md`.
+
+Use `.claude/reference/business-primitives/offer-bet-push-proof.md` for
+whether the idea belongs in an offer, bet, push, proof file, or decision.
+
+## Workflow Routing
+
+Use `/mb-think` for:
+
+- sharpening the offer, audience, mechanism, proof, objections, guarantee, or
+  style before creation;
+- sales-video teardown, pitch extraction, objection mining, and codifying the
+  mechanism;
+- keyword gate, market-intent research, competitor offer mapping, and
+  customer-language synthesis;
+- deciding whether a live idea remains a bet or becomes durable offer truth.
+
+Use `/mb-site` for:
+
+- landing pages, minisites, websites, pricing pages, about pages, checkout-
+  adjacent pages, and owned-surface sales videos;
+- converting the sharpened offer into page structure, page copy, proof
+  placement, CTA, and conversion endpoint choices.
+
+Use `/mb-ads` for:
+
+- hooks, claims, paid creative, video ads, policy fit, Google Ads launch-plan
+  inputs, and continue/change/stop checks;
+- applying `mb site check` readiness states before traffic recommendations.
+
+Use `/mb-organic` for:
+
+- organic scripts, posts, carousels, short clips, and creator-style sales-video
+  repurposing;
+- translating offer angles into value-first content without claiming organic
+  comments are buyer proof.
+
+Use `/mb-start` launch orchestration for:
+
+- resolving the offer, creating/selecting the launch push, running keyword
+  gate, building the lander, preparing the ads plan, and checkpointing accepted
+  artifacts.
+
+## Evidence Handling
+
+Useful signals:
+
+- conversion data and booked-call quality;
+- sales-call objections and buyer language;
+- comments, DMs, support questions, and survey language;
+- refund, churn, cancellation, or no-show reasons;
+- ad hook, search-term, and landing-page performance;
+- page behavior notes, heatmaps, and session observations when available.
+
+Do not overstate evidence:
+
+- comments are language and demand signal, not proof;
+- competitor winners are inferred unless performance data exists;
+- one testimonial is proof for that person, not typicality;
+- high CTR is attention, not offer-market fit;
+- a launch-readiness `ready` state is not provider launch permission.
+
+## Public / Private Boundary
+
+Do not commit raw sales calls, DMs, customer/member records, account exports,
+private screenshots, provider tokens, local paths, unpublished GTM exports,
+conversion uploads, or private strategy.
+
+Commit approved summaries, claims, caveats, decisions, proof angles, and
+public-safe examples. Keep raw evidence in OS temp or local scratch when needed
+for handoff.
+
+## Stop Conditions
+
+Stop and ask before writing or scaling when:
+
+- the offer promises an uncontrollable result;
+- proof is missing for a concrete claim;
+- urgency, scarcity, refund, or guarantee terms are not operationally true;
+- the category may be regulated or provider-policy-sensitive;
+- buyer, outcome, mechanism, or next step is unclear;
+- the source material includes private account or customer data;
+- the next action would publish, spend, mutate accounts, or contact customers.

--- a/.claude/reference/conversion/vsl-routing.md
+++ b/.claude/reference/conversion/vsl-routing.md
@@ -28,6 +28,9 @@ Load these only when the task needs long-form sales video structure:
 ## Context Rules
 
 - Resolve offer context through current `core/` and `core/offers/` paths.
+- Load `.claude/reference/conversion/offer-sharpening.md` when the script,
+  teardown, or repurpose work changes the offer promise, proof, objections,
+  mechanism, guarantee, urgency, or next step.
 - Treat `.vip/local.yaml` as legacy audit input only; never use it as the
   active-offer source of truth.
 - Verify every claim against offer, audience, proof, typicality, and live

--- a/.claude/skills/mb-ads/SKILL.md
+++ b/.claude/skills/mb-ads/SKILL.md
@@ -103,6 +103,11 @@ as the source of truth for setup, stale context, GitHub, provider readiness, and
 repair commands. Only run the direct scoring below for ad-specific creative
 depth when status is unavailable or lacks the needed ad-specific detail.
 
+When the request depends on a new, thin, or underperforming offer, load
+`.claude/reference/conversion/offer-sharpening.md` before writing hooks or
+launch-plan claims. Route to `/mb-think` when audience, outcome, mechanism,
+proof, risk reversal, objections, reason to act, or next step is unclear.
+
 ### 0b. Score Reference Files (fast — direct Read only, NO agents)
 
 **NEVER spawn Explore or Task agents for pre-flight.** Read files directly at the known repo path. Pre-flight should complete in under 10 seconds.

--- a/.claude/skills/mb-ads/references/google-ads-campaign-plan.md
+++ b/.claude/skills/mb-ads/references/google-ads-campaign-plan.md
@@ -34,6 +34,8 @@ and volume calibration.
 Read or ask for:
 
 - active offer, audience, promise, proof, and current lander;
+- offer-sharpening style choice and rubric state from
+  `.claude/reference/conversion/offer-sharpening.md`;
 - launch push at `pushes/<push>/push.md`;
 - geography shape: single-city radius, multi-city service area, statewide,
   national, or multi-location;
@@ -130,9 +132,11 @@ steps.
 
 ### 1. Offer And Policy Fit
 
-Confirm the offer can be advertised as stated. For regulated categories, read
-provider policy before writing copy. If the offer or lander triggers a
-restricted classification, stop and present options:
+Confirm the offer can be advertised as stated. Apply the offer-sharpening
+rubric first: audience, outcome, transformation, mechanism, proof, price/value
+logic, risk reversal, objections, reason to act, and next step. For regulated
+categories, read provider policy before writing copy. If the offer or lander
+triggers a restricted classification, stop and present options:
 
 - rewrite the offer/lander/copy into a policy-safe form;
 - build a separate product or front door only if the operator accepts the

--- a/.claude/skills/mb-ads/references/launch-plan-check.md
+++ b/.claude/skills/mb-ads/references/launch-plan-check.md
@@ -14,6 +14,9 @@ adapter ships with approval gates and smoke evidence.
 From the business repo:
 
 - active offer and audience;
+- offer-sharpening facts from
+  `.claude/reference/conversion/offer-sharpening.md`, especially mechanism,
+  proof, risk reversal, objections, reason to act, and next step;
 - the launch push at `pushes/<push>/push.md`;
 - keyword-gate research, especially ready-to-buy terms and negative seeds;
 - site record or linked site repo;
@@ -89,6 +92,8 @@ before launch review.
 Before preparing launch copy:
 
 - run the normal ad compliance review flow;
+- apply the offer-sharpening rubric; stop when proof, guarantee, urgency,
+  mechanism, buyer, outcome, or next step is too thin for paid traffic;
 - check for regulated verticals: medical, finance, credit, employment,
   housing, legal, social issues/politics;
 - decide whether the request needs `/mb-think` first for offer/policy research,

--- a/.claude/skills/mb-organic/SKILL.md
+++ b/.claude/skills/mb-organic/SKILL.md
@@ -115,6 +115,12 @@ content/assets for proof, and metrics/constraints for the success bar. If the
 brief names a resource-delivery mechanic, write or update a push playbook as a
 plan only; do not execute provider mutation.
 
+When organic work is meant to sharpen an offer instead of only create content,
+load `.claude/reference/conversion/offer-sharpening.md`. Use the rubric to turn
+audience language, objections, proof angles, and soft CTAs into durable offer
+updates through `/mb-think`; do not treat comments or saves as buyer proof by
+themselves.
+
 For the full mining methodology (Visual/Audible/Emotional framework, AI capabilities and limits, why mining flows into reference) see [references/mining-methodology.md](references/mining-methodology.md).
 
 ---

--- a/.claude/skills/mb-site/SKILL.md
+++ b/.claude/skills/mb-site/SKILL.md
@@ -86,7 +86,10 @@ Say `/mb-site` again after compaction, context loss, or switching focus. It relo
      - **skip for now:** record the blocker in the push/site notes and stage a follow-up task.
    - `cfat_` account tokens route automatically when `account_id` is present; keep `token_type=account` in examples because it is explicit and works on older `mb` versions. User API tokens remain supported as a fallback by omitting `token_type=account`.
 5. Resolve the active offer and required business context with [`references/site-context.md`](references/site-context.md).
-6. Ask what the operator is building, then load only the shape reference needed next.
+6. When the page, sales video, or lander depends on a weak offer, load
+   `.claude/reference/conversion/offer-sharpening.md` and route to `/mb-think`
+   before writing page copy from thin claims.
+7. Ask what the operator is building, then load only the shape reference needed next.
 
 ## Operating Principles
 
@@ -150,6 +153,7 @@ If the operator cannot articulate the shape, ask: "What goal are you trying to h
 
 - [`references/site-repo-workflow.md`](references/site-repo-workflow.md) - business repo mode vs site repo mode, source links, reverse records.
 - [`references/site-context.md`](references/site-context.md) - prerequisites, active offer resolution, required `core/...` files, and section mapping.
+- `.claude/reference/conversion/offer-sharpening.md` - universal offer rubric, style spectrum, evidence handling, and stop conditions.
 - [`references/sales-video.md`](references/sales-video.md) - sales video, VSL, about-page video, lander video, and embedded pitch scripts for owned surfaces.
 - [`references/site-measurement.md`](references/site-measurement.md) - `mb site check` and paid-traffic readiness states.
 - [`references/site-recovery.md`](references/site-recovery.md) - compaction recovery and scope boundaries.

--- a/.claude/skills/mb-site/references/minisite-brief.md
+++ b/.claude/skills/mb-site/references/minisite-brief.md
@@ -8,6 +8,8 @@ The brief is the locked source of truth for the minisite. Compose it from:
 
 - resolved `offer.md`: framing, value prop, pricing, transformation;
 - resolved `audience.md`: pain frame, language, objections;
+- `.claude/reference/conversion/offer-sharpening.md`: offer fundamentals,
+  style choice, proof/typicality, risk reversal, reason to act, and next step;
 - `voice.md`: tone, register, named enemies, "never say";
 - persisted research files from [`minisite-research.md`](minisite-research.md);
 - any `brief_format: grok-8` researched brief that names the offer, audience,

--- a/.claude/skills/mb-site/references/sales-video.md
+++ b/.claude/skills/mb-site/references/sales-video.md
@@ -20,8 +20,11 @@ Hand off instead when:
 
 ## Shared References
 
-Load `.claude/reference/conversion/vsl-routing.md` first. Load the specific
-long-form framework only when the task needs structured sales-video sections:
+Load `.claude/reference/conversion/vsl-routing.md` first. Load
+`.claude/reference/conversion/offer-sharpening.md` when the script sharpens or
+changes the offer promise, mechanism, proof, objections, risk reversal,
+urgency, or next step. Load the specific long-form framework only when the task
+needs structured sales-video sections:
 
 - Skool / membership: `.claude/reference/conversion/vsl/skool-18-section.md`
 - B2B high-ticket: `.claude/reference/conversion/vsl/b2b-haynes.md`

--- a/.claude/skills/mb-site/references/site-context.md
+++ b/.claude/skills/mb-site/references/site-context.md
@@ -94,6 +94,12 @@ Detail per shape:
 - Minisite: [`minisite-generation-system.md`](minisite-generation-system.md) and [`anti-patterns.md`](anti-patterns.md).
 - Website: [`section-patterns.md`](section-patterns.md) and [`frontend-design.md`](frontend-design.md).
 
+If the resolved offer cannot clearly answer audience, problem/outcome,
+transformation, mechanism, proof, price/value logic, risk reversal, objections,
+reason to act, and next step, load
+`.claude/reference/conversion/offer-sharpening.md` and route to `/mb-think`
+before treating the site as conversion-ready.
+
 ## Pipeline Position
 
 The site is infrastructure, not recurring content. It is the destination the content pipeline drives traffic to.

--- a/.claude/skills/mb-start/references/launch-orchestration.md
+++ b/.claude/skills/mb-start/references/launch-orchestration.md
@@ -58,8 +58,8 @@ Show exactly one current step plus the next two steps:
 
 ```text
 Current step: sharpen the offer.
-Next: keyword gate the demand.
-After that: create/update the launch push, build the lander, and prepare ads.
+Next: create/update the launch push.
+After that: keyword gate the demand before lander and ads work.
 ```
 
 Use numbered choices when blocked:

--- a/.claude/skills/mb-start/references/launch-orchestration.md
+++ b/.claude/skills/mb-start/references/launch-orchestration.md
@@ -25,15 +25,19 @@ cited repair command.
 
 1. **Resolve the offer.** Use the normal active-offer rules. If no offer exists,
    route to `/mb-think` to codify the offer and audience before launch work.
-2. **Create or select a push.** Use `pushes/<YYYY-MM-DD-slug>/push.md` with
+2. **Sharpen the offer.** Load
+   `.claude/reference/conversion/offer-sharpening.md`. If audience, outcome,
+   mechanism, proof, risk reversal, objections, reason to act, or next step is
+   thin, route to `/mb-think` before keyword gate, lander, or ads work.
+3. **Create or select a push.** Use `pushes/<YYYY-MM-DD-slug>/push.md` with
    `type: push`, `kind: launch`, structured `goal`, `owner`, `audience`,
    `offer`, and a short `promise`. If a matching active/planned launch push
    exists, ask whether to continue it instead of creating a duplicate.
-3. **Keyword gate.** Route to `/mb-think` keyword-gate mode. A "kill" verdict
+4. **Keyword gate.** Route to `/mb-think` keyword-gate mode. A "kill" verdict
    stops the default path unless the operator explicitly overrides.
-4. **Lander plan/build.** Route to `/mb-site` lander mode. If paid traffic is in
+5. **Lander plan/build.** Route to `/mb-site` lander mode. If paid traffic is in
    scope, require the site measurement checks from `/mb-site` before ads work.
-5. **Ad launch plan/check.** Route to `/mb-ads` launch-plan or check mode. For
+6. **Ad launch plan/check.** Route to `/mb-ads` launch-plan or check mode. For
    Google Ads, the skill should load the Google Ads campaign-plan reference,
    decide whether `/mb-think` policy/keyword research is needed, reuse useful
    account history when the operator provides it or an approved read-only
@@ -44,7 +48,7 @@ cited repair command.
    facts, but do not treat them as proof that Google Ads campaign creation is
    supported from the terminal. It does not mutate Google Ads/GTM/Meta
    accounts.
-6. **Checkpoint.** After each accepted artifact or approval record, run
+7. **Checkpoint.** After each accepted artifact or approval record, run
    `mb checkpoint --plan --json`, validate the message, and save only after
    operator approval.
 
@@ -53,9 +57,9 @@ cited repair command.
 Show exactly one current step plus the next two steps:
 
 ```text
-Current step: keyword gate the offer.
-Next: create/update the launch push.
-After that: build the lander and prepare ads for review.
+Current step: sharpen the offer.
+Next: keyword gate the demand.
+After that: create/update the launch push, build the lander, and prepare ads.
 ```
 
 Use numbered choices when blocked:

--- a/.claude/skills/mb-think/SKILL.md
+++ b/.claude/skills/mb-think/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mb-think
-description: "Combined research, decision, and codification workflow. Use when: (1) Exploring a question before committing (2) Making a decision that needs documentation (3) User says research, decide, figure out, explore, codify, enrich, add context, keyword gate, analyze this VSL, extract the pitch, script teardown, objection mining, or sales video research (4) Updating reference files based on decisions (5) User wants to add testimonials, angles, proof, mechanisms, or pitch context. Supports modes: full flow, research-only, keyword-gate, decide-only, codify."
+description: "Combined research, decision, and codification workflow. Use when: (1) Exploring a question before committing (2) Making a decision that needs documentation (3) User says research, decide, figure out, explore, codify, enrich, sharpen this offer, improve the offer, add context, keyword gate, analyze this VSL, extract the pitch, script teardown, objection mining, or sales video research (4) Updating reference files based on decisions (5) User wants to add testimonials, angles, proof, mechanisms, objections, guarantees, or pitch context. Supports modes: full flow, research-only, keyword-gate, decide-only, codify."
 loops: [sense, decide, ship]
 ---
 
@@ -158,6 +158,7 @@ Detect mode from user's natural language:
 | "figure out", "explore", "I'm trying to..." | Full Flow | - |
 | "research", "investigate", "what do we know about" | Research | [research-phase.md](references/research-phase.md) |
 | "--brief-format=grok-8", "researched brief", "site brief", "launch brief" | Research Brief | [grok-8-brief-format.md](references/grok-8-brief-format.md) |
+| "sharpen this offer", "improve the offer", "make this offer convert", "pressure-test this offer" | Full Flow | `.claude/reference/conversion/offer-sharpening.md` |
 | "what are people saying", "sentiment", "X/Twitter", "trending" | Research (Grok) | [grok-social.md](references/grok-social.md) |
 | "analyze this VSL", "extract the pitch", "script teardown", "objection mining" | Research | [sales-video-research.md](references/sales-video-research.md) |
 | "winning ads", "review mining", "customer language", "competitor ads", "comment mining" | Research | [winning-ad-research.md](references/winning-ad-research.md) |

--- a/.claude/skills/mb-think/references/keyword-gate.md
+++ b/.claude/skills/mb-think/references/keyword-gate.md
@@ -21,6 +21,11 @@ Start from the active offer and audience:
 - accumulated proof and voice files when they clarify pain, promise, and
   forbidden claims.
 
+Before ranking terms, load `.claude/reference/conversion/offer-sharpening.md`
+and check the offer's audience, outcome, mechanism, proof, risk reversal,
+objections, reason to act, and next step. If the offer cannot answer those in
+plain language, stop and sharpen before judging paid-search demand.
+
 If a launch push already exists, link the research to it. If no push exists,
 write the research so `/mb-start` and `/mb-site` can create one later.
 

--- a/.claude/skills/mb-think/references/sales-video-research.md
+++ b/.claude/skills/mb-think/references/sales-video-research.md
@@ -20,8 +20,11 @@ ask for clips or excerpts, hand off to `/mb-organic`.
 
 ## Shared References
 
-Load `.claude/reference/conversion/vsl-routing.md` first. Load a long-form
-framework only when structure helps the teardown:
+Load `.claude/reference/conversion/vsl-routing.md` first. Load
+`.claude/reference/conversion/offer-sharpening.md` when the teardown should
+change offer truth, proof, objection handling, risk reversal, urgency,
+mechanism, or CTA. Load a long-form framework only when structure helps the
+teardown:
 
 - Skool / membership: `.claude/reference/conversion/vsl/skool-18-section.md`
 - B2B high-ticket: `.claude/reference/conversion/vsl/b2b-haynes.md`

--- a/.claude/skills/mb-think/references/winning-ad-research.md
+++ b/.claude/skills/mb-think/references/winning-ad-research.md
@@ -24,6 +24,12 @@ Route here when the user asks for:
 After the research is synthesized and codified, route production to `/mb-ads`,
 `/mb-organic`, `/mb-site`, or `/mb-ads` sales-video workflows.
 
+When research is meant to improve the offer, load
+`.claude/reference/conversion/offer-sharpening.md` before codifying. Separate
+universal offer fundamentals from style choices so customer language can
+sharpen the buyer, mechanism, proof, objections, risk reversal, or next step
+without forcing one tone system on the operator.
+
 ## Research Bundle
 
 Run only the tracks needed for the user's question. For broad "research winning

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   intent routing, bookkeeping/books setup, provider setup, save/sync wording,
   stronger update posture, and the rule that generic "set up" must not override
   the user's specific business noun. Refs MAIN-333, #511.
+- Added an offer-sharpening guide and shared conversion reference so `/mb-think`,
+  `/mb-site`, `/mb-ads`, `/mb-organic`, sales-video routing, and launch
+  orchestration use the same offer rubric, style spectrum, evidence boundary,
+  and stop conditions before scaling pages, ads, videos, or launch work. Refs
+  MAIN-336, #516.
 
 ### Changed
 

--- a/docs/offer-sharpening.md
+++ b/docs/offer-sharpening.md
@@ -1,0 +1,125 @@
+# Offer Sharpening
+
+Offer sharpening is the Main Branch loop for making an offer clearer, more
+believable, easier to act on, and truer to the operator's voice before and
+after traffic starts.
+
+It is not one copywriting style. Main Branch can use direct-response pressure,
+calm trust-building, premium expert positioning, community-led framing,
+open-source transparency, high-ticket qualification, low-ticket clarity, or a
+free entry offer. The style is a choice. The fundamentals are not.
+
+## Universal Rubric
+
+Every offer should answer these ten questions:
+
+1. **Audience:** who this is for, who it is not for, and what situation they are
+   in.
+2. **Problem or outcome:** the painful problem, trigger event, desired result,
+   or job they want handled.
+3. **Transformation:** the specific before-and-after, not a vague improvement.
+4. **Mechanism:** why this works, what changes, and what makes it different
+   from the obvious alternative.
+5. **Proof:** evidence the claim is true, plus typicality and caveats when the
+   result is not guaranteed for everyone.
+6. **Price/value logic:** why the ask makes sense for the outcome, speed,
+   certainty, access, or saved cost.
+7. **Risk reversal:** what makes action safer: trial, refund, guarantee,
+   pilot, deposit, cancellation, proof-first step, or manual qualification.
+8. **Objections:** what blocks belief or action, including price, trust, time,
+   implementation, fit, timing, and switching cost.
+9. **Reason to act:** urgency, timing, opportunity, consequence, review window,
+   capacity, or another honest reason to move now.
+10. **Next step:** one clear action the buyer can take.
+
+If one of those is weak, sharpen the offer before scaling traffic or content.
+
+## Style Spectrum
+
+Use style to fit the operator and buyer. Do not use style to skip the rubric.
+
+| Style | Strong when | Watch for |
+| --- | --- | --- |
+| Direct-response | The buyer needs urgency, a clear value stack, strong risk reversal, and an explicit decision. | Fake scarcity, invented proof, unsupported guarantees, or pressure that outpaces trust. |
+| Calm clarity | The brand earns trust through plain truth, restraint, and precise product claims. | Taste becoming an excuse for weak value, vague proof, or no next step. |
+| Premium expert | The buyer wants diagnosis, judgment, selectivity, and high-confidence fit. | Authority claims without evidence or qualification that feels arbitrary. |
+| Community-led | The buyer wants belonging, peer examples, shared momentum, and participation. | Making community the whole promise when the offer still needs a concrete outcome. |
+| Open-source / trust-first | Transparency, ownership, public proof, and durable context are part of the value. | Assuming philosophy replaces conversion clarity. |
+| High-ticket service | The offer needs qualification, proof, risk reversal, scope boundaries, and a consultative path. | Guaranteeing outcomes the team cannot control or hiding delivery constraints. |
+| Low-ticket productized | The buyer needs a fast, clear, low-friction result. | Over-explaining, hiding the deliverable, or making the purchase path feel larger than the product. |
+| Free lead magnet / entry offer | The first step proves usefulness and earns permission for deeper help. | Gated fluff, unclear bridge to the paid offer, or resource-delivery automation that lacks a supported provider path. |
+
+The operator may choose a strong direct-response style or a calmer trust-first
+style. Both can convert. The system should make the choice explicit and keep
+the claim honest.
+
+## What To Sharpen
+
+Use this order when an offer feels fuzzy:
+
+1. Name the buyer situation in plain language.
+2. Make the outcome specific enough that a buyer can tell if it happened.
+3. Explain the mechanism without hiding behind jargon.
+4. Separate the claim from the proof that supports it.
+5. Add typicality, caveats, or qualification when results vary.
+6. Choose the style intentionally.
+7. Write the page, ad, video, or content angle from that source truth.
+8. After traffic or sales calls, update the offer from evidence.
+
+## Evidence Over Time
+
+Offer sharpening continues after launch. Useful signals include:
+
+- conversion data and booked-call quality;
+- sales-call objections and repeated buyer language;
+- comments, replies, DMs, and support questions;
+- refund, churn, cancellation, or no-show reasons;
+- ad hook and search-term performance;
+- landing-page behavior notes, heatmaps, or session observations when available;
+- qualitative customer language from surveys, onboarding, and fulfillment.
+
+Treat those as inputs, not automatic truth. A noisy comment thread is language
+and demand signal, not proof. A single testimonial is proof for that person,
+not typicality for everyone. A high-click ad hook is attention, not necessarily
+offer-market fit.
+
+## Workflow Routing
+
+- Use `/mb-think` when the offer, audience, mechanism, proof, objections, or
+  style needs research or a decision before creating assets.
+- Use `/mb-site` when the sharpened offer needs a lander, minisite, website,
+  page copy, or owned-surface sales video.
+- Use `/mb-ads` when the sharpened offer needs paid creative, Google Ads
+  launch-plan inputs, policy review, or a continue/change/stop check.
+- Use `/mb-organic` when the sharpened offer needs organic scripts, posts,
+  carousels, or sales-video repurposing.
+- Use `/mb-start` launch orchestration when the operator needs one guided path
+  through offer resolution, push creation, keyword gate, lander, ads plan, and
+  checkpoint.
+
+VSLs and sales videos are conversion formats inside those workflows, not a
+separate durable business primitive.
+
+## Public / Private Boundary
+
+Public docs, examples, issues, and fixtures may describe source categories and
+sanitized patterns. They must not include raw sales-call transcripts, private
+DMs, customer/member records, account exports, screenshots with private
+account data, local paths, tokens, provider secrets, or private strategy.
+
+When source material is sensitive, use sanitized summaries, short approved
+excerpts, or local scratch space. Durable public truth should contain the
+approved lesson, claim, caveat, or decision, not the raw source dump.
+
+## Stop Conditions
+
+Stop and ask before scaling or publishing when:
+
+- the offer promises a result the business cannot control;
+- proof is missing for a concrete claim;
+- a guarantee, refund, scarcity, or urgency mechanic is not operationally true;
+- the offer appears regulated or policy-sensitive;
+- the buyer, outcome, mechanism, or next step is unclear;
+- source material contains private customer, account, or provider data;
+- the work would mutate a provider account, publish, spend money, or contact a
+  customer without explicit operator approval.


### PR DESCRIPTION
## Summary

Adds a shared offer-sharpening system so Main Branch can assess offer fundamentals separately from operator style. Routes the rubric through `/mb-think`, `/mb-site`, `/mb-ads`, `/mb-organic`, sales-video/VSL references, and `/mb-start` launch orchestration.

## Linked issue

Closes #516
Refs #523

## Why

Main Branch already has strong page, ads, VSL, bet, and launch workflows, but they needed one conversion model for sharpening offers before traffic scales. This gives agents a shared rubric for audience, outcome, mechanism, proof, risk reversal, objections, reason to act, and next step without forcing one direct-response or calm trust-first style.

## Commits by concern

- [x] `d5c82ed [add] MAIN-336 offer sharpening system`
- [x] Each commit body bullet-lists the changes in that commit
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`

## Validation

Pre-push gate from repo root:

```bash
scripts/check.sh
```

Level 1 static: `scripts/check.sh` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: `80 files already formatted`; `Success: no issues found in 79 source files`; pytest collected 570 items; skill validation summary `errors: 0`, `warnings: 0`.

- [x] Level 1 static: `scripts/check.sh` passes
- [ ] Level 2 CLI contract: not required; no CLI behavior, exit code, JSON, or TTY surface changed.
- [ ] Level 3 package/install smoke: not required; no packaging, entrypoint, bundled data loading, install, or update path changed.
- [ ] Level 4 fixture repo: not required; no init/onboard/status/start/update repo-shape behavior changed.
- [ ] Level 5 runtime smoke / dogfood harness / simulation-tier: not run; this is docs and bundled skill prose, with no runtime discovery, first-run handoff, or release validation change.
- [x] SKILL.md <=500 lines (if any skill touched)
- [ ] Package-visible release gate evidence before tag/publish: not required; this is not a release branch.
- [ ] Supply-chain review: not required; no workflow, Dependabot, dependency, `id-token`, or permissions changes.

## Success metric

Agents and operators can use one offer-sharpening rubric across think, site, ads, organic, sales-video, and launch workflows, while follow-up #523 tracks any future deterministic CLI readiness facts separately.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [ ] N/A — change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [x] No
- [ ] Yes — migration note below

## Public / private boundary

No private operator strategy, machine-specific paths, customer/member data, provider secrets, raw sales calls, DMs, account exports, or private screenshots were committed. Private Noontide context was used only as local read-only discovery and translated into generic public guidance.
