### PR TITLE
[update] Route /mb-start money prompts through MoneyPath

### DIFF
--- a/.claude/skills/mb-start/SKILL.md
+++ b/.claude/skills/mb-start/SKILL.md
@@ -31,8 +31,8 @@ actual file paths in commands.
 `mb status --json --peek` before asking setup or routing questions. Treat JSON
 as source of truth for update severity, readiness, drift, onboarding,
 integrations, GitHub, bets, dirty git, since-last-check, `content_strategy`,
-`money_path`, and `ranked_actions`; avoid ad hoc probes unless status says a
-section is unavailable.
+`money_path`, and `ranked_actions`. Parse the full JSON once; do not slice
+status output with `head` or `sed` in the normal path.
 
 **Continuity facts:** Use `since_last_check.journal`, top-level `journal`,
 GitHub activity, and `checkpoint` from status to explain "where we left off."
@@ -315,7 +315,7 @@ selected research path.
 
 ## Step 5: Tool Status Audit (Deterministic Facts First)
 
-Run a lightweight provider/readiness audit before routing:
+Run a lightweight provider/readiness audit:
 
 - Use `mb status --json --peek` facts already gathered.
 - Run `mb connect doctor --json` when a provider section is degraded, missing,
@@ -376,7 +376,7 @@ If `core/offers` is absent and `core/` is also absent, legacy
 `reference/offers` is fallback only. In current repos it bridges to
 `core/offers`.
 
-**If no offers/ folder:** Single-offer mode. Skip to Step 2. Everything reads from `core/`.
+**If no offers/ folder:** Single-offer mode. Skip to Step 2. Read from `core/`.
 
 **If offers/ found:** Multi-offer mode.
 1. Check current CLI status facts first. If a future `mb` JSON field exposes
@@ -429,7 +429,7 @@ to `/mb-think`.
 
 **Respect readiness gates from Step 6.** If status is MINIMAL or EMPTY, do not offer output skills. If THIN, warn. See [readiness-assessment.md](references/readiness-assessment.md) for skill-specific requirements.
 
-**Show context:** Before presenting options, show: "Business: **[repo name]** | Offer: **[active offer or 'single']**"
+**Show context:** "Business: **[repo name]** | Offer: **[active offer or 'single']**"
 
 If the user stated intent, route directly using
 [references/router-and-language.md](references/router-and-language.md). If the

--- a/.claude/skills/mb-start/references/router-and-language.md
+++ b/.claude/skills/mb-start/references/router-and-language.md
@@ -188,6 +188,48 @@ Route:
 - Use `mb validate --cross-refs` only when relationship/link health is the
   stated task or status points there.
 
+### Path to money, revenue, offer readiness
+
+Signals: path to money, revenue, make money, next dollar, what sells, paid step,
+CTA, offer readiness, product ladder, proof, launch readiness, sales path.
+
+Route:
+
+- Keep hard gates first. Required updates, broken wiring, unsafe provider
+  operations, private-data boundaries, and repair blockers pause business
+  routing before MoneyPath interpretation.
+- Use the `money_path` object from the already-run `mb status --json --peek`
+  report. Parse the full status JSON once; do not slice it with `head`, `sed`,
+  or partial shell chunks that can drop late-added sections.
+- Start the first business interpretation from `money_path.overall_level`,
+  `money_path.overall_label`, `money_path.objects.offer`,
+  `money_path.objects.proof`, `money_path.objects.product_ladder`,
+  `money_path.objects.cta_path`, `money_path.objects.channel_strategy`,
+  `money_path.objects.active_push`,
+  `money_path.objects.outcome_feedback_loop`, and
+  `money_path.ranked_actions`.
+- Translate the facts. Name the current bottleneck and gaps in business
+  language without dumping JSON and without conversion judgment.
+- Explain whether top-level `ranked_actions` agree with the MoneyPath
+  bottleneck. If they disagree, say which gate or route is taking priority.
+- Only after that, read supporting offer, product ladder, decision, research,
+  finance-summary, push, or channel files for judgment.
+- If routing to `/mb-think`, include a MoneyPath snapshot in the handoff so the
+  worker starts from the same facts.
+
+Good handoff shape:
+
+> "MoneyPath snapshot: overall Level 2 / structured. Bottleneck: CTA path
+> missing. Proof exists but is generic and not outcome-backed. Offer is
+> structured but missing risk reversal. Recommended route: clarify the paid
+> entry step and CTA before creating more content or ads."
+
+Avoid:
+
+> "Your offer is bad."
+
+> "This will not convert."
+
 ### Decide, codify, research
 
 Signals: think, decide, figure out, explore, research, compare, tool decision,

