### PR TITLE
[docs] Design hledger-backed books reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   parallel research file contracts, synthesis and promotion rules, MoneyPath
   readiness language, and an MCP-first optional Apify research-provider
   boundary. Refs MAIN-344, #529.
+- Added a MAIN-357 design sprint report set for the hledger-backed `mb books`
+  reporting path, recommending a fake packaged sample monthly report before
+  private-vault reporting and documenting hledger command families, chat-first
+  UX, JSON shape, privacy boundaries, and follow-up implementation slices. Refs
+  #560, #128.
 - Added compact, privacy-safe books readiness facts to `mb status --json --peek`
   and `mb start --json`, so daily-loop agents can see bookkeeping setup,
   hledger availability, vault/ignore safety, unsafe artifact counts, and the

--- a/docs/reports/2026-05-13-books-operator-ux-spec.md
+++ b/docs/reports/2026-05-13-books-operator-ux-spec.md
@@ -1,0 +1,265 @@
+---
+title: books operator UX spec for sample reports
+date: 2026-05-13
+linked_issue: https://github.com/noontide-co/mainbranch/issues/560
+linked_linear: MAIN-357
+release: unscheduled
+status: complete
+tags: [bookkeeping, hledger, operator-ux, chat]
+---
+
+# Books Operator UX Spec For Sample Reports
+
+## Decision
+
+Build a chat-first sample bookkeeping report before private-vault reporting.
+
+The operator should ask the agent for a books summary. The agent should run
+deterministic `mb books` commands internally, then answer in plain business
+language. The user does not need to know hledger flags, JSON, journal paths,
+`.gitignore`, or double-entry mechanics unless they ask.
+
+The first experience should be:
+
+```text
+User asks: "Show me a sample monthly bookkeeping report."
+Agent runs: mb books report sample-monthly --json
+Agent says: "Here is a fake sample report so you can see the shape."
+```
+
+The command name is a recommendation for the next implementation issue, not a
+shipped surface in this report.
+
+## Product Surface
+
+The product surface is the chat answer, not the terminal command.
+
+```text
+hledger = accounting/reporting engine
+mb books = safe wrapper, JSON layer, privacy boundary, workflow contract
+skills/agents = chat UX and operator guidance
+```
+
+The agent may mention hledger as a short detail:
+
+```text
+Under the hood, Main Branch uses hledger as the reporting engine.
+```
+
+Do not make hledger the user-facing noun. The user-facing noun is
+bookkeeping.
+
+## Good User Prompts
+
+- "Show me a sample monthly bookkeeping report."
+- "What would a Main Branch books summary look like?"
+- "Can you show revenue, expenses, and cash for the sample books?"
+- "Is my bookkeeping setup ready?"
+- "Explain the books status in plain English."
+
+Future private reporting prompts, after the privacy contract ships:
+
+- "Read my private books vault and summarize last month."
+- "Show me last month's high-level bookkeeping summary."
+- "Check whether my private books are ready for a read-only report."
+
+## Prompts That Need Clarification
+
+Clarify before acting on vague or risky prompts:
+
+- "Run my books."
+- "Check my finances."
+- "Tell me if my books are right."
+- "Am I tax ready?"
+- "Reconcile last month."
+
+Recommended clarification:
+
+```text
+I can help with a read-only bookkeeping summary, but raw finance needs a
+stricter boundary. Do you want the fake sample report, or are you asking me to
+read your private bookkeeping vault?
+```
+
+## Internal Agent Checks
+
+For the first sample-report slice, the agent should start from safe facts:
+
+```bash
+mb status --json --peek
+mb books status --json
+mb books check --fixture --json
+mb books report sample-monthly --json
+```
+
+If `mb books report sample-monthly --json` does not exist yet, the agent should
+not improvise private reporting. It should explain that the sample report is
+planned and use current readiness commands only.
+
+For future private-vault reporting, the agent should run readiness checks first:
+
+```bash
+mb books status --json
+mb books doctor --plan --json
+```
+
+Then it must ask permission before reading a private journal.
+
+## What The Agent Says Back
+
+For sample data:
+
+```text
+I checked the sample books fixture and generated a fake monthly report. This is
+packaged sample data, not your business.
+```
+
+Do not say:
+
+```text
+I ran hledger with `-f` and parsed `-O json`.
+```
+
+Technical detail is available on request, but it should not lead the normal
+answer.
+
+## Sample Monthly Report Copy
+
+```text
+Here is the sample monthly bookkeeping report for Acme Fixture Inc. This is
+fake packaged data, not your business.
+
+January 2026 sample
+
+Revenue: $250.00
+Expenses: $67.50
+Net income: $182.50
+Checking cash at month end: $1,250.00
+Credit card balance: $67.50 owed
+
+Plain-English read: the sample business received one customer payment, recorded
+two small expenses, and ended the month positive. Because this is fixture data,
+do not treat it as financial advice or evidence about your own books.
+
+Next safe step: I can check whether your private bookkeeping setup is ready,
+without reading the private ledger yet.
+```
+
+This copy is intentionally modest. It explains the reporting shape without
+claiming anything about the operator's real business.
+
+## Fake Vs Private Data
+
+Use this distinction:
+
+```text
+The sample report uses fake packaged data so you can see the reporting shape
+safely. Your private books are different: they live in a private bookkeeping
+vault and may contain real transactions, bank exports, customer payments,
+payroll, tax records, and account details. I will not read those unless you
+explicitly approve it.
+```
+
+Short version:
+
+```text
+Sample books show the shape. Private books are your real records.
+```
+
+## Permission Before Future Private Reads
+
+Before any private-vault read:
+
+```text
+I can generate this from your private bookkeeping vault, but that means reading
+real financial records on this machine. I will keep it read-only and summarize
+only high-level totals unless you ask for detail. Do you approve reading the
+private books vault for this report?
+```
+
+For team-private repo mode:
+
+```text
+This may require access to a restricted finance repo. Only approve if this
+chat/session is allowed to see that data.
+```
+
+If denied:
+
+```text
+No problem. I will stay with the fake sample report or setup readiness only.
+```
+
+## Hidden By Default
+
+Hide unless the user asks for technical detail or is debugging setup:
+
+- hledger command flags;
+- hledger binary path;
+- JSON schema details;
+- private vault paths, especially absolute paths;
+- `.gitignore` mechanics;
+- raw hledger output;
+- ledger row details;
+- account identifiers;
+- vendor, customer, payroll, tax, receipt, and statement details.
+
+## Beginner-Safe Language
+
+Use:
+
+- "bookkeeping";
+- "sample books";
+- "fake sample data";
+- "private bookkeeping vault";
+- "read-only report";
+- "setup is ready" / "setup needs attention";
+- "safe summary";
+- "the agent checked the bookkeeping safety rules".
+
+Avoid leading with:
+
+- hledger;
+- double-entry;
+- journal file;
+- gitignored;
+- JSON;
+- CLI;
+- account directives;
+- balance assertions.
+
+## Claims To Avoid
+
+Never claim:
+
+- "your finances are healthy";
+- "your books are accurate";
+- "tax ready";
+- "GAAP compliant";
+- "reconciled";
+- "audited";
+- "QuickBooks replacement";
+- "bookkeeper replacement";
+- "automated accounting";
+- "we imported your bank data";
+- "we read your private books" unless explicit permission was granted and the
+  command actually did.
+
+Allowed claim:
+
+```text
+This is a read-only summary from the sample hledger fixture. It is useful for
+showing the reporting shape, not for judging a real business.
+```
+
+## Non-hledger User Feel
+
+The experience should feel like asking an operations assistant:
+
+- "Show me last month's bookkeeping summary."
+- "Is setup ready?"
+- "What is missing before we can use real books?"
+- "Show me a fake example first."
+
+The agent uses hledger internally. The operator gets a plain-language report
+with clear boundaries.

