### PR TITLE
[fix] MAIN-332 books dogfood followups

### DIFF
--- a/.claude/skills/mb-start/SKILL.md
+++ b/.claude/skills/mb-start/SKILL.md
@@ -72,8 +72,8 @@ meaning before suggesting file moves.
 
 **Books/finance routing:** When the user mentions bookkeeping, books, finance,
 accounting, ledgers, statements, P&L, chart of accounts, tax, payroll, hledger,
-or a restricted `finance` child repo, run `mb books check --repo "$REPO_PATH"
---json` before drafting files. Keep raw private finance records out of the
+or a restricted `finance` child repo, run `mb books check "$REPO_PATH" --json`
+before drafting files. Keep raw private finance records out of the
 team-safe hub repo; use the books contract, `storage_mode`, and topology
 visibility (`restricted` or `local_only`) to route raw records.
 

--- a/.claude/skills/mb-start/references/router-and-language.md
+++ b/.claude/skills/mb-start/references/router-and-language.md
@@ -147,7 +147,7 @@ hledger, receipts, tax, payroll, revenue report.
 
 Route:
 
-- Run `mb books check --repo "$REPO_PATH" --json` before inventing structure.
+- Run `mb books check "$REPO_PATH" --json` before inventing structure.
 - Keep raw ledgers, statements, credentials, account numbers, payroll rows, tax
   IDs, and exact private numbers out of the public/team-safe business repo.
 - Preserve public topology terms: hub repo, child repo, hub registry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   protections, and check health; `mb books doctor --plan` now gives a
   non-mutating repair plan for safe bookkeeping setup gaps without reading or
   mutating real ledger contents. Refs #552, #128.
