### PR TITLE
[add] Decide security review sidecars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ### Added
 
+- Added an accepted decision for agentic security review sidecars: DeepSec may
+  be used as an optional local pre-release review aid for security-sensitive
+  branches, while Greptile remains a hosted PR-review candidate pending a
+  separate privacy/setup evaluation. Release and post-release docs now route
+  sidecar evidence through targeted pre-release checks and sanitized
+  post-release follow-up, and contributor/release-agent docs cover sidecar
+  evidence capture. Refs #554.
 - Added the first narrow MAIN-128 `mb books` setup slice: `mb books status`
   now reports hledger availability, sanitized private-books-vault setup, ignore
   protections, and check health; `mb books doctor --plan` now gives a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,8 +85,8 @@ When a release candidate or PR changes security-sensitive surfaces, add a
 targeted agentic security sidecar review over the changed risky files or
 scanner candidates. DeepSec is the accepted local sidecar today; keep raw output
 under `.agent/`, time-box AI processing, and publish only sanitized summaries.
-Do not treat DeepSec, Greptile, or any other AI reviewer as a required gate for
-ordinary PRs. See
+Do not treat DeepSec, Greptile, or any other AI reviewer as a required gate;
+sidecar output is review input. See
 [the sidecar decision](decisions/2026-05-13-agentic-security-review-sidecars.md)
 and [the supply-chain policy](docs/supply-chain-policy.md).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,6 +81,15 @@ against the best available release artifact whenever feasible, and manually
 review the transcript for whether Claude actually used `mb` facts or only
 handled a permission-distorted fallback.
 
+When a release candidate or PR changes security-sensitive surfaces, add a
+targeted agentic security sidecar review over the changed risky files or
+scanner candidates. DeepSec is the accepted local sidecar today; keep raw output
+under `.agent/`, time-box AI processing, and publish only sanitized summaries.
+Do not treat DeepSec, Greptile, or any other AI reviewer as a required gate for
+ordinary PRs. See
+[the sidecar decision](decisions/2026-05-13-agentic-security-review-sidecars.md)
+and [the supply-chain policy](docs/supply-chain-policy.md).
+
 For Go tools (Phase 2):
 
 ```bash

--- a/decisions/2026-05-13-agentic-security-review-sidecars.md
+++ b/decisions/2026-05-13-agentic-security-review-sidecars.md
@@ -122,9 +122,10 @@ pnpm deepsec process --project-id mainbranch --agent codex --diff origin/main --
 pnpm deepsec process --project-id mainbranch --agent codex --files .github/workflows/publish-pypi.yml --concurrency 1 --batch-size 1
 ```
 
-Fill `data/mainbranch/INFO.md` before `process`; it is injected into each AI
-investigation batch. Keep it short and public-safe. Time-box the AI phase and
-record partial/stalled runs honestly.
+Fill `.agent/deepsec/data/mainbranch/INFO.md` before `process`; it is injected
+into each AI investigation batch from the gitignored scratch workspace. Keep it
+short and public-safe. Time-box the AI phase and record partial/stalled runs
+honestly.
 
 ## Do Not Use DeepSec When
 

