### PR TITLE
[add] MoneyPath readiness in mb status

### DIFF
--- a/.claude/skills/mb-start/SKILL.md
+++ b/.claude/skills/mb-start/SKILL.md
@@ -31,8 +31,8 @@ actual file paths in commands.
 `mb status --json --peek` before asking setup or routing questions. Treat that
 JSON as the source of truth for update severity, readiness, drift, onboarding,
 integrations, GitHub issue/proposal facts, bets, dirty git, since-last-check, and
-`ranked_actions`. Do not duplicate those checks with ad hoc shell probes unless
-the status report says a section is unavailable.
+`money_path` / `ranked_actions`. Do not duplicate those checks with ad hoc
+shell probes unless the status report says a section is unavailable.
 
 **Continuity facts:** Use `since_last_check.journal`, top-level `journal`,
 GitHub activity, and `checkpoint` from status to explain "where we left off."
@@ -173,6 +173,9 @@ Use this report before asking additional questions:
 - `ranked_actions` is the deterministic list of one to three business moves.
   Surface the first action as the recommendation, including its reason and
   cited signal summaries.
+- `money_path` maps customer progress, offer, proof, CTA, channel, push,
+  playbook, page readiness, and outcome feedback. Use levels, objects, and
+  ranked actions as evidence; do not call the offer "good" or "will convert."
 - `readiness` gates whether setup/repair work must happen before output skills.
 - `drift.items` names stale or broken status signals and repair commands.
 - `onboarding.summary` and `onboarding.checklist` replace separate onboarding
@@ -324,9 +327,9 @@ See [tool-status-audit.md](references/tool-status-audit.md) for the full procedu
 
 ## Step 6: Readiness Assessment
 
-Use `readiness` and `ranked_actions` from `mb status --json --peek` before
-routing. The reference below is fallback detail for gaps that status does not
-expose yet.
+Use `readiness`, `money_path`, and `ranked_actions` from
+`mb status --json --peek` before routing. The reference below is fallback detail
+for gaps that status does not expose yet.
 
 See [readiness-assessment.md](references/readiness-assessment.md) for complete scoring rubric, session state checks, soul health check, skill-specific requirements, and display format.
 
@@ -404,9 +407,9 @@ before persisting any future local state that clears an active offer.
 
 ## Step 9: Detect State and Assess Completeness
 
-Use `readiness`, `onboarding`, `drift.items`, and `ranked_actions` from
-`mb status --json --peek` first. If those sections are unavailable, use this
-fallback check.
+Use `readiness`, `onboarding`, `drift.items`, `money_path`, and `ranked_actions`
+from status first. Prefer `money_path.ranked_actions` for path gaps unless the
+top-level ranked action already incorporates it.
 
 Fallback: check `core/*.md`, then legacy `reference/core/*.md` only when
 `core/` is absent. No folder → `/mb-setup`. If two or more
@@ -428,10 +431,10 @@ to `/mb-think`.
 
 If the user stated intent, route directly using
 [references/router-and-language.md](references/router-and-language.md). If the
-session is open-ended, surface the top ranked action, the strongest update
-recommendation, or the compact route menu without reusing numbers from offers or
-recommendations. Use [references/triage-menu.md](references/triage-menu.md) only
-when the user wants prioritization or deep triage.
+session is open-ended, surface the top ranked action, update recommendation, top
+non-duplicated MoneyPath action, or compact route menu. Use
+[references/triage-menu.md](references/triage-menu.md) only for prioritization
+or deep triage.
 
 ---
 

--- a/.claude/skills/mb-start/references/launch-orchestration.md
+++ b/.claude/skills/mb-start/references/launch-orchestration.md
@@ -21,6 +21,12 @@ If status reports relationship-health gaps, legacy `campaigns/` drift, missing
 provider readiness, or update/repair blockers, surface those first and use the
 cited repair command.
 
+Also read `status.money_path` before launch routing. If MoneyPath reports
+missing customer progress, offer, proof, CTA path, channel strategy, active
+push, playbook, page readiness, or outcome feedback, use those facts as launch
+prerequisites. The CLI names legibility and connection gaps; offer judgment
+still belongs in offer sharpening and the downstream skills.
+
 ## Sequence
 
 1. **Resolve the offer.** Use the normal active-offer rules. If no offer exists,

--- a/.claude/skills/mb-start/references/readiness-assessment.md
+++ b/.claude/skills/mb-start/references/readiness-assessment.md
@@ -2,9 +2,14 @@
 
 Complete fallback reference for readiness assessment when `/mb-start` needs
 detail that `mb status --json --peek` does not expose. Use status `readiness`,
-`drift.items`, `onboarding`, `since_last_check`, and `ranked_actions` first.
-Only use the checks below for section-level detail or when status reports that
-a section is unavailable/degraded.
+`drift.items`, `onboarding`, `since_last_check`, `money_path`, and
+`ranked_actions` first. Only use the checks below for section-level detail or
+when status reports that a section is unavailable/degraded.
+
+Do not mix this fallback 0-3 file score with MoneyPath's 0-5 path scale.
+MoneyPath reports whether customer progress, offer, proof, CTA, channel, push,
+playbook, page readiness, and outcome feedback are legible, supported,
+connected, and instrumented.
 
 ---
 
@@ -578,7 +583,7 @@ Use these tables to determine the specific gap language for each file at each sc
 | 0 | File doesn't exist | "No offer.md. /mb-ads, /mb-site, and conversion outputs can't generate without knowing what you sell." | "What do you sell? What transformation does the buyer get? What does it cost?" |
 | 1 | <20 lines | "offer.md exists but is missing: [check for Pricing, Mechanism, Guarantee, Value Stack sections]." | "Your offer mentions [what exists] but I don't see [missing section]. What's your guarantee? What makes your mechanism unique?" |
 | 2 | 20-80 lines, developing | "offer.md is developing. [Specific weak area: e.g., 'Mechanism section is one sentence -- this is what makes conversion scripts compelling.']" | "Walk me through HOW your product/service actually works. What's the step-by-step transformation?" |
-| 3 | Strong | "offer.md is strong. Ready for /mb-ads, /mb-site, and conversion outputs." | No question. Note if Price section hasn't been updated in 60+ days. |
+| 3 | Strong | "offer.md has enough structure for `/mb-ads`, `/mb-site`, and conversion workflows to use as source context." | No question. Note if Price section hasn't been updated in 60+ days. |
 
 ### audience.md
 

--- a/.claude/skills/mb-start/references/router-and-language.md
+++ b/.claude/skills/mb-start/references/router-and-language.md
@@ -24,7 +24,7 @@ first.
    operation.
 3. Use status facts as evidence: `ranked_actions`, `update`, `readiness`,
    `onboarding`, `drift`, `integrations`, `github`, `brain`, `checkpoint`,
-   `since_last_check`, and `journal`.
+   `since_last_check`, `journal`, and `money_path`.
 4. Choose the smallest useful next workflow. Do not present the full route menu
    when a clear intent maps to one route.
 5. If two routes are plausible, ask one business question that separates them.

--- a/.claude/skills/mb-start/references/triage-menu.md
+++ b/.claude/skills/mb-start/references/triage-menu.md
@@ -40,8 +40,8 @@ write path, treat the banner as session-scoped.
 
 If user is ready to work, ask or infer intent. Use numbered options only when
 this is the single active choice list in the response. If ranked actions were
-already numbered or offers are also being shown, use a named route such as
-`triage` instead of reusing `1`.
+already numbered, MoneyPath recommendations were numbered, or offers are also
+being shown, use a named route such as `triage` instead of reusing `1`.
 
 ### Triage (User-Initiated)
 

--- a/.claude/skills/mb-status/SKILL.md
+++ b/.claude/skills/mb-status/SKILL.md
@@ -24,13 +24,18 @@ mb status --json --peek
 
 3. Treat the JSON as the source of truth for setup, update, drift, GitHub,
    onboarding, integrations, bets, journal activity, since-last-check,
-   readiness, vocabulary, and ranked actions.
+   readiness, vocabulary, money_path, and ranked actions.
 4. Summarize the top `ranked_actions` first. For each one, include:
    - title
    - command or slash command
    - reason
    - cited signal summaries
 5. Then summarize only the sections that matter for the operator's question.
+   Use `money_path` when the question is about the path from customer progress
+   to offer, proof, CTA, channel, push, playbook, page readiness, or outcome
+   feedback. Keep the language evidence-based: legible, supported, connected,
+   instrumented. Do not say the offer is good, bad, likely to convert, or ready
+   to win.
    If `vocabulary.terms.push` defines display words, use them in
    operator-facing prose without changing current paths, frontmatter, JSON
    keys, validator rules, or command names.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ### Added
 
+- Added MoneyPath readiness facts to `mb status --json --peek`, giving skills
+  and scripts a read-only, gated view of customer progress, offer, audience,
+  proof, product ladder, CTA, channel, push, playbook, page readiness, and
+  outcome feedback. Refs MAIN-343, #528.
 - Added a Mermaid-powered Main Branch system map with source-of-truth tables
   for architecture boundaries, provider rails, private data, validation, and
   runtime stance. Refs MAIN-339, #519.

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ The `mb` CLI is the deterministic control plane. The agent runs it for normal us
 |---|---|
 | `mb onboard`             | Human setup flow: create or connect a business folder, wire Claude Code skills, show next steps. |
 | `mb init`                | Quiet scriptable primitive underneath `mb onboard`. |
-| `mb status`              | Local-first daily briefing: ranked next actions, since-last-check changes, drift, repo health, runtime wiring, recent activity, GitHub tasks/proposals. `--json` and `--peek` for callers. |
+| `mb status`              | Local-first daily briefing: ranked next actions, MoneyPath readiness, since-last-check changes, drift, repo health, runtime wiring, recent activity, GitHub tasks/proposals. `--json` and `--peek` for callers. |
 | `mb doctor`              | Check environment, repo shape, frontmatter, settings. `mb doctor repair --plan` / `--apply` walks through guided reconciliation, including migration drift. |
 | `mb connect`             | Register provider credentials, test provider health, inspect repair-safe integration status without committing secrets. |
 | `mb site check`          | Local paid-traffic measurement readiness for a site folder: GTM install, dataLayer events, consent posture, Google Ads metadata, operator-review gates. |