--- a/.claude/skills/mb-start/references/router-and-language.md
+++ b/.claude/skills/mb-start/references/router-and-language.md
@@ -198,6 +198,9 @@ Route:
 - Keep hard gates first. Required updates, broken wiring, unsafe provider
   operations, private-data boundaries, and repair blockers pause business
   routing before MoneyPath interpretation.
+- Required update, broken install/runtime/wiring, repair blockers, validation
+  blockers, relationship health blockers, playbook health blockers, and unsafe
+  provider/private-data blockers all win before MoneyPath routing.
 - Use the `money_path` object from the already-run `mb status --json --peek`
   report. Parse the full status JSON once; do not slice it with `head`, `sed`,
   or partial shell chunks that can drop late-added sections.
@@ -221,14 +224,22 @@ Good handoff shape:
 
 > "MoneyPath snapshot: overall Level 2 / structured. Bottleneck: CTA path
 > missing. Proof exists but is generic and not outcome-backed. Offer is
-> structured but missing risk reversal. Recommended route: clarify the paid
-> entry step and CTA before creating more content or ads."
+> structured but missing risk reversal. Product ladder is stated but has no
+> clear paid entry step. Channel strategy exists, but no active push is
+> attached. Outcome feedback loop is missing. Recommended route: use `/mb-think`
+> to clarify the paid entry step and CTA before creating more content or ads."
 
 Avoid:
 
 > "Your offer is bad."
 
 > "This will not convert."
+
+> "This will convert."
+
+> "The business is weak."
+
+> "This is ready to win."
 
 ### Decide, codify, research
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   PyPI release-acceptance evidence, print-mode proxy limits, post-release docs
   alignment, and the #539 path-to-money follow-up route. Refs #538, #539.
 
+### Changed
+
+- Updated `/mb-start` routing guidance so path-to-money, revenue, next-dollar,
+  and offer-readiness prompts start from deterministic `money_path` facts, carry
+  the MoneyPath snapshot into `/mb-think` handoffs, and avoid normal-path
+  `head` / `sed` status JSON chunking. Refs MAIN-349, #539.
+
 ## [0.3.19] - 2026-05-12
 
 v0.3.19 makes daily status more business-aware: MoneyPath, proof-quality, and

--- a/mb/tests/test_start_router_contract.py
+++ b/mb/tests/test_start_router_contract.py
@@ -47,6 +47,40 @@ def test_router_contract_covers_books_save_sync_and_updates() -> None:
     assert "noontide-admin" not in router.lower()
 
 
+def test_start_router_routes_money_intent_from_moneypath_facts() -> None:
+    start = _read(START_SKILL)
+    router = _read(ROUTER_REF)
+
+    assert "Parse the full JSON once" in start
+    assert "do not slice\nstatus output with `head` or `sed`" in start
+
+    required_phrases = [
+        "Path to money, revenue, offer readiness",
+        "path to money",
+        "next dollar",
+        "offer readiness",
+        "Keep hard gates first",
+        "`money_path.overall_level`",
+        "`money_path.overall_label`",
+        "`money_path.objects.offer`",
+        "`money_path.objects.proof`",
+        "`money_path.objects.product_ladder`",
+        "`money_path.objects.cta_path`",
+        "`money_path.objects.channel_strategy`",
+        "`money_path.objects.active_push`",
+        "`money_path.objects.outcome_feedback_loop`",
+        "`money_path.ranked_actions`",
+        "without conversion judgment",
+        "Explain whether top-level `ranked_actions` agree with the MoneyPath\n  bottleneck",
+        "include a MoneyPath snapshot in the handoff",
+    ]
+    for phrase in required_phrases:
+        assert phrase in router
+
+    assert "Your offer is bad." in router
+    assert "This will not convert." in router
+
+
 def test_start_router_no_longer_blindly_pulls_business_repo() -> None:
     start = _read(START_SKILL)
     update = _read(UPDATE_REF)

--- a/mb/tests/test_start_router_contract.py
+++ b/mb/tests/test_start_router_contract.py
@@ -60,6 +60,9 @@ def test_start_router_routes_money_intent_from_moneypath_facts() -> None:
         "next dollar",
         "offer readiness",
         "Keep hard gates first",