--- a/docs/reports/2026-05-13-books-operator-ux-spec.md
+++ b/docs/reports/2026-05-13-books-operator-ux-spec.md
@@ -23,12 +23,13 @@ The first experience should be:
 
 ```text
 User asks: "Show me a sample monthly bookkeeping report."
-Agent runs: mb books report sample-monthly --json
+Agent runs: mb books report monthly --sample --month 2026-01 --json
 Agent says: "Here is a fake sample report so you can see the shape."
 ```
 
-The command name is a recommendation for the next implementation issue, not a
-shipped surface in this report.
+The command spelling is a recommendation for the next implementation issue, not
+a shipped surface in this report. `mb books report sample-monthly --json` is an
+acceptable simpler candidate if implementation chooses a named sample action.
 
 ## Product Surface
 
@@ -89,12 +90,12 @@ For the first sample-report slice, the agent should start from safe facts:
 mb status --json --peek
 mb books status --json
 mb books check --fixture --json
-mb books report sample-monthly --json
+mb books report monthly --sample --month 2026-01 --json
 ```
 
-If `mb books report sample-monthly --json` does not exist yet, the agent should
-not improvise private reporting. It should explain that the sample report is
-planned and use current readiness commands only.
+If the sample report command does not exist yet, the agent should not improvise
+private reporting. It should explain that the sample report is planned and use
+current readiness commands only.
 
 For future private-vault reporting, the agent should run readiness checks first:
 

--- a/docs/reports/2026-05-13-books-privacy-and-integration-plan.md
+++ b/docs/reports/2026-05-13-books-privacy-and-integration-plan.md
@@ -82,11 +82,15 @@ Daily-loop status should remain safe to share and route-oriented.
 The first sample report command should produce a Main Branch envelope rather
 than exposing hledger's raw JSON.
 
-Recommended command:
+Recommended command shape:
 
 ```bash