--- a/decisions/2026-05-13-agentic-security-review-sidecars.md
+++ b/decisions/2026-05-13-agentic-security-review-sidecars.md
@@ -1,0 +1,172 @@
+---
+type: decision
+date: 2026-05-13
+status: accepted
+topic: Agentic security review sidecars for releases and pull requests
+linked_issues:
+  - https://github.com/noontide-co/mainbranch/issues/554
+linked_decisions:
+  - decisions/2026-05-11-supply-chain-security-gates.md
+  - decisions/2026-05-11-repo-setup-visibility-and-checks-model.md
+  - decisions/2026-05-04-workspace-repo-sensitive-data-boundaries.md
+linked_docs:
+  - docs/supply-chain-policy.md
+  - docs/post-release-alignment.md
+  - docs/dependency-choices.md
+  - SECURITY.md
+tags: [security, release, code-review, ai-review, deepsec, greptile]
+---
+
+# Agentic Security Review Sidecars For Releases And Pull Requests
+
+## Decision
+
+Main Branch may use agentic security-review tooling as **optional sidecar
+evidence**, not as a required release, merge, or support gate.
+
+- **DeepSec is accepted as a local optional pre-release sidecar.** Use it when a
+  branch touches security-sensitive release surfaces: GitHub Actions, PyPI
+  publishing, dependency handling, install/update paths, credentials, provider
+  auth, repo writes, untrusted file parsing, or external-account mutation.
+- **For edited release/security files, the spend is justified.** The intended
+  use is a targeted review of changed high-risk files or candidates, where a
+  few dollars and minutes are worth it if the sidecar catches a publishing,
+  credential, or provider-authority flaw before release.
+- **DeepSec output is review input, not release truth.** A finding is a lead for
+  human/agent review. It does not replace `scripts/check.sh`, package/install
+  smoke, release simulations, GitHub Environment approval, Dependabot review,
+  or the supply-chain checks in `docs/supply-chain-policy.md`.
+- **Run DeepSec from ignored local scratch by default.** Keep workspaces,
+  model logs, raw findings, and local paths under `.agent/` or another
+  gitignored evidence directory. Public docs, issues, and PR bodies may include
+  only sanitized summaries.
+- **Do not adopt Greptile as release infrastructure yet.** Greptile remains a
+  hosted PR-review candidate because it is designed around GitHub/GitLab PR
+  review, repo indexing, comments, status checks, and persistent team rules.
+  Evaluate it separately before installing a GitHub App, granting repo access,
+  requiring checks, or committing Greptile config.
+- **No AI reviewer is a required gate today.** The current release posture stays
+  small, boring, explicit, and human-approved. A future branch may promote a
+  sidecar only after smoke evidence proves it adds signal without noisy,
+  expensive, or privacy-risky automation.
+
+## Why
+
+Main Branch is a public package-publishing project. The highest-risk mistakes
+are release-pipeline changes, broadened workflow permissions, dependency
+updates hidden inside feature work, credential leakage, and false runtime or
+provider claims. Agentic scanners can help spot those issues, but they also add
+new risks: repo access, model cost, noisy findings, tool execution authority,
+and a temptation to treat model output as proof.
+
+A local DeepSec smoke on this repository showed the useful shape. The regex
+scan completed quickly, activated GitHub Actions matchers, and surfaced three
+candidate files: CI workflow action refs, publish workflow OIDC/secret/action
+refs, and `hashlib` use in `mb connect`. Those candidates are exactly the kind
+of review prompts that matter for release hardening, but the initial matches
+were candidates rather than confirmed vulnerabilities.
+
+This means DeepSec is built closely enough for Main Branch's current shape to
+justify use: it recognized GitHub Actions, Python, workflow permission and
+secret-reference surfaces, and crypto-adjacent code in a small public Python
+CLI. It is not limited to web applications, though many of its built-in
+matchers are strongest around common web, auth, and service-entry patterns.
+
+The bounded AI investigation pass also showed the operational cost. A Codex
+`process` run completed the CI workflow candidate with zero findings, taking
+about two minutes and roughly $0.64 of model cost for one file. The second
+candidate then stalled long enough that the run was stopped, leaving the
+remaining local records in a processing state. That is acceptable exploratory
+evidence, and it argues for scoped runs with timeouts rather than a blanket
+required gate.
+
+DeepSec fits Main Branch best as a deliberate local tool because it can run
+from ignored scratch, produce inspectable candidate records, and let release
+agents choose a small `process` pass over the files that matter. That matches
+the existing validation ladder: extra evidence for risky surfaces, not an
+always-on dependency.
+
+Greptile solves a different problem. Its public docs describe a hosted code
+review agent that installs into GitHub/GitLab, indexes the codebase, reviews
+PRs, posts inline comments, supports manual `@greptileai` triggers, exposes
+status-check behavior, and can be configured with `.greptile/` or
+`greptile.json`. That may be useful for broad PR quality in repositories like
+OpenClaw, Hermes, or Paperclip-adjacent work, but it is a bigger trust and
+workflow decision than a local release-sidecar smoke.
+
+## Use DeepSec When
+
+- A PR changes `.github/workflows/`, `.github/dependabot.yml`, package metadata,
+  release scripts, or publish behavior.
+- A PR adds or changes provider auth, credential references, keychain/env
+  handling, repo writes, network calls, external-account mutation, or untrusted
+  parsing.
+- A release candidate has enough security-sensitive surface that a targeted
+  sidecar review would help reviewers ask better questions.
+
+Preferred local sequence:
+
+```bash
+npx deepsec init .agent/deepsec . --id mainbranch
+cd .agent/deepsec
+pnpm install
+pnpm deepsec scan --project-id mainbranch
+pnpm deepsec process --project-id mainbranch --agent codex --limit <N> --concurrency 1 --batch-size 1
+```
+
+For release branches where only a few risky files changed, prefer the diff or
+file-scoped process modes after scan:
+
+```bash
+pnpm deepsec process --project-id mainbranch --agent codex --diff origin/main --concurrency 1 --batch-size 1
+pnpm deepsec process --project-id mainbranch --agent codex --files .github/workflows/publish-pypi.yml --concurrency 1 --batch-size 1
+```
+
+Fill `data/mainbranch/INFO.md` before `process`; it is injected into each AI
+investigation batch. Keep it short and public-safe. Time-box the AI phase and
+record partial/stalled runs honestly.
+
+## Do Not Use DeepSec When
+
+- The branch is docs-only or does not touch security-sensitive surfaces.
+- The release is already published; post-release use should only route sanitized
+  findings into issues or reports.
+- The run would require publishing credentials, private customer data, raw
+  transcripts, or private operator strategy in model prompts or public output.
+- The cost or time would displace the required validation ladder.
+
+## Greptile Boundary
+
+Greptile may be evaluated later as a PR-review service, not as the first
+security release gate. Before adoption, require a separate issue and decision
+covering:
+
+- GitHub App permissions, repository access, data retention, and public/private
+  boundary.
+- Whether reviews are manual-only, label-triggered, draft-only, or automatic.
+- Whether status checks are informational or merge-blocking.
+- Repo-level `.greptile/` or `greptile.json` rules that map to Main Branch's
+  existing review focus without adding nitpick noise.
+- A trial on non-release PRs, with false-positive examples and useful findings
+  summarized publicly.
+
+## Evidence Standard
+
+For DeepSec or any comparable sidecar, PR evidence should state:
+
+- command, scope, and whether AI `process` ran;
+- exit code and ignored evidence path;
+- candidate/finding count;
+- which findings were confirmed, rejected as false positives, or routed to
+  follow-up issues;
+- explicit note that raw local logs and local paths were not committed.
+
+## Consequences
+
+- Release agents can reach for DeepSec on high-risk branches without asking
+  whether the tool is allowed.
+- Reviewers should not block ordinary PRs because DeepSec or Greptile did not
+  run.
+- Hosted AI review remains a separate product/workflow decision.
+- `docs/supply-chain-policy.md` should name agentic security review as an
+  optional pre-release sidecar, not a mandatory release step.