--- a/decisions/2026-05-12-moneypath-status-readiness.md
+++ b/decisions/2026-05-12-moneypath-status-readiness.md
@@ -1,0 +1,146 @@
+---
+type: decision
+date: 2026-05-12
+status: accepted
+topic: MoneyPath status readiness model
+linked_issues:
+  - https://github.com/noontide-co/mainbranch/issues/528
+linked_decisions:
+  - decisions/2026-05-01-mb-cli-vs-agent-workflows-boundary.md
+  - decisions/2026-05-06-push-primitive-and-operator-vocabulary.md
+  - decisions/2026-05-11-connecting-notes-data-and-history.md
+  - decisions/2026-05-11-operator-facing-gitops-and-migration-planning.md
+linked_docs:
+  - docs/offer-sharpening.md
+  - docs/operator-loops.md
+  - docs/system-architecture.md
+tags: [v0-3, status, moneypath, offers, pushes, readiness]
+---
+
+# MoneyPath Status Readiness Model
+
+## Decision
+
+Main Branch adds **MoneyPath** as a read-only `mb status` readiness model over
+existing business primitives. It answers whether the repo has a connected path
+from customer progress to offer, proof, CTA, channel, push, playbook, outcome,
+and durable learning.
+
+MoneyPath is not a new business primitive and does not replace product ladder,
+offer files, pushes, playbooks, proof, decisions, or outcomes. It is an
+additive status view that helps skills and future dashboards read the path
+between those files.
+
+## Boundary
+
+The CLI reports legibility, support, connection, and instrumentation from
+observable repo facts. Skills and the operator own strategic judgment.
+
+Good CLI language:
+
+- "Offer is structured but has no linked proof or CTA path."
+- "Active push exists, but no outcome feedback link was found."
+
+Bad CLI language:
+
+- "This offer is good."
+- "This will convert."
+- "This launch is ready to win."
+
+## JSON Contract
+
+`mb status --json --peek` emits an additive top-level `money_path` object:
+
+```json
+{
+  "money_path": {
+    "schema_version": "1.0",
+    "overall_level": 2,
+    "overall_label": "structured",
+    "objects": {
+      "offer": {
+        "level": 2,
+        "label": "structured",
+        "status": "structured",
+        "summary": "Offer has several expected guardrail signals.",
+        "paths": ["core/offer.md"],
+        "missing": ["proof", "next_step"],
+        "evidence": [],
+        "references": ["docs/offer-sharpening.md"],
+        "recommended_route": "/mb-think",
+        "safe_to_share": true
+      }
+    },
+    "ranked_actions": []
+  }
+}
+```
+
+Every component uses the same object contract where possible: `level`, `label`,
+`status`, `summary`, `paths`, `missing`, `evidence`, `references`,
+`recommended_route`, and `safe_to_share`. Components may add specific nested
+facts, such as an offer `guardrails` block, when the CLI can support them
+deterministically.
+
+## Components
+
+V1 reads:
+
+- `offer` from `core/offer.md` and `core/offers/<slug>/offer.md`;
+- `audience` from `core/audience.md` and per-offer audience files;
+- `proof` from `core/proof/` and offer-specific proof folders;
+- `product_ladder` from `core/product-ladder.md`;
+- `cta_path` from next-step text, playbook resources, and conversion facts;
+- `channel_strategy` from content strategy and push channels;
+- `active_push` from `pushes/<slug>/push.md`;
+- `playbook` from `pushes/<push>/playbooks/*.md`;
+- `page_readiness` from declared `mb site check` readiness facts;
+- `outcome_feedback_loop` from typed outcome relationships.
+
+Product ladder is a component, not MoneyPath itself. In single-offer repos it
+is optional until offer relationships matter. In multi-offer repos it should
+explain entry, ascension, retention, cross-sell, upgrade, or offer-family
+logic.
+
+## Scoring
+
+MoneyPath uses the existing issue's 0-5 scale, but scores are gated rather than
+averaged:
+
+- `0 missing`: no file, section, relationship, or linked object exists.
+- `1 stated`: a claim or object exists as loose text.
+- `2 structured`: expected fields, sections, or frontmatter are present.
+- `3 evidence-backed`: proof, examples, research, testimonials, typicality,
+  decision records, or source-backed notes support the object.
+- `4 field-tested`: real-world signals, push outcomes, sales/customer language,
+  conversion notes, or reviewed run records are tied to the object.
+- `5 instrumented`: offer, proof, CTA/page, channel, push/playbook, metric or
+  measurement, and outcome feedback form a connected loop.
+
+A repo cannot reach a high overall level by averaging rich files with missing
+links. Missing offer caps the path at 0. Missing audience or unstructured
+offer/audience caps it at 1. Missing proof or CTA caps it at 2. Missing
+channel, push, or playbook caps it at 3. Missing outcome feedback caps it at 4.
+Level 5 requires declared measurement/readiness and outcome feedback.
+
+## Consequences
+
+- `/mb-start`, `/mb-status`, generated Claude Code guidance, and generated
+  Codex guidance should read `money_path` facts before falling back to ad hoc
+  file checks.
+- Top-level `ranked_actions` may incorporate the top MoneyPath recommendation,
+  but required updates, broken runtime wiring, validation debt, relationship
+  health, and playbook health stay higher priority.
+- Multiple live per-offer files with no active-offer status fact are an
+  ambiguity. Status should not silently choose one.
+- V1 declared readiness is enough. Main Branch reports what is connected and
+  instrumented; it does not infer market strength or conversion quality.
+
+## Non-Goals
+
+- No `mb money` command yet.
+- No provider mutation, publishing, spend decisions, customer contact, or
+  automated edits.
+- No universal funnel requirement.
+- No claim that every business should use the same channel, CTA, product
+  ladder, or proof style.

--- a/decisions/2026-05-12-moneypath-status-readiness.md
+++ b/decisions/2026-05-12-moneypath-status-readiness.md
@@ -110,9 +110,9 @@ averaged:
 - `0 missing`: no file, section, relationship, or linked object exists.
 - `1 stated`: a claim or object exists as loose text.
 - `2 structured`: expected fields, sections, or frontmatter are present.
-- `3 evidence-backed`: proof, examples, research, testimonials, typicality,
+- `3 evidence_backed`: proof, examples, research, testimonials, typicality,
   decision records, or source-backed notes support the object.
-- `4 field-tested`: real-world signals, push outcomes, sales/customer language,
+- `4 field_tested`: real-world signals, push outcomes, sales/customer language,
   conversion notes, or reviewed run records are tied to the object.
 - `5 instrumented`: offer, proof, CTA/page, channel, push/playbook, metric or
   measurement, and outcome feedback form a connected loop.

--- a/docs/architecture/system-map.md
+++ b/docs/architecture/system-map.md
@@ -240,8 +240,8 @@ Sources: [Data-source registry](../data-source-registry.md),
 
 | Loop | Main Branch surfaces | External rails and views |
 | --- | --- | --- |
-| Sense | `mb status`, `mb start`, `mb doctor`, `mb graph`, `mb connect status`, core files, data-source records, GitHub activity. | Provider APIs, scheduled sync, Obsidian, future dashboard. |
-| Decide | `/mb-start`, `/mb-think`, ranked actions, decisions, bets, GitHub issues. | Linear board, provider readiness signals, roadmap lanes. |
+| Sense | `mb status`, `mb start`, `mb doctor`, `mb graph`, `mb connect status`, core files, MoneyPath readiness, data-source records, GitHub activity. | Provider APIs, scheduled sync, Obsidian, future dashboard. |
+| Decide | `/mb-start`, `/mb-think`, ranked actions, MoneyPath blockers, decisions, bets, GitHub issues. | Linear board, provider readiness signals, roadmap lanes. |
 | Ship | `/mb-site`, `/mb-ads`, `/mb-organic`, `mb connect`, `mb update`, `mb issue open`, `mb checkpoint`, pushes, playbooks. | Cloudflare Pages/DNS, GitHub PRs/checks, provider dashboards, scheduling rails. |
 | Reflect | `/mb-end`, bet close/narrate, retros, CHANGELOG, release notes, checkpoint history. | GitHub Releases, PyPI verification, Linear releases, dashboard/history views. |
 

--- a/docs/json-output-contract.md
+++ b/docs/json-output-contract.md
@@ -51,6 +51,13 @@ status schema object, `mb doctor repair --json` keeps
 can keep a domain `status` such as `ready` while the envelope reports
 `result_status: "ok"`.
 
+`mb status --json` includes a `money_path` section for read-only business-path
+readiness. It reports gated component objects for customer progress, offer,
+audience, proof, product ladder, CTA path, channel strategy, active push,
+playbook, page readiness, and outcome feedback. These facts describe whether
+the path is legible, supported, connected, and instrumented; they do not infer
+conversion quality, market strength, or strategic correctness.
+
 ## First Migrated Surfaces
 
 The v1 envelope is present on:

--- a/docs/offer-sharpening.md
+++ b/docs/offer-sharpening.md
@@ -34,6 +34,12 @@ Every offer should answer these ten questions:
 
 If one of those is weak, sharpen the offer before scaling traffic or content.
 
+`mb status --json --peek` exposes these inputs through `money_path` as
+deterministic readiness facts. Treat that section as evidence about whether the
+offer path is legible, supported, connected, and instrumented. It does not
+replace strategic judgment about positioning, demand, copy quality, or market
+strength.
+
 ## Style Spectrum
 
 Use style to fit the operator and buyer. Do not use style to skip the rubric.

--- a/docs/operator-loops.md
+++ b/docs/operator-loops.md
@@ -38,7 +38,9 @@ chain:
 
 - **Sense:** `/mb-start`, `/mb-status`, or `mb status --json --peek` reads
   repo health, graph links, provider readiness, recent activity, update state,
-  and GitHub task/proposal signals.
+  GitHub task/proposal signals, and MoneyPath readiness for the path from
+  customer progress to offer, proof, CTA, channel, push, playbook, page, and
+  outcome feedback.
 - **Decide:** the agent and operator choose the next business move: a bet to
   frame, a piece of research to run, a decision to codify, a push to advance, a
   playbook to draft, or a repair to approve.
@@ -72,7 +74,8 @@ reference-file reads sit here.
 
 **Current surfaces**
 
-- `mb status` (with `--json` topology and "Business map" line)
+- `mb status` (with `--json` topology, "Business map" line, and MoneyPath
+  readiness)
 - `mb doctor` and `mb doctor repair --plan` (including migration drift and
   topology-drift previews)
 - `mb graph` (with `repo` nodes and hub/child relationship edges)
@@ -108,7 +111,7 @@ options. Discrete moments, not continuous activity.
 
 - `/mb-start`
 - `/mb-think`
-- `mb status` ranked actions
+- `mb status` ranked actions and MoneyPath blockers
 - GitHub issues and priorities
 - `mb issue draft` (frame friction or a feature gap clearly enough to commit
   to acting on it)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -28,6 +28,10 @@ Main Branch already ships:
 - graph, status, and topology primitives (including repo-topology facts in
   `mb status --json`, `mb graph --json`, and `mb doctor repair --plan --json`)
   for future dashboard and agent workflows;
+- MoneyPath readiness in `mb status --json --peek`, so daily status can show
+  whether customer progress, offer, proof, CTA, channel, push, playbook, page,
+  and outcome feedback are legible and connected without turning CLI output
+  into strategic judgment;
 - privacy-safe GitHub issue drafting and submission (`mb issue draft`,
   `mb issue open`) for user friction;
 - push, reusable playbook, and per-push run-record vocabulary for coordinated
@@ -75,7 +79,7 @@ The work clusters into a few durable buckets:
 - **Start and status.** `/mb-start`, `/mb-status`, and `mb status` should read
   the same facts: since-last-check changes, ranked next actions, drift,
   onboarding progress, update severity, provider readiness, GitHub
-  tasks/proposals, and recent business activity.
+  tasks/proposals, MoneyPath readiness, and recent business activity.
 - **Repair and migration.** `mb doctor`, `mb doctor repair`, `mb update`, and
   `mb migrate` should make stale installs, old repo layouts, broken skill
   wiring, ignored local state, and provider setup problems visible and

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -125,6 +125,18 @@ Standard filenames: `testimonials.md` for individual permissioned testimonials,
 `typicality.md` for average-case outcome context, and `angles/` for durable
 messaging angles.
 
