### PR TITLE
[add] /mb-think research depth ladder

### DIFF
--- a/.claude/reference/conversion/offer-sharpening.md
+++ b/.claude/reference/conversion/offer-sharpening.md
@@ -80,6 +80,8 @@ Use `/mb-think` for:
 
 - sharpening the offer, audience, mechanism, proof, objections, guarantee, or
   style before creation;
+- choosing research depth before spending tokens on source collection, using
+  `.claude/skills/mb-think/references/research-depth-ladder.md`;
 - sales-video teardown, pitch extraction, objection mining, and codifying the
   mechanism;
 - keyword gate, market-intent research, competitor offer mapping, and

--- a/.claude/skills/mb-think/SKILL.md
+++ b/.claude/skills/mb-think/SKILL.md
@@ -24,8 +24,7 @@ Something came your way — a video, a voice memo, a vague feeling, a problem to
 
 **Save progress at natural boundaries.** After a research batch, accepted
 decision, codify pass, or major reference-file update, ask whether to checkpoint.
-Run `mb checkpoint --plan --json`, show the proposed message, validate with
-`mb checkpoint --validate "..." --json`, then save only after operator approval; no hidden checkpoints.
+Run `mb checkpoint --plan --json`, show the proposed message, validate with `mb checkpoint --validate "..." --json`, then save with `mb checkpoint --message "..." --yes` only after approval; no hidden checkpoints.
 
 When research identifies a reusable growth mechanic such as a comment-keyword,
 DM-keyword, public reply/link, resource delivery, provider setup recipe, or

--- a/.claude/skills/mb-think/SKILL.md
+++ b/.claude/skills/mb-think/SKILL.md
@@ -23,12 +23,9 @@ Something came your way — a video, a voice memo, a vague feeling, a problem to
 - Anytime you feel lost
 
 **Save progress at natural boundaries.** After a research batch, accepted
-decision, codify pass, or major reference-file update, ask whether to save a
-checkpoint before moving to the next phase. Run `mb checkpoint --plan --json`,
-show the proposed message, changed files, and blockers, then ask whether to save
-it. Validate the final message with `mb checkpoint --validate "..." --json`;
-after operator approval, run `mb checkpoint --message "..." --yes`. Do not save
-hidden checkpoints.
+decision, codify pass, or major reference-file update, ask whether to checkpoint.
+Run `mb checkpoint --plan --json`, show the proposed message, validate with
+`mb checkpoint --validate "..." --json`, then save only after operator approval; no hidden checkpoints.
 
 When research identifies a reusable growth mechanic such as a comment-keyword,
 DM-keyword, public reply/link, resource delivery, provider setup recipe, or
@@ -54,16 +51,12 @@ unless the operator chooses it.
 
 ## Two Modes of Work
 
-Before diving in, know which mode you're in:
-
 | Mode | You're doing | Examples |
 |------|--------------|----------|
 | **Enriching the core** | Pulling insights → reference files | Mining videos, making decisions, updating offer.md, **building content-strategy.md** |
 | **Creating for the world** | Reference files → output | Ads, scripts, courses, code, posts |
 
 `/mb-think` is for **enriching the core**. When you're ready to create, use `/mb-ads`, `/mb-organic`, `/mb-site`, or just ask.
-
-Both are work. Enriching the core levels up everything downstream.
 
 ---
 