--- a/docs/post-release-alignment.md
+++ b/docs/post-release-alignment.md
@@ -30,14 +30,18 @@ next parallel batch:
 3. Audit release simulation transcripts when the release touched package,
    runtime, first-run, generated guidance, or operator workflow behavior. Use
    the transcript audit below.
-4. Align repo docs and decisions if anything shipped changed the product
+4. If a pre-release security sidecar such as DeepSec ran, review the sanitized
+   result alongside the release evidence. Route confirmed product gaps to
+   GitHub issues or a public-safe report; keep raw logs, local paths, model
+   traces, and private security details out of public docs.
+5. Align repo docs and decisions if anything shipped changed the product
    stance. Use the alignment sweep below.
-5. Audit agent cold-start guidance when the release taught a new protocol,
+6. Audit agent cold-start guidance when the release taught a new protocol,
    review habit, validation rule, or task-triggered read path. Use
    `docs/agent-cold-start.md` as the public source of truth.
-6. Align local agent preferences only when a private local workflow reminder
+7. Align local agent preferences only when a private local workflow reminder
    changed. Use the local-preferences policy below.
-7. Start the next parallel batch.
+8. Start the next parallel batch.
 
 ## 2. Alignment sweep
 

--- a/docs/release-agent-contract.md
+++ b/docs/release-agent-contract.md
@@ -21,6 +21,8 @@ Applies to any agent or human driver running:
 - wheel build + fresh-install smoke for a release candidate;
 - `scripts/claude-runtime-dogfood.py` at any simulation tier;
 - post-publish PyPI verification;