+        "Required update, broken install/runtime/wiring, repair blockers, validation\n"
+        "  blockers, relationship health blockers, playbook health blockers, and unsafe\n"
+        "  provider/private-data blockers all win before MoneyPath routing.",
         "`money_path.overall_level`",
         "`money_path.overall_label`",
         "`money_path.objects.offer`",
@@ -73,12 +76,19 @@ def test_start_router_routes_money_intent_from_moneypath_facts() -> None:
         "without conversion judgment",
         "Explain whether top-level `ranked_actions` agree with the MoneyPath\n  bottleneck",
         "include a MoneyPath snapshot in the handoff",
+        "Product ladder is stated but has no\n> clear paid entry step",
+        "Channel strategy exists, but no active push is\n> attached",
+        "Outcome feedback loop is missing",
+        "Recommended route: use `/mb-think`",
     ]
     for phrase in required_phrases:
         assert phrase in router
 
     assert "Your offer is bad." in router
     assert "This will not convert." in router
+    assert "This will convert." in router
+    assert "The business is weak." in router
+    assert "This is ready to win." in router
 
 
 def test_start_router_no_longer_blindly_pulls_business_repo() -> None:

--- a/mb/tests/test_start_router_contract.py
+++ b/mb/tests/test_start_router_contract.py
@@ -14,6 +14,11 @@ def _read(path: Path) -> str:
     return path.read_text(encoding="utf-8")
 
 
+def _normalize(text: str) -> str:
+    lines = [line.removeprefix("> ").strip() for line in text.splitlines()]
+    return " ".join(" ".join(lines).split())
+
+
 def test_mb_start_delegates_router_detail_without_bloating_skill_body() -> None:
     start = _read(START_SKILL)
 
@@ -50,9 +55,11 @@ def test_router_contract_covers_books_save_sync_and_updates() -> None:
 def test_start_router_routes_money_intent_from_moneypath_facts() -> None:
     start = _read(START_SKILL)
     router = _read(ROUTER_REF)
+    normalized_start = _normalize(start)
+    normalized_router = _normalize(router)
 
-    assert "Parse the full JSON once" in start
-    assert "do not slice\nstatus output with `head` or `sed`" in start
+    assert "Parse the full JSON once" in normalized_start
+    assert "do not slice status output with `head` or `sed`" in normalized_start
 
     required_phrases = [
         "Path to money, revenue, offer readiness",
@@ -60,9 +67,9 @@ def test_start_router_routes_money_intent_from_moneypath_facts() -> None:
         "next dollar",
         "offer readiness",
         "Keep hard gates first",
-        "Required update, broken install/runtime/wiring, repair blockers, validation\n"
-        "  blockers, relationship health blockers, playbook health blockers, and unsafe\n"
-        "  provider/private-data blockers all win before MoneyPath routing.",
+        "Required update, broken install/runtime/wiring, repair blockers, validation "
+        "blockers, relationship health blockers, playbook health blockers, and unsafe "
+        "provider/private-data blockers all win before MoneyPath routing.",
         "`money_path.overall_level`",
         "`money_path.overall_label`",
         "`money_path.objects.offer`",
@@ -74,21 +81,21 @@ def test_start_router_routes_money_intent_from_moneypath_facts() -> None:
         "`money_path.objects.outcome_feedback_loop`",
         "`money_path.ranked_actions`",
         "without conversion judgment",
-        "Explain whether top-level `ranked_actions` agree with the MoneyPath\n  bottleneck",
+        "Explain whether top-level `ranked_actions` agree with the MoneyPath bottleneck",
         "include a MoneyPath snapshot in the handoff",
-        "Product ladder is stated but has no\n> clear paid entry step",
-        "Channel strategy exists, but no active push is\n> attached",
+        "Product ladder is stated but has no clear paid entry step",
+        "Channel strategy exists, but no active push is attached",
         "Outcome feedback loop is missing",
         "Recommended route: use `/mb-think`",
     ]
     for phrase in required_phrases:
-        assert phrase in router
+        assert phrase in normalized_router
 
-    assert "Your offer is bad." in router
-    assert "This will not convert." in router
-    assert "This will convert." in router
-    assert "The business is weak." in router
-    assert "This is ready to win." in router
+    assert "Your offer is bad." in normalized_router
+    assert "This will not convert." in normalized_router
+    assert "This will convert." in normalized_router
+    assert "The business is weak." in normalized_router
+    assert "This is ready to win." in normalized_router
 
 
 def test_start_router_no_longer_blindly_pulls_business_repo() -> None:


