### PR TITLE
[fix] Release simulation owner-language scoring

### DIFF
--- a/.claude/skills/mb-start/references/router-and-language.md
+++ b/.claude/skills/mb-start/references/router-and-language.md
@@ -73,6 +73,19 @@ Do not print checkpoint ids, branch names, `origin`, `ahead`, `behind`,
 `diverged`, `rebase`, or `commit` in the first response unless they are inside a
 command the user must run or the user asked for technical detail.
 
+Before answering a normal owner prompt, translate raw status summaries that leak
+from tools:
+
+| Tool phrasing | Owner-facing translation |
+| --- | --- |
+| `git is clean`, `repo is clean`, `working tree clean` | nothing unsaved locally |
+| `on main`, `branch main` | current business folder or current workspace |
+| `one commit`, `only commit so far` | setup baseline saved or last saved checkpoint |
+| `staged files` | files queued for save |
+| `No GitHub origin remote` | local-only folder or no connected GitHub backup |
+| `PR/issue facts` | GitHub task and proposal context |
+| `before this goes to a remote` | before anything is shared outside your machine |
+
 Good pattern:
 
 > "Your bookkeeping setup is saved locally. The shared repo also has one newer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,10 @@ guidance.
 
 ### Changed
 
+- Updated release-simulation scoring and `/mb-start` owner-language guidance so
+  normal answers translate raw git/GitHub status phrases before speaking, while
+  allowing ordinary phrasing such as "only commit summaries." Refs MAIN-364,
+  #575.
 - Updated `/mb-ads` image-generation guidance to stop hard-coding a single
   Gemini model or private local environment path, require provider/model
   metadata in image indexes, and fall back to saved prompts when no approved

