### PR TITLE
[add] mb books status and doctor plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   now reports hledger availability, sanitized private-books-vault setup, ignore
   protections, and check health; `mb books doctor --plan` now gives a
   non-mutating repair plan for safe bookkeeping setup gaps without reading or
-  mutating real ledger contents. Refs MAIN-128, #128.
+  mutating real ledger contents. Refs #552, #128.
 - Added the first shared workflow source prototype for the daily start ->
   MoneyPath `/mb-think` handoff, with generated Claude/Codex shell snapshots
   and drift tests that require shared `mb` commands and JSON facts to stay

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ### Added
 
+- Added the first narrow MAIN-128 `mb books` setup slice: `mb books status`
+  now reports hledger availability, sanitized private-books-vault setup, ignore
+  protections, and check health; `mb books doctor --plan` now gives a
+  non-mutating repair plan for safe bookkeeping setup gaps without reading or
+  mutating real ledger contents. Refs MAIN-128, #128.
 - Added the first shared workflow source prototype for the daily start ->
   MoneyPath `/mb-think` handoff, with generated Claude/Codex shell snapshots
   and drift tests that require shared `mb` commands and JSON facts to stay

--- a/decisions/2026-05-11-mb-books-foundation.md
+++ b/decisions/2026-05-11-mb-books-foundation.md
@@ -402,9 +402,9 @@ The first fixture lives under `docs/examples/books/`. Packaging it
 into `mb/mb/_data/` is a follow-up concern when `mb books check`
 ships.
 
-## First `mb books` Surface
+## First `mb books` Surfaces
 
-The first command, deferred to a follow-up implementation issue, is:
+The first command shipped in the follow-up implementation issue is:
 
 ```text
 mb books check [--json]
@@ -437,11 +437,12 @@ What it must do:
 - emit an `mb` JSON envelope when `--json` is passed, matching the
   pattern used by `mb doctor` / `mb validate`.
 
-A sibling `mb books status` command (also deferred to the follow-up)
-prints the storage-mode summary shown above and the
-GitHub-as-backup warning when appropriate. A sibling `mb books doctor`
-repairs missing ignore rules and missing vault scaffolding without
-ever touching real ledger contents.
+A sibling `mb books status` command prints the storage-mode summary
+shown above and the GitHub-as-backup warning when appropriate. A
+sibling `mb books doctor --plan` produces a non-mutating repair plan
+for missing ignore rules, missing vault scaffolding, hledger
+availability, and private journal placeholder setup without ever
+touching real ledger contents.
 
 What it must not do in the first surface:
 

--- a/docs/books.md
+++ b/docs/books.md
@@ -8,9 +8,9 @@ function is bookkeeping.
 
 ## The Short Version
 
-- Main Branch ships `mb books check`, the first surface in the `mb books`
-  command group. It validates bookkeeping safety without reading any
-  real ledger contents.
+- Main Branch ships the first safe `mb books` setup surfaces:
+  `check`, `status`, and `doctor --plan`. They validate and explain
+  bookkeeping safety without reading any real ledger contents.
 - **Main Branch uses hledger as the bookkeeping engine for `mb books`.**
   The hledger journal is the only authoritative ledger.
 - hledger is **optional** for base `mb` installs, but it is the chosen
@@ -202,10 +202,12 @@ There is no `mb` command for it.
 
 ## What `mb books` Does Today
 
-The shipped surface is:
+The shipped safe setup surfaces are:
 
 ```bash
 mb books check [REPO] [--fixture] [--fixture-path PATH] [--json]
