### PR TITLE
[docs] Align post-release release evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+### Added
+
+- Added a Mermaid-powered Main Branch system map with source-of-truth tables
+  for architecture boundaries, provider rails, private data, validation, and
+  runtime stance. Refs MAIN-339, #519.
+- Added an offer-sharpening guide and shared conversion reference so `/mb-think`,
+  `/mb-site`, `/mb-ads`, `/mb-organic`, sales-video routing, and launch
+  orchestration use the same offer rubric, style spectrum, evidence boundary,
+  and stop conditions before scaling pages, ads, videos, or launch work. Refs
+  MAIN-336, #516.
+- Added a public-safe v0.3.18 post-release transcript review report that records
+  the PyPI release-acceptance evidence, print-mode proxy limits, and follow-up
+  harness gap, and linked it from the release simulation transcript-review
+  guidance. Refs MAIN-340, #521, #526.
+
 ## [0.3.18] - 2026-05-12
 
 v0.3.18 is a package-visible skill and operator-loop patch. It strengthens
@@ -21,9 +36,6 @@ aliases.
 
 ### Added
 
-- Added a Mermaid-powered Main Branch system map with source-of-truth tables
-  for architecture boundaries, provider rails, private data, validation, and
-  runtime stance. Refs MAIN-339, #519.
 - Added `docs/agent-cold-start.md` as the public source for agent read order,
   progressive discovery, release-doc boundaries, and the local preference split,
   so maintainer-local preferences can stay short and private. Refs MAIN-330,
@@ -32,11 +44,6 @@ aliases.
   intent routing, bookkeeping/books setup, provider setup, save/sync wording,
   stronger update posture, and the rule that generic "set up" must not override
   the user's specific business noun. Refs MAIN-333, #511.
-- Added an offer-sharpening guide and shared conversion reference so `/mb-think`,
-  `/mb-site`, `/mb-ads`, `/mb-organic`, sales-video routing, and launch
-  orchestration use the same offer rubric, style spectrum, evidence boundary,
-  and stop conditions before scaling pages, ads, videos, or launch work. Refs
-  MAIN-336, #516.
 
 ### Changed
 

--- a/docs/release-simulations.md
+++ b/docs/release-simulations.md
@@ -221,6 +221,9 @@ and the v0.3.9 post-release lesson is captured in
 The v0.3.10 release-candidate review shows the pre-tag shape, including a
 release-specific launch-offer simulation:
 [reports/2026-05-08-v0-3-10-release-transcript-review.md](reports/2026-05-08-v0-3-10-release-transcript-review.md).
+The v0.3.18 post-publish review shows the package-visible acceptance shape
+with print-mode proxy limits and follow-up routing:
+[reports/2026-05-12-v0-3-18-post-release-transcript-review.md](reports/2026-05-12-v0-3-18-post-release-transcript-review.md).
 
 ## Evidence Rules
 

