### PR TITLE
[add] mb connect Meta Ads readiness

### DIFF
--- a/.claude/educational/provider-readiness.md
+++ b/.claude/educational/provider-readiness.md
@@ -127,13 +127,16 @@ system user token, and scopes including `business_management`, `ads_management`,
 Connect through `mb` so the token stays outside the repo:
 
 ```bash
-mb connect meta --token-stdin --metadata ad_account_id=<act_id>
+mb connect meta --token-stdin \
+  --metadata=ad_account_id=<act_id> \
+  --metadata=business_id=<business_portfolio_id>
 mb connect test meta --json
 ```
 
-Safe metadata in `.mb/connect.yaml` may include `ad_account_id`, optional
-`business_id`, an account label, and validation summaries. Raw tokens and raw
-provider responses do not belong in tracked files.
+Safe metadata in `.mb/connect.yaml` may include `ad_account_id` (use the `act_`
+ad account ID), optional `business_id` (Meta calls this the Business portfolio
+ID on the business info page), an account label, and validation summaries. Raw
+tokens and raw provider responses do not belong in tracked files.
 
 Practical read-only commands that `mb connect test meta` can smoke through the
 official CLI include:

--- a/.claude/educational/provider-readiness.md
+++ b/.claude/educational/provider-readiness.md
@@ -53,8 +53,8 @@ mb connect doctor --json
 4. **Meta Ads / Google Ads** - account facts, campaign references, pixels, and
    future performance context where official paths are verified.
    - Meta Ads uses Meta's official `meta-ads` package and `meta` CLI. Main
-     Branch can explain setup requirements now, but live account checks stay
-     unavailable until `mb` owns detection and read-only smoke.
+     Branch can store the token outside the repo, keep safe account metadata
+     in `.mb/connect.yaml`, and run read-only account smoke.
    - Connect only when paid work needs account facts and Main Branch reports the
      path ready.
 
@@ -73,8 +73,16 @@ mb connect doctor --json
   not yet wire a safe setup, detection, or validation path.
 - `readiness` means the official provider path and setup requirements are known,
   but `mb` does not yet validate the account or use live provider data.
+- `wrong_python` means the local install path needs Python 3.12 or newer.
+- `missing_cli` means the provider CLI is not installed or cannot run.
 - `missing_secret` means metadata exists but the local secret is missing.
+- `missing_metadata` means the token exists but a safe local identifier, such as
+  `ad_account_id`, is missing.
 - `unvalidated` means a credential is stored, but it has not been tested.
+- `waiting_for_admin_approval` means the provider needs an account admin to
+  approve the connection before local validation can pass.
+- `auth_failed` and `read_smoke_failed` mean auth or read-only smoke failed
+  without exposing raw provider output.
 - `invalid` means validation failed and the credential should be replaced.
 - `ready` means the safest available check passed.
 
@@ -99,9 +107,9 @@ Main Branch should teach this while setup happens. Numbered choices,
 readiness checks, and exact next commands beat a long essay and a pile of
 manual account setup.
 
-## Meta Ads readiness
+## Meta Ads read-only readiness
 
-Meta Ads is at `readiness` support. The official path is the Meta Ads CLI:
+Meta Ads uses the official Meta Ads CLI:
 
 ```bash
 pipx install meta-ads
@@ -116,7 +124,19 @@ system user token, and scopes including `business_management`, `ads_management`,
 `pages_show_list`, `pages_read_engagement`, `pages_manage_ads`,
 `catalog_management`, and `read_insights`.
 
-Practical read-only commands available through the official CLI include:
+Connect through `mb` so the token stays outside the repo:
+
+```bash
+mb connect meta --token-stdin --metadata ad_account_id=<act_id>
+mb connect test meta --json
+```
+
+Safe metadata in `.mb/connect.yaml` may include `ad_account_id`, optional
+`business_id`, an account label, and validation summaries. Raw tokens and raw
+provider responses do not belong in tracked files.
+
+Practical read-only commands that `mb connect test meta` can smoke through the
+official CLI include:
 
 ```bash
 meta ads adaccount list
@@ -128,14 +148,9 @@ meta ads insights get --fields spend,impressions,clicks,ctr,cpc
 meta ads dataset list
 ```
 
-Main Branch should make this easy before promoting support:
-
-1. detect `meta` and `meta --version`;
-2. run `meta auth status` without printing tokens;
-3. verify a read-only account/campaign/insights smoke;
-4. report safe readiness facts through `mb connect status`, `mb connect doctor`,
-   and `mb status --json --peek`;
-5. keep raw exports, tokens, and account-private IDs out of tracked files.
+Main Branch reports safe readiness facts through `mb connect status`, `mb
+connect doctor`, and `mb status --json --peek`. `/mb-ads` should consume those
+facts before asking whether to use live account context.
 
 Write-capable CLI commands exist for campaigns, ad sets, ads, creatives,
 datasets, and catalogs. They remain out of scope for Main Branch until approval

--- a/.claude/skills/mb-ads/SKILL.md
+++ b/.claude/skills/mb-ads/SKILL.md
@@ -187,14 +187,14 @@ context. Do not duplicate provider setup or health checks in prose.
 1. Read `mb status --json --peek` → integrations/providers/measurement facts.
 2. If the operator needs setup choices, run `mb connect plan`.
 3. If something looks broken, run `mb connect doctor --json`.
-4. Only after `mb` says Meta Ads account context is ready or repairable, check
-   whether the current Claude Code session exposes the required read-only MCP
-   tools.
+4. If `mb` says Meta Ads account context is `ready`, ask whether to pull live
+   performance before generating.
 5. Never block generation on missing ad account access.
 ```
 
-**Graceful degradation:** If Meta Ads account context is not ready, skip all
-account-related features. The skill works fully from repo reference files.
+**Graceful degradation:** If Meta Ads account context is not `ready`, mention
+the optional account context once, quote the `mb` repair command when useful,
+then continue from repo reference files.
 
 ### User-Facing Display
 

--- a/.claude/skills/mb-ads/references/meta-ads-integration.md
+++ b/.claude/skills/mb-ads/references/meta-ads-integration.md
@@ -5,10 +5,10 @@ live account context only after deterministic `mb` provider facts say the Meta
 path is ready and the current runtime exposes verified read-only account tools.
 
 Main Branch no longer supports third-party Meta MCP setup or detection as a
-fallback. The official Meta Ads CLI is real and installable, and Main Branch
-can explain setup requirements. Main Branch has not wired safe detection and
-read-only smoke yet. Until `mb` reports Meta as ready, skills must work from
-repo reference files and manual Ads Manager input.
+fallback. The official Meta Ads CLI is real and installable, and `mb connect
+meta` owns setup guidance, safe token capture, and read-only smoke. Until `mb`
+reports Meta as `ready`, skills must work from repo reference files and manual
+Ads Manager input.
 
 ---
 
@@ -26,11 +26,11 @@ Meta's package metadata classifies `meta-ads` 1.0.1 as Alpha and requires
 Python 3.12+. Expect setup and command details to move over the next few
 months.
 
-Main Branch support level is `readiness`: the official path and setup
-requirements are known, but `mb` does not yet validate accounts or use live
-provider data. Therefore:
+Main Branch support level is read-only readiness: the official path and setup
+requirements are known, and `mb connect test meta` can validate local token,
+metadata, auth, and read-only account smoke. Therefore:
 
-- do not tell users Meta account access is ready unless `mb` says it is ready;
+- do not tell users Meta account access is ready unless `mb` says it is `ready`;
 - do not ask users to configure third-party Meta connector fallbacks;
 - do not ask users to paste Meta tokens into chat or repo files;
 - do not run live campaign mutations from this skill.
@@ -45,15 +45,14 @@ Official docs:
 
 ## Official CLI Setup Facts
 
-When Main Branch wires this provider, the setup path should follow Meta's CLI
-docs:
+The setup path follows Meta's CLI docs:
 
 1. Install the package as `meta-ads`; the binary is `meta`.
 2. Use a Meta Developer App and a system user access token for the CLI path.
-3. Store `ACCESS_TOKEN`, `AD_ACCOUNT_ID`, and optional `BUSINESS_ID` in a
-   gitignored project-level `.env` file, or in Meta's user-level
-   `~/.config/meta/` fallback.
-4. Verify with `meta auth status`.
+3. Use `mb connect meta --token-stdin --metadata ad_account_id=<act_id>` so
+   `ACCESS_TOKEN` lands in `SecretStore` and only safe metadata lands in
+   `.mb/connect.yaml`.
+4. Verify with `mb connect test meta --json`.
 
 The CLI uses this precedence: CLI flag, environment variable, project `.env`,
 then user-level `~/.config/meta/`.