+- Added the MAIN-332 post-#553 bookkeeping dogfood report covering `mb books
+  check`, `mb books status`, `mb books doctor --plan`, skill routing, status
+  gaps, and privacy boundary findings. Refs #510, #555.
 - Added the first shared workflow source prototype for the daily start ->
   MoneyPath `/mb-think` handoff, with generated Claude/Codex shell snapshots
   and drift tests that require shared `mb` commands and JSON facts to stay
@@ -42,6 +45,14 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   setup and read-only command surface, and keeps live account checks out of
   scope until `mb` owns detection and sanitized read-only smoke. Refs MAIN-350,
   #542.
+
+### Fixed
+
+- Fixed post-#553 bookkeeping dogfood gaps: `/mb-start` now routes bookkeeping
+  checks through the shipped positional `mb books check "$REPO_PATH" --json`
+  syntax, and `mb books status` / `mb books doctor --plan` now warn when
+  non-local books storage is selected without a safe private vault label. Refs
+  MAIN-332, #510.
 
 ## [0.3.19] - 2026-05-12
 

--- a/docs/books.md
+++ b/docs/books.md
@@ -244,6 +244,8 @@ mb books doctor [REPO] --plan [--json]
 - sanitized private-vault location labels. Relative paths inside the
   business repo may be shown; external absolute vault paths are
   reported as external private paths instead of printed;
+- a warning when team/private or advanced storage mode is selected but
+  the policy does not name a safe private repo or vault label;
 - whether the configured local vault exists;
 - whether a private `main.journal` placeholder exists, without
   reading its contents;
@@ -259,6 +261,7 @@ gaps:
 - add a safe `core/finance/books.md` policy when the operator is
   ready;
 - add or fix `storage_mode`;
+- add a safe private repo or vault label for non-local storage modes;
 - add bookkeeping ignore protections;
 - create the private books vault directory;
 - create a private hledger journal placeholder from a safe template

--- a/docs/reports/2026-05-13-books-status-doctor-dogfood.md
+++ b/docs/reports/2026-05-13-books-status-doctor-dogfood.md
@@ -65,7 +65,7 @@ had no repair. This report's branch fixes that.
 
 **Is `doctor --plan` obviously non-mutating?**
 
-Yes. The command name, human heading, JSON `mode: plan`, and
+Yes. The command name, human heading, and each JSON action's `mode: plan` plus
 `safe_to_apply: false` make the posture clear. The command exits `2` without
 `--plan`, so there is no accidental apply path.
 

--- a/docs/reports/2026-05-13-books-status-doctor-dogfood.md
+++ b/docs/reports/2026-05-13-books-status-doctor-dogfood.md
@@ -1,0 +1,115 @@
+---
+title: mb books status and doctor plan dogfood
+date: 2026-05-13
+linked_issue: https://github.com/noontide-co/mainbranch/issues/510
+release: next patch candidate after v0.3.19
+status: complete
+tags: [bookkeeping, dogfood, hledger, privacy]
+---
+
+# `mb books status` And `doctor --plan` Dogfood
+
+## Summary
+
+Post-#553 bookkeeping dogfood confirms that the current `mb books` setup
+surface is safe enough for the next slice: keep the CLI group named `books`,
+use "bookkeeping" in operator-facing prose, and route setup/check requests
+through deterministic `mb books` facts before drafting finance files.
+
+The dogfood also produced two focused fixes:
+
+- `/mb-start` now uses the shipped positional command shape:
+  `mb books check "$REPO_PATH" --json`.
+- `mb books status` and `mb books doctor --plan` now flag
+  `team-private-repo` / `advanced-vault` policy files that omit a safe private
+  vault label.
+
+## Scope Exercised
+
+Fake business repos covered:
+
+- hledger missing and available;
+- no books policy;
+- invalid books policy, including unknown `storage_mode` and broken
+  frontmatter;
+- team-private books policy with no configured vault label;
+- configured external vault;
+- default `.mb/private/books` vault;
+- configured local vault missing;
+- configured local vault present;
+- missing `.gitignore` protections;
+- force-tracked fake journal-shaped file;
+- missing chart of accounts;
+- external absolute path redaction.
+
+No real ledgers, bank exports, provider credentials, account identifiers,
+financial amounts, or private absolute paths were committed. Raw evidence lives
+only in ignored `.context/` scratch output.
+
+## Answers
+
+**Is `ok: true` with `state: warn` understandable?**
+
+Yes for this slice. `ok` means the command can complete and no hard error was
+found; `state: warn` means the operator should review setup before using real
+books. Human output makes this legible enough when the warning has an exact
+repair. Broken frontmatter still returns `ok: false` / `state: error`.
+
+**Are status findings clear enough for a normal operator?**
+
+Mostly. Good cases: missing hledger, missing policy, invalid storage mode,
+missing local vault, missing ignore protections, and tracked journal-shaped
+files all explain the issue in business-safe language. The dogfood found one
+gap: non-local storage with no `vault_location` looked configured in prose but
+had no repair. This report's branch fixes that.
+
+**Is `doctor --plan` obviously non-mutating?**
+
+Yes. The command name, human heading, JSON `mode: plan`, and
+`safe_to_apply: false` make the posture clear. The command exits `2` without
+`--plan`, so there is no accidental apply path.
+
+**Are repair actions useful and safe?**
+
+Useful for setup. They name the files or local ignored paths they would touch
+and avoid reads from real vault contents. The unsafe tracked-file action is
+safe because it tells the operator to move the file and run `git rm --cached`;
+it does not mutate history or rotate data automatically.
+
+**Do `mb status`, `mb start`, and relevant skills route bookkeeping setup/check
+requests?**
+
+Skills now route correctly. `/mb-start` and its router reference tell agents to
+run `mb books check "$REPO_PATH" --json` before inventing structure and to keep
+raw finance records out of the team-safe hub. `mb start --json` runs, but it
+does not include books readiness. `mb status --json --peek` also has no
+top-level `books` object yet. Follow-up #555 covers adding a compact books
+readiness summary to `mb status` / `mb start` once the product wants
+bookkeeping readiness in the daily briefing rather than only intent-triggered
+routing.
+
+**Does output avoid private absolute paths and real financial data?**
+
+Yes. External absolute vault paths render as `external private path`. The
+status surface reports whether a private `main.journal` placeholder exists but
+does not read or print its contents. hledger availability reports the command
+name, not the local binary path.
+
+**Should docs use "books," "bookkeeping," or both?**
+
+Both. Keep `mb books` as the short CLI group. Use "bookkeeping" in headings,
+operator explanations, and safety language. This matches the current docs:
+"The command group is named `mb books` because it is short; the business
+function is bookkeeping."
+
+## Recommendation
+
+Next slice should improve daily-loop surfacing, not add accounting product
+depth:
+
+- ship #555 for read-only books readiness in `mb status --json --peek` and
+  `mb start` only if it stays compact and privacy-safe;
+- keep `/mb-start` intent-triggered routing through `mb books check` until
+  status owns a stable books summary;
+- do not add imports, reconcile, close, reports, Mercury, provider credentials,
+  or real financial data yet.

--- a/mb/mb/books.py
+++ b/mb/mb/books.py
@@ -369,29 +369,6 @@ def _status_extra_findings(
         )
 
     vault = _vault_info(repo, fm)
-    storage_mode = vault["storage_mode"]
-    if storage_mode in NON_LOCAL_STORAGE_MODES and not vault["configured"]:
-        findings.append(
-            _finding(
-                id="books-vault-location-missing",
-                title="Private books vault location is not configured",
-                state="warn",
-                detail=(
-                    f"storage_mode={storage_mode!r} expects the real books to live "
-                    "outside this repo, but core/finance/books.md does not name "
-                    "the private repo or vault handle."
-                ),
-                audience="operator_decision",
-                operator_summary=(
-                    "Set vault_location in core/finance/books.md so the operator "
-                    "knows where the private books live."
-                ),
-                repair=(
-                    "Add a safe vault_location label to core/finance/books.md; "
-                    "do not paste an absolute private path or real ledger data."
-                ),
-            )
-        )
     policy_present = _has_books_policy(repo)
     if vault["exists"] is True:
         findings.append(
@@ -467,6 +444,34 @@ def _status_extra_findings(
             )
         )
     return findings
+
+
+def _non_local_vault_location_findings(fm: dict[str, Any]) -> list[dict[str, Any]]:
+    storage_mode = _policy_storage_mode(fm)
+    raw_location = str(fm.get("vault_location") or "").strip()
+    if storage_mode not in NON_LOCAL_STORAGE_MODES or raw_location:
+        return []
+    return [
+        _finding(
+            id="books-vault-location-missing",
+            title="Private books vault location is not configured",
+            state="warn",
+            detail=(
+                f"storage_mode={storage_mode!r} expects the real books to live "
+                "outside this repo, but core/finance/books.md does not name "
+                "the private repo or vault handle."
+            ),
+            audience="operator_decision",
+            operator_summary=(
+                "Set vault_location in core/finance/books.md so the operator "
+                "knows where the private books live."
+            ),
+            repair=(
+                "Add a safe vault_location label to core/finance/books.md; "
+                "do not paste an absolute private path or real ledger data."
+            ),
+        )
+    ]
 
 
 def _detect_books_policy(repo: Path) -> tuple[dict[str, Any], list[dict[str, Any]]]:
@@ -928,6 +933,7 @@ def run(
     findings.extend(policy_findings)
     findings.extend(_detect_chart_of_accounts(repo_path))
     storage_mode = str(fm.get("storage_mode") or "").strip()
+    findings.extend(_non_local_vault_location_findings(fm))
     findings.extend(_check_vault_ignore_rule(repo_path, storage_mode))
     findings.extend(_detect_unsafe_paths(repo_path))
 

--- a/mb/mb/books.py
+++ b/mb/mb/books.py
@@ -369,6 +369,29 @@ def _status_extra_findings(
         )
 
     vault = _vault_info(repo, fm)
+    storage_mode = vault["storage_mode"]
+    if storage_mode in NON_LOCAL_STORAGE_MODES and not vault["configured"]:
+        findings.append(
+            _finding(
+                id="books-vault-location-missing",
+                title="Private books vault location is not configured",
+                state="warn",
+                detail=(
+                    f"storage_mode={storage_mode!r} expects the real books to live "
+                    "outside this repo, but core/finance/books.md does not name "
+                    "the private repo or vault handle."
+                ),
+                audience="operator_decision",
+                operator_summary=(
+                    "Set vault_location in core/finance/books.md so the operator "
+                    "knows where the private books live."
+                ),
+                repair=(
+                    "Add a safe vault_location label to core/finance/books.md; "
+                    "do not paste an absolute private path or real ledger data."
+                ),
+            )
+        )
     policy_present = _has_books_policy(repo)
     if vault["exists"] is True:
         findings.append(
@@ -1107,6 +1130,23 @@ def doctor_plan(repo: str | Path = ".") -> dict[str, Any]:
                 ),
                 writes=["core/finance/chart-of-accounts.md"],
                 audience="informational",
+            )
+        )
+
+    if "books-vault-location-missing" in findings:
+        finding = findings["books-vault-location-missing"]
+        actions.append(
+            _plan_action(
+                id="configure-private-books-vault-location",
+                title="Configure private books vault location",
+                state="warn",
+                reason=finding["operator_summary"],
+                command=(
+                    "Set vault_location in core/finance/books.md to a safe private "
+                    "repo or vault label; keep raw finance data out of this repo."
+                ),
+                writes=["core/finance/books.md"],
+                audience="operator_decision",
             )
         )
 

--- a/mb/tests/test_books.py
+++ b/mb/tests/test_books.py
@@ -472,6 +472,36 @@ vault_location: "{private_path.parent}"
     assert str(private_path.parent) not in result.output
 
 
+def test_books_status_and_doctor_flag_missing_external_vault_location(tmp_path: Path) -> None:
+    repo = _init_business_repo(tmp_path)
+    _write(
+        repo / "core/finance/books.md",
+        """---
+type: books
+ledger: hledger
+storage_mode: team-private-repo
+---
+
+# Books
+""",
+    )
+    _write(repo / ".gitignore", ".mb/private/\n*.journal\n*.hledger\n*.ledger\n*.beancount\n")
+
+    status_result = runner.invoke(app, ["books", "status", str(repo), "--json"])
+    assert status_result.exit_code == 0, status_result.output
+    status_payload = json.loads(status_result.output)
+    findings = _findings_by_id(status_payload)
+    assert findings["books-vault-location-missing"]["state"] == "warn"
+    assert status_payload["vault"]["location"] == "not configured"
+
+    doctor_result = runner.invoke(app, ["books", "doctor", str(repo), "--plan", "--json"])
+    assert doctor_result.exit_code == 0, doctor_result.output
+    doctor_payload = json.loads(doctor_result.output)
+    actions = {action["id"]: action for action in doctor_payload["actions"]}
+    assert "configure-private-books-vault-location" in actions
+    assert actions["configure-private-books-vault-location"]["writes"] == ["core/finance/books.md"]
+
+
 def test_books_doctor_plan_json_lists_safe_repairs(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/mb/tests/test_books.py
+++ b/mb/tests/test_books.py
@@ -472,7 +472,9 @@ vault_location: "{private_path.parent}"
     assert str(private_path.parent) not in result.output
 
 
-def test_books_status_and_doctor_flag_missing_external_vault_location(tmp_path: Path) -> None:
+def test_books_check_status_and_doctor_flag_missing_external_vault_location(
+    tmp_path: Path,
+) -> None:
     repo = _init_business_repo(tmp_path)
     _write(
         repo / "core/finance/books.md",
@@ -487,6 +489,12 @@ storage_mode: team-private-repo
     )
     _write(repo / ".gitignore", ".mb/private/\n*.journal\n*.hledger\n*.ledger\n*.beancount\n")
 
+    check_result = runner.invoke(app, ["books", "check", str(repo), "--json"])
+    assert check_result.exit_code == 0, check_result.output
+    check_payload = json.loads(check_result.output)
+    check_findings = _findings_by_id(check_payload)
+    assert check_findings["books-vault-location-missing"]["state"] == "warn"
+
     status_result = runner.invoke(app, ["books", "status", str(repo), "--json"])
     assert status_result.exit_code == 0, status_result.output
     status_payload = json.loads(status_result.output)
@@ -500,6 +508,28 @@ storage_mode: team-private-repo
     actions = {action["id"]: action for action in doctor_payload["actions"]}
     assert "configure-private-books-vault-location" in actions
     assert actions["configure-private-books-vault-location"]["writes"] == ["core/finance/books.md"]
+
+
+def test_books_check_does_not_flag_configured_non_local_vault_location(tmp_path: Path) -> None:
+    repo = _init_business_repo(tmp_path)
+    _write(
+        repo / "core/finance/books.md",
+        """---
+type: books
+ledger: hledger
+storage_mode: team-private-repo
+vault_location: "private-books-repo"
+---
+
+# Books
+""",
+    )
+
+    result = runner.invoke(app, ["books", "check", str(repo), "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    findings = _findings_by_id(payload)
+    assert "books-vault-location-missing" not in findings
 
 
 def test_books_doctor_plan_json_lists_safe_repairs(

--- a/mb/tests/test_start_router_contract.py
+++ b/mb/tests/test_start_router_contract.py
@@ -39,7 +39,7 @@ def test_router_contract_covers_books_save_sync_and_updates() -> None:
         "proposal/review path",
         "ad hoc PR-instruction attachments",
         "Update strongly recommended",
-        'Run `mb books check --repo "$REPO_PATH" --json`',
+        'Run `mb books check "$REPO_PATH" --json`',
         "`storage_mode`",
         "hub registry",
         "child descriptor `.mainbranch/repo.json`",


### PR DESCRIPTION
<!--
  Thanks for contributing to Main Branch.

  See CONTRIBUTING.md for branch + PR shape, concern-based commit
  organization, and pre-push gates. Keep PRs scoped — one logical
  change per PR, ideally 3–5 commits by concern.
-->

## Summary

Adds the MAIN-332 post-#553 bookkeeping dogfood report and ships the focused follow-up fixes it found: `/mb-start` now calls the shipped `mb books check "$REPO_PATH" --json` syntax, and `mb books status` / `mb books doctor --plan` now flag non-local books storage without a safe private vault label.

## Linked issue

Closes #510
Refs #555
Refs MAIN-332, MAIN-355

## Why

Post-#553 dogfood needed to answer whether the new `mb books check`, `mb books status`, and `mb books doctor --plan` surfaces are understandable, non-mutating, privacy-safe, and ready to guide the next bookkeeping slice without drifting into imports, reconciliation, reports, Mercury, or provider credentials.

## Commits by concern

- [x] `8f773fd [fix] MAIN-332 books dogfood followups`
  - Adds the public-safe dogfood report and recommendation.
  - Fixes `/mb-start` and router guidance to use the shipped positional books command syntax.
  - Adds `books-vault-location-missing` plus a non-mutating doctor plan action for missing non-local vault labels.
  - Updates docs, changelog, and focused tests.
- [x] `ebe5aad [fix] MAIN-332 surface vault label warning in check`
  - Moves the missing non-local vault label warning into `mb books check` so `/mb-start` receives the same safety signal it routes to.
  - Adds the negative test for configured non-local vault labels.
  - Tightens the dogfood report wording so `mode: plan` and `safe_to_apply: false` are clearly per-action fields.
- [x] Integration merge commits bring `origin/main` current; the PR diff against `origin/main` remains scoped to MAIN-332 files.
- [x] Reviewer reading `git log --oneline origin/main..HEAD` sees the shape of the work.
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`.

