### PR TITLE
[add] Refine MoneyPath proof quality facts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ### Added
 
+- Added deterministic MoneyPath offer guardrail detail and proof-quality facts
+  under `money_path.objects.offer` and `money_path.objects.proof`, including
+  generic vs. specific testimonials, offer-linked proof, typicality signals,
+  and proof boundary warnings. Refs MAIN-341, #523.
 - Added MoneyPath readiness facts to `mb status --json --peek`, giving skills
   and scripts a read-only, gated view of customer progress, offer, audience,
   proof, product ladder, CTA, channel, push, playbook, page readiness, and

--- a/mb/mb/status.py
+++ b/mb/mb/status.py
@@ -1848,15 +1848,17 @@ def _money_path_proof(
         level = 4
         status = "field_tested"
         summary = "Proof includes multiple specific, source or outcome-backed entries."
+    has_active_path = bool(instrumentation["active_push"]) or bool(instrumentation["playbook"])
     if (
         level >= 3
         and int(testimonial_quality["linked_to_offer"]) > 0
         and bool(typicality_quality["exists"])
-        and any(bool(value) for value in instrumentation.values())
+        and has_active_path
+        and bool(instrumentation["outcome_feedback"])
     ):
         level = 5
         status = "instrumented"
-        summary = "Proof is linked to an offer and connected to active path instrumentation."
+        summary = "Proof is linked to an offer and connected to outcome feedback."
     return (
         _money_path_object(
             level=level,
@@ -2364,6 +2366,43 @@ def _money_path_ranked_actions(
         if key == "outcome_feedback_loop":
             if level != 0:
                 continue
+        elif key == "proof" and level >= 2:
+            quality = component.get("quality") or {}
+            testimonial_quality = quality.get("testimonials") or {}
+            typicality_quality = quality.get("typicality") or {}
+            claim_links = quality.get("claim_links") or {}
+            instrumentation = quality.get("instrumentation") or {}
+            proof_quality_gaps: list[str] = []
+            if int(testimonial_quality.get("generic") or 0) > 0:
+                proof_quality_gaps.append("specific_testimonials")
+            if int(testimonial_quality.get("linked_to_offer") or 0) == 0:
+                proof_quality_gaps.append("offer_linked_proof")
+            if not bool(typicality_quality.get("exists")):
+                proof_quality_gaps.append("typicality")
+            if claim_links.get("unsupported_offer_claims"):
+                proof_quality_gaps.append("supported_offer_claims")
+            if not bool(instrumentation.get("outcome_feedback")):
+                proof_quality_gaps.append("outcome_feedback")
+            if not proof_quality_gaps:
+                continue
+            actions.append(
+                {
+                    "id": "strengthen-proof-quality",
+                    "title": "Strengthen proof quality",
+                    "reason": (
+                        "Proof exists, but testimonials are generic or not linked to an "
+                        "offer, outcome, typicality, or claim."
+                    ),
+                    "route": "/mb-think",
+                    "source": "money_path.objects.proof.quality",
+                    "component": "proof",
+                    "confidence": "medium",
+                    "effort_hint": "medium",
+                    "missing": proof_quality_gaps[:5],
+                    "safe_to_share": True,
+                }
+            )
+            continue
         elif level >= 2:
             continue
         actions.append(

--- a/mb/mb/status.py
+++ b/mb/mb/status.py
@@ -131,6 +131,93 @@ CHANNEL_KEYWORDS = (
     "ads",
     "search",
 )
+PROOF_BEFORE_KEYWORDS = (
+    "before",
+    "previously",
+    "used to",
+    "started with",
+    "came in",
+    "stuck",
+)
+PROOF_OUTCOME_KEYWORDS = (
+    "after",
+    "outcome",
+    "result",
+    "shipped",
+    "booked",
+    "won",
+    "increased",
+    "reduced",
+    "saved",
+)
+PROOF_TIMEFRAME_KEYWORDS = (
+    "time to outcome",
+    "within",
+    "deadline",
+    "review period",
+)
+PROOF_METRIC_KEYWORDS = (
+    "%",
+    "$",
+    "revenue",
+    "calls",
+    "signups",
+    "leads",
+    "conversion",
+    "sales",
+    "hours",
+)
+PROOF_MECHANISM_KEYWORDS = (
+    "mechanism",
+    "method",
+    "process",
+    "because",
+    "using",
+    "through",
+    "workflow",
+)
+PROOF_OBJECTION_KEYWORDS = (
+    "objection",
+    "concern",
+    "skeptical",
+    "worried",
+    "hesitated",
+    "trust",
+    "time",
+    "price",
+)
+PROOF_PERMISSION_KEYWORDS = (
+    "permissioned",
+    "approved for public",
+    "public: true",
+    "safe to share",
+)
+PROOF_AVERAGE_CASE_KEYWORDS = (
+    "average",
+    "median",
+    "typical",
+    "most users",
+    "usual",
+    "common case",
+)
+PROOF_CAVEAT_KEYWORDS = ("caveat", "constraint", "not guaranteed", "depends", "varies")
+PROOF_FAILURE_CONTEXT_KEYWORDS = (
+    "failure",
+    "fails",
+    "does not work",
+    "doesn't work",
+    "when this breaks",
+    "poor fit",
+)
+PROOF_SOURCE_KEYWORDS = (
+    "source",
+    "customer language",
+    "sales call",
+    "interview",
+    "conversion",
+    "outcome log",
+    "recorded",
+)
 
 
 def _utc_now() -> datetime:
@@ -621,6 +708,170 @@ def _keyword_hits(text: str, groups: dict[str, tuple[str, ...]]) -> list[str]:
 def _contains_any(text: str, keywords: tuple[str, ...]) -> bool:
     lowered = text.lower()
     return any(keyword in lowered for keyword in keywords)
+
+
+def _markdown_body_without_frontmatter(text: str) -> str:
+    lines = text.splitlines()
+    if lines and lines[0].strip() == "---":
+        for index, line in enumerate(lines[1:], start=1):
+            if line.strip() == "---":
+                return "\n".join(lines[index + 1 :]).strip()
+    return text.strip()
+
+
+def _offer_slug_from_path(path: str) -> str:
+    match = re.match(r"core/offers/([^/]+)/offer\.md$", path)
+    return match.group(1) if match else ""
+
+
+def _proof_linked_offer_refs(repo: Path, proof_path: str) -> set[str]:
+    meta = _read_frontmatter(repo / proof_path)
+    refs = set(_coerce_string_list(meta.get("offer")))
+    refs.update(_coerce_string_list(meta.get("linked_offers")))
+    match = re.match(r"core/offers/([^/]+)/proof/", proof_path)
+    if match:
+        refs.add(f"core/offers/{match.group(1)}/offer.md")
+    return {ref for ref in refs if ref}
+
+
+def _testimonial_entries(text: str, meta: dict[str, Any]) -> list[str]:
+    entries: list[str] = []
+    frontmatter_entries = meta.get("testimonials")
+    if isinstance(frontmatter_entries, list):
+        for item in frontmatter_entries:
+            if isinstance(item, dict):
+                entries.append(json.dumps(item, sort_keys=True))
+            elif isinstance(item, str) and item.strip():
+                entries.append(item.strip())
+    body = _markdown_body_without_frontmatter(text)
+    sections = [
+        section.strip()
+        for section in re.split(r"(?m)^#{2,6}\s+", body)
+        if section.strip() and len(section.strip()) >= 20
+    ]
+    if len(sections) > 1:
+        entries.extend(sections)
+    else:
+        list_entries = [
+            line.strip(" >-*")
+            for line in body.splitlines()
+            if re.match(r"^\s*(?:[-*]\s+|>\s*)", line) and len(line.strip(" >-*")) >= 20
+        ]
+        if list_entries:
+            entries.extend(list_entries)
+        else:
+            cleaned = "\n".join(
+                line for line in body.splitlines() if not line.strip().startswith("#")
+            ).strip()
+            if len(cleaned) >= 20:
+                entries.append(cleaned)
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for entry in entries:
+        key = entry.strip()
+        if key and key not in seen:
+            deduped.append(key)
+            seen.add(key)
+    return deduped
+
+
+def _proof_text_has_timeframe(text: str) -> bool:
+    lowered = text.lower()
+    return bool(re.search(r"\b\d+\s+(?:day|days|week|weeks|month|months)\b", lowered)) or any(
+        keyword in lowered for keyword in PROOF_TIMEFRAME_KEYWORDS
+    )
+
+
+def _proof_text_has_metric(text: str) -> bool:
+    lowered = text.lower()
+    return bool(
+        re.search(r"(?:\d+%|\$\d+|\b\d+\s+(?:calls|signups|leads|sales|hours)\b)", lowered)
+    ) or any(keyword in lowered for keyword in PROOF_METRIC_KEYWORDS)
+
+
+def _testimonial_signal_counts(
+    entries: list[str],
+    *,
+    linked_offer_refs: set[str],
+    offer_paths: list[str],
+) -> dict[str, int]:
+    counts = {
+        "total": len(entries),
+        "generic": 0,
+        "specific": 0,
+        "permissioned_public": 0,
+        "linked_to_offer": 0,
+        "with_before_state": 0,
+        "with_outcome": 0,
+        "with_timeframe": 0,
+        "with_metric": 0,
+        "with_mechanism": 0,
+        "with_objection": 0,
+    }
+    offer_refs = set(offer_paths)
+    offer_refs.update(_offer_slug_from_path(path) for path in offer_paths)
+    offer_refs.discard("")
+    has_path_offer_link = bool(linked_offer_refs & set(offer_paths))
+    for entry in entries:
+        lowered = entry.lower()
+        has_before = _contains_any(lowered, PROOF_BEFORE_KEYWORDS)
+        has_outcome = _contains_any(lowered, PROOF_OUTCOME_KEYWORDS)
+        has_timeframe = _proof_text_has_timeframe(lowered)
+        has_metric = _proof_text_has_metric(lowered)
+        has_mechanism = _contains_any(lowered, PROOF_MECHANISM_KEYWORDS)
+        has_objection = _contains_any(lowered, PROOF_OBJECTION_KEYWORDS)
+        has_permission = _contains_any(lowered, PROOF_PERMISSION_KEYWORDS)
+        has_offer_link = has_path_offer_link or any(ref.lower() in lowered for ref in offer_refs)
+        signals = [
+            has_before,
+            has_outcome,
+            has_timeframe,
+            has_metric,
+            has_mechanism,
+            has_objection,
+        ]
+        counts["with_before_state"] += int(has_before)
+        counts["with_outcome"] += int(has_outcome)
+        counts["with_timeframe"] += int(has_timeframe)
+        counts["with_metric"] += int(has_metric)
+        counts["with_mechanism"] += int(has_mechanism)
+        counts["with_objection"] += int(has_objection)
+        counts["permissioned_public"] += int(has_permission)
+        counts["linked_to_offer"] += int(has_offer_link)
+        if any(signals):
+            counts["specific"] += 1
+        else:
+            counts["generic"] += 1
+    return counts
+
+
+def _empty_proof_quality() -> dict[str, Any]:
+    return {
+        "testimonials": {
+            "total": 0,
+            "generic": 0,
+            "specific": 0,
+            "permissioned_public": 0,
+            "linked_to_offer": 0,
+            "with_before_state": 0,
+            "with_outcome": 0,
+            "with_timeframe": 0,
+            "with_metric": 0,
+            "with_mechanism": 0,
+            "with_objection": 0,
+        },
+        "typicality": {
+            "exists": False,
+            "has_average_case": False,
+            "has_caveats": False,
+            "has_common_failure_context": False,
+            "has_time_to_outcome": False,
+        },
+        "claim_links": {
+            "linked_offers": [],
+            "unsupported_offer_claims": [],
+        },
+    }
 
 
 def _frontmatter_status(repo: Path, rel_path: str) -> str:
@@ -1197,7 +1448,12 @@ def _playbook_health(
     }
 
 
-def _money_path_offer(repo: Path, *, proof_paths: list[str]) -> dict[str, Any]:
+def _money_path_offer(
+    repo: Path,
+    *,
+    proof_paths: list[str],
+    proof_quality: dict[str, Any],
+) -> dict[str, Any]:
     per_offer_paths = sorted(
         path.relative_to(repo).as_posix()
         for path in repo.glob("core/offers/*/offer.md")
@@ -1217,10 +1473,19 @@ def _money_path_offer(repo: Path, *, proof_paths: list[str]) -> dict[str, Any]:
             references=["docs/offer-sharpening.md"],
         )
 
-    texts = [_read_markdown_text(repo / path) for path in paths]
+    texts_by_path = {path: _read_markdown_text(repo / path) for path in paths}
+    texts = list(texts_by_path.values())
     combined = "\n".join(texts)
     guardrails = _keyword_hits(combined, OFFER_GUARDRAIL_KEYWORDS)
     missing = [key for key in OFFER_GUARDRAIL_KEYWORDS if key not in guardrails]
+    guardrail_checks: dict[str, dict[str, Any]] = {}
+    for field, keywords in OFFER_GUARDRAIL_KEYWORDS.items():
+        hit_paths = [path for path, text in texts_by_path.items() if _contains_any(text, keywords)]
+        guardrail_checks[field] = {
+            "present": bool(hit_paths),
+            "paths": hit_paths[:5],
+            "keywords": [keyword for keyword in keywords if keyword in combined.lower()][:5],
+        }
     stubs = [path for path in paths if _is_stub_content(repo, path)]
     evidence = [
         _money_path_evidence(
@@ -1243,6 +1508,15 @@ def _money_path_offer(repo: Path, *, proof_paths: list[str]) -> dict[str, Any]:
     live_offer_paths = [
         path for path in per_offer_paths if _frontmatter_status(repo, path) in LIVE_OFFER_STATUSES
     ]
+    testimonial_quality = proof_quality.get("testimonials") or {}
+    claim_links = proof_quality.get("claim_links") or {}
+    proof_boundary_warnings: list[str] = []
+    if "proof" in guardrails and not proof_paths:
+        proof_boundary_warnings.append("proof_claim_without_proof_file")
+    if proof_paths and int(testimonial_quality.get("permissioned_public") or 0) == 0:
+        proof_boundary_warnings.append("proof_files_without_permissioned_public_signal")
+    if claim_links.get("unsupported_offer_claims"):
+        proof_boundary_warnings.append("offer_claims_without_offer_linked_proof")
 
     level = 1
     status = "stated"
@@ -1280,6 +1554,8 @@ def _money_path_offer(repo: Path, *, proof_paths: list[str]) -> dict[str, Any]:
     item["guardrails"] = {
         "answered": guardrails,
         "missing": missing,
+        "checks": guardrail_checks,
+        "proof_boundary_warnings": proof_boundary_warnings,
         "reference": "docs/offer-sharpening.md",
     }
     return item
@@ -1418,7 +1694,84 @@ def _money_path_customer_progress(repo: Path) -> dict[str, Any]:
     )
 
 
-def _money_path_proof(repo: Path) -> tuple[dict[str, Any], list[str]]:
+def _proof_quality(
+    repo: Path,
+    *,
+    paths: list[str],
+    offer_paths: list[str],
+    pushes: list[dict[str, Any]],
+    playbooks: list[dict[str, Any]],
+    measurement: dict[str, Any],
+    relationship_health: dict[str, Any],
+) -> dict[str, Any]:
+    quality = _empty_proof_quality()
+    testimonial_counts = quality["testimonials"]
+    linked_offers: set[str] = set()
+    any_structured_entry = False
+    proof_texts: list[str] = []
+    for path in paths:
+        text = _read_markdown_text(repo / path)
+        proof_texts.append(text)
+        linked_refs = _proof_linked_offer_refs(repo, path)
+        linked_offers.update(linked_refs)
+        if path.endswith("testimonials.md"):
+            meta = _read_frontmatter(repo / path)
+            entries = _testimonial_entries(text, meta)
+            any_structured_entry = any_structured_entry or len(entries) > 1 or bool(meta)
+            counts = _testimonial_signal_counts(
+                entries,
+                linked_offer_refs=linked_refs,
+                offer_paths=offer_paths,
+            )
+            for key, value in counts.items():
+                testimonial_counts[key] += value
+        if path.endswith("typicality.md"):
+            lowered = text.lower()
+            typicality = quality["typicality"]
+            typicality["exists"] = True
+            typicality["has_average_case"] = _contains_any(lowered, PROOF_AVERAGE_CASE_KEYWORDS)
+            typicality["has_caveats"] = _contains_any(lowered, PROOF_CAVEAT_KEYWORDS)
+            typicality["has_common_failure_context"] = _contains_any(
+                lowered,
+                PROOF_FAILURE_CONTEXT_KEYWORDS,
+            )
+            typicality["has_time_to_outcome"] = _proof_text_has_timeframe(lowered)
+    quality["claim_links"]["linked_offers"] = sorted(linked_offers)
+    unsupported_claims: list[str] = []
+    if offer_paths and paths and not (linked_offers & set(offer_paths)):
+        unsupported_claims.extend(
+            f"{path}: no offer-linked proof detected" for path in offer_paths[:5]
+        )
+    quality["claim_links"]["unsupported_offer_claims"] = unsupported_claims
+    quality["structured_entries"] = any_structured_entry
+    quality["source_backed"] = _contains_any("\n".join(proof_texts), PROOF_SOURCE_KEYWORDS)
+    quality["instrumentation"] = {
+        "active_push": bool(
+            [
+                push
+                for push in pushes
+                if str(push.get("status") or "").lower() in ACTIVE_PUSH_STATUSES
+            ]
+        ),
+        "playbook": bool(playbooks),
+        "page_readiness": bool(measurement.get("available")),
+        "outcome_feedback": bool(
+            (relationship_health.get("sections") or {}).get("outcomes", {}).get("linked_count")
+        )
+        or any(playbook.get("linked_outcomes") for playbook in playbooks),
+    }
+    return quality
+
+
+def _money_path_proof(
+    repo: Path,
+    *,
+    offer_paths: list[str],
+    pushes: list[dict[str, Any]],
+    playbooks: list[dict[str, Any]],
+    measurement: dict[str, Any],
+    relationship_health: dict[str, Any],
+) -> tuple[dict[str, Any], list[str]]:
     proof_files = [
         path
         for root in [repo / "core" / "proof", *repo.glob("core/offers/*/proof")]
@@ -1434,6 +1787,7 @@ def _money_path_proof(repo: Path) -> tuple[dict[str, Any], list[str]]:
     proof_files.extend(legacy_proof)
     paths = sorted({path.relative_to(repo).as_posix() for path in proof_files})
     if not paths:
+        quality = _empty_proof_quality()
         return (
             _money_path_object(
                 level=0,
@@ -1443,10 +1797,20 @@ def _money_path_proof(repo: Path) -> tuple[dict[str, Any], list[str]]:
                 missing=["testimonials", "typicality", "proof_angles"],
                 references=["docs/offer-sharpening.md"],
                 recommended_route="/mb-think",
-            ),
+            )
+            | {"quality": quality},
             [],
         )
 
+    quality = _proof_quality(
+        repo,
+        paths=paths,
+        offer_paths=offer_paths,
+        pushes=pushes,
+        playbooks=playbooks,
+        measurement=measurement,
+        relationship_health=relationship_health,
+    )
     has_testimonials = any(path.endswith("testimonials.md") for path in paths)
     has_typicality = any(path.endswith("typicality.md") for path in paths)
     has_angles = any("/angles/" in path for path in paths)
@@ -1462,14 +1826,37 @@ def _money_path_proof(repo: Path) -> tuple[dict[str, Any], list[str]]:
     level = 1
     status = "stated"
     summary = "Proof files exist."
-    if has_testimonials or has_typicality:
+    testimonial_quality = quality["testimonials"]
+    typicality_quality = quality["typicality"]
+    instrumentation = quality["instrumentation"]
+    if has_testimonials or has_typicality or quality["structured_entries"]:
         level = 2
         status = "structured"
-        summary = "Proof includes standard testimonial or typicality files."
-    if has_testimonials and has_typicality:
+        summary = "Proof includes standard files, entries, or frontmatter."
+    if int(testimonial_quality["specific"]) > 0 and (
+        has_typicality or int(testimonial_quality["linked_to_offer"]) > 0
+    ):
         level = 3
         status = "evidence_backed"
-        summary = "Proof includes both testimonials and typicality context."
+        summary = "Proof includes specific outcomes tied to typicality or an offer."
+    if int(testimonial_quality["specific"]) >= 2 and (
+        quality["source_backed"]
+        or int(testimonial_quality["permissioned_public"]) > 0
+        or int(testimonial_quality["with_metric"]) > 0
+        or int(testimonial_quality["with_timeframe"]) > 0
+    ):
+        level = 4
+        status = "field_tested"
+        summary = "Proof includes multiple specific, source or outcome-backed entries."
+    if (
+        level >= 3
+        and int(testimonial_quality["linked_to_offer"]) > 0
+        and bool(typicality_quality["exists"])
+        and any(bool(value) for value in instrumentation.values())
+    ):
+        level = 5
+        status = "instrumented"
+        summary = "Proof is linked to an offer and connected to active path instrumentation."
     return (
         _money_path_object(
             level=level,
@@ -1485,7 +1872,8 @@ def _money_path_proof(repo: Path) -> tuple[dict[str, Any], list[str]]:
             ],
             references=["docs/offer-sharpening.md"],
             recommended_route="/mb-think",
-        ),
+        )
+        | {"quality": quality},
         paths,
     )
 
@@ -2028,10 +2416,29 @@ def _money_path(repo: Path, report: dict[str, Any]) -> dict[str, Any]:
     playbook_health = report.get("playbook_health") or {}
     relationship_health = report.get("relationship_health") or {}
     measurement = report.get("measurement") or {}
-    proof, proof_paths = _money_path_proof(repo)
-    offer = _money_path_offer(repo, proof_paths=proof_paths)
-    offer_paths = [str(path) for path in offer.get("paths") or [] if (repo / str(path)).is_file()]
     playbooks = _playbook_summaries(repo)
+    candidate_offer_paths = sorted(
+        path.relative_to(repo).as_posix()
+        for path in repo.glob("core/offers/*/offer.md")
+        if path.is_file()
+    )
+    candidate_offer_paths.extend(
+        _relative_existing_paths(repo, ["core/offer.md", "reference/core/offer.md"])
+    )
+    proof, proof_paths = _money_path_proof(
+        repo,
+        offer_paths=candidate_offer_paths,
+        pushes=pushes,
+        playbooks=playbooks,
+        measurement=measurement,
+        relationship_health=relationship_health,
+    )
+    offer = _money_path_offer(
+        repo,
+        proof_paths=proof_paths,
+        proof_quality=proof.get("quality") or _empty_proof_quality(),
+    )
+    offer_paths = [str(path) for path in offer.get("paths") or [] if (repo / str(path)).is_file()]
     multi_offer = bool(list(repo.glob("core/offers/*/offer.md")))
     collected_objects = {
         "customer_progress": _money_path_customer_progress(repo),

--- a/mb/mb/status.py
+++ b/mb/mb/status.py
@@ -724,23 +724,54 @@ def _offer_slug_from_path(path: str) -> str:
     return match.group(1) if match else ""
 
 
-def _proof_linked_offer_refs(repo: Path, proof_path: str) -> set[str]:
+TestimonialEntry = str | dict[str, Any]
+
+
+def _known_offer_refs(offer_paths: list[str]) -> dict[str, str]:
+    refs: dict[str, str] = {}
+    for path in offer_paths:
+        refs[path] = path
+        slug = _offer_slug_from_path(path)
+        if slug:
+            refs[slug] = path
+            refs[f"core/offers/{slug}"] = path
+            refs[f"core/offers/{slug}/"] = path
+            refs[f"core/offers/{slug}/offer.md"] = path
+    return refs
+
+
+def _normalize_offer_ref(value: Any, offer_paths: list[str]) -> str:
+    if not isinstance(value, str):
+        return ""
+    clean = value.strip().strip("\"'")
+    if not clean:
+        return ""
+    clean = clean.removeprefix("./")
+    return _known_offer_refs(offer_paths).get(clean, "")
+
+
+def _proof_linked_offer_refs(repo: Path, proof_path: str, offer_paths: list[str]) -> set[str]:
     meta = _read_frontmatter(repo / proof_path)
-    refs = set(_coerce_string_list(meta.get("offer")))
-    refs.update(_coerce_string_list(meta.get("linked_offers")))
+    raw_refs = set(_coerce_string_list(meta.get("offer")))
+    raw_refs.update(_coerce_string_list(meta.get("linked_offers")))
+    refs = {
+        normalized for ref in raw_refs if (normalized := _normalize_offer_ref(ref, offer_paths))
+    }
     match = re.match(r"core/offers/([^/]+)/proof/", proof_path)
-    if match:
-        refs.add(f"core/offers/{match.group(1)}/offer.md")
+    if match and (
+        normalized := _normalize_offer_ref(f"core/offers/{match.group(1)}/offer.md", offer_paths)
+    ):
+        refs.add(normalized)
     return {ref for ref in refs if ref}
 
 
-def _testimonial_entries(text: str, meta: dict[str, Any]) -> list[str]:
-    entries: list[str] = []
+def _testimonial_entries(text: str, meta: dict[str, Any]) -> list[TestimonialEntry]:
+    entries: list[TestimonialEntry] = []
     frontmatter_entries = meta.get("testimonials")
     if isinstance(frontmatter_entries, list):
         for item in frontmatter_entries:
             if isinstance(item, dict):
-                entries.append(json.dumps(item, sort_keys=True))
+                entries.append(item)
             elif isinstance(item, str) and item.strip():
                 entries.append(item.strip())
     body = _markdown_body_without_frontmatter(text)
@@ -765,14 +796,79 @@ def _testimonial_entries(text: str, meta: dict[str, Any]) -> list[str]:
             ).strip()
             if len(cleaned) >= 20:
                 entries.append(cleaned)
-    deduped: list[str] = []
+    deduped: list[TestimonialEntry] = []
     seen: set[str] = set()
     for entry in entries:
-        key = entry.strip()
+        key = json.dumps(entry, sort_keys=True) if isinstance(entry, dict) else entry.strip()
         if key and key not in seen:
-            deduped.append(key)
+            deduped.append(entry)
             seen.add(key)
     return deduped
+
+
+def _testimonial_text(entry: TestimonialEntry) -> str:
+    if isinstance(entry, str):
+        return entry
+    values: list[str] = []
+
+    def collect(value: Any) -> None:
+        if isinstance(value, dict):
+            for item in value.values():
+                collect(item)
+        elif isinstance(value, list):
+            for item in value:
+                collect(item)
+        elif isinstance(value, str):
+            values.append(value)
+        elif isinstance(value, (int, float)):
+            values.append(str(value))
+
+    collect(entry)
+    return " ".join(values)
+
+
+def _truthy_structured_value(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"true", "yes", "approved", "public", "permissioned"}
+    return False
+
+
+def _testimonial_structured_permission(entry: TestimonialEntry) -> bool:
+    if not isinstance(entry, dict):
+        return False
+    permission_fields = {
+        "public",
+        "permissioned_public",
+        "approved_for_public",
+        "safe_to_share",
+        "public_approved",
+    }
+    for key, value in entry.items():
+        normalized = str(key).strip().lower().replace("-", "_")
+        if normalized in permission_fields and _truthy_structured_value(value):
+            return True
+    return False
+
+
+def _testimonial_structured_offer_refs(entry: TestimonialEntry) -> list[str]:
+    if not isinstance(entry, dict):
+        return []
+    refs: list[str] = []
+    for key in ("offer", "linked_offer", "linked_offers"):
+        refs.extend(_coerce_string_list(entry.get(key)))
+    return refs
+
+
+def _testimonial_explicit_offer_refs(text: str) -> list[str]:
+    refs: list[str] = []
+    for match in re.finditer(
+        r"(?im)(?:^|\b)(?:offer|linked_offer|linked_offers)\s*:\s*(?:-\s*)?([^\n,;#]+)",
+        text,
+    ):
+        refs.append(match.group(1).strip().strip("\"'`"))
+    return refs
 
 
 def _proof_text_has_timeframe(text: str) -> bool:
@@ -790,7 +886,7 @@ def _proof_text_has_metric(text: str) -> bool:
 
 
 def _testimonial_signal_counts(
-    entries: list[str],
+    entries: list[TestimonialEntry],
     *,
     linked_offer_refs: set[str],
     offer_paths: list[str],
@@ -808,20 +904,25 @@ def _testimonial_signal_counts(
         "with_mechanism": 0,
         "with_objection": 0,
     }
-    offer_refs = set(offer_paths)
-    offer_refs.update(_offer_slug_from_path(path) for path in offer_paths)
-    offer_refs.discard("")
     has_path_offer_link = bool(linked_offer_refs & set(offer_paths))
     for entry in entries:
-        lowered = entry.lower()
+        entry_text = _testimonial_text(entry)
+        lowered = entry_text.lower()
         has_before = _contains_any(lowered, PROOF_BEFORE_KEYWORDS)
         has_outcome = _contains_any(lowered, PROOF_OUTCOME_KEYWORDS)
         has_timeframe = _proof_text_has_timeframe(lowered)
         has_metric = _proof_text_has_metric(lowered)
         has_mechanism = _contains_any(lowered, PROOF_MECHANISM_KEYWORDS)
         has_objection = _contains_any(lowered, PROOF_OBJECTION_KEYWORDS)
-        has_permission = _contains_any(lowered, PROOF_PERMISSION_KEYWORDS)
-        has_offer_link = has_path_offer_link or any(ref.lower() in lowered for ref in offer_refs)
+        has_permission = _testimonial_structured_permission(entry) or _contains_any(
+            lowered, PROOF_PERMISSION_KEYWORDS
+        )
+        explicit_offer_refs = _testimonial_structured_offer_refs(entry)
+        explicit_offer_refs.extend(_testimonial_explicit_offer_refs(entry_text))
+        has_entry_offer_link = any(
+            _normalize_offer_ref(ref, offer_paths) for ref in explicit_offer_refs
+        )
+        has_offer_link = has_path_offer_link or has_entry_offer_link
         signals = [
             has_before,
             has_outcome,
@@ -1513,8 +1614,11 @@ def _money_path_offer(
     proof_boundary_warnings: list[str] = []
     if "proof" in guardrails and not proof_paths:
         proof_boundary_warnings.append("proof_claim_without_proof_file")
-    if proof_paths and int(testimonial_quality.get("permissioned_public") or 0) == 0:
-        proof_boundary_warnings.append("proof_files_without_permissioned_public_signal")
+    if (
+        int(testimonial_quality.get("total") or 0) > 0
+        and int(testimonial_quality.get("permissioned_public") or 0) == 0
+    ):
+        proof_boundary_warnings.append("testimonials_without_permissioned_public_signal")
     if claim_links.get("unsupported_offer_claims"):
         proof_boundary_warnings.append("offer_claims_without_offer_linked_proof")
 
@@ -1712,7 +1816,7 @@ def _proof_quality(
     for path in paths:
         text = _read_markdown_text(repo / path)
         proof_texts.append(text)
-        linked_refs = _proof_linked_offer_refs(repo, path)
+        linked_refs = _proof_linked_offer_refs(repo, path, offer_paths)
         linked_offers.update(linked_refs)
         if path.endswith("testimonials.md"):
             meta = _read_frontmatter(repo / path)
@@ -1839,11 +1943,15 @@ def _money_path_proof(
         level = 3
         status = "evidence_backed"
         summary = "Proof includes specific outcomes tied to typicality or an offer."
-    if int(testimonial_quality["specific"]) >= 2 and (
-        quality["source_backed"]
-        or int(testimonial_quality["permissioned_public"]) > 0
-        or int(testimonial_quality["with_metric"]) > 0
-        or int(testimonial_quality["with_timeframe"]) > 0
+    if (
+        level >= 3
+        and int(testimonial_quality["specific"]) >= 2
+        and (
+            quality["source_backed"]
+            or int(testimonial_quality["permissioned_public"]) > 0
+            or int(testimonial_quality["with_metric"]) > 0
+            or int(testimonial_quality["with_timeframe"]) > 0
+        )
     ):
         level = 4
         status = "field_tested"

--- a/mb/tests/test_status.py
+++ b/mb/tests/test_status.py
@@ -386,9 +386,56 @@ def test_status_money_path_generic_proof_quality_stays_structured(
     assert quality["claim_links"]["unsupported_offer_claims"] == [
         "core/offer.md: no offer-linked proof detected"
     ]
+    assert report["money_path"]["ranked_actions"][0]["id"] == "strengthen-proof-quality"
+    assert report["money_path"]["ranked_actions"][0]["missing"] == [
+        "specific_testimonials",
+        "offer_linked_proof",
+        "typicality",
+        "supported_offer_claims",
+        "outcome_feedback",
+    ]
 
 
-def test_status_money_path_specific_offer_linked_proof_can_be_instrumented(
+def test_status_money_path_specific_typicality_without_offer_link_reaches_evidence_backed(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+    _write_money_path_core(repo)
+    proof = repo / "core" / "proof"
+    proof.mkdir(parents=True, exist_ok=True)
+    (proof / "testimonials.md").write_text(
+        (
+            "# Testimonials\n\n"
+            "## Founder A\n"
+            "Before: stuck rebuilding context. Outcome: booked 3 calls within 2 weeks.\n"
+        ),
+        encoding="utf-8",
+    )
+    (proof / "typicality.md").write_text(
+        (
+            "# Typicality\n\n"
+            "Average case: most users need one setup week. Caveat: outcomes vary. "
+            "Common failure context: poor fit. Time to outcome is usually 2 weeks.\n"
+        ),
+        encoding="utf-8",
+    )
+
+    report = status_mod.run(path=str(repo), update_marker=False)
+
+    proof_object = report["money_path"]["objects"]["proof"]
+    quality = proof_object["quality"]
+    assert proof_object["level"] == 3
+    assert proof_object["status"] == "evidence_backed"
+    assert quality["testimonials"]["specific"] == 1
+    assert quality["testimonials"]["linked_to_offer"] == 0
+    assert quality["claim_links"]["unsupported_offer_claims"] == [
+        "core/offer.md: no offer-linked proof detected"
+    ]
+
+
+def test_status_money_path_offer_linked_proof_without_outcome_feedback_is_not_instrumented(
     tmp_path: Path, monkeypatch
 ) -> None:
     monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
@@ -436,8 +483,8 @@ def test_status_money_path_specific_offer_linked_proof_can_be_instrumented(
 
     proof_object = report["money_path"]["objects"]["proof"]
     quality = proof_object["quality"]
-    assert proof_object["level"] == 5
-    assert proof_object["status"] == "instrumented"
+    assert proof_object["level"] == 4
+    assert proof_object["status"] == "field_tested"
     assert quality["testimonials"]["total"] == 2
     assert quality["testimonials"]["specific"] == 2
     assert quality["testimonials"]["permissioned_public"] == 2
@@ -453,6 +500,77 @@ def test_status_money_path_specific_offer_linked_proof_can_be_instrumented(
     }
     assert quality["claim_links"]["linked_offers"] == ["core/offers/coaching/offer.md"]
     assert quality["claim_links"]["unsupported_offer_claims"] == []
+    assert quality["instrumentation"]["active_push"] is True
+    assert quality["instrumentation"]["playbook"] is True
+    assert quality["instrumentation"]["outcome_feedback"] is False
+    assert any(
+        action["id"] == "strengthen-proof-quality" and "outcome_feedback" in action["missing"]
+        for action in report["money_path"]["ranked_actions"]
+    )
+
+
+def test_status_money_path_level_five_proof_requires_outcome_feedback(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+    offer = repo / "core" / "offers" / "coaching"
+    offer.mkdir(parents=True, exist_ok=True)
+    (offer / "offer.md").write_text(
+        (
+            "---\nslug: coaching\nstatus: running\n---\n\n"
+            "# Coaching\n\n"
+            "Audience, transformation, mechanism, pricing, proof, objections, "
+            "reason to act, and next step.\n"
+        ),
+        encoding="utf-8",
+    )
+    proof = offer / "proof"
+    proof.mkdir(parents=True, exist_ok=True)
+    (proof / "testimonials.md").write_text(
+        (
+            "# Testimonials\n\n"
+            "## Founder A\n"
+            "Permissioned public source: sales call. Before: stuck rebuilding context. "
+            "Outcome: booked 3 calls within 2 weeks using the workflow. "
+            "Objection: worried about time.\n\n"
+            "## Founder B\n"
+            "Approved for public source: interview. Previously scattered launches. "
+            "Result: saved 5 hours in 10 days through the process.\n"
+        ),
+        encoding="utf-8",
+    )
+    (proof / "typicality.md").write_text(
+        (
+            "# Typicality\n\n"
+            "Average case: most users need one setup week before speed improves. "
+            "Caveat: outcomes vary. Common failure context: poor fit when no offer "
+            "exists. Time to outcome is usually 2 weeks.\n"
+        ),
+        encoding="utf-8",
+    )
+    push = _write_push(repo, "2026-05-06-launch", offer="core/offers/coaching/offer.md")
+    _write_playbook(
+        push,
+        status="active",
+        approval_status="approved",
+        linked_outcomes='["log/2026-05-20-launch-outcome.md"]',
+    )
+
+    report = status_mod.run(path=str(repo), update_marker=False)
+
+    proof_object = report["money_path"]["objects"]["proof"]
+    quality = proof_object["quality"]
+    assert proof_object["level"] == 5
+    assert proof_object["status"] == "instrumented"
+    assert quality["instrumentation"]["active_push"] is True
+    assert quality["instrumentation"]["playbook"] is True
+    assert quality["instrumentation"]["outcome_feedback"] is True
+    assert all(
+        action["id"] != "strengthen-proof-quality"
+        for action in report["money_path"]["ranked_actions"]
+    )
 
 
 def test_status_money_path_detects_multi_offer_product_ladder(tmp_path: Path, monkeypatch) -> None:

--- a/mb/tests/test_status.py
+++ b/mb/tests/test_status.py
@@ -396,6 +396,147 @@ def test_status_money_path_generic_proof_quality_stays_structured(
     ]
 
 
+def test_status_money_path_frontmatter_public_true_counts_as_permission(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+    _write_money_path_core(repo)
+    proof = repo / "core" / "proof"
+    proof.mkdir(parents=True, exist_ok=True)
+    (proof / "testimonials.md").write_text(
+        (
+            "---\n"
+            "testimonials:\n"
+            "  - public: true\n"
+            "    before: stuck rebuilding context\n"
+            "    outcome: booked 3 calls\n"
+            "    timeframe: within 2 weeks\n"
+            "---\n\n"
+            "# Testimonials\n"
+        ),
+        encoding="utf-8",
+    )
+
+    report = status_mod.run(path=str(repo), update_marker=False)
+
+    testimonials = report["money_path"]["objects"]["proof"]["quality"]["testimonials"]
+    assert testimonials["total"] == 1
+    assert testimonials["permissioned_public"] == 1
+    assert testimonials["specific"] == 1
+
+
+def test_status_money_path_proof_cannot_reach_field_tested_without_level_three(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+    _write_money_path_core(repo)
+    proof = repo / "core" / "proof"
+    proof.mkdir(parents=True, exist_ok=True)
+    (proof / "testimonials.md").write_text(
+        (
+            "# Testimonials\n\n"
+            "## Founder A\n"
+            "Permissioned public source: sales call. Before: stuck. "
+            "Outcome: booked 3 calls within 2 weeks.\n\n"
+            "## Founder B\n"
+            "Approved for public source: interview. Previously scattered. "
+            "Result: saved 5 hours in 10 days.\n"
+        ),
+        encoding="utf-8",
+    )
+
+    report = status_mod.run(path=str(repo), update_marker=False)
+
+    proof_object = report["money_path"]["objects"]["proof"]
+    quality = proof_object["quality"]
+    assert quality["testimonials"]["specific"] == 2
+    assert quality["testimonials"]["permissioned_public"] == 2
+    assert quality["testimonials"]["linked_to_offer"] == 0
+    assert quality["typicality"]["exists"] is False
+    assert proof_object["level"] == 2
+    assert proof_object["status"] == "structured"
+
+
+def test_status_money_path_common_offer_slug_in_prose_does_not_link_offer(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+    _write_money_path_core(repo)
+    offer = repo / "core" / "offers" / "coaching"
+    offer.mkdir(parents=True, exist_ok=True)
+    (offer / "offer.md").write_text(
+        "---\nslug: coaching\nstatus: running\n---\n\n# Coaching\n\nAudience and proof.\n",
+        encoding="utf-8",
+    )
+    proof = repo / "core" / "proof"
+    proof.mkdir(parents=True, exist_ok=True)
+    (proof / "testimonials.md").write_text(
+        (
+            "# Testimonials\n\n"
+            "## Founder A\n"
+            "Before: stuck rebuilding context. Outcome: booked 3 calls within 2 weeks "
+            "after coaching helped clarify the workflow.\n"
+        ),
+        encoding="utf-8",
+    )
+
+    report = status_mod.run(path=str(repo), update_marker=False)
+
+    quality = report["money_path"]["objects"]["proof"]["quality"]
+    assert quality["testimonials"]["specific"] == 1
+    assert quality["testimonials"]["linked_to_offer"] == 0
+    assert quality["claim_links"]["linked_offers"] == []
+    assert (
+        "core/offers/coaching/offer.md: no offer-linked proof detected"
+        in quality["claim_links"]["unsupported_offer_claims"]
+    )
+
+
+def test_status_money_path_permission_warning_only_applies_to_testimonials(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
+    typicality_repo = tmp_path / "typicality"
+    init_run(path=str(typicality_repo), name="Typicality")
+    _write_money_path_core(typicality_repo)
+    typicality_proof = typicality_repo / "core" / "proof"
+    typicality_proof.mkdir(parents=True, exist_ok=True)
+    (typicality_proof / "typicality.md").write_text(
+        "# Typicality\n\nMost users need setup help first.\n",
+        encoding="utf-8",
+    )
+
+    typicality_report = status_mod.run(path=str(typicality_repo), update_marker=False)
+
+    typicality_warnings = typicality_report["money_path"]["objects"]["offer"]["guardrails"][
+        "proof_boundary_warnings"
+    ]
+    assert "testimonials_without_permissioned_public_signal" not in typicality_warnings
+
+    testimonial_repo = tmp_path / "testimonial"
+    init_run(path=str(testimonial_repo), name="Testimonial")
+    _write_money_path_core(testimonial_repo)
+    testimonial_proof = testimonial_repo / "core" / "proof"
+    testimonial_proof.mkdir(parents=True, exist_ok=True)
+    (testimonial_proof / "testimonials.md").write_text(
+        "# Testimonials\n\nGreat work from a happy customer.\n",
+        encoding="utf-8",
+    )
+
+    testimonial_report = status_mod.run(path=str(testimonial_repo), update_marker=False)
+
+    testimonial_warnings = testimonial_report["money_path"]["objects"]["offer"]["guardrails"][
+        "proof_boundary_warnings"
+    ]
+    assert "testimonials_without_permissioned_public_signal" in testimonial_warnings
+
+
 def test_status_money_path_specific_typicality_without_offer_link_reaches_evidence_backed(
     tmp_path: Path, monkeypatch
 ) -> None:

--- a/mb/tests/test_status.py
+++ b/mb/tests/test_status.py
@@ -343,6 +343,118 @@ def test_status_money_path_single_offer_structured_caps_without_proof(
     assert money_path["ranked_actions"][0]["component"] == "proof"
 
 
+def test_status_money_path_offer_exposes_guardrail_detail(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+    _write_money_path_core(repo)
+
+    report = status_mod.run(path=str(repo), update_marker=False)
+
+    offer = report["money_path"]["objects"]["offer"]
+    guardrails = offer["guardrails"]
+    assert guardrails["checks"]["audience"]["present"] is True
+    assert guardrails["checks"]["audience"]["paths"] == ["core/offer.md"]
+    assert guardrails["checks"]["risk_reversal"]["present"] is False
+    assert "risk_reversal" in guardrails["missing"]
+    assert guardrails["proof_boundary_warnings"] == ["proof_claim_without_proof_file"]
+
+
+def test_status_money_path_generic_proof_quality_stays_structured(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+    _write_money_path_core(repo)
+    proof = repo / "core" / "proof"
+    proof.mkdir(parents=True, exist_ok=True)
+    (proof / "testimonials.md").write_text(
+        "# Testimonials\n\nGreat work from a happy customer.\n",
+        encoding="utf-8",
+    )
+
+    report = status_mod.run(path=str(repo), update_marker=False)
+
+    proof_object = report["money_path"]["objects"]["proof"]
+    quality = proof_object["quality"]
+    assert proof_object["level"] == 2
+    assert proof_object["status"] == "structured"
+    assert quality["testimonials"]["total"] == 1
+    assert quality["testimonials"]["generic"] == 1
+    assert quality["testimonials"]["specific"] == 0
+    assert quality["claim_links"]["unsupported_offer_claims"] == [
+        "core/offer.md: no offer-linked proof detected"
+    ]
+
+
+def test_status_money_path_specific_offer_linked_proof_can_be_instrumented(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+    offer = repo / "core" / "offers" / "coaching"
+    offer.mkdir(parents=True, exist_ok=True)
+    (offer / "offer.md").write_text(
+        (
+            "---\nslug: coaching\nstatus: running\n---\n\n"
+            "# Coaching\n\n"
+            "Audience, transformation, mechanism, pricing, proof, objections, "
+            "reason to act, and next step.\n"
+        ),
+        encoding="utf-8",
+    )
+    proof = offer / "proof"
+    proof.mkdir(parents=True, exist_ok=True)
+    (proof / "testimonials.md").write_text(
+        (
+            "# Testimonials\n\n"
+            "## Founder A\n"
+            "Permissioned public source: sales call. Before: stuck rebuilding context. "
+            "Outcome: booked 3 calls within 2 weeks using the workflow. "
+            "Objection: worried about time.\n\n"
+            "## Founder B\n"
+            "Approved for public source: interview. Previously scattered launches. "
+            "Result: saved 5 hours in 10 days through the process.\n"
+        ),
+        encoding="utf-8",
+    )
+    (proof / "typicality.md").write_text(
+        (
+            "# Typicality\n\n"
+            "Average case: most users need one setup week before speed improves. "
+            "Caveat: outcomes vary. Common failure context: poor fit when no offer "
+            "exists. Time to outcome is usually 2 weeks.\n"
+        ),
+        encoding="utf-8",
+    )
+    push = _write_push(repo, "2026-05-06-launch", offer="core/offers/coaching/offer.md")
+    _write_playbook(push, status="active", approval_status="approved")
+
+    report = status_mod.run(path=str(repo), update_marker=False)
+
+    proof_object = report["money_path"]["objects"]["proof"]
+    quality = proof_object["quality"]
+    assert proof_object["level"] == 5
+    assert proof_object["status"] == "instrumented"
+    assert quality["testimonials"]["total"] == 2
+    assert quality["testimonials"]["specific"] == 2
+    assert quality["testimonials"]["permissioned_public"] == 2
+    assert quality["testimonials"]["linked_to_offer"] == 2
+    assert quality["testimonials"]["with_timeframe"] == 2
+    assert quality["testimonials"]["with_metric"] == 2
+    assert quality["typicality"] == {
+        "exists": True,
+        "has_average_case": True,
+        "has_caveats": True,
+        "has_common_failure_context": True,
+        "has_time_to_outcome": True,
+    }
+    assert quality["claim_links"]["linked_offers"] == ["core/offers/coaching/offer.md"]
+    assert quality["claim_links"]["unsupported_offer_claims"] == []
+
+
 def test_status_money_path_detects_multi_offer_product_ladder(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
     repo = tmp_path / "acme"


### PR DESCRIPTION
## Summary

Adds deterministic MoneyPath offer guardrail and proof-quality facts to `mb status --json --peek` so agents can cite evidence about offer readiness without subjective scoring. Proof now distinguishes generic vs. specific testimonials, offer-linked proof, typicality signals, unsupported claims, and whether the proof loop has outcome feedback.

Note: component-level `status: structured` means a standard proof file exists. The nested `quality.structured_entries` field is narrower: it reports whether the testimonial file itself has multiple entries or frontmatter-backed structure.

## Linked issue

Refs #523 / MAIN-341

## Why

MAIN-343 added the broader MoneyPath surface, but proof and offer readiness still needed finer deterministic calibration. This PR keeps the CLI factual while giving `/mb-start` and related skills a clearer signal when proof exists but is generic, unlinked, missing typicality, or not tied back to outcomes.

## Commits by concern

- [x] `310137c [add] MAIN-341 MoneyPath proof quality facts`
- [x] `11ab59e [fix] MAIN-341 tighten proof instrumentation gate`
- [x] `9ac1647 [fix] MAIN-341 tighten proof quality review gates`
- [x] Each commit body bullet-lists the changes in that commit
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`

## Validation

Pre-push gate from repo root:

```bash
scripts/check.sh
```

- [x] Level 1 static: `scripts/check.sh` passes
- [x] Level 2 CLI contract: focused Typer/CliRunner tests, exit codes, `--json` behavior, TTY vs non-TTY (if CLI behavior touched)
- [ ] Level 3 package/install smoke (if packaging touched)
- [ ] Level 4 fixture repo (if init/onboard/status/start/update touched)
- [ ] Level 5 runtime smoke / dogfood harness / simulation-tier (if runtime, first-run, skill discovery, or release validation touched)
- [ ] SKILL.md ≤500 lines (if any skill touched)
- [ ] Package-visible release gate evidence before tag/publish (if preparing a release)
- [ ] Supply-chain review (if `.github/workflows/`, `.github/dependabot.yml`, `mb/pyproject.toml` deps, or `id-token`/`permissions` blocks touched — see [docs/supply-chain-policy.md](../docs/supply-chain-policy.md))

Level 1 static: `scripts/check.sh` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: excerpt `80 files already formatted`; `All checks passed!`; `Success: no issues found in 79 source files`; `589 passed`; skill validation summary `errors: 0, warnings: 0`.
Level 2 CLI contract: `cd mb && pytest tests/test_status.py -q` — runtime: `python3` — exit: 0 — log: excerpt `73 passed in 45.31s`.
Level 3 package/install: not required; no packaging, entrypoint, bundled-data, install, or update path changed.
Level 4 fixture repo: not required; no init/onboard/repo-shape/start/update behavior changed.
Level 5 runtime: not required; no runtime discovery, skill invocation, or first-run handoff changed.
SKILL.md line gate: not required by changed files, but `scripts/check.sh` still ran skill validation successfully.
Supply-chain review: not required; no workflow, dependency, Dependabot, permission, or id-token files changed.

## Success metric

`mb status --json --peek` exposes proof-quality facts under `money_path.objects.proof.quality` and raises `strengthen-proof-quality` when structured proof is generic, unlinked, missing typicality, has unsupported offer claims, or lacks outcome feedback.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [ ] N/A — change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [x] No
- [ ] Yes — migration note below

## Public / private boundary

No private operator strategy, machine-specific paths, customer/member data, credentials, or runtime internals were committed. The new checks inspect public repo text and report deterministic safe-to-share facts only.