@@ -82,8 +75,10 @@ mb status --json --peek
 mb connect doctor --json
 ```
 
-Use those facts for GitHub, Google/Workspace, Meta Ads, Apify, and other
-provider repair language. Runtime-local tool checks happen only after a
+Use those facts for GitHub, Google/Workspace, Meta Ads, and other provider
+repair language. Apify research remains MCP-first for now: treat it as an
+agent-side research tool surface unless a later CLI contract exposes stable
+provider-readiness facts. Runtime-local tool checks happen only after a
 selected research path needs them and `mb` cannot inspect the tool directly.
 
 **Quick gist:** On first `/mb-think` invocation, read status/connect facts. When
@@ -170,6 +165,11 @@ Detect mode from user's natural language:
 | "content strategy", "pillars", "what platforms", "content plan", "cadence", "channel strategy", "account strategy", "founder voice", "weekly content plan" | Full Flow (codify to the right content strategy layer) | [codify-phase.md](references/codify-phase.md) |
 | "where was I", "continue", "pick up" | Recovery | [recovery.md](references/recovery.md) |
 | "here's a PDF", "ingest this", "convert this document", file path (.pdf/.docx/.pptx) | Document Ingestion | [document-ingestion.md](references/document-ingestion.md) |
+
+For offer, audience, proof, CTA, content strategy, ads/pages, and positioning
+requests, use [research-depth-ladder.md](references/research-depth-ladder.md)
+before selecting source tools. The ladder chooses how much research is enough;
+the routing references choose which tools to use.
 
 If unclear, ask: "Are you exploring a question, documenting a decision, or updating reference files?"
 

--- a/.claude/skills/mb-think/references/research-architecture.md
+++ b/.claude/skills/mb-think/references/research-architecture.md
@@ -12,6 +12,8 @@
 - Adding API keys unlocks new capabilities
 - Skills auto-detect what's available and route accordingly
 - Users never blocked — always graceful fallback
+- Apify is MCP-first research-provider enrichment for now, not automatically an
+  `mb connect` provider.
 
 ---
 
@@ -440,23 +442,27 @@ Tool missing + User wants that research type → Offer setup once per session
 2. Check Capabilities
    └─> Is preferred tool available?
 
-3. Route
+3. Recommend Depth
+   ├─> For offer/audience/proof/CTA/content/ads/pages/positioning
+   └─> Use research-depth-ladder.md to decide how much research is enough
+
+4. Route
    ├─> If available: Use preferred tool
    └─> If not: Offer setup or fallback
 
-4. Execute
+5. Execute
    ├─> Gather data (with token limits)
    └─> Estimate cost/tokens before running
 
-5. Synthesize (REQUIRED)
+6. Synthesize (REQUIRED)
    ├─> One-sentence summary (20 words max)
    ├─> Key findings (5-10 bullets)
    └─> Implications for reference files
 
-6. Save
+7. Save
    └─> research/YYYY-MM-DD-topic-[source].md
 
-7. Checkpoint
+8. Checkpoint
    └─> "Ready to make a decision, or need more research?"
 ```
 

