### PR TITLE
[add] Shared workflow source prototype

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ### Added
 
+- Added the first shared workflow source prototype for the daily start ->
+  MoneyPath `/mb-think` handoff, with generated Claude/Codex shell snapshots
+  and drift tests that require shared `mb` commands and JSON facts to stay
+  present. Refs MAIN-351, #549.
 - Added a proposed shared workflow corpus and native runtime renderer decision
   that names `workflows/<workflow>/` as the portable source for selected
   workflow semantics, keeps Claude Code and Codex runtime shells native, and

--- a/mb/mb/workflows.py
+++ b/mb/mb/workflows.py
@@ -1,0 +1,356 @@
+"""Shared workflow source validation and snapshot rendering."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+VALID_LOOP_SLUGS = {"sense", "decide", "ship", "reflect"}
+REQUIRED_FRONTMATTER_FIELDS = {
+    "name",
+    "title",
+    "description",
+    "loops",
+    "runtime_support",
+    "required_mb_commands",
+    "json_facts",
+    "writes_business_files",
+    "provider_mutation",
+    "publishing_or_spend",
+}
+REQUIRED_SECTIONS = {
+    "Intent And Triggers",
+    "Required Mb Commands",
+    "Required JSON Fact Paths",
+    "Routing Rules",
+    "Read Boundaries",
+    "Write Boundaries",
+    "Approval Gates",
+    "Handoff Format",
+    "Validation Commands",
+    "Runtime-Specific Notes",
+}
+REQUIRED_RUNTIME_SUPPORT = {
+    "claude_code": "supported_shell",
+    "codex_cli": "experimental_shell",
+}
+MINIMUM_MB_COMMANDS = {
+    "mb status --json --peek",
+    "mb start --json",
+    "mb doctor repair --plan",
+}
+MINIMUM_JSON_FACTS = {
+    "money_path",
+    "money_path.objects.proof.quality",
+    "content_strategy",
+    "ranked_actions",
+    "update",
+    "readiness",
+    "drift.items",
+}
+PUBLIC_PRIVATE_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("local user path", re.compile(r"/Users/[^\s`)]+")),
+    ("private maintainer handle", re.compile(r"devonmeadows", re.I)),
+    ("GitHub token", re.compile(r"gh[pousr]_[A-Za-z0-9_]{20,}")),
+    ("AWS access key", re.compile(r"AKIA[0-9A-Z]{16}")),
+    ("Stripe key", re.compile(r"sk_(?:live|test)_[A-Za-z0-9]{12,}")),
+    (
+        "inline secret assignment",
+        re.compile(r"(?i)\b(?:api[_-]?key|password|secret|token)\s*[:=]\s*\S+"),
+    ),
+)
+
+
+@dataclass(frozen=True)
+class WorkflowSource:
+    """Parsed workflow source file."""
+
+    path: Path
+    frontmatter: dict[str, Any]
+    body: str
+
+    @property
+    def name(self) -> str:
+        return str(self.frontmatter["name"])
+
+    @property
+    def title(self) -> str:
+        return str(self.frontmatter["title"])
+
+    @property
+    def required_mb_commands(self) -> list[str]:
+        return [str(item) for item in self.frontmatter["required_mb_commands"]]
+
+    @property
+    def json_facts(self) -> list[str]:
+        return [str(item) for item in self.frontmatter["json_facts"]]
+
+
+class WorkflowValidationError(ValueError):
+    """Raised when a workflow source cannot be rendered safely."""
+
+
+def _split_frontmatter(text: str) -> tuple[dict[str, Any] | None, str, str | None]:
+    if not text.startswith("---\n"):
+        return None, text, "missing YAML frontmatter"
+    end = text.find("\n---", 4)
+    if end == -1:
+        return None, text, "unterminated YAML frontmatter"
+    try:
+        parsed = yaml.safe_load(text[4:end]) or {}
+    except yaml.YAMLError as exc:
+        return None, text, f"frontmatter does not parse as YAML: {exc}"
+    if not isinstance(parsed, dict):
+        return None, text, "frontmatter must be a mapping"
+    return parsed, text[end + len("\n---") :].lstrip("\n"), None
+
+
+def _coerce_string_list(value: Any) -> list[str] | None:
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        return None
+    return [str(item) for item in value]
+
+
+def _section_titles(body: str) -> set[str]:
+    return {
+        match.group("title").strip()
+        for match in re.finditer(r"^## (?P<title>.+?)\s*$", body, flags=re.MULTILINE)
+    }
+
+
+def read_workflow(path: Path) -> WorkflowSource:
+    """Read a workflow source without validating every contract rule."""
+
+    text = path.read_text(encoding="utf-8")
+    frontmatter, body, error = _split_frontmatter(text)
+    if error is not None or frontmatter is None:
+        raise WorkflowValidationError(error or "invalid workflow frontmatter")
+    return WorkflowSource(path=path, frontmatter=frontmatter, body=body)
+
+
+def validate_workflow(path: Path) -> list[str]:
+    """Return workflow source validation errors."""
+
+    errors: list[str] = []
+    if not path.is_file():
+        return [f"{path}: workflow source does not exist"]
+
+    text = path.read_text(encoding="utf-8")
+    frontmatter, body, frontmatter_error = _split_frontmatter(text)
+    if frontmatter_error is not None or frontmatter is None:
+        return [frontmatter_error or "invalid workflow frontmatter"]
+
+    for field in sorted(REQUIRED_FRONTMATTER_FIELDS):
+        if field not in frontmatter:
+            errors.append(f"missing frontmatter field: {field}")
+
+    loops = _coerce_string_list(frontmatter.get("loops"))
+    if loops is None:
+        errors.append("frontmatter field loops must be a list of strings")
+    else:
+        invalid_loops = sorted(set(loops) - VALID_LOOP_SLUGS)
+        if invalid_loops:
+            errors.append(f"frontmatter field loops has invalid slugs: {invalid_loops}")
+        if len(set(loops)) != len(loops):
+            errors.append("frontmatter field loops must not contain duplicate slugs")
+
+    runtime_support = frontmatter.get("runtime_support")
+    if not isinstance(runtime_support, dict):
+        errors.append("frontmatter field runtime_support must be a mapping")
+    else:
+        for runtime, expected in REQUIRED_RUNTIME_SUPPORT.items():
+            actual = runtime_support.get(runtime)
+            if actual != expected:
+                errors.append(f"runtime_support.{runtime} must be {expected!r}, got {actual!r}")
+
+    commands = _coerce_string_list(frontmatter.get("required_mb_commands"))
+    if commands is None:
+        errors.append("frontmatter field required_mb_commands must be a list of strings")
+    else:
+        missing_commands = sorted(MINIMUM_MB_COMMANDS - set(commands))
+        if missing_commands:
+            errors.append(f"required_mb_commands missing minimum commands: {missing_commands}")
+
+    facts = _coerce_string_list(frontmatter.get("json_facts"))
+    if facts is None:
+        errors.append("frontmatter field json_facts must be a list of strings")
+    else:
+        missing_facts = sorted(MINIMUM_JSON_FACTS - set(facts))
+        if missing_facts:
+            errors.append(f"json_facts missing minimum paths: {missing_facts}")
+
+    for field in ("writes_business_files", "provider_mutation", "publishing_or_spend"):
+        if field in frontmatter and not isinstance(frontmatter[field], bool):
+            errors.append(f"frontmatter field {field} must be true or false")
+
+    missing_sections = sorted(REQUIRED_SECTIONS - _section_titles(body))
+    for section in missing_sections:
+        errors.append(f"missing workflow section: {section}")
+
+    errors.extend(public_private_boundary_errors(text))
+    return errors
+
+
+def load_workflow(path: Path) -> WorkflowSource:
+    """Validate and read a workflow source."""
+
+    errors = validate_workflow(path)
+    if errors:
+        raise WorkflowValidationError("; ".join(errors))
+    return read_workflow(path)
+
+
+def shell_drift_errors(workflow: WorkflowSource, shell_text: str) -> list[str]:
+    """Return missing required commands or JSON facts for a rendered shell."""
+
+    errors: list[str] = []
+    for command in workflow.required_mb_commands:
+        if command not in shell_text:
+            errors.append(f"shell missing required mb command: {command}")
+    for fact in workflow.json_facts:
+        if fact not in shell_text:
+            errors.append(f"shell missing required JSON fact path: {fact}")
+    return errors
+
+
+def public_private_boundary_errors(text: str) -> list[str]:
+    """Flag obvious private paths, tokens, or inline secret assignments."""
+
+    errors: list[str] = []
+    for label, pattern in PUBLIC_PRIVATE_PATTERNS:
+        if pattern.search(text):
+            errors.append(f"public/private boundary violation: {label}")
+    return errors
+
+
+def _bullet_list(items: list[str]) -> str:
+    return "\n".join(f"- `{item}`" for item in items)
+
+
+def _display_path(path: Path) -> str:
+    parts = path.parts
+    if "workflows" in parts:
+        index = parts.index("workflows")
+        return Path(*parts[index:]).as_posix()
+    return path.as_posix()
+
+
+def render_claude_shell(workflow: WorkflowSource) -> str:
+    """Render a Claude Code shell snapshot for a workflow source."""
+
+    output = f"""# Generated Claude Shell: {workflow.title}
+
+Source workflow: `{_display_path(workflow.path)}`
+Runtime support: `claude_code: supported_shell`
+
+Use from `/mb-start` when the operator asks about revenue, offer readiness, the
+next dollar, or the path to money. Preserve slash-command-native language and
+handoff to `/mb-think` only when the next useful move is to clarify, decide,
+research, or codify durable business truth.
+
+This snapshot does not replace shipped `.claude/skills` prose.
+
+## Required mb Commands
+
+{_bullet_list(workflow.required_mb_commands)}
+
+## Required JSON Fact Paths
+
+{_bullet_list(workflow.json_facts)}
+
+## Routing
+
+1. Run hard gates first: required updates, broken repo wiring, repair blockers,
+   validation blockers, relationship-health blockers, unsafe provider
+   operations, private-data boundaries, and destructive-operation requests.
+2. Start MoneyPath interpretation from `money_path.overall_level`,
+   `money_path.overall_label`, the required `money_path.objects.*` paths, and
+   `money_path.ranked_actions`.
+3. Compare top-level `ranked_actions` with the MoneyPath bottleneck. If they
+   disagree, name the gate or route taking priority.
+4. Read supporting markdown only after deterministic facts identify the
+   bottleneck.
+5. Hand off to `/mb-think` with the MoneyPath snapshot when the next move is a
+   decision, research pass, or codify write.
+
+## Handoff Shape
+
+```text
+MoneyPath snapshot: overall <level> / <label>.
+Bottleneck: <object or gate>.
+Proof: <generic/specific/offer-linked/typicality/outcome-feedback facts>.
+Offer and ladder: <structured facts and missing fields>.
+CTA/channel/push: <connection facts>.
+Outcome feedback: <instrumentation facts>.
+Ranked actions: <agreement or disagreement with MoneyPath bottleneck>.
+Recommended route: use /mb-think to <decision or write target>.
+Approval needed before writes: yes.
+```
+
+Avoid subjective conversion judgment. Do not say an offer is bad, will convert,
+or will not convert.
+"""
+    return output
+
+
+def render_codex_shell(workflow: WorkflowSource) -> str:
+    """Render a Codex CLI guidance snapshot for a workflow source."""
+
+    output = f"""# Generated Codex Workflow Guidance: {workflow.title}
+
+Source workflow: `{_display_path(workflow.path)}`
+Runtime support: `codex_cli: experimental_shell`
+
+Codex remains experimental and CLI-first. This guidance is a generated snapshot
+for validation; it does not mean `/mb-start` slash commands work inside Codex
+and it does not claim selected Codex workflow support.
+
+Start from deterministic `mb` facts before reading business markdown or giving
+path-to-money advice.
+
+## Required mb Commands
+
+{_bullet_list(workflow.required_mb_commands)}
+
+## Required JSON Fact Paths
+
+{_bullet_list(workflow.json_facts)}
+
+## Codex Route
+
+1. Use the business repo `AGENTS.md` bootstrap posture: read facts first, keep
+   writes approval-gated, and translate git/provider details into business
+   language.
+2. Run hard gates before MoneyPath interpretation: required updates, repair
+   blockers, readiness blockers, unsafe provider operations, private-data
+   boundaries, and destructive-operation requests.
+3. Use `money_path`, `money_path.objects.proof.quality`, `content_strategy`,
+   `ranked_actions`, `update`, `readiness`, and `drift.items` as cited facts.
+4. If a thinking/codification step is needed, propose the route in Codex-native
+   language instead of pretending Claude slash commands are available.
+5. Ask before writing business files, saving checkpoints, opening public
+   issues, publishing, mutating providers, spending money, or contacting
+   customers.
+
+## Handoff Shape
+
+```text
+MoneyPath snapshot: overall <level> / <label>.
+Bottleneck: <object or gate>.
+Proof: <generic/specific/offer-linked/typicality/outcome-feedback facts>.
+Offer and ladder: <structured facts and missing fields>.
+CTA/channel/push: <connection facts>.
+Outcome feedback: <instrumentation facts>.
+Ranked actions: <agreement or disagreement with MoneyPath bottleneck>.
+Recommended route: clarify or codify <decision or write target> after approval.
+Approval needed before writes: yes.
+```
+
+Runtime smoke is required before docs say this selected workflow is supported
+or available in Codex.
+"""
+    return output

--- a/mb/mb/workflows.py
+++ b/mb/mb/workflows.py
@@ -209,12 +209,17 @@ def shell_drift_errors(workflow: WorkflowSource, shell_text: str) -> list[str]:
 
     errors: list[str] = []
     for command in workflow.required_mb_commands:
-        if command not in shell_text:
+        if not _has_exact_bullet_item(shell_text, command):
             errors.append(f"shell missing required mb command: {command}")
     for fact in workflow.json_facts:
-        if fact not in shell_text:
+        if not _has_exact_bullet_item(shell_text, fact):
             errors.append(f"shell missing required JSON fact path: {fact}")
     return errors
+
+
+def _has_exact_bullet_item(text: str, item: str) -> bool:
+    expected = f"- `{item}`"
+    return any(line.strip() == expected for line in text.splitlines())
 
 
 def public_private_boundary_errors(text: str) -> list[str]:

--- a/mb/tests/fixtures/workflows/mb-start-money-path.claude.md
+++ b/mb/tests/fixtures/workflows/mb-start-money-path.claude.md
@@ -1,0 +1,67 @@
+# Generated Claude Shell: Start To MoneyPath Think Handoff
+
+Source workflow: `workflows/mb-start-money-path/workflow.md`
+Runtime support: `claude_code: supported_shell`
+
+Use from `/mb-start` when the operator asks about revenue, offer readiness, the
+next dollar, or the path to money. Preserve slash-command-native language and
+handoff to `/mb-think` only when the next useful move is to clarify, decide,
+research, or codify durable business truth.
+
+This snapshot does not replace shipped `.claude/skills` prose.
+
+## Required mb Commands
+
+- `mb status --json --peek`
+- `mb start --json`
+- `mb doctor repair --plan`
+
+## Required JSON Fact Paths
+
+- `money_path`
+- `money_path.objects.offer`
+- `money_path.objects.proof`
+- `money_path.objects.proof.quality`
+- `money_path.objects.product_ladder`
+- `money_path.objects.cta_path`
+- `money_path.objects.channel_strategy`
+- `money_path.objects.active_push`
+- `money_path.objects.outcome_feedback_loop`
+- `money_path.ranked_actions`
+- `content_strategy`
+- `ranked_actions`
+- `update`
+- `readiness`
+- `drift.items`
+
+## Routing
+
+1. Run hard gates first: required updates, broken repo wiring, repair blockers,
+   validation blockers, relationship-health blockers, unsafe provider
+   operations, private-data boundaries, and destructive-operation requests.
+2. Start MoneyPath interpretation from `money_path.overall_level`,
+   `money_path.overall_label`, the required `money_path.objects.*` paths, and
+   `money_path.ranked_actions`.
+3. Compare top-level `ranked_actions` with the MoneyPath bottleneck. If they
+   disagree, name the gate or route taking priority.
+4. Read supporting markdown only after deterministic facts identify the
+   bottleneck.
+5. Hand off to `/mb-think` with the MoneyPath snapshot when the next move is a
+   decision, research pass, or codify write.
+
+## Handoff Shape
+
+```text
+MoneyPath snapshot: overall <level> / <label>.
+Bottleneck: <object or gate>.
+Proof: <generic/specific/offer-linked/typicality/outcome-feedback facts>.
+Offer and ladder: <structured facts and missing fields>.
+CTA/channel/push: <connection facts>.
+Outcome feedback: <instrumentation facts>.
+Ranked actions: <agreement or disagreement with MoneyPath bottleneck>.
+Recommended route: use /mb-think to <decision or write target>.
+Approval needed before writes: yes.
+```
+
+Avoid subjective conversion judgment. Do not say an offer is bad, will convert,
+or will not convert.

--- a/mb/tests/fixtures/workflows/mb-start-money-path.codex.md
+++ b/mb/tests/fixtures/workflows/mb-start-money-path.codex.md
@@ -1,0 +1,68 @@
+# Generated Codex Workflow Guidance: Start To MoneyPath Think Handoff
+
+Source workflow: `workflows/mb-start-money-path/workflow.md`
+Runtime support: `codex_cli: experimental_shell`
+
+Codex remains experimental and CLI-first. This guidance is a generated snapshot
+for validation; it does not mean `/mb-start` slash commands work inside Codex
+and it does not claim selected Codex workflow support.
+
+Start from deterministic `mb` facts before reading business markdown or giving
+path-to-money advice.
+
+## Required mb Commands
+
+- `mb status --json --peek`
+- `mb start --json`
+- `mb doctor repair --plan`
+
+## Required JSON Fact Paths
+
+- `money_path`
+- `money_path.objects.offer`
+- `money_path.objects.proof`
+- `money_path.objects.proof.quality`
+- `money_path.objects.product_ladder`
+- `money_path.objects.cta_path`
+- `money_path.objects.channel_strategy`
+- `money_path.objects.active_push`
+- `money_path.objects.outcome_feedback_loop`
+- `money_path.ranked_actions`
+- `content_strategy`
+- `ranked_actions`
+- `update`
+- `readiness`
+- `drift.items`
+
+## Codex Route
+
+1. Use the business repo `AGENTS.md` bootstrap posture: read facts first, keep
+   writes approval-gated, and translate git/provider details into business
+   language.
+2. Run hard gates before MoneyPath interpretation: required updates, repair
+   blockers, readiness blockers, unsafe provider operations, private-data
+   boundaries, and destructive-operation requests.
+3. Use `money_path`, `money_path.objects.proof.quality`, `content_strategy`,
+   `ranked_actions`, `update`, `readiness`, and `drift.items` as cited facts.
+4. If a thinking/codification step is needed, propose the route in Codex-native
+   language instead of pretending Claude slash commands are available.
+5. Ask before writing business files, saving checkpoints, opening public
+   issues, publishing, mutating providers, spending money, or contacting
+   customers.
+
+## Handoff Shape
+
+```text
+MoneyPath snapshot: overall <level> / <label>.
+Bottleneck: <object or gate>.
+Proof: <generic/specific/offer-linked/typicality/outcome-feedback facts>.
+Offer and ladder: <structured facts and missing fields>.
+CTA/channel/push: <connection facts>.
+Outcome feedback: <instrumentation facts>.
+Ranked actions: <agreement or disagreement with MoneyPath bottleneck>.
+Recommended route: clarify or codify <decision or write target> after approval.
+Approval needed before writes: yes.
+```
+
+Runtime smoke is required before docs say this selected workflow is supported
+or available in Codex.

--- a/mb/tests/test_workflows.py
+++ b/mb/tests/test_workflows.py
@@ -1,0 +1,93 @@
+"""Shared workflow source validation and renderer drift tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from mb.workflows import (
+    load_workflow,
+    public_private_boundary_errors,
+    render_claude_shell,
+    render_codex_shell,
+    shell_drift_errors,
+    validate_workflow,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / "workflows" / "mb-start-money-path" / "workflow.md"
+FIXTURES = REPO_ROOT / "mb" / "tests" / "fixtures" / "workflows"
+
+
+def test_start_money_path_workflow_source_validates() -> None:
+    assert validate_workflow(WORKFLOW) == []
+
+
+def test_workflow_validation_flags_missing_required_section(tmp_path: Path) -> None:
+    broken = tmp_path / "workflow.md"
+    broken.write_text(
+        WORKFLOW.read_text(encoding="utf-8").replace("## Approval Gates", "## Approval Gatez"),
+        encoding="utf-8",
+    )
+
+    errors = validate_workflow(broken)
+
+    assert "missing workflow section: Approval Gates" in errors
+
+
+def test_workflow_validation_flags_missing_required_json_fact(tmp_path: Path) -> None:
+    broken = tmp_path / "workflow.md"
+    broken.write_text(
+        WORKFLOW.read_text(encoding="utf-8").replace("  - money_path.objects.proof.quality\n", ""),
+        encoding="utf-8",
+    )
+
+    errors = validate_workflow(broken)
+
+    assert any("json_facts missing minimum paths" in error for error in errors)
+    assert any("money_path.objects.proof.quality" in error for error in errors)
+
+
+def test_generated_claude_and_codex_snapshots_match_fixtures() -> None:
+    workflow = load_workflow(WORKFLOW)
+
+    assert render_claude_shell(workflow) == (FIXTURES / "mb-start-money-path.claude.md").read_text(
+        encoding="utf-8"
+    )
+    assert render_codex_shell(workflow) == (FIXTURES / "mb-start-money-path.codex.md").read_text(
+        encoding="utf-8"
+    )
+
+
+def test_supported_shells_preserve_required_commands_and_json_facts() -> None:
+    workflow = load_workflow(WORKFLOW)
+    shells = [
+        render_claude_shell(workflow),
+        render_codex_shell(workflow),
+    ]
+
+    for shell in shells:
+        assert shell_drift_errors(workflow, shell) == []
+
+
+def test_drift_detection_flags_omitted_required_command_or_fact() -> None:
+    workflow = load_workflow(WORKFLOW)
+    shell = render_codex_shell(workflow)
+    drifted = shell.replace("mb status --json --peek", "mb status")
+    drifted = drifted.replace("money_path.objects.proof.quality", "proof_quality")
+
+    errors = shell_drift_errors(workflow, drifted)
+
+    assert "shell missing required mb command: mb status --json --peek" in errors
+    assert "shell missing required JSON fact path: money_path.objects.proof.quality" in errors
+
+
+def test_workflow_source_and_snapshots_stay_public_safe() -> None:
+    texts = [
+        WORKFLOW.read_text(encoding="utf-8"),
+        (FIXTURES / "mb-start-money-path.claude.md").read_text(encoding="utf-8"),
+        (FIXTURES / "mb-start-money-path.codex.md").read_text(encoding="utf-8"),
+    ]
+
+    errors = [error for text in texts for error in public_private_boundary_errors(text)]
+
+    assert errors == []

--- a/mb/tests/test_workflows.py
+++ b/mb/tests/test_workflows.py
@@ -81,6 +81,18 @@ def test_drift_detection_flags_omitted_required_command_or_fact() -> None:
     assert "shell missing required JSON fact path: money_path.objects.proof.quality" in errors
 
 
+def test_drift_detection_requires_exact_bulleted_fact_paths() -> None:
+    workflow = load_workflow(WORKFLOW)
+    shell = render_codex_shell(workflow)
+    drifted = shell.replace("- `money_path`\n", "")
+    drifted = drifted.replace("- `ranked_actions`\n", "")
+
+    errors = shell_drift_errors(workflow, drifted)
+
+    assert "shell missing required JSON fact path: money_path" in errors
+    assert "shell missing required JSON fact path: ranked_actions" in errors
+
+
 def test_workflow_source_and_snapshots_stay_public_safe() -> None:
     texts = [
         WORKFLOW.read_text(encoding="utf-8"),

--- a/workflows/mb-start-money-path/workflow.md
+++ b/workflows/mb-start-money-path/workflow.md
@@ -1,0 +1,207 @@
+---
+name: mb-start-money-path
+title: Start To MoneyPath Think Handoff
+description: Ground daily start path-to-money prompts in deterministic MoneyPath facts before handing off to thinking or codification work.
+loops: [sense, decide, ship]
+runtime_support:
+  claude_code: supported_shell
+  codex_cli: experimental_shell
+  future: planned
+required_mb_commands:
+  - mb status --json --peek
+  - mb start --json
+  - mb doctor repair --plan
+json_facts:
+  - money_path
+  - money_path.objects.offer
+  - money_path.objects.proof
+  - money_path.objects.proof.quality
+  - money_path.objects.product_ladder
+  - money_path.objects.cta_path
+  - money_path.objects.channel_strategy
+  - money_path.objects.active_push
+  - money_path.objects.outcome_feedback_loop
+  - money_path.ranked_actions
+  - content_strategy
+  - ranked_actions
+  - update
+  - readiness
+  - drift.items
+writes_business_files: true
+provider_mutation: false
+publishing_or_spend: false
+---
+
+# Start To MoneyPath Think Handoff
+
+This workflow source is the portable contract for daily start prompts where the
+operator asks about revenue, offer readiness, the next dollar, or the path to
+money. It exists to keep Claude Code and Codex shells aligned without changing
+shipped runtime behavior in this prototype.
+
+## Intent And Triggers
+
+Use this workflow when the operator starts or returns to a business repo and
+asks what matters for revenue, what sells, what blocks the next paid step, or
+whether the offer, proof, CTA, channel, push, page, or feedback loop is ready.
+
+Trigger phrases include path to money, revenue, make money, next dollar, what
+sells, paid step, CTA, offer readiness, product ladder, proof, launch readiness,
+and sales path.
+
+Do not use this workflow for a full research run, a full `/mb-think` port, a
+site build, provider setup, publishing, spend, customer contact, or direct model
+execution from `mb`.
+
+## Required Mb Commands
+
+Run or preserve these deterministic facts before interpreting business files:
+
+- `mb status --json --peek`
+- `mb start --json`
+- `mb doctor repair --plan`
+
+`mb status --json --peek` is the normal first read. `mb start --json` is the
+daily-start contract for runtime bootstraps that need a compact owner briefing.
+`mb doctor repair --plan` supplies repair blockers when status reports drift or
+broken wiring.
+
+## Required JSON Fact Paths
+
+The runtime shell must preserve these paths from the workflow source:
+
+- `money_path`
+- `money_path.objects.offer`
+- `money_path.objects.proof`
+- `money_path.objects.proof.quality`
+- `money_path.objects.product_ladder`
+- `money_path.objects.cta_path`
+- `money_path.objects.channel_strategy`
+- `money_path.objects.active_push`
+- `money_path.objects.outcome_feedback_loop`
+- `money_path.ranked_actions`
+- `content_strategy`
+- `ranked_actions`
+- `update`
+- `readiness`
+- `drift.items`
+
+Treat these as facts, not strategy. The CLI reports legibility, connection, and
+instrumentation. The runtime may recommend a route, but it must not claim that
+an offer will or will not convert.
+
+## Routing Rules
+
+Hard gates win before MoneyPath interpretation: required updates, broken repo
+wiring, repair blockers, validation blockers, relationship-health blockers,
+unsafe provider operations, private-data boundaries, and destructive-operation
+requests.
+
+When hard gates are clear, start from `money_path.overall_level`,
+`money_path.overall_label`, the required object paths above, and
+`money_path.ranked_actions`. Compare the top-level `ranked_actions` with the
+MoneyPath bottleneck. If they disagree, name which gate or route takes priority.
+
+Read supporting offer, proof, product ladder, decision, research, finance
+summary, push, or channel files only after the deterministic facts identify why
+that file can help.
+
+Route to the thinking/codification workflow only when the next useful move is
+to clarify, decide, research, or write durable business truth. Do not hand off
+to a production workflow when the missing fact is a decision, CTA, proof
+quality, paid entry step, or outcome feedback loop.
+
+## Read Boundaries
+
+Read deterministic `mb` facts before raw markdown. After the fact pass, read
+only the business files needed for the stated bottleneck or handoff:
+
+- `core/offer.md` or `core/offers/<slug>/offer.md`
+- `core/proof/` or offer-specific proof files
+- `core/product-ladder.md` or current product-ladder equivalent
+- `core/content-strategy.md` and indexed content strategy layers
+- relevant `decisions/`, `research/`, `pushes/`, and safe finance summaries
+
+Do not inspect secrets, raw provider exports, raw finance/legal records,
+customer/member records, local runtime settings, or private maintainer notes.
+
+## Write Boundaries
+
+The workflow may hand off to a route that writes business files only after the
+operator agrees to codify, decide, research, or save a checkpoint. Valid write
+targets live in the business repo, such as `research/`, `decisions/`, `core/`,
+`bets/`, `pushes/`, `log/`, and `documents/`.
+
+The workflow source itself does not authorize writes to shipped runtime files,
+generated repo guidance, provider accounts, public sites, ad accounts, customer
+systems, or release surfaces.
+
+## Approval Gates
+
+Ask before:
+
+- applying updates, repairs, or migrations;
+- creating, editing, moving, deleting, or archiving business files;
+- saving a checkpoint;
+- publishing a site, opening a public issue, submitting a proposal, spending
+  money, mutating provider state, or contacting customers;
+- reading or moving private, restricted, local-only, finance, legal, customer,
+  member, credential, or raw provider data.
+
+Never ask the operator to paste secrets into repo files or workflow sources.
+
+## Handoff Format
+
+When handing off to thinking or codification, include a compact snapshot:
+
+```text
+MoneyPath snapshot: overall <level> / <label>.
+Bottleneck: <object or gate>.
+Proof: <generic/specific/offer-linked/typicality/outcome-feedback facts>.
+Offer and ladder: <structured facts and missing fields>.
+CTA/channel/push: <connection facts>.
+Outcome feedback: <instrumentation facts>.
+Ranked actions: <agreement or disagreement with MoneyPath bottleneck>.
+Recommended route: use the thinking/codification workflow to <decision or write target>.
+Approval needed before writes: yes.
+```
+
+Use business language. Avoid subjective conversion judgment such as "your offer
+is bad," "this will convert," or "this will not convert."
+
+## Validation Commands
+
+Minimum validation for this prototype:
+
+- focused workflow schema tests;
+- generated Claude and Codex shell snapshot tests;
+- drift tests that fail when a supported shell omits a required `mb` command or
+  JSON fact path;
+- public/private boundary review;
+- `scripts/check.sh`.
+
+Runtime smoke is required before generated shell output replaces shipped
+Claude Code skill prose or before docs claim selected Codex workflow support.
+
+## Runtime-Specific Notes
+
+### Claude Code
+
+Claude Code remains the supported runtime. Rendered Claude shell snapshots must
+preserve slash-command-native language, `/mb-start` to `/mb-think` handoff
+shape, MoneyPath-first routing, hard gates before MoneyPath interpretation, and
+no subjective conversion judgment.
+
+This prototype does not replace `.claude/skills/mb-start/SKILL.md` or
+`.claude/skills/mb-think/SKILL.md`. Replacing shipped Claude prose requires
+skill validation and runtime evidence.
+
+### Codex CLI
+
+Codex remains experimental and CLI-first. Rendered Codex shell snapshots must
+start from generated `AGENTS.md` style grounding and deterministic `mb` facts.
+
+Do not say `/mb-start` works inside Codex. Do not claim selected Codex workflow
+support until a fresh fixture repo and read-only `codex exec --json --ephemeral
+--sandbox read-only -C <repo>` smoke prove the generated shell is actually
+used.


### PR DESCRIPTION
## Summary

Adds the first shared workflow source prototype for the daily start -> MoneyPath `/mb-think` handoff. The prototype keeps runtime behavior unchanged while snapshot-testing Claude and Codex shell guidance against one workflow definition.

## Linked issue

Closes #549
Refs #451
Refs #453
Refs #539

## Why

MAIN-351 is the first implementation slice after the shared workflow source decision. It proves one workflow family can declare required `mb` commands, JSON facts, boundaries, handoff shape, and runtime notes once, then render Claude and Codex snapshots without semantic drift or overclaiming Codex support.

## Commits by concern

- [ ] Each commit body bullet-lists the changes in that commit
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`

Commit list:

- `f1b33ee [add] MAIN-351 workflow source prototype`

## Validation

Pre-push gate from repo root:

```bash
scripts/check.sh
```

- [x] Level 1 static: `scripts/check.sh` passes
- [x] Level 2 CLI contract: focused Typer/CliRunner tests, exit codes, `--json` behavior, TTY vs non-TTY (if CLI behavior touched)
- [ ] Level 3 package/install smoke (if packaging touched)
- [ ] Level 4 fixture repo (if init/onboard/status/start/update touched)
- [ ] Level 5 runtime smoke / dogfood harness / simulation-tier (if runtime, first-run, skill discovery, or release validation touched)
- [x] SKILL.md <=500 lines (if any skill touched)
- [ ] Package-visible release gate evidence before tag/publish (if preparing a release)
- [ ] Supply-chain review (if `.github/workflows/`, `.github/dependabot.yml`, `mb/pyproject.toml` deps, or `id-token`/`permissions` blocks touched — see [docs/supply-chain-policy.md](../docs/supply-chain-policy.md))

Level 1 static: `scripts/check.sh` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: `83 files already formatted`; `All checks passed!`; `Success: no issues found in 82 source files`.

Level 2 CLI contract: `scripts/check.sh` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: `tests/test_workflows.py` passed all 7 workflow schema, snapshot, drift, and public/private-boundary tests; full suite collected 606 tests and passed.

Level 3 package/install: not required; no packaging, entrypoint, install, or bundled-data behavior changed.

Level 4 fixture repo: not required; the branch does not change init, onboard, status, start, update, or business-repo generated files.

Level 5 runtime smoke: not required; generated outputs are committed test fixtures only and do not replace shipped Claude skill prose, generated repo guidance, or Codex runtime behavior.

SKILL.md line gate: `scripts/check.sh` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: `mb skill validate --all --json` summary reported 15 passed, 0 failed, 0 errors, 0 warnings.

## Success metric

One workflow family is represented once in `workflows/mb-start-money-path/workflow.md` and checked against both Claude and Codex generated shell snapshots, with tests failing if required `mb` commands or JSON fact paths drift.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [ ] N/A — change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [x] No
- [ ] Yes — migration note below

## Public / private boundary

No private operator strategy, machine-specific paths, credentials, account data, customer/member data, raw business data, or local transcript text were committed. The new tests include public/private boundary checks for the workflow source and generated snapshot fixtures.