+- optional agentic security sidecars such as DeepSec when a release candidate
+  touches security-sensitive surfaces;
 - any other validation that takes more than ~10 seconds and produces output
   worth preserving.
 
@@ -143,6 +145,18 @@ Before re-running any long check, check in order:
 
 Re-run only when the previous result is genuinely unknown or a code change
 warrants a fresh run.
+
+### 3a. Time-box optional security sidecars.
+
+Agentic security sidecars are review aids, not release truth. When a
+security-sensitive release branch runs DeepSec or a comparable tool, scope it
+to changed high-risk files or scanner candidates, capture the first run's log
+and exit state, and record partial or stalled runs honestly.
+
+Keep raw model output, local paths, and scanner workspaces under `.agent/` or
+another ignored evidence directory. Public PR evidence should include only the
+command shape, scope, exit/timeout result, candidate/finding count, and which
+items were confirmed, rejected, or routed to follow-up issues.
 
 ### 4. Release PRs stay release-only.
 

--- a/docs/supply-chain-policy.md
+++ b/docs/supply-chain-policy.md
@@ -153,11 +153,12 @@ it. Run them before tagging an `oe-v*` release.
    `grep -RIn "id-token\|permissions:" .github/workflows/`.
 4. Confirm Dependabot is current. No open security advisories,
    no overdue grouped upgrades that should land in this release.
-5. For release candidates that touch security-sensitive surfaces, run a
+5. For release candidates that touch security-sensitive surfaces, consider a
    targeted local agentic security review sidecar over the changed risky files
-   or candidates. DeepSec is the accepted local sidecar for this purpose; keep
-   raw output under `.agent/`, publish only sanitized summaries, time-box AI
-   processing, and treat findings as review leads rather than release truth. See
+   or candidates. DeepSec is the accepted local sidecar for this optional
+   review aid; keep raw output under `.agent/`, publish only sanitized
+   summaries, time-box AI processing, and treat findings as review leads rather
+   than release truth. See
    [`decisions/2026-05-13-agentic-security-review-sidecars.md`](../decisions/2026-05-13-agentic-security-review-sidecars.md).
 6. Confirm the `pypi` GitHub Environment still requires a reviewer.
    This is a settings check, not a YAML check.

--- a/docs/supply-chain-policy.md
+++ b/docs/supply-chain-policy.md
@@ -153,14 +153,20 @@ it. Run them before tagging an `oe-v*` release.
    `grep -RIn "id-token\|permissions:" .github/workflows/`.
 4. Confirm Dependabot is current. No open security advisories,
    no overdue grouped upgrades that should land in this release.
-5. Confirm the `pypi` GitHub Environment still requires a reviewer.
+5. For release candidates that touch security-sensitive surfaces, run a
+   targeted local agentic security review sidecar over the changed risky files
+   or candidates. DeepSec is the accepted local sidecar for this purpose; keep
+   raw output under `.agent/`, publish only sanitized summaries, time-box AI
+   processing, and treat findings as review leads rather than release truth. See
+   [`decisions/2026-05-13-agentic-security-review-sidecars.md`](../decisions/2026-05-13-agentic-security-review-sidecars.md).
+6. Confirm the `pypi` GitHub Environment still requires a reviewer.
    This is a settings check, not a YAML check.
-6. Tag and publish via the GitHub Releases UI. The publish workflow
+7. Tag and publish via the GitHub Releases UI. The publish workflow
    triggers on `release: published`; the publish job blocks on the
    `pypi` environment approval.