-mb books report sample-monthly --json
+mb books report monthly --sample --month 2026-01 --json
 ```
+
+The first implementation issue can still choose `mb books report
+sample-monthly --json` if a named sample action proves cleaner, but the
+`monthly --sample --month` shape ages better once private monthly reports land.
 
 Recommended schema name:
 
@@ -103,7 +107,7 @@ Recommended sample envelope:
     "name": "mainbranch.books.report.v1",
     "version": "1.0"
   },
-  "mb_command": "mb books report sample-monthly",
+  "mb_command": "mb books report monthly --sample --month 2026-01",
   "safe_to_share": true,
   "source": {
     "kind": "packaged_fixture",

--- a/docs/reports/2026-05-13-books-privacy-and-integration-plan.md
+++ b/docs/reports/2026-05-13-books-privacy-and-integration-plan.md
@@ -113,7 +113,6 @@ Recommended sample envelope:
     "kind": "packaged_fixture",
     "fixture": true,
     "engine": "hledger",
-    "engine_version": "1.52.1",
     "journal": {
       "label": "acme-fixture",
       "location_kind": "packaged",
@@ -176,6 +175,10 @@ Recommended sample envelope:
 For future real private-vault reports, default `safe_to_share` should be
 `false` unless the command explicitly produces an approved sanitized summary.
 The envelope should still omit private paths and raw transaction rows.
+
+Do not hardcode hledger versions in the JSON schema. If implementation adds an
+`engine_version` diagnostic later, populate it from the live `hledger --version`
+result for the command run.
 
 ## Fields Never To Expose In Readiness
 

--- a/docs/reports/2026-05-13-books-privacy-and-integration-plan.md
+++ b/docs/reports/2026-05-13-books-privacy-and-integration-plan.md
@@ -1,0 +1,267 @@
+---
+title: books privacy and integration plan for hledger reports
+date: 2026-05-13
+linked_issue: https://github.com/noontide-co/mainbranch/issues/560
+linked_linear: MAIN-357
+release: unscheduled
+status: complete
+tags: [bookkeeping, privacy, hledger, integration]
+---
+
+# Books Privacy And Integration Plan For hledger Reports
+
+## Summary
+
+Keep readiness and reporting separate.
+
+Status/readiness answers: "Is bookkeeping configured safely, and what should
+the operator do next?"
+
+Report output answers: "What did hledger compute from an explicitly selected
+fake or private journal?"
+
+The first report implementation should read only fake packaged data. It should
+not read real private books, copy fixture journals into generated business
+repos, or expand daily status with private financial totals.
+
+## Where Sample Journals Should Live
+
+Use the existing public/package split:
+
+```text
+docs/examples/books/acme-fixture.journal
+mb/mb/_data/books/acme-fixture.journal
+```
+
+The docs copy is the human-readable public example. The packaged copy is what
+installed `mb` can use for fixture-backed checks and sample reports.
+
+Tests already require both copies to carry a fixture marker and stay
+byte-identical. Keep that pattern for any future fake report fixture outputs.
+
+Do not copy fake journals into generated business repos with `mb init` or
+`mb onboard`. A sample report should be available from the package, not by
+placing ledger-shaped files in the user's business repo.
+
+## Package Data Shape
+
+If the first implementation needs cached expected output fixtures, keep them
+under the same fake-data namespace:
+
+```text
+docs/examples/books/
+  acme-fixture.journal
+  reports/
+    sample-monthly.json
+
+mb/mb/_data/books/
+  acme-fixture.journal
+  reports/
+    sample-monthly.json
+```
+
+Only fake fixture outputs generated from fake fixture data belong there. Do not
+package real ledgers, real statement exports, or private-vault examples.
+
+## Status And Start Integration
+
+Preserve the current split:
+
+- `mb books status --json`: detailed safe setup/storage health.
+- `mb books doctor --plan --json`: non-mutating setup repair plan.
+- `mb status --json --peek`: compact, safe `books` readiness.
+- `mb start --json`: compact, safe `books` readiness for daily-loop agents.
+- `/mb-start`: starts from status/start facts and routes explicit bookkeeping
+  intent to `mb books` commands.
+
+Do not add report totals to `mb status --json --peek` or `mb start --json`.
+Daily-loop status should remain safe to share and route-oriented.
+
+## Proposed Report JSON Envelope
+
+The first sample report command should produce a Main Branch envelope rather
+than exposing hledger's raw JSON.
+
+Recommended command:
+
+```bash
+mb books report sample-monthly --json
+```
+
+Recommended schema name:
+
+```text
+mainbranch.books.report.v1
+```
+
+Recommended sample envelope:
+
+```json
+{
+  "schema_version": "1.0",
+  "result_schema": {
+    "name": "mainbranch.books.report.v1",
+    "version": "1.0"
+  },
+  "mb_command": "mb books report sample-monthly",
+  "safe_to_share": true,
+  "source": {
+    "kind": "packaged_fixture",
+    "fixture": true,
+    "engine": "hledger",
+    "engine_version": "1.52.1",
+    "journal": {
+      "label": "acme-fixture",
+      "location_kind": "packaged",
+      "path_exposed": false,
+      "content_read": true
+    }
+  },
+  "report": {
+    "kind": "sample_monthly",
+    "period": {
+      "start": "2026-01-01",
+      "end": "2026-02-01",
+      "label": "January 2026"
+    },
+    "currency": "USD"
+  },
+  "totals": {
+    "revenue": {
+      "commodity": "USD",
+      "decimal_mantissa": 25000,
+      "decimal_places": 2,
+      "display": "$250.00"
+    },
+    "expenses": {
+      "commodity": "USD",
+      "decimal_mantissa": 6750,
+      "decimal_places": 2,
+      "display": "$67.50"
+    },
+    "net_income": {
+      "commodity": "USD",
+      "decimal_mantissa": 18250,
+      "decimal_places": 2,
+      "display": "$182.50"
+    },
+    "cash": {
+      "commodity": "USD",
+      "decimal_mantissa": 125000,
+      "decimal_places": 2,
+      "display": "$1,250.00"
+    },
+    "credit_card": {
+      "commodity": "USD",
+      "decimal_mantissa": 6750,
+      "decimal_places": 2,
+      "display": "$67.50 owed"
+    }
+  },
+  "operator_summary": "This fake sample month shows the reporting shape; it is not your business data.",
+  "redactions": {
+    "private_paths": true,
+    "account_identifiers": true,
+    "payees": true,
+    "transaction_memos": true
+  },
+  "findings": []
+}
+```
+
+For future real private-vault reports, default `safe_to_share` should be
+`false` unless the command explicitly produces an approved sanitized summary.
+The envelope should still omit private paths and raw transaction rows.
+
+## Fields Never To Expose In Readiness
+
+Never expose these through `mb status`, `mb start`, or generated runtime
+guidance:
+
+- real ledger contents;
+- transaction rows;
+- hledger binary absolute path;
+- private absolute vault path outside the business repo;
+- bank, card, routing, tax, payroll, customer, vendor, invoice, dispute, or
+  legal identifiers;
+- raw CSV, OFX, QFX, QBO, QIF, or statement contents;
+- unsafe artifact filenames in compact readiness;
+- private finance repo local paths;
+- detailed account balances, payees, memos, or transaction dates from real
+  books.
+
+The current readiness adapter already omits contents, hledger binary paths,
+external private paths, and unsafe filenames. Keep that property as reporting
+lands.
+
+## Private Vault Boundaries
+
+Use the accepted storage model from
+[docs/books.md](../books.md) and the
+[books foundation decision](../../decisions/2026-05-11-mb-books-foundation.md):
+
+- `solo-local`: real books live under `.mb/private/books/`, ignored by the
+  business repo. `main.journal`, imports, cache, detailed reports, and
+  attachments stay there.
+- `team-private-repo`: real books live in a restricted finance repo. The hub
+  repo stores only safe policy, topology, and approved summaries.
+- `advanced-vault`: real books live in encrypted or off-platform storage. The
+  hub repo stores only a safe label/handle, not the literal private path.
+
+Team-visible hub content that can be safe:
+
+- `core/finance/books.md`;
+- `core/finance/chart-of-accounts.md`;
+- safe import-rule templates with no real identifiers;
+- sanitized summaries under `docs/reports/finance/`;
+- topology references to a restricted finance repo.
+
+Not safe by default:
+
+- real `.journal`, `.hledger`, `.ledger`, or `.beancount` files;
+- bank, payment-processor, payroll, or tax exports;
+- detailed reports from real books;
+- account identifiers and row-level payment history.
+
+## Tests For The Implementation Issues
+
+Fixture packaging tests:
+
+- sample journals carry explicit fake markers;
+- docs and packaged copies are byte-identical;
+- packaged report fixtures are generated from fake data only;
+- the fake fixture passes `hledger check -s accounts commodities ordereddates`
+  once strict reporting fixtures land.
+
+Redaction tests:
+
+- external absolute vault paths never appear in JSON or human output;
+- hledger binary paths never appear;
+- private journal content markers never appear in status/readiness;
+- unsafe artifact filenames do not appear in compact status/start facts;
+- real-data report output defaults `safe_to_share: false`.
+
+No-real-data tests:
+
+- committed unmarked `.journal` and statement-shaped `.csv` files still warn;
+- marked fixtures remain exempt;
+- `.mb/private/books/main.journal` presence is statted but not read by
+  `status`, `start`, or readiness;
+- report commands read private ledgers only in explicit report mode, not in
+  status/start/readiness.
+
+Integration tests:
+
+- `mb status --json --peek` keeps compact `books` schema stable;
+- `mb start --json` preserves the same compact `books` object;
+- `/mb-start` docs route explicit finance intent through `mb books` facts;
+- report output does not get folded into ranked actions except as a safe route
+  or summary.
+
+## Reporting Vs Readiness Rule
+
+Report commands may be private. Readiness commands must stay safe to share.
+
+That rule should drive every future `mb books` surface. If a command reads real
+ledger rows, it is a report/import/reconcile command with explicit permission
+and private output. It is not status, start, or daily-loop readiness.

--- a/docs/reports/2026-05-13-books-reporting-roadmap.md
+++ b/docs/reports/2026-05-13-books-reporting-roadmap.md
@@ -129,6 +129,10 @@ mainbranch.books.report.v1
 
 Minimum fields:
 
+Build this payload through the shared JSON result helper so standard top-level
+fields such as `result_envelope_version`, `ok`, `result_status`, `errors`,
+`warnings`, and `actions` stay consistent with other `mb --json` commands.
+
 ```json
 {
   "schema_version": "1.0",

--- a/docs/reports/2026-05-13-books-reporting-roadmap.md
+++ b/docs/reports/2026-05-13-books-reporting-roadmap.md
@@ -1,0 +1,364 @@
+---
+title: hledger-backed books reporting roadmap
+date: 2026-05-13
+linked_issue: https://github.com/noontide-co/mainbranch/issues/560
+linked_linear: MAIN-357
+release: unscheduled
+status: complete
+tags: [bookkeeping, hledger, roadmap, reports]
+---
+
+# hledger-backed Books Reporting Roadmap
+
+## Recommendation
+
+Build sample reporting before private-vault reporting.
+
+The first implementation should add a beginner-safe sample monthly report using
+hledger and fake packaged data:
+
+```bash
+mb books report sample-monthly --json
+```
+
+The command should run hledger internally against the packaged Acme fixture,
+translate hledger JSON into a stable Main Branch JSON envelope, and produce
+plain-language output for agents to use in chat.
+
+This is the fastest safe path from the current setup/readiness layer to useful
+bookkeeping reports because it proves the full wrapper without touching real
+Class B data.
+
+## First Report Experience
+
+User asks in chat:
+
+```text
+Show me a sample monthly bookkeeping report.
+```
+
+Agent runs internally:
+
+```bash
+mb status --json --peek
+mb books status --json
+mb books check --fixture --json
+mb books report sample-monthly --json
+```
+
+Agent answers:
+
+```text
+Here is the sample monthly bookkeeping report for Acme Fixture Inc. This is
+fake packaged data, not your business.
+
+January 2026 sample
+
+Revenue: $250.00
+Expenses: $67.50
+Net income: $182.50
+Checking cash at month end: $1,250.00
+Credit card balance: $67.50 owed
+
+Plain-English read: the sample business received one customer payment, recorded
+two small expenses, and ended the month positive. Because this is fixture data,
+do not treat it as financial advice or evidence about your own books.
+
+Next safe step: I can check whether your private bookkeeping setup is ready,
+without reading the private ledger yet.
+```
+
+The user-facing UX is plain language. The skill/agent runs CLI commands
+internally.
+
+## hledger Commands To Power It
+
+Use:
+
+```bash
+hledger -n -f <packaged-fixture> check
+hledger -n -f <packaged-fixture> incomestatement -M -O json -b 2026-01-01 -e 2026-02-01
+hledger -n -f <packaged-fixture> balance assets:bank assets:cash -H -M -O json -b 2026-01-01 -e 2026-02-01
+hledger -n -f <packaged-fixture> balance liabilities:credit-card -H -M -O json -b 2026-01-01 -e 2026-02-01
+```
+
+The implementation may call `balancesheetequity -O json` as a broader validation
+or future report primitive, but the first chat answer only needs revenue,
+expenses, net income, cash, and credit card balance.
+
+Do not parse terminal text. Read hledger JSON and convert it into a stable
+Main Branch envelope.
+
+## Sample Data Required
+
+Use a small fake hledger journal with:
+
+- explicit fixture marker in the first 1024 bytes;
+- obviously fake company name;
+- `commodity 1000.00 USD`;
+- account directives with hledger account types for cash, liability, equity,
+  revenue, and expense accounts;
+- one opening balance;
+- one sample customer payment;
+- two sample expenses;
+- one simple balance assertion.
+
+Store it in:
+
+```text
+docs/examples/books/acme-fixture.journal
+mb/mb/_data/books/acme-fixture.journal
+```
+
+Keep the two files byte-identical and covered by tests. Do not copy the fixture
+into generated business repos.
+
+## JSON Shape For Agents
+
+Use this schema name:
+
+```text
+mainbranch.books.report.v1
+```
+
+Minimum fields:
+
+```json
+{
+  "schema_version": "1.0",
+  "result_schema": {
+    "name": "mainbranch.books.report.v1",
+    "version": "1.0"
+  },
+  "mb_command": "mb books report sample-monthly",
+  "safe_to_share": true,
+  "source": {
+    "kind": "packaged_fixture",
+    "fixture": true,
+    "engine": "hledger",
+    "journal": {
+      "label": "acme-fixture",
+      "location_kind": "packaged",
+      "path_exposed": false,
+      "content_read": true
+    }
+  },
+  "report": {
+    "kind": "sample_monthly",
+    "period": {
+      "start": "2026-01-01",
+      "end": "2026-02-01",
+      "label": "January 2026"
+    },
+    "currency": "USD"
+  },
+  "totals": {
+    "revenue": {},
+    "expenses": {},
+    "net_income": {},
+    "cash": {},
+    "credit_card": {}
+  },
+  "operator_summary": "This fake sample month shows the reporting shape; it is not your business data.",
+  "redactions": {
+    "private_paths": true,
+    "account_identifiers": true,
+    "payees": true,
+    "transaction_memos": true
+  },
+  "findings": []
+}
+```
+
+Amounts should carry commodity, decimal mantissa, decimal places, and display
+string. Do not expose hledger internals directly as the public contract.
+
+## Privacy Boundaries
+
+Allowed in the first implementation:
+
+- fake packaged journal;
+- fake generated report totals;
+- hledger availability checks without printing the binary path;
+- Main Branch JSON summaries marked as fixture data.
+
+Disallowed in the first implementation:
+
+- reading real private books vaults;
+- reading private finance repos;
+- importing provider exports;
+- committing raw ledgers or statement exports;
+- showing private paths;
+- storing raw hledger JSON from private books;
+- claiming accuracy, reconciliation, tax readiness, GAAP compliance, or
+  bookkeeper replacement.
+
+Future private reporting requires an explicit permission prompt before reading
+the private vault:
+
+```text
+I can generate this from your private bookkeeping vault, but that means reading
+real financial records on this machine. I will keep it read-only and summarize
+only high-level totals unless you ask for detail. Do you approve reading the
+private books vault for this report?
+```
+
+## Allowed And Disallowed Claims
+
+Allowed:
+
+- "sample bookkeeping report";
+- "hledger-backed sample report";
+- "fake packaged data";
+- "setup/readiness";
+- "private bookkeeping vault";
+- "read-only report";
+- "agent uses CLI facts internally";
+- "chat-first bookkeeping experience".
+
+Disallowed:
+
+- "your finances are healthy";
+- "your books are accurate";
+- "tax ready";
+- "GAAP compliant";
+- "reconciled";
+- "audited";
+- "QuickBooks replacement";
+- "bookkeeper replacement";
+- "automated accounting".
+
+## Implementation Issue Sequence
+
+### 1. Add hledger-backed sample monthly report
+
+```md
+## Goal
+
+Add a beginner-safe sample books report using hledger and fake packaged data.
+
+## Scope
+
+- `mb books report sample-monthly`
+- hledger-backed sample report
+- human output for chat/agent UX
+- stable JSON output for agents
+- fake packaged journal only
+- no real vault reads
+
+## Acceptance Criteria
+
+- output is clearly sample/fake data
+- hledger is used as the engine
+- JSON is stable and public-safe
+- human output is beginner-safe
+- no private financial data is committed
+- tests cover missing hledger, invalid month, fixture success, JSON shape,
+  package data, and privacy boundary
+```
+
+Validation:
+
+- focused `mb/tests/test_books.py` coverage;
+- `mb books report sample-monthly --json`;
+- `mb books report sample-monthly`;
+- missing-hledger path;
+- package fixture byte-identity test;
+- `scripts/check.sh`;
+- package/install smoke because packaged data and CLI behavior change.
+
+Runtime smoke: not required unless generated skill behavior changes.
+
+### 2. Route `/mb-start` and books skill guidance to sample reports
+
+```md
+## Goal
+
+Teach agents to answer sample bookkeeping prompts through the shipped sample
+report command.
+
+## Scope
+
+- `/mb-start` bookkeeping route update
+- generated repo guidance if needed
+- runtime command reference tests
+- no private-vault reporting
+```
+
+Validation:
+
+- tests that skill/guidance references use the shipped command shape;
+- `scripts/check.sh`;
+- Claude Code runtime/manual note if bundled skill behavior changes.
+
+### 3. Design private-vault read-only report permission gate
+
+```md
+## Goal
+
+Specify and test the permission boundary for future private books summaries.
+
+## Scope
+
+- permission prompt copy
+- report envelope for real private data
+- redaction rules
+- no import/reconcile/mutation
+- no raw transaction rows in public output
+```
+
+Validation:
+
+- CLI tests for denied permission / no-read path;
+- redaction tests for private paths, binary paths, account identifiers, and raw
+  row markers;
+- fixture repo smoke with fake private vault only;
+- no runtime smoke unless skill behavior changes.
+
+### 4. Add read-only private monthly summary
+
+```md
+## Goal
+
+Generate a private, read-only monthly bookkeeping summary after explicit
+operator approval.
+
+## Scope
+
+- real private vault read after approval
+- high-level totals only by default
+- `safe_to_share: false`
+- no import, reconcile, close, or mutation
+```
+
+Validation:
+
+- fake private-vault fixture repo smoke;
+- tests proving status/start do not read the ledger;
+- tests proving report mode does read only after explicit approval path;
+- redaction and no-public-output tests;
+- package/install smoke if packaged behavior changes;
+- runtime/manual validation if bundled skill guidance changes.
+
+## Follow-up To Track Separately
+
+The current Acme fixture works for the shipped basic check. The first sample
+report implementation should add a `commodity` directive and strict fixture
+validation so `hledger check -s accounts commodities ordereddates` can pass.
+
+Do not broaden the first implementation into import, reconcile, close, tax,
+payroll, dashboard, or provider work.
+
+## Success Metric
+
+An implementation agent can build the sample report without re-deciding product
+shape:
+
+- command name is known;
+- hledger command families are known;
+- fake data location is known;
+- JSON envelope is known;
+- chat output is known;
+- privacy boundary is known;
+- validation ladder is known;
+- private-vault reporting is explicitly later.

--- a/docs/reports/2026-05-13-books-reporting-roadmap.md
+++ b/docs/reports/2026-05-13-books-reporting-roadmap.md
@@ -15,11 +15,17 @@ tags: [bookkeeping, hledger, roadmap, reports]
 Build sample reporting before private-vault reporting.
 
 The first implementation should add a beginner-safe sample monthly report using
-hledger and fake packaged data:
+hledger and fake packaged data. The command/action should mean "monthly report
+using fake sample data." The exact CLI spelling can be settled in the
+implementation issue; the preferred scalable shape is:
 
 ```bash
-mb books report sample-monthly --json
+mb books report monthly --sample --month 2026-01 --json
 ```
+
+`mb books report sample-monthly --json` remains an acceptable simpler candidate
+if the implementation chooses a named sample action instead of a `monthly`
+report subcommand with `--sample`.
 
 The command should run hledger internally against the packaged Acme fixture,
 translate hledger JSON into a stable Main Branch JSON envelope, and produce
@@ -43,7 +49,7 @@ Agent runs internally:
 mb status --json --peek
 mb books status --json
 mb books check --fixture --json
-mb books report sample-monthly --json
+mb books report monthly --sample --month 2026-01 --json
 ```
 
 Agent answers:
@@ -130,7 +136,7 @@ Minimum fields:
     "name": "mainbranch.books.report.v1",
     "version": "1.0"
   },
-  "mb_command": "mb books report sample-monthly",
+  "mb_command": "mb books report monthly --sample --month 2026-01",
   "safe_to_share": true,
   "source": {
     "kind": "packaged_fixture",
@@ -239,7 +245,8 @@ Add a beginner-safe sample books report using hledger and fake packaged data.
 
 ## Scope
 
-- `mb books report sample-monthly`
+- monthly sample report command syntax, likely
+  `mb books report monthly --sample --month 2026-01`
 - hledger-backed sample report
 - human output for chat/agent UX
 - stable JSON output for agents
@@ -260,8 +267,8 @@ Add a beginner-safe sample books report using hledger and fake packaged data.
 Validation:
 
 - focused `mb/tests/test_books.py` coverage;
-- `mb books report sample-monthly --json`;
-- `mb books report sample-monthly`;
+- chosen sample monthly report command with `--json`;
+- chosen sample monthly report command in human mode;
 - missing-hledger path;
 - package fixture byte-identity test;
 - `scripts/check.sh`;

--- a/docs/reports/2026-05-13-hledger-capability-map.md
+++ b/docs/reports/2026-05-13-hledger-capability-map.md
@@ -155,7 +155,7 @@ The fake sample journal should stay small and obviously synthetic:
 
 commodity 1000.00 USD
 
-account assets:bank:checking          ; type:C
+account assets:bank:checking          ; type:A
 account liabilities:credit-card       ; type:L
 account equity:opening-balances       ; type:E
 account income:sales                  ; type:R

--- a/docs/reports/2026-05-13-hledger-capability-map.md
+++ b/docs/reports/2026-05-13-hledger-capability-map.md
@@ -1,0 +1,201 @@
+---
+title: hledger capability map for mb books reports
+date: 2026-05-13
+linked_issue: https://github.com/noontide-co/mainbranch/issues/560
+linked_linear: MAIN-357
+release: unscheduled
+status: complete
+tags: [bookkeeping, hledger, reports, planning]
+---
+
+# hledger Capability Map For `mb books` Reports
+
+## Summary
+
+Main Branch should wrap hledger's read-only report commands before any import,
+reconcile, or private-vault mutation workflow.
+
+The first reporting slice should be a fake packaged monthly sample report. It
+should run hledger against bundled fixture data, normalize hledger's structured
+output into a small Main Branch JSON envelope, and let skills explain the result
+in chat. Real private-vault reporting should follow only after the sample
+report path proves command routing, JSON shape, redaction, and beginner-safe
+copy.
+
+Use hledger for accounting math. Use `mb books` for privacy, command routing,
+JSON contracts, and plain-language summaries.
+
+## Sources Checked
+
+- Local `hledger 1.52.1` help for `check`, `balance`, `incomestatement`, and
+  `register`.
+- The official hledger manual: <https://hledger.org/hledger.html>.
+- The hledger error guide: <https://hledger.org/ERRORS.html>.
+- Existing Main Branch books docs and decisions:
+  - [docs/books.md](../books.md)
+  - [decisions/2026-05-11-mb-books-foundation.md](../../decisions/2026-05-11-mb-books-foundation.md)
+  - [docs/reports/2026-05-11-hledger-vs-beancount-fit.md](2026-05-11-hledger-vs-beancount-fit.md)
+- Current fake fixture:
+  [docs/examples/books/acme-fixture.journal](../examples/books/acme-fixture.journal).
+
+## First Command Families To Wrap
+
+Wrap these first, always with an explicit journal path and no local hledger
+config:
+
+```bash
+hledger -n -f <journal> check
+hledger -n -f <journal> incomestatement -M -O json -b <start> -e <end>
+hledger -n -f <journal> balance assets:bank assets:cash -H -M -O json -b <start> -e <end>
+hledger -n -f <journal> balancesheetequity -M -O json -b <start> -e <end>
+hledger -n -f <journal> register <account-query> -H -O json -b <start> -e <end>
+```
+
+Use `hledger print -O json` only for internal parse diagnostics. Do not expose
+or persist its raw output in public docs, status, or chat summaries because it
+contains full transaction rows and can include source locations.
+
+## Report Mapping
+
+| User need | hledger command family | Main Branch handling |
+| --- | --- | --- |
+| Monthly revenue | `incomestatement -M -O json` | Read hledger's revenue section; present as sample or private summary. |
+| Monthly expenses | `incomestatement -M -O json` | Read hledger's expense section; preserve hledger sign handling. |
+| Net income | `incomestatement -M -O json` | Use hledger's report total, not Main Branch arithmetic. |
+| Cash/bank ending balance | `balance <cash/accounts> -H -M -O json` | Query configured cash/bank roots; `-H` keeps ending balances historical. |
+| Balance sheet | `balancesheet -O json` or `balancesheetequity -O json` | Prefer high-level commands when account types are declared. |
+| Account-level balances | `balance -H -O json <query>` | Use for configured account groups, not broad private detail by default. |
+| Register detail | `register <query> -H -O json` | Keep detail private; use for debugging or approved private workflows later. |
+| Parse/check | `check` and sometimes `print -O json` | `check` has human stderr, not JSON; wrap return code and redacted diagnostics. |
+
+Do not use `cashflow` as the first answer for bank balance. `cashflow` reports
+cash movement; `balance -H` is the better primitive for ending balances.
+
+## Structured Output
+
+The official hledger manual lists JSON support for the report families Main
+Branch needs first: `balance`, `balancesheet`, `balancesheetequity`,
+`cashflow`, `incomestatement`, `register`, `aregister`, and `print`.
+
+Use `-O json` for machine reads. hledger's JSON is verbose and shaped around
+hledger internals, so `mb books` should translate it into a small stable
+schema. Preserve amounts as decimal parts from hledger JSON:
+
+```json
+{
+  "commodity": "USD",
+  "decimal_mantissa": 18250,
+  "decimal_places": 2,
+  "display": "$182.50"
+}
+```
+
+Do not treat `floatingPoint` as the durable numeric value. It is convenient for
+display checks but not the stable representation.
+
+CSV/TSV can be useful for future exports. They are not the best first agent
+contract because report-specific layouts vary. Text tables are for humans only;
+Main Branch should never scrape terminal-formatted report tables.
+
+`hledger check` does not produce JSON in the local 1.52.1 CLI. It exits `0`
+with no output when clean, and exits non-zero with a human error on stderr when
+the journal is missing, malformed, unbalanced, or fails assertions.
+
+## Flags To Rely On
+
+- `-n` / `--no-conf`: ignore hledger config so scripted reports are stable.
+- `-f <journal>`: always choose the journal explicitly; never fall back to
+  `$LEDGER_FILE` or `~/.hledger.journal`.
+- `-b YYYY-MM-DD` and `-e YYYY-MM-DD`: use bounded periods. Treat `end` as the
+  exclusive bound that hledger expects.
+- `-M`: monthly interval.
+- `-H`: historical accumulation for ending balances and bounded register views.
+- `-O json`: structured output for report commands.
+- `--pager=no --color=n`: when a future troubleshooting path captures text.
+- `-s` / `--strict`: useful for fixture and private validation once fixtures
+  declare accounts and commodities.
+
+## Flags And Commands To Avoid First
+
+- `-I` / `--ignore-assertions`, except as an explicit troubleshooting escape
+  hatch. It disables balance assertion checks.
+- `--auto`, `--forecast`, `--value`, `-V`, `-X`, and `--infer-*` until valuation
+  and generated postings are explicitly in scope.
+- `import` without `--dry-run`. Import mutates journals and `.latest.*` state.
+- `add`, `close`, `rewrite`, `ui`, `web`, or any command that mutates data or
+  starts a UI.
+- `-o FILE` in early wrappers. Capture stdout and keep persistence under Main
+  Branch's explicit report/privacy contract.
+- Raw `print -O json` in public surfaces. It is useful for parsing but too
+  detailed for safe summaries.
+
+## Error Behavior To Wrap
+
+hledger's failure mode is useful but not public-safe by default. It can include
+file paths, account names, transaction descriptions, and line excerpts. `mb
+books` should capture return code, stdout, and capped stderr, then emit a
+redacted Main Branch finding.
+
+| Condition | Observed hledger behavior | Main Branch wrapper behavior |
+| --- | --- | --- |
+| Missing journal file | Exit `1`, stderr says the data file was not found. | Report `journal_missing`; do not print absolute private path. |
+| Invalid date / parse error | Exit `1`, stderr points to the bad line. | Report `journal_parse_error`; cap and redact detail. |
+| Unbalanced transaction | Exit `1`, stderr shows transaction excerpt and imbalance. | Report `journal_unbalanced`; do not expose row text in shared output. |
+| Balance assertion failure | Exit non-zero with assertion context. | Report `balance_assertion_failed`; keep details private unless explicitly requested. |
+| Query matches no rows | Exit `0`, empty structured output. | Report `no_matching_activity`, not a failure. |
+| `check -O json` | Exit non-zero because `check` does not support `-O`. | Do not call this shape. |
+
+## Sample Journal Shape
+
+The fake sample journal should stay small and obviously synthetic:
+
+```journal
+; SAMPLE FIXTURE -- NOT A REAL LEDGER
+; Fictional company: Acme Fixture Inc.
+
+commodity 1000.00 USD
+
+account assets:bank:checking          ; type:C
+account liabilities:credit-card       ; type:L
+account equity:opening-balances       ; type:E
+account income:sales                  ; type:R
+account expenses:software             ; type:X
+account expenses:office:supplies      ; type:X
+
+2026-01-01 opening balance
+    assets:bank:checking      1000.00 USD
+    equity:opening-balances
+
+2026-01-15 sample customer payment
+    assets:bank:checking       250.00 USD
+    income:sales
+
+2026-01-20 sample software subscription
+    expenses:software           49.00 USD
+    liabilities:credit-card
+```
+
+The current fixture already works for the shipped basic fixture check. The
+first reporting implementation should add a commodity directive so strict
+fixture validation can include the `commodities` check.
+
+## What Main Branch Must Not Compute
+
+Main Branch should not compute accounting math itself:
+
+- revenue totals;
+- expense totals;
+- net income;
+- bank/cash balances;
+- balance sheet totals;
+- running register balances;
+- sign normalization;
+- balance assertions;
+- historical accumulation;
+- valuation or currency conversion;
+- import overlap handling;
+- reconciliation.
+
+hledger owns those results. Main Branch owns the wrapper: privacy boundaries,
+redaction, stable JSON, command selection, fixture packaging, repair guidance,
+and chat-ready summaries.


### PR DESCRIPTION
## Summary

Adds the MAIN-357 public design sprint reports for the hledger-backed `mb books` reporting path. The roadmap recommends sample/fake hledger reporting before private-vault reporting, with chat-first UX, safe JSON, privacy boundaries, and follow-up implementation slices.

## Linked issue

Closes #560
Refs #128

## Why

`mb books` already has setup/readiness surfaces, but the next report/import/reconcile work needed a clear public-safe reporting path before implementation. This design keeps hledger as the accounting engine, Main Branch as the safe wrapper and JSON contract, and agents as the chat UX layer.

## Commits by concern

- [x] `20dd114 [add] MAIN-357 books reporting design`
  - Adds the hledger capability map.
  - Adds the chat-first operator UX spec.
  - Adds the privacy/status integration plan.
  - Adds the synthesized implementation roadmap.
  - Adds the Unreleased changelog entry.
- [x] `72643c6 [update] MAIN-357 clarify report command naming`
  - Keeps sample monthly reporting as the first slice.
  - Makes `mb books report monthly --sample --month 2026-01 --json` the preferred scalable command shape.
  - Leaves exact CLI spelling open for the implementation issue.
- [x] Each commit body bullet-lists the changes in that commit.
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work.
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`.

## Validation

Pre-push gate from repo root:

```bash
scripts/check.sh
```

- [x] Level 1 static: `scripts/check.sh` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: excerpt shows formatting passed, mypy passed, 634 pytest tests passed, and skill validation passed.
- [x] Level 2 CLI contract: not required; this PR changes reports and changelog only.
- [x] Level 3 package/install smoke: not required; no packaging or package data changed.
- [x] Level 4 fixture repo: not required; no init/onboard/status/start/update behavior changed.
- [x] Level 5 runtime smoke / dogfood harness / simulation-tier: not required; no runtime, first-run, skill discovery, or generated skill behavior changed.
- [x] SKILL.md ≤500 lines: not required; no skills changed.
- [x] Package-visible release gate evidence before tag/publish: not required; this is not a release prep PR.
- [x] Supply-chain review: not required; no workflows, dependency files, or permissions changed.

## Success metric

An implementation agent can build the first hledger-backed sample monthly report without re-deciding command families, sample data placement, JSON shape, chat output, privacy boundaries, or validation expectations.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [ ] N/A — change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [x] No
- [ ] Yes — migration note below

## Public / private boundary

No real financial data, account IDs, provider exports, private paths, raw hledger experiment logs, `.agent/`, `.context/`, screenshots, or private scan output were committed. Disallowed accounting/tax claims appear only inside explicit "do not claim" lists.
