### PR TITLE
[add] MAIN-355 books readiness facts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 - Added compact, privacy-safe books readiness facts to `mb status --json --peek`
   and `mb start --json`, so daily-loop agents can see bookkeeping setup,
   hledger availability, vault/ignore safety, unsafe artifact counts, and the
-  next safe books command without reading ledger contents or exposing private
+  next safe books route without reading ledger contents or exposing private
   paths. Refs MAIN-355, #555, #510, #553, #128.
 - Added an accepted decision for agentic security review sidecars: DeepSec may
   be used as an optional local pre-release review aid for security-sensitive

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ### Added
 
+- Added compact, privacy-safe books readiness facts to `mb status --json --peek`
+  and `mb start --json`, so daily-loop agents can see bookkeeping setup,
+  hledger availability, vault/ignore safety, unsafe artifact counts, and the
+  next safe books command without reading ledger contents or exposing private
+  paths. Refs MAIN-355, #555, #510, #553, #128.
 - Added an accepted decision for agentic security review sidecars: DeepSec may
   be used as an optional local pre-release review aid for security-sensitive
   branches, while Greptile remains a hosted PR-review candidate pending a

--- a/mb/mb/books.py
+++ b/mb/mb/books.py
@@ -1027,6 +1027,94 @@ def status(repo: str | Path = ".") -> dict[str, Any]:
     }
 
 
