### PR TITLE
[fix] Reduce release print-mode evidence noise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   fresh sessions, categorized permission-denial summaries, direct read-only
   `mb books check` / `mb educational` allowlist coverage, and prompt
   guardrails against shell-wrapped parsing in proxy runs. Refs MAIN-342, #526.
+- Added explicit two-layer transcript review guidance so release audits check
+  deterministic proof first, then mine the agent transcript for product
+  opportunities, repair gaps, and avoidable operator friction. Refs MAIN-342,
+  #526.
 - Added a Mermaid-powered Main Branch system map with source-of-truth tables
   for architecture boundaries, provider rails, private data, validation, and
   runtime stance. Refs MAIN-339, #519.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,8 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   outcome feedback. Refs MAIN-343, #528.
 - Added clearer release dogfood print-mode evidence handling: per-simulation
   fresh sessions, categorized permission-denial summaries, direct read-only
-  `mb books check` / `mb educational` allowlist coverage, and prompt guardrails
-  against shell-wrapped parsing in proxy runs. Refs MAIN-342, #526.
+  `mb books check` / `mb educational` allowlist coverage, and prompt
+  guardrails against shell-wrapped parsing in proxy runs. Refs MAIN-342, #526.
 - Added a Mermaid-powered Main Branch system map with source-of-truth tables
   for architecture boundaries, provider rails, private data, validation, and
   runtime stance. Refs MAIN-339, #519.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   and scripts a read-only, gated view of customer progress, offer, audience,
   proof, product ladder, CTA, channel, push, playbook, page readiness, and
   outcome feedback. Refs MAIN-343, #528.
+- Added clearer release dogfood print-mode evidence handling: per-simulation
+  fresh sessions, categorized permission-denial summaries, direct read-only
+  `mb books check` / `mb educational` allowlist coverage, and prompt guardrails
+  against shell-wrapped parsing in proxy runs. Refs MAIN-342, #526.
 - Added a Mermaid-powered Main Branch system map with source-of-truth tables
   for architecture boundaries, provider rails, private data, validation, and
   runtime stance. Refs MAIN-339, #519.

--- a/docs/claude-code-runtime-dogfood.md
+++ b/docs/claude-code-runtime-dogfood.md
@@ -101,8 +101,9 @@ For a release smoke against PyPI:
 scripts/claude-runtime-dogfood.py --install-mode pypi --pypi-version 0.3.6
 ```
 
-The optional print-mode proxy path runs chained `claude -p` prompts and
-preserves the returned session id when Claude Code emits one:
+The optional print-mode proxy path runs each `claude -p` prompt in a fresh
+session for its per-simulation fixture repo and records the returned session
+ids when Claude Code emits them:
 
 ```bash
 scripts/claude-runtime-dogfood.py --install-mode editable --run-claude-print --max-budget-usd 0.25
@@ -119,13 +120,16 @@ after publication.
 When print mode runs, the harness prepends the temp venv `mb` executable to
 `PATH` and passes Claude Code a read-only tool allowlist for deterministic
 grounding commands such as `mb status`, `mb start`, `mb doctor`, `mb validate`,
-and `mb checkpoint --plan`. It does not use permission-bypass mode and does not
-allowlist write/edit tools, checkpoint saves, repair applies, migrations, or git
-commits. Transcript review still has to answer whether Claude actually ran/read
-the `mb` facts, whether permissions distorted the run, and which deterministic
-CLI artifacts are only fallback evidence. The harness labels permission-denied
-grounding as proxy evidence; when profile `mb` facts are available, it records
-that as deterministic fallback rather than an interactive TUI pass.
+`mb books check`, `mb educational`, and `mb checkpoint --plan`. It also tells
+Claude not to use shell pipes, redirects, temp files, Python parsers, local
+Claude tool-result paths, or `AskUserQuestion` in print mode. It does not use
+permission-bypass mode and does not allowlist write/edit tools, checkpoint
+saves, repair applies, migrations, or git commits. Transcript review still has
+to answer whether Claude actually ran/read the `mb` facts, whether permissions
+distorted the run, and which deterministic CLI artifacts are only fallback
+evidence. The harness labels permission-denied grounding as proxy evidence;
+when profile `mb` facts are available, it records that as deterministic
+fallback rather than an interactive TUI pass.
 
 Print-mode evidence is a proxy. It is useful for repeatable regression signal,
 budget/auth failures, transcript excerpts, and rubric scoring, but it is not

--- a/docs/post-release-alignment.md
+++ b/docs/post-release-alignment.md
@@ -85,16 +85,20 @@ Use this sequence:
    recover wording.
 2. Compare each run against `docs/release-simulations.md` transcript-review
    categories and the manifest's `must_observe` / `must_not` rubric.
