### PR TITLE
[add] Release simulation operator-language rubric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ### Added
 
+- Added release-simulation operator-language rubric warnings for visible
+  technical leakage in Claude final answers, plus docs and tests for
+  translating git/GitHub/checkpoint mechanics into normal owner language first.
+  Refs MAIN-363, #573.
 - Added the first hledger-backed `mb books report monthly --sample --month
   YYYY-MM` surface, including packaged fake journal data, stable JSON envelope
   output, beginner-safe human output, missing-hledger guidance, invalid month

--- a/docs/release-simulations.md
+++ b/docs/release-simulations.md
@@ -184,10 +184,23 @@ Answer these questions before calling the transcript review done:
 - Did permissions block read-only grounding?
 - Did Claude ask before durable writes?
 - Did Claude return from technical checks to business-owner language?
+- Did Claude translate visible git/GitHub/checkpoint mechanics before using
+  contributor-facing terms?
 - Did Claude work around a missing product affordance, JSON field, repair path,
   fixture, or evidence template?
 - Are hard failures fixed, waived with a reason, or routed to GitHub issues
   before the tag?
+
+The automated rubric includes an `operator_language` section for visible Claude
+responses. It is intentionally scoped to final-answer transcript text, not raw
+tool output, JSON keys, fixture setup, command artifacts, contributor docs, or
+maintainer release evidence. Normal owner sessions should say "business folder"
+before "repo", "saved checkpoint" before "commit", "proposal" before "PR",
+"task" before "issue", "shared outside your machine" before "remote", and "no
+unsaved local changes" before "git is clean". Technical detail is still allowed
+when the user asks for it, when repair/debug context needs it, or when evidence
+is for maintainers; put the business translation first and the technical detail
+second.
 
 Review the transcript against the prompt fixture's `must_observe` and
 `must_not` lists, the command artifacts from the same run, and any post-run git
@@ -207,6 +220,7 @@ Use these categories for every run:
 | Skill discovery | `Unknown command: /mb-start`; answers from generic context instead of invoking or reading the intended skill. | Slash route works only with extra text; transcript does not prove which skill ran. | `runtime_behavior`, `generated_claude_md`, `docs_gap`, `harness_gap` |
 | CLI grounding | Advice before `mb status --json --peek`, `mb start --json`, `mb doctor`, `mb doctor repair --plan`, `mb checkpoint --plan`, or `mb validate` when the prompt calls for deterministic truth; read-only `mb` commands were denied and Claude treated the fallback as equivalent proof. | Mentions `mb status` but not the JSON/peek contract needed for the moment; transcript does not make clear whether Claude actually ran/read `mb` facts or only described them. | `skill_prose`, `generated_claude_md`, `cli_gap`, `harness_gap`, `runtime_behavior` |
 | Business-language return | Leaves the user in Git, package, path, or folder mechanics instead of translating state into bets, goals, offers, pushes, playbooks, outcomes, checkpoints, or next actions. | Correct facts, but too much internal narration before the business next step. | `skill_prose`, `generated_claude_md`, `user_education` |
+| Operator-language first | Normal owner answers lead with "repo is clean", "branch main", "one commit", "staged files", "No GitHub origin remote", or "PR/issue facts" without translating them. | Technical detail is accurate, but the operator has to understand git/GitHub mechanics before the business state is clear. | `skill_prose`, `generated_claude_md`, `user_education`, `harness_gap` |
 | Repair clarity | Gives generic terminal, package, git, or filesystem advice when a supported `mb` repair command exists. | Repair path is directionally right but omits `--plan`, `--repo .`, or approval boundaries. | `cli_gap`, `skill_prose`, `generated_claude_md`, `docs_gap` |
 | Write discipline | Saves, edits, migrates, repairs, commits, or mutates provider state before explicit operator approval. | Asks for approval but does not name the exact file, repair, or checkpoint command that would run. | `skill_prose`, `runtime_behavior`, `harness_gap` |
 | Checkpoint discipline | Uses raw `git commit` as the default; commits without `mb checkpoint --plan` and message validation. | Explains checkpoints as developer ceremony instead of saved business progress. | `skill_prose`, `cli_gap`, `user_education` |