@@ -66,8 +65,8 @@ meta --version
 meta auth status
 ```
 
-If the user's default Python is too old, a future `mb` repair path can suggest
-an equivalent Python 3.12+ tool install. Do not recommend `meta auth login`,
+If the user's default Python is too old, quote the Python 3.12+ repair command
+from `mb connect plan` or `mb connect doctor --json`. Do not recommend `meta auth login`,
 `meta-ads-cli`, `npm install -g @meta/ads-cli`, or `mcp.meta.com/ads`.
 
 Meta's documented baseline token scopes are:
@@ -99,8 +98,8 @@ mb connect doctor --json
 Use the CLI's `summary`, `next_command`, and `repair_command` fields. Do not
 write provider readiness into business-repo config from this skill.
 
-If `mb connect` reports Meta as anything other than ready, explain that live
-Meta account access is not wired for this repo yet and continue from reference
+If `mb connect` reports Meta as anything other than `ready`, mention the account
+context once, quote the repair or setup command, and continue from reference
 files.
 
 ---
@@ -112,16 +111,11 @@ Triggered lazily at `/mb-think` or `/mb-ads` when the topic is ads-related:
 ```
 1. Read `mb status --json --peek`.
 2. If the operator needs setup choices, run `mb connect plan`.
-3. If provider facts are `readiness`, degraded, missing, invalid, or otherwise
-   not `ready`, run
+3. If provider facts are degraded, missing, invalid, waiting for admin approval,
+   or otherwise not `ready`, run
    `mb connect doctor --json` and quote the repair/setup guidance.
-4. Only if `mb` reports Meta account context ready, check the current runtime
-   for the verified official CLI:
-   - `which meta`
-   - `meta --version`
-   - `meta auth status`
-   - `meta -o json ads campaign list`
-   - `meta -o json ads insights get --fields spend,impressions,clicks,ctr,cpc`
+4. Only if `mb` reports Meta account context `ready`, ask whether to pull live
+   performance before generating.
 5. Never block generation on missing account access.
 ```
 
@@ -171,14 +165,12 @@ campaign changes.
 
 Before any future write operation exists, Main Branch needs:
 
-1. wired `mb connect` detection for `meta auth status`;
-2. read-only smoke from a fresh business repo;
-3. a `pushes/<push>/playbooks/<playbook>.md` plan with preview, approval
+1. a `pushes/<push>/playbooks/<playbook>.md` plan with preview, approval
    state, safe provider state, validation evidence, and outcome links;
-4. explicit preview of every account change;
-5. explicit operator approval in chat;
-6. PAUSED-by-default campaign/ad/ad-set creation preserved;
-7. no budget changes without a separate approval gate.
+2. explicit preview of every account change;
+3. explicit operator approval in chat;
+4. PAUSED-by-default campaign/ad/ad-set creation preserved;
+5. no budget changes without a separate approval gate.
 
 Until those conditions are met, write operations are roadmap only.
 
@@ -186,7 +178,7 @@ Until those conditions are met, write operations are roadmap only.
 
 ## CLI Sharp Edges
 
-Future implementers should preserve these constraints in setup and repair copy:
+Preserve these constraints in setup and repair copy:
 
 - `meta auth status` is the documented auth check. There is no documented
   `meta auth login`.
@@ -195,9 +187,8 @@ Future implementers should preserve these constraints in setup and repair copy:
   operator action.
 - Creating fresh creatives can require the Meta Developer App to be in Live
   Mode; document this because the CLI docs do not surface it clearly.
-- Use project-level `.env` as the default credential location, and keep it
-  gitignored.
-- Use `~/.config/meta/` only as the user-level fallback.
+- Store tokens through `SecretStore`; keep only safe metadata and validation
+  summaries in `.mb/connect.yaml`.
 - If the operator hits a two-admin token approval gate, explain that it depends
   on the Business Manager's security configuration.
 

--- a/.claude/skills/mb-ads/references/meta-ads-integration.md
+++ b/.claude/skills/mb-ads/references/meta-ads-integration.md
@@ -83,6 +83,10 @@ Some Business Manager configurations require a second admin to approve system
 user token generation. Surface that as conditional repair copy, not a universal
 rule.
 
+When the user is in Meta's business info page, the UI label "Business portfolio
+ID" is the optional `business_id` metadata value. The ad account metadata should
+be the `act_` ad account ID.
+
 ---
 
 ## Provider Facts

--- a/.claude/skills/mb-help/references/provider-readiness.md
+++ b/.claude/skills/mb-help/references/provider-readiness.md
@@ -47,7 +47,8 @@ GitHub.
    - Check/fix: `mb connect doctor --json`.
 
 4. **Meta Ads** - ad accounts, campaigns, pixels, and future performance facts
-   through the official Meta Ads CLI once Main Branch wiring is verified.
+   through the official Meta Ads CLI after read-only `mb connect test meta`
+   smoke passes.
    - Use when: paid-ad generation, review, or learning needs account context.
    - Check/fix: `mb connect doctor --json`.
 

--- a/.claude/skills/mb-start/references/mcp-preflight.md
+++ b/.claude/skills/mb-start/references/mcp-preflight.md
@@ -44,7 +44,7 @@ Required provider choices for the setup/provider loop:
 | GitHub | durable work threads, proposals, reviews, shipped history | `mb connect doctor --json` |
 | Cloudflare | sites, DNS, Pages, Workers | `mb connect doctor --json` |
 | Google / Workspace | Drive, Docs, Sheets, Slides | `mb connect doctor --json` |
-| Meta Ads | readiness: official `meta-ads` / `meta` CLI path known; live account checks wait for `mb` detection and read-only smoke | `mb connect doctor --json` |
+| Meta Ads | ready only after `mb connect test meta` passes official CLI read-only smoke | `mb connect doctor --json` |
 | Apify | scraping, YouTube, Instagram, research sidecars | `mb connect doctor --json` |
 
 Only continue to MCP/tool presence checks when the selected skill needs runtime

--- a/.claude/skills/mb-think/references/tool-detection.md
+++ b/.claude/skills/mb-think/references/tool-detection.md
@@ -77,8 +77,8 @@ pip3 list 2>/dev/null | grep -i "mlx-whisper" && echo "WHISPER=mlx_whisper"
 
 **Meta Ads account access:** Use `mb connect doctor --json` for provider
 readiness first. The official path is the Meta Ads CLI (`meta-ads` package,
-`meta` binary). Main Branch support is `readiness`: setup requirements are
-known, but live account checks wait for `mb` detection and read-only smoke.
+`meta` binary). Treat live account context as available only when `mb` reports
+Meta as `ready`.
 ```bash
 # Future detection once mb reports Meta ready:
 # which meta

--- a/.claude/skills/mb-think/references/tool-surfacing.md
+++ b/.claude/skills/mb-think/references/tool-surfacing.md
@@ -156,7 +156,7 @@ After completing research with a fallback, optionally mention the upgrade:
 | Grok | `.claude/skills/mb-think/references/grok-setup.md` |
 | Gemini | `.claude/skills/mb-think/references/gemini-setup.md` |
 | whisper | `.claude/skills/mb-think/references/local-transcription.md` |
-| Meta ad account context | Official Meta Ads CLI path pending Main Branch wiring. See `.claude/skills/mb-ads/references/meta-ads-integration.md` |
+| Meta ad account context | Official Meta Ads CLI path through `mb connect meta`; use only after `mb` reports Meta as `ready`. See `.claude/skills/mb-ads/references/meta-ads-integration.md` |
 | markitdown | `pip install 'markitdown[all]'` (no guide needed) |
 | pandoc | `brew install pandoc` or OS package manager |
 | marker | `pip install marker-pdf` (may need system deps) |

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ __pycache__/
 # .claude/*.lock is local Claude Code session state (pid, sessionId).
 .agent/
 .context/