### PR DESCRIPTION
## Summary

Updates `/mb-start` so path-to-money, revenue, next-dollar, and offer-readiness prompts route through deterministic MoneyPath facts before freeform file interpretation. The router now carries a MoneyPath snapshot into `/mb-think` handoffs, keeps hard blockers ahead of business routing, and avoids normal-path `head` / `sed` JSON slicing.

## Linked issue

Closes #539

## Why

The v0.3.19 dogfood showed that `/mb-start` could produce a useful owner loop while still handling path-to-money questions through ad hoc file triage. Operators need the agent's first business interpretation to visibly start from `mb status --json --peek` `money_path` facts, then use skill judgment and supporting files after the deterministic bottleneck is clear.

## Commits by concern

- [ ] Each commit body bullet-lists the changes in that commit; these are small follow-up commits with descriptive subjects and no bodies.
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work.
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`.

Commits:

- `b7c1de6 [update] MAIN-349 Route money prompts through MoneyPath`
- `71c7948 [update] MAIN-349 Tighten MoneyPath route guardrails`

## Validation

Level 1 static: `scripts/check.sh` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: terminal excerpt; formatting, Ruff, mypy passed, 599 tests passed, and 15/15 bundled skills validated.

Level 2 CLI/product contract: `cd mb && pytest tests/test_start_router_contract.py -q` — runtime: Python 3.13 — exit: 0 — log: terminal excerpt, `4 passed in 0.17s`.

Level 3 package/install smoke: `cd mb && python3 -m build`; `python3 -m venv /tmp/mainbranch-main-349-smoke`; `/tmp/mainbranch-main-349-smoke/bin/pip install mb/dist/*.whl`; `/tmp/mainbranch-main-349-smoke/bin/mb --version`; `/tmp/mainbranch-main-349-smoke/bin/mb skill list` — runtime: `/tmp/mainbranch-main-349-smoke/bin/python` — exit: 0 — log: terminal excerpt; wheel built, installed, `mb --version` reported `mb 0.3.19`, and `mb skill list` included `mb-start`.

Level 4 fixture repo: wheel-created fixture at `/tmp/mainbranch-main-349-business` with read-only `mb status --json --peek` and `mb start --json` evidence — runtime: `/tmp/mainbranch-main-349-smoke/bin/mb` — exit: 0 — log: `.agent/main-349-runtime-smoke/status.json` and `.agent/main-349-runtime-smoke/start.json`; status included MoneyPath level/gap facts and start reported handoff ready.

Level 5 runtime proxy: Claude Code print-mode path-to-money smoke from the fresh wheel-created fixture — runtime: Claude Code 2.1.140 with `/tmp/mainbranch-main-349-smoke/bin/mb` first on PATH — exit: 0 — log: `.agent/main-349-runtime-smoke/claude-path-to-money.txt`; Claude used MoneyPath facts first, named level/gaps, routed to `/mb-think`, and left the fixture clean. This is Claude Code print-mode proxy evidence, not full interactive TUI proof.

- [x] Level 1 static: `scripts/check.sh` passes.
- [x] Level 2 CLI contract: focused product-contract test covers `/mb-start` and router prose.
- [x] Level 3 package/install smoke: wheel built and installed; `mb --version` and `mb skill list` passed.
- [x] Level 4 fixture repo: fresh wheel-created business repo produced `mb status --json --peek` and `mb start --json` evidence.
- [x] Level 5 runtime smoke / dogfood harness / simulation-tier: Claude Code print-mode proxy run completed; not interactive TUI proof.
- [x] SKILL.md <=500 lines: `mb-start` validated at 500 lines.
- [ ] Package-visible release gate evidence before tag/publish not required; this is not a release-prep branch.
- [ ] Supply-chain review not required; no workflows, dependency files, or permissions changed.

## Success metric

When an operator asks `/mb-start` a path-to-money question, the agent starts from MoneyPath level/gap facts, names the bottleneck in business language, explains whether ranked actions agree, and hands `/mb-think` the MoneyPath snapshot before reading supporting files.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section.
- [ ] N/A - change is invisible to users (internal refactor, CI-only, etc.).

## Breaking changes

- [x] No
- [ ] Yes - migration note below

## Public / private boundary

No private operator strategy, raw Noontide transcript text, local machine paths, secrets, customer/member data, or raw runtime logs were committed. Runtime evidence remains in local `.agent/` scratch and is summarized as public-safe proxy evidence.