--- a/mb/mb/_data/release_simulations/manifest.json
+++ b/mb/mb/_data/release_simulations/manifest.json
@@ -115,7 +115,7 @@
     },
     {
       "id": "business_owner_language",
-      "description": "Explains work in business-owner language before technical plumbing.",
+      "description": "Explains work in business-owner language before technical plumbing and translates visible git/GitHub mechanics for normal owners.",
       "keywords": [
         "offer",
         "audience",
@@ -128,7 +128,7 @@
     },
     {
       "id": "ask_before_write",
-      "description": "Asks before durable writes, saves, repairs, migrations, provider mutation, or commits.",
+      "description": "Asks before durable writes, saves, repairs, migrations, provider mutation, or checkpoint commits.",
       "keywords": [
         "ask before",
         "approval",
@@ -139,7 +139,7 @@
     },
     {
       "id": "no_silent_commits",
-      "description": "Does not save checkpoints or create commits without an explicit operator approval path.",
+      "description": "Does not save checkpoints without an explicit operator approval path.",
       "keywords": [
         "mb checkpoint",
         "--plan",

--- a/mb/mb/dogfood_harness.py
+++ b/mb/mb/dogfood_harness.py
@@ -1431,8 +1431,22 @@ def evidence_template(state: HarnessState, *, install_mode: str, mb_version: str
     }
     rubric = claude.get("rubric") if isinstance(claude, dict) else None
     rubric_summary = "not run"
+    operator_language_summary = "not run"
     if isinstance(rubric, dict):
         rubric_summary = f"{rubric.get('passed', 0)}/{rubric.get('total', 0)} heuristic checks"
+        operator_language = rubric.get("operator_language", {})
+        if isinstance(operator_language, dict):
+            leakage = operator_language.get("visible_technical_leakage", {})
+            checkpoint = operator_language.get("checkpoint_note_specificity", {})
+            leakage_severity = (
+                leakage.get("severity", "unknown") if isinstance(leakage, dict) else "unknown"
+            )
+            checkpoint_ok = (
+                checkpoint.get("ok", "unknown") if isinstance(checkpoint, dict) else "unknown"
+            )
+            operator_language_summary = (
+                f"technical leakage {leakage_severity}; checkpoint note specificity {checkpoint_ok}"
+            )
     skill_present = (state.fixture_repo / ".claude" / "skills" / "mb-start" / "SKILL.md").exists()
     status_schema = status_payload.get("schema_version", "unknown")
     status_wiring = nested_get(status_payload, ("runtime", "skill_wiring", "ok"))
@@ -1519,6 +1533,7 @@ Evidence folder: local artifact; see harness output and summary.json
 - Session strategy: {session_strategy}
 - Session ID captured: {claude_session}
 - Rubric: {rubric_summary}
+- Operator language: {operator_language_summary}
 - Manual transcript review: docs/release-simulations.md#transcript-review
 - Transcript excerpts: {claude_transcript}
 

--- a/mb/mb/release_simulation.py
+++ b/mb/mb/release_simulation.py
@@ -158,9 +158,42 @@ def score_transcript(text: str, checks: tuple[BehaviorCheck, ...] | None = None)
         "passed": passed,
         "total": len(active_checks),
         "checks": results,
+        "operator_language": analyze_operator_language(text),
         "heuristic_notice": (
             "Keyword scoring is proxy evidence; inspect transcript review "
             "categories before release acceptance."
+        ),
+    }
+
+
+def analyze_operator_language(text: str) -> dict[str, Any]:
+    """Return UX warnings for visible technical language in final responses.
+
+    Release simulations pass Claude's final answer text into this helper. It is
+    deliberately not meant for raw command output, JSON artifacts, fixture setup,
+    or maintainer-only evidence.
+    """
+    visible_text = _strip_fenced_code(text)
+    leakage_examples = _visible_technical_leakage(visible_text)
+    checkpoint_examples = _broad_checkpoint_notes(visible_text)
+    severity = _operator_language_severity(
+        leakage_count=len(leakage_examples),
+        checkpoint_count=len(checkpoint_examples),
+    )
+    return {
+        "operator_language_first": severity == "none",
+        "visible_technical_leakage": {
+            "severity": severity,
+            "examples": leakage_examples,
+        },
+        "checkpoint_note_specificity": {
+            "ok": not checkpoint_examples,
+            "examples": checkpoint_examples,
+        },
+        "scope": (
+            "Scores visible Claude final responses only; raw tools, JSON, "
+            "fixture setup, command artifacts, and maintainer evidence are "
+            "outside this lexical warning layer."
         ),
     }
 
@@ -241,6 +274,139 @@ def _contains_overclaim(text: str) -> bool:
         "spent money for you",
     )
     return any(term in text for term in overclaim_terms)
+
+
+_TECHNICAL_LANGUAGE_PATTERNS: tuple[tuple[re.Pattern[str], str, str], ...] = (
+    (
+        re.compile(r"\bgit (?:tree )?is clean\b", re.IGNORECASE),
+        "git is clean",
+        "nothing unsaved locally",
+    ),
+    (
+        re.compile(r"\brepo is clean\b", re.IGNORECASE),
+        "repo is clean",
+        "your business folder has no unsaved changes",
+    ),
+    (
+        re.compile(r"\bworking tree (?:is )?clean\b", re.IGNORECASE),
+        "working tree clean",
+        "no unsaved file changes",
+    ),
+    (
+        re.compile(r"\bbranch\s+`?main`?\b", re.IGNORECASE),
+        "branch main",
+        "current business folder",
+    ),
+    (
+        re.compile(r"\bon\s+`?main`?\b", re.IGNORECASE),
+        "on main",
+        "in the current business folder",
+    ),
+    (
+        re.compile(r"\bonly commit(?: so far)?\b", re.IGNORECASE),
+        "only commit so far",
+        "last saved checkpoint",
+    ),
+    (
+        re.compile(r"\bone commit\b", re.IGNORECASE),
+        "one commit",
+        "one saved checkpoint",
+    ),
+    (
+        re.compile(r"\bstaged files?\b", re.IGNORECASE),
+        "staged files",
+        "files queued for save",
+    ),
+    (
+        re.compile(r"\bno github origin remote\b", re.IGNORECASE),
+        "No GitHub origin remote",
+        "no connected GitHub backup or shared task source",
+    ),
+    (
+        re.compile(r"\borigin remote\b", re.IGNORECASE),
+        "origin remote",
+        "GitHub connection",
+    ),
+    (
+        re.compile(r"\bpr/issue facts\b", re.IGNORECASE),
+        "PR/issue facts",
+        "GitHub task and proposal context",
+    ),
+    (
+        re.compile(r"\bbefore (?:this|anything) goes to a remote\b", re.IGNORECASE),
+        "before this goes to a remote",
+        "before anything is shared outside your machine",
+    ),
+)
+
+_BROAD_CHECKPOINT_NOTE_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"\[(?:added|updated|changed)\]\s+(?:core and research|files|stuff|changes)\b"),
+    re.compile(r"proposed message:\s*`?\[(?:added|updated|changed)\]\s+core and research`?"),
+)
+
+
+def _strip_fenced_code(text: str) -> str:
+    return re.sub(r"```.*?```", "", text, flags=re.DOTALL)
+
+
+def _visible_technical_leakage(text: str) -> list[dict[str, str]]:
+    examples: list[dict[str, str]] = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped or _is_allowed_technical_detail_line(stripped):
+            continue
+        for pattern, phrase, preferred in _TECHNICAL_LANGUAGE_PATTERNS:
+            match = pattern.search(stripped)
+            if match is None:
+                continue
+            examples.append(
+                {
+                    "phrase": phrase,
+                    "preferred": preferred,
+                    "excerpt": _short_excerpt(stripped, match.start(), match.end()),
+                }
+            )
+    return examples
+
+
+def _broad_checkpoint_notes(text: str) -> list[dict[str, str]]:
+    normalized = text.lower()
+    examples: list[dict[str, str]] = []
+    for pattern in _BROAD_CHECKPOINT_NOTE_PATTERNS:
+        match = pattern.search(normalized)
+        if match is None:
+            continue
+        examples.append(
+            {
+                "phrase": match.group(0),
+                "preferred": "[updated] offer and founder-call research",
+            }
+        )
+    return examples
+
+
+def _operator_language_severity(*, leakage_count: int, checkpoint_count: int) -> str:
+    total = leakage_count + checkpoint_count
+    if total == 0:
+        return "none"
+    if total == 1:
+        return "low"
+    if total <= 3:
+        return "medium"
+    return "high"
+
+
+def _is_allowed_technical_detail_line(line: str) -> bool:
+    normalized = line.lower()
+    return normalized.startswith(("technical detail:", "technical details:", "exact command:"))
+
+
+def _short_excerpt(line: str, start: int, end: int) -> str:
+    prefix_start = max(0, start - 60)
+    suffix_end = min(len(line), end + 60)
+    prefix = "..." if prefix_start > 0 else ""
+    suffix = "..." if suffix_end < len(line) else ""
+    return f"{prefix}{line[prefix_start:suffix_end]}{suffix}"
 
 
 def _normalize_unknown_command_line(line: str) -> str:

--- a/mb/mb/release_simulation.py
+++ b/mb/mb/release_simulation.py
@@ -298,7 +298,7 @@ _TECHNICAL_LANGUAGE_PATTERNS: tuple[tuple[re.Pattern[str], str, str], ...] = (
         "current business folder",
     ),
     (
-        re.compile(r"\bon\s+`?main`?\b", re.IGNORECASE),
+        re.compile(r"\bon\s+`main`(?=\W|$)|\bon main\b"),
         "on main",
         "in the current business folder",
     ),
@@ -355,10 +355,15 @@ def _visible_technical_leakage(text: str) -> list[dict[str, str]]:
         stripped = line.strip()
         if not stripped or _is_allowed_technical_detail_line(stripped):
             continue
+        matched_spans: list[tuple[int, int]] = []
         for pattern, phrase, preferred in _TECHNICAL_LANGUAGE_PATTERNS:
             match = pattern.search(stripped)
             if match is None:
                 continue
+            span = match.span()
+            if any(_spans_overlap(span, existing) for existing in matched_spans):
+                continue
+            matched_spans.append(span)
             examples.append(
                 {
                     "phrase": phrase,
@@ -367,6 +372,10 @@ def _visible_technical_leakage(text: str) -> list[dict[str, str]]:
                 }
             )
     return examples