+mb books status [REPO] [--json]
+mb books doctor [REPO] --plan [--json]
 ```
 
 `mb books check` runs read-only checks against a business repo. It:
@@ -235,11 +237,49 @@ mb books check [REPO] [--fixture] [--fixture-path PATH] [--json]
 - emits a JSON envelope with `--json` for scripts and skills, with
   every finding carrying `audience` and `operator_summary` fields.
 
+`mb books status` shows readable setup/storage health:
+
+- hledger availability, without printing the local binary path;
+- configured storage mode from `core/finance/books.md`;
+- sanitized private-vault location labels. Relative paths inside the
+  business repo may be shown; external absolute vault paths are
+  reported as external private paths instead of printed;
+- whether the configured local vault exists;
+- whether a private `main.journal` placeholder exists, without
+  reading its contents;
+- whether `.gitignore` includes the expected private-vault and
+  ledger-extension protections;
+- the GitHub private repo warning when team-private mode or GitHub
+  backup is configured.
+
+`mb books doctor --plan` prints a non-mutating repair plan for setup
+gaps:
+
+- install hledger when deeper local journal checks are needed;
+- add a safe `core/finance/books.md` policy when the operator is
+  ready;
+- add or fix `storage_mode`;
+- add bookkeeping ignore protections;
+- create the private books vault directory;
+- create a private hledger journal placeholder from a safe template
+  shape;
+- move unsafe tracked finance artifacts out of the business repo.
+
+It does not apply repairs yet. The plan is designed for operator
+review and avoids printing private external vault paths or real
+financial data.
+
 Exit codes:
 
-- `0` — no error findings (info or warn states allowed);
-- `1` — at least one error finding (e.g. broken policy frontmatter,
+- `mb books check`: `0` when there are no error findings (info or
+  warn states allowed); `1` when there is at least one error finding
+  (e.g. broken policy frontmatter,
   or `.mb/private/` exists without a matching ignore rule).
+- `mb books status`: `0` when there are no error findings; `1` when
+  status finds an error.
+- `mb books doctor --plan`: `0` after printing a plan. Running
+  `mb books doctor` without `--plan` exits `2` because applying
+  repairs is not implemented.
 
 It does **not**:
 
@@ -250,10 +290,9 @@ It does **not**:
 - read the real ledger contents inside the vault;
 - mutate any file.
 
-Sibling commands `mb books status` (storage-mode summary plus the
-GitHub-as-backup warning) and `mb books doctor` (mechanical repairs
-to ignore rules and vault scaffolding) are named in the foundation
-decision and not yet shipped.
+Later slices may add real imports, reconciliation, month close, or
+fixture-safe reporting only after separate decisions and smoke
+evidence. They are not part of the current command surface.
 
 The full first-surface spec lives in
 [the mb books foundation decision](../decisions/2026-05-11-mb-books-foundation.md).
@@ -289,10 +328,9 @@ The setup path, when the time comes:
    journal contents in.
 5. Optionally add `core/finance/chart-of-accounts.md` describing your
    account-naming convention.
-6. Run `mb books check` to verify the policy parses and the
-   `.mb/private/` ignore rule is in place. When the sibling
-   `mb books doctor` ships, it will mechanically add missing ignore
-   rules for you.
+6. Run `mb books status` to review setup/storage health, then
+   `mb books doctor --plan` for safe repair guidance. Run
+   `mb books check` when you need the lower-level safety findings.
 
 ## Related
 

--- a/mb/mb/books.py
+++ b/mb/mb/books.py
@@ -38,13 +38,26 @@ STATEMENT_EXTENSIONS = (".csv", ".ofx", ".qfx", ".qbo", ".qif")
 UNSAFE_EXTENSIONS = LEDGER_EXTENSIONS + STATEMENT_EXTENSIONS
 
 VAULT_RELATIVE = Path(".mb/private")
+DEFAULT_BOOKS_VAULT_RELATIVE = Path(".mb/private/books")
 VAULT_IGNORE_ENTRIES = (".mb/private/", ".mb/private")
+BOOKS_IGNORE_ENTRIES = (
+    ".mb/private/",
+    "*.journal",
+    "*.hledger",
+    "*.ledger",
+    "*.beancount",
+)
 
 VALID_STORAGE_MODES = frozenset({"solo-local", "team-private-repo", "advanced-vault"})
 NON_LOCAL_STORAGE_MODES = frozenset({"team-private-repo", "advanced-vault"})
 
 BUNDLED_FIXTURE_NAME = "acme-fixture.journal"
 DOCS_BOOKS_PATH = "docs/books.md"
+GITHUB_PRIVATE_WARNING = (
+    "GitHub private repos are private, not financial vaults. Anyone with repo "
+    "access can read the full ledger and history. Removing a transaction later "
+    "does not remove it from history."
+)
 
 # Fixture markers an operator can put in a sample journal/CSV to opt the
 # file out of unsafe-path detection. See the foundation decision.
@@ -189,6 +202,252 @@ def _has_fixture_marker(path: Path) -> bool:
 
 def _ignore_rule_present(entries: set[str]) -> bool:
     return any(entry in entries for entry in VAULT_IGNORE_ENTRIES)
+
+
+def _books_ignore_missing(entries: set[str]) -> list[str]:
+    return [entry for entry in BOOKS_IGNORE_ENTRIES if entry not in entries]
+
+
+def _has_books_policy(repo: Path) -> bool:
+    return (repo / "core" / "finance" / "books.md").exists()
+
+
+def _policy_storage_mode(fm: dict[str, Any]) -> str:
+    return str(fm.get("storage_mode") or "").strip()
+
+
+def _safe_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
+
+
+def _vault_info(repo: Path, fm: dict[str, Any]) -> dict[str, Any]:
+    """Return sanitized private-books-vault facts.
+
+    The report deliberately avoids printing absolute vault paths outside the
+    business repo. It only stats relative paths or absolute paths that resolve
+    under ``repo``. External locations are reported as configured, but the
+    literal path is not included.
+    """
+    storage_mode = _policy_storage_mode(fm)
+    raw_location = str(fm.get("vault_location") or "").strip()
+    defaulted = False
+    if not raw_location and storage_mode not in NON_LOCAL_STORAGE_MODES:
+        raw_location = DEFAULT_BOOKS_VAULT_RELATIVE.as_posix()
+        defaulted = True
+
+    if storage_mode in NON_LOCAL_STORAGE_MODES:
+        configured = bool(raw_location)
+        return {
+            "storage_mode": storage_mode,
+            "configured": configured,
+            "defaulted": False,
+            "location": (
+                "configured external private books repo"
+                if storage_mode == "team-private-repo" and configured
+                else "configured external private books vault"
+                if configured
+                else "not configured"
+            ),
+            "location_kind": "external",
+            "local_path": "",
+            "exists": None,
+            "journal_placeholder": "not_checked",
+        }
+
+    if not raw_location:
+        return {
+            "storage_mode": storage_mode,
+            "configured": False,
+            "defaulted": False,
+            "location": "not configured",
+            "location_kind": "missing",
+            "local_path": "",
+            "exists": False,
+            "journal_placeholder": "missing",
+        }
+
+    candidate = Path(raw_location)
+    repo_resolved = repo.resolve()
+    if candidate.is_absolute():
+        resolved = candidate.resolve()
+        try:
+            rel = resolved.relative_to(repo_resolved)
+        except ValueError:
+            return {
+                "storage_mode": storage_mode,
+                "configured": True,
+                "defaulted": defaulted,
+                "location": "external private path",
+                "location_kind": "external",
+                "local_path": "",
+                "exists": None,
+                "journal_placeholder": "not_checked",
+            }
+        local_path = repo / rel
+        display = rel.as_posix()
+    else:
+        local_path = repo / candidate
+        display = candidate.as_posix().rstrip("/") or "."
+
+    exists = local_path.exists()
+    journal = local_path / "main.journal"
+    return {
+        "storage_mode": storage_mode,
+        "configured": True,
+        "defaulted": defaulted,
+        "location": display,
+        "location_kind": "repo_relative",
+        "local_path": display,
+        "exists": exists,
+        "journal_placeholder": "present" if journal.exists() else "missing",
+    }
+
+
+def _status_extra_findings(
+    repo: Path, fm: dict[str, Any], check_report: dict[str, Any]
+) -> list[dict[str, Any]]:
+    findings: list[dict[str, Any]] = []
+    hledger_path = shutil.which("hledger")
+    if hledger_path:
+        findings.append(
+            _finding(
+                id="hledger-available",
+                title="hledger is available",
+                state="ok",
+                detail="The hledger command is available on PATH.",
+                audience="informational",
+                operator_summary="hledger is installed for deeper local books checks.",
+            )
+        )
+    else:
+        findings.append(
+            _finding(
+                id="hledger-missing",
+                title="hledger is not installed",
+                state="info",
+                detail=(
+                    "hledger is optional for base Main Branch installs, but it is "
+                    "needed for real local journal checks."
+                ),
+                audience="informational",
+                operator_summary="Install hledger before validating real local journals.",
+                repair="Install hledger from https://hledger.org/install.html",
+            )
+        )
+
+    entries = _gitignore_entries(repo)
+    missing_ignore = _books_ignore_missing(entries)
+    if missing_ignore:
+        findings.append(
+            _finding(
+                id="books-ignore-protections-missing",
+                title="Bookkeeping ignore protections are incomplete",
+                state="warn",
+                detail=(
+                    "The business repo .gitignore is missing bookkeeping safety "
+                    f"entries: {', '.join(missing_ignore)}."
+                ),
+                audience="mechanical",
+                operator_summary=(
+                    "Add the missing books ignore rules so real ledgers and the "
+                    "private vault do not enter tracked history."
+                ),
+                repair="Add the missing entries to .gitignore.",
+                evidence=missing_ignore,
+            )
+        )
+    else:
+        findings.append(
+            _finding(
+                id="books-ignore-protections-ok",
+                title="Bookkeeping ignore protections are present",
+                state="ok",
+                detail="The expected private-vault and ledger-extension ignore rules are present.",
+                audience="informational",
+                operator_summary="Books ignore protections are present.",
+            )
+        )
+
+    vault = _vault_info(repo, fm)
+    policy_present = _has_books_policy(repo)
+    if vault["exists"] is True:
+        findings.append(
+            _finding(
+                id="books-vault-present",
+                title="Private books vault exists",
+                state="ok",
+                detail=f"Configured vault location: {vault['location']}.",
+                audience="informational",
+                operator_summary="Private books vault directory exists.",
+            )
+        )
+    elif vault["exists"] is False:
+        findings.append(
+            _finding(
+                id="books-vault-missing",
+                title="Private books vault is not set up yet",
+                state="warn" if policy_present else "info",
+                detail=f"Configured vault location: {vault['location']}.",
+                audience="mechanical" if policy_present else "informational",
+                operator_summary=(
+                    "Create the private books vault before storing real journals."
+                    if policy_present
+                    else "No private books vault yet. Set it up when you start real bookkeeping."
+                ),
+                repair=f"mkdir -p {DEFAULT_BOOKS_VAULT_RELATIVE.as_posix()}",
+            )
+        )
+
+    if vault["journal_placeholder"] == "missing" and vault["exists"] is True:
+        findings.append(
+            _finding(
+                id="books-journal-placeholder-missing",
+                title="No private main.journal placeholder",
+                state="info",
+                detail=(
+                    f"{vault['location']}/main.journal is not present. Main Branch "
+                    "does not create or edit real journals in this slice."
+                ),
+                audience="operator_decision",
+                operator_summary=(
+                    "Create a private hledger main.journal when you are ready to start books."
+                ),
+                repair=(
+                    "Create a private hledger journal inside the books vault; use "
+                    "docs/examples/books/acme-fixture.journal only as a fake shape reference."
+                ),
+            )
+        )
+    elif vault["journal_placeholder"] == "present":
+        findings.append(
+            _finding(
+                id="books-journal-placeholder-present",
+                title="Private main.journal placeholder exists",
+                state="ok",
+                detail=f"{vault['location']}/main.journal exists; contents were not read.",
+                audience="informational",
+                operator_summary="Private main.journal exists; Main Branch did not read it.",
+            )
+        )
+
+    if check_report.get("storage_mode") == "team-private-repo" or _safe_bool(
+        fm.get("github_backup")
+    ):
+        findings.append(
+            _finding(
+                id="github-private-books-warning",
+                title="GitHub private repo warning",
+                state="warn",
+                detail=GITHUB_PRIVATE_WARNING,
+                audience="operator_decision",
+                operator_summary=GITHUB_PRIVATE_WARNING,
+            )
+        )
+    return findings
 
 
 def _detect_books_policy(repo: Path) -> tuple[dict[str, Any], list[dict[str, Any]]]:
@@ -679,6 +938,266 @@ def run(
     }
 
 
+def status(repo: str | Path = ".") -> dict[str, Any]:
+    """Return read-only books setup and storage health.
+
+    This is the safe operator-facing status surface for the private hledger
+    books vault. It never reads real ledger contents and it sanitizes private
+    vault paths that point outside the business repo.
+    """
+    repo_path = Path(repo).resolve()
+    check_report = run(repo=repo_path)
+    fm, _ = _detect_books_policy(repo_path)
+    extra_findings = _status_extra_findings(repo_path, fm, check_report)
+    findings = [*check_report["findings"], *extra_findings]
+    state = _max_state([finding["state"] for finding in findings])
+    errors = [finding["operator_summary"] for finding in findings if finding["state"] == "error"]
+    warnings = [finding["operator_summary"] for finding in findings if finding["state"] == "warn"]
+
+    hledger_available = any(finding["id"] == "hledger-available" for finding in extra_findings)
+    entries = _gitignore_entries(repo_path)
+    missing_ignore = _books_ignore_missing(entries)
+    vault = _vault_info(repo_path, fm)
+    storage_mode = check_report.get("storage_mode") or _policy_storage_mode(fm)
+    status_summary = "Books setup passed." if state == "ok" else _summary(state, findings)
+
+    return {
+        "ok": state not in {"error"},
+        "state": state,
+        "repo": str(repo_path),
+        "engine": "hledger",
+        "hledger": {
+            "available": hledger_available,
+            "command": "hledger",
+            "install": "https://hledger.org/install.html",
+        },
+        "policy": {
+            "present": _has_books_policy(repo_path),
+            "path": "core/finance/books.md",
+            "storage_mode": storage_mode,
+            "valid_storage_mode": bool(storage_mode in VALID_STORAGE_MODES),
+        },
+        "vault": vault,
+        "ignore": {
+            "missing": missing_ignore,
+            "ok": not missing_ignore,
+            "expected": list(BOOKS_IGNORE_ENTRIES),
+        },
+        "check": {
+            "state": check_report["state"],
+            "summary": check_report["summary"],
+            "warnings": check_report["warnings"],
+            "errors": check_report["errors"],
+        },
+        "github_private_warning": (
+            GITHUB_PRIVATE_WARNING
+            if storage_mode == "team-private-repo" or _safe_bool(fm.get("github_backup"))
+            else ""
+        ),
+        "summary": status_summary,
+        "findings": findings,
+        "errors": errors,
+        "warnings": warnings,
+        "safe_to_share": True,
+    }
+
+
+def _plan_action(
+    *,
+    id: str,
+    title: str,
+    state: str,
+    reason: str,
+    command: str,
+    writes: list[str] | None = None,
+    evidence: list[str] | None = None,
+    audience: str = "operator_decision",
+) -> dict[str, Any]:
+    return {
+        "id": id,
+        "title": title,
+        "state": state,
+        "mode": "plan",
+        "safe_to_apply": False,
+        "reason": reason,
+        "command": command,
+        "writes": writes or [],
+        "evidence": evidence or [],
+        "audience": audience if audience in AUDIENCE_VALUES else "operator_decision",
+        "operator_summary": reason,
+    }
+
+
+def doctor_plan(repo: str | Path = ".") -> dict[str, Any]:
+    """Return a non-mutating books repair plan."""
+    status_report = status(repo=repo)
+    findings = {finding["id"]: finding for finding in status_report["findings"]}
+    actions: list[dict[str, Any]] = []
+
+    if "hledger-missing" in findings:
+        finding = findings["hledger-missing"]
+        actions.append(
+            _plan_action(
+                id="install-hledger",
+                title="Install hledger",
+                state="info",
+                reason=finding["operator_summary"],
+                command="Install hledger from https://hledger.org/install.html",
+                evidence=finding.get("evidence") or [],
+                audience="informational",
+            )
+        )
+
+    if "books-policy-missing" in findings:
+        finding = findings["books-policy-missing"]
+        actions.append(
+            _plan_action(
+                id="add-books-policy",
+                title="Add a safe books policy",
+                state="info",
+                reason=finding["operator_summary"],
+                command=(
+                    "Use docs/examples/books/books.md as the shape for "
+                    "core/finance/books.md; keep real ledger data out of it."
+                ),
+                writes=["core/finance/books.md"],
+                audience="informational",
+            )
+        )
+    elif "books-policy-frontmatter-error" in findings:
+        finding = findings["books-policy-frontmatter-error"]
+        actions.append(
+            _plan_action(
+                id="fix-books-policy-frontmatter",
+                title="Fix books policy frontmatter",
+                state="error",
+                reason=finding["operator_summary"],
+                command=finding["repair"],
+                writes=["core/finance/books.md"],
+            )
+        )
+    elif (
+        "books-policy-storage-mode-missing" in findings
+        or "books-policy-storage-mode-invalid" in findings
+    ):
+        key = (
+            "books-policy-storage-mode-missing"
+            if "books-policy-storage-mode-missing" in findings
+            else "books-policy-storage-mode-invalid"
+        )
+        finding = findings[key]
+        actions.append(
+            _plan_action(
+                id="fix-books-storage-mode",
+                title="Fix books storage mode",
+                state="warn",
+                reason=finding["operator_summary"],
+                command=finding["repair"],
+                writes=["core/finance/books.md"],
+            )
+        )
+
+    if "chart-of-accounts-missing" in findings:
+        finding = findings["chart-of-accounts-missing"]
+        actions.append(
+            _plan_action(
+                id="add-chart-of-accounts",
+                title="Add chart of accounts when ready",
+                state="info",
+                reason=finding["operator_summary"],
+                command=(
+                    "Use docs/examples/books/chart-of-accounts.md as the shape "
+                    "for core/finance/chart-of-accounts.md; do not include real balances."
+                ),
+                writes=["core/finance/chart-of-accounts.md"],
+                audience="informational",
+            )
+        )
+
+    missing_ignore = status_report["ignore"]["missing"]
+    if missing_ignore:
+        actions.append(
+            _plan_action(
+                id="add-books-ignore-protections",
+                title="Add books ignore protections",
+                state="warn",
+                reason=(
+                    "The business repo is missing books ignore rules for the "
+                    "private vault or ledger-shaped files."
+                ),
+                command=(
+                    "Add these lines to .gitignore: "
+                    + ", ".join(f"`{entry}`" for entry in missing_ignore)
+                ),
+                writes=[".gitignore"],
+                evidence=missing_ignore,
+                audience="mechanical",
+            )
+        )
+
+    if "books-vault-missing" in findings:
+        finding = findings["books-vault-missing"]
+        actions.append(
+            _plan_action(
+                id="create-private-books-vault",
+                title="Create private books vault",
+                state=finding["state"],
+                reason=finding["operator_summary"],
+                command=f"mkdir -p {DEFAULT_BOOKS_VAULT_RELATIVE.as_posix()}",
+                writes=[DEFAULT_BOOKS_VAULT_RELATIVE.as_posix()],
+                audience=finding["audience"],
+            )
+        )
+
+    if "books-journal-placeholder-missing" in findings:
+        finding = findings["books-journal-placeholder-missing"]
+        actions.append(
+            _plan_action(
+                id="create-private-journal-placeholder",
+                title="Create private hledger journal placeholder",
+                state="info",
+                reason=finding["operator_summary"],
+                command=finding["repair"],
+                writes=[f"{DEFAULT_BOOKS_VAULT_RELATIVE.as_posix()}/main.journal"],
+                audience="operator_decision",
+            )
+        )
+
+    if "unsafe-paths-detected" in findings:
+        finding = findings["unsafe-paths-detected"]
+        actions.append(
+            _plan_action(
+                id="move-unsafe-finance-artifacts",
+                title="Move unsafe tracked finance artifacts",
+                state="warn",
+                reason=finding["operator_summary"],
+                command=finding["repair"],
+                evidence=finding.get("evidence") or [],
+                audience="operator_decision",
+            )
+        )
+
+    action_state = _max_state([action["state"] for action in actions])
+    state = action_state if actions else "ok"
+    return {
+        "ok": True,
+        "state": state,
+        "repo": status_report["repo"],
+        "summary": (
+            f"{len(actions)} planned repair action(s)." if actions else "No books repairs planned."
+        ),
+        "actions": actions,
+        "status": {
+            "state": status_report["state"],
+            "summary": status_report["summary"],
+            "hledger": status_report["hledger"],
+            "vault": status_report["vault"],
+            "ignore": status_report["ignore"],
+        },
+        "safe_to_share": True,
+    }
+
+
 def _summary(state: str, findings: list[dict[str, Any]]) -> str:
     counts = {"ok": 0, "info": 0, "warn": 0, "error": 0}
     for finding in findings:
@@ -720,3 +1239,58 @@ def render_human(report: dict[str, Any]) -> None:
             typer.echo(f"           - {item}")
     typer.echo("")
     typer.echo(f"See {DOCS_BOOKS_PATH} for the full books contract.")
+
+
+def render_status(report: dict[str, Any]) -> None:
+    """Print ``mb books status`` for humans."""
+    import typer
+
+    hledger = "available" if report["hledger"]["available"] else "missing"
+    vault = report["vault"]
+    typer.echo(f"mb books status — {report['summary']}")
+    typer.echo(f"Books engine:      {report['engine']}")
+    typer.echo(f"hledger:           {hledger}")
+    typer.echo(f"Storage mode:      {report['policy']['storage_mode'] or 'not configured'}")
+    typer.echo(f"Bookkeeping vault: {vault['location']}")
+    if vault["exists"] is not None:
+        typer.echo(f"Vault exists:      {'yes' if vault['exists'] else 'no'}")
+    typer.echo(f"Ignore rules:      {'ok' if report['ignore']['ok'] else 'missing'}")
+    if report.get("github_private_warning"):
+        typer.echo("")
+        typer.echo(report["github_private_warning"])
+    typer.echo("")
+    for finding in report.get("findings", []):
+        if finding.get("state") == "ok":
+            continue
+        marker = {"info": "info", "warn": "WARN", "error": "FAIL"}.get(
+            finding.get("state", "info"), "    "
+        )
+        typer.echo(f"  [{marker}] {finding['title']}")
+        if finding.get("operator_summary"):
+            typer.echo(f"         {finding['operator_summary']}")
+        if finding.get("repair"):
+            typer.echo(f"         repair: {finding['repair']}")
+        for item in (finding.get("evidence") or [])[:5]:
+            typer.echo(f"           - {item}")
+    typer.echo("")
+    typer.echo("Run `mb books doctor --plan` for safe setup repair guidance.")
+
+
+def render_doctor_plan(report: dict[str, Any]) -> None:
+    """Print ``mb books doctor --plan`` for humans."""
+    import typer
+
+    typer.echo(f"mb books doctor --plan — {report['summary']}")
+    if not report.get("actions"):
+        return
+    typer.echo("")
+    for action in report["actions"]:
+        marker = {"info": "info", "warn": "WARN", "error": "FAIL"}.get(
+            action.get("state", "info"), "    "
+        )
+        typer.echo(f"  [{marker}] {action['title']}")
+        typer.echo(f"         {action['reason']}")
+        if action.get("command"):
+            typer.echo(f"         plan: {action['command']}")
+        for item in (action.get("evidence") or [])[:5]:
+            typer.echo(f"           - {item}")

--- a/mb/mb/books.py
+++ b/mb/mb/books.py
@@ -205,7 +205,15 @@ def _ignore_rule_present(entries: set[str]) -> bool:
 
 
 def _books_ignore_missing(entries: set[str]) -> list[str]:
-    return [entry for entry in BOOKS_IGNORE_ENTRIES if entry not in entries]
+    missing: list[str] = []
+    if not _ignore_rule_present(entries):
+        missing.append(".mb/private/")
+    missing.extend(
+        entry
+        for entry in BOOKS_IGNORE_ENTRIES
+        if entry not in VAULT_IGNORE_ENTRIES and entry not in entries
+    )
+    return missing
 
 
 def _has_books_policy(repo: Path) -> bool:
@@ -256,18 +264,6 @@ def _vault_info(repo: Path, fm: dict[str, Any]) -> dict[str, Any]:
             "local_path": "",
             "exists": None,
             "journal_placeholder": "not_checked",
-        }
-
-    if not raw_location:
-        return {
-            "storage_mode": storage_mode,
-            "configured": False,
-            "defaulted": False,
-            "location": "not configured",
-            "location_kind": "missing",
-            "local_path": "",
-            "exists": False,
-            "journal_placeholder": "missing",
         }
 
     candidate = Path(raw_location)
@@ -1125,10 +1121,7 @@ def doctor_plan(repo: str | Path = ".") -> dict[str, Any]:
                     "The business repo is missing books ignore rules for the "
                     "private vault or ledger-shaped files."
                 ),
-                command=(
-                    "Add these lines to .gitignore: "
-                    + ", ".join(f"`{entry}`" for entry in missing_ignore)
-                ),
+                command=("Add these lines to .gitignore: " + ", ".join(missing_ignore)),
                 writes=[".gitignore"],
                 evidence=missing_ignore,
                 audience="mechanical",

--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -1007,7 +1007,7 @@ def books_doctor_cmd(
                         "safe_to_share": True,
                     },
                     command="mb books doctor",
-                    schema_name="mainbranch.books.doctor.result",
+                    schema_name="mainbranch.books.doctor.plan.result",
                 )
             )
         else:

--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -963,6 +963,71 @@ def books_check_cmd(
     raise typer.Exit(0 if report["ok"] else 1)
 
 
+@books_app.command("status")
+def books_status_cmd(
+    repo: str = typer.Argument(".", help="Business repo to inspect."),
+    json_out: bool = typer.Option(False, "--json", help="Machine-readable output."),
+) -> None:
+    """Show hledger/private-books-vault setup and storage health."""
+    report = books_mod.status(repo=repo)
+    if json_out:
+        typer.echo(
+            _json_payload(
+                report,
+                command="mb books status",
+                schema_name="mainbranch.books.status.result",
+            )
+        )
+    else:
+        books_mod.render_status(report)
+    raise typer.Exit(0 if report["ok"] else 1)
+
+
+@books_app.command("doctor")
+def books_doctor_cmd(
+    repo: str = typer.Argument(".", help="Business repo to inspect."),
+    plan: bool = typer.Option(
+        False,
+        "--plan",
+        help="Print a non-mutating repair plan. Required; apply is not implemented.",
+    ),
+    json_out: bool = typer.Option(False, "--json", help="Machine-readable output."),
+) -> None:
+    """Plan safe books setup repairs without touching real ledger contents."""
+    if not plan:
+        message = "mb books doctor: --plan is required; apply is not implemented"
+        if json_out:
+            typer.echo(
+                _json_payload(
+                    {
+                        "ok": False,
+                        "state": "error",
+                        "summary": message,
+                        "errors": [message],
+                        "safe_to_share": True,
+                    },
+                    command="mb books doctor",
+                    schema_name="mainbranch.books.doctor.result",
+                )
+            )
+        else:
+            typer.echo(message, err=True)
+        raise typer.Exit(2)
+
+    report = books_mod.doctor_plan(repo=repo)
+    if json_out:
+        typer.echo(
+            _json_payload(
+                report,
+                command="mb books doctor --plan",
+                schema_name="mainbranch.books.doctor.plan.result",
+            )
+        )
+    else:
+        books_mod.render_doctor_plan(report)
+    raise typer.Exit(0)
+
+
 @site_app.command("check")
 def site_check_cmd(
     site_repo: str = typer.Argument(".", help="Site repo or built static site to inspect."),

--- a/mb/mb/skill_validate.py
+++ b/mb/mb/skill_validate.py
@@ -107,11 +107,7 @@ _RAW_GIT_ALLOW_TERMS = (
     "wiki repo",
     "technical detail",
 )
-_UNSHIPPED_COMMANDS = (
-    "mb publish --plan",
-    "mb books status",
-    "mb books doctor",
-)
+_UNSHIPPED_COMMANDS = ("mb publish --plan",)
 _UNSHIPPED_COMMAND_ALLOW_TERMS = (
     "not shipped",
     "not yet shipped",

--- a/mb/tests/test_books.py
+++ b/mb/tests/test_books.py
@@ -356,6 +356,147 @@ def test_books_check_unsafe_paths_warn_does_not_exit_one(tmp_path: Path) -> None
     assert "WARN" in result.output
 
 
+def test_books_status_json_reports_missing_hledger_and_vault(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _init_business_repo(tmp_path)
+    _write(
+        repo / "core/finance/books.md",
+        """---
+type: books
+ledger: hledger
+storage_mode: solo-local
+vault_location: ".mb/private/books/"
+---
+
+# Books
+""",
+    )
+    _write(repo / ".gitignore", ".mb/private/\n*.journal\n*.hledger\n*.ledger\n*.beancount\n")
+    monkeypatch.setattr("mb.books.shutil.which", lambda name: "")
+
+    result = runner.invoke(app, ["books", "status", str(repo), "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["mb_command"] == "mb books status"
+    assert payload["result_schema"]["name"] == "mainbranch.books.status.result"
+    assert payload["engine"] == "hledger"
+    assert payload["hledger"]["available"] is False
+    assert payload["vault"]["location"] == ".mb/private/books"
+    assert payload["vault"]["exists"] is False
+    assert payload["ignore"]["ok"] is True
+    assert "books-vault-missing" in {finding["id"] for finding in payload["findings"]}
+
+
+def test_books_status_reports_hledger_and_private_journal_without_reading_contents(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _init_business_repo(tmp_path)
+    _write(
+        repo / "core/finance/books.md",
+        """---
+type: books
+ledger: hledger
+storage_mode: solo-local
+vault_location: ".mb/private/books/"
+---
+
+# Books
+""",
+    )
+    _write(repo / ".gitignore", ".mb/private/\n*.journal\n*.hledger\n*.ledger\n*.beancount\n")
+    _write(repo / ".mb/private/books/main.journal", "; PRIVATE_ACCOUNT_ID\n")
+    monkeypatch.setattr("mb.books.shutil.which", lambda name: "/fake/private/bin/hledger")
+
+    result = runner.invoke(app, ["books", "status", str(repo), "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["hledger"]["available"] is True
+    assert payload["vault"]["exists"] is True
+    assert payload["vault"]["journal_placeholder"] == "present"
+    assert "/fake/private/bin/hledger" not in result.output
+    assert "PRIVATE_ACCOUNT_ID" not in result.output
+
+
+def test_books_status_sanitizes_external_absolute_vault_path(tmp_path: Path) -> None:
+    repo = _init_business_repo(tmp_path)
+    private_path = tmp_path / "private-books" / "main.journal"
+    _write(
+        repo / "core/finance/books.md",
+        f"""---
+type: books
+ledger: hledger
+storage_mode: solo-local
+vault_location: "{private_path.parent}"
+---
+
+# Books
+""",
+    )
+
+    result = runner.invoke(app, ["books", "status", str(repo), "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["vault"]["location"] == "external private path"
+    assert str(private_path.parent) not in result.output
+
+
+def test_books_doctor_plan_json_lists_safe_repairs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _init_business_repo(tmp_path)
+    _write(repo / "core/finance/main.journal", "; leaked real journal\n")
+    _git_add_all(repo)
+    monkeypatch.setattr("mb.books.shutil.which", lambda name: "")
+
+    result = runner.invoke(app, ["books", "doctor", str(repo), "--plan", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["mb_command"] == "mb books doctor --plan"
+    assert payload["result_schema"]["name"] == "mainbranch.books.doctor.plan.result"
+    actions = {action["id"]: action for action in payload["actions"]}
+    assert "install-hledger" in actions
+    assert "create-private-books-vault" in actions
+    assert "add-books-ignore-protections" in actions
+    assert "move-unsafe-finance-artifacts" in actions
+    assert "core/finance/main.journal" in actions["move-unsafe-finance-artifacts"]["evidence"]
+    assert payload["safe_to_share"] is True
+
+
+def test_books_doctor_plan_reports_missing_private_journal_placeholder(tmp_path: Path) -> None:
+    repo = _init_business_repo(tmp_path)
+    _write(
+        repo / "core/finance/books.md",
+        """---
+type: books
+ledger: hledger
+storage_mode: solo-local
+vault_location: ".mb/private/books/"
+---
+
+# Books
+""",
+    )
+    _write(repo / ".gitignore", ".mb/private/\n*.journal\n*.hledger\n*.ledger\n*.beancount\n")
+    (repo / ".mb/private/books").mkdir(parents=True)
+
+    result = runner.invoke(app, ["books", "doctor", str(repo), "--plan", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    actions = {action["id"]: action for action in payload["actions"]}
+    assert "create-private-journal-placeholder" in actions
+    assert actions["create-private-journal-placeholder"]["writes"] == [
+        ".mb/private/books/main.journal"
+    ]
+
+
+def test_books_doctor_requires_plan(tmp_path: Path) -> None:
+    repo = _init_business_repo(tmp_path)
+    result = runner.invoke(app, ["books", "doctor", str(repo)])
+    assert result.exit_code == 2
+    assert "--plan is required" in result.output
+
+
 def test_books_check_packaged_fixtures_carry_marker() -> None:
     """The shipped fixtures must continue to carry an explicit marker.
 

--- a/mb/tests/test_books.py
+++ b/mb/tests/test_books.py
@@ -388,6 +388,37 @@ vault_location: ".mb/private/books/"
     assert "books-vault-missing" in {finding["id"] for finding in payload["findings"]}
 
 
+def test_books_status_and_doctor_accept_no_slash_private_ignore_entry(
+    tmp_path: Path,
+) -> None:
+    repo = _init_business_repo(tmp_path)
+    _write(
+        repo / "core/finance/books.md",
+        """---
+type: books
+ledger: hledger
+storage_mode: solo-local
+vault_location: ".mb/private/books/"
+---
+
+# Books
+""",
+    )
+    _write(repo / ".gitignore", ".mb/private\n*.journal\n*.hledger\n*.ledger\n*.beancount\n")
+
+    status_result = runner.invoke(app, ["books", "status", str(repo), "--json"])
+    assert status_result.exit_code == 0, status_result.output
+    status_payload = json.loads(status_result.output)
+    assert status_payload["ignore"]["ok"] is True
+    assert status_payload["ignore"]["missing"] == []
+
+    doctor_result = runner.invoke(app, ["books", "doctor", str(repo), "--plan", "--json"])
+    assert doctor_result.exit_code == 0, doctor_result.output
+    doctor_payload = json.loads(doctor_result.output)
+    actions = {action["id"] for action in doctor_payload["actions"]}
+    assert "add-books-ignore-protections" not in actions
+
+
 def test_books_status_reports_hledger_and_private_journal_without_reading_contents(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -495,6 +526,34 @@ def test_books_doctor_requires_plan(tmp_path: Path) -> None:
     result = runner.invoke(app, ["books", "doctor", str(repo)])
     assert result.exit_code == 2
     assert "--plan is required" in result.output
+
+
+def test_books_doctor_requires_plan_json_uses_plan_schema(tmp_path: Path) -> None:
+    repo = _init_business_repo(tmp_path)
+    result = runner.invoke(app, ["books", "doctor", str(repo), "--json"])
+    assert result.exit_code == 2
+    payload = json.loads(result.output)
+    assert payload["result_schema"]["name"] == "mainbranch.books.doctor.plan.result"
+    assert "--plan is required" in payload["summary"]
+
+
+def test_books_status_cli_human_output_mentions_plan(tmp_path: Path) -> None:
+    repo = _init_business_repo(tmp_path)
+    result = runner.invoke(app, ["books", "status", str(repo)])
+    assert result.exit_code == 0, result.output
+    assert "mb books status" in result.output
+    assert "Ignore rules:      missing" in result.output
+    assert "Run `mb books doctor --plan`" in result.output
+
+
+def test_books_doctor_plan_cli_human_output_formats_ignore_entries(tmp_path: Path) -> None:
+    repo = _init_business_repo(tmp_path)
+    result = runner.invoke(app, ["books", "doctor", str(repo), "--plan"])
+    assert result.exit_code == 0, result.output
+    assert "mb books doctor --plan" in result.output
+    assert "Add books ignore protections" in result.output
+    assert "plan: Add these lines to .gitignore: .mb/private/, *.journal" in result.output
+    assert "`.mb/private/`" not in result.output
 
 
 def test_books_check_packaged_fixtures_carry_marker() -> None:


### PR DESCRIPTION
## Summary

Adds the first narrow `mb books` setup slice: `mb books status` for hledger/private-books-vault health and `mb books doctor --plan` for non-mutating repair guidance. The slice preserves `mb books check` behavior and keeps real finance imports, reports, reconciliation, and ledger mutation out of scope.

## Linked issue

Closes #552
Refs #128
Refs MAIN-353, MAIN-128

## Why

MAIN-128 is the broader books umbrella, but the first reviewable finance slice should only make setup/storage health visible without touching real ledgers. This gives operators safe facts and repair plans before any provider import, reconciliation, close, or reporting surface exists.

## Commits by concern

- [x] `997e7e0 [add] MAIN-128 books status and doctor plan`
  - Adds `mb books status` and `mb books doctor --plan`.
  - Adds JSON envelopes, human output, safe external-path redaction, and plan-only repair actions.
  - Adds focused books tests for hledger presence, vault state, ignore protections, unsafe tracked artifacts, JSON output, non-mutating posture, and private-output boundaries.
  - Updates docs, decision text, changelog, and shipped-command validation.
- [x] `be59a1a [update] Reference books status slice issue`
  - Updates the changelog reference so this PR closes #552 and only references #128.
- [x] `300ecfa [fix] Address books status review notes`
  - Treats `.mb/private` and `.mb/private/` as equivalent vault ignore protections for status and doctor.
  - Removes unreachable vault-location code, aligns the doctor JSON error schema, and removes noisy backticks from the ignore-repair plan.
  - Adds CLI tests for no-slash ignore compatibility, doctor error schema, and human status/doctor output.
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work.
- [x] Commit subjects use this repo's bracketed vocabulary.

## Validation

Pre-push gate from repo root:

```bash
scripts/check.sh
```

- [x] Level 1 static: `scripts/check.sh` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: formatting, Ruff, mypy, 617 tests, coverage gate, bundled skill validation passed.
- [x] Level 2 CLI contract: `cd mb && pytest tests/test_books.py -q` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: 28 passed.
- [x] Level 3 package/install smoke: `cd mb && python3 -m build && python3 -m venv /tmp/mainbranch-main-353-review-smoke && /tmp/mainbranch-main-353-review-smoke/bin/pip install mb/dist/*.whl && /tmp/mainbranch-main-353-review-smoke/bin/mb --version && /tmp/mainbranch-main-353-review-smoke/bin/mb skill list` — runtime: `/tmp/mainbranch-main-353-review-smoke/bin/python3.13` — exit: 0 — log: built wheel, installed `mainbranch 0.3.19`, `mb --version` printed `mb 0.3.19`, `mb skill list` listed 15 skills.
- [x] Level 4 fixture repo: `/tmp/mainbranch-main-353-review-smoke/bin/mb onboard --yes --name "Books Review Smoke" --path /tmp/mainbranch-main-353-review-business --json && /tmp/mainbranch-main-353-review-smoke/bin/mb books status /tmp/mainbranch-main-353-review-business && /tmp/mainbranch-main-353-review-smoke/bin/mb books doctor /tmp/mainbranch-main-353-review-business --plan && /tmp/mainbranch-main-353-review-smoke/bin/mb books status /tmp/mainbranch-main-353-review-business --json && /tmp/mainbranch-main-353-review-smoke/bin/mb books doctor /tmp/mainbranch-main-353-review-business --plan --json` — runtime: `/tmp/mainbranch-main-353-review-smoke/bin/python3.13` — exit: 0 — log: status and doctor JSON returned `ok: true`; human status included `Run \`mb books doctor --plan\``; human doctor output had no `` `.mb/private/` `` backtick noise.
- [ ] Level 5 runtime smoke / dogfood harness / simulation-tier: not required; no runtime discovery, skill invocation, first-run handoff, or release validation behavior changed.
- [ ] SKILL.md <=500 lines: not required; no skill files changed.
- [ ] Package-visible release gate evidence before tag/publish: not required; this PR is not preparing a release.
- [ ] Supply-chain review: not required; no workflows, Dependabot, dependency, id-token, or permissions files changed.

## Success metric

A fresh business repo can run `mb books status --json` and `mb books doctor --plan --json` to see safe hledger/private-vault setup facts and repair guidance without reading real ledger contents, printing external private vault paths, or mutating files.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [ ] N/A — change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [x] No
- [ ] Yes — migration note below

## Public / private boundary

No real ledgers, bank statements, raw exports, account IDs, vendor/customer-sensitive records, payroll, tax docs, Mercury data, Devon-private finance paths, or private numbers were used or committed. External absolute private vault paths render as `external private path`, and `mb books doctor --plan` emits suggestions only without creating directories, editing `.gitignore`, creating ledgers, setting up providers, or reading/mutating private-vault contents.