--- a/.claude/skills/mb-think/references/research-architecture.md
+++ b/.claude/skills/mb-think/references/research-architecture.md
@@ -436,17 +436,17 @@ Tool missing + User wants that research type → Offer setup once per session
 ### Standard Flow (All Research Types)
 
 ```
-1. Detect Intent
-   └─> Determine research type from user message
+1. Define Question
+   └─> What specifically are you trying to learn?
 
-2. Check Capabilities
-   └─> Is preferred tool available?
-
-3. Recommend Depth
+2. Recommend Depth
    ├─> For offer/audience/proof/CTA/content/ads/pages/positioning
    └─> Use research-depth-ladder.md to decide how much research is enough
 
-4. Route
+3. Detect Intent & Route
+   └─> Determine research type from user message
+
+4. Check Capabilities
    ├─> If available: Use preferred tool
    └─> If not: Offer setup or fallback
 

--- a/.claude/skills/mb-think/references/research-depth-ladder.md
+++ b/.claude/skills/mb-think/references/research-depth-ladder.md
@@ -76,8 +76,9 @@ research depth would improve confidence.
 | Level 4 | Sales calls, customer language, ad tests, real content response, or outcome logs support the path. | Durable performance without instrumentation. |
 | Level 5 | Channel/page/push metrics, outcome feedback, and reviewed learning loops support the path. | Future results or claims beyond the evidence. |
 
-Do not convert this into a new score unless a separate CLI issue accepts that
-contract. For now, this is skill guidance.
+These are agent-side explanatory labels, not a parallel MoneyPath score. Do not
+convert this into a new score unless a separate CLI issue accepts that contract.
+For now, this is skill guidance.
 
 ## Source Quality
 

--- a/.claude/skills/mb-think/references/research-depth-ladder.md
+++ b/.claude/skills/mb-think/references/research-depth-ladder.md
@@ -1,0 +1,212 @@
+# Research Depth Ladder
+
+Use this before offer sharpening, audience work, proof/typicality work, product
+ladder choices, CTA choices, content strategy, ads/pages, or market/category
+positioning. The ladder decides how much research is worth spending before the
+operator makes the next business move.
+
+This is a decision layer, not a scraping implementation. After choosing the
+depth, use [research-phase.md](research-phase.md),
+[research-architecture.md](research-architecture.md), and the source-specific
+references for tool routing.
+
+## The Rule
+
+Spend the smallest amount of research that can make the next decision honest.
+
+More depth is not always better. A copy cleanup may only need repo context. A
+major repositioning, proof claim, or market entry may need source-backed
+research, structured collection, field evidence, or a small push/test.
+
+## Depth Levels
+
+| Level | Name | Use when | Typical sources | Durable output |
+| --- | --- | --- | --- | --- |
+| 0 | Operator memory | The operator already knows enough and the move is low-risk. | Operator answer in chat. | Optional note or direct codify after confirmation. |
+| 1 | Repo context | Existing `core/`, `research/`, `decisions/`, `bets/`, `pushes/`, and `log/` can answer the question. | Business repo files, `mb status --json --peek`, MoneyPath facts. | Research note only if synthesis is useful; otherwise update accepted target files. |
+| 2 | Lightweight public/manual research | Repo context is thin but the decision only needs quick outside orientation. | Public web, competitor pages, operator-pasted examples, manual screenshots, short customer snippets. | One research file with source notes and implications. |
+| 3 | Multi-source synthesis | Offer, audience, proof, page, ad, or content decisions need repeated public patterns. | Several public sources, reviews, competitor pages, YouTube transcripts, X/social sentiment, ChatGPT/Gemini-style synthesis. | Source-specific files when useful plus a synthesis file. |
+| 4 | Structured approved-source collection | Customer language lives in accessible sources and manual collection would miss patterns. | Apify through MCP, approved provider setup, or another structured collection path for public/approved YouTube, reviews, X/public posts, Reddit, Instagram, or operator-approved exports. | Source-specific mining files with access notes, caveats, and no raw dumps. |
+| 5 | High-resolution market analysis | The move changes positioning, offer architecture, launch strategy, or MoneyPath confidence. | Multiple source files, parallel agents, structured collection, customer calls, outcome logs, push/page/channel data. Apify/MCP may be one provider rail. | Synthesis file, accepted decisions, and reviewed updates to core/push/playbook/log files. |
+
+## Recommendation Block
+
+Before deeper research, give the operator a compact recommendation:
+
+```text
+Research Depth Recommendation
+- current_depth: 1
+- recommended_depth: 3
+- reason: audience language is thin and proof claims are not source-backed
+- useful_sources: customer calls, reviews, YouTube transcripts, competitor pages
+- optional_tools: Apify, Grok, Gemini
+- fallback: manual transcript, screenshots, pasted examples, or public web
+- stop_condition: repeated language is clear enough to update audience and objections
+- durable_targets: core/audience.md, core/offer.md, core/proof/angles/, decisions/
+```
+
+If the operator chooses less depth, proceed with the caveat. If the operator
+chooses more depth, explain the cost, token use, source limits, and stop rule.
+
+## Enough Signal By Task
+
+| Task | Minimum useful depth | Escalate when | Stop when | Durable targets |
+| --- | --- | --- | --- | --- |
+| Offer sharpening | 1 for copy cleanup, 2-3 for meaningful repositioning | Buyer, problem, mechanism, proof, or objections are thin. | The next offer edit is clear and honest. | `core/offer.md`, `core/offers/<slug>/offer.md`, `decisions/` |
+| Audience definition | 1 for existing segment cleanup, 3-4 for new segment language | The repo lacks repeated customer words, trigger events, or exclusions. | Repeated situations, pains, desires, and disqualifiers are visible. | `core/audience.md`, `core/offers/<slug>/audience.md` |
+| Proof / typicality | 1 only for cataloging existing approved proof, 3-5 for claims | A claim needs outcome, timeframe, metric, permission, or average-case support. | Supportable claim, caveat, and typicality language are clear. | `core/proof/`, `core/offers/<slug>/proof/` |
+| Product ladder | 1-2 for naming existing offers, 3-5 for architecture changes | Ascension logic, entry offer, or high-ticket path is speculative. | The ladder has a clear next step and unresolved assumptions are named. | `core/product-ladder.md`, offer files, `decisions/` |
+| CTA path | 1-2 for choosing among known paths, 3 when buyer friction is unknown | The next step is unclear, too high-friction, or not proof-backed. | One honest next action and fallback path are selected. | Offer file, page/push notes, `decisions/` |
+| Content strategy | 1 for repo cleanup, 2-4 for platform/account strategy | Pillars, account voice, audience behavior, or platform fit are thin. | Recognition target, pillars, jobs, and channel/account caveats are clear. | `core/content-strategy.md`, `core/marketing/...`, `core/people/...` |
+| Ads/page launch | 2 for small tests, 3-5 for meaningful spend or new landing page | Claims, objections, proof, search demand, or competitor context are weak. | The launch can be tested with clear caveats and success signals. | `pushes/`, page brief, ad brief, offer/proof files |
+| Market/category positioning | 3 minimum, usually 4-5 for durable changes | The business is entering or renaming a category. | Category language, alternatives, gaps, and risks are sourced enough to decide. | `research/*-synthesis.md`, `decisions/`, offer/content strategy |
+| Influence/style/playbook capture | 1-2 for operator taste, 3 when sourcing public examples | The operator wants a named style to shape offer, voice, or playbook patterns. | Approved principles are captured without copying protected material. | `core/voice.md`, offer style notes, `pushes/*/playbooks/`, `decisions/` |
+
+## MoneyPath Connection
+
+Use the ladder to explain readiness without making `mb` judge market strength.
+`mb status --json --peek` reports deterministic facts; the skill explains what
+research depth would improve confidence.
+
+| MoneyPath depth language | What it can rely on | What it cannot prove |
+| --- | --- | --- |
+| Level 0-1 | Operator memory and repo context are enough to start. | Market demand, typicality, or field performance. |
+| Level 2 | Structured offer, audience, proof, CTA, and content files exist. | Whether outside buyers use the same language. |
+| Level 3 | Public/source-backed research, testimonials, examples, or typicality notes support the path. | Whether the offer works in the field. |
+| Level 4 | Sales calls, customer language, ad tests, real content response, or outcome logs support the path. | Durable performance without instrumentation. |
+| Level 5 | Channel/page/push metrics, outcome feedback, and reviewed learning loops support the path. | Future results or claims beyond the evidence. |
+
+Do not convert this into a new score unless a separate CLI issue accepts that
+contract. For now, this is skill guidance.
+
+## Source Quality
+
+Prefer sources that are close to buyer behavior:
+
+1. Direct customer/buyer language with permission and context.
+2. Outcome logs, sales calls, support, surveys, reviews, and refund/churn notes.
+3. Public reviews, comments, questions, competitor pages, and platform posts.
+4. Expert frameworks and market reports.
+5. Operator taste, beliefs, and preferred influences.
+
+Weak sources can still be useful. Label them as language, inspiration, or
+directional signal rather than proof.
+
+## Structured Collection Boundary
+
+Apify is an optional research provider rail, preferably through MCP for now.
+Treat MCP as an agent-side tool surface, not automatically as an `mb connect`
+provider. Do not add or imply `mb connect apify` behavior unless a later CLI
+issue accepts stable provider-readiness facts.
+
+Use Apify/MCP or another approved structured collection path only when:
+
+- the operator chooses Level 4 or Level 5 depth;
+- the operator has access or the source is public;
+- the operator accepts the source, terms, cost, and reliability tradeoffs;
+- terms, legal, and access boundaries are clear;
+- the decision justifies structured collection;
+- the output will be synthesized, not committed as a raw dump.
+
+For gated or private communities, require access, permission, terms/legal
+review where needed, and operator judgment. If that is unclear, stop and ask.
+
+Never imply Main Branch can scrape private DMs, private analytics, protected
+accounts, gated communities without permission, or provider systems without
+accepted support and smoke evidence.
+
+Levels 0-3 require no Apify. Level 4 may use Apify/MCP when access and
+permission are clear. Level 5 may use Apify/MCP as one rail among multiple
+source files, caveats, synthesis, and durable promotion decisions.
+
+If agents need deterministic CLI facts later, open a follow-up for Apify/MCP
+research-provider readiness. Candidate facts include MCP configured, token
+present, allowed actor list, last smoke result, approved source types,
+dataset/cache policy, and no-raw-dump policy.
+
+## Parallel Research Files
+
+For multi-source or parallel-agent research, each source gets its own file and
+the main thread writes the synthesis.
+
+```text
+research/YYYY-MM-DD-offer-audience-youtube-customer-language.md
+research/YYYY-MM-DD-offer-audience-reddit-pain-points.md
+research/YYYY-MM-DD-offer-audience-competitor-positioning.md
+research/YYYY-MM-DD-offer-audience-synthesis.md
+```
+
+Each source file should include:
+
+- research question;
+- source type;
+- access or permission note;
+- collection method;
+- source quality;
+- key patterns;
+- counter-signals;
+- caveats;
+- what should and should not be promoted;
+- public/private handling.
+
+The synthesis file should include:
+
+- strongest repeated language;
+- market pains, desires, and buying triggers;
+- objections and proof gaps;
+- competitor/category positioning;
+- source quality and confidence;
+- recommended durable updates;
+- whether the stop condition was met.
+
+## Graduation Rules
+
+Research does not automatically overwrite core truth.
+
+- `research/` preserves evidence, caveats, source quality, and open questions.
+- `core/` preserves accepted operating truth.
+- `core/proof/` preserves approved proof, typicality, caveats, permission, and
+  offer linkage.
+- `core/content-strategy.md`, `core/marketing/...`, and `core/people/...`
+  preserve accepted content strategy and voice constraints.
+- `pushes/` and `playbooks/` preserve bounded execution plans and approval
+  records.
+- `decisions/` explain why a meaningful change was accepted.
+- `log/` preserves field results and lessons from shipped work.
+
+When the research suggests a meaningful business change, recommend a decision
+or operator review before codifying.
+
+## Influence And Taste
+
+When the operator likes a style, thinker, creator, or playbook, capture the
+operator-approved principle rather than copying the source.
+
+Good durable notes:
+
+- what the operator likes;
+- what not to copy;
+- what principle transfers;
+- voice/style constraints;
+- attribution when useful;
+- whether this becomes a reusable playbook candidate.
+
+Do not copy protected material wholesale, present a person's style as universal
+truth, or flatten the operator's voice into generic internet marketing.
+
+## Stop Rules
+
+Stop researching and synthesize when:
+
+- repeated language patterns are clear enough to update audience, offer,
+  objections, or proof angles;
+- the next business move is obvious and more research would delay shipping;
+- sources are low-quality, repetitive, or no longer changing the answer;
+- the operator needs field evidence, not more desk research;
+- the source is gated/private and access, permission, or terms are unclear;
+- the decision requires launching a small push/test rather than more analysis;
+- the research would require raw copyrighted dumps, private customer data,
+  account exports, session cookies, or unsupported provider access.
+
+If the stop rule is "field evidence needed," route to a small push, page/ad
+test, sales-call plan, or outcome log instead of more research.

--- a/.claude/skills/mb-think/references/research-phase.md
+++ b/.claude/skills/mb-think/references/research-phase.md
@@ -25,11 +25,14 @@ silently route from `.vip/local.yaml`. Use legacy `reference/offers/` only when
 ## Workflow
 
 1. **Define the question** — What specifically are you trying to learn?
-2. **Detect intent & route** — Determine which research tools to use (see [research-routing-quick-ref.md](research-routing-quick-ref.md))
-3. **Check capabilities** — Are preferred tools available? Offer setup or fallback if not
-4. **Gather findings** — Execute with token management and cost awareness
-5. **Synthesize** (required) — Distill findings into actionable insight
-6. **Save** — Write to `research/YYYY-MM-DD-topic-[source].md`
+2. **Recommend depth** — For offer, audience, proof, CTA, content strategy,
+   ads/pages, and positioning work, choose the smallest useful depth with
+   [research-depth-ladder.md](research-depth-ladder.md)
+3. **Detect intent & route** — Determine which research tools to use (see [research-routing-quick-ref.md](research-routing-quick-ref.md))
+4. **Check capabilities** — Are preferred tools available? Offer setup or fallback if not
+5. **Gather findings** — Execute with token management and cost awareness
+6. **Synthesize** (required) — Distill findings into actionable insight
+7. **Save** — Write to `research/YYYY-MM-DD-topic-[source].md`
 
 If the operator passes `--brief-format=grok-8`, asks for a researched brief,
 or wants research to feed a site, ads, organic content, or a push playbook,
@@ -153,11 +156,13 @@ only concise excerpts needed to support the synthesis.
 
 ### Provider Routing
 
-- Use Apify only as optional read-only enrichment when configured: YouTube
-  transcripts, Instagram mining, public web scraping, and public X
-  profile/post/reply samples when actor metadata, operator-accepted terms, and
-  a small smoke run support the source. Treat public X actors as sidecar
-  research, not an official X integration.
+- Use Apify only as optional read-only enrichment, preferably through MCP for
+  now: YouTube transcripts, Instagram mining, public web scraping, and public X
+  profile/post/reply samples when actor metadata, operator-accepted terms,
+  access/permission boundaries, and a small smoke run support the source. Treat
+  public X actors as sidecar research, not an official X integration. Treat
+  Apify MCP as an agent-side research tool surface, not automatically as an
+  `mb connect` provider.
 - Use Grok/xAI or web search for topic-level X/social sentiment when
   configured; otherwise ask for screenshots, public embeds, or manual exports.
 - Treat Postiz as planned scheduling/publishing support only where current docs

--- a/.claude/skills/mb-think/references/research-phase.md
+++ b/.claude/skills/mb-think/references/research-phase.md
@@ -33,6 +33,8 @@ silently route from `.vip/local.yaml`. Use legacy `reference/offers/` only when
 5. **Gather findings** — Execute with token management and cost awareness
 6. **Synthesize** (required) — Distill findings into actionable insight
 7. **Save** — Write to `research/YYYY-MM-DD-topic-[source].md`
+8. **Checkpoint** — Ask whether to make the research batch durable before the
+   next decision or codify pass
 
 If the operator passes `--brief-format=grok-8`, asks for a researched brief,
 or wants research to feed a site, ads, organic content, or a push playbook,

--- a/.claude/skills/mb-think/references/research-routing-quick-ref.md
+++ b/.claude/skills/mb-think/references/research-routing-quick-ref.md
@@ -23,6 +23,14 @@ Fast lookup table for routing research requests in /mb-think skill.
 - Tier 1 (Flash): **TESTED** - works via REST API
 - Tier 2 (Deep Research): **TESTED** - works via REST API (verified 2026-01-26, ~6min completion)
 
+For offer, audience, proof, CTA, content strategy, ads/pages, and positioning
+work, choose research depth with
+[research-depth-ladder.md](research-depth-ladder.md) before selecting tools.
+Levels 0-3 require no Apify. Level 4 may use Apify/MCP or another structured
+collection path when access, permission, terms, and source quality justify it.
+Level 5 may use Apify/MCP as one provider rail inside multi-source synthesis
+with caveats and durable promotion decisions.
+
 ---
 
 ## Tool Availability Check
@@ -30,7 +38,7 @@ Fast lookup table for routing research requests in /mb-think skill.
 **Run once per session, cache results:**
 
 ```bash