+.mb/connect.yaml
 .claude/*.lock
 # Claude local runtime state
 .claude/settings.local.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   technical leakage in Claude final answers, plus docs and tests for
   translating git/GitHub/checkpoint mechanics into normal owner language first.
   Refs MAIN-363, #573.
+- Added Meta Ads read-only `mb connect` readiness wiring: `mb connect meta`
+  now stores tokens through `SecretStore`, keeps safe account metadata in
+  `.mb/connect.yaml`, and `mb connect test meta --json` models Python/CLI,
+  secret, metadata, admin-approval, auth, read-smoke, and ready states for
+  `/mb-ads` and status consumers. Refs MAIN-352, #550.
 - Added the first hledger-backed `mb books report monthly --sample --month
   YYYY-MM` surface, including packaged fake journal data, stable JSON envelope
   output, beginner-safe human output, missing-hledger guidance, invalid month

--- a/mb/mb/_data/educational/provider-readiness.md
+++ b/mb/mb/_data/educational/provider-readiness.md
@@ -127,13 +127,16 @@ system user token, and scopes including `business_management`, `ads_management`,
 Connect through `mb` so the token stays outside the repo:
 
 ```bash
-mb connect meta --token-stdin --metadata ad_account_id=<act_id>
+mb connect meta --token-stdin \
+  --metadata=ad_account_id=<act_id> \
+  --metadata=business_id=<business_portfolio_id>
 mb connect test meta --json
 ```
 
-Safe metadata in `.mb/connect.yaml` may include `ad_account_id`, optional
-`business_id`, an account label, and validation summaries. Raw tokens and raw
-provider responses do not belong in tracked files.
+Safe metadata in `.mb/connect.yaml` may include `ad_account_id` (use the `act_`
+ad account ID), optional `business_id` (Meta calls this the Business portfolio
+ID on the business info page), an account label, and validation summaries. Raw
+tokens and raw provider responses do not belong in tracked files.
 
 Practical read-only commands that `mb connect test meta` can smoke through the
 official CLI include:

--- a/mb/mb/_data/educational/provider-readiness.md
+++ b/mb/mb/_data/educational/provider-readiness.md
@@ -53,8 +53,8 @@ mb connect doctor --json
 4. **Meta Ads / Google Ads** - account facts, campaign references, pixels, and
    future performance context where official paths are verified.
    - Meta Ads uses Meta's official `meta-ads` package and `meta` CLI. Main
-     Branch can explain setup requirements now, but live account checks stay
-     unavailable until `mb` owns detection and read-only smoke.
+     Branch can store the token outside the repo, keep safe account metadata
+     in `.mb/connect.yaml`, and run read-only account smoke.
    - Connect only when paid work needs account facts and Main Branch reports the
      path ready.
 
@@ -73,8 +73,16 @@ mb connect doctor --json
   not yet wire a safe setup, detection, or validation path.
 - `readiness` means the official provider path and setup requirements are known,
   but `mb` does not yet validate the account or use live provider data.
+- `wrong_python` means the local install path needs Python 3.12 or newer.
+- `missing_cli` means the provider CLI is not installed or cannot run.
 - `missing_secret` means metadata exists but the local secret is missing.
+- `missing_metadata` means the token exists but a safe local identifier, such as
+  `ad_account_id`, is missing.
 - `unvalidated` means a credential is stored, but it has not been tested.
+- `waiting_for_admin_approval` means the provider needs an account admin to
+  approve the connection before local validation can pass.
+- `auth_failed` and `read_smoke_failed` mean auth or read-only smoke failed
+  without exposing raw provider output.
 - `invalid` means validation failed and the credential should be replaced.
 - `ready` means the safest available check passed.
 
@@ -99,9 +107,9 @@ Main Branch should teach this while setup happens. Numbered choices,
 readiness checks, and exact next commands beat a long essay and a pile of
 manual account setup.
 
-## Meta Ads readiness
+## Meta Ads read-only readiness
 
-Meta Ads is at `readiness` support. The official path is the Meta Ads CLI:
+Meta Ads uses the official Meta Ads CLI:
 
 ```bash
 pipx install meta-ads
@@ -116,7 +124,19 @@ system user token, and scopes including `business_management`, `ads_management`,
 `pages_show_list`, `pages_read_engagement`, `pages_manage_ads`,
 `catalog_management`, and `read_insights`.
 
-Practical read-only commands available through the official CLI include:
+Connect through `mb` so the token stays outside the repo:
+
+```bash
+mb connect meta --token-stdin --metadata ad_account_id=<act_id>
+mb connect test meta --json
+```
+
+Safe metadata in `.mb/connect.yaml` may include `ad_account_id`, optional
+`business_id`, an account label, and validation summaries. Raw tokens and raw
+provider responses do not belong in tracked files.
+
+Practical read-only commands that `mb connect test meta` can smoke through the
+official CLI include:
 
 ```bash
 meta ads adaccount list
@@ -128,14 +148,9 @@ meta ads insights get --fields spend,impressions,clicks,ctr,cpc
 meta ads dataset list
 ```
 
-Main Branch should make this easy before promoting support:
-
-1. detect `meta` and `meta --version`;
-2. run `meta auth status` without printing tokens;
-3. verify a read-only account/campaign/insights smoke;
-4. report safe readiness facts through `mb connect status`, `mb connect doctor`,
-   and `mb status --json --peek`;
-5. keep raw exports, tokens, and account-private IDs out of tracked files.
+Main Branch reports safe readiness facts through `mb connect status`, `mb
+connect doctor`, and `mb status --json --peek`. `/mb-ads` should consume those
+facts before asking whether to use live account context.
 
 Write-capable CLI commands exist for campaigns, ad sets, ads, creatives,
 datasets, and catalogs. They remain out of scope for Main Branch until approval

--- a/mb/mb/connect.py
+++ b/mb/mb/connect.py
@@ -794,14 +794,14 @@ def _meta_prerequisite_state(
 ) -> str:
     which = which_func or shutil.which
     run = command_runner or _run_command
+    if which("meta"):
+        version = run(["meta", "--version"], None, 5.0)
+        if version.get("ok"):
+            return ""
+        return "missing_cli"
     if not _meta_python_ready(which_func=which, command_runner=run):
         return "wrong_python"
-    if not which("meta"):
-        return "missing_cli"
-    version = run(["meta", "--version"], None, 5.0)
-    if not version.get("ok"):
-        return "missing_cli"
-    return ""
+    return "missing_cli"
 
 
 def _meta_setup() -> dict[str, Any]:

--- a/mb/mb/connect.py
+++ b/mb/mb/connect.py
@@ -208,6 +208,7 @@ PROVIDER_GUIDANCE: dict[str, dict[str, Any]] = {
 META_SETUP_REQUIREMENTS = (
     "Meta Business Portfolio / Business Manager access",
     "An ad account assigned to the user or system user",
+    "The Business portfolio ID from Meta business info when available",
     "A Meta developer app selected during token generation",
     "A system user token or individual user token with assigned assets",
     "Possible second-admin approval in stricter Business Manager setups",
@@ -808,7 +809,11 @@ def _meta_setup() -> dict[str, Any]:
         "requirements": list(META_SETUP_REQUIREMENTS),
         "token_scopes": list(META_TOKEN_SCOPES),
         "credential_paths": ["--token-stdin", "--from-env", "hidden prompt"],
-        "safe_metadata": ["ad_account_id", "business_id", "account label"],
+        "safe_metadata": [
+            "ad_account_id (use the act_ ad account ID)",
+            "business_id (Meta calls this Business portfolio ID)",
+            "account label",
+        ],
         "test_command": "mb connect test meta --json",
         "safe_to_share": True,
     }

--- a/mb/mb/connect.py
+++ b/mb/mb/connect.py
@@ -27,7 +27,7 @@ SERVICE_NAME = "mainbranch"
 SENSITIVE_KEY_PARTS = ("token", "secret", "password", "credential", "api_key", "apikey", "key")
 SAFE_METADATA_KEYS = {"token_type", "token_scope", "api_token_type"}
 VALIDATION_TIMEOUT_SECONDS = 8
-CommandRunner = Callable[[list[str], Path | None, float], dict[str, Any]]
+CommandRunner = Callable[..., dict[str, Any]]
 Which = Callable[[str], str | None]
 
 
@@ -69,14 +69,14 @@ PROVIDERS: tuple[Provider, ...] = (
         id="meta",
         name="Meta",
         category="ads",
-        auth="meta_cli_readiness",
-        required_secrets=(),
+        auth="meta_ads_cli_read_only",
+        required_secrets=("access_token",),
         metadata_fields=("ad_account_id", "business_id"),
         description=(
-            "Meta Ads account access through Meta's official Ads CLI. Main Branch "
-            "documents setup requirements now; read-only account checks need mb "
-            "detection and smoke before support is promoted."
+            "Meta Ads account access through Meta's official Ads CLI, with local "
+            "credential storage and read-only account smoke before skills use live facts."
         ),
+        env_vars=("ACCESS_TOKEN", "META_ACCESS_TOKEN"),
     ),
     Provider(
         id="cloudflare",
@@ -178,13 +178,13 @@ PROVIDER_GUIDANCE: dict[str, dict[str, Any]] = {
     "meta": {
         "priority": 4,
         "why": (
-            "Meta Ads readiness lets ad workflows prepare for account, campaign, "
-            "insights, creative, and pixel context through Meta's official Ads CLI."
+            "Meta Ads readiness lets ad workflows use account, campaign, insights, "
+            "creative, and pixel context through Meta's official Ads CLI."
         ),
         "use_when": (
             "Use when the business is generating, reviewing, or learning from Meta/Facebook ads. "
-            "Main Branch can explain setup requirements today; treat live account "
-            "access as unavailable until mb detection and read-only smoke are wired."
+            "Main Branch stores the token outside the repo and only treats live account "
+            "access as ready after read-only CLI smoke passes."
         ),
         "defer_when": (
             "Defer for organic, research, or site work that does not need ad-account facts."
@@ -204,6 +204,44 @@ PROVIDER_GUIDANCE: dict[str, dict[str, Any]] = {
         "status_command": "mb connect doctor --json",
     },
 }
+
+META_SETUP_REQUIREMENTS = (
+    "Meta Business Portfolio / Business Manager access",
+    "An ad account assigned to the user or system user",
+    "A Meta developer app selected during token generation",
+    "A system user token or individual user token with assigned assets",
+    "Possible second-admin approval in stricter Business Manager setups",
+)
+
+META_TOKEN_SCOPES = (
+    "business_management",
+    "ads_management",
+    "pages_show_list",
+    "pages_read_engagement",
+    "pages_manage_ads",
+    "catalog_management",
+    "read_insights",
+)
+
+META_READ_SMOKE_COMMANDS: tuple[tuple[str, list[str], bool], ...] = (
+    ("adaccount_list", ["meta", "-o", "json", "ads", "adaccount", "list"], False),
+    ("campaign_list", ["meta", "-o", "json", "ads", "campaign", "list"], False),
+    (
+        "insights_get",
+        [
+            "meta",
+            "-o",
+            "json",
+            "ads",
+            "insights",
+            "get",
+            "--fields",
+            "spend,impressions,clicks,ctr,cpc",
+        ],
+        False,
+    ),
+    ("dataset_list", ["meta", "-o", "json", "ads", "dataset", "list"], True),
+)
 
 
 def provider_map() -> dict[str, Provider]:
@@ -408,18 +446,7 @@ def _repair(
             "repair_command": validation_repair_command,
         }
     if provider.id == "meta":
-        return {
-            "summary": (
-                "Meta Ads CLI readiness is documented, but live account checks are "
-                "not wired in this mb release."
-            ),
-            "repair": (
-                "Use reference-file ad workflows for now. The official path is "
-                "`meta-ads` / `meta`; keep credentials outside repo files and wait "
-                "for mb-owned detection/read-only smoke before using live account facts."
-            ),
-            "repair_command": "",
-        }
+        return _meta_repair(state, missing)
     missing_fields = ", ".join(missing or provider.required_secrets)
     connect_command = f"mb connect {provider.id} --token-stdin"
     if state == "not_connected":
@@ -459,6 +486,93 @@ def _repair(
         }
     return {
         "summary": f"{provider.name} is ready.",
+        "repair": "",
+        "repair_command": "",
+    }
+
+
+def _meta_repair(state: str, missing: list[str] | None = None) -> dict[str, str]:
+    connect_command = "mb connect meta --token-stdin --metadata ad_account_id=<act_id>"
+    install_command = "pipx install --python <python3.12-or-newer> meta-ads"
+    if state == "wrong_python":
+        return {
+            "summary": "Meta Ads CLI requires Python 3.12 or newer.",
+            "repair": (
+                "Install Python 3.12+, then install Meta's official Ads CLI with "
+                f"`{install_command}`."
+            ),
+            "repair_command": install_command,
+        }
+    if state == "missing_cli":
+        return {
+            "summary": "Meta Ads CLI is not installed or `meta --version` failed.",
+            "repair": (
+                "Install Meta's official Ads CLI with Python 3.12+, then rerun "
+                "`mb connect test meta`."
+            ),
+            "repair_command": install_command,
+        }
+    if state == "not_connected":
+        return {
+            "summary": "Meta Ads is not connected.",
+            "repair": (
+                "Prepare the Meta Business Portfolio, ad account, app, assigned assets, "
+                f"and token, then run `{connect_command}`."
+            ),
+            "repair_command": connect_command,
+        }
+    if state == "missing_secret":
+        missing_fields = ", ".join(missing or ("access_token",))
+        return {
+            "summary": "Meta Ads metadata exists, but local token material is missing.",
+            "repair": (
+                f"Run `{connect_command}` to replace the missing credential ({missing_fields})."
+            ),
+            "repair_command": connect_command,
+        }
+    if state == "missing_metadata":
+        return {
+            "summary": "Meta Ads needs non-secret `ad_account_id` metadata before validation.",
+            "repair": (
+                "Run `mb connect meta --metadata ad_account_id=<act_id>`, then "
+                "`mb connect test meta`."
+            ),
+            "repair_command": "mb connect meta --metadata ad_account_id=<act_id>",
+        }
+    if state == "unvalidated":
+        return {
+            "summary": "Meta Ads has local setup metadata, but read-only smoke has not passed.",
+            "repair": "Run `mb connect test meta`.",
+            "repair_command": "mb connect test meta",
+        }
+    if state == "waiting_for_admin_approval":
+        return {
+            "summary": "Meta needs another business admin to approve this connection.",
+            "repair": (
+                "Meta needs another business admin to approve this connection. "
+                "Nothing is broken locally."
+            ),
+            "repair_command": "",
+        }
+    if state == "auth_failed":
+        return {
+            "summary": "Meta Ads auth did not pass.",
+            "repair": (
+                "Check token scopes, app, system user, assigned assets, and ad account "
+                "metadata, then rerun `mb connect test meta`."
+            ),
+            "repair_command": "mb connect test meta",
+        }
+    if state == "read_smoke_failed":
+        return {
+            "summary": "Meta Ads auth passed, but read-only account smoke failed.",
+            "repair": (
+                "Check ad account access and token scopes, then rerun `mb connect test meta`."
+            ),
+            "repair_command": "mb connect test meta",
+        }
+    return {
+        "summary": "Meta Ads read-only account context is ready.",
         "repair": "",
         "repair_command": "",
     }
@@ -636,6 +750,70 @@ def _cloudflare_token_type(metadata: dict[str, Any], secret: str = "") -> str:
     return "user"
 
 
+def _python_version_ok(value: str) -> bool:
+    parts = value.strip().split(".")
+    if len(parts) < 2:
+        return False
+    try:
+        major = int(parts[0])
+        minor = int(parts[1])
+    except ValueError:
+        return False
+    return (major, minor) >= (3, 12)
+
+
+def _meta_python_ready(
+    *,
+    which_func: Which | None = None,
+    command_runner: CommandRunner | None = None,
+) -> bool:
+    if sys.version_info >= (3, 12):
+        return True
+    which = which_func or shutil.which
+    run = command_runner or _run_command
+    python312 = which("python3.12")
+    if not python312:
+        return False
+    result = run(
+        [
+            python312,
+            "-c",
+            "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')",
+        ],
+        None,
+        3.0,
+    )
+    return bool(result.get("ok")) and _python_version_ok(str(result.get("stdout") or ""))
+
+
+def _meta_prerequisite_state(
+    *,
+    which_func: Which | None = None,
+    command_runner: CommandRunner | None = None,
+) -> str:
+    which = which_func or shutil.which
+    run = command_runner or _run_command
+    if not _meta_python_ready(which_func=which, command_runner=run):
+        return "wrong_python"
+    if not which("meta"):
+        return "missing_cli"
+    version = run(["meta", "--version"], None, 5.0)
+    if not version.get("ok"):
+        return "missing_cli"
+    return ""
+
+
+def _meta_setup() -> dict[str, Any]:
+    return {
+        "requirements": list(META_SETUP_REQUIREMENTS),
+        "token_scopes": list(META_TOKEN_SCOPES),
+        "credential_paths": ["--token-stdin", "--from-env", "hidden prompt"],
+        "safe_metadata": ["ad_account_id", "business_id", "account label"],
+        "test_command": "mb connect test meta --json",
+        "safe_to_share": True,
+    }
+
+
 def connect_provider(
     provider_id: str,
     repo: str | Path = ".",
@@ -648,12 +826,6 @@ def connect_provider(
     """Connect a provider by writing repo metadata and local secrets."""
 
     provider = normalize_provider(provider_id)
-    if provider.id == "meta":
-        raise ValueError(
-            "Meta Ads CLI readiness is documented but live connection storage is "
-            "not wired in this mb release; "
-            "run `mb connect plan` or `mb educational provider-readiness`."
-        )
     target = Path(repo).resolve()
     config = _read_config(target)
     repo_id = _ensure_repo_id(config, target)
@@ -694,16 +866,27 @@ def connect_provider(
         "config_path": str(path),
         "credential_backend": store.backend,
         "credential_boundary": store.boundary(),
+        "setup": _meta_setup() if provider.id == "meta" else {},
         "status": status,
     }
 
 
-def status_provider(provider_id: str, repo: str | Path = ".") -> dict[str, Any]:
+def status_provider(
+    provider_id: str,
+    repo: str | Path = ".",
+    *,
+    which_func: Which | None = None,
+    command_runner: CommandRunner | None = None,
+) -> dict[str, Any]:
     provider = normalize_provider(provider_id)
     target = Path(repo).resolve()
     config = _read_config(target)
     entry = config["providers"].get(provider.id)
     if provider.id == "meta":
+        prereq_state = _meta_prerequisite_state(
+            which_func=which_func,
+            command_runner=command_runner,
+        )
         raw_entry = entry if isinstance(entry, dict) else {}
         raw_meta_metadata = raw_entry.get("metadata")
         meta_metadata: dict[str, Any] = (
@@ -713,25 +896,72 @@ def status_provider(provider_id: str, repo: str | Path = ".") -> dict[str, Any]:
         meta_validation: dict[str, Any] = (
             raw_meta_validation if isinstance(raw_meta_validation, dict) else {}
         )
-        repair = _repair(provider, "readiness", validation=meta_validation)
+        stored_secrets = (
+            raw_entry.get("secrets") if isinstance(raw_entry.get("secrets"), dict) else {}
+        )
+        raw_secret = stored_secrets.get("access_token") if isinstance(stored_secrets, dict) else {}
+        raw_secret = raw_secret if isinstance(raw_secret, dict) else {}
+        ref = str(raw_secret.get("ref") or "")
+        backend = str(raw_secret.get("backend") or "local-file")
+        secret_present = bool(ref and SecretStore(backend).get(ref))
+        validation_state = str(meta_validation.get("state") or "unvalidated")
+        if prereq_state:
+            state = prereq_state
+            ok = False
+        elif not isinstance(entry, dict):
+            state = "not_connected"
+            ok = False
+        elif not secret_present:
+            state = "missing_secret"
+            ok = False
+        elif not str(meta_metadata.get("ad_account_id") or "").strip():
+            state = "missing_metadata"
+            ok = False
+        elif validation_state == "ready":
+            state = "ready"
+            ok = True
+        elif validation_state in {
+            "waiting_for_admin_approval",
+            "auth_failed",
+            "read_smoke_failed",
+            "missing_cli",
+            "wrong_python",
+            "missing_metadata",
+        }:
+            state = validation_state
+            ok = False
+        else:
+            state = "unvalidated"
+            ok = False
+        repair = _repair(
+            provider, state, ["access_token"] if not secret_present else [], meta_validation
+        )
         return {
             "provider": provider.id,
             "name": provider.name,
-            "connected": False,
-            "ok": False,
-            "state": "readiness",
+            "connected": bool(isinstance(entry, dict) and raw_entry.get("connected", False)),
+            "ok": ok,
+            "state": state,
             "summary": repair["summary"],
             "repair": repair["repair"],
             "repair_command": repair["repair_command"],
             "safe_to_share": True,
             "account_label": str(raw_entry.get("account_label") or ""),
             "metadata": meta_metadata,
-            "secrets": {},
+            "secrets": {
+                "access_token": {"present": secret_present, "ref": ref, "backend": backend}
+            },
             "last_checked_at": str(raw_entry.get("last_checked_at") or ""),
+            "setup": _meta_setup(),
             "validation": {
-                "state": str(meta_validation.get("state") or "readiness"),
+                "state": str(meta_validation.get("state") or state),
                 "checked_at": str(meta_validation.get("checked_at") or ""),
-                "summary": str(meta_validation.get("summary") or repair["summary"]),
+                "summary": str(meta_validation.get("summary") or ""),
+                "upstream": meta_validation.get("upstream")
+                if isinstance(meta_validation.get("upstream"), dict)
+                else {},
+                "repair": str(meta_validation.get("repair") or ""),
+                "repair_command": str(meta_validation.get("repair_command") or ""),
                 "safe_to_share": True,
             },
         }
@@ -981,8 +1211,201 @@ def _http_get_json(
     }
 
 
+def _meta_env(secret: str, metadata: dict[str, Any]) -> dict[str, str]:
+    keep = ("PATH", "HOME", "LANG", "LC_ALL", "SSL_CERT_FILE", "REQUESTS_CA_BUNDLE")
+    env = {key: os.environ[key] for key in keep if key in os.environ}
+    env["ACCESS_TOKEN"] = secret
+    env["AD_ACCOUNT_ID"] = str(metadata.get("ad_account_id") or "").strip()
+    business_id = str(metadata.get("business_id") or "").strip()
+    if business_id:
+        env["BUSINESS_ID"] = business_id
+    return env
+
+
+def _safe_command_check(name: str, args: list[str], result: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "name": name,
+        "command": " ".join(args),
+        "ok": bool(result.get("ok")),
+        "returncode": int(result.get("returncode") or 0),
+        "stdout_present": bool(str(result.get("stdout") or "")),
+        "stderr_present": bool(str(result.get("stderr") or "")),
+        "safe_to_share": True,
+    }
+
+
+def _run_meta_command(
+    run: CommandRunner,
+    args: list[str],
+    repo: Path,
+    env: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    try:
+        return run(args, repo, VALIDATION_TIMEOUT_SECONDS, env=env)
+    except TypeError:
+        return run(args, repo, VALIDATION_TIMEOUT_SECONDS)
+
+
+def _looks_like_admin_approval(result: dict[str, Any]) -> bool:
+    text = f"{result.get('stdout') or ''}\n{result.get('stderr') or ''}".lower()
+    admin_words = ("admin", "business admin", "administrator")
+    approval_words = ("approval", "approve", "pending", "waiting")
+    return any(word in text for word in admin_words) and any(
+        word in text for word in approval_words
+    )
+
+
+def _meta_validation_result(
+    *,
+    ok: bool,
+    state: str,
+    checked_at: str,
+    summary: str,
+    checks: list[dict[str, Any]],
+    repair: str = "",
+    repair_command: str = "",
+) -> dict[str, Any]:
+    return {
+        "ok": ok,
+        "state": state,
+        "checked_at": checked_at,
+        "summary": summary,
+        "repair": repair,
+        "repair_command": repair_command,
+        "safe_to_share": True,
+        "upstream": {
+            "endpoint_family": "meta_ads_cli",
+            "checks": checks,
+            "safe_to_share": True,
+        },
+    }
+
+
+def _validate_meta_with_cli(
+    provider: Provider,
+    secret: str,
+    metadata: dict[str, Any],
+    repo: Path,
+    *,
+    which_func: Which | None = None,
+    command_runner: CommandRunner | None = None,
+) -> dict[str, Any]:
+    checked_at = _now()
+    checks: list[dict[str, Any]] = []
+    prereq_state = _meta_prerequisite_state(
+        which_func=which_func,
+        command_runner=command_runner,
+    )
+    if prereq_state:
+        repair = _meta_repair(prereq_state)
+        checks.append(
+            {
+                "name": "local_prerequisites",
+                "ok": False,
+                "state": prereq_state,
+                "safe_to_share": True,
+            }
+        )
+        return _meta_validation_result(
+            ok=False,
+            state=prereq_state,
+            checked_at=checked_at,
+            summary=repair["summary"],
+            checks=checks,
+            repair=repair["repair"],
+            repair_command=repair["repair_command"],
+        )
+    if not secret:
+        repair = _meta_repair("missing_secret", ["access_token"])
+        return _meta_validation_result(
+            ok=False,
+            state="missing_secret",
+            checked_at=checked_at,
+            summary=repair["summary"],
+            checks=checks,
+            repair=repair["repair"],
+            repair_command=repair["repair_command"],
+        )
+    ad_account_id = str(metadata.get("ad_account_id") or "").strip()
+    if not ad_account_id:
+        repair = _meta_repair("missing_metadata")
+        return _meta_validation_result(
+            ok=False,
+            state="missing_metadata",
+            checked_at=checked_at,
+            summary=repair["summary"],
+            checks=checks,
+            repair=repair["repair"],
+            repair_command=repair["repair_command"],
+        )
+
+    run = command_runner or _run_command
+    env = _meta_env(secret, metadata)
+    auth_args = ["meta", "auth", "status"]
+    auth = _run_meta_command(run, auth_args, repo, env)
+    checks.append(_safe_command_check("auth_status", auth_args, auth))
+    if not auth.get("ok"):
+        state = "waiting_for_admin_approval" if _looks_like_admin_approval(auth) else "auth_failed"
+        repair = _meta_repair(state)
+        return _meta_validation_result(
+            ok=False,
+            state=state,
+            checked_at=checked_at,
+            summary=repair["summary"],
+            checks=checks,
+            repair=repair["repair"],
+            repair_command=repair["repair_command"],
+        )
+
+    for name, args, needs_business_id in META_READ_SMOKE_COMMANDS:
+        if needs_business_id and not str(metadata.get("business_id") or "").strip():
+            checks.append(
+                {
+                    "name": name,
+                    "command": " ".join(args),
+                    "ok": True,
+                    "skipped": True,
+                    "reason": "business_id metadata not set",
+                    "safe_to_share": True,
+                }
+            )
+            continue
+        result = _run_meta_command(run, args, repo, env)
+        checks.append(_safe_command_check(name, args, result))
+        if not result.get("ok"):
+            state = (
+                "waiting_for_admin_approval"
+                if _looks_like_admin_approval(result)
+                else "read_smoke_failed"
+            )
+            repair = _meta_repair(state)
+            return _meta_validation_result(
+                ok=False,
+                state=state,
+                checked_at=checked_at,
+                summary=repair["summary"],
+                checks=checks,
+                repair=repair["repair"],
+                repair_command=repair["repair_command"],
+            )
+
+    return _meta_validation_result(
+        ok=True,
+        state="ready",
+        checked_at=checked_at,
+        summary=f"{provider.name} read-only account smoke passed.",
+        checks=checks,
+    )
+
+
 def _validate_with_provider(
-    provider: Provider, secret: str, metadata: dict[str, Any] | None = None
+    provider: Provider,
+    secret: str,
+    metadata: dict[str, Any] | None = None,
+    *,
+    repo: Path | None = None,
+    which_func: Which | None = None,
+    command_runner: CommandRunner | None = None,
 ) -> dict[str, Any]:
     checked_at = _now()
     metadata = metadata or {}
@@ -1056,6 +1479,15 @@ def _validate_with_provider(
             provider_name=provider.name,
             endpoint_family="apify_user_me",
         )
+    elif provider.id == "meta":
+        return _validate_meta_with_cli(
+            provider,
+            secret,
+            metadata,
+            repo or Path.cwd(),
+            which_func=which_func,
+            command_runner=command_runner,
+        )
     else:
         return {
             "ok": True,
@@ -1079,14 +1511,23 @@ def _validate_with_provider(
     }
 
 
-def test_provider(provider_id: str, repo: str | Path = ".") -> dict[str, Any]:
+def test_provider(
+    provider_id: str,
+    repo: str | Path = ".",
+    *,
+    which_func: Which | None = None,
+    command_runner: CommandRunner | None = None,
+) -> dict[str, Any]:
     provider = normalize_provider(provider_id)
     target = Path(repo).resolve()
     config = _read_config(target)
     entry = config["providers"].get(provider.id)
-    status = status_provider(provider.id, target)
-    if provider.id == "meta":
-        return {"ok": False, "provider": provider.id, "status": status, "safe_to_share": True}
+    status = status_provider(
+        provider.id,
+        target,
+        which_func=which_func,
+        command_runner=command_runner,
+    )
     if not isinstance(entry, dict) or status["state"] in {"not_connected", "missing_secret"}:
         return {"ok": False, "provider": provider.id, "status": status, "safe_to_share": True}
 
@@ -1104,12 +1545,24 @@ def test_provider(provider_id: str, repo: str | Path = ".") -> dict[str, Any]:
             return {
                 "ok": False,
                 "provider": provider.id,
-                "status": status_provider(provider.id, target),
+                "status": status_provider(
+                    provider.id,
+                    target,
+                    which_func=which_func,
+                    command_runner=command_runner,
+                ),
                 "safe_to_share": True,
             }
         raw_metadata = entry.get("metadata")
         metadata = raw_metadata if isinstance(raw_metadata, dict) else {}
-        validation = _validate_with_provider(provider, secret, metadata)
+        validation = _validate_with_provider(
+            provider,
+            secret,
+            metadata,
+            repo=target,
+            which_func=which_func,
+            command_runner=command_runner,
+        )
 
     entry["validation"] = {
         "state": validation["state"],
@@ -1125,7 +1578,12 @@ def test_provider(provider_id: str, repo: str | Path = ".") -> dict[str, Any]:
     entry["last_checked_at"] = validation["checked_at"]
     config["providers"][provider.id] = entry
     _write_config(target, config)
-    status = status_provider(provider.id, target)
+    status = status_provider(
+        provider.id,
+        target,
+        which_func=which_func,
+        command_runner=command_runner,
+    )
     return {
         "ok": bool(validation["ok"]),
         "provider": provider.id,
@@ -1169,7 +1627,13 @@ def status_all(
     }
 
 
-def _run_command(args: list[str], cwd: Path | None = None, timeout: float = 5.0) -> dict[str, Any]:
+def _run_command(
+    args: list[str],
+    cwd: Path | None = None,
+    timeout: float = 5.0,
+    *,
+    env: dict[str, str] | None = None,
+) -> dict[str, Any]:
     try:
         result = subprocess.run(
             args,
@@ -1177,6 +1641,7 @@ def _run_command(args: list[str], cwd: Path | None = None, timeout: float = 5.0)
             capture_output=True,
             text=True,
             timeout=timeout,
+            env=env,
         )
     except FileNotFoundError:
         return {"ok": False, "returncode": 127, "stdout": "", "stderr": f"{args[0]} not found"}
@@ -1490,6 +1955,11 @@ def render_test_result(result: dict[str, Any]) -> None:
 
 def render_connect_result(result: dict[str, Any]) -> None:
     status = result["status"]
+    setup = result.get("setup") if result["provider"] == "meta" else {}
+    if isinstance(setup, dict) and setup.get("requirements"):
+        print("Meta Ads setup requirements:")
+        for item in setup["requirements"]:
+            print(f"  - {item}")
     if status["state"] == "ready":
         print(f"connected {result['provider']} and ready")
     elif status["state"] == "unvalidated":

--- a/mb/tests/test_connect.py
+++ b/mb/tests/test_connect.py
@@ -251,6 +251,46 @@ def test_connect_test_meta_missing_cli_has_python312_repair(tmp_path: Path, monk
     )
 
 
+def test_connect_test_meta_uses_installed_cli_before_python_repair(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _local_secret_env(monkeypatch, tmp_path)
+    monkeypatch.setattr(sys, "version_info", (3, 11))
+    repo = tmp_path / "biz"
+    repo.mkdir()
+    connect_mod.connect_provider(
+        "meta",
+        repo=repo,
+        token="meta-secret-token",
+        metadata_pairs=["ad_account_id=act_test"],
+    )
+    calls: list[list[str]] = []
+
+    def fake_run(
+        args: list[str],
+        cwd: Path | None = None,
+        timeout: float = 5.0,
+        *,
+        env: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        calls.append(args)
+        if args == ["meta", "--version"]:
+            return {"ok": True, "returncode": 0, "stdout": "meta 1.0.1\n", "stderr": ""}
+        return {"ok": True, "returncode": 0, "stdout": "{}\n", "stderr": ""}
+
+    result = connect_mod.test_provider(
+        "meta",
+        repo,
+        which_func=lambda name: "/opt/pipx/bin/meta" if name == "meta" else None,
+        command_runner=fake_run,
+    )
+
+    assert result["ok"] is True
+    assert result["status"]["state"] == "ready"
+    assert calls[0] == ["meta", "--version"]
+    assert all("python" not in call[0] for call in calls)
+
+
 def test_connect_test_meta_read_only_smoke_passes_with_sanitized_env(
     tmp_path: Path, monkeypatch
 ) -> None:

--- a/mb/tests/test_connect.py
+++ b/mb/tests/test_connect.py
@@ -26,6 +26,16 @@ def _local_secret_env(monkeypatch, tmp_path: Path) -> None:
             monkeypatch.delenv(env_var, raising=False)
 
 
+def _connect_meta_ready_prereqs(monkeypatch) -> None:
+    monkeypatch.setattr(connect_mod, "_meta_prerequisite_state", lambda **kwargs: "")
+
+
+def _fake_meta_which(name: str) -> str | None:
+    if name in {"meta", "python3.12"}:
+        return f"/usr/bin/{name}"
+    return None
+
+
 def test_provider_registry_includes_initial_foundation() -> None:
     providers = {provider["id"]: provider for provider in connect_mod.provider_registry()}
 
@@ -40,6 +50,9 @@ def test_provider_registry_includes_initial_foundation() -> None:
     }.issubset(providers)
     assert "beancount" not in providers
     assert providers["cloudflare"]["required_secrets"] == ["api_token"]
+    assert providers["meta"]["auth"] == "meta_ads_cli_read_only"
+    assert providers["meta"]["required_secrets"] == ["access_token"]
+    assert "ACCESS_TOKEN" in providers["meta"]["env_vars"]
     assert providers["hledger"]["required_secrets"] == []
     assert providers["hledger"]["metadata_fields"] == [
         "journal_path",
@@ -47,7 +60,8 @@ def test_provider_registry_includes_initial_foundation() -> None:
     ]
 
 
-def test_connect_list_json_does_not_create_repo_metadata(tmp_path: Path) -> None:
+def test_connect_list_json_does_not_create_repo_metadata(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(connect_mod, "_meta_prerequisite_state", lambda **kwargs: "missing_cli")
     repo = tmp_path / "biz"
     repo.mkdir()
 
@@ -57,7 +71,7 @@ def test_connect_list_json_does_not_create_repo_metadata(tmp_path: Path) -> None
     payload = json.loads(result.stdout)
     assert any(provider["id"] == "cloudflare" for provider in payload["providers"])
     meta = next(provider for provider in payload["providers"] if provider["id"] == "meta")
-    assert meta["auth"] == "meta_cli_readiness"
+    assert meta["auth"] == "meta_ads_cli_read_only"
     cloudflare = next(
         provider for provider in payload["providers"] if provider["id"] == "cloudflare"
     )
@@ -78,6 +92,7 @@ def test_connect_plan_returns_numbered_provider_choices(tmp_path: Path, monkeypa
         "safe_to_share": True,
     }
     monkeypatch.setattr(connect_mod, "github_context", lambda repo: github_context)
+    monkeypatch.setattr(connect_mod, "_meta_prerequisite_state", lambda **kwargs: "missing_cli")
 
     result = runner.invoke(app, ["connect", "plan", "--repo", str(repo), "--json"])
 
@@ -87,24 +102,59 @@ def test_connect_plan_returns_numbered_provider_choices(tmp_path: Path, monkeypa
     assert list(steps) == ["github", "cloudflare", "google", "meta", "apify"]
     assert steps["github"]["next_command"] == "gh auth login"
     assert steps["github"]["safe_to_share"] is True
-    assert steps["meta"]["state"] == "readiness"
-    assert steps["meta"]["next_command"] == "mb educational provider-readiness"
+    assert steps["meta"]["state"] == "missing_cli"
+    assert steps["meta"]["next_command"] == "pipx install --python <python3.12-or-newer> meta-ads"
     assert payload["summary"]["total"] == 5
     assert not (repo / ".mb" / "connect.yaml").exists()
 
 
-def test_connect_meta_is_readiness_and_does_not_write_metadata(tmp_path: Path) -> None:
+def test_connect_meta_token_stdin_stores_secret_outside_repo(tmp_path: Path, monkeypatch) -> None:
+    _local_secret_env(monkeypatch, tmp_path)
+    monkeypatch.setattr(connect_mod, "_meta_prerequisite_state", lambda **kwargs: "")
     repo = tmp_path / "biz"
     repo.mkdir()
 
-    result = runner.invoke(app, ["connect", "meta", "--repo", str(repo), "--json"])
+    result = runner.invoke(
+        app,
+        [
+            "connect",
+            "meta",
+            "--repo",
+            str(repo),
+            "--token-stdin",
+            "--metadata",
+            "ad_account_id=act_test",
+            "--account",
+            "Meta Test",
+            "--json",
+        ],
+        input="meta-secret-token\n",
+    )
 
-    assert result.exit_code == 2
-    assert "Meta Ads CLI readiness is documented" in result.stderr
-    assert not (repo / ".mb" / "connect.yaml").exists()
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["status"]["state"] == "unvalidated"
+    assert payload["credential_source"]["type"] == "stdin"
+    assert "Meta Business Portfolio" in payload["setup"]["requirements"][0]
+
+    config_text = (repo / ".mb" / "connect.yaml").read_text(encoding="utf-8")
+    assert "meta-secret-token" not in config_text
+    config = yaml.safe_load(config_text)
+    meta = config["providers"]["meta"]
+    assert meta["metadata"] == {"ad_account_id": "act_test"}
+    assert meta["account_label"] == "Meta Test"
+    assert meta["secrets"]["access_token"]["backend"] == "local-file"
+
+    secret_file = tmp_path / "home" / "secrets" / "connect.json"
+    assert "meta-secret-token" in secret_file.read_text(encoding="utf-8")
 
 
-def test_meta_status_remains_readiness_even_with_stale_metadata(tmp_path: Path) -> None:
+def test_meta_status_preserves_stale_metadata_but_reports_missing_secret(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _local_secret_env(monkeypatch, tmp_path)
+    monkeypatch.setattr(connect_mod, "_meta_prerequisite_state", lambda **kwargs: "")
     repo = tmp_path / "biz"
     repo.mkdir()
     config_path = repo / ".mb" / "connect.yaml"
@@ -129,20 +179,242 @@ def test_meta_status_remains_readiness_even_with_stale_metadata(tmp_path: Path) 
 
     status = connect_mod.status_provider("meta", repo)
 
-    assert status["state"] == "readiness"
-    assert status["connected"] is False
-    assert status["repair_command"] == ""
+    assert status["state"] == "missing_secret"
+    assert status["connected"] is True
+    assert status["repair_command"] == (
+        "mb connect meta --token-stdin --metadata ad_account_id=<act_id>"
+    )
     assert status["metadata"] == {"ad_account_id": "act_123"}
 
     aggregate = connect_mod.status_all(repo)
-    assert aggregate["ok"] is True
-    assert aggregate["summary"]["configured"] == 0
-    assert aggregate["summary"]["needs_repair"] == 0
-    assert aggregate["providers"][0]["state"] == "readiness"
+    assert aggregate["ok"] is False
+    assert aggregate["summary"]["configured"] == 1
+    assert aggregate["summary"]["needs_repair"] == 1
+    assert aggregate["providers"][0]["state"] == "missing_secret"
 
     check = connect_mod.doctor_check(repo, status=aggregate)
-    assert check["ok"] is True
-    assert check["detail"] == "no providers connected"
+    assert check["ok"] is False
+    assert "meta" in check["detail"]
+
+
+def test_connect_test_meta_reports_missing_metadata(tmp_path: Path, monkeypatch) -> None:
+    _local_secret_env(monkeypatch, tmp_path)
+    _connect_meta_ready_prereqs(monkeypatch)
+    repo = tmp_path / "biz"
+    repo.mkdir()
+    runner.invoke(
+        app,
+        ["connect", "meta", "--repo", str(repo), "--token", "meta-secret-token"],
+    )
+
+    result = runner.invoke(app, ["connect", "test", "meta", "--repo", str(repo), "--json"])
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["status"]["state"] == "missing_metadata"
+    assert (
+        payload["status"]["repair_command"] == "mb connect meta --metadata ad_account_id=<act_id>"
+    )
+    assert "meta-secret-token" not in result.stdout
+
+
+def test_connect_test_meta_missing_cli_has_python312_repair(tmp_path: Path, monkeypatch) -> None:
+    _local_secret_env(monkeypatch, tmp_path)
+    repo = tmp_path / "biz"
+    repo.mkdir()
+    connect_mod.connect_provider(
+        "meta",
+        repo=repo,
+        token="meta-secret-token",
+        metadata_pairs=["ad_account_id=act_test"],
+    )
+
+    result = connect_mod.test_provider(
+        "meta",
+        repo,
+        which_func=lambda name: "/usr/bin/python3.12" if name == "python3.12" else None,
+        command_runner=lambda args, cwd=None, timeout=5.0: {
+            "ok": True,
+            "returncode": 0,
+            "stdout": "3.12\n",
+            "stderr": "",
+        },
+    )
+
+    assert result["ok"] is False
+    assert result["status"]["state"] == "missing_cli"
+    assert result["status"]["repair_command"] == (
+        "pipx install --python <python3.12-or-newer> meta-ads"
+    )
+
+
+def test_connect_test_meta_read_only_smoke_passes_with_sanitized_env(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _local_secret_env(monkeypatch, tmp_path)
+    repo = tmp_path / "biz"
+    repo.mkdir()
+    connect_mod.connect_provider(
+        "meta",
+        repo=repo,
+        token="meta-secret-token",
+        metadata_pairs=["ad_account_id=act_test", "business_id=biz_test"],
+    )
+    calls: list[tuple[list[str], dict[str, str]]] = []
+
+    def fake_run(
+        args: list[str],
+        cwd: Path | None = None,
+        timeout: float = 5.0,
+        *,
+        env: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        if args == ["meta", "--version"]:
+            return {"ok": True, "returncode": 0, "stdout": "meta 1.0.1\n", "stderr": ""}
+        calls.append((args, env or {}))
+        return {"ok": True, "returncode": 0, "stdout": "{}\n", "stderr": ""}
+
+    result = connect_mod.test_provider(
+        "meta",
+        repo,
+        which_func=_fake_meta_which,
+        command_runner=fake_run,
+    )
+
+    assert result["ok"] is True
+    assert result["status"]["state"] == "ready"
+    assert [call[0] for call in calls] == [
+        ["meta", "auth", "status"],
+        ["meta", "-o", "json", "ads", "adaccount", "list"],
+        ["meta", "-o", "json", "ads", "campaign", "list"],
+        [
+            "meta",
+            "-o",
+            "json",
+            "ads",
+            "insights",
+            "get",
+            "--fields",
+            "spend,impressions,clicks,ctr,cpc",
+        ],
+        ["meta", "-o", "json", "ads", "dataset", "list"],
+    ]
+    assert calls[0][1]["ACCESS_TOKEN"] == "meta-secret-token"
+    assert calls[0][1]["AD_ACCOUNT_ID"] == "act_test"
+    assert calls[0][1]["BUSINESS_ID"] == "biz_test"
+    assert "meta-secret-token" not in json.dumps(result)
+
+
+def test_connect_test_meta_admin_approval_state(tmp_path: Path, monkeypatch) -> None:
+    _local_secret_env(monkeypatch, tmp_path)
+    repo = tmp_path / "biz"
+    repo.mkdir()
+    connect_mod.connect_provider(
+        "meta",
+        repo=repo,
+        token="meta-secret-token",
+        metadata_pairs=["ad_account_id=act_test"],
+    )
+
+    def fake_run(
+        args: list[str],
+        cwd: Path | None = None,
+        timeout: float = 5.0,
+        *,
+        env: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        if args == ["meta", "--version"]:
+            return {"ok": True, "returncode": 0, "stdout": "meta 1.0.1\n", "stderr": ""}
+        return {
+            "ok": False,
+            "returncode": 1,
+            "stdout": "",
+            "stderr": "Waiting for another business admin approval.",
+        }
+
+    result = connect_mod.test_provider(
+        "meta",
+        repo,
+        which_func=_fake_meta_which,
+        command_runner=fake_run,
+    )
+
+    assert result["ok"] is False
+    assert result["status"]["state"] == "waiting_for_admin_approval"
+    assert result["status"]["summary"] == (
+        "Meta needs another business admin to approve this connection."
+    )
+    assert result["status"]["repair"] == (
+        "Meta needs another business admin to approve this connection. Nothing is broken locally."
+    )
+
+
+def test_connect_test_meta_read_smoke_failure_state(tmp_path: Path, monkeypatch) -> None:
+    _local_secret_env(monkeypatch, tmp_path)
+    repo = tmp_path / "biz"
+    repo.mkdir()
+    connect_mod.connect_provider(
+        "meta",
+        repo=repo,
+        token="meta-secret-token",
+        metadata_pairs=["ad_account_id=act_test"],
+    )
+    calls: list[list[str]] = []
+
+    def fake_run(
+        args: list[str],
+        cwd: Path | None = None,
+        timeout: float = 5.0,
+        *,
+        env: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        if args == ["meta", "--version"]:
+            return {"ok": True, "returncode": 0, "stdout": "meta 1.0.1\n", "stderr": ""}
+        calls.append(args)
+        ok = args == ["meta", "auth", "status"]
+        return {
+            "ok": ok,
+            "returncode": 0 if ok else 1,
+            "stdout": "{}\n" if ok else "",
+            "stderr": "" if ok else "permission denied",
+        }
+
+    result = connect_mod.test_provider(
+        "meta",
+        repo,
+        which_func=_fake_meta_which,
+        command_runner=fake_run,
+    )
+
+    assert result["ok"] is False
+    assert result["status"]["state"] == "read_smoke_failed"
+    assert calls == [
+        ["meta", "auth", "status"],
+        ["meta", "-o", "json", "ads", "adaccount", "list"],
+    ]
+
+
+def test_status_peek_exposes_meta_integration_state(tmp_path: Path, monkeypatch) -> None:
+    _local_secret_env(monkeypatch, tmp_path)
+    monkeypatch.setattr(connect_mod, "_meta_prerequisite_state", lambda **kwargs: "")
+    repo = tmp_path / "biz"
+    repo.mkdir()
+    connect_mod.connect_provider(
+        "meta",
+        repo=repo,
+        token="meta-secret-token",
+        metadata_pairs=["ad_account_id=act_test"],
+    )
+
+    result = runner.invoke(app, ["status", str(repo), "--json", "--peek"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    meta = payload["integrations"]["providers"][0]
+    assert meta["provider"] == "meta"
+    assert meta["state"] == "unvalidated"
+    assert meta["repair_command"] == "mb connect test meta"
+    assert "meta-secret-token" not in result.stdout
 
 
 def test_connect_plan_human_output_uses_numbered_choices(tmp_path: Path, monkeypatch) -> None:
@@ -157,6 +429,7 @@ def test_connect_plan_human_output_uses_numbered_choices(tmp_path: Path, monkeyp
         "safe_to_share": True,
     }
     monkeypatch.setattr(connect_mod, "github_context", lambda repo: github_context)
+    monkeypatch.setattr(connect_mod, "_meta_prerequisite_state", lambda **kwargs: "missing_cli")
 
     result = runner.invoke(app, ["connect", "plan", "--repo", str(repo)])
 

--- a/mb/tests/test_connect.py
+++ b/mb/tests/test_connect.py
@@ -137,6 +137,9 @@ def test_connect_meta_token_stdin_stores_secret_outside_repo(tmp_path: Path, mon
     assert payload["status"]["state"] == "unvalidated"
     assert payload["credential_source"]["type"] == "stdin"
     assert "Meta Business Portfolio" in payload["setup"]["requirements"][0]
+    assert "Business portfolio ID" in payload["setup"]["requirements"][2]
+    assert "act_" in payload["setup"]["safe_metadata"][0]
+    assert "Business portfolio ID" in payload["setup"]["safe_metadata"][1]
 
     config_text = (repo / ".mb" / "connect.yaml").read_text(encoding="utf-8")
     assert "meta-secret-token" not in config_text


### PR DESCRIPTION
## Summary

Wires Meta Ads into `mb connect` as a safe read-only readiness path: token capture goes through `SecretStore`, safe account metadata stays local, and `mb connect test meta --json` exposes deterministic provider states for status and `/mb-ads` consumers.

## Linked issue

Closes #550

## Why

Meta Ads previously had setup/readiness guidance but no deterministic `mb` path for safe credential capture, read-only smoke, or skill-facing provider facts. This keeps `/mb-ads` from independently discovering or assuming live account access, while preserving graceful fallback to repo notes/manual Ads Manager context.

## Commits by concern

- [x] `ca4b7b5 [add] MAIN-352 wire Meta Ads read-only connect readiness` adds the CLI implementation, state modeling, tests, docs, skill guidance, and changelog entry.
- [x] `71469e0 [fix] MAIN-352 ignore local connect metadata` keeps `.mb/connect.yaml` local-only for the engine repo.
- [x] `f59408f [update] MAIN-352 clarify Meta business portfolio metadata` documents that Meta's Business portfolio ID maps to `business_id` and that `ad_account_id` expects the `act_` ad account ID.
- [x] `f2aebfd [fix] MAIN-352 prefer installed Meta CLI before Python repair` fixes review feedback so a working installed `meta` binary is checked before Python install-repair guidance.
- [x] Each commit body bullet-lists the changes in that commit
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`

## Validation

Pre-push gate from repo root:

```bash
scripts/check.sh
```

- [x] Level 1 static: `scripts/check.sh` passes
- [x] Level 2 CLI contract: focused Typer/CliRunner tests, exit codes, `--json` behavior, TTY vs non-TTY (if CLI behavior touched)
- [x] Level 3 package/install smoke (if packaging touched)
- [x] Level 4 fixture repo (if init/onboard/status/start/update touched)
- [ ] Level 5 runtime smoke / dogfood harness / simulation-tier (if runtime, first-run, skill discovery, or release validation touched)
- [x] SKILL.md ≤500 lines (if any skill touched)
- [ ] Package-visible release gate evidence before tag/publish (if preparing a release)
- [ ] Supply-chain review (if `.github/workflows/`, `.github/dependabot.yml`, `mb/pyproject.toml` deps, or `id-token`/`permissions` blocks touched — see [docs/supply-chain-policy.md](../docs/supply-chain-policy.md))

Level 1 static: `scripts/check.sh` — runtime: Python 3.13.7 — exit: 0 — log: `84 files already formatted`; `All checks passed!`; `Success: no issues found in 83 source files`; `660 passed`; skill validation summary `15 passed`.
Level 2 CLI contract: `cd mb && pytest tests/test_connect.py -q` — runtime: Python 3.13.7 — exit: 0 — log: `42 passed`, including regression coverage for an installed `meta` CLI under Python 3.10/3.11-style runtime before Python install-repair guidance.
Level 2 status integration: `cd mb && pytest tests/test_status.py -q` — runtime: Python 3.13.7 — exit: 0 — log: `81 passed`.
Level 3 package/install: wheel build + temp venv install + `mb --version` + `mb skill list` — runtime: temp venv — exit: 0 — log: installed `mainbranch-0.3.20`; `mb 0.3.20`; bundled skill list rendered.
Level 4 fixture repo: installed-wheel fixture smoke with `mb onboard`, `mb doctor`, `mb status --json --peek`, `mb start --json`, `mb validate`, `mb connect plan --json`, `mb connect status --all --json`, and `mb connect test meta --json` — runtime: temp venv — exit: 0 for setup/status commands and expected exit 1 for no-key Meta test — log: Meta state stayed safely `not_connected` without a real key.
Level 5 runtime smoke: not run interactively; skill behavior was validated with `mb skill validate --all --json` and docs/tests, and the operator-run real business-repo smoke remains local-only.
Package-visible release gate: not required; this PR is not tagging or publishing a release.
Supply-chain review: not required; no workflow, dependency, token-permission, or publish configuration changed.

Real business-repo smoke is not complete from this agent session because it does not have `META_ACCESS_TOKEN` and the target repo is not connected yet. Current target output is safely `not_connected`. The connect/test command is ready for operator-run local smoke.

## Success metric

`mb connect meta` can store a Meta token outside the repo, `mb connect test meta --json` can distinguish ready, admin approval, auth, CLI, secret, metadata, and read-smoke states without raw payloads, and `/mb-ads` treats live Meta context as optional.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [ ] N/A — change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [x] No
- [ ] Yes — migration note below

## Public / private boundary

No real Meta token, real ad account ID, real Business portfolio ID, raw provider payload, raw performance dump, screenshot, or private auth note is committed. Public examples use placeholders such as `<act_id>` and `<business_portfolio_id>`; `.mb/connect.yaml` is ignored/local-only, and token material remains in `SecretStore`/Keychain.