-3. Classify each miss as hard failure, quality concern, or product opportunity.
+3. Review in two layers: first confirm deterministic proof, then read the
+   transcript as an operator session and ask what product affordance, wording,
+   repair path, JSON field, fixture, or evidence template would make the next
+   run naturally better.
+4. Classify each miss as hard failure, quality concern, or product opportunity.
    Name the likely fix type: skill prose, generated repo guidance, CLI gap,
    docs gap, harness gap, runtime behavior, or user education.
-4. Route public product gaps to GitHub issues. Use `Closes #N` only when a PR
+5. Route public product gaps to GitHub issues. Use `Closes #N` only when a PR
    fully resolves the public issue; use `Refs #N` for partial slices.
-5. Keep private local runtime logs, raw transcripts, local machine details, and
+6. Keep private local runtime logs, raw transcripts, local machine details, and
    maintainer-only notes out of GitHub and public docs. If the synced Linear
    issue needs that context, add a Linear-only comment; otherwise keep it in
    private local scratch space.
-6. Update `docs/release-simulations.md`, the packaged simulation manifest, or
+7. Update `docs/release-simulations.md`, the packaged simulation manifest, or
    the dogfood harness only when the audit finds a repeatable gap that should
    protect future releases.
 

--- a/docs/release-simulations.md
+++ b/docs/release-simulations.md
@@ -107,8 +107,8 @@ profiles include the healthy first-day repo, broken project-local skill wiring,
 synthetic private-data refusal material, legacy campaigns/schema drift, launch
 readiness gaps, and dirty approved business files for checkpoint planning.
 Evidence records the profile name, mutations applied, relevant read-only `mb`
-command facts, post-run git state, permission-denial count, and grounding
-verdict.
+command facts, post-run git state, fresh-session ids, permission-denial summary
+by category, and grounding verdict.
 
 ## Running The Suite
 
@@ -152,11 +152,13 @@ checklist. Keep raw local paths and long transcripts out of public comments.
 Print-mode runs intentionally prepend the harness venv's `mb` executable to
 `PATH` and pass Claude Code a read-only allowlist for deterministic `mb`
 grounding commands such as `mb status`, `mb start`, `mb doctor`, `mb validate`,
-and `mb checkpoint --plan`. The harness does not use permission-bypass mode and
-does not allowlist write/edit tools, checkpoint saves, repair applies,
-migrations, or git commits. If a transcript still shows read-only `mb` commands
-were denied, classify the run as permission-distorted proxy evidence and record
-the fallback rather than treating the heuristic rubric as a full pass.
+`mb books check`, `mb educational`, and `mb checkpoint --plan`. Each
+simulation runs in a fresh print-mode session because every simulation has its
+own fixture repo. The harness does not use permission-bypass mode and does not
+allowlist write/edit tools, checkpoint saves, repair applies, migrations, or git
+commits. If a transcript still shows read-only `mb` commands were denied,
+classify the run as permission-distorted proxy evidence and record the fallback
+rather than treating the heuristic rubric as a full pass.
 When deterministic fixture facts were captured for the same scenario, the
 harness labels that as partial proxy evidence with deterministic fallback,
 still not as interactive TUI proof.

--- a/docs/release-simulations.md
+++ b/docs/release-simulations.md
@@ -169,6 +169,26 @@ Do not stop at pass/fail. The keyword rubric in `rubric.json` is proxy
 evidence; the release question is whether Claude behaved like Main Branch in a
 normal owner session.
 
+Review in two layers:
+
+1. **Deterministic proof.** Confirm the fixture, command artifacts, post-run
+   git state, permissions, and release gates prove what the release claims.
+2. **Agent judgment.** Read the transcript as an operator session. Look for
+   product opportunities even when the deterministic layer passed: missing
+   `mb` affordances, weak business routing, unclear repair guidance, avoidable
+   plumbing, or places where Claude had to work around missing product facts.
+
+Answer these questions before calling the transcript review done:
+
+- Did Claude actually run or read `mb` facts?
+- Did permissions block read-only grounding?
+- Did Claude ask before durable writes?
+- Did Claude return from technical checks to business-owner language?
+- Did Claude work around a missing product affordance, JSON field, repair path,
+  fixture, or evidence template?
+- Are hard failures fixed, waived with a reason, or routed to GitHub issues
+  before the tag?
+
 Review the transcript against the prompt fixture's `must_observe` and
 `must_not` lists, the command artifacts from the same run, and any post-run git
 state. Use this severity scale:

--- a/mb/mb/dogfood_harness.py
+++ b/mb/mb/dogfood_harness.py
@@ -43,18 +43,25 @@ CLAUDE_PRINT_READ_ONLY_TOOLS = (
     "Bash(mb doctor . --json)",
     "Bash(mb doctor repair --plan)",
     "Bash(mb doctor repair --plan *)",
+    "Bash(mb doctor repair --plan --json)",
+    "Bash(mb doctor repair --repo * --plan --json)",
     "Bash(mb status)",
     "Bash(mb status *)",
+    "Bash(mb status --json --peek)",
     "Bash(mb start)",
     "Bash(mb start --json)",
     "Bash(mb start --repo * --json)",
     "Bash(mb start --json --repo *)",
     "Bash(mb validate)",
     "Bash(mb validate *)",
+    "Bash(mb validate --cross-refs --json)",
     "Bash(mb graph)",
     "Bash(mb graph *)",
     "Bash(mb connect status)",
     "Bash(mb connect status *)",
+    "Bash(mb educational *)",
+    "Bash(mb books check)",
+    "Bash(mb books check *)",
     "Bash(mb checkpoint --hook-status)",
     "Bash(mb checkpoint --hook-status *)",
     "Bash(mb checkpoint --status)",
@@ -78,6 +85,18 @@ CLAUDE_PRINT_WRITE_DENY_TOOLS = (
     "Bash(git reset *)",
     "Bash(git checkout *)",
 )
+CLAUDE_PRINT_PROMPT_PREFIX = """Release simulation harness constraints:
+- Work from this disposable fixture repo only.
+- If you need deterministic Main Branch facts, run direct read-only commands only.
+- Prefer these exact commands when relevant: `mb status --json --peek`,
+  `mb start --json`, `mb doctor --json`, `mb doctor repair --plan --json`,
+  `mb validate --cross-refs --json`, `mb checkpoint --plan --json`,
+  `mb books check`, and `mb educational <topic>`.
+- Do not use shell pipes, redirects, temp files, Python parsers, or Claude
+  tool-result paths to transform command output.
+- Do not call AskUserQuestion in print mode. Put any question for the operator
+  in the final answer.
+"""
 
 SAFE_FIXTURE_FILES: dict[str, str] = {
     "core/offer.md": """# Offer
@@ -1023,6 +1042,11 @@ def score_transcript(text: str) -> dict[str, Any]:
     return release_simulation.score_transcript(text)
 
 
+def claude_print_prompt(simulation: release_simulation.Simulation) -> str:
+    """Return a prompt with harness constraints before the simulation text."""
+    return f"{CLAUDE_PRINT_PROMPT_PREFIX}\nSimulation prompt:\n{simulation.prompt}"
+
+
 def claude_print_env(state: HarnessState) -> dict[str, str]:
     env = os.environ.copy()
     existing_path = env.get("PATH", "")
@@ -1044,7 +1068,7 @@ def run_claude_print(state: HarnessState, *, max_budget_usd: str, simulation_tie
         }
         return
 
-    session_id = ""
+    session_ids: list[str] = []
     turns: list[dict[str, Any]] = []
     transcript_parts: list[str] = []
     permission_denials: list[Any] = []
@@ -1056,6 +1080,7 @@ def run_claude_print(state: HarnessState, *, max_budget_usd: str, simulation_tie
         "allowed_tools": list(CLAUDE_PRINT_READ_ONLY_TOOLS),
         "disallowed_tools": list(CLAUDE_PRINT_WRITE_DENY_TOOLS),
         "bypass_permissions": False,
+        "session_strategy": "fresh_session_per_simulation",
         "write_boundary": (
             "Write/edit tools, git commits, checkpoint saves, repair applies, "
             "and migrations are not allowlisted for print-mode proxy runs."
@@ -1074,10 +1099,7 @@ def run_claude_print(state: HarnessState, *, max_budget_usd: str, simulation_tie
             f"--allowedTools={','.join(CLAUDE_PRINT_READ_ONLY_TOOLS)}",
             f"--disallowedTools={','.join(CLAUDE_PRINT_WRITE_DENY_TOOLS)}",
         ]
-        command = [*base_command]
-        if session_id:
-            command.extend(["--resume", session_id])
-        command.append(simulation.prompt)
+        command = [*base_command, claude_print_prompt(simulation)]
         result = run_command(
             state,
             f"claude-print-{simulation.label}",
@@ -1086,24 +1108,6 @@ def run_claude_print(state: HarnessState, *, max_budget_usd: str, simulation_tie
             env=print_env,
             timeout=600,
         )
-        if (
-            result.returncode != 0
-            and session_id
-            and "No conversation found with session ID" in result.stderr
-        ):
-            state.warn(
-                f"Claude print-mode resume failed at {simulation.label}; "
-                "retried as a fresh print-mode session"
-            )
-            command = [*base_command, simulation.prompt]
-            result = run_command(
-                state,
-                f"claude-print-{simulation.label}-fresh-session",
-                command,
-                cwd=profile_repo,
-                env=print_env,
-                timeout=600,
-            )
         post_status = git_text(profile_repo, "status", "--short")
         post_diff = git_text(profile_repo, "diff", "--stat")
         profile_record["post_run_git_status"] = post_status
@@ -1141,7 +1145,8 @@ def run_claude_print(state: HarnessState, *, max_budget_usd: str, simulation_tie
                 turn["permission_denials"] = len(denials)
             new_session_id = extract_session_id(payload)
             if new_session_id:
-                session_id = new_session_id
+                session_ids.append(new_session_id)
+                turn["session_id"] = new_session_id
             text = transcript_text_from_payload(payload)
             if text:
                 transcript_parts.append(f"## {simulation.label}\n\n{text.strip()}\n")
@@ -1169,8 +1174,10 @@ def run_claude_print(state: HarnessState, *, max_budget_usd: str, simulation_tie
     if transcript_text and observed_unknown_command:
         state.fail("Claude print-mode transcript reported an unknown command")
 
+    permission_summary = summarize_permission_denials(permission_denials)
     grounding = classify_print_grounding(
         permission_denials=permission_denials,
+        permission_summary=permission_summary,
         fixture_profiles=state.fixture_profiles,
         rubric=rubric,
         turns=turns,
@@ -1185,10 +1192,13 @@ def run_claude_print(state: HarnessState, *, max_budget_usd: str, simulation_tie
         "proxy_notice": "Print-mode evidence is not the same as interactive TUI evidence.",
         "simulation_tier": simulation_tier,
         "max_budget_usd": max_budget_usd,
-        "session_id": session_id,
+        "session_id": session_ids[-1] if session_ids else "",
+        "session_ids": session_ids,
+        "session_strategy": "fresh_session_per_simulation",
         "permission_policy": permission_policy,
         "permission_denials": permission_denials,
         "permission_denial_count": len(permission_denials),
+        "permission_denial_summary": permission_summary,
         "grounding": grounding,
         "turns": turns,
         "simulations": [
@@ -1213,12 +1223,17 @@ def run_claude_print(state: HarnessState, *, max_budget_usd: str, simulation_tie
 def classify_print_grounding(
     *,
     permission_denials: list[Any],
+    permission_summary: dict[str, Any] | None = None,
     fixture_profiles: list[dict[str, Any]],
     rubric: dict[str, Any],
     turns: list[dict[str, Any]],
 ) -> dict[str, Any]:
     """Classify whether print-mode grounding is clean, fallback, or distorted."""
-    permission_denial_count = len(permission_denials)
+    permission_summary = permission_summary or summarize_permission_denials(permission_denials)
+    permission_denial_count = int(permission_summary.get("total", len(permission_denials)) or 0)
+    grounding_denial_count = int(
+        permission_summary.get("read_only_mb_grounding", permission_denial_count) or 0
+    )
     facts_available = any(
         bool(
             profile.get("mb_command_facts", {}).get("facts_available")
@@ -1240,19 +1255,27 @@ def classify_print_grounding(
         if isinstance(check, dict) and check.get("ok") is False
     ]
 
-    if permission_denial_count and not facts_available:
+    if grounding_denial_count and not facts_available:
         verdict = "permission_distorted_proxy"
         clean_pass = False
         reason = (
             "Read-only mb grounding was denied and the harness did not capture "
             "equivalent deterministic fixture facts."
         )
-    elif permission_denial_count:
+    elif grounding_denial_count:
         verdict = "partial_proxy_with_deterministic_fallback"
         clean_pass = False
         reason = (
             "Read-only mb grounding saw permission denial(s); deterministic "
             "fixture facts are available as fallback evidence."
+        )
+    elif permission_denial_count:
+        verdict = "print_proxy_manual_review_required"
+        clean_pass = not failed_turns and not failed_checks
+        reason = (
+            "Print-mode recorded permission denial(s), but none were classified "
+            "as read-only mb grounding denials. Manual transcript review is "
+            "still required for release claims."
         )
     else:
         verdict = "print_proxy_manual_review_required"
@@ -1266,12 +1289,107 @@ def classify_print_grounding(
         "verdict": verdict,
         "clean_pass": clean_pass,
         "permission_denial_count": permission_denial_count,
+        "read_only_mb_grounding_denial_count": grounding_denial_count,
+        "permission_denial_summary": permission_summary,
         "deterministic_fixture_facts": facts_available,
         "failed_turns": failed_turns,
         "failed_heuristic_checks": failed_checks,
         "reason": reason,
         "evidence_level": "print-mode proxy",
     }
+
+
+def summarize_permission_denials(permission_denials: list[Any]) -> dict[str, Any]:
+    """Summarize Claude Code permission denials by evidence impact."""
+    summary: dict[str, Any] = {
+        "total": len(permission_denials),
+        "read_only_mb_grounding": 0,
+        "direct_read_only_mb": 0,
+        "shell_wrapped_mb": 0,
+        "operator_question": 0,
+        "local_runtime_artifact": 0,
+        "other": 0,
+        "examples": [],
+    }
+    examples: list[dict[str, str]] = []
+    for denial in permission_denials:
+        tool_name, command = permission_denial_tool(denial)
+        category = permission_denial_category(tool_name, command)
+        summary[category] = int(summary.get(category, 0) or 0) + 1
+        if category in {"direct_read_only_mb", "shell_wrapped_mb"}:
+            summary["read_only_mb_grounding"] = int(summary["read_only_mb_grounding"]) + 1
+        if len(examples) < 10:
+            examples.append(
+                {
+                    "tool": tool_name or "unknown",
+                    "category": category,
+                    "command": command[:240],
+                }
+            )
+    summary["examples"] = examples
+    return summary
+
+
+def permission_denial_tool(denial: Any) -> tuple[str, str]:
+    """Extract a normalized tool name and command from a Claude denial payload."""
+    if isinstance(denial, str):
+        if denial.startswith("Bash(") and denial.endswith(")"):
+            return "Bash", denial.removeprefix("Bash(").removesuffix(")")
+        return denial, ""
+    if not isinstance(denial, dict):
+        return "", ""
+    tool_name = str(denial.get("tool_name") or denial.get("tool") or "")
+    tool_input = denial.get("tool_input")
+    command = ""
+    if isinstance(tool_input, dict):
+        command_value = tool_input.get("command")
+        if isinstance(command_value, str):
+            command = command_value
+    if not command and tool_name.startswith("Bash(") and tool_name.endswith(")"):
+        command = tool_name.removeprefix("Bash(").removesuffix(")")
+        tool_name = "Bash"
+    return tool_name, command
+
+
+def permission_denial_category(tool_name: str, command: str) -> str:
+    """Classify a permission denial without treating every denial as mb grounding."""
+    stripped = command.strip()
+    if tool_name == "AskUserQuestion":
+        return "operator_question"
+    if tool_name == "Bash" and "/.claude/projects/" in stripped:
+        return "local_runtime_artifact"
+    if tool_name == "Bash" and stripped.startswith("mb "):
+        if not is_read_only_mb_command(stripped):
+            return "other"
+        if is_shell_wrapped_command(stripped):
+            return "shell_wrapped_mb"
+        return "direct_read_only_mb"
+    return "other"
+
+
+def is_shell_wrapped_command(command: str) -> bool:
+    """Return whether a command uses shell control or redirection syntax."""
+    return any(marker in command for marker in ("|", ">", "<", ";", "&&", "||"))
+
+
+def is_read_only_mb_command(command: str) -> bool:
+    """Return whether a denied mb command starts from a known read-only surface."""
+    read_only_prefixes = (
+        "mb --version",
+        "mb doctor",
+        "mb status",
+        "mb start",
+        "mb validate",
+        "mb graph",
+        "mb connect status",
+        "mb educational",
+        "mb books check",
+        "mb checkpoint --hook-status",
+        "mb checkpoint --status",
+        "mb checkpoint --plan",
+        "mb checkpoint --validate",
+    )
+    return command.startswith(read_only_prefixes)
 
 
 def collect_post_run_state(state: HarnessState) -> None:
@@ -1334,10 +1452,17 @@ def evidence_template(state: HarnessState, *, install_mode: str, mb_version: str
         if isinstance(permission_policy, dict)
         else "not run"
     )
-    permission_denials = claude.get("permission_denials", []) if isinstance(claude, dict) else []
-    permission_denial_summary: str | int = "not run"
-    if isinstance(permission_denials, list):
-        permission_denial_summary = len(permission_denials)
+    session_strategy = (
+        claude.get("session_strategy", "not run") if isinstance(claude, dict) else "not run"
+    )
+    permission_summary = (
+        claude.get("permission_denial_summary", {}) if isinstance(claude, dict) else {}
+    )
+    permission_denial_summary = "not run"
+    grounding_denial_summary = "not run"
+    if isinstance(permission_summary, dict):
+        permission_denial_summary = permission_summary.get("total", "not run")
+        grounding_denial_summary = permission_summary.get("read_only_mb_grounding", "not run")
     grounding = claude.get("grounding", {}) if isinstance(claude, dict) else {}
     grounding_verdict = (
         grounding.get("verdict", "not run") if isinstance(grounding, dict) else "not run"
@@ -1385,10 +1510,12 @@ Evidence folder: local artifact; see harness output and summary.json
 - Proxy notice: {claude_notice}
 - Permission policy: {permission_mode}
 - Permission denials: {permission_denial_summary}
+- Read-only `mb` grounding denials: {grounding_denial_summary}
 - Grounding verdict: {grounding_verdict}
 - Grounding note: {grounding_reason}
 - Write boundary: {permission_boundary}
-- Session ID preserved: {claude_session}
+- Session strategy: {session_strategy}
+- Session ID captured: {claude_session}
 - Rubric: {rubric_summary}
 - Manual transcript review: docs/release-simulations.md#transcript-review
 - Transcript excerpts: {claude_transcript}
@@ -1621,7 +1748,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--run-claude-print",
         action="store_true",
-        help="Run optional chained claude -p print-mode proxy smoke.",
+        help="Run optional fresh-session claude -p print-mode proxy smoke.",
     )
     parser.add_argument(
         "--simulation-tier",

--- a/mb/mb/dogfood_harness.py
+++ b/mb/mb/dogfood_harness.py
@@ -1374,6 +1374,8 @@ def is_shell_wrapped_command(command: str) -> bool:
 
 def is_read_only_mb_command(command: str) -> bool:
     """Return whether a denied mb command starts from a known read-only surface."""
+    # Keep this list command-specific. If a future read command grows a write
+    # flag, add an explicit negative guard before treating it as grounding.
     read_only_prefixes = (
         "mb --version",
         "mb doctor",

--- a/mb/tests/test_dogfood_harness.py
+++ b/mb/tests/test_dogfood_harness.py
@@ -209,12 +209,18 @@ def test_run_claude_print_allows_readonly_mb_and_denies_write_tools(
 
     assert "--dangerously-skip-permissions" not in command
     assert "--permission-mode" not in command
-    assert command[-1] == simulation.prompt
+    assert command[-1].endswith(simulation.prompt)
+    assert "Do not use shell pipes" in command[-1]
+    assert "Do not call AskUserQuestion" in command[-1]
     assert "Bash(mb status)" in allowed
     assert "Bash(mb status *)" in allowed
+    assert "Bash(mb status --json --peek)" in allowed
     assert "Bash(mb start)" in allowed
     assert "Bash(mb start --json --repo *)" in allowed
     assert "Bash(mb doctor repair --plan)" in allowed
+    assert "Bash(mb doctor repair --plan --json)" in allowed
+    assert "Bash(mb educational *)" in allowed
+    assert "Bash(mb books check)" in allowed
     assert "Bash(mb checkpoint --plan)" in allowed
     assert "Bash(mb checkpoint --plan *)" in allowed
     assert "Bash(mb checkpoint --message *)" in disallowed
@@ -222,10 +228,11 @@ def test_run_claude_print_allows_readonly_mb_and_denies_write_tools(
     assert captured["env"]["PATH"].split(os.pathsep)[0] == str(state.mb_path.parent)
     assert state.claude["permission_policy"]["bypass_permissions"] is False
     assert state.claude["permission_policy"]["mode"] == "read_only_mb_allowlist"
+    assert state.claude["session_strategy"] == "fresh_session_per_simulation"
     assert state.claude["permission_denials"] == []
 
 
-def test_run_claude_print_retries_when_resume_session_is_missing(
+def test_run_claude_print_uses_fresh_sessions_for_profile_repos(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     state = harness.HarnessState(
@@ -237,6 +244,7 @@ def test_run_claude_print_retries_when_resume_session_is_missing(
     )
     state.fixture_repo.mkdir(parents=True)
     calls: list[list[str]] = []
+    claude_calls = 0
 
     simulations = (
         release_simulation.Simulation(
@@ -272,24 +280,25 @@ def test_run_claude_print_retries_when_resume_session_is_missing(
         env: dict[str, str] | None = None,
         timeout: int | None = None,
     ) -> harness.CommandResult:
+        nonlocal claude_calls
         del state, cwd, env, timeout
         calls.append(command)
         stdout_path = tmp_path / f"{label}.stdout"
         stderr_path = tmp_path / f"{label}.stderr"
         metadata_path = tmp_path / f"{label}.json"
-        if "--resume" in command:
-            stdout = ""
-            stderr = "No conversation found with session ID: missing\n"
-            returncode = 1
+        if label.startswith("claude-print-"):
+            claude_calls += 1
+            session_id = f"session-{claude_calls}"
         else:
-            stdout = json.dumps(
-                {
-                    "session_id": "session-1",
-                    "result": {"content": [{"text": "/mb-start ran mb status."}]},
-                }
-            )
-            stderr = ""
-            returncode = 0
+            session_id = "setup-session"
+        stdout = json.dumps(
+            {
+                "session_id": session_id,
+                "result": {"content": [{"text": "/mb-start ran mb status."}]},
+            }
+        )
+        stderr = ""
+        returncode = 0
         stdout_path.write_text(stdout, encoding="utf-8")
         stderr_path.write_text(stderr, encoding="utf-8")
         metadata_path.write_text("{}", encoding="utf-8")
@@ -311,10 +320,12 @@ def test_run_claude_print_retries_when_resume_session_is_missing(
 
     harness.run_claude_print(state, max_budget_usd="0.01", simulation_tier="pr_smoke")
 
-    assert any("--resume" in command for command in calls)
-    assert any("retried as a fresh print-mode session" in warning for warning in state.warnings)
+    assert not any("--resume" in command for command in calls)
+    assert not any("retried as a fresh print-mode session" in warning for warning in state.warnings)
     assert [turn["simulation_id"] for turn in state.claude["turns"]] == ["one", "two"]
     assert state.claude["turns"][1]["returncode"] == 0
+    assert state.claude["session_ids"] == ["session-1", "session-2"]
+    assert state.claude["session_strategy"] == "fresh_session_per_simulation"
 
 
 def test_read_json_rejects_non_object_payload() -> None:
@@ -370,7 +381,9 @@ def test_evidence_template_labels_print_mode_as_proxy(tmp_path: Path) -> None:
         "ran": True,
         "proxy_notice": "Print-mode evidence is not the same as interactive TUI evidence.",
         "session_id": "session-1",
+        "session_strategy": "fresh_session_per_simulation",
         "permission_denials": [],
+        "permission_denial_summary": {"total": 0, "read_only_mb_grounding": 0},
         "transcript_excerpts": str(tmp_path / "transcript.md"),
         "rubric": {"passed": 6, "total": 7},
     }
@@ -378,8 +391,10 @@ def test_evidence_template_labels_print_mode_as_proxy(tmp_path: Path) -> None:
     template = harness.evidence_template(state, install_mode="editable", mb_version="mb 0.3.6")
 
     assert "Print-mode evidence is not the same as interactive TUI evidence" in template
-    assert "Session ID preserved: True" in template
+    assert "Session strategy: fresh_session_per_simulation" in template
+    assert "Session ID captured: True" in template
     assert "Permission denials: 0" in template
+    assert "Read-only `mb` grounding denials: 0" in template
     assert "Rubric: 6/7 heuristic checks" in template
     assert "Manual transcript review: docs/release-simulations.md#transcript-review" in template
     assert f"Evidence folder: {state.evidence_dir}" not in template
@@ -541,6 +556,43 @@ def test_print_grounding_classifies_permission_denial_with_fixture_facts_as_part
 
     assert verdict["verdict"] == "partial_proxy_with_deterministic_fallback"
     assert verdict["clean_pass"] is False
+
+
+def test_permission_denial_summary_separates_grounding_from_other_denials() -> None:
+    summary = harness.summarize_permission_denials(
+        [
+            {
+                "tool_name": "AskUserQuestion",
+                "tool_input": {"questions": [{"question": "Choose?"}]},
+            },
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": "mb books check"},
+            },
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": "mb status --json --peek | python3 -c 'pass'"},
+            },
+            {
+                "tool_name": "Bash",
+                "tool_input": {
+                    "command": "cat /home/example/.claude/projects/demo/tool-results/abc.txt"
+                },
+            },
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": "mb checkpoint --message '[added] demo' --yes"},
+            },
+        ]
+    )
+
+    assert summary["total"] == 5
+    assert summary["operator_question"] == 1
+    assert summary["direct_read_only_mb"] == 1
+    assert summary["shell_wrapped_mb"] == 1
+    assert summary["read_only_mb_grounding"] == 2
+    assert summary["local_runtime_artifact"] == 1
+    assert summary["other"] == 1
 
 
 def test_run_command_captures_artifacts_and_parses_json(tmp_path: Path) -> None:

--- a/mb/tests/test_dogfood_harness.py
+++ b/mb/tests/test_dogfood_harness.py
@@ -558,6 +558,29 @@ def test_print_grounding_classifies_permission_denial_with_fixture_facts_as_part
     assert verdict["clean_pass"] is False
 
 
+def test_print_grounding_keeps_non_grounding_denials_as_manual_review() -> None:
+    verdict = harness.classify_print_grounding(
+        permission_denials=[
+            {
+                "tool_name": "AskUserQuestion",
+                "tool_input": {"questions": [{"question": "Choose?"}]},
+            },
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": "mb checkpoint --message '[added] demo' --yes"},
+            },
+        ],
+        fixture_profiles=[{"fixture_profile": "fresh", "mb_command_facts": {}}],
+        rubric={"checks": {"control_plane_usage": {"ok": True}}},
+        turns=[{"simulation_id": "fresh_first_day", "returncode": 0}],
+    )
+
+    assert verdict["verdict"] == "print_proxy_manual_review_required"
+    assert verdict["permission_denial_count"] == 2
+    assert verdict["read_only_mb_grounding_denial_count"] == 0
+    assert verdict["clean_pass"] is True
+
+
 def test_permission_denial_summary_separates_grounding_from_other_denials() -> None:
     summary = harness.summarize_permission_denials(
         [


### PR DESCRIPTION
## Summary

This PR reduces release dogfood print-mode evidence noise by making each simulation use a fresh Claude session for its fixture repo, tightening print-mode prompt guardrails, and separating read-only `mb` grounding denials from other permission denials. It also updates the release simulation and dogfood docs so future release reviewers know the expected fresh-session strategy.

## Linked issue

Closes #526.

## Why

The v0.3.18 release acceptance run repeatedly tried to resume Claude sessions across different per-simulation fixture repos, then mixed direct `mb` grounding denials with operator questions, shell-wrapped parsing, and local Claude artifact reads. That made reviewers work harder to tell whether a release simulation actually used the intended Main Branch facts.

## Commits by concern

- [x] Each commit body bullet-lists the changes in that commit
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`

Commit:
- `957c9cf [fix] MAIN-342 reduce print-mode evidence noise`

## Validation

Pre-push gate from repo root:

```bash
scripts/check.sh
```

- [x] Level 1 static: `scripts/check.sh` passes
- [x] Level 2 CLI contract: focused Typer/CliRunner tests, exit codes, `--json` behavior, TTY vs non-TTY (if CLI behavior touched)
- [ ] Level 3 package/install smoke (if packaging touched)
- [ ] Level 4 fixture repo (if init/onboard/status/start/update touched)
- [x] Level 5 runtime smoke / dogfood harness / simulation-tier (if runtime, first-run, skill discovery, or release validation touched)
- [ ] SKILL.md ≤500 lines (if any skill touched)
- [ ] Package-visible release gate evidence before tag/publish (if preparing a release)
- [ ] Supply-chain review (if `.github/workflows/`, `.github/dependabot.yml`, `mb/pyproject.toml` deps, or `id-token`/`permissions` blocks touched — see [docs/supply-chain-policy.md](../docs/supply-chain-policy.md))

- Level 1 static: `scripts/check.sh` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: `0` — log: `.agent/main-342/check-final.out` (`571 passed`, `15/15` skill validations).
- Level 2 CLI contract: `python3 -m pytest tests/test_release_simulation.py tests/test_dogfood_harness.py -q` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: `0` — excerpt: `38 passed`.
- Level 5 runtime/dogfood harness: `python3 scripts/claude-runtime-dogfood.py --install-mode editable --evidence-dir .agent/main-342/dogfood-no-print` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: `0` — log: `.agent/main-342/dogfood-no-print.log`; deterministic harness passed with clean fixture and engine repo boundaries.
- Level 5 print-mode proxy: not rerun after the patch because the pre-change PR-smoke attempt hit the Claude budget cap before useful transcript evidence; command construction, fresh-session behavior, allowlist coverage, and permission-denial categorization are covered by focused tests.
- Level 3 package/install: not required; no package metadata, entrypoint, or bundled data packaging changed.
- Level 4 fixture repo: covered by the deterministic dogfood harness above; no init/onboard/status/start/update behavior changed outside harness evidence capture.
- SKILL.md line-count and supply-chain review: not required; no skill or workflow/dependency files changed.

## Success metric

Future release-acceptance print-mode runs record a clear fresh-session-per-simulation strategy, avoid known shell-wrapped parsing prompts, allow direct read-only `mb books` and `mb educational` checks, and report read-only `mb` grounding denials separately from other permission denials.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [ ] N/A — change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [x] No
- [ ] Yes — migration note below

## Public / private boundary

Committed docs and tests use sanitized examples only. No raw transcripts, local machine paths, account data, secrets, or private business context are committed.