+### MoneyPath Status
+
+MoneyPath is a read-only `mb status` view over existing primitives, not a new
+business file or replacement for offer truth. It checks whether customer
+progress, offer, audience, proof, product ladder, CTA, channel, active push,
+playbook, page readiness, and outcome feedback are legible and connected.
+
+The score is gated. A missing CTA path, ambiguous active offer, or missing
+outcome feedback caps the overall level even when other files are rich. The CLI
+reports deterministic readiness facts; skills and operators still own offer
+strategy, conversion quality, and market judgment.
+
 ### `research/`
 
 Point-in-time findings from when the operator went looking. Research can cite

--- a/mb/mb/_data/templates/AGENTS.md.tmpl
+++ b/mb/mb/_data/templates/AGENTS.md.tmpl
@@ -22,9 +22,10 @@ mb doctor repair --plan
 
 Use `mb status --json --peek` as the default daily briefing before routing the
 operator. It names readiness, drift, onboarding progress, update state, GitHub
-activity, provider signals, recent work, ranked actions, bets, pushes, and
-checkpoint state. Do not replace those facts with ad hoc shell inspection unless
-`mb` says a section is unavailable or the command itself is missing.
+activity, provider signals, recent work, MoneyPath, ranked actions, bets,
+pushes, and checkpoint state. Do not replace those facts with ad hoc shell
+inspection unless `mb` says a section is unavailable or the command itself is
+missing.
 
 Read-only commands can be run without asking first. Commands that write files,
 refresh local runtime wiring, update packages, migrate business files, create
@@ -53,8 +54,8 @@ command.
    ask for the business repo path instead of guessing.
 2. Use the status JSON as the source of truth for
    readiness, drift, onboarding, update severity, GitHub facts, provider
-   readiness, recent work, ranked actions, bets, pushes, vocabulary, and
-   checkpoint state.
+   readiness, recent work, MoneyPath, ranked actions, bets, pushes,
+   vocabulary, and checkpoint state.
 3. Run `mb start --json` when you need runtime handoff, repo-boundary, or
    adapter-readiness facts.
 4. Run `mb doctor repair --plan` before recommending setup or repair. Quote the
@@ -76,6 +77,10 @@ before acting.
 
 - If `ranked_actions` has entries, lead with the first action, its reason, and
   the cited signal summaries.
+- Use `money_path` when the next move depends on customer progress, offer,
+  proof, CTA, channel, push, playbook, page readiness, or outcome feedback.
+  Keep the language evidence-based: legible, supported, connected,
+  instrumented.
 - If readiness is blocked or drift has errors, handle repair before output
   work.
 - If onboarding is incomplete, use the `onboarding.summary` and checklist from

--- a/mb/mb/_data/templates/CLAUDE.md.tmpl
+++ b/mb/mb/_data/templates/CLAUDE.md.tmpl
@@ -21,9 +21,10 @@ mb doctor repair --plan
 
 Use `mb status --json --peek` as the default daily briefing before routing the
 operator. It names readiness, drift, onboarding progress, update state, GitHub
-activity, provider signals, recent work, ranked actions, bets, pushes, and
-checkpoint state. Do not replace those facts with ad hoc shell inspection unless
-`mb` says a section is unavailable or the command itself is missing.
+activity, provider signals, recent work, MoneyPath, ranked actions, bets,
+pushes, and checkpoint state. Do not replace those facts with ad hoc shell
+inspection unless `mb` says a section is unavailable or the command itself is
+missing.
 
 Read-only commands can be run without asking first. Commands that write files,
 refresh local runtime wiring, move personal skill shadows, update packages,
@@ -124,6 +125,12 @@ multi-offer repo, `core/offer.md` is the portfolio thesis and
 in `core/proof/`; offer-specific proof belongs in `core/offers/<slug>/proof/`.
 Use standard proof files such as `testimonials.md`, `typicality.md`, and
 `angles/` inside those proof folders.
+`mb status --json --peek` also emits `money_path`, a read-only map of whether
+customer progress, offer, proof, CTA, channel, push, playbook, page readiness,
+and outcome feedback are legible and connected. Use MoneyPath from
+`mb status --json --peek` for routing when the path needs to be legible,
+supported, connected, and instrumented, but do not claim the offer is good,
+bad, or likely to convert.
 A live idea can be both a bet and an offer candidate: open the bet first, then
 create or update the offer only when the operator wants durable sellable truth.
 

--- a/mb/mb/codex.py
+++ b/mb/mb/codex.py
@@ -46,9 +46,10 @@ mb doctor repair --plan
 
 Use `mb status --json --peek` as the default daily briefing before routing the
 operator. It names readiness, drift, onboarding progress, update state, GitHub
-activity, provider signals, recent work, ranked actions, bets, pushes, and
-checkpoint state. Do not replace those facts with ad hoc shell inspection unless
-`mb` says a section is unavailable or the command itself is missing.
+activity, provider signals, recent work, MoneyPath, ranked actions, bets,
+pushes, and checkpoint state. Do not replace those facts with ad hoc shell
+inspection unless `mb` says a section is unavailable or the command itself is
+missing.
 
 Read-only commands can be run without asking first. Commands that write files,
 refresh local runtime wiring, update packages, migrate business files, create
@@ -77,8 +78,8 @@ command.
    ask for the business repo path instead of guessing.
 2. Use the status JSON as the source of truth for
    readiness, drift, onboarding, update severity, GitHub facts, provider
-   readiness, recent work, ranked actions, bets, pushes, vocabulary, and
-   checkpoint state.
+   readiness, recent work, MoneyPath, ranked actions, bets, pushes,
+   vocabulary, and checkpoint state.
 3. Run `mb start --json` when you need runtime handoff, repo-boundary, or
    adapter-readiness facts.
 4. Run `mb doctor repair --plan` before recommending setup or repair. Quote the
@@ -100,6 +101,10 @@ before acting.
 
 - If `ranked_actions` has entries, lead with the first action, its reason, and
   the cited signal summaries.
+- Use `money_path` when the next move depends on customer progress, offer,
+  proof, CTA, channel, push, playbook, page readiness, or outcome feedback.
+  Keep the language evidence-based: legible, supported, connected,
+  instrumented.
 - If readiness is blocked or drift has errors, handle repair before output
   work.
 - If onboarding is incomplete, use the `onboarding.summary` and checklist from

--- a/mb/mb/init.py
+++ b/mb/mb/init.py
@@ -237,9 +237,10 @@ mb doctor repair --plan
 
 Use `mb status --json --peek` as the default daily briefing before routing the
 operator. It names readiness, drift, onboarding progress, update state, GitHub
-activity, provider signals, recent work, ranked actions, bets, pushes, and
-checkpoint state. Do not replace those facts with ad hoc shell inspection unless
-`mb` says a section is unavailable or the command itself is missing.
+activity, provider signals, recent work, MoneyPath, ranked actions, bets,
+pushes, and checkpoint state. Do not replace those facts with ad hoc shell
+inspection unless `mb` says a section is unavailable or the command itself is
+missing.
 
 Read-only commands can be run without asking first. Commands that write files,
 refresh local runtime wiring, move personal skill shadows, update packages,
@@ -340,6 +341,12 @@ multi-offer repo, `core/offer.md` is the portfolio thesis and
 in `core/proof/`; offer-specific proof belongs in `core/offers/<slug>/proof/`.
 Use standard proof files such as `testimonials.md`, `typicality.md`, and
 `angles/` inside those proof folders.
+`mb status --json --peek` also emits `money_path`, a read-only map of whether
+customer progress, offer, proof, CTA, channel, push, playbook, page readiness,
+and outcome feedback are legible and connected. Use MoneyPath from
+`mb status --json --peek` for routing when the path needs to be legible,
+supported, connected, and instrumented, but do not claim the offer is good,
+bad, or likely to convert.
 A live idea can be both a bet and an offer candidate: open the bet first, then
 create or update the offer only when the operator wants durable sellable truth.
 

--- a/mb/mb/ranker.py
+++ b/mb/mb/ranker.py
@@ -23,6 +23,7 @@ WEIGHTS: dict[str, int] = {
     "blocked_or_stale_tasks": 60,
     "playbook_health_gaps": 84,
     "relationship_health_gaps": 82,
+    "money_path_gaps": 72,
     "due_bets": 58,
     "stale_decisions": 50,
     "stale_research": 35,
@@ -54,6 +55,7 @@ def rank_status_report(
     _add_drift_actions(actions, report)
     _add_playbook_actions(actions, report)
     _add_relationship_actions(actions, report)
+    _add_money_path_actions(actions, report)
     _add_bet_actions(actions, report)
     _add_github_actions(actions, report)
     _add_since_last_check_action(actions, report)
@@ -427,6 +429,40 @@ def _add_playbook_actions(actions: list[dict[str, Any]], report: dict[str, Any])
                     safe_to_share=all(bool(item.get("safe_to_share", True)) for item in gaps),
                 )
             ],
+        )
+    )
+
+
+def _add_money_path_actions(actions: list[dict[str, Any]], report: dict[str, Any]) -> None:
+    money_path = _dict(report.get("money_path"))
+    money_actions = [_dict(item) for item in _list(money_path.get("ranked_actions"))]
+    if not money_actions:
+        return
+    first = money_actions[0]
+    score = WEIGHTS["money_path_gaps"]
+    component = str(first.get("component") or "money_path")
+    missing = [str(item) for item in _list(first.get("missing"))]
+    actions.append(
+        _action(
+            action_id=f"review_money_path_{component}",
+            title=str(first.get("title") or "Review MoneyPath gap"),
+            command=str(first.get("route") or "/mb-think"),
+            severity="info",
+            score=score,
+            confidence=str(first.get("confidence") or "medium"),
+            reason=str(first.get("reason") or "MoneyPath found a business-path gap."),
+            signals=[
+                _signal(
+                    f"money_path.objects.{component}",
+                    severity="info",
+                    summary=str(first.get("reason") or "MoneyPath component needs review."),
+                    evidence=missing,
+                    weight=score,
+                    safe_to_share=bool(first.get("safe_to_share", True)),
+                )
+            ],
+            audience="operator_decision",
+            operator_summary=str(first.get("reason") or "MoneyPath found a business-path gap."),
         )
     )
 

--- a/mb/mb/status.py
+++ b/mb/mb/status.py
@@ -54,6 +54,90 @@ PLAYBOOK_PROVIDER_BOUNDARIES_NEEDING_ATTENTION = {
     "external-manual",
     "manual-provider",
 }
