### PR TITLE
[fix] Harden release and connect boundaries

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -18,9 +18,10 @@ name: publish-pypi
 #   - Top-level permissions are contents: read; jobs widen explicitly.
 #   - The release artifact is built once in `build` and republished by
 #     `publish`; no rebuild happens in the publish environment.
-#   - The publish job is double-gated: the `pypi` environment requires a
-#     human approver, and an `if:` guard requires the release tag to match
-#     `oe-v*` so a stray release on a non-Main-Branch tag cannot publish.
+#   - The release metadata job validates the tag as `oe-vMAJOR.MINOR.PATCH`
+#     before any version-derived value is used by downstream jobs.
+#   - Release workflow actions are pinned to commit SHAs. Update them
+#     intentionally during dependency/security maintenance.
 #
 # Release notes: the `extract-changelog` job parses CHANGELOG.md for the
 # section matching the release tag and updates the GitHub Release body
@@ -34,16 +35,42 @@ permissions:
   contents: read
 
 jobs:
+  release-metadata:
+    name: Validate release tag
+    runs-on: ubuntu-latest
+    outputs:
+      valid: ${{ steps.validate.outputs.valid }}
+      tag: ${{ steps.validate.outputs.tag }}
+      version: ${{ steps.validate.outputs.version }}
+      name: ${{ steps.validate.outputs.name }}
+    steps:
+      - name: Validate Main Branch release tag
+        id: validate
+        run: |
+          tag="${GITHUB_REF_NAME}"
+          if [[ ! "$tag" =~ ^oe-v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+            echo "::error::Release tag must match oe-vMAJOR.MINOR.PATCH."
+            exit 1
+          fi
+          version="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.${BASH_REMATCH[3]}"
+          {
+            echo "valid=true"
+            echo "tag=$tag"
+            echo "version=$version"
+            echo "name=Main Branch $version"
+          } >> "$GITHUB_OUTPUT"
+
   build:
     name: Build sdist + wheel
+    needs: [release-metadata]
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: mb
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.12"
           cache: pip
@@ -55,7 +82,7 @@ jobs:
         run: python -m build
 
       - name: Upload dist artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: dist
           path: mb/dist/
@@ -63,23 +90,23 @@ jobs:
 
   release-notes:
     name: Sync release notes from CHANGELOG
+    needs: [release-metadata]
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Extract CHANGELOG section for this release
         id: extract
+        env:
+          RELEASE_VERSION: ${{ needs.release-metadata.outputs.version }}
         run: |
-          # Tag scheme: oe-vMAJOR.MINOR.PATCH (e.g. oe-v0.1.0).
+          # Tag scheme is validated by the release-metadata job.
           # CHANGELOG heading: ## [MAJOR.MINOR.PATCH] - YYYY-MM-DD ...
-          tag="${GITHUB_REF_NAME}"
-          version="${tag#oe-v}"
-          echo "tag=$tag version=$version"
-          python3 - <<PY > release-notes.md
-          import re, sys, pathlib
-          version = "$version"
+          python3 - <<'PY' > release-notes.md
+          import os, pathlib, re, sys
+          version = os.environ["RELEASE_VERSION"]
           body = pathlib.Path("CHANGELOG.md").read_text(encoding="utf-8")
           # Match "## [<version>]" through the next "## [" or EOF.
           pattern = re.compile(
@@ -108,18 +135,15 @@ jobs:
       - name: Update GitHub Release body
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ needs.release-metadata.outputs.tag }}
         run: |
-          gh release edit "${GITHUB_REF_NAME}" --notes-file release-notes.md
+          gh release edit "$RELEASE_TAG" --notes-file release-notes.md
 
   publish:
     name: Publish to PyPI
-    needs: [build, release-notes]
+    needs: [release-metadata, build, release-notes]
     runs-on: ubuntu-latest
-    # Defense in depth: trusted publishing + `pypi` environment approval are
-    # the primary gates. This `if:` blocks any GitHub Release whose tag does
-    # not match the Main Branch release scheme (`oe-vMAJOR.MINOR.PATCH`)
-    # from claiming an OIDC token, even if the environment is approved.
-    if: startsWith(github.event.release.tag_name, 'oe-v')
+    if: needs.release-metadata.outputs.valid == 'true'
     environment:
       name: pypi
       url: https://pypi.org/p/mainbranch
@@ -127,37 +151,35 @@ jobs:
       id-token: write
     steps:
       - name: Download dist artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: dist
           path: dist/
 
       - name: Publish via trusted publisher
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
 
   linear-release:
     name: Sync Linear release
-    needs: [publish]
+    needs: [release-metadata, publish]
     runs-on: ubuntu-latest
-    if: startsWith(github.event.release.tag_name, 'oe-v')
+    if: needs.release-metadata.outputs.valid == 'true'
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
       - name: Derive Linear release metadata
         id: meta
         run: |
-          tag="${{ github.event.release.tag_name }}"
-          version="${tag#oe-v}"
-          echo "tag=$tag" >> "$GITHUB_OUTPUT"
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-          echo "name=Main Branch $version" >> "$GITHUB_OUTPUT"
+          echo "tag=${{ needs.release-metadata.outputs.tag }}" >> "$GITHUB_OUTPUT"
+          echo "version=${{ needs.release-metadata.outputs.version }}" >> "$GITHUB_OUTPUT"
+          echo "name=${{ needs.release-metadata.outputs.name }}" >> "$GITHUB_OUTPUT"
 
       - name: Sync issues into Linear release
-        uses: linear/linear-release-action@v0.10.0
+        uses: linear/linear-release-action@0917777589db006387af296dde440385f88d6ac4 # v0.10.0
         with:
           access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
           command: sync
@@ -165,7 +187,7 @@ jobs:
           version: ${{ steps.meta.outputs.tag }}
 
       - name: Mark Linear release as released
-        uses: linear/linear-release-action@v0.10.0
+        uses: linear/linear-release-action@0917777589db006387af296dde440385f88d6ac4 # v0.10.0
         with:
           access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
           command: complete

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,13 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   non-local books storage is selected without a safe private vault label. Refs
   MAIN-332, #510.
 
+### Security
+
+- Tightened package release workflow tag validation, release-notes extraction,
+  and release-action pinning; tightened `.mb/connect.yaml` local-state boundary
+  handling so provider metadata paths stay inside the selected repo. Refs
+  MAIN-356, #558.
+
 ## [0.3.19] - 2026-05-12
 
 v0.3.19 makes daily status more business-aware: MoneyPath, proof-quality, and

--- a/docs/supply-chain-policy.md
+++ b/docs/supply-chain-policy.md
@@ -78,8 +78,9 @@ human approval over clever automation.
   individual PRs so the release-pipeline review is not hidden inside a
   group diff. See
   [`.github/dependabot.yml`](../.github/dependabot.yml).
-- Pinning to commit SHAs is preferred for higher-risk supply chains.
-  The original release-gates decision tracked SHA pinning as follow-up in
+- Pinning to commit SHAs remains the preferred control for higher-risk supply
+  chains. The original release-gates decision tracked SHA pinning as follow-up;
+  the release workflow now carries that control. See
   [`decisions/2026-05-11-supply-chain-security-gates.md`](../decisions/2026-05-11-supply-chain-security-gates.md).
 
 ### Package metadata and dependency surface

--- a/docs/supply-chain-policy.md
+++ b/docs/supply-chain-policy.md
@@ -22,8 +22,8 @@ human approval over clever automation.
   dotfiles, or in any GitHub Actions workflow.
 - The publish workflow triggers on `release: published`, not on raw tag
   push. A release is a deliberate Releases-UI action by a maintainer.
-- The publish job carries a defensive `if:` guard so it only runs when
-  the release tag matches `oe-v*`. Defense in depth — the trusted
+- A release metadata job validates the tag as `oe-vMAJOR.MINOR.PATCH` before
+  downstream jobs use the tag-derived version. Defense in depth — the trusted
   publisher binding is the primary gate.
 - The release artifact is built once in the `build` job, uploaded as an
   artifact, then downloaded and published by the `publish` job. No
@@ -54,16 +54,23 @@ human approval over clever automation.
   CHANGELOG slice. It does not have `id-token: write` and cannot publish
   to PyPI.
 - The `linear-release` job requests `contents: read` and uses the
-  `LINEAR_ACCESS_KEY` secret. It is gated on the `oe-v*` tag prefix and
-  only runs after `publish` succeeds.
+  `LINEAR_ACCESS_KEY` secret. It uses the same strict release metadata output
+  as the PyPI publish job and only runs after `publish` succeeds.
 - New workflows or jobs must declare the minimum permissions they need
   and document any deviation from `contents: read` in the workflow file
   header.
 
 ### Action pinning
 
-- GitHub Actions are pinned to major-version tags
-  (e.g. `actions/checkout@v6`, `pypa/gh-action-pypi-publish@release/v1`).
+- Actions in `.github/workflows/publish-pypi.yml` are pinned to full commit
+  SHAs because the release path can claim PyPI OIDC and use release-related
+  secrets.
+- Maintainers update release-workflow actions intentionally during dependency
+  or security maintenance. Verify the upstream tag or branch maps to the chosen
+  SHA before changing the workflow, and keep the trailing version comment next
+  to the pinned SHA current.
+- Lower-risk CI actions may remain pinned to major-version tags
+  (e.g. `actions/checkout@v6`) until their risk profile changes.
 - Dependabot's `github-actions` ecosystem opens weekly PRs when a pinned
   major changes, with minor/patch updates grouped into a `github-actions-official`
   PR (the `actions/*` family) and a `github-actions-release` PR (the
@@ -72,8 +79,7 @@ human approval over clever automation.
   group diff. See
   [`.github/dependabot.yml`](../.github/dependabot.yml).
 - Pinning to commit SHAs is preferred for higher-risk supply chains.
-  Main Branch defers SHA pinning until the publish surface grows; it is
-  tracked as a follow-up in
+  The original release-gates decision tracked SHA pinning as follow-up in
   [`decisions/2026-05-11-supply-chain-security-gates.md`](../decisions/2026-05-11-supply-chain-security-gates.md).
 
 ### Package metadata and dependency surface

--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -768,7 +768,7 @@ def connect_cmd(
     if not target:
         try:
             result = connect_mod.list_providers(repo)
-        except ValueError as exc:
+        except connect_mod.ConfigBoundaryError as exc:
             _connect_boundary_exit("mb connect", exc)
         if json_out:
             typer.echo(json.dumps(result, indent=2))
@@ -778,7 +778,7 @@ def connect_cmd(
     if target == "list":
         try:
             result = connect_mod.list_providers(repo)
-        except ValueError as exc:
+        except connect_mod.ConfigBoundaryError as exc:
             _connect_boundary_exit("mb connect list", exc)
         if json_out:
             typer.echo(json.dumps(result, indent=2))
@@ -788,7 +788,7 @@ def connect_cmd(
     if target == "plan":
         try:
             result = connect_mod.provider_plan(repo)
-        except ValueError as exc:
+        except connect_mod.ConfigBoundaryError as exc:
             _connect_boundary_exit("mb connect plan", exc)
         if json_out:
             typer.echo(json.dumps(result, indent=2))
@@ -798,7 +798,7 @@ def connect_cmd(
     if target == "status":
         try:
             result = connect_mod.status_all(repo, include_all=all_providers)
-        except ValueError as exc:
+        except connect_mod.ConfigBoundaryError as exc:
             _connect_boundary_exit("mb connect status", exc)
         if json_out:
             typer.echo(json.dumps(result, indent=2))
@@ -808,7 +808,7 @@ def connect_cmd(
     if target == "doctor":
         try:
             result = connect_mod.doctor(repo)
-        except ValueError as exc:
+        except connect_mod.ConfigBoundaryError as exc:
             _connect_boundary_exit("mb connect doctor", exc)
         if json_out:
             typer.echo(json.dumps(result, indent=2))

--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -11,7 +11,7 @@ import json
 import os
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, NoReturn
 
 import typer
 
@@ -121,6 +121,11 @@ def _json_payload(payload: dict[str, Any], *, command: str, schema_name: str) ->
 
 def _is_interactive_terminal() -> bool:
     return sys.stdin.isatty() and sys.stdout.isatty()
+
+
+def _connect_boundary_exit(command: str, exc: ValueError) -> NoReturn:
+    typer.echo(f"{command}: {exc}", err=True)
+    raise typer.Exit(2) from exc
 
 
 def _render_launch_screen() -> None:
@@ -761,35 +766,50 @@ def connect_cmd(
 ) -> None:
     """Connect provider credentials without committing secrets."""
     if not target:
-        result = connect_mod.list_providers(repo)
+        try:
+            result = connect_mod.list_providers(repo)
+        except ValueError as exc:
+            _connect_boundary_exit("mb connect", exc)
         if json_out:
             typer.echo(json.dumps(result, indent=2))
         else:
             connect_mod.render_list(result)
         raise typer.Exit(0)
     if target == "list":
-        result = connect_mod.list_providers(repo)
+        try:
+            result = connect_mod.list_providers(repo)
+        except ValueError as exc:
+            _connect_boundary_exit("mb connect list", exc)
         if json_out:
             typer.echo(json.dumps(result, indent=2))
         else:
             connect_mod.render_list(result)
         raise typer.Exit(0)
     if target == "plan":
-        result = connect_mod.provider_plan(repo)
+        try:
+            result = connect_mod.provider_plan(repo)
+        except ValueError as exc:
+            _connect_boundary_exit("mb connect plan", exc)
         if json_out:
             typer.echo(json.dumps(result, indent=2))
         else:
             connect_mod.render_plan(result)
         raise typer.Exit(0)
     if target == "status":
-        result = connect_mod.status_all(repo, include_all=all_providers)
+        try:
+            result = connect_mod.status_all(repo, include_all=all_providers)
+        except ValueError as exc:
+            _connect_boundary_exit("mb connect status", exc)
         if json_out:
             typer.echo(json.dumps(result, indent=2))
         else:
             connect_mod.render_status(result)
         raise typer.Exit(0 if result["ok"] else 1)
     if target == "doctor":
-        result = connect_mod.doctor(repo)
+        try:
+            result = connect_mod.doctor(repo)
+        except ValueError as exc:
+            _connect_boundary_exit("mb connect doctor", exc)
         if json_out:
             typer.echo(json.dumps(result, indent=2))
         else:

--- a/mb/mb/connect.py
+++ b/mb/mb/connect.py
@@ -31,6 +31,10 @@ CommandRunner = Callable[[list[str], Path | None, float], dict[str, Any]]
 Which = Callable[[str], str | None]
 
 
+class ConfigBoundaryError(ValueError):
+    """Raised when local connect metadata is outside the selected repo boundary."""
+
+
 @dataclass(frozen=True)
 class Provider:
     """Provider registry entry.
@@ -245,12 +249,43 @@ def _config_path(repo: Path) -> Path:
     return repo / CONFIG_RELATIVE_PATH
 
 
+def _is_within(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+    except ValueError:
+        return False
+    return True
+
+
+def _checked_config_path(repo: Path) -> Path:
+    root = repo.resolve()
+    path = _config_path(root)
+    config_dir = path.parent
+
+    if config_dir.is_symlink() or path.is_symlink():
+        raise ConfigBoundaryError(
+            "Refusing to use .mb/connect.yaml because the local state path is a symlink."
+        )
+    if config_dir.exists() and not config_dir.is_dir():
+        raise ConfigBoundaryError(
+            "Refusing to use .mb/connect.yaml because the local state directory is invalid."
+        )
+
+    parent_resolved = config_dir.resolve(strict=False)
+    path_resolved = path.resolve(strict=False)
+    if not _is_within(parent_resolved, root) or not _is_within(path_resolved, root):
+        raise ConfigBoundaryError(
+            "Refusing to use .mb/connect.yaml because it is outside the selected repo boundary."
+        )
+    return path
+
+
 def _empty_config() -> dict[str, Any]:
     return {"version": 1, "repo_id": "", "repo_identity": {}, "providers": {}}
 
 
 def _read_config(repo: Path) -> dict[str, Any]:
-    path = _config_path(repo)
+    path = _checked_config_path(repo)
     if not path.exists():
         return _empty_config()
     try:
@@ -342,8 +377,9 @@ def _ensure_repo_id(config: dict[str, Any], repo: Path) -> str:
 
 
 def _write_config(repo: Path, config: dict[str, Any]) -> Path:
-    path = _config_path(repo)
+    path = _checked_config_path(repo)
     path.parent.mkdir(parents=True, exist_ok=True)
+    path = _checked_config_path(repo)
     text = yaml.safe_dump(config, sort_keys=False)
     path.write_text(text, encoding="utf-8")
     return path
@@ -1118,7 +1154,7 @@ def status_all(
     return {
         "ok": not broken,
         "repo": str(target),
-        "config_path": str(_config_path(target)),
+        "config_path": str(_checked_config_path(target)),
         "repo_id": str(config.get("repo_id") or identity["repo_id"]),
         "providers": providers,
         "github": github or github_context(target),

--- a/mb/mb/connect.py
+++ b/mb/mb/connect.py
@@ -379,6 +379,7 @@ def _ensure_repo_id(config: dict[str, Any], repo: Path) -> str:
 def _write_config(repo: Path, config: dict[str, Any]) -> Path:
     path = _checked_config_path(repo)
     path.parent.mkdir(parents=True, exist_ok=True)
+    # Re-check after creating .mb so a swapped local-state path cannot escape the repo.
     path = _checked_config_path(repo)
     text = yaml.safe_dump(config, sort_keys=False)
     path.write_text(text, encoding="utf-8")

--- a/mb/tests/test_connect.py
+++ b/mb/tests/test_connect.py
@@ -8,6 +8,7 @@ import sys
 from pathlib import Path
 from typing import Any
 
+import pytest
 import yaml
 from typer.testing import CliRunner
 
@@ -826,6 +827,128 @@ def test_connect_status_tolerates_malformed_config_version(tmp_path: Path, monke
     assert status.exit_code == 0
     status_payload = json.loads(status.stdout)
     assert status_payload["summary"]["configured"] == 0
+
+
+def test_connect_status_missing_config_still_reports_empty_state(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _local_secret_env(monkeypatch, tmp_path)
+    repo = tmp_path / "biz"
+    repo.mkdir()
+
+    status = runner.invoke(app, ["connect", "status", "--repo", str(repo), "--json"])
+
+    assert status.exit_code == 0
+    payload = json.loads(status.stdout)
+    assert payload["summary"]["configured"] == 0
+    assert not (repo / ".mb" / "connect.yaml").exists()
+
+
+def test_connect_refuses_symlinked_mb_directory_without_leaking_path(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _local_secret_env(monkeypatch, tmp_path)
+    repo = tmp_path / "biz"
+    outside = tmp_path / "outside"
+    repo.mkdir()
+    outside.mkdir()
+    (repo / ".mb").symlink_to(outside, target_is_directory=True)
+
+    result = runner.invoke(
+        app,
+        [
+            "connect",
+            "hledger",
+            "--repo",
+            str(repo),
+            "--metadata",
+            "vault_path=.mb/private/books",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert "local state path is a symlink" in result.stderr
+    assert str(tmp_path) not in result.stderr
+    assert not (outside / "connect.yaml").exists()
+
+
+def test_connect_refuses_symlinked_connect_yaml_without_leaking_path(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _local_secret_env(monkeypatch, tmp_path)
+    repo = tmp_path / "biz"
+    outside = tmp_path / "outside"
+    repo.mkdir()
+    outside.mkdir()
+    (repo / ".mb").mkdir()
+    (repo / ".mb" / "connect.yaml").symlink_to(outside / "connect.yaml")
+
+    result = runner.invoke(
+        app,
+        [
+            "connect",
+            "hledger",
+            "--repo",
+            str(repo),
+            "--metadata",
+            "vault_path=.mb/private/books",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert "local state path is a symlink" in result.stderr
+    assert str(tmp_path) not in result.stderr
+    assert not (outside / "connect.yaml").exists()
+
+
+def test_connect_status_refuses_config_that_resolves_outside_repo(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _local_secret_env(monkeypatch, tmp_path)
+    repo = tmp_path / "biz"
+    outside = tmp_path / "outside"
+    repo.mkdir()
+    outside.mkdir()
+    (outside / "connect.yaml").write_text(
+        yaml.safe_dump({"version": 1, "providers": {"hledger": {"connected": True}}}),
+        encoding="utf-8",
+    )
+    (repo / ".mb").symlink_to(outside, target_is_directory=True)
+
+    status = runner.invoke(app, ["connect", "status", "--repo", str(repo), "--json"])
+
+    assert status.exit_code == 2
+    assert "local state path is a symlink" in status.stderr
+    assert str(tmp_path) not in status.stderr
+
+
+def test_checked_connect_config_path_rejects_outside_boundary(tmp_path: Path, monkeypatch) -> None:
+    repo = tmp_path / "biz"
+    outside = tmp_path / "outside" / "connect.yaml"
+    repo.mkdir()
+    outside.parent.mkdir()
+    monkeypatch.setattr(connect_mod, "_config_path", lambda repo: outside)
+
+    with pytest.raises(connect_mod.ConfigBoundaryError) as exc_info:
+        connect_mod.status_all(repo)
+
+    assert str(exc_info.value) == (
+        "Refusing to use .mb/connect.yaml because it is outside the selected repo boundary."
+    )
+    assert str(tmp_path) not in str(exc_info.value)
+
+
+def test_checked_connect_config_path_rejects_invalid_local_state_directory(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "biz"
+    repo.mkdir()
+    (repo / ".mb").write_text("not a directory", encoding="utf-8")
+
+    with pytest.raises(connect_mod.ConfigBoundaryError, match="local state directory is invalid"):
+        connect_mod.status_all(repo)
 
 
 def test_doctor_and_status_include_integration_state(tmp_path: Path, monkeypatch) -> None:

--- a/mb/tests/test_release_workflow_security.py
+++ b/mb/tests/test_release_workflow_security.py
@@ -1,0 +1,40 @@
+"""Static guards for the package release workflow."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PUBLISH_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "publish-pypi.yml"
+
+
+def _publish_workflow_text() -> str:
+    return PUBLISH_WORKFLOW.read_text(encoding="utf-8")
+
+
+def test_publish_workflow_validates_release_tag_before_downstream_jobs() -> None:
+    text = _publish_workflow_text()
+
+    assert "release-metadata:" in text
+    assert r"^oe-v([0-9]+)\.([0-9]+)\.([0-9]+)$" in text
+    assert "needs.release-metadata.outputs.valid == 'true'" in text
+    assert "startsWith(github.event.release.tag_name" not in text
+
+
+def test_publish_workflow_does_not_interpolate_release_tag_into_python_source() -> None:
+    text = _publish_workflow_text()
+
+    assert 'version = "$version"' not in text
+    assert "python3 - <<PY" not in text
+    assert "python3 - <<'PY'" in text
+    assert 'os.environ["RELEASE_VERSION"]' in text
+
+
+def test_publish_workflow_actions_are_pinned_to_commit_shas() -> None:
+    text = _publish_workflow_text()
+    refs = re.findall(r"^\s*uses:\s*([^@\s#]+)@([0-9a-f]{40})(?:\s+#\s+\S+)?$", text, re.M)
+    uses_lines = re.findall(r"^\s*uses:\s*(\S+)", text, re.M)
+
+    assert uses_lines
+    assert len(refs) == len(uses_lines)


### PR DESCRIPTION
## Summary

Tightens release workflow validation and local state file boundaries.
Pins release-workflow actions and adds regression coverage for the hardened paths.

## Linked issue

Closes #558
Refs MAIN-356

## Why

The release path and provider metadata path both needed stricter boundaries before accepting derived release metadata or local operational state.

## Commits by concern

- [x] Each commit body bullet-lists the changes in that commit
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`

Commit list:
- `[fix] Harden release and connect boundaries`

## Validation

- [x] Level 1 static: `scripts/check.sh` — runtime: `python3` 3.13.7 — exit: 0 — log: `.agent/main-356-check.out` (`626` tests collected/passed, skill validation green).
- [x] Level 2 CLI contract: `cd mb && python3 -m pytest tests/test_connect.py tests/test_release_workflow_security.py -q` — runtime: `python3` 3.13.7 — exit: 0 — log: `.agent/main-356-focused.out` (`38 passed`).
- [ ] Level 3 package/install smoke (not required; no packaging entrypoint or bundled-data behavior changed).
- [ ] Level 4 fixture repo (not required; no init/onboard/status/start/update fixture behavior changed).
- [ ] Level 5 runtime smoke / dogfood harness / simulation-tier (not required; no runtime, first-run, skill discovery, or release-simulation behavior changed).
- [x] SKILL.md ≤500 lines (covered by `scripts/check.sh`; no skill files changed).
- [ ] Package-visible release gate evidence before tag/publish (not required; this is not a release-prep PR).
- [x] Supply-chain review (`publish-pypi.yml` touched; tag validation, SHA pinning, and minimal permissions reviewed against `docs/supply-chain-policy.md`).

## Success metric

Package release jobs only consume validated release metadata, release-workflow actions are pinned, and `mb connect` refuses local metadata paths outside the selected repo boundary without printing private paths.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [ ] N/A — change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [x] No
- [ ] Yes — migration note below

## Public / private boundary

No raw scan output, local evidence, exploit proof, model traces, machine-specific paths, or `.agent/` files are committed.