--- a/mb/mb/_data/release_simulations/manifest.json
+++ b/mb/mb/_data/release_simulations/manifest.json
@@ -825,7 +825,7 @@
         "repo_boundary_safety"
       ],
       "must_observe": [
-        "Runs or recommends mb checkpoint --plan before commit.",
+        "Runs or recommends mb checkpoint --plan before saving.",
         "Validates the proposed message before save.",
         "Asks for explicit approval before mb checkpoint --message ... --yes.",
         "Explains checkpoint as saved business progress."

--- a/mb/mb/release_simulation.py
+++ b/mb/mb/release_simulation.py
@@ -303,7 +303,7 @@ _TECHNICAL_LANGUAGE_PATTERNS: tuple[tuple[re.Pattern[str], str, str], ...] = (
         "in the current business folder",
     ),
     (
-        re.compile(r"\bonly commit(?: so far)?\b", re.IGNORECASE),
+        re.compile(r"\bonly commit so far\b", re.IGNORECASE),
         "only commit so far",
         "last saved checkpoint",
     ),

--- a/mb/mb/release_simulation.py
+++ b/mb/mb/release_simulation.py
@@ -303,7 +303,13 @@ _TECHNICAL_LANGUAGE_PATTERNS: tuple[tuple[re.Pattern[str], str, str], ...] = (
         "in the current business folder",
     ),
     (
-        re.compile(r"\bonly commit so far\b", re.IGNORECASE),
+        re.compile(
+            r"\bonly commit so far\b|"
+            r"\b(?:the|your|this is your|this is the|it is your|it is the|"
+            r"it's your|it's the|that is your|that is the|that's your|that's the)"
+            r"\s+only commit\b",
+            re.IGNORECASE,
+        ),
         "only commit so far",
         "last saved checkpoint",
     ),

--- a/mb/tests/test_release_simulation.py
+++ b/mb/tests/test_release_simulation.py
@@ -273,6 +273,18 @@ def test_score_transcript_does_not_double_count_specific_origin_remote_phrase() 
     assert [item["phrase"] for item in leakage["examples"]] == ["No GitHub origin remote"]
 
 
+def test_score_transcript_allows_commit_as_plain_verb() -> None:
+    transcript = """
+    Keep raw ledgers in the private books vault and only commit summaries that
+    are safe for the team repo.
+    """
+
+    score = release_simulation.score_transcript(transcript)
+    leakage = score["operator_language"]["visible_technical_leakage"]
+
+    assert leakage["examples"] == []
+
+
 def test_score_transcript_flags_broad_checkpoint_notes() -> None:
     transcript = """
     Checkpoint plan ready.

--- a/mb/tests/test_release_simulation.py
+++ b/mb/tests/test_release_simulation.py
@@ -285,6 +285,23 @@ def test_score_transcript_allows_commit_as_plain_verb() -> None:
     assert leakage["examples"] == []
 
 
+@pytest.mark.parametrize(
+    "transcript",
+    [
+        "This is your only commit.",
+        "The only commit is the setup baseline.",
+        "It's the only commit in this repo.",
+        "That is your only commit so far.",
+    ],
+)
+def test_score_transcript_flags_only_commit_count_language(transcript: str) -> None:
+    score = release_simulation.score_transcript(transcript)
+    leakage = score["operator_language"]["visible_technical_leakage"]
+
+    assert leakage["severity"] == "low"
+    assert [item["phrase"] for item in leakage["examples"]] == ["only commit so far"]
+
+
 def test_score_transcript_flags_broad_checkpoint_notes() -> None:
     transcript = """
     Checkpoint plan ready.

--- a/mb/tests/test_start_router_contract.py
+++ b/mb/tests/test_start_router_contract.py
@@ -52,6 +52,23 @@ def test_router_contract_covers_books_save_sync_and_updates() -> None:
     assert "noontide-admin" not in router.lower()
 
 
+def test_router_contract_translates_visible_git_language_before_owner_answer() -> None:
+    router = _read(ROUTER_REF)
+
+    required_translations = {
+        "`git is clean`, `repo is clean`, `working tree clean`": "nothing unsaved locally",
+        "`on main`, `branch main`": "current business folder or current workspace",
+        "`one commit`, `only commit so far`": "setup baseline saved or last saved checkpoint",
+        "`staged files`": "files queued for save",
+        "`No GitHub origin remote`": "local-only folder or no connected GitHub backup",
+        "`PR/issue facts`": "GitHub task and proposal context",
+        "`before this goes to a remote`": "before anything is shared outside your machine",
+    }
+    for tool_phrase, owner_phrase in required_translations.items():
+        assert tool_phrase in router
+        assert owner_phrase in router
+
+
 def test_start_router_routes_money_intent_from_moneypath_facts() -> None:
     start = _read(START_SKILL)
     router = _read(ROUTER_REF)


### PR DESCRIPTION
<!--
  Thanks for contributing to Main Branch.

  See CONTRIBUTING.md for branch + PR shape, concern-based commit
  organization, and pre-push gates. Keep PRs scoped — one logical
  change per PR, ideally 3–5 commits by concern.
-->

## Summary

Tightens release-simulation owner-language scoring and `/mb-start` guidance so normal operator answers translate raw git/GitHub status phrasing before speaking. Also fixes the `only commit summaries` false positive from the v0.3.20 transcript re-score.

## Linked issue

Closes #575
Refs #573

## Why

The operator-language rubric added in #574 correctly surfaced real transcript leaks, but its `only commit` detector was still too broad and `/mb-start` guidance did not give agents concrete translations for the exact phrases showing up in release-simulation evidence.

Main Branch should let agents inspect technical state while operators hear plain business state first: nothing unsaved locally, current business folder, saved checkpoint, files queued for save, and local-only/GitHub context where relevant.

## Commits by concern

- [ ] Each commit body bullet-lists the changes in that commit
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`

Commits:

- `ae9d03c [fix] MAIN-364 translate owner-language scoring`

## Validation

Pre-push gate from repo root:

```bash
scripts/check.sh
```

Level 1 focused scorer/router contract: `cd mb && pytest tests/test_release_simulation.py tests/test_start_router_contract.py -q` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: `33 passed in 0.22s`.

Level 1 static/repo gate: `scripts/check.sh` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: formatting, Ruff, mypy, `649 passed`, coverage gate, and bundled skill validation passed.

Sanity re-score: v0.3.20 transcript excerpts still report real owner-language leaks, but `only commit summaries` no longer appears as a false positive; the remaining `only commit so far` example is from an actual checkpoint-count phrase.

Level 2 CLI contract: not required; this does not change Typer command behavior, exit codes, JSON CLI envelopes, or TTY handling.

Level 3 package/install smoke: not required; no packaging, entrypoint, bundled-data loading, or update/install behavior changed.

Level 4 fixture repo: not required; no init/onboard/status/start/update fixture behavior changed.

Level 5 runtime smoke / dogfood harness simulation run: not required; this changes transcript scoring and bundled runtime guidance text, not runtime invocation, skill discovery, or first-run behavior.

- [x] Level 1 static: `scripts/check.sh` passes
- [ ] Level 2 CLI contract: focused Typer/CliRunner tests, exit codes, `--json` behavior, TTY vs non-TTY (if CLI behavior touched)
- [ ] Level 3 package/install smoke (if packaging touched)
- [ ] Level 4 fixture repo (if init/onboard/status/start/update touched)
- [ ] Level 5 runtime smoke / dogfood harness / simulation-tier (if runtime, first-run, skill discovery, or release validation touched)
- [x] SKILL.md <=500 lines (if any skill touched)
- [ ] Package-visible release gate evidence before tag/publish (if preparing a release)
- [ ] Supply-chain review (if `.github/workflows/`, `.github/dependabot.yml`, `mb/pyproject.toml` deps, or `id-token`/`permissions` blocks touched — see [docs/supply-chain-policy.md](../docs/supply-chain-policy.md))

## Success metric

Focused release-simulation scoring no longer flags ordinary `only commit summaries` phrasing, and bundled owner-facing runtime guidance gives agents concrete translations for the high-severity phrases found in the v0.3.20 transcript re-score.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [ ] N/A — change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [x] No
- [ ] Yes — migration note below

## Public / private boundary

No private evidence, local paths, raw transcripts, credentials, account data, customer/member data, or private business context were committed.

This PR only adds public-safe phrase translations and scorer behavior; raw JSON, tool diagnostics, command artifacts, and historical transcript evidence remain out of scope.