+MONEY_PATH_SCHEMA_VERSION = "1.0"
+MONEY_PATH_LEVEL_LABELS = {
+    0: "missing",
+    1: "stated",
+    2: "structured",
+    3: "evidence-backed",
+    4: "field-tested",
+    5: "instrumented",
+}
+MONEY_PATH_COMPONENTS = (
+    "customer_progress",
+    "offer",
+    "audience",
+    "proof",
+    "product_ladder",
+    "cta_path",
+    "channel_strategy",
+    "active_push",
+    "playbook",
+    "page_readiness",
+    "outcome_feedback_loop",
+)
+OFFER_GUARDRAIL_KEYWORDS = {
+    "audience": ("audience", "who this is for", "who they are", "buyer", "customer"),
+    "transformation": ("transformation", "outcome", "before", "after", "result"),
+    "mechanism": ("mechanism", "method", "how it works", "process"),
+    "price_value": ("pricing", "price", "value", "$", "investment"),
+    "proof": ("proof", "testimonial", "case study", "typicality", "evidence"),
+    "risk_reversal": ("risk reversal", "guarantee", "refund", "trial", "pilot"),
+    "objections": ("objection", "concern", "blocker", "why not"),
+    "reason_to_act": ("urgency", "reason to act", "timing", "capacity", "deadline"),
+    "next_step": ("next step", "cta", "call", "apply", "buy", "checkout", "join", "book"),
+}
+AUDIENCE_SIGNAL_KEYWORDS = {
+    "customer_progress": ("progress", "job", "trying to", "desired outcome", "what they want"),
+    "buyer_language": ("what they say", "language", "phrases", "interviews", "reviews", "dms"),
+    "pain_or_gain": ("pain", "gain", "escaping", "status quo", "problem"),
+    "objections": ("objection", "concern", "trust", "time", "price", "fit"),
+}
+CUSTOMER_PROGRESS_KEYWORDS = {
+    "job_to_be_done": ("job", "trying to", "progress", "switching", "hire"),
+    "pain": ("pain", "problem", "stuck", "struggle", "escaping", "status quo"),
+    "gain": ("gain", "desired outcome", "result", "better", "wants"),
+    "language": ("what they say", "language", "phrases", "interviews", "reviews", "dms"),
+}
+CTA_KEYWORDS = (
+    "next step",
+    "cta",
+    "call to action",
+    "book",
+    "apply",
+    "buy",
+    "checkout",
+    "join",
+    "subscribe",
+    "download",
+    "waitlist",
+    "sign up",
+    "schedule",
+)
+PRODUCT_LADDER_KEYWORDS = (
+    "entry",
+    "first step",
+    "ascension",
+    "retention",
+    "cross-sell",
+    "upgrade",
+    "feeds from",
+    "feeds into",
+    "price",
+    "paid",
+)
+CHANNEL_KEYWORDS = (
+    "paid",
+    "organic",
+    "email",
+    "site",
+    "community",
+    "partner",
+    "outreach",
+    "content",
+    "ads",
+    "search",
+)
 
 
 def _utc_now() -> datetime:
@@ -472,6 +556,88 @@ def _read_frontmatter(path: Path) -> dict[str, Any]:
     except yaml.YAMLError:
         return {}
     return parsed if isinstance(parsed, dict) else {}
+
+
+def _read_markdown_text(path: Path, *, limit: int = 80_000) -> str:
+    try:
+        return path.read_text(encoding="utf-8")[:limit]
+    except OSError:
+        return ""
+
+
+def _relative_existing_paths(repo: Path, candidates: list[str]) -> list[str]:
+    return [rel for rel in candidates if (repo / rel).is_file()]
+
+
+def _money_path_label(level: int) -> str:
+    return MONEY_PATH_LEVEL_LABELS.get(level, "missing")
+
+
+def _money_path_evidence(
+    *,
+    kind: str,
+    path: str,
+    summary: str,
+    field: str = "",
+) -> dict[str, Any]:
+    return {
+        "kind": kind,
+        "path": path,
+        "field": field,
+        "summary": summary,
+    }
+
+
+def _money_path_object(
+    *,
+    level: int,
+    status: str,
+    summary: str,
+    paths: list[str],
+    missing: list[str],
+    evidence: list[dict[str, Any]] | None = None,
+    references: list[str] | None = None,
+    recommended_route: str = "/mb-think",
+    confidence: str = "high",
+) -> dict[str, Any]:
+    resolved_level = max(0, min(5, int(level)))
+    return {
+        "level": resolved_level,
+        "label": _money_path_label(resolved_level),
+        "status": status,
+        "summary": summary,
+        "paths": paths[:10],
+        "missing": missing[:10],
+        "evidence": (evidence or [])[:10],
+        "references": references or [],
+        "recommended_route": recommended_route,
+        "confidence": confidence,
+        "safe_to_share": True,
+    }
+
+
+def _keyword_hits(text: str, groups: dict[str, tuple[str, ...]]) -> list[str]:
+    lowered = text.lower()
+    return [
+        group
+        for group, keywords in groups.items()
+        if any(keyword in lowered for keyword in keywords)
+    ]
+
+
+def _contains_any(text: str, keywords: tuple[str, ...]) -> bool:
+    lowered = text.lower()
+    return any(keyword in lowered for keyword in keywords)
+
+
+def _frontmatter_status(repo: Path, rel_path: str) -> str:
+    return str(_read_frontmatter(repo / rel_path).get("status") or "").lower()
+
+
+def _is_stub_content(repo: Path, rel_path: str) -> bool:
+    status = _frontmatter_status(repo, rel_path)
+    text = _read_markdown_text(repo / rel_path).lower()
+    return status == "stub" or "public stub" in text or "[from state]" in text
 
 
 def _parse_date(value: Any, fallback_path: Path) -> date | None:
@@ -1034,6 +1200,879 @@ def _playbook_health(
                 "provider_boundary_attention": provider_boundary_attention[:5],
             },
         },
