### PR TITLE
[update] Prepare v0.3.19 release

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mainbranch",
-  "version": "0.3.18",
+  "version": "0.3.19",
   "description": "Main Branch Claude Code skills for running a business from markdown files in git.",
   "author": {
     "name": "Noontide"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,15 +11,26 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+## [0.3.19] - 2026-05-12
+
+v0.3.19 makes daily status more business-aware: MoneyPath, proof-quality, and
+layered content-strategy facts now surface through deterministic CLI JSON so
+`/mb-start`, bundled skills, and future dashboard views can reason from the same
+repo-backed truth without turning the CLI into a strategist. The release also
+makes recommended Main Branch updates pause `/mb-start` business routing before
+ranked actions.
+
 ### Added
 
 - Added deterministic MoneyPath offer guardrail detail and proof-quality facts
   under `money_path.objects.offer` and `money_path.objects.proof`, including
   generic vs. specific testimonials, offer-linked proof, typicality signals,
-  and proof boundary warnings. Refs MAIN-341, #523.
+  unsupported-claim warnings, outcome-feedback signals, and an instrumentation
+  gate that requires outcome feedback. Refs MAIN-341, #523.
 - Added layered content strategy validation and normalized `content_strategy`
   status facts for simple, layered, disconnected, unindexed, and stale strategy
-  files, so future dashboard views can read CLI facts instead of parsing
+  files, including `content_strategy_unindexed_layer` findings for unindexed
+  layers, so future dashboard views can read CLI facts instead of parsing
   markdown. Refs MAIN-346, #536.
 - Added a layered content strategy model for business repos covering
   business-level content strategy, distribution strategy, channel strategy,
@@ -28,7 +39,9 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 - Added MoneyPath readiness facts to `mb status --json --peek`, giving skills
   and scripts a read-only, gated view of customer progress, offer, audience,
   proof, product ladder, CTA, channel, push, playbook, page readiness, and
-  outcome feedback. Refs MAIN-343, #528.
+  outcome feedback. The CLI reports legibility, support, connection, and
+  instrumentation; skills and operators still own conversion judgment. Refs
+  MAIN-343, #528.
 - Added clearer release dogfood print-mode evidence handling: per-simulation
   fresh sessions, categorized permission-denial summaries, direct read-only
   `mb books check` / `mb educational` allowlist coverage, and prompt

--- a/mb/mb/__init__.py
+++ b/mb/mb/__init__.py
@@ -7,6 +7,6 @@ file stays a thin dispatcher.
 
 from __future__ import annotations
 
-__version__ = "0.3.18"
+__version__ = "0.3.19"
 
 __all__ = ["__version__"]

--- a/mb/pyproject.toml
+++ b/mb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mainbranch"
-version = "0.3.18"
+version = "0.3.19"
 description = "Main Branch engine umbrella - scaffolds, validates, and graphs business-as-files repos. Claude Code first, runtime-agnostic by design."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Prepares the package-visible v0.3.19 release by moving current release notes into a dated changelog section and bumping the package/plugin version sites to `0.3.19`.

## Linked issue

Refs #538

## Why

MAIN-348 needs a release-prep branch that records the MoneyPath, proof-quality, layered content strategy, `/mb-start` update posture, and release-evidence changes under the version users will install, without implying the GitHub Release or PyPI package has already shipped.

## Commits by concern

- [ ] Each commit body bullet-lists the changes in that commit
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`

Commits:
- `b664dcc [update] MAIN-348 Prepare v0.3.19 release`

## Validation

Level 0 release preflight: version-site scan + `cd mb && python3 -m pytest tests/test_smoke_coverage.py::test_claude_plugin_manifest_points_at_prefixed_skills -q` — runtime: `python3` — exit: 0 — log: `.agent/release-evidence/0.3.19/` and command output; all version sites read `0.3.19`, `[Unreleased]` is empty, and the focused manifest test passed.

Level 1 static: `scripts/check.sh` — runtime: `python3` — exit: 0 — log: `.agent/release-evidence/0.3.19/check.out`; `81 files already formatted`, Ruff passed, mypy passed over 80 source files, 598 tests passed, and 15/15 skills validated.

Level 2 CLI contract: covered by `scripts/check.sh` plus focused update-posture smoke — runtime: `python3` — exit: 0 — log: `.agent/release-evidence/0.3.19/start-update-json.out`; simulated recommended update in `mb start --json` returned update severity `recommended`, `mb update` next action, and no `ranked_actions` before routing.

Level 3 package/install: `(cd mb && python3 -m build)` + fresh venv install of `mb/dist/mainbranch-0.3.19-py3-none-any.whl` — runtime: `python3` and `/tmp/mainbranch-0319-smoke/bin/python` — exit: 0 — logs: `.agent/release-evidence/0.3.19/build.out` and `.agent/release-evidence/0.3.19/install.out`.

Level 4 fixture/package smoke: installed wheel ran `mb --version`, `mb skill list`, fresh `mb onboard`, `mb status --json --peek`, `mb start --json`, and `mb validate` — runtime: `/tmp/mainbranch-0319-smoke/bin/mb` — exit: 0 — log: `.agent/release-evidence/0.3.19/package-smoke.out`; status JSON included `money_path` and top-level `content_strategy`.

Level 5 runtime proxy: `scripts/claude-runtime-dogfood.py --install-mode wheel --wheel mb/dist/mainbranch-0.3.19-py3-none-any.whl --run-claude-print --simulation-tier release_acceptance --max-budget-usd 0.75` — runtime: `python3`, Claude Code 2.1.140 — exit: 0 — evidence: `.agent/release-evidence/0.3.19/dogfood/`; print-mode proxy passed 11/11 heuristic checks with clean engine repo boundary, but one shell-wrapped `mb status` grounding command was denied, so interactive TUI smoke remains a pre-tag/release-owner check for slash-command proof.

Supply-chain review: workflow permissions scan recorded in `.agent/release-evidence/0.3.19/workflow-permissions.out`; this branch changes no workflows, Dependabot config, or dependency declarations beyond the package version. The `pypi` environment reviewer setting still needs maintainer verification before publishing because it is a GitHub settings check.

- [x] Level 1 static: `scripts/check.sh` passes
- [x] Level 2 CLI contract: focused Typer/CliRunner tests, exit codes, `--json` behavior, TTY vs non-TTY (if CLI behavior touched)
- [x] Level 3 package/install smoke (if packaging touched)
- [x] Level 4 fixture repo (if init/onboard/status/start/update touched)
- [x] Level 5 runtime smoke / dogfood harness / simulation-tier (if runtime, first-run, skill discovery, or release validation touched)
- [x] SKILL.md ≤500 lines (if any skill touched)
- [x] Package-visible release gate evidence before tag/publish (if preparing a release)
- [x] Supply-chain review (if `.github/workflows/`, `.github/dependabot.yml`, `mb/pyproject.toml` deps, or `id-token`/`permissions` blocks touched — see [docs/supply-chain-policy.md](../docs/supply-chain-policy.md))

## Success metric

Reviewers can merge a release-prep branch where v0.3.19 release truth, package version sites, plugin metadata, validation evidence, and public/private transcript boundaries are aligned before the maintainer creates `oe-v0.3.19` and approves PyPI publishing.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [ ] N/A — change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [x] No
- [ ] Yes — migration note below

## Public / private boundary

No raw Noontide transcript text, private local paths, private operator strategy, credentials, customer/member data, or local runtime logs were committed. The release notes use public-safe summary language and frame dashboard-related work only as normalized status facts for future dashboard views.