-# Check for Apify (YouTube, Instagram, optional public X post/profile/comment mining)
+# Check for Apify MCP (YouTube, Instagram, optional public X post/profile/comment mining)
 if mcp__apify__* exists: APIFY=true
 
 # Check for Grok (X/Twitter) — requires Python SDK, not just API key

--- a/.claude/skills/mb-think/references/templates/research-template.md
+++ b/.claude/skills/mb-think/references/templates/research-template.md
@@ -42,6 +42,7 @@ source_url:                    # Optional: Gemini/GPT share link for provenance
 model: opus-4.5
 status: draft
 brief_format: standard         # Use grok-8 for the 8-category researched brief
+research_depth: 1              # 0-5; see research-depth-ladder.md
 linked_decisions: []
 linked_pushes: []
 ---
@@ -64,6 +65,25 @@ a typed frontmatter link, inline link, entity tag, data reference, or no link.]
 ## Methodology
 
 [2-4 sentences: How you approached this research. What tools, what context provided, what attachments. Not the full prompt — just enough to reproduce or audit.]
+
+---
+
+## Research Depth
+
+```text
+current_depth:
+recommended_depth:
+reason:
+useful_sources:
+optional_tools:
+fallback:
+stop_condition:
+durable_targets:
+```
+
+Explain why this depth was enough, or what would justify escalation. If using
+Apify/MCP or another structured collection path, include access, permission,
+terms, source-quality, and no-raw-dump notes.
 
 ---
 