+        "safe_to_share": True,
+    }
+
+
+def _money_path_offer(repo: Path, *, proof_paths: list[str]) -> dict[str, Any]:
+    per_offer_paths = sorted(
+        path.relative_to(repo).as_posix()
+        for path in repo.glob("core/offers/*/offer.md")
+        if path.is_file()
+    )
+    paths = per_offer_paths + _relative_existing_paths(
+        repo,
+        ["core/offer.md", "reference/core/offer.md"],
+    )
+    if not paths:
+        return _money_path_object(
+            level=0,
+            status="missing",
+            summary="No offer file was found.",
+            paths=["core/offer.md"],
+            missing=["offer"],
+            references=["docs/offer-sharpening.md"],
+        )
+
+    texts = [_read_markdown_text(repo / path) for path in paths]
+    combined = "\n".join(texts)
+    guardrails = _keyword_hits(combined, OFFER_GUARDRAIL_KEYWORDS)
+    missing = [key for key in OFFER_GUARDRAIL_KEYWORDS if key not in guardrails]
+    stubs = [path for path in paths if _is_stub_content(repo, path)]
+    evidence = [
+        _money_path_evidence(
+            kind="file",
+            path=path,
+            field="offer",
+            summary="Offer file exists.",
+        )
+        for path in paths[:5]
+    ]
+    evidence.extend(
+        _money_path_evidence(
+            kind="section",
+            path=paths[0],
+            field=field,
+            summary=f"{field.replace('_', ' ')} signal appears in offer text.",
+        )
+        for field in guardrails[:5]
+    )
+    live_offer_paths = [
+        path for path in per_offer_paths if _frontmatter_status(repo, path) in LIVE_OFFER_STATUSES
+    ]
+
+    level = 1
+    status = "stated"
+    summary = "Offer exists as durable repo text."
+    if len(guardrails) >= 4 and not stubs:
+        level = 2
+        status = "structured"
+        summary = "Offer has several expected guardrail signals."
+    if proof_paths and level >= 2:
+        level = 3
+        status = "evidence_backed"
+        summary = "Offer is structured and proof files exist."
+    if stubs:
+        missing = sorted(set(missing + ["replace_stub_offer"]))
+        summary = "Offer file is still a public stub."
+    if len(live_offer_paths) > 1:
+        level = min(level, 1)
+        status = "ambiguous_multi_offer"
+        missing = sorted(set(missing + ["active_offer_selection"]))
+        summary = (
+            "Multiple live offer files exist and no active offer selection is "
+            "available in status facts."
+        )
+
+    item = _money_path_object(
+        level=level,
+        status=status,
+        summary=summary,
+        paths=paths,
+        missing=missing,
+        evidence=evidence,
+        references=["docs/offer-sharpening.md"],
+        recommended_route="/mb-think",
+    )
+    item["guardrails"] = {
+        "answered": guardrails,
+        "missing": missing,
+        "reference": "docs/offer-sharpening.md",
+    }
+    return item
+
+
+def _money_path_audience(repo: Path) -> dict[str, Any]:
+    paths = sorted(
+        path.relative_to(repo).as_posix()
+        for path in repo.glob("core/offers/*/audience.md")
+        if path.is_file()
+    )
+    paths.extend(_relative_existing_paths(repo, ["core/audience.md", "reference/core/audience.md"]))
+    if not paths:
+        return _money_path_object(
+            level=0,
+            status="missing",
+            summary="No audience file was found.",
+            paths=["core/audience.md"],
+            missing=["audience", "customer_progress", "buyer_language"],
+            references=["docs/offer-sharpening.md"],
+        )
+
+    combined = "\n".join(_read_markdown_text(repo / path) for path in paths)
+    hits = _keyword_hits(combined, AUDIENCE_SIGNAL_KEYWORDS)
+    missing = [key for key in AUDIENCE_SIGNAL_KEYWORDS if key not in hits]
+    stubs = [path for path in paths if _is_stub_content(repo, path)]
+    level = 1
+    status = "stated"
+    summary = "Audience exists as durable repo text."
+    if len(hits) >= 2 and not stubs:
+        level = 2
+        status = "structured"
+        summary = "Audience includes buyer language, progress, pain, or objection signals."
+    if "buyer_language" in hits and "objections" in hits and not stubs:
+        level = 3
+        status = "evidence_backed"
+        summary = "Audience includes source-language and objection signals."
+    if stubs:
+        missing = sorted(set(missing + ["replace_stub_audience"]))
+        summary = "Audience file is still a public stub."
+
+    return _money_path_object(
+        level=level,
+        status=status,
+        summary=summary,
+        paths=paths,
+        missing=missing,
+        evidence=[
+            _money_path_evidence(
+                kind="file", path=path, field="audience", summary="Audience file exists."
+            )
+            for path in paths[:5]
+        ]
+        + [
+            _money_path_evidence(
+                kind="section",
+                path=paths[0],
+                field=field,
+                summary=f"{field.replace('_', ' ')} signal appears in audience text.",
+            )
+            for field in hits[:5]
+        ],
+        references=["docs/offer-sharpening.md"],
+        recommended_route="/mb-think",
+        confidence="medium" if level >= 2 else "high",
+    )
+
+
+def _money_path_customer_progress(repo: Path) -> dict[str, Any]:
+    paths = _relative_existing_paths(repo, ["core/audience.md", "reference/core/audience.md"])
+    paths.extend(
+        sorted(
+            path.relative_to(repo).as_posix()
+            for path in repo.glob("core/offers/*/audience.md")
+            if path.is_file()
+        )
+    )
+    research_paths = [
+        path.relative_to(repo).as_posix()
+        for path in _relative_markdown_files(repo, "research")[:8]
+        if _contains_any(
+            _read_markdown_text(path), tuple(sum(CUSTOMER_PROGRESS_KEYWORDS.values(), ()))
+        )
+    ]
+    paths.extend(research_paths[:5])
+    if not paths:
+        return _money_path_object(
+            level=0,
+            status="missing",
+            summary="No customer-progress, job, pain, gain, or buyer-language source was found.",
+            paths=["core/audience.md", "research/"],
+            missing=["customer_progress", "buyer_language"],
+            references=["docs/offer-sharpening.md"],
+            recommended_route="/mb-think",
+        )
+
+    combined = "\n".join(
+        _read_markdown_text(repo / path) for path in paths if (repo / path).is_file()
+    )
+    hits = _keyword_hits(combined, CUSTOMER_PROGRESS_KEYWORDS)
+    missing = [key for key in CUSTOMER_PROGRESS_KEYWORDS if key not in hits]
+    stubs = [path for path in paths if (repo / path).is_file() and _is_stub_content(repo, path)]
+    level = 1
+    status = "stated"
+    summary = "Customer progress exists as loose audience or research text."
+    if len(hits) >= 2 and not stubs:
+        level = 2
+        status = "structured"
+        summary = "Customer progress includes job, pain, gain, or language signals."
+    if "language" in hits and ("job_to_be_done" in hits or "pain" in hits) and not stubs:
+        level = 3
+        status = "evidence_backed"
+        summary = "Customer progress includes buyer language tied to a job, pain, or gain."
+    if stubs:
+        missing = sorted(set(missing + ["replace_stub_customer_progress"]))
+        summary = "Customer-progress source is still a public audience stub."
+
+    return _money_path_object(
+        level=level,
+        status=status,
+        summary=summary,
+        paths=sorted(set(paths)),
+        missing=missing,
+        evidence=[
+            _money_path_evidence(
+                kind="text",
+                path=paths[0],
+                field=field,
+                summary=f"{field.replace('_', ' ')} signal appears in repo text.",
+            )
+            for field in hits[:5]
+        ],
+        references=["docs/offer-sharpening.md"],
+        recommended_route="/mb-think",
+        confidence="medium" if level >= 2 else "high",
+    )
+
+
+def _money_path_proof(repo: Path) -> tuple[dict[str, Any], list[str]]:
+    proof_files = [
+        path
+        for root in [repo / "core" / "proof", *repo.glob("core/offers/*/proof")]
+        if root.exists()
+        for path in sorted(root.rglob("*.md"))
+        if path.is_file()
+    ]
+    legacy_proof = [
+        path
+        for path in repo.glob("core/offers/*/*.md")
+        if path.name in {"testimonials.md", "typicality.md"}
+    ]
+    proof_files.extend(legacy_proof)
+    paths = sorted({path.relative_to(repo).as_posix() for path in proof_files})
+    if not paths:
+        return (
+            _money_path_object(
+                level=0,
+                status="missing",
+                summary="No reusable proof files were found.",
+                paths=["core/proof/"],
+                missing=["testimonials", "typicality", "proof_angles"],
+                references=["docs/offer-sharpening.md"],
+                recommended_route="/mb-think",
+            ),
+            [],
+        )
+
+    has_testimonials = any(path.endswith("testimonials.md") for path in paths)
+    has_typicality = any(path.endswith("typicality.md") for path in paths)
+    has_angles = any("/angles/" in path for path in paths)
+    missing = [
+        name
+        for name, present in {
+            "testimonials": has_testimonials,
+            "typicality": has_typicality,
+            "proof_angles": has_angles,
+        }.items()
+        if not present
+    ]
+    level = 1
+    status = "stated"
+    summary = "Proof files exist."
+    if has_testimonials or has_typicality:
+        level = 2
+        status = "structured"
+        summary = "Proof includes standard testimonial or typicality files."
+    if has_testimonials and has_typicality:
+        level = 3
+        status = "evidence_backed"
+        summary = "Proof includes both testimonials and typicality context."
+    return (
+        _money_path_object(
+            level=level,
+            status=status,
+            summary=summary,
+            paths=paths,
+            missing=missing,
+            evidence=[
+                _money_path_evidence(
+                    kind="file", path=path, field="proof", summary="Proof file exists."
+                )
+                for path in paths[:5]
+            ],
+            references=["docs/offer-sharpening.md"],
+            recommended_route="/mb-think",
+        ),
+        paths,
+    )
+
+
+def _money_path_product_ladder(repo: Path, *, multi_offer: bool) -> dict[str, Any]:
+    paths = _relative_existing_paths(
+        repo, ["core/product-ladder.md", "reference/core/product-ladder.md"]
+    )
+    if not paths and not multi_offer:
+        return _money_path_object(
+            level=1,
+            status="single_offer_mode",
+            summary=(
+                "Single-offer repo; product ladder is optional until offers need "
+                "relationship logic."
+            ),
+            paths=["core/product-ladder.md"],
+            missing=[],
+            evidence=[],
+            references=[".claude/reference/business-primitives/setup-patterns.md"],
+            recommended_route="/mb-think",
+        )
+    if not paths:
+        return _money_path_object(
+            level=0,
+            status="missing",
+            summary="Multiple offer files exist, but no product ladder explains how they relate.",
+            paths=["core/product-ladder.md"],
+            missing=["entry_step", "ascension_path", "retention_offer"],
+            references=[".claude/reference/business-primitives/setup-patterns.md"],
+            recommended_route="/mb-think",
+        )
+    text = "\n".join(_read_markdown_text(repo / path) for path in paths)
+    hits = [keyword for keyword in PRODUCT_LADDER_KEYWORDS if keyword in text.lower()]
+    level = 2 if len(hits) >= 3 else 1
+    return _money_path_object(
+        level=level,
+        status="structured" if level >= 2 else "stated",
+        summary="Product ladder explains offer relationships."
+        if level >= 2
+        else "Product ladder exists as loose text.",
+        paths=paths,
+        missing=[
+            item
+            for item in ("entry_step", "ascension_path", "retention_offer")
+            if item.replace("_", " ") not in " ".join(hits)
+        ],
+        evidence=[
+            _money_path_evidence(
+                kind="file",
+                path=paths[0],
+                field="product_ladder",
+                summary="Product ladder file exists.",
+            )
+        ],
+        references=[".claude/reference/business-primitives/setup-patterns.md"],
+        recommended_route="/mb-think",
+    )
+
+
+def _money_path_cta(
+    repo: Path,
+    *,
+    offer_paths: list[str],
+    playbooks: list[dict[str, Any]],
+    pushes: list[dict[str, Any]],
+    measurement: dict[str, Any],
+) -> dict[str, Any]:
+    paths: list[str] = []
+    evidence: list[dict[str, Any]] = []
+    text_only_paths: list[str] = []
+    for rel in offer_paths:
+        if _contains_any(_read_markdown_text(repo / rel), CTA_KEYWORDS):
+            paths.append(rel)
+            text_only_paths.append(rel)
+            evidence.append(
+                _money_path_evidence(
+                    kind="text",
+                    path=rel,
+                    field="cta",
+                    summary="CTA or next-step language appears in offer text.",
+                )
+            )
+    push_goal_paths = [
+        str(push.get("path") or "") for push in pushes if push.get("path") and push.get("goal")
+    ]
+    if push_goal_paths:
+        paths.extend(push_goal_paths[:5])
+        evidence.append(
+            _money_path_evidence(
+                kind="frontmatter",
+                path=push_goal_paths[0],
+                field="goal",
+                summary="Push goal can anchor the entry or conversion step.",
+            )
+        )
+    playbook_paths = [str(item.get("path") or "") for item in playbooks if item.get("path")]
+    if playbook_paths:
+        paths.extend(playbook_paths[:5])
+        evidence.append(
+            _money_path_evidence(
+                kind="frontmatter",
+                path=playbook_paths[0],
+                field="resource",
+                summary="A playbook resource or trigger can carry the next step.",
+            )
+        )
+    if measurement.get("available"):
+        source = str(
+            measurement.get("source_record")
+            or measurement.get("site_repo")
+            or ".mainbranch/conversion.json"
+        )
+        paths.append(source)
+        evidence.append(
+            _money_path_evidence(
+                kind="measurement",
+                path=source,
+                field="conversion",
+                summary=str(measurement.get("summary") or "Conversion plan found."),
+            )
+        )
+
+    if not paths:
+        return _money_path_object(
+            level=0,
+            status="missing",
+            summary="No CTA path, resource handoff, or conversion endpoint was found.",
+            paths=["core/offer.md"],
+            missing=["next_step", "conversion_endpoint"],
+            references=["docs/offer-sharpening.md"],
+            recommended_route="/mb-think",
+        )
+    level = 2 if measurement.get("available") or playbook_paths or push_goal_paths else 1
+    return _money_path_object(
+        level=level,
+        status="structured" if level >= 2 else "stated",
+        summary=(
+            "CTA path is connected to a playbook, push goal, or conversion plan."
+            if level >= 2
+            else "CTA language exists, but no connected page, push goal, or playbook was found."
+        ),
+        paths=sorted(set(paths)),
+        missing=[] if level >= 2 else ["conversion_endpoint"],
+        evidence=evidence,
+        references=["docs/offer-sharpening.md"],
+        recommended_route="/mb-site" if level >= 1 else "/mb-think",
+        confidence="high" if level >= 2 else ("medium" if text_only_paths else "high"),
+    )
+
+
+def _money_path_channel_strategy(repo: Path, *, pushes: list[dict[str, Any]]) -> dict[str, Any]:
+    paths = _relative_existing_paths(
+        repo, ["core/content-strategy.md", "reference/core/content-strategy.md"]
+    )
+    active_channels = sorted(
+        {
+            str(channel)
+            for push in pushes
+            if str(push.get("status") or "").lower()
+            in ACTIVE_PUSH_STATUSES | COMPLETED_PUSH_STATUSES
+            for channel in (push.get("channels") or [])
+            if isinstance(channel, str) and channel.strip()
+        }
+    )
+    evidence = [
+        _money_path_evidence(
+            kind="file",
+            path=path,
+            field="channel_strategy",
+            summary="Content strategy file exists.",
+        )
+        for path in paths
+    ]
+    if active_channels and pushes:
+        evidence.append(
+            _money_path_evidence(
+                kind="frontmatter",
+                path=str(pushes[0].get("path") or "pushes/"),
+                field="channels",
+                summary=f"Push channel(s) recorded: {', '.join(active_channels[:5])}.",
+            )
+        )
+    if not paths and not active_channels:
+        return _money_path_object(
+            level=0,
+            status="missing",
+            summary="No channel strategy or push channels were found.",
+            paths=["core/content-strategy.md"],
+            missing=["active_channel", "distribution_strategy"],
+            references=["docs/operator-loops.md"],
+            recommended_route="/mb-think",
+        )
+    level = 2 if active_channels else 1
+    return _money_path_object(
+        level=level,
+        status="structured" if level >= 2 else "stated",
+        summary="Channel strategy has active channel facts."
+        if active_channels
+        else "Channel strategy exists as durable text.",
+        paths=paths + [str(push.get("path")) for push in pushes[:5] if push.get("path")],
+        missing=[] if active_channels else ["active_channel"],
+        evidence=evidence,
+        references=["docs/operator-loops.md"],
+        recommended_route="/mb-think",
+    )
+
+
+def _money_path_active_push(pushes: list[dict[str, Any]]) -> dict[str, Any]:
+    active = [
+        push for push in pushes if str(push.get("status") or "").lower() in ACTIVE_PUSH_STATUSES
+    ]
+    if not active:
+        return _money_path_object(
+            level=0,
+            status="missing",
+            summary="No active or planned push is moving the money path forward.",
+            paths=["pushes/"],
+            missing=["active_push"],
+            references=["docs/system-architecture.md"],
+            recommended_route="/mb-start",
+        )
+    first = active[0]
+    required = ("goal", "audience", "offer", "promise", "channels")
+    missing = [key for key in required if not first.get(key)]
+    level = 2 if not missing else 1
+    return _money_path_object(
+        level=level,
+        status="structured" if level >= 2 else "stated",
+        summary="Active push has goal, audience, offer, promise, and channels."
+        if level >= 2
+        else "Active push exists but is missing route fields.",
+        paths=[str(push.get("path") or "") for push in active[:5] if push.get("path")],
+        missing=missing,
+        evidence=[
+            _money_path_evidence(
+                kind="frontmatter",
+                path=str(first.get("path") or "pushes/"),
+                field="status",
+                summary=f"Push status is {first.get('status')}.",
+            )
+        ],
+        references=["docs/system-architecture.md"],
+        recommended_route="/mb-start",
+    )
+
+
+def _money_path_playbook(
+    playbooks: list[dict[str, Any]], playbook_health: dict[str, Any]
+) -> dict[str, Any]:
+    if not playbooks:
+        return _money_path_object(
+            level=0,
+            status="missing",
+            summary="No push playbook run record was found.",
+            paths=["pushes/<push>/playbooks/"],
+            missing=["playbook_run"],
+            references=["docs/playbooks.md"],
+            recommended_route="/mb-start",
+        )
+    approved = [
+        item
+        for item in playbooks
+        if str((item.get("approval") or {}).get("status") or "").lower() == "approved"
+    ]
+    active_or_completed = [
+        item
+        for item in playbooks
+        if str(item.get("status") or "").lower() in {"active", "completed"}
+    ]
+    missing = []
+    if not approved:
+        missing.append("approval")
+    if not active_or_completed:
+        missing.append("active_or_completed_run")
+    level = 1
+    if active_or_completed:
+        level = 2
+    if approved and active_or_completed and not (playbook_health.get("gaps") or []):
+        level = 3
+    first = playbooks[0]
+    return _money_path_object(
+        level=level,
+        status="evidence_backed" if level >= 3 else ("structured" if level >= 2 else "stated"),
+        summary="Push playbook is approved, active/completed, and has no status health gaps."
+        if level >= 3
+        else "Push playbook exists but still needs approval, activation, or review.",
+        paths=[str(item.get("path") or "") for item in playbooks[:5] if item.get("path")],
+        missing=missing,
+        evidence=[
+            _money_path_evidence(
+                kind="frontmatter",
+                path=str(first.get("path") or ""),
+                field="provider_boundary",
+                summary=f"Provider boundary is {first.get('provider_boundary') or 'unspecified'}.",
+            )
+        ],
+        references=["docs/playbooks.md"],
+        recommended_route="/mb-start",
+    )
+
+
+def _money_path_page_readiness(measurement: dict[str, Any]) -> dict[str, Any]:
+    if not measurement.get("available"):
+        return _money_path_object(
+            level=0,
+            status="missing",
+            summary="No paid-traffic site conversion plan was found.",
+            paths=[".mainbranch/conversion.json"],
+            missing=["page_or_lander", "conversion_plan"],
+            references=["docs/google-ads-gtm-conversion-rubric.md"],
+            recommended_route="/mb-site",
+        )
+    state = str(measurement.get("state") or "missing")
+    state_levels = {
+        "missing": 0,
+        "blocked": 1,
+        "ready_for_preview": 2,
+        "ready_for_operator_review": 3,
+        "ready": 5,
+    }
+    level = state_levels.get(state, 1)
+    source = str(
+        measurement.get("source_record")
+        or measurement.get("site_repo")
+        or ".mainbranch/conversion.json"
+    )
+    return _money_path_object(
+        level=level,
+        status=state,
+        summary=str(measurement.get("summary") or f"Site measurement state is {state}."),
+        paths=[source],
+        missing=[] if level >= 2 else ["conversion_plan_ready"],
+        evidence=[
+            _money_path_evidence(
+                kind="measurement",
+                path=source,
+                field="state",
+                summary=f"Site readiness state is {state}.",
+            )
+        ],
+        references=["docs/google-ads-gtm-conversion-rubric.md"],
+        recommended_route="/mb-site",
+    )
+
+
+def _money_path_outcome_feedback(
+    relationship_health: dict[str, Any],
+    playbook_health: dict[str, Any],
+    playbooks: list[dict[str, Any]],
+) -> dict[str, Any]:
+    relationship_outcomes = (relationship_health.get("sections") or {}).get("outcomes") or {}
+    linked_count = int(relationship_outcomes.get("linked_count") or 0)
+    playbooks_with_outcomes = [item for item in playbooks if item.get("linked_outcomes")]
+    playbook_summary = playbook_health.get("summary") or {}
+    missing_count = int(playbook_summary.get("completed_playbooks_without_outcome") or 0) + int(
+        (relationship_health.get("summary") or {}).get("completed_pushes_without_outcome") or 0
+    )
+    if linked_count or playbooks_with_outcomes:
+        evidence = (
+            [
+                _money_path_evidence(
+                    kind="relationship",
+                    path="",
+                    field="linked_outcomes",
+                    summary=f"{linked_count} linked outcome relationship(s) found.",
+                )
+            ]
+            if linked_count
+            else []
+        )
+        if playbooks_with_outcomes:
+            evidence.append(
+                _money_path_evidence(
+                    kind="frontmatter",
+                    path=str(playbooks_with_outcomes[0].get("path") or ""),
+                    field="linked_outcomes",
+                    summary=f"{len(playbooks_with_outcomes)} playbook(s) link outcomes.",
+                )
+            )
+        return _money_path_object(
+            level=3,
+            status="evidence_backed",
+            summary=("Outcome links feed learning back into the repo."),
+            paths=[
+                str(item.get("path") or "")
+                for item in playbooks_with_outcomes[:5]
+                if item.get("path")
+            ],
+            missing=[] if not missing_count else ["some_completed_runs_missing_outcomes"],
+            evidence=evidence,
+            references=["docs/business-connections.md"],
+            recommended_route="/mb-end",
+        )
+    return _money_path_object(
+        level=0,
+        status="missing",
+        summary="No outcome feedback link was found.",
+        paths=["pushes/", "bets/", "log/"],
+        missing=["linked_outcomes", "review_or_outcome_note"],
+        evidence=[],
+        references=["docs/business-connections.md"],
+        recommended_route="/mb-end",
+    )
+
+
+def _money_path_ranked_actions(
+    objects: dict[str, dict[str, Any]], overall_level: int
+) -> list[dict[str, Any]]:
+    candidates = [
+        (
+            "define-customer-progress",
+            "Define the customer progress",
+            "customer_progress",
+            (
+                "The money path needs the buyer's job, pain, gain, or language before "
+                "offer routing can be trusted."
+            ),
+            "/mb-think",
+        ),
+        (
+            "clarify-offer",
+            "Clarify the offer",
+            "offer",
+            "The money path needs a legible offer before downstream routing can help.",
+            "/mb-think",
+        ),
+        (
+            "define-audience-progress",
+            "Define the buyer progress",
+            "audience",
+            "The money path needs a clear audience and customer-progress signal.",
+            "/mb-think",
+        ),
+        (
+            "attach-proof",
+            "Attach proof to the promise",
+            "proof",
+            "The path needs proof, typicality, or evidence before scaling traffic.",
+            "/mb-think",
+        ),
+        (
+            "define-cta-path",
+            "Define the CTA path",
+            "cta_path",
+            "Offer and audience facts need a next step or conversion endpoint.",
+            "/mb-think",
+        ),
+        (
+            "connect-channel-strategy",
+            "Connect an active channel",
+            "channel_strategy",
+            "The path needs a demand source or distribution channel.",
+            "/mb-think",
+        ),
+        (
+            "open-or-select-push",
+            "Open or select the active push",
+            "active_push",
+            "The path needs coordinated work moving it forward.",
+            "/mb-start",
+        ),
+        (
+            "record-playbook-run",
+            "Record the push playbook",
+            "playbook",
+            "The path needs a run record for approval, provider boundary, and outcome hooks.",
+            "/mb-start",
+        ),
+        (
+            "prepare-page-readiness",
+            "Prepare page readiness",
+            "page_readiness",
+            "Demand needs somewhere measurable to land before launch advice is useful.",
+            "/mb-site",
+        ),
+        (
+            "close-outcome-loop",
+            "Close the outcome feedback loop",
+            "outcome_feedback_loop",
+            "Completed or active work needs outcome evidence feeding back into durable memory.",
+            "/mb-end",
+        ),
+    ]
+    actions: list[dict[str, Any]] = []
+    for action_id, title, key, fallback_reason, route in candidates:
+        component = objects.get(key) or {}
+        level = int(component.get("level") or 0)
+        missing = component.get("missing") or []
+        if level >= 2 and not (key == "outcome_feedback_loop" and overall_level >= 4):
+            continue
+        actions.append(
+            {
+                "id": action_id,
+                "title": title,
+                "reason": str(component.get("summary") or fallback_reason),
+                "route": route,
+                "source": f"money_path.objects.{key}",
+                "component": key,
+                "confidence": "high" if level == 0 else "medium",
+                "effort_hint": "medium",
+                "missing": [str(item) for item in missing[:5]],
+                "safe_to_share": True,
+            }
+        )
+    return actions[:5]
+
+
+def _money_path_overall_level(objects: dict[str, dict[str, Any]]) -> int:
+    customer_progress = int((objects.get("customer_progress") or {}).get("level") or 0)
+    offer = int((objects.get("offer") or {}).get("level") or 0)
+    audience = int((objects.get("audience") or {}).get("level") or 0)
+    proof = int((objects.get("proof") or {}).get("level") or 0)
+    cta = int((objects.get("cta_path") or {}).get("level") or 0)
+    channel = int((objects.get("channel_strategy") or {}).get("level") or 0)
+    active_push = int((objects.get("active_push") or {}).get("level") or 0)
+    playbook = int((objects.get("playbook") or {}).get("level") or 0)
+    page = int((objects.get("page_readiness") or {}).get("level") or 0)
+    outcome = int((objects.get("outcome_feedback_loop") or {}).get("level") or 0)
+    if offer == 0:
+        return 0
+    if customer_progress == 0 or audience == 0 or offer < 2 or audience < 2:
+        return 1
+    if proof == 0 or cta == 0:
+        return 2
+    if min(channel, active_push, playbook) == 0:
+        return 3
+    if outcome == 0:
+        return 4
+    if page >= 5 and outcome >= 3 and min(proof, cta, channel, active_push, playbook) >= 2:
+        return 5
+    return 4
+
+
+def _money_path(repo: Path, report: dict[str, Any]) -> dict[str, Any]:
+    brain = report.get("brain") or {}
+    push_report = brain.get("pushes") or {}
+    pushes = [item for item in push_report.get("records", []) if isinstance(item, dict)]
+    playbook_health = report.get("playbook_health") or {}
+    relationship_health = report.get("relationship_health") or {}
+    measurement = report.get("measurement") or {}
+    proof, proof_paths = _money_path_proof(repo)
+    offer = _money_path_offer(repo, proof_paths=proof_paths)
+    offer_paths = [str(path) for path in offer.get("paths") or [] if (repo / str(path)).is_file()]
+    playbooks = _playbook_summaries(repo)
+    multi_offer = bool(list(repo.glob("core/offers/*/offer.md")))
+    objects = {
+        "customer_progress": _money_path_customer_progress(repo),
+        "offer": offer,
+        "audience": _money_path_audience(repo),
+        "proof": proof,
+        "product_ladder": _money_path_product_ladder(repo, multi_offer=multi_offer),
+        "cta_path": _money_path_cta(
+            repo,
+            offer_paths=offer_paths,
+            playbooks=playbooks,
+            pushes=pushes,
+            measurement=measurement,
+        ),
+        "channel_strategy": _money_path_channel_strategy(repo, pushes=pushes),
+        "active_push": _money_path_active_push(pushes),
+        "playbook": _money_path_playbook(playbooks, playbook_health),
+        "page_readiness": _money_path_page_readiness(measurement),
+        "outcome_feedback_loop": _money_path_outcome_feedback(
+            relationship_health,
+            playbook_health,
+            playbooks,
+        ),
+    }
+    overall_level = _money_path_overall_level(objects)
+    return {
+        "schema_version": MONEY_PATH_SCHEMA_VERSION,
+        "overall_level": overall_level,
+        "overall_label": _money_path_label(overall_level),
+        "summary": (
+            "MoneyPath reports legibility, support, connection, and instrumentation "
+            "from repo facts."
+        ),
+        "objects": objects,
+        "ranked_actions": _money_path_ranked_actions(objects, overall_level),
         "safe_to_share": True,
     }
 