--- a/docs/reports/2026-05-12-v0-3-18-post-release-transcript-review.md
+++ b/docs/reports/2026-05-12-v0-3-18-post-release-transcript-review.md
@@ -1,0 +1,86 @@
+# v0.3.18 Post-Release Transcript Review Note
+
+This is a public-safe review note for the v0.3.18 post-publish
+`release_acceptance` simulation run. It is not a raw Claude transcript. It
+avoids local paths, account data, private business context, and long excerpts.
+
+## Evidence Set
+
+- Date: 2026-05-12
+- Published package: `mainbranch 0.3.18` from PyPI
+- Evidence level: fresh PyPI install deterministic harness plus `claude -p`
+  print-mode proxy simulation
+- Simulation tier: `release_acceptance`
+- Simulation count: 12 packaged prompts
+- Claude Code version: 2.1.137
+- Public/private boundary: sanitized summary only
+
+## Deterministic Harness Result
+
+- `pip install --no-cache-dir mainbranch==0.3.18`: ok after PyPI index
+  propagation
+- `mb --version`: `mb 0.3.18`
+- `mb skill list`: ok
+- `mb onboard --yes --json`: ok
+- `.claude/skills/mb-start/SKILL.md`: present
+- `mb doctor --json`: ok
+- `mb doctor repair --plan --json`: ok
+- `mb checkpoint --hook-status --json`: ok
+- `mb validate --cross-refs --json`: ok
+- `mb status --json --peek`: schema 1.0, skill wiring ok
+- `mb start --json`: handoff ready, follow-up `/mb-start`
+- Fresh business repo smoke: ok
+- `mb books check --fixture --json`: ok with hledger present and ok with the
+  documented hledger-missing fallback
+- Fixture business repo after run: clean
+- Engine repo unexpected changes: false
+
+## Claude Print-Mode Proxy Result
+
+- Print-mode ran: yes
+- Rubric score: 11/11 heuristic checks
+- Grounding verdict: partial proxy with deterministic fallback
+- Permission denials: 17
+- Session ID preserved: yes
+- Interactive Claude Code TUI smoke: not run in this branch-author pass
+
+The deterministic harness captured the required `mb` facts before each prompt.
+The Claude print-mode run then answered in business language, respected write
+boundaries, and kept repo boundaries clean. The permission denials mean this is
+still proxy evidence, not proof of interactive slash-command behavior.
+
+## Manual Review Summary
+
+| Finding | Severity | Categories | Release lesson |
+|---|---|---|---|
+| Fresh-start and thought-dump prompts grounded in repo state, named onboarding gaps, and routed to bounded next choices. | Pass | skill discovery, CLI grounding, business-language return | The v0.3.18 `/mb-start` and routing language is safe for the shipped daily-loop patch. |
+| Ambiguous offer choice and migration triage refused to rely on legacy `.vip` state and asked for explicit offer/session choice before writes. | Pass | repo boundary, write discipline, stale-state handling | Legacy state remains audit material, not current active-offer truth. |
+| Conversion-video prompts routed VSL, owned-surface sales video, paid video ad, pitch extraction, and short clips to `/mb-site`, `/mb-ads`, `/mb-think`, and `/mb-organic` correctly. | Pass | skill discovery, business-language return | Retiring `/mb-vsl` did not leave a routing hole in the packaged prompt suite. |
+| Books-safety prompt kept raw finance data out of shared history and named `mb books check` as the supported validator. | Pass | bookkeeping safety, public/private boundary | The hledger/private-vault contract is visible in release behavior. |
+| Checkpoint prompt planned files and messages, asked before saving, and flagged self-referential content before commit. | Pass | checkpoint discipline, write discipline | Checkpoint-first language is strong enough for post-publish acceptance. |
+| Shadow-repair prompt used `mb doctor repair --plan` and `mb skill link --repo .` rather than generic filesystem advice. | Pass | repair clarity, supported repair path | Runtime wiring repair stayed on shipped `mb` rails. |
+| Private-data prompt refused customer/member/account/API-key material and offered public-safe alternatives. | Pass | public/private boundary | Synthetic fixture evidence stayed sanitized. |
+| Claude print-mode resume failed for every non-initial prompt and had 17 read-only command permission denials, though deterministic fallback facts were available. | Quality concern | evidence quality, runtime behavior, harness gap | Future release simulations should reduce resume/permission distortion so reviewers can see cleaner per-prompt grounding evidence. |
+
+## Release Decision
+
+v0.3.18 is acceptable as shipped. GitHub Release, PyPI publish, fresh PyPI
+install, fixture repo smoke, Linear release completion, and post-publish
+release-acceptance proxy all succeeded. The transcript review found no hard
+failure in skill discovery, CLI grounding fallback, business-language return,
+write discipline, repo boundary, provider honesty, or public/private handling.
+
+Do not overstate the runtime evidence. This run proves deterministic CLI
+fixtures plus `claude -p` proxy behavior from the published package. It does
+not replace interactive Claude Code TUI smoke for future slash-command support
+claims.
+
+## Follow-Up Route
+
+- Attach this note to
+  [#521](https://github.com/noontide-co/mainbranch/issues/521) as the
+  post-release transcript audit.
+- Track the repeated print-mode resume failures and read-only
+  permission-denial distortion in
+  [#526](https://github.com/noontide-co/mainbranch/issues/526) before the next
+  package-visible release relies on release-acceptance proxy evidence.


### PR DESCRIPTION
## Summary

This PR completes the v0.3.18 post-release alignment sweep by adding a public-safe transcript review report and linking it from the release simulation guidance. It also moves work that merged after the `oe-v0.3.18` tag back under `CHANGELOG.md` `[Unreleased]` so release truth matches the published package.

## Linked issue

Refs #521, #526.

Related post-tag changelog entries: #519, #516.

## Why

The v0.3.18 release shipped before the system map and offer-sharpening docs merged, so those entries should not live inside the dated 0.3.18 changelog section. The post-release playbook also calls for a public-safe simulation transcript audit when package-visible runtime/operator behavior changes.

## Commits by concern

- [x] Each commit body bullet-lists the changes in that commit
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`

Commit:
- `5d5c014 [update] Align post-release release evidence`

## Validation

Pre-push gate from repo root:

```bash
scripts/check.sh
```

- [x] Level 1 static: `scripts/check.sh` passes
- [ ] Level 2 CLI contract: focused Typer/CliRunner tests, exit codes, `--json` behavior, TTY vs non-TTY (if CLI behavior touched)
- [ ] Level 3 package/install smoke (if packaging touched)
- [ ] Level 4 fixture repo (if init/onboard/status/start/update touched)
- [ ] Level 5 runtime smoke / dogfood harness / simulation-tier (if runtime, first-run, skill discovery, or release validation touched)
- [ ] SKILL.md ≤500 lines (if any skill touched)
- [ ] Package-visible release gate evidence before tag/publish (if preparing a release)
- [ ] Supply-chain review (if `.github/workflows/`, `.github/dependabot.yml`, `mb/pyproject.toml` deps, or `id-token`/`permissions` blocks touched — see [docs/supply-chain-policy.md](../docs/supply-chain-policy.md))

- Level 0 docs/release truth: changelog, report, and release-simulation guidance reviewed for post-release alignment — runtime: n/a — exit: n/a — log: diff review.
- Level 1 static: `scripts/check.sh` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: `0` — log: `.agent/post-release-alignment/check-final.out` (`570 passed`, `15/15` skill validations).
- Level 2 CLI contract: not required for docs-only alignment; no CLI behavior changed.
- Level 3 package/install: not required; no packaging or entrypoint files changed.
- Level 4 fixture repo: not required; no init/onboard/status/start/update behavior changed.
- Level 5 runtime: not rerun for this docs-only branch; the new report summarizes the completed v0.3.18 post-publish release acceptance evidence and routes the remaining harness gap to #526.

## Success metric

Future release reviewers can find the v0.3.18 transcript audit from the release simulation docs, `CHANGELOG.md` no longer attributes post-tag work to 0.3.18, and the print-mode evidence-quality gap has a focused follow-up issue.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [ ] N/A — change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [x] No
- [ ] Yes — migration note below

## Public / private boundary

The committed report is sanitized and avoids raw transcripts, local paths, account data, private business context, and long excerpts.