+def _unsafe_artifact_count(findings: list[dict[str, Any]]) -> int:
+    for finding in findings:
+        if finding.get("id") == "unsafe-paths-detected":
+            evidence = finding.get("evidence")
+            return len(evidence) if isinstance(evidence, list) else 0
+    return 0
+
+
+def _readiness_state(status_report: dict[str, Any], unsafe_count: int) -> str:
+    policy = status_report.get("policy") or {}
+    raw_state = str(status_report.get("state") or "")
+    if raw_state == "error":
+        return "blocked"
+    if unsafe_count:
+        return "warn"
+    if not policy.get("present"):
+        return "not_configured"
+    if raw_state == "warn":
+        return "warn"
+    if raw_state == "info":
+        return "missing"
+    return "ok"
+
+
+def _readiness_summary(state: str, status_report: dict[str, Any]) -> str:
+    if state == "not_configured":
+        return "Bookkeeping is not configured."
+    if state == "blocked":
+        return "Bookkeeping setup is blocked; run the books repair plan."
+    if state == "warn":
+        return "Bookkeeping setup has warnings."
+    if state == "missing":
+        return "Bookkeeping setup is missing optional pieces."
+    return str(status_report.get("summary") or "Bookkeeping setup passed.")
+
+
+def readiness(repo: str | Path = ".") -> dict[str, Any]:
+    """Return compact books readiness facts for daily status/start JSON.
+
+    This adapter intentionally exposes less than ``mb books status``. It keeps
+    routing signals and counts, but omits ledger contents, hledger binary paths,
+    private vault paths, raw exports, and unsafe artifact filenames.
+    """
+    status_report = status(repo=repo)
+    policy = status_report.get("policy") or {}
+    vault = status_report.get("vault") or {}
+    ignore = status_report.get("ignore") or {}
+    hledger = status_report.get("hledger") or {}
+    unsafe_count = _unsafe_artifact_count(status_report.get("findings") or [])
+    chart_present = any(
+        finding.get("id") == "chart-of-accounts-ok"
+        for finding in status_report.get("findings") or []
+    )
+    state = _readiness_state(status_report, unsafe_count)
+    next_command = (
+        "mb books doctor --plan --json"
+        if state in {"blocked", "warn", "missing"}
+        else "mb books status --json"
+    )
+    return {
+        "schema_version": "1.0",
+        "state": state,
+        "summary": _readiness_summary(state, status_report),
+        "configured": bool(policy.get("present")),
+        "mention": state in {"blocked", "warn", "missing"},
+        "hledger": {"available": bool(hledger.get("available"))},
+        "policy": {
+            "present": bool(policy.get("present")),
+            "storage_mode": str(policy.get("storage_mode") or ""),
+            "valid_storage_mode": bool(policy.get("valid_storage_mode")),
+        },
+        "vault": {
+            "configured": bool(vault.get("configured")),
+            "location_kind": str(vault.get("location_kind") or ""),
+            "exists": vault.get("exists") if vault.get("location_kind") != "external" else None,
+        },
+        "ignore": {
+            "ok": bool(ignore.get("ok")),
+            "missing_count": len(ignore.get("missing") or []),
+        },
+        "unsafe_artifacts": {"count": unsafe_count},
+        "chart_of_accounts": {"present": chart_present},
+        "next_command": next_command,
+        "source": "mb books status",
+        "safe_to_share": True,
+    }
+
+
 def _plan_action(
     *,
     id: str,

--- a/mb/mb/books.py
+++ b/mb/mb/books.py
@@ -1063,6 +1063,18 @@ def _readiness_summary(state: str, status_report: dict[str, Any]) -> str:
     return str(status_report.get("summary") or "Bookkeeping setup passed.")
 
 
+def _readiness_route(state: str) -> dict[str, str]:
+    if state in {"blocked", "warn", "missing"}:
+        return {
+            "tool": "mb books doctor --plan",
+            "reason": "plan bookkeeping setup repairs",
+        }
+    return {
+        "tool": "mb books status",
+        "reason": "inspect bookkeeping setup",
+    }
+
+
 def readiness(repo: str | Path = ".") -> dict[str, Any]:
     """Return compact books readiness facts for daily status/start JSON.
 
@@ -1086,6 +1098,7 @@ def readiness(repo: str | Path = ".") -> dict[str, Any]:
         if state in {"blocked", "warn", "missing"}
         else "mb books status --json"
     )
+    recommended_route = _readiness_route(state)
     return {
         "schema_version": "1.0",
         "state": state,
@@ -1110,6 +1123,7 @@ def readiness(repo: str | Path = ".") -> dict[str, Any]:
         "unsafe_artifacts": {"count": unsafe_count},
         "chart_of_accounts": {"present": chart_present},
         "next_command": next_command,
+        "recommended_route": recommended_route,
         "source": "mb books status",
         "safe_to_share": True,
     }

--- a/mb/mb/start.py
+++ b/mb/mb/start.py
@@ -10,6 +10,7 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from mb import books as books_mod
 from mb import checkpoint as checkpoint_mod
 from mb import codex as codex_mod
 from mb import journal as journal_mod
@@ -270,6 +271,7 @@ def run(repo: str = ".", launch: bool = False) -> dict[str, Any]:
     journal = journal_mod.collect(repo_path, limit=8, since="14 days ago")
     push_report = push_facts(repo_path)
     vocabulary_report = vocabulary.facts(repo_path)
+    books = books_mod.readiness(repo_path)
     checks = _build_checks(repo_shape, git, claude_path, wiring, codex, update)
     hard_failures = _hard_failures(checks)
     handoff_ready = not hard_failures
@@ -315,6 +317,7 @@ def run(repo: str = ".", launch: bool = False) -> dict[str, Any]:
         "update": update,
         "checkpoint": checkpoint,
         "journal": journal,
+        "books": books,
         "pushes": push_report["records"],
         "active_pushes": push_report["active"],
         "push_count": push_report["count"],

--- a/mb/mb/status.py
+++ b/mb/mb/status.py
@@ -13,6 +13,7 @@ from typing import Any
 import yaml
 
 from mb import __version__, github_activity, relationships, vocabulary
+from mb import books as books_mod
 from mb import codex as codex_mod
 from mb import connect as connect_mod
 from mb import content_strategy as content_strategy_mod
@@ -3682,6 +3683,7 @@ def run(
         "deprecated_campaign_keys": True,
         "push_compatibility": push_report["compatibility"],
         "vocabulary": vocabulary.facts(repo_path),
+        "books": books_mod.readiness(repo_path),
         "onboarding": onboard_mod.onboarding_status(repo_path),
         "integrations": connect_mod.status_all(repo_path, github=github.get("context")),
         "measurement": _measurement(repo_path),

--- a/mb/tests/fixtures/status/schema-v1-basic.json
+++ b/mb/tests/fixtures/status/schema-v1-basic.json
@@ -4,6 +4,7 @@
   "top_level_keys": [
     "active_campaigns",
     "active_pushes",
+    "books",
     "brain",
     "campaign_count",
     "campaigns",
@@ -109,6 +110,22 @@
       "recent_research",
       "stale_decisions",
       "stale_research"
+    ],
+    "books": [
+      "chart_of_accounts",
+      "configured",
+      "hledger",
+      "ignore",
+      "mention",
+      "next_command",
+      "policy",
+      "safe_to_share",
+      "schema_version",
+      "source",
+      "state",
+      "summary",
+      "unsafe_artifacts",
+      "vault"
     ],
     "vocabulary": [
       "errors",

--- a/mb/tests/fixtures/status/schema-v1-basic.json
+++ b/mb/tests/fixtures/status/schema-v1-basic.json
@@ -119,6 +119,7 @@
       "mention",
       "next_command",
       "policy",
+      "recommended_route",
       "safe_to_share",
       "schema_version",
       "source",

--- a/mb/tests/test_books.py
+++ b/mb/tests/test_books.py
@@ -472,6 +472,90 @@ vault_location: "{private_path.parent}"
     assert str(private_path.parent) not in result.output
 
 
+def test_books_readiness_ok_for_configured_fake_books_repo(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _init_business_repo(tmp_path)
+    _write(
+        repo / "core/finance/books.md",
+        """---
+type: books
+ledger: hledger
+storage_mode: solo-local
+vault_location: ".mb/private/books/"
+---
+
+# Books
+""",
+    )
+    _write(
+        repo / "core/finance/chart-of-accounts.md",
+        """---
+type: chart-of-accounts
+ledger: hledger
+---
+
+# Chart
+""",
+    )
+    _write(repo / ".gitignore", ".mb/private/\n*.journal\n*.hledger\n*.ledger\n*.beancount\n")
+    _write(repo / ".mb/private/books/main.journal", "; PRIVATE_LEDGER_CONTENT\n")
+    monkeypatch.setattr("mb.books.shutil.which", lambda name: "/fake/private/bin/hledger")
+
+    readiness = books_mod.readiness(repo=repo)
+    payload = json.dumps(readiness)
+
+    assert readiness["state"] == "ok"
+    assert readiness["configured"] is True
+    assert readiness["mention"] is False
+    assert readiness["hledger"]["available"] is True
+    assert readiness["ignore"]["ok"] is True
+    assert readiness["unsafe_artifacts"]["count"] == 0
+    assert readiness["chart_of_accounts"]["present"] is True
+    assert "PRIVATE_LEDGER_CONTENT" not in payload
+    assert "/fake/private/bin/hledger" not in payload
+
+
+def test_books_readiness_counts_unsafe_artifacts_without_names(tmp_path: Path) -> None:
+    repo = _init_business_repo(tmp_path)
+    _write(repo / "exports/customer-bank-statement.csv", "vendor,amount\nAcme,100\n")
+    _git_add_all(repo)
+
+    readiness = books_mod.readiness(repo=repo)
+    payload = json.dumps(readiness)
+
+    assert readiness["state"] == "warn"
+    assert readiness["mention"] is True
+    assert readiness["unsafe_artifacts"]["count"] == 1
+    assert readiness["next_command"] == "mb books doctor --plan --json"
+    assert "customer-bank-statement.csv" not in payload
+    assert "Acme,100" not in payload
+
+
+def test_books_readiness_redacts_external_vault_path(tmp_path: Path) -> None:
+    repo = _init_business_repo(tmp_path)
+    private_path = tmp_path / "private-books" / "main.journal"
+    _write(
+        repo / "core/finance/books.md",
+        f"""---
+type: books
+ledger: hledger
+storage_mode: solo-local
+vault_location: "{private_path.parent}"
+---
+
+# Books
+""",
+    )
+
+    readiness = books_mod.readiness(repo=repo)
+    payload = json.dumps(readiness)
+
+    assert readiness["vault"]["location_kind"] == "external"
+    assert readiness["vault"]["exists"] is None
+    assert str(private_path.parent) not in payload
+
+
 def test_books_check_status_and_doctor_flag_missing_external_vault_location(
     tmp_path: Path,
 ) -> None:

--- a/mb/tests/test_books.py
+++ b/mb/tests/test_books.py
@@ -512,6 +512,10 @@ ledger: hledger
     assert readiness["ignore"]["ok"] is True
     assert readiness["unsafe_artifacts"]["count"] == 0
     assert readiness["chart_of_accounts"]["present"] is True
+    assert readiness["recommended_route"] == {
+        "tool": "mb books status",
+        "reason": "inspect bookkeeping setup",
+    }
     assert "PRIVATE_LEDGER_CONTENT" not in payload
     assert "/fake/private/bin/hledger" not in payload
 
@@ -528,6 +532,10 @@ def test_books_readiness_counts_unsafe_artifacts_without_names(tmp_path: Path) -
     assert readiness["mention"] is True
     assert readiness["unsafe_artifacts"]["count"] == 1
     assert readiness["next_command"] == "mb books doctor --plan --json"
+    assert readiness["recommended_route"] == {
+        "tool": "mb books doctor --plan",
+        "reason": "plan bookkeeping setup repairs",
+    }
     assert "customer-bank-statement.csv" not in payload
     assert "Acme,100" not in payload
 

--- a/mb/tests/test_start.py
+++ b/mb/tests/test_start.py
@@ -213,6 +213,10 @@ def test_start_json_preserves_books_readiness(
     assert report["books"]["hledger"]["available"] is False
     assert report["books"]["ignore"]["ok"] is False
     assert report["books"]["next_command"] == "mb books doctor --plan --json"
+    assert report["books"]["recommended_route"] == {
+        "tool": "mb books doctor --plan",
+        "reason": "plan bookkeeping setup repairs",
+    }
 
 
 def test_start_degrades_when_claude_is_missing(tmp_path: Path, monkeypatch) -> None:

--- a/mb/tests/test_start.py
+++ b/mb/tests/test_start.py
@@ -10,6 +10,7 @@ import sys
 from pathlib import Path
 from typing import Any
 
+import pytest
 from typer.testing import CliRunner
 
 from mb import codex as codex_mod
@@ -97,6 +98,8 @@ def test_start_json_prints_ready_handoff(tmp_path: Path, monkeypatch) -> None:
     assert report["command"]["follow_up"] == "/mb-start"
     assert report["launch"]["requested"] is False
     assert report["checkpoint"]["pending"]["status"] == "ready"
+    assert report["books"]["schema_version"] == "1.0"
+    assert report["books"]["safe_to_share"] is True
     assert report["push_count"] == 0
     assert report["deprecated_campaign_keys"] is True
     assert report["push_compatibility"]["legacy_campaigns_read"] is True
@@ -172,6 +175,44 @@ def test_start_json_exposes_push_and_legacy_campaign_facts(tmp_path: Path, monke
         "campaigns/2026-05-legacy/campaign.md",
     }
     assert report["campaigns"][0]["deprecated"] is True
+
+
+def test_start_json_preserves_books_readiness(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    real_which = shutil.which
+    monkeypatch.setattr(start_mod, "_which", _with_claude)
+    monkeypatch.setattr(
+        "mb.books.shutil.which",
+        lambda name: "" if name == "hledger" else real_which(name),
+    )
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+    (repo / "core" / "finance").mkdir(parents=True, exist_ok=True)
+    (repo / "core" / "finance" / "books.md").write_text(
+        (
+            "---\n"
+            "type: books\n"
+            "ledger: hledger\n"
+            "storage_mode: solo-local\n"
+            'vault_location: ".mb/private/books/"\n'
+            "---\n\n"
+            "# Books\n"
+        ),
+        encoding="utf-8",
+    )
+    (repo / ".gitignore").write_text("", encoding="utf-8")
+
+    result = runner.invoke(app, ["start", "--repo", str(repo), "--json"])
+
+    assert result.exit_code == 0
+    report = json.loads(result.stdout)
+    assert report["books"]["state"] == "warn"
+    assert report["books"]["configured"] is True
+    assert report["books"]["mention"] is True
+    assert report["books"]["hledger"]["available"] is False
+    assert report["books"]["ignore"]["ok"] is False
+    assert report["books"]["next_command"] == "mb books doctor --plan --json"
 
 
 def test_start_degrades_when_claude_is_missing(tmp_path: Path, monkeypatch) -> None:

--- a/mb/tests/test_status.py
+++ b/mb/tests/test_status.py
@@ -9,6 +9,7 @@ from datetime import date, datetime, timezone
 from pathlib import Path
 from typing import Any
 
+import pytest
 from typer.testing import CliRunner
 
 from mb import codex as codex_mod
@@ -252,6 +253,8 @@ def test_status_json_degrades_without_github(tmp_path: Path, monkeypatch) -> Non
     assert report["vocabulary"]["terms"]["statuses"]["active"] == "live"
     assert report["vocabulary"]["terms"]["channels"]["paid"] == "paid traffic"
     assert report["vocabulary"]["terms"]["kinds"]["launch"] == "launch"
+    assert report["books"]["schema_version"] == "1.0"
+    assert report["books"]["safe_to_share"] is True
     assert report["since_last_check"]["first_run"] is True
     assert report["marker_update"]["ok"] is True
     assert (repo / ".mb" / "last-status-seen.json").is_file()
@@ -287,6 +290,7 @@ def test_status_schema_v1_matches_golden_fixture(tmp_path: Path, monkeypatch) ->
                 "git_activity",
                 "journal",
                 "brain",
+                "books",
                 "vocabulary",
                 "onboarding",
                 "integrations",
@@ -325,6 +329,73 @@ def test_status_money_path_default_repo_stays_low(tmp_path: Path, monkeypatch) -
     assert money_path["overall_level"] <= 1
     assert "customer_progress" in money_path["objects"]
     assert money_path["ranked_actions"]
+
+
+def test_status_books_readiness_fresh_repo_is_compact(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
+    monkeypatch.setattr("mb.books.shutil.which", lambda name: "")
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+
+    report = status_mod.run(path=str(repo), update_marker=False)
+
+    books = report["books"]
+    assert books["state"] == "not_configured"
+    assert books["configured"] is False
+    assert books["mention"] is False
+    assert books["hledger"]["available"] is False
+    assert books["policy"]["present"] is False
+    assert books["next_command"] == "mb books status --json"
+    assert books["safe_to_share"] is True
+
+
+def test_status_books_readiness_redacts_private_paths_and_contents(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
+    monkeypatch.setattr("mb.books.shutil.which", lambda name: "/private/bin/hledger")
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+    private_vault = tmp_path / "private-books"
+    books_path = repo / "core" / "finance" / "books.md"
+    books_path.parent.mkdir(parents=True, exist_ok=True)
+    books_path.write_text(
+        (
+            "---\n"
+            "type: books\n"
+            "ledger: hledger\n"
+            "storage_mode: solo-local\n"
+            f'vault_location: "{private_vault}"\n'
+            "---\n\n"
+            "# Books\n"
+        ),
+        encoding="utf-8",
+    )
+    (repo / "core" / "finance" / "chart-of-accounts.md").write_text(
+        "---\ntype: chart-of-accounts\nledger: hledger\n---\n\n# Chart\n",
+        encoding="utf-8",
+    )
+    (repo / ".gitignore").write_text(
+        ".mb/private/\n*.journal\n*.hledger\n*.ledger\n*.beancount\n",
+        encoding="utf-8",
+    )
+    private_vault.mkdir(parents=True)
+    (private_vault / "main.journal").write_text("; PRIVATE_LEDGER_CONTENT\n", encoding="utf-8")
+
+    report = status_mod.run(path=str(repo), update_marker=False)
+    payload = json.dumps(report["books"])
+
+    books = report["books"]
+    assert books["hledger"]["available"] is True
+    assert books["vault"]["location_kind"] == "external"
+    assert books["vault"]["exists"] is None
+    assert books["ignore"]["ok"] is True
+    assert books["chart_of_accounts"]["present"] is True
+    assert str(private_vault) not in payload
+    assert "/private/bin/hledger" not in payload
+    assert "PRIVATE_LEDGER_CONTENT" not in payload
 
 
 def test_status_money_path_single_offer_structured_caps_without_proof(

--- a/mb/tests/test_status.py
+++ b/mb/tests/test_status.py
@@ -348,6 +348,10 @@ def test_status_books_readiness_fresh_repo_is_compact(
     assert books["hledger"]["available"] is False
     assert books["policy"]["present"] is False
     assert books["next_command"] == "mb books status --json"
+    assert books["recommended_route"] == {
+        "tool": "mb books status",
+        "reason": "inspect bookkeeping setup",
+    }
     assert books["safe_to_share"] is True
 
 


### PR DESCRIPTION
## Summary

Adds compact, privacy-safe books readiness facts to `mb status --json --peek` and `mb start --json` so daily-loop agents can route bookkeeping setup from deterministic JSON. The new object carries setup/readiness only, including `recommended_route` as an internal routing hint instead of user-facing command copy.

## Linked issue

Closes #555 / MAIN-355
Refs #510 / MAIN-332
Refs #553 / MAIN-353
Refs #128 / MAIN-128

## Why

After `mb books status` and `mb books doctor --plan` shipped, `/mb-start` could route bookkeeping only when the operator explicitly mentioned it. Daily status/start facts now expose safe setup health without parsing books command prose or reading real financial data.

## Commits by concern

- [ ] Each commit body bullet-lists the changes in that commit
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`

Commits:
- `2a75d6f [add] MAIN-355 books readiness facts`
- `a43fde1 [update] MAIN-355 clarify books route hint`

## Validation

Pre-push gate from repo root:

```bash
scripts/check.sh
```

- [x] Level 1 static: `scripts/check.sh` passes
- [x] Level 2 CLI contract: focused Typer/CliRunner tests, exit codes, `--json` behavior, TTY vs non-TTY (if CLI behavior touched)
- [ ] Level 3 package/install smoke (if packaging touched)
- [ ] Level 4 fixture repo (if init/onboard/status/start/update touched)
- [ ] Level 5 runtime smoke / dogfood harness / simulation-tier (if runtime, first-run, skill discovery, or release validation touched)
- [x] SKILL.md <=500 lines (if any skill touched)
- [ ] Package-visible release gate evidence before tag/publish (if preparing a release)
- [ ] Supply-chain review (if `.github/workflows/`, `.github/dependabot.yml`, `mb/pyproject.toml` deps, or `id-token`/`permissions` blocks touched — see [docs/supply-chain-policy.md](../docs/supply-chain-policy.md))

Level 1 static: `scripts/check.sh` — runtime: `python3` — exit: 0 — log: excerpt `ruff format`, `ruff check`, and `mypy` passed.
Level 2 CLI contract: `cd mb && pytest tests/test_books.py tests/test_status.py tests/test_start.py -q` — runtime: `python3` — exit: 0 — log: excerpt `128 passed`.
Level 2 full suite: `scripts/check.sh` — runtime: `python3` — exit: 0 — log: excerpt `625 passed`, coverage `83.90%`, `mb skill validate --all --json` ok.
Level 3 package/install smoke: not required locally; no packaging, entrypoint, bundled data, install, or update path changed. CI wheel-install-smoke passed on PR #561.
Level 4 fixture repo: not required as a full first-run smoke; the changed `status`/`start` JSON facts are covered by focused temp-repo tests and manual temp-repo JSON sanity checks for fresh, configured, missing-ignore, unsafe-artifact, and external-vault cases.
Level 5 runtime smoke: not run and not required for this slice; no generated skill prose, runtime discovery, slash-command invocation, first-run handoff, or skill packaging behavior changed. Closest verified fallback is CLI JSON evidence from `mb status --json --peek` and `mb start --json`, plus `mb skill validate --all --json` through `scripts/check.sh`.
Supply-chain review: not required; no workflow, dependency, permission, or publish configuration changed.
CI: PR #561 checks passed for Python 3.10, 3.11, 3.12, SKILL.md line-count gate, and wheel-install-smoke.

## Success metric

A fresh business repo and a configured fake books repo expose enough compact, read-only `books` facts in `mb status --json --peek` and `mb start --json` for `/mb-start` to route bookkeeping setup without running `mb books check` first.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [ ] N/A — change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [x] No
- [ ] Yes — migration note below

## Public / private boundary

The committed JSON contract exposes setup/readiness only: hledger availability, policy state, vault state, ignore protections, unsafe artifact count, chart-of-accounts presence, `next_command`, and `recommended_route`. It does not expose ledger contents, private absolute vault paths, hledger binary paths, unsafe artifact filenames, account IDs, provider data, or private numbers.