@@ -2087,6 +3126,7 @@ def run(
         today=current_time.date(),
     )
     report["playbook_health"] = _playbook_health(repo_path, brain=brain)
+    report["money_path"] = _money_path(repo_path, report)
     report["since_last_check"] = _since_last_check(
         repo_path,
         marker=marker,

--- a/mb/mb/status.py
+++ b/mb/mb/status.py
@@ -59,8 +59,8 @@ MONEY_PATH_LEVEL_LABELS = {
     0: "missing",
     1: "stated",
     2: "structured",
-    3: "evidence-backed",
-    4: "field-tested",
+    3: "evidence_backed",
+    4: "field_tested",
     5: "instrumented",
 }
 MONEY_PATH_COMPONENTS = (
@@ -114,18 +114,11 @@ CTA_KEYWORDS = (
     "sign up",
     "schedule",
 )
-PRODUCT_LADDER_KEYWORDS = (
-    "entry",
-    "first step",
-    "ascension",
-    "retention",
-    "cross-sell",
-    "upgrade",
-    "feeds from",
-    "feeds into",
-    "price",
-    "paid",
-)
+PRODUCT_LADDER_REQUIREMENTS = {
+    "entry_step": ("entry", "first step", "front end", "lead magnet"),
+    "ascension_path": ("ascension", "cross-sell", "upgrade", "feeds from", "feeds into"),
+    "retention_offer": ("retention", "renewal", "continuity", "membership", "community"),
+}
 CHANNEL_KEYWORDS = (
     "paid",
     "organic",
@@ -1526,7 +1519,7 @@ def _money_path_product_ladder(repo: Path, *, multi_offer: bool) -> dict[str, An
             recommended_route="/mb-think",
         )
     text = "\n".join(_read_markdown_text(repo / path) for path in paths)
-    hits = [keyword for keyword in PRODUCT_LADDER_KEYWORDS if keyword in text.lower()]
+    hits = _keyword_hits(text, PRODUCT_LADDER_REQUIREMENTS)
     level = 2 if len(hits) >= 3 else 1
     return _money_path_object(
         level=level,
@@ -1536,9 +1529,7 @@ def _money_path_product_ladder(repo: Path, *, multi_offer: bool) -> dict[str, An
         else "Product ladder exists as loose text.",
         paths=paths,
         missing=[
-            item
-            for item in ("entry_step", "ascension_path", "retention_offer")
-            if item.replace("_", " ") not in " ".join(hits)
+            item for item in ("entry_step", "ascension_path", "retention_offer") if item not in hits
         ],
         evidence=[
             _money_path_evidence(
@@ -1982,7 +1973,10 @@ def _money_path_ranked_actions(
         component = objects.get(key) or {}
         level = int(component.get("level") or 0)
         missing = component.get("missing") or []
-        if level >= 2 and not (key == "outcome_feedback_loop" and overall_level >= 4):
+        if key == "outcome_feedback_loop":
+            if level != 0:
+                continue
+        elif level >= 2:
             continue
         actions.append(
             {
@@ -2039,7 +2033,7 @@ def _money_path(repo: Path, report: dict[str, Any]) -> dict[str, Any]:
     offer_paths = [str(path) for path in offer.get("paths") or [] if (repo / str(path)).is_file()]
     playbooks = _playbook_summaries(repo)
     multi_offer = bool(list(repo.glob("core/offers/*/offer.md")))
-    objects = {
+    collected_objects = {
         "customer_progress": _money_path_customer_progress(repo),
         "offer": offer,
         "audience": _money_path_audience(repo),
@@ -2062,6 +2056,7 @@ def _money_path(repo: Path, report: dict[str, Any]) -> dict[str, Any]:
             playbooks,
         ),
     }
+    objects = {component: collected_objects[component] for component in MONEY_PATH_COMPONENTS}
     overall_level = _money_path_overall_level(objects)
     return {
         "schema_version": MONEY_PATH_SCHEMA_VERSION,

--- a/mb/tests/fixtures/status/schema-v1-basic.json
+++ b/mb/tests/fixtures/status/schema-v1-basic.json
@@ -19,6 +19,7 @@
     "journal",
     "marker_update",
     "measurement",
+    "money_path",
     "ok",
     "onboarding",
     "playbook_health",
@@ -162,6 +163,15 @@
       "review_requests",
       "sections",
       "source",
+      "summary"
+    ],
+    "money_path": [
+      "objects",
+      "overall_label",
+      "overall_level",
+      "ranked_actions",
+      "safe_to_share",
+      "schema_version",
       "summary"
     ],
     "since_last_check": [

--- a/mb/tests/test_init.py
+++ b/mb/tests/test_init.py
@@ -23,9 +23,11 @@ def _assert_claude_md_cli_first_contract(text: str) -> None:
     assert "mb start --launch" in text
     assert "mb --version" in text
     assert "mb status --json --peek" in text
+    assert "MoneyPath" in text
     assert "mb start --json" in text
     assert "mb doctor repair --plan" in text
-    assert "Do not replace those facts with ad hoc shell inspection" in text
+    assert "Do not replace those facts with ad hoc shell" in text
+    assert "inspection unless `mb` says a section is unavailable" in text
     assert "Read-only commands can be run without asking first" in text
     assert "require explicit operator approval before applying" in text
     assert "mb skill repair --repo ." in text
@@ -50,6 +52,10 @@ def _assert_claude_md_primitive_routing_contract(text: str) -> None:
     assert "Reusable playbook: an engine recipe" in text
     assert "Push playbook: this push's approval" in text
     assert "Proof: evidence that a claim is true" in text
+    assert "Use MoneyPath from" in text
+    assert "`mb status --json --peek` for routing" in text
+    assert "legible," in text
+    assert "supported, connected, and instrumented" in text
     assert "single-offer repo, `core/offer.md` is the durable offer truth" in text
     assert "multi-offer repo, `core/offer.md` is the portfolio thesis" in text
     assert "`core/offers/<slug>/offer.md` holds per-offer truth" in text
@@ -77,6 +83,8 @@ def _assert_agents_md_codex_start_contract(text: str) -> None:
     assert "business-owner language" in text
     assert "bets, goals, offers, pushes" in text
     assert "`vocabulary` block from `mb status --json --peek`" in text
+    assert "MoneyPath" in text
+    assert "Use `money_path` when the next move depends on customer progress" in text
     assert "current paths, frontmatter, JSON keys" in text
     assert "If `ranked_actions` has entries" in text
     assert "Do not pretend" in text

--- a/mb/tests/test_ranker.py
+++ b/mb/tests/test_ranker.py
@@ -126,6 +126,39 @@ def test_ranker_surfaces_playbook_health() -> None:
     assert actions[0]["signals"][0]["evidence"] == ["pushes_without_playbook"]
 
 
+def test_ranker_surfaces_money_path_below_repair_blockers() -> None:
+    report = _base_report()
+    report["update"] = {
+        "severity": "required",
+        "command": "pipx upgrade mainbranch",
+        "reason": "Installed version is below the supported floor.",
+        "installed": "0.1.0",
+        "latest": "0.2.6",
+    }
+    report["money_path"] = {
+        "ranked_actions": [
+            {
+                "id": "define-cta-path",
+                "title": "Define the CTA path",
+                "reason": "Offer and audience facts need a next step.",
+                "route": "/mb-think",
+                "component": "cta_path",
+                "confidence": "high",
+                "missing": ["conversion_endpoint"],
+                "safe_to_share": True,
+            }
+        ]
+    }
+
+    actions = ranker.rank_status_report(report)
+
+    assert actions[0]["id"] == "mainbranch_update_required"
+    money_path = next(action for action in actions if action["id"] == "review_money_path_cta_path")
+    assert money_path["command"] == "/mb-think"
+    assert money_path["signals"][0]["id"] == "money_path.objects.cta_path"
+    assert money_path["score"] < actions[0]["score"]
+
+
 def test_ranker_action_carries_audience_and_operator_summary() -> None:
     action = ranker._action(
         action_id="any.id",

--- a/mb/tests/test_status.py
+++ b/mb/tests/test_status.py
@@ -93,6 +93,7 @@ def _write_push(
             "audience: founders\n"
             f"offer: {offer}\n"
             "promise: Ship a sanitized launch.\n"
+            "channels: [email]\n"
             "started: 2026-05-06\n"
             "review_on: 2026-05-20\n"
             "---\n\n"
@@ -144,6 +145,58 @@ def _write_playbook(
             "# Launch playbook\n"
         ),
         encoding="utf-8",
+    )
+
+
+def _write_money_path_core(repo: Path) -> None:
+    (repo / "core" / "offer.md").write_text(
+        (
+            "---\n"
+            "type: offer\n"
+            "status: active\n"
+            "---\n\n"
+            "# Offer\n\n"
+            "## Audience\n"
+            "Solo founders who keep losing launch context.\n\n"
+            "## Transformation\n"
+            "Scattered launch work becomes durable operating memory.\n\n"
+            "## Mechanism\n"
+            "A repo-backed workflow connects research, offer, proof, and pushes.\n\n"
+            "## Pricing\n"
+            "$500 setup sprint.\n\n"
+            "## Next step\n"
+            "Book a fit call for the setup sprint.\n"
+        ),
+        encoding="utf-8",
+    )
+    (repo / "core" / "audience.md").write_text(
+        (
+            "---\n"
+            "type: audience\n"
+            "status: active\n"
+            "---\n\n"
+            "# Audience\n\n"
+            "## Customer progress\n"
+            "They are trying to turn AI-assisted launch work into repeatable progress.\n\n"
+            "## Pain\n"
+            "They are stuck rebuilding context every session.\n\n"
+            "## What they say\n"
+            '"I know we learned something, but I cannot find where it went."\n\n'
+            "## Common objections\n"
+            "Time, trust, and switching cost.\n"
+        ),
+        encoding="utf-8",
+    )
+
+
+def _write_money_path_proof(repo: Path) -> None:
+    proof = repo / "core" / "proof"
+    proof.mkdir(parents=True, exist_ok=True)
+    (proof / "testimonials.md").write_text(
+        "# Testimonials\n\nA founder shipped faster.\n", encoding="utf-8"
+    )
+    (proof / "typicality.md").write_text(
+        "# Typicality\n\nMost users need setup help first.\n", encoding="utf-8"
     )
 
 
@@ -239,6 +292,7 @@ def test_status_schema_v1_matches_golden_fixture(tmp_path: Path, monkeypatch) ->
                 "integrations",
                 "measurement",
                 "github",
+                "money_path",
                 "since_last_check",
                 "drift",
                 "readiness",
@@ -256,6 +310,152 @@ def test_status_schema_v1_matches_golden_fixture(tmp_path: Path, monkeypatch) ->
     )
 
     assert actual == expected
+
+
+def test_status_money_path_default_repo_stays_low(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+
+    report = status_mod.run(path=str(repo), update_marker=False)
+
+    money_path = report["money_path"]
+    assert money_path["schema_version"] == "1.0"
+    assert money_path["overall_level"] <= 1
+    assert "customer_progress" in money_path["objects"]
+    assert money_path["ranked_actions"]
+
+
+def test_status_money_path_single_offer_structured_caps_without_proof(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+    _write_money_path_core(repo)
+
+    report = status_mod.run(path=str(repo), update_marker=False)
+
+    money_path = report["money_path"]
+    assert money_path["objects"]["offer"]["level"] == 2
+    assert money_path["objects"]["proof"]["level"] == 0
+    assert money_path["overall_level"] == 2
+    assert money_path["ranked_actions"][0]["component"] == "proof"
+
+
+def test_status_money_path_detects_multi_offer_product_ladder(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+    _write_money_path_core(repo)
+    offer = repo / "core" / "offers" / "community"
+    offer.mkdir(parents=True, exist_ok=True)
+    (offer / "offer.md").write_text(
+        (
+            "---\nslug: community\nstatus: running\n---\n\n"
+            "# Community\n\n"
+            "Audience, transformation, mechanism, pricing, next step.\n"
+        ),
+        encoding="utf-8",
+    )
+    (repo / "core" / "product-ladder.md").write_text(
+        (
+            "# Product ladder\n\n"
+            "Entry offer feeds into the paid community. Ascension moves into "
+            "retention and upgrade offers.\n"
+        ),
+        encoding="utf-8",
+    )
+
+    report = status_mod.run(path=str(repo), update_marker=False)
+
+    ladder = report["money_path"]["objects"]["product_ladder"]
+    assert ladder["level"] >= 2
+    assert ladder["paths"] == ["core/product-ladder.md"]
+
+
+def test_status_money_path_flags_ambiguous_live_multi_offer(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+    _write_money_path_core(repo)
+    for slug in ("community", "workshop"):
+        offer = repo / "core" / "offers" / slug
+        offer.mkdir(parents=True, exist_ok=True)
+        (offer / "offer.md").write_text(
+            (
+                f"---\nslug: {slug}\nstatus: running\n---\n\n"
+                f"# {slug}\n\nAudience, transformation, mechanism, pricing, next step.\n"
+            ),
+            encoding="utf-8",
+        )
+
+    report = status_mod.run(path=str(repo), update_marker=False)
+
+    offer = report["money_path"]["objects"]["offer"]
+    assert offer["status"] == "ambiguous_multi_offer"
+    assert "active_offer_selection" in offer["missing"]
+    assert report["money_path"]["overall_level"] <= 1
+
+
+def test_status_money_path_push_playbook_without_outcome_cannot_reach_instrumented(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+    _write_money_path_core(repo)
+    _write_money_path_proof(repo)
+    push = _write_push(repo, "2026-05-06-launch", offer="core/offer.md")
+    _write_playbook(push, status="active", approval_status="approved")
+
+    report = status_mod.run(path=str(repo), update_marker=False)
+
+    money_path = report["money_path"]
+    assert money_path["objects"]["playbook"]["level"] >= 2
+    assert money_path["objects"]["outcome_feedback_loop"]["level"] == 0
+    assert money_path["overall_level"] == 4
+
+
+def test_status_money_path_fully_connected_path_can_reach_instrumented(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+    _write_money_path_core(repo)
+    _write_money_path_proof(repo)
+    push = _write_push(repo, "2026-05-06-launch", offer="core/offer.md")
+    _write_playbook(
+        push,
+        status="active",
+        approval_status="approved",
+        linked_outcomes='["log/2026-05-20-launch-outcome.md"]',
+    )
+
+    def ready_measurement(_repo: Path) -> dict[str, Any]:
+        return {
+            "available": True,
+            "state": "ready",
+            "ok": True,
+            "summary": "Local readiness checks passed.",
+            "repair": "",
+            "repair_command": "mb site check",
+            "site_repo": "",
+            "business_repo": str(repo),
+            "facts": {"conversion_kind": "lead_form"},
+            "blocked_count": 0,
+            "manual_count": 0,
+            "safe_to_share": True,
+        }
+
+    monkeypatch.setattr(status_mod, "_measurement", ready_measurement)
+
+    report = status_mod.run(path=str(repo), update_marker=False)
+
+    assert report["money_path"]["objects"]["page_readiness"]["level"] == 5
+    assert report["money_path"]["objects"]["outcome_feedback_loop"]["level"] >= 3
+    assert report["money_path"]["overall_level"] == 5
 
 
 def test_status_vocabulary_falls_back_with_warnings_for_unknown_terms(

--- a/mb/tests/test_status.py
+++ b/mb/tests/test_status.py
@@ -372,6 +372,36 @@ def test_status_money_path_detects_multi_offer_product_ladder(tmp_path: Path, mo
     ladder = report["money_path"]["objects"]["product_ladder"]
     assert ladder["level"] >= 2
     assert ladder["paths"] == ["core/product-ladder.md"]
+    assert ladder["missing"] == []
+
+
+def test_status_money_path_product_ladder_names_missing_requirements(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+    _write_money_path_core(repo)
+    offer = repo / "core" / "offers" / "community"
+    offer.mkdir(parents=True, exist_ok=True)
+    (offer / "offer.md").write_text(
+        (
+            "---\nslug: community\nstatus: running\n---\n\n"
+            "# Community\n\n"
+            "Audience, transformation, mechanism, pricing, next step.\n"
+        ),
+        encoding="utf-8",
+    )
+    (repo / "core" / "product-ladder.md").write_text(
+        "# Product ladder\n\nEntry offer only.\n",
+        encoding="utf-8",
+    )
+
+    report = status_mod.run(path=str(repo), update_marker=False)
+
+    ladder = report["money_path"]["objects"]["product_ladder"]
+    assert ladder["level"] == 1
+    assert ladder["missing"] == ["ascension_path", "retention_offer"]
 
 
 def test_status_money_path_flags_ambiguous_live_multi_offer(tmp_path: Path, monkeypatch) -> None:
@@ -456,6 +486,9 @@ def test_status_money_path_fully_connected_path_can_reach_instrumented(
     assert report["money_path"]["objects"]["page_readiness"]["level"] == 5
     assert report["money_path"]["objects"]["outcome_feedback_loop"]["level"] >= 3
     assert report["money_path"]["overall_level"] == 5
+    assert all(
+        action["id"] != "close-outcome-loop" for action in report["money_path"]["ranked_actions"]
+    )
 
 
 def test_status_vocabulary_falls_back_with_warnings_for_unknown_terms(


### PR DESCRIPTION
## Summary

Adds read-only MoneyPath readiness facts to `mb status --json --peek`, with gated scoring and ranked actions for customer progress, offer, proof, CTA, channel, push, playbook, page readiness, and outcome feedback. Wires those facts through `/mb-start`, `/mb-status`, generated runtime guidance, docs, and an accepted decision so skills use deterministic evidence without making conversion-quality claims.

## Linked issue

Closes #528

## Why

Daily status could show repo health, tasks, and repair blockers, but it did not have a durable way to answer whether the business path from customer progress to outcome feedback was legible and connected. MoneyPath gives the CLI a deterministic readiness map while keeping strategic judgment in skills and operator decisions.

## Commits by concern

- `8f5a065 [add] MAIN-343 MoneyPath status readiness`
- `279e583 [update] MAIN-343 wire MoneyPath guidance`

- [ ] Each commit body bullet-lists the changes in that commit
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`

## Validation

Pre-push gate from repo root:

```bash
scripts/check.sh
```

Level 1 static: `scripts/check.sh` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: `80 files already formatted`; `All checks passed`; `Success: no issues found in 79 source files`; `577 passed`.

Level 2 CLI contract: `cd mb && pytest tests/test_status.py tests/test_ranker.py tests/test_init.py tests/test_skill_validate.py tests/test_runtime_command_references.py -q` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: `106 passed in 39.77s`.

Level 3 package/install smoke: `cd mb && python3 -m build`; `/tmp/mainbranch-moneypath-smoke/bin/pip install mb/dist/*.whl`; `/tmp/mainbranch-moneypath-smoke/bin/mb --version`; `/tmp/mainbranch-moneypath-smoke/bin/mb skill list`; `/tmp/mainbranch-moneypath-smoke/bin/mb skill validate mb-start`; `/tmp/mainbranch-moneypath-smoke/bin/mb skill validate mb-status` — runtime: `/tmp/mainbranch-moneypath-smoke/bin/python3.13` — exit: 0 — log: `Successfully built mainbranch-0.3.18.tar.gz and mainbranch-0.3.18-py3-none-any.whl`; `mb 0.3.18`; `ok mb-start (498 lines)`; `ok mb-status (77 lines)`.

Level 4 fixture repo: `/tmp/mainbranch-moneypath-smoke/bin/mb onboard --yes --name "Installed MoneyPath" --path "$repo" --json`; `/tmp/mainbranch-moneypath-smoke/bin/mb status "$repo" --json --peek`; `/tmp/mainbranch-moneypath-smoke/bin/mb start --repo "$repo" --json`; `/tmp/mainbranch-moneypath-smoke/bin/mb validate "$repo"` — runtime: `/tmp/mainbranch-moneypath-smoke/bin/python3.13` — exit: 0 — log: `status_ok=True`; `status_money_path=missing:0`; `status_first_money_path_action=define-customer-progress`; `start_ok=True`; `validate_marker_exists=False`.

Level 5 runtime smoke: not run — interactive Claude Code was not launched from this workspace; closest verified fallback is installed-package skill validation plus fresh-repo `mb status --json --peek` / `mb start --json` smoke.

- [x] Level 1 static: `scripts/check.sh` passes
- [x] Level 2 CLI contract: focused Typer/CliRunner tests, exit codes, `--json` behavior, TTY vs non-TTY (if CLI behavior touched)
- [x] Level 3 package/install smoke (if packaging touched)
- [x] Level 4 fixture repo (if init/onboard/status/start/update touched)
- [ ] Level 5 runtime smoke / dogfood harness / simulation-tier (if runtime, first-run, skill discovery, or release validation touched)
- [x] SKILL.md ≤500 lines (if any skill touched)
- [ ] Package-visible release gate evidence before tag/publish (if preparing a release)
- [ ] Supply-chain review (if `.github/workflows/`, `.github/dependabot.yml`, `mb/pyproject.toml` deps, or `id-token`/`permissions` blocks touched — see [docs/supply-chain-policy.md](../docs/supply-chain-policy.md))

## Success metric

`mb status --json --peek` emits a `money_path` object with gated overall readiness, uniform component objects, and ranked actions that can surface MoneyPath gaps without outranking hard repair/update blockers.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [ ] N/A — change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [x] No
- [ ] Yes — migration note below

## Public / private boundary

Only public-safe CLI behavior, tests, docs, decisions, and bundled runtime guidance were committed. Local research notes, Conductor attachments, and cold-start scratch stayed in `.context/`; no private operator strategy, machine-specific paths, secrets, customer data, or provider credentials were committed.