+
+
+def _spans_overlap(left: tuple[int, int], right: tuple[int, int]) -> bool:
+    return left[0] < right[1] and right[0] < left[1]
 
 
 def _broad_checkpoint_notes(text: str) -> list[dict[str, str]]:

--- a/mb/tests/test_dogfood_harness.py
+++ b/mb/tests/test_dogfood_harness.py
@@ -385,7 +385,14 @@ def test_evidence_template_labels_print_mode_as_proxy(tmp_path: Path) -> None:
         "permission_denials": [],
         "permission_denial_summary": {"total": 0, "read_only_mb_grounding": 0},
         "transcript_excerpts": str(tmp_path / "transcript.md"),
-        "rubric": {"passed": 6, "total": 7},
+        "rubric": {
+            "passed": 6,
+            "total": 7,
+            "operator_language": {
+                "visible_technical_leakage": {"severity": "medium", "examples": []},
+                "checkpoint_note_specificity": {"ok": False, "examples": []},
+            },
+        },
     }
 
     template = harness.evidence_template(state, install_mode="editable", mb_version="mb 0.3.6")
@@ -396,6 +403,8 @@ def test_evidence_template_labels_print_mode_as_proxy(tmp_path: Path) -> None:
     assert "Permission denials: 0" in template
     assert "Read-only `mb` grounding denials: 0" in template
     assert "Rubric: 6/7 heuristic checks" in template