-7. Approve the deployment in the GitHub Actions UI only after the build
+8. Approve the deployment in the GitHub Actions UI only after the build
    and release-notes jobs have completed and the artifact looks right.
-8. After publish, verify the fresh PyPI install per
+9. After publish, verify the fresh PyPI install per
    `docs/release-simulations.md` (Release Acceptance tier).
 
 ## Post-Compromise Response
@@ -198,6 +204,7 @@ proves the gap.
 ## Related Links
 
 - [Supply-chain security gates decision](../decisions/2026-05-11-supply-chain-security-gates.md)
+- [Agentic security review sidecars decision](../decisions/2026-05-13-agentic-security-review-sidecars.md)
 - [Repo setup, visibility, and checks model decision](../decisions/2026-05-11-repo-setup-visibility-and-checks-model.md)
 - [Workspace, repo, and sensitive-data boundaries decision](../decisions/2026-05-04-workspace-repo-sensitive-data-boundaries.md)
 - [Dependency choices](dependency-choices.md)


### PR DESCRIPTION
## Summary

Adds an accepted decision for agentic security review sidecars and wires it into the release, post-release, contributor, and validation-evidence docs.

## Linked issue

Closes #554

## Why

Main Branch needed a clear answer on whether DeepSec, Greptile, or similar AI security review tools belong in pre-release or post-release workflows. This keeps DeepSec available for targeted high-risk release/security diffs while avoiding a blanket mandatory AI-review gate or hosted Greptile adoption before privacy/setup review.

## Commits by concern

- [ ] Each commit body bullet-lists the changes in that commit
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`

Commit list:

- `b7f979e [add] Decide security review sidecars`

## Validation

Pre-push gate from repo root:

```bash
scripts/check.sh
```

- [x] Level 1 static: `scripts/check.sh` passes
- [ ] Level 2 CLI contract: focused Typer/CliRunner tests, exit codes, `--json` behavior, TTY vs non-TTY (if CLI behavior touched)
- [ ] Level 3 package/install smoke (if packaging touched)
- [ ] Level 4 fixture repo (if init/onboard/status/start/update touched)
- [ ] Level 5 runtime smoke / dogfood harness / simulation-tier (if runtime, first-run, skill discovery, or release validation touched)
- [ ] SKILL.md ≤500 lines (if any skill touched)
- [ ] Package-visible release gate evidence before tag/publish (if preparing a release)
- [ ] Supply-chain review (if `.github/workflows/`, `.github/dependabot.yml`, `mb/pyproject.toml` deps, or `id-token`/`permissions` blocks touched — see [docs/supply-chain-policy.md](../docs/supply-chain-policy.md))

Evidence:

- Level 1 static: `scripts/check.sh` — runtime: local `python3` via repo script — exit: `0` — log: `.agent/checks/check-final-final.out` (`skills: 15`, `passed: 15`, `failed: 0`, `errors: 0`, `warnings: 0`).
- Level 2 CLI contract: not required; no CLI behavior changed.
- Level 3 package/install smoke: not required; no packaging, entrypoint, or bundled-data behavior changed.
- Level 4 fixture repo: not required; no init/onboard/status/start/update behavior changed.
- Level 5 runtime smoke: not required; no runtime, first-run, skill discovery, or release simulation behavior changed.
- Supply-chain review: not required by checklist trigger; no workflow, Dependabot, dependency, permission, or `id-token` files changed. The supply-chain policy text itself was updated.
- Exploratory sidecar evidence: `deepsec scan` ran from ignored `.agent/` scratch, found three candidates, and a bounded Codex `process` pass completed one candidate with zero findings before stalling on the next; this is recorded in the decision as evidence for targeted/time-boxed use.

## Success metric

Future release agents can tell when to use DeepSec, why Greptile is not adopted yet, where sidecar evidence belongs in pre-release/post-release docs, and how to report scanner output without publishing raw local logs.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [ ] N/A — change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [x] No
- [ ] Yes — migration note below

## Public / private boundary

No private operator strategy, machine-specific paths, raw scanner logs, model traces, or suspected vulnerability details were committed. Local DeepSec and validation evidence stayed under ignored `.agent/` scratch.
