### PR TITLE
[update] Design Meta Ads read-only summary

### DIFF
--- a/.claude/skills/mb-ads/SKILL.md
+++ b/.claude/skills/mb-ads/SKILL.md
@@ -200,8 +200,8 @@ Manager notes.
 ### User-Facing Display
 
 In user-facing messages, describe the capability: connecting a Meta ad account,
-pulling live performance, or auditing active campaigns. Do not mention connector
-vendor names or unsupported setup paths.
+pulling a compact read-only account summary, or auditing active campaigns. Do
+not mention connector vendor names or unsupported setup paths.
 
 **Pre-flight status line (add after image-provider check):**
 
@@ -370,7 +370,7 @@ Before creating ads, the business repo must have:
 | Visual Style | `core/brand/visual-style.md` | Optional (affects image gen) |
 | Content Strategy | `core/content-strategy.md` plus relevant `core/marketing/...` and `core/people/...` layers | Optional (improves topic and amplification fit) |
 | Skool Surfaces | `core/operations/funnel/skool-surfaces.md` | Optional (congruence check) |
-| Ad Account Access | `mb status --json --peek` + `mb connect doctor --json` | Optional (enables live performance data) |
+| Ad Account Access | `mb status --json --peek` + `mb connect doctor --json` | Optional (enables compact read-only account context) |
 
 If required files are missing, Step 0 pre-flight catches this and routes appropriately.
 

--- a/.claude/skills/mb-ads/SKILL.md
+++ b/.claude/skills/mb-ads/SKILL.md
@@ -187,14 +187,15 @@ context. Do not duplicate provider setup or health checks in prose.
 1. Read `mb status --json --peek` → integrations/providers/measurement facts.
 2. If the operator needs setup choices, run `mb connect plan`.
 3. If something looks broken, run `mb connect doctor --json`.