## Validation

Pre-push gate from repo root:

```bash
scripts/check.sh
```

`scripts/check.sh` was attempted twice, but the Conductor tool session interrupted the long verbose pytest stream before the wrapper could complete; the equivalent component commands below were run separately and passed.

- [ ] Level 1 static: `scripts/check.sh` wrapper — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: interrupted by Conductor session before completion — log: verbose pytest stream stopped around `tests/test_status.py`.
- [x] Level 1 static: `python3 -m ruff format --check . && python3 -m ruff check .` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: 83 files already formatted; all checks passed.
- [x] Level 1 static: `python3 -m mypy mb tests` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: success, no issues in 82 source files.
- [x] Level 2 CLI contract: `pytest tests/test_books.py tests/test_start_router_contract.py -q` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: 34 passed after the review follow-up.
- [x] Level 2 full CLI/test suite: `python3 -m pytest tests/ -q --cov=mb --cov-report=term-missing --cov-fail-under=79` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: 619 passed, coverage 83.72%.
- [ ] Level 3 package/install smoke: not required; no packaging, entrypoint, bundled-data install, or update path changed.
- [x] Level 4 fixture repo: dogfood matrix over fake business repos — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: covered hledger missing/available, policy/vault/ignore/tracked-file/chart states, `mb status`, `mb start`, and external path redaction.
- [ ] Level 5 runtime smoke / dogfood harness / simulation-tier: not required; no runtime discovery, first-run handoff, or release validation behavior changed. `/mb-start` string routing is covered by `tests/test_start_router_contract.py`.
- [x] SKILL.md <=500 lines: `python3 -m mb skill validate --all --json` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: 15 skills passed, 0 errors, 0 warnings.
- [ ] Package-visible release gate evidence before tag/publish: not required; this PR is not preparing a release.
- [ ] Supply-chain review: not required; no workflow, dependency, Dependabot, id-token, or permissions files changed.

## Success metric

The bookkeeping dogfood recommendation is public and actionable, `/mb-start` routes setup/check requests through the real shipped books command syntax, and non-local books policies without a safe private vault label produce a clear warning and non-mutating repair plan.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [ ] N/A — change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [x] No
- [ ] Yes — migration note below

## Public / private boundary

No real financial data, provider credentials, account IDs, private vault paths, private numbers, raw ledgers, bank exports, Mercury data, or private operator strategy were committed. Dogfood evidence used fake repos and ignored `.context/` scratch output; committed examples and report language stay sanitized and public-safe.