@@ -133,6 +153,16 @@ or long tweet threads into committed research files.
 
 - [What we still don't know]
 - [What needs follow-up research]
+
+### Promotion Review
+
+| Candidate Durable Target | Promote? | Reason / Caveat |
+|---|---|---|
+| `core/offer.md` | yes/no | [What should change, or why not yet] |
+| `core/audience.md` | yes/no | [What should change, or why not yet] |
+| `core/proof/` | yes/no | [Permission, typicality, outcome, or caveat note] |
+| `core/content-strategy.md` / `core/marketing/...` / `core/people/...` | yes/no | [Strategy or voice implication] |
+| `decisions/` | yes/no | [Decision needed before changing core truth] |
 
 ---
 

--- a/.claude/skills/mb-think/references/tool-detection.md
+++ b/.claude/skills/mb-think/references/tool-detection.md
@@ -1,9 +1,11 @@
 # Tool Detection (CLI Facts First, Runtime Probes Second)
 
 Provider readiness belongs to `mb status --json --peek`, `mb connect plan`, and
-`mb connect doctor --json`. Use those facts before probing local runtime tools.
-The checks below are for runtime-local capabilities that `mb` cannot inspect
-directly inside the current Claude Code session.
+`mb connect doctor --json`. Use those facts before probing local runtime tools
+for providers that `mb` owns. Apify research is MCP-first for now, so treat it
+as an agent-side tool surface unless a later CLI contract exposes stable Apify
+readiness facts. The checks below are for runtime-local capabilities that `mb`
+cannot inspect directly inside the current Claude Code session.
 
 ---
 
@@ -44,9 +46,11 @@ For full self-healing contract (stale semantics, status-change messaging, and tr
 
 ## Detection Methods
 
-**Apify:** Use `mb connect doctor --json` for provider readiness first. Then
-check if `mcp__apify__search-actors` exists in session when the selected path
-needs Apify runtime tools.
+**Apify:** Treat Apify as MCP-first agent-side research enrichment. When the
+selected path needs Level 4/5 structured collection, check if `mcp__apify__*`
+tools exist in session, then verify source access, permission, terms/cost,
+actor shape, and no-raw-dump handling before use. Do not require or imply
+`mb connect apify` until a later CLI issue accepts provider-readiness facts.
 
 **Gemini:**
 ```bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ### Added
 
+- Added a `/mb-think` research-depth ladder for offer, audience, proof,
+  product-ladder, CTA, content strategy, ads/page launch, market positioning,
+  and influence/playbook work, including enough-signal thresholds, stop rules,
+  parallel research file contracts, synthesis and promotion rules, MoneyPath
+  readiness language, and an MCP-first optional Apify research-provider
+  boundary. Refs MAIN-344, #529.
 - Added compact, privacy-safe books readiness facts to `mb status --json --peek`
   and `mb start --json`, so daily-loop agents can see bookkeeping setup,
   hledger availability, vault/ignore safety, unsafe artifact counts, and the

--- a/docs/content-strategy.md
+++ b/docs/content-strategy.md
@@ -179,6 +179,12 @@ Offer clarity comes before content volume. Use
 believe or buy something and the audience, outcome, mechanism, proof, CTA, or
 style is unclear.
 
+Use `/mb-think` research-depth guidance before deep platform, audience, or
+competitor research. Repo context can be enough for cleaning up an existing
+strategy; public/source-backed research or structured approved-source
+collection may be worth it before committing to a new channel, account voice,
+campaign angle, or market position.
+
 AI/search recognition work is related but separate. This model records what the
 business wants to be known for and how owned/public distribution reinforces
 that target. Site/wiki recognition checklists, entity pages, schema, and AI SEO

--- a/docs/offer-sharpening.md
+++ b/docs/offer-sharpening.md
@@ -41,6 +41,12 @@ offer path is legible, supported, connected, and instrumented. It does not
 replace strategic judgment about positioning, demand, copy quality, or market
 strength.
 
+Use `/mb-think` to choose the research depth before spending tokens on deeper
+source collection. Operator memory and repo context may be enough for a small
+copy edit. Source-backed synthesis, structured collection, field evidence, or a
+small push/test may be necessary before changing positioning, proof claims,
+pages, ads, or content strategy.
+
 ## Style Spectrum
 
 Use style to fit the operator and buyer. Do not use style to skip the rubric.


### PR DESCRIPTION
## Summary

Adds a `/mb-think` research-depth ladder so offer, audience, proof, CTA, content strategy, ads/page, market positioning, and influence/playbook work can choose the smallest useful research depth before spending tokens.
The guidance keeps Apify MCP-first and optional, adds stop rules and durable promotion rules, and leaves CLI/provider/runtime behavior unchanged.

## Linked issue

Closes #529 / MAIN-344
Refs MAIN-336
Refs MAIN-337
Refs MAIN-253
Refs MAIN-345

## Why

The existing `/mb-think` research docs already covered source/tool routing, but they did not clearly answer how much research is enough for the business decision at hand. This PR adds the missing decision layer so agents can stop at operator memory or repo context when that is enough, escalate only when useful, and route to field evidence instead of researching forever.

## Commits by concern

- [x] `be1ddba [add] MAIN-344 research depth ladder`
  - Adds `research-depth-ladder.md` with levels 0-5, task thresholds, MoneyPath guidance, stop rules, source quality, Apify/MCP boundary, parallel file contracts, synthesis, graduation rules, and influence/style capture.
  - Links the ladder from `/mb-think` routing, research phase, research architecture, quick reference, tool detection, research template, offer sharpening, content strategy, and `CHANGELOG.md`.
- [x] `c1bab6c [update] MAIN-344 research guidance clarity`
  - Restores the explicit `mb checkpoint --message "..." --yes` save command in `/mb-think` checkpoint guidance.
  - Clarifies that MoneyPath depth labels are agent-side explanation, not a parallel CLI score.
  - Aligns research workflow step ordering across the research phase and architecture references.
- [x] Each commit body bullet-lists the changes in that commit
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`

## Validation

Level 1 static: `cd mb && python3 -m mb skill validate --all --json` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: summary showed `skills: 15`, `passed: 15`, `failed: 0`, `errors: 0`, `warnings: 0`; `mb-think/SKILL.md` line count is 499.
Level 1 static: `scripts/check.sh` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: `84 files already formatted`; `All checks passed!`; `Success: no issues found in 83 source files`; `634 passed`.
Level 2 CLI contract: not required; no CLI command behavior, exit codes, JSON output, or TTY behavior changed.
Level 3 package/install smoke: not required; no packaging, entrypoint, bundled-data install path, or update path changed.
Level 4 fixture repo: not required; no init/onboard/status/start/update repo-shape behavior changed.
Level 5 runtime smoke: not required; this changes docs and bundled skill guidance only, with no skill discovery, runtime invocation, provider setup, or generated repo behavior changes.
Supply-chain review: not required; no workflows, dependency metadata, permissions, or publish surfaces changed.

- [x] Level 1 static: `scripts/check.sh` passes
- [ ] Level 2 CLI contract: focused Typer/CliRunner tests, exit codes, `--json` behavior, TTY vs non-TTY (if CLI behavior touched)
- [ ] Level 3 package/install smoke (if packaging touched)
- [ ] Level 4 fixture repo (if init/onboard/status/start/update touched)
- [ ] Level 5 runtime smoke / dogfood harness / simulation-tier (if runtime, first-run, skill discovery, or release validation touched)
- [x] SKILL.md <=500 lines (if any skill touched)
- [ ] Package-visible release gate evidence before tag/publish (if preparing a release)
- [ ] Supply-chain review (if `.github/workflows/`, `.github/dependabot.yml`, `mb/pyproject.toml` deps, or `id-token`/`permissions` blocks touched — see [docs/supply-chain-policy.md](../docs/supply-chain-policy.md))

## Success metric

`/mb-think` can recommend Level 0-5 research depth, name the stop condition, synthesize source files safely, and promote accepted findings into durable business files without implying Apify support beyond MCP-first optional enrichment or turning MoneyPath into a market-strength score.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [ ] N/A — change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [x] No
- [ ] Yes — migration note below

## Public / private boundary

No private operator strategy, customer/member data, secrets, local paths, raw source dumps, or provider credentials were committed. The new guidance explicitly keeps gated/private sources permission-aware, blocks raw scraped/copyrighted dumps, and treats Apify as MCP-first optional research enrichment rather than `mb connect apify`.
