### PR TITLE
[update] Prepare v0.3.20 release

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mainbranch",
-  "version": "0.3.19",
+  "version": "0.3.20",
   "description": "Main Branch Claude Code skills for running a business from markdown files in git.",
   "author": {
     "name": "Noontide"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+## [0.3.20] - 2026-05-13
+
+v0.3.20 packages the chat-first, fact-backed daily operating loop. It adds
+privacy-safe books readiness facts for status and start, introduces the first
+shared workflow source prototype for the daily start -> MoneyPath handoff,
+deepens `/mb-think` research-depth guidance, hardens release and local-state
+boundaries, and refreshes the public narrative around agents using
+deterministic `mb` facts internally while operators see plain business
+guidance.
+
 ### Added
 
 - Added a `/mb-think` research-depth ladder for offer, audience, proof,
@@ -48,6 +58,10 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   MoneyPath `/mb-think` handoff, with generated Claude/Codex shell snapshots
   and drift tests that require shared `mb` commands and JSON facts to stay
   present. Refs MAIN-351, #549.
+- Added a public-safe Codex Stage 1 dogfood report documenting the experimental
+  CLI-first support boundary, generated `AGENTS.md` grounding, deterministic
+  `mb` fact usage, and follow-up route for native workflow decisions without
+  claiming Codex slash-command parity. Refs MAIN-304, #453.
 - Added a proposed shared workflow corpus and native runtime renderer decision
   that names `workflows/<workflow>/` as the portable source for selected
   workflow semantics, keeps Claude Code and Codex runtime shells native, and

--- a/mb/mb/__init__.py
+++ b/mb/mb/__init__.py
@@ -7,6 +7,6 @@ file stays a thin dispatcher.
 
 from __future__ import annotations
 
-__version__ = "0.3.19"
+__version__ = "0.3.20"
 
 __all__ = ["__version__"]

--- a/mb/pyproject.toml
+++ b/mb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mainbranch"
-version = "0.3.19"
+version = "0.3.20"
 description = "Main Branch engine umbrella - scaffolds, validates, and graphs business-as-files repos. Claude Code first, runtime-agnostic by design."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
<!--
  Thanks for contributing to Main Branch.

  See CONTRIBUTING.md for branch + PR shape, concern-based commit
  organization, and pre-push gates. Keep PRs scoped — one logical
  change per PR, ideally 3–5 commits by concern.
-->

## Summary

Prepares the v0.3.20 package release by moving the current changelog entries into a dated release section and bumping the Python package, engine version, and Claude plugin manifest to `0.3.20`.

## Linked issue

Refs #564

## Why

MAIN-359 needs a release-only branch that turns the merged daily-loop, books-readiness, workflow-source, research-depth, and release-hardening work into a package-visible release candidate without overclaiming unshipped provider, dashboard, runtime, or books-reporting behavior.

## Commits by concern

- [ ] Each commit body bullet-lists the changes in that commit
- [x] Reviewer reading `git log origin/main..HEAD` sees the shape of the work
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`

Commits:

- `e3a8ba9 [update] Prepare v0.3.20 release`

## Validation

Pre-push gate from repo root:

```bash
scripts/check.sh
```

Level 0 release notes/public boundary: manual review of `CHANGELOG.md` v0.3.20 section — runtime: reviewer — exit: 0 — log: release notes avoid books-report, Apify support, Meta live-account, dashboard, Codex slash-command, finance-accuracy, private-data, and local-path overclaims.

Level 1 release-file preflight: `cd mb && python3 -m pytest tests/test_smoke_coverage.py::test_claude_plugin_manifest_points_at_prefixed_skills -q` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: `.agent/release-evidence/0.3.20/preflight-smoke-coverage.out` (`1 passed`).

Level 1 static: `scripts/check.sh` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: `.agent/release-evidence/0.3.20/check.out` (`84 files already formatted`, Ruff passed, mypy passed, `634 passed`, bundled skills `15/15` validated).

Level 2 CLI contract: package-visible release smoke exercised installed-wheel command surfaces — runtime: `/tmp/mainbranch-release-smoke-0.3.20/bin/mb` — exit: 0 — logs: `.agent/release-evidence/0.3.20/mb-version.out`, `skill-list.out`, `skill-validate-json.out`, `fixture-status-positional.out`, `fixture-start-positional.out`, and `fixture-doctor-repair-plan-positional.out`.

Level 3 package/install: `(cd mb && python3 -m build)` plus fresh venv install of `mb/dist/mainbranch-0.3.20-py3-none-any.whl` — runtime: `/tmp/mainbranch-release-smoke-0.3.20/bin/python3` — exit: 0 — logs: `.agent/release-evidence/0.3.20/build.out` and `install.out`; `mb --version` returned `mb 0.3.20`, `mb skill list` returned 15 skills, and `mb skill validate --all --json` passed.

Level 3 books fixture: `mb books check --fixture --json` with hledger available and with hledger absent from `PATH` — runtime: `/tmp/mainbranch-release-smoke-0.3.20/bin/mb` — exit: 0 for both — logs: `.agent/release-evidence/0.3.20/books-fixture-hledger.out` and `books-fixture-no-hledger.out` (`result_status: ok`).

Level 4 fixture repo: installed-wheel `mb onboard --yes`, `mb status --json --peek`, `mb start --json`, and `mb doctor repair --plan` against a temp business repo — runtime: `/tmp/mainbranch-release-smoke-0.3.20/bin/mb` — exit: 0 — logs: `.agent/release-evidence/0.3.20/fixture-*.out`; status/start included `books.safe_to_share: true`, no unsafe artifacts, and repo-relative vault state.

Level 5 release simulation: `scripts/claude-runtime-dogfood.py --install-mode wheel --wheel mb/dist/mainbranch-0.3.20-py3-none-any.whl --run-claude-print --simulation-tier prerelease_candidate --max-budget-usd 0.75` — runtime: Claude Code 2.1.140 print-mode proxy + wheel venv — exit: 0 — evidence: `.agent/release-evidence/0.3.20/prerelease-candidate/`; 11/11 heuristic checks, 0 read-only `mb` grounding denials, manual transcript skim passed for books/privacy, write approval, business routing, and provider/runtime honesty.

Level 5 release acceptance: `scripts/claude-runtime-dogfood.py --install-mode wheel --wheel mb/dist/mainbranch-0.3.20-py3-none-any.whl --run-claude-print --simulation-tier release_acceptance --max-budget-usd 0.75` — runtime: Claude Code 2.1.140 print-mode proxy + wheel venv — exit: 0 — evidence: `.agent/release-evidence/0.3.20/release-acceptance-wheel/`; 11/11 heuristic checks, 0 permission denials, clean repo-boundary check, manual transcript skim passed.

Supply-chain review: release-time checks from `docs/supply-chain-policy.md` — runtime: `gh` + local workflow scan — exit: 0 — log: `[Unreleased]` is empty; no runtime dependency changes; actual `id-token: write` appears only on `publish-pypi.yml` publish job; Dependabot open alert count is 0; open dependency PR list is empty; GitHub `pypi` environment has required reviewers.

- [x] Level 1 static: `scripts/check.sh` passes
- [x] Level 2 CLI contract: focused Typer/CliRunner tests, exit codes, `--json` behavior, TTY vs non-TTY (if CLI behavior touched)
- [x] Level 3 package/install smoke (if packaging touched)
- [x] Level 4 fixture repo (if init/onboard/status/start/update touched)
- [x] Level 5 runtime smoke / dogfood harness / simulation-tier (if runtime, first-run, skill discovery, or release validation touched)
- [x] SKILL.md ≤500 lines (if any skill touched)
- [x] Package-visible release gate evidence before tag/publish (if preparing a release)
- [x] Supply-chain review (if `.github/workflows/`, `.github/dependabot.yml`, `mb/pyproject.toml` deps, or `id-token`/`permissions` blocks touched — see [docs/supply-chain-policy.md](../docs/supply-chain-policy.md))

Interactive Claude Code TUI smoke and fresh PyPI install verification remain post-merge/release-owner gates because this PR has not yet been tagged, published, or installed from PyPI.

## Success metric

After merge, Devon can create the `oe-v0.3.20` GitHub Release from a branch whose version sites, changelog section, package artifacts, release simulations, and supply-chain checks agree on `0.3.20`.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [ ] N/A — change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [x] No
- [ ] Yes — migration note below

## Public / private boundary

The PR commits only release metadata and public changelog copy. Local cold-start notes, package/build logs, fixture paths, raw transcript artifacts, and release evidence stay in ignored `.context/` and `.agent/` scratch space; the committed release notes avoid real financial data, private vault paths, provider credentials, account IDs, customer/member data, raw private transcripts, local machine paths, and unsupported runtime/provider claims.