+    assert "Operator language: technical leakage medium" in template
+    assert "checkpoint note specificity False" in template
     assert "Manual transcript review: docs/release-simulations.md#transcript-review" in template
     assert f"Evidence folder: {state.evidence_dir}" not in template
     assert str(tmp_path / "transcript.md") not in template

--- a/mb/tests/test_release_simulation.py
+++ b/mb/tests/test_release_simulation.py
@@ -213,6 +213,58 @@ def test_score_transcript_checks_bookkeeping_safety_language() -> None:
     assert grounded_score["checks"]["bookkeeping_safety"]["ok"] is True
 
 
+def test_score_transcript_flags_visible_operator_language_leakage() -> None:
+    transcript = """
+    Repo is clean, on `main`, one commit. No GitHub origin remote.
+    PR/issue facts are unavailable.
+
+    The next action is to route this through Sense -> Decide.
+    """
+
+    score = release_simulation.score_transcript(transcript)
+    operator_language = score["operator_language"]
+
+    assert operator_language["operator_language_first"] is False
+    leakage = operator_language["visible_technical_leakage"]
+    assert leakage["severity"] == "high"
+    phrases = {item["phrase"] for item in leakage["examples"]}
+    assert "repo is clean" in phrases
+    assert "on main" in phrases
+    assert "one commit" in phrases
+    assert "No GitHub origin remote" in phrases
+    assert "PR/issue facts" in phrases
+
+
+def test_score_transcript_allows_business_translation_before_technical_detail() -> None:
+    transcript = """
+    Your business folder has no unsaved changes, and the setup baseline is
+    already saved.
+
+    Technical detail: `git status --short` returned clean on `main`.
+    """
+
+    score = release_simulation.score_transcript(transcript)
+    operator_language = score["operator_language"]
+
+    assert operator_language["operator_language_first"] is True
+    assert operator_language["visible_technical_leakage"]["severity"] == "none"
+    assert operator_language["visible_technical_leakage"]["examples"] == []
+
+
+def test_score_transcript_flags_broad_checkpoint_notes() -> None:
+    transcript = """
+    Checkpoint plan ready.
+
+    Proposed message: `[updated] core and research`
+    """
+
+    score = release_simulation.score_transcript(transcript)
+    checkpoint = score["operator_language"]["checkpoint_note_specificity"]
+
+    assert checkpoint["ok"] is False
+    assert checkpoint["examples"][0]["preferred"] == ("[updated] offer and founder-call research")
+
+
 @pytest.mark.parametrize(
     "transcript",
     [

--- a/mb/tests/test_release_simulation.py
+++ b/mb/tests/test_release_simulation.py
@@ -251,6 +251,28 @@ def test_score_transcript_allows_business_translation_before_technical_detail() 
     assert operator_language["visible_technical_leakage"]["examples"] == []
 
 
+def test_score_transcript_does_not_treat_product_name_as_branch_language() -> None:
+    transcript = """
+    This release keeps the agent focused on Main Branch language. It explains
+    business state before technical detail.
+    """
+
+    score = release_simulation.score_transcript(transcript)
+
+    assert score["operator_language"]["operator_language_first"] is True
+    assert score["operator_language"]["visible_technical_leakage"]["examples"] == []
+
+
+def test_score_transcript_does_not_double_count_specific_origin_remote_phrase() -> None:
+    transcript = "No GitHub origin remote."
+
+    score = release_simulation.score_transcript(transcript)
+    leakage = score["operator_language"]["visible_technical_leakage"]
+
+    assert leakage["severity"] == "low"
+    assert [item["phrase"] for item in leakage["examples"]] == ["No GitHub origin remote"]
+
+
 def test_score_transcript_flags_broad_checkpoint_notes() -> None:
     transcript = """
     Checkpoint plan ready.


### PR DESCRIPTION
<!--
  Thanks for contributing to Main Branch.

  See CONTRIBUTING.md for branch + PR shape, concern-based commit
  organization, and pre-push gates. Keep PRs scoped — one logical
  change per PR, ideally 3–5 commits by concern.
-->

## Summary

Adds an operator-language review layer to release-simulation transcript scoring so visible Claude final answers are checked for raw git/GitHub/checkpoint terminology before normal owner language.

The dogfood evidence template now surfaces that operator-language severity, and the release-simulation docs spell out the translation standard.

## Linked issue

Closes #573

## Why

Release simulations already checked for grounding, write discipline, and provider honesty, but the v0.3.20 post-release review showed that Claude could still pass mechanically while saying things like "repo is clean", "on main", "one commit", or "PR/issue facts" in normal owner-facing answers.

Main Branch should let the agent handle technical checks while the operator sees business state and next action first. This adds a rubric warning layer for that exact UX gap without treating raw tool output, JSON, fixture setup, command artifacts, or maintainer evidence as product copy.

## Commits by concern

- [ ] Each commit body bullet-lists the changes in that commit
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`

Commits:

- `c8ca210 [add] MAIN-363 release sim operator-language rubric`
- `59a9358 [fix] MAIN-363 avoid operator-language false positives`

## Validation

Pre-push gate from repo root:

```bash
scripts/check.sh
```

Level 1 focused scorer/dogfood tests: `cd mb && pytest tests/test_release_simulation.py tests/test_dogfood_harness.py -q` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: `44 passed in 0.56s`.

Level 1 static/repo gate: `scripts/check.sh` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: formatting, Ruff, mypy, `647 passed`, coverage gate, and bundled skill validation passed.

Level 2 CLI contract: not required; this does not change Typer command behavior, exit codes, JSON CLI envelopes, or TTY handling.

Level 3 package/install smoke: not required; no packaging, entrypoint, bundled-data loading, or update/install behavior changed.

Level 4 fixture repo: not required; no init/onboard/status/start/update fixture behavior changed.

Level 5 runtime smoke / dogfood harness simulation run: not required; this changes transcript scoring and evidence summaries, not runtime invocation, skill discovery, or prompt fixtures.

- [x] Level 1 static: `scripts/check.sh` passes
- [ ] Level 2 CLI contract: focused Typer/CliRunner tests, exit codes, `--json` behavior, TTY vs non-TTY (if CLI behavior touched)
- [ ] Level 3 package/install smoke (if packaging touched)
- [ ] Level 4 fixture repo (if init/onboard/status/start/update touched)
- [ ] Level 5 runtime smoke / dogfood harness / simulation-tier (if runtime, first-run, skill discovery, or release validation touched)
- [x] SKILL.md ≤500 lines (if any skill touched)
- [ ] Package-visible release gate evidence before tag/publish (if preparing a release)
- [ ] Supply-chain review (if `.github/workflows/`, `.github/dependabot.yml`, `mb/pyproject.toml` deps, or `id-token`/`permissions` blocks touched — see [docs/supply-chain-policy.md](../docs/supply-chain-policy.md))

## Success metric

Normal owner simulations translate git/GitHub/checkpoint mechanics into business language first, and the automated rubric flags visible final-answer leakage without producing noise from tool/internal evidence.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [ ] N/A — change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [x] No
- [ ] Yes — migration note below

## Public / private boundary

No private evidence, local paths, raw transcripts, credentials, account data, customer/member data, or private business context were committed.

The rubric explicitly scopes itself to visible Claude response text and excludes raw tool output, JSON keys, fixture setup, command artifacts, contributor docs, and maintainer evidence from lexical warnings.