-4. If `mb` says Meta Ads account context is `ready`, ask whether to pull live
-   performance before generating.
+4. If `mb` says Meta Ads account context is `ready`, ask whether to pull a
+   compact read-only account summary before generating.
 5. Never block generation on missing ad account access.
 ```
 
 **Graceful degradation:** If Meta Ads account context is not `ready`, mention
 the optional account context once, quote the `mb` repair command when useful,
-then continue from repo reference files.
+then continue from repo reference files, exported screenshots, or manual Ads
+Manager notes.
 
 ### User-Facing Display
 
@@ -205,16 +206,16 @@ vendor names or unsupported setup paths.
 **Pre-flight status line (add after image-provider check):**
 
 If ready:
-> `Ad account:   ✓ connected (I can check what's performing before we create)`
+> `Ad account:   ✓ connected (I can pull a compact read-only summary before we create)`
 
 If not ready:
-> `Ad account:   — not connected (optional — lets me see your live Meta ad performance to inform new ads)`
+> `Ad account:   — not connected (optional — lets me use live Meta context to inform new ads)`
 
 **Never say:** "provider tool not configured" or name an implementation detail
 the user does not need. Keep the status line capability-first.
 
 **If user asks what this means:**
-> "You can optionally connect your Meta/Facebook ad account so I can pull live performance data — what's spending, what's winning, CPAs, creative that's working. This helps me create ads that fit your account structure and build on what's already performing. Want to run `mb connect plan`, or skip and work from your reference files?"
+> "You can optionally connect your Meta/Facebook ad account so I can pull a compact read-only summary before making recommendations. This helps me see account readiness, broad activity, and useful next steps without saving raw account data. Want to run `mb connect plan`, or skip and work from your reference files?"
 
 ---
 
@@ -268,19 +269,18 @@ steps, and approval records; do not mutate ad accounts or start spend.
 If `mb status --json --peek` / `mb connect doctor --json` reports Meta Ads
 ready and the current runtime exposes the read-only ad account tools:
 
-**Before generating:** Suggest checking the account first. Explain the value briefly — don't assume the user knows what this does:
-> "Your Meta ad account is connected. Want me to pull your live performance data first? I can see what's spending, which creative has the best CPA, and use that to inform what we create. (Takes ~30 seconds.)"
+**Before generating:** Ask before pulling live account context:
+> "Meta appears connected for read-only checks. Do you want me to pull a compact account summary before making recommendations?"
 
 If user says yes, run Account Check component (see [references/meta-ads-integration.md](references/meta-ads-integration.md)):
-- Pull active campaigns and top performers
-- Surface winning patterns (angles, hooks, images with low CPA)
-- Extract naming conventions so new ads match
-- Show where new creative fits in existing structure
+- Say: "I'll pull a read-only summary and avoid saving raw account data."
+- Pull only the compact account summary the current runtime supports
+- Use safe readiness, activity, and naming-pattern context only
 
 If user says no, proceed to generation with reference files only.
 
-**After generating:** If Meta Ads account context is available, show account context:
-> "Here's what's currently live. Your new creative could fit as [suggested placement]."
+**After generating:** If the operator approved a read-only summary, use it to
+frame next steps without exposing raw account data or implying account mutation.
 
 Account awareness is currently read-only. Write operations are on the roadmap
 and require explicit operator approval gates -- see
@@ -496,5 +496,5 @@ For review: Which lenses completed?
 **Hook library (creative variations):** Flexible quantity (default 30), Andromeda-optimized
 **Video scripts:** 15-30 diverse scripts, spoken-word optimized
 **Review:** 6 lenses, P1/P2/P3 report, fix suggestions
-**Account check:** read-only Meta Ads context -- campaigns, performance, creative audit when `mb connect` and runtime tools are ready
+**Account check:** compact read-only Meta Ads summary when `mb connect` and runtime tools are ready
 **Launch plan/check:** provider-safe Google Ads/GTM/paid-traffic plan or outcome check; no account mutation without a shipped adapter and explicit approval

--- a/.claude/skills/mb-ads/references/meta-ads-integration.md
+++ b/.claude/skills/mb-ads/references/meta-ads-integration.md
@@ -125,20 +125,54 @@ Triggered lazily at `/mb-think` or `/mb-ads` when the topic is ads-related:
 
 ---
 
+## First Account Summary Surface
+
+The first product surface should be a compact read-only account summary, not a
+raw reporting import. The proposed command is:
+
+```bash
+mb ads meta summary --repo <BUSINESS_REPO> --window 7d --json
+```
+
+Use `mb connect` for setup, credential storage, readiness, repair, and smoke
+tests. Use the future `mb ads` family for paid-channel read-only summaries and
+any later approval-gated account work.
+
+Before calling a live summary, ask:
+
+```text
+Meta appears connected for read-only checks. Do you want me to pull a compact account summary before making recommendations?
+```
+
+If approved, say:
+
+```text
+I'll pull a read-only summary and avoid saving raw account data.
+```
+
+The summary should default to account readiness, safe label, currency/timezone,
+active campaign count, recent spend presence or bounded total, broad direction,
+dataset/pixel readiness, creative counts or naming patterns when safe, findings,
+and next actions. Campaign names require current-run approval.
+
+Do not save raw provider payloads, account IDs, business IDs, full campaign
+dumps, performance caches, or private paths into tracked files.
+
 ## Account Context Uses
 
 When read-only account context is verified, use it for these workflows:
 
 | Workflow | Purpose |
 |----------|---------|
-| Account overview | See active campaigns, current spend, and broad performance direction |
+| Account overview | See readiness, active campaign count, current spend context, and broad direction |
 | Creative audit | Find winning angles, hooks, offers, formats, and naming conventions |
 | Performance check | Compare recent CPA, ROAS, spend, and volume trends |
 | Performance iteration | Generate variants that build on known winners |
 | Pixel/event survey | Inspect datasets/pixels and conversion-source readiness |
 
-Keep account data in conversation context only. Do not write raw account exports,
-customer data, tokens, or sensitive performance details into public files.
+Keep account data in conversation context only. Do not write raw account
+exports, customer data, tokens, account IDs, or sensitive performance details
+into public files.
 
 ---
 
@@ -156,9 +190,7 @@ Ad account context is optional. The entire `/mb-ads` skill works without it.
 If live account access is missing, mention the option once per session and move
 on. Use this framing:
 
-> "Live Meta ad account context is optional. It is not ready in this repo yet,
-> so I will work from your reference files. If you want account context today,
-> check Ads Manager manually and paste the specific metrics you want me to use."
+> "I do not have live Meta account context yet. I can still work from your repo, exported screenshots, or manual Ads Manager notes."
 
 ---
 
@@ -205,7 +237,7 @@ Describe the capability, not the vendor or transport.
 
 | Context | Suggestion |
 |---------|------------|
-| Before generating new creative | "Your Meta ad account is connected. Want me to pull live performance data first? I can see what's spending, which creative has the best CPA, and use that to inform what we create." |
+| Before generating new creative | "Meta appears connected for read-only checks. Do you want me to pull a compact account summary before making recommendations?" |
 | After generating a batch | "Want to compare this against what's currently live before you upload it?" |
 | In `/mb-think` with an ad-related topic | "Should we use live ad account data for this research, or stay with reference files?" |
 | Monday review cadence | "Want to check this week's Meta ad performance?" |

--- a/.claude/skills/mb-ads/references/meta-ads-integration.md
+++ b/.claude/skills/mb-ads/references/meta-ads-integration.md
@@ -118,8 +118,8 @@ Triggered lazily at `/mb-think` or `/mb-ads` when the topic is ads-related:
 3. If provider facts are degraded, missing, invalid, waiting for admin approval,
    or otherwise not `ready`, run
    `mb connect doctor --json` and quote the repair/setup guidance.
-4. Only if `mb` reports Meta account context `ready`, ask whether to pull live
-   performance before generating.
+4. Only if `mb` reports Meta account context `ready`, ask whether to pull a
+   compact read-only account summary before generating.
 5. Never block generation on missing account access.
 ```
 
@@ -182,7 +182,7 @@ Ad account context is optional. The entire `/mb-ads` skill works without it.
 
 | With Account Context | Without Account Context |
 |----------------------|-------------------------|
-| Ask whether to pull live performance before generating | Skip to generation |
+| Ask whether to pull a compact read-only account summary before generating | Skip to generation |
 | Use winning patterns before generating | Generate from reference files |
 | Match account naming conventions | Ask the operator for naming conventions if needed |
 | Suggest where new creative fits | Operator decides placement in Ads Manager |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ### Added
 
+- Added a MAIN-366 design for the first compact read-only Meta Ads account
+  summary surface, keeping `mb connect` as the readiness rail and routing the
+  next paid-channel summary shape toward `mb ads meta summary --json` with raw
+  payloads, account IDs, tracked caches, and mutations out of scope. Refs
+  MAIN-366, #581.
 - Added release-simulation operator-language rubric warnings for visible
   technical leakage in Claude final answers, plus docs and tests for
   translating git/GitHub/checkpoint mechanics into normal owner language first.
@@ -34,6 +39,10 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ### Changed
 
+- Updated `/mb-ads` Meta account guidance so agents ask before pulling a
+  compact read-only account summary, continue from repo files, screenshots, or
+  manual Ads Manager notes when Meta is not ready, and avoid implying raw
+  performance imports or account mutation. Refs MAIN-366, #581.
 - Updated `/mb-ads` image-generation guidance and dependency choices to use
   provider-neutral prompt/output records, push-local image indexes, direct
   OpenAI GPT Image 2 as the first smoke target, configurable media storage

--- a/docs/reports/2026-05-13-meta-ads-readiness-summary-design.md
+++ b/docs/reports/2026-05-13-meta-ads-readiness-summary-design.md
@@ -57,7 +57,7 @@ test_exit=0 status_exit=0 peek_exit=0
 business_repo_git_status_count=0
 ```
 
-Direct `meta` CLI read-only API ping also passed with sanitized exit evidence:
+Direct `meta` CLI read-only API ping also passed with exit-only evidence:
 
 ```text
 auth_status_exit=0
@@ -66,17 +66,6 @@ campaign_list_exit=0
 insights_get_exit=0
 dataset_list_exit=0
 ```
-
-Sanitized direct-ping shape:
-
-- `meta --version` returned Meta Ads CLI `1.0.1`;
-- `meta auth status` returned authenticated and showed only a CLI-redacted token
-  preview;
-- ad account listing returned one readable account with active account status,
-  USD currency, and `America/Los_Angeles` timezone;
-- campaign listing returned at least one active campaign plus paused historical
-  campaigns across sales, lead, traffic, and engagement objectives;
-- insights and dataset read commands completed with exit `0`.
 
 Raw command output belongs in ignored local scratch and should not be copied to
 GitHub, docs, PR bodies, or tracked files.
@@ -95,6 +84,11 @@ Default behavior:
 - emit JSON to stdout only;
 - write no raw provider payloads or cache files;
 - redact account IDs and business IDs;
+- set `safe_to_share: false` because even compact account summaries can expose
+  private account context;
+- show spend presence or a coarse spend range by default, not exact spend;
+- include exact spend only behind explicit current-run approval such as
+  `--include-exact-spend`;
 - omit campaign names unless the operator explicitly approves including names
   for the current run.
 
@@ -103,20 +97,29 @@ Suggested options:
 ```bash
 mb ads meta summary --repo <BUSINESS_REPO> --window 7d --json
 mb ads meta summary --repo <BUSINESS_REPO> --since 2026-05-01 --until 2026-05-07 --json
+mb ads meta summary --repo <BUSINESS_REPO> --include-exact-spend --json
 mb ads meta summary --repo <BUSINESS_REPO> --include-campaign-names --json
 ```
 
-`--include-campaign-names` should be current-run only. It should not change
-saved provider metadata or cause names to be written into tracked files.
+`--include-exact-spend` and `--include-campaign-names` should be current-run
+only. They should not change saved provider metadata or cause values or names to
+be written into tracked files. Any exact spend output still forces
+`safe_to_share: false`.
 
 ## JSON Shape
 
-Keep the envelope small and stable:
+Use the shared `mb.json_result` envelope pattern for the actual CLI response.
+Do not invent a competing result shape. The implementation should preserve
+normal result fields such as `mb_command`, `result_schema`, `result_status`,
+`errors`, and `actions` where current CLI conventions expect them.
+
+The domain payload inside that shared envelope should stay small and stable:
 
 ```json
 {
   "ok": true,
-  "schema_version": 1,
+  "schema_version": "1.0",
+  "safe_to_share": false,
   "provider": "meta",
   "command": "mb ads meta summary",
   "state": "ready",
@@ -127,10 +130,10 @@ Keep the envelope small and stable:
     "until": "2026-05-13"
   },
   "privacy": {
-    "safe_to_share_publicly": false,
     "raw_payload_written": false,
     "tracked_files_written": false,
     "account_ids_redacted": true,
+    "exact_spend_included": false,
     "campaign_names_included": false
   },
   "readiness": {
@@ -176,6 +179,12 @@ Keep the envelope small and stable:
 }
 ```
 
+`safe_to_share: false` means the command output is appropriate for the
+operator's local chat/session after approval, but should not be copied into
+public issues, PRs, docs, or tracked business files. The flag stays false even
+when raw IDs are redacted because account activity, spend context,
+currency/timezone, counts, and campaign context can still be private.
+
 If Meta is not ready, the command should return a non-zero exit with the same
 readiness state and repair command that `mb connect` reports. It should not
 probe account data after a readiness failure.
@@ -208,7 +217,8 @@ The summary may include:
 - safe account label;
 - currency and timezone;
 - active campaign count;
-- recent spend presence, range, or total for the requested window;
+- recent spend presence or a coarse range by default;
+- exact spend only with explicit current-run approval;
 - campaign names only with current-run approval;
 - broad performance direction;
 - dataset or pixel readiness when available;
@@ -229,7 +239,7 @@ The summary must avoid:
 ## Follow-Up Implementation
 
 Implementation is tracked in
-[GitHub issue #582](https://github.com/noontide-co/mainbranch/issues/582). It
-is scoped to `mb ads meta summary --json`, focused tests, and a read-only smoke
-path. It does not include mutation, dashboards, durable performance caches, or
-broad reporting imports.
+[GitHub issue #582 / MAIN-367](https://github.com/noontide-co/mainbranch/issues/582).
+It is scoped to `mb ads meta summary --json`, focused tests, and a read-only
+smoke path. It does not include mutation, dashboards, durable performance
+caches, or broad reporting imports.

--- a/docs/reports/2026-05-13-meta-ads-readiness-summary-design.md
+++ b/docs/reports/2026-05-13-meta-ads-readiness-summary-design.md
@@ -44,12 +44,18 @@ closed:
 - no raw account payload, account ID, business ID, token, private path, or
   performance dump was included in public evidence.
 
-Agent-run real operator smoke was blocked because this workspace had Meta's
-`meta` CLI installed but did not have operator-held Meta token, ad account, or
-business ID values available. That is the expected privacy boundary: the agent
-should not ask for or receive those secrets in chat. A local-only command block
-was provided so the maintainer can run the real-account smoke and share only
-sanitized state lines.
+Real operator smoke reached `ready` with operator-held credentials. Sanitized
+evidence:
+
+```text
+connect_state=unvalidated
+test_state=ready
+connect_status_state=ready
+status_peek_meta_state=ready
+credential_backend=macos-keychain
+test_exit=0 status_exit=0 peek_exit=0
+business_repo_git_status_count=0
+```
 
 Raw command output belongs in ignored local scratch and should not be copied to
 GitHub, docs, PR bodies, or tracked files.

--- a/docs/reports/2026-05-13-meta-ads-readiness-summary-design.md
+++ b/docs/reports/2026-05-13-meta-ads-readiness-summary-design.md
@@ -57,6 +57,16 @@ test_exit=0 status_exit=0 peek_exit=0
 business_repo_git_status_count=0
 ```
 
+Direct `meta` CLI read-only API ping also passed with sanitized exit evidence:
+
+```text
+auth_status_exit=0
+adaccount_list_exit=0
+campaign_list_exit=0
+insights_get_exit=0
+dataset_list_exit=0
+```
+
 Raw command output belongs in ignored local scratch and should not be copied to
 GitHub, docs, PR bodies, or tracked files.
 

--- a/docs/reports/2026-05-13-meta-ads-readiness-summary-design.md
+++ b/docs/reports/2026-05-13-meta-ads-readiness-summary-design.md
@@ -67,6 +67,17 @@ insights_get_exit=0
 dataset_list_exit=0
 ```
 
+Sanitized direct-ping shape:
+
+- `meta --version` returned Meta Ads CLI `1.0.1`;
+- `meta auth status` returned authenticated and showed only a CLI-redacted token
+  preview;
+- ad account listing returned one readable account with active account status,
+  USD currency, and `America/Los_Angeles` timezone;
+- campaign listing returned at least one active campaign plus paused historical
+  campaigns across sales, lead, traffic, and engagement objectives;
+- insights and dataset read commands completed with exit `0`.
+
 Raw command output belongs in ignored local scratch and should not be copied to
 GitHub, docs, PR bodies, or tracked files.
 

--- a/docs/reports/2026-05-13-meta-ads-readiness-summary-design.md
+++ b/docs/reports/2026-05-13-meta-ads-readiness-summary-design.md
@@ -1,0 +1,208 @@
+---
+title: Meta Ads readiness dogfood and read-only summary design
+date: 2026-05-13
+linked_issue: https://github.com/noontide-co/mainbranch/issues/581
+linked_linear: MAIN-366
+release: unreleased
+status: complete
+tags: [integrations, meta-ads, provider-readiness, paid, privacy]
+---
+
+# Meta Ads Readiness And Read-Only Summary Design
+
+## Summary
+
+MAIN-366 keeps Meta Ads at the readiness/read-only boundary. The first useful
+account surface should be a compact read-only summary that the agent asks
+permission to pull before making ad recommendations. It should not import raw
+performance data, cache account payloads, or mutate Meta campaigns, ad sets,
+ads, budgets, audiences, pixels, datasets, or account settings.
+
+The next implementation command should be:
+
+```bash
+mb ads meta summary --repo <BUSINESS_REPO> --window 7d --json
+```
+
+Use a new `mb ads` command group rather than extending `mb connect`. `mb
+connect` should remain the setup, credential, readiness, repair, and smoke-test
+surface. `mb ads` can become the paid-channel read-only and future
+approval-gated work surface without overloading connection verbs.
+
+## Dogfood Status
+
+Local source smoke with fixture credentials proved the command path fails
+closed:
+
+- `mb connect meta` stored a token through `SecretStore` and did not write the
+  token to `.mb/connect.yaml`;
+- `.mb/connect.yaml` was ignored and did not become tracked after `git add .`;
+- `mb connect test meta --json` reached `read_smoke_failed` with fixture
+  credentials;
+- `mb connect status meta --json` and `mb status --json --peek` exposed the
+  same safe provider state;
+- no raw account payload, account ID, business ID, token, private path, or
+  performance dump was included in public evidence.
+
+Agent-run real operator smoke was blocked because this workspace had Meta's
+`meta` CLI installed but did not have operator-held Meta token, ad account, or
+business ID values available. That is the expected privacy boundary: the agent
+should not ask for or receive those secrets in chat. A local-only command block
+was provided so the maintainer can run the real-account smoke and share only
+sanitized state lines.
+
+Raw command output belongs in ignored local scratch and should not be copied to
+GitHub, docs, PR bodies, or tracked files.
+
+## First Summary Contract
+
+The first summary should answer: "Is there enough live account context to
+inform the next ad recommendation?"
+
+Default behavior:
+
+- read only after `mb connect` reports Meta `ready`;
+- ask before live account reads;
+- read a bounded recent window, defaulting to `7d`;
+- summarize account readiness, broad activity, and safe next actions;
+- emit JSON to stdout only;
+- write no raw provider payloads or cache files;
+- redact account IDs and business IDs;
+- omit campaign names unless the operator explicitly approves including names
+  for the current run.
+
+Suggested options:
+
+```bash
+mb ads meta summary --repo <BUSINESS_REPO> --window 7d --json
+mb ads meta summary --repo <BUSINESS_REPO> --since 2026-05-01 --until 2026-05-07 --json
+mb ads meta summary --repo <BUSINESS_REPO> --include-campaign-names --json
+```
+
+`--include-campaign-names` should be current-run only. It should not change
+saved provider metadata or cause names to be written into tracked files.
+
+## JSON Shape
+
+Keep the envelope small and stable:
+
+```json
+{
+  "ok": true,
+  "schema_version": 1,
+  "provider": "meta",
+  "command": "mb ads meta summary",
+  "state": "ready",
+  "checked_at": "2026-05-13T00:00:00Z",
+  "window": {
+    "label": "7d",
+    "since": "2026-05-06",
+    "until": "2026-05-13"
+  },
+  "privacy": {
+    "safe_to_share_publicly": false,
+    "raw_payload_written": false,
+    "tracked_files_written": false,
+    "account_ids_redacted": true,
+    "campaign_names_included": false
+  },
+  "readiness": {
+    "state": "ready",
+    "summary": "Meta Ads read-only account context is ready.",
+    "repair_command": ""
+  },
+  "account": {
+    "label": "Meta Ads",
+    "currency": "USD",
+    "timezone": "America/Los_Angeles",
+    "ad_account_id": "<redacted>"
+  },
+  "campaigns": {
+    "active_count": 3,
+    "names": [],
+    "names_redacted": true
+  },
+  "spend": {
+    "amount": "redacted",
+    "range_label": "recent spend present",
+    "currency": "USD"
+  },
+  "performance_direction": {
+    "state": "unknown",
+    "summary": "Not enough prior-window context to compare direction."
+  },
+  "datasets": {
+    "state": "readable",
+    "count": 1
+  },
+  "creatives": {
+    "state": "not_read",
+    "count": null,
+    "naming_patterns": []
+  },
+  "findings": [
+    "Meta account context is readable for a bounded summary."
+  ],
+  "next_actions": [
+    "Use this summary to choose whether to generate new creative, audit active campaigns, or work from repo reference files."
+  ]
+}
+```
+
+If Meta is not ready, the command should return a non-zero exit with the same
+readiness state and repair command that `mb connect` reports. It should not
+probe account data after a readiness failure.
+
+## Chat UX
+
+When Meta is not ready:
+
+```text
+I do not have live Meta account context yet. I can still work from your repo, exported screenshots, or manual Ads Manager notes.
+```
+
+When Meta is ready:
+
+```text
+Meta appears connected for read-only checks. Do you want me to pull a compact account summary before making recommendations?
+```
+
+If approved:
+
+```text
+I'll pull a read-only summary and avoid saving raw account data.
+```
+
+## Boundaries
+
+The summary may include:
+
+- account readiness state;
+- safe account label;
+- currency and timezone;
+- active campaign count;
+- recent spend presence, range, or total for the requested window;
+- campaign names only with current-run approval;
+- broad performance direction;
+- dataset or pixel readiness when available;
+- creative count or naming patterns when read safely;
+- sanitized findings and next actions.
+
+The summary must avoid:
+
+- raw Graph API payloads;
+- full campaign, ad set, ad, or creative dumps;
+- customer, member, or contact data;
+- account IDs in normal output;
+- private absolute paths;
+- tracked performance caches;
+- mutation commands;
+- spend recommendations without operator context.
+
+## Follow-Up Implementation
+
+Implementation is tracked in
+[GitHub issue #582](https://github.com/noontide-co/mainbranch/issues/582). It
+is scoped to `mb ads meta summary --json`, focused tests, and a read-only smoke
+path. It does not include mutation, dashboards, durable performance caches, or
+broad reporting imports.


### PR DESCRIPTION
## Summary

Designs and dogfoods the first Meta Ads read-only readiness path, then defines the next safe account-summary surface for `/mb-ads` as a future `mb ads meta summary --json` command. The branch keeps Meta account data read-only, permissioned, local-session scoped, and outside tracked files.

## Linked issue

Closes #581 / MAIN-366
Refs #550 / MAIN-352
Refs #582 / MAIN-367

## Why

MAIN-366 needed proof that the merged Meta Ads readiness rail works against a real account without leaking private account details, plus a concrete design for the first useful summary surface. This branch records exit/status-only smoke evidence, clarifies the privacy and JSON-envelope contract, and tightens skill guidance so agents ask before live account reads.

## Commits by concern

- [ ] Each commit body bullet-lists the changes in that commit
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`

Commit list, oldest first:

- `6498fdf [update] MAIN-366 design Meta Ads summary`
- `f3bf1f0 [update] MAIN-366 record Meta smoke evidence`
- `9f58ddd [update] MAIN-366 record Meta CLI ping`
- `1508a85 [update] MAIN-366 record Meta ping shape`
- `52f53ac [update] MAIN-366 tighten Meta summary contract`

## Validation

Pre-push gate from repo root:

```bash
scripts/check.sh
```

Level 1 static: `scripts/check.sh` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: `0` — log: `84 files already formatted`; `All checks passed!`; `Success: no issues found in 83 source files`; `660 passed`.
Level 2 CLI contract: `pytest tests/test_connect.py -q` — runtime: `python3` / repo pytest environment — exit: `0` — log: `42 passed`.
Level 5 provider dogfood/manual: local `mb connect meta`, `mb connect test meta --json`, `mb connect status meta --json`, and `mb status --json --peek` smoke with operator-held credentials — runtime: source checkout via `PYTHONPATH="$PWD/mb" python3` and Meta Ads CLI `meta` — exit: `0` for test/status/peek — log: sanitized evidence in `docs/reports/2026-05-13-meta-ads-readiness-summary-design.md`.
Level 5 direct provider ping/manual: `meta auth status`, `meta -o json ads adaccount list`, `meta -o json ads campaign list`, `meta -o json ads insights get --fields spend,impressions,clicks,ctr,cpc`, `meta -o json ads dataset list` — runtime: Meta Ads CLI `1.0.1` — exit: `0` for all commands — log: exit-only evidence in the report.
Skill validation: `mb skill validate mb-ads` — runtime: `python3 -c 'from mb.cli import app; app()'` — exit: `0` — log: `ok mb-ads (500 lines)`.
Skill validation: `mb skill validate --all` — runtime: `python3 -c 'from mb.cli import app; app()'` — exit: `0` — log: `15 skill(s) validated`.
Level 3 package/install smoke: not required; no packaging, entrypoint, bundled-data install, or update path changed.
Level 4 fixture repo smoke: not required beyond the local fixture Meta connect smoke captured in the report; no init/onboard/status/start repo-shape behavior changed.
Package-visible release gate evidence: not required; this is not a release-prep branch.
Supply-chain review: not required; no workflow, dependency, package metadata, id-token, or permissions files changed.

- [x] Level 1 static: `scripts/check.sh` passes
- [x] Level 2 CLI contract: focused Typer/CliRunner tests, exit codes, `--json` behavior, TTY vs non-TTY (if CLI behavior touched)
- [ ] Level 3 package/install smoke (if packaging touched)
- [ ] Level 4 fixture repo (if init/onboard/status/start/update touched)
- [x] Level 5 runtime smoke / dogfood harness / simulation-tier (if runtime, first-run, skill discovery, or release validation touched)
- [x] SKILL.md ≤500 lines (if any skill touched)
- [ ] Package-visible release gate evidence before tag/publish (if preparing a release)
- [ ] Supply-chain review (if `.github/workflows/`, `.github/dependabot.yml`, `mb/pyproject.toml` deps, or `id-token`/`permissions` blocks touched — see [docs/supply-chain-policy.md](../docs/supply-chain-policy.md))

## Success metric

A real business repo can reach Meta `ready` through `mb connect`, direct read-only Meta CLI calls exit `0`, public evidence remains exit/status-only, and #582 / MAIN-367 has a precise implementation contract for `mb ads meta summary --json`.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [ ] N/A — change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [x] No
- [ ] Yes — migration note below

## Public / private boundary

Confirmed: committed files do not include real `act_...` account IDs, business portfolio IDs, Meta tokens or token previews, raw Graph/Meta payloads, local absolute repo paths, private account labels, campaign names/IDs, or raw performance numbers. Raw Meta output stayed in ignored `.context/` scratch; the public report records only sanitized exit/status evidence and privacy-boundary design.
