### PR TITLE
[add] Port /mb-think to Codex workflow shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   next paid-channel summary shape toward `mb ads meta summary --json` with raw
   payloads, account IDs, tracked caches, and mutations out of scope. Refs
   MAIN-366, #581.
+- Added an accepted shared workflow source and runtime shells decision, plus a
+  `/mb-think` shared workflow source with generated Claude/Codex shell snapshots
+  and drift tests for required `mb` facts, research-depth guidance,
+  public/private boundaries, approval gates, and Codex overclaim language. Refs
+  MAIN-368, #583.
 - Added release-simulation operator-language rubric warnings for visible
   technical leakage in Claude final answers, plus docs and tests for
   translating git/GitHub/checkpoint mechanics into normal owner language first.

--- a/decisions/2026-05-13-shared-workflow-source-and-runtime-shells.md
+++ b/decisions/2026-05-13-shared-workflow-source-and-runtime-shells.md
@@ -1,0 +1,173 @@
+---
+type: decision
+date: 2026-05-13
+status: accepted
+topic: Shared workflow source and runtime shells
+linked_decisions:
+  - decisions/2026-05-01-mb-cli-vs-agent-workflows-boundary.md
+  - decisions/2026-05-04-skill-cli-runtime-adapter-contract.md
+  - decisions/2026-05-08-codex-adapter-plan.md
+  - decisions/2026-05-13-shared-workflow-corpus-and-native-runtime-renderers.md
+linked_issues:
+  - https://github.com/noontide-co/mainbranch/issues/583
+  - https://github.com/noontide-co/mainbranch/issues/451
+  - https://github.com/noontide-co/mainbranch/issues/453
+  - https://github.com/noontide-co/mainbranch/issues/125
+participants: [Devon, Codex]
+tags: [runtime-adapters, codex, claude-code, workflows, shared-workflow-source]
+---
+
+# Shared Workflow Source And Runtime Shells
+
+## Decision
+
+Main Branch workflow semantics belong in a shared workflow source under
+`workflows/<workflow>/workflow.md`.
+
+Runtime-specific files are shells or guidance over that source. They should
+explain discovery, invocation, runtime limits, and support level for one
+runtime. They should not become a second copy of the workflow.
+
+For the current adapter path:
+
+- `workflows/<workflow>/workflow.md` is the canonical source for durable
+  workflow semantics.
+- `.claude/skills/` remains the first-class Claude Code UX for shipped slash
+  skills.
+- Codex uses `AGENTS.md` and generated or referenced runtime guidance as the
+  entrypoint.
+- `mb` CLI JSON remains the deterministic fact layer.
+- Runtime smoke decides what support language is allowed.
+
+Do not make `.claude/skills/<workflow>` or `.agents/skills/<workflow>` the
+canonical workflow source for Main Branch workflows.
+
+## Why This Exists
+
+The first Codex adapter slice proved that Codex can be grounded by generated
+`AGENTS.md` and deterministic `mb` facts, but it did not prove Claude-style
+slash-command parity or selected workflow support.
+
+The first shared source prototype proved that a portable workflow file can
+declare intent, required `mb` commands, JSON fact paths, routing rules,
+boundaries, approval gates, handoff shape, runtime notes, and validation.
+
+The next risk is choosing the wrong permanent source. Putting workflow truth in
+runtime-specific skill folders would make the directory layout feel native for
+one runtime while making drift more likely across runtimes. The workflow source
+needs to be above runtime packaging.
+
+## Source Ownership
+
+Shared workflow source owns durable semantics:
+
+- intent and trigger boundaries;
+- required `mb` commands;
+- required JSON fact paths;
+- repo files to read;
+- research-depth or routing rules;
+- public/private boundaries;
+- approval gates;
+- durable promotion and codification rules;
+- output or handoff shape;
+- validation expectations;
+- support evidence required before runtime claims.
+
+Runtime shells own presentation and discovery:
+
+- how this runtime discovers the workflow;
+- how a user asks for the workflow in that runtime;
+- runtime-specific warnings;
+- slash-command availability or non-availability;
+- support level and smoke requirement;
+- concise guidance that points back to shared semantics instead of duplicating
+  them.
+
+`mb` owns deterministic facts and validation. It may render, validate, and
+repair runtime files. It must not invoke a model or run the conversation.
+
+## Codex Boundary
+
+Codex is CLI/instruction-file-first in the current Main Branch support model.
+Fresh business repos include `AGENTS.md`; `mb status`, `mb start`, and
+`mb doctor repair` expose Codex readiness. That is not slash-command parity.
+
+Codex guidance should say how to treat a natural request as a Main Branch
+workflow, starting from read-only `mb` facts. It should not tell users to run
+Claude Code slash commands.
+
+The narrow support claim after a successful `/mb-think` read-only smoke is:
+
+> Codex has experimental `/mb-think` workflow guidance through shared workflow
+> source.
+
+Do not claim:
+
+- Codex supports all Main Branch skills.
+- Codex has `/mb-think` slash-command parity.
+- Claude Code skills work in Codex.
+
+## `.agents/skills` Boundary
+
+Codex skills and `.agents/skills` may become useful later, but they are not the
+canonical source for MAIN-368.
+
+Do not use this branch to:
+
+- create `.agents/skills`;
+- symlink Claude skills into another tree;
+- copy `.claude/skills/mb-think`;
+- make `.agents/skills` the distribution layer;
+- create a generic runtime framework;
+- port every skill.
+
+If a later issue decides Main Branch needs a Codex skill distribution layer, it
+should explicitly cover `.agents/skills`, plugin packaging, symlinks vs copies
+vs generated files, PyPI package behavior, generated business repos,
+Windows/WSL behavior, and runtime smoke evidence.
+
+## What MAIN-368 Should Prove
+
+MAIN-368 should prove:
+
+- a shared workflow source can represent `/mb-think`;
+- Codex can follow the workflow through Codex-native guidance;
+- Claude Code behavior is preserved unless explicitly replaced and smoked;
+- drift tests catch missing commands, facts, gates, and support boundaries;
+- support language stays honest.
+
+Tests should catch:
+
+- missing `mb status --json --peek`;
+- missing `mb start --json` when declared;
+- missing research-depth ladder;
+- missing approval gates;
+- missing public/private boundaries;
+- Codex guidance saying "Run `/mb-think`";
+- Codex guidance claiming Claude skill parity;
+- runtime shells accumulating full workflow logic instead of staying concise;
+- stale product naming in touched files.
+
+## Consequences
+
+This keeps Main Branch from becoming a pile of runtime-specific prompt copies.
+It also keeps Codex support honest: Codex can get native guidance without
+pretending it has the same slash-command UX as Claude Code.
+
+The tradeoff is that a workflow source and renderer layer must be maintained.
+That cost is acceptable because it gives the project mechanical drift tests and
+a clear future adapter path.
+
+## What Changes
+
+`workflows/mb-think/workflow.md` becomes the canonical shared source for the
+portable `/mb-think` workflow semantics. Renderer snapshot tests should cover
+both Claude and Codex shells. Public docs should use current naming:
+
+- shared workflow source;
+- runtime shell;
+- runtime guidance;
+- runtime adapter.
+
+Future `.agents/skills` or Codex plugin distribution work needs its own issue
+and decision if it becomes the right adapter surface.

--- a/mb/mb/workflows.py
+++ b/mb/mb/workflows.py
@@ -52,6 +52,25 @@ MINIMUM_JSON_FACTS = {
     "readiness",
     "drift.items",
 }
+REQUIRED_SHELL_PHRASES_BY_WORKFLOW: dict[str, dict[str, str]] = {
+    "mb-think": {
+        "research-depth ladder": "research depth recommendation",
+        "parallel research file pattern": "parallel research files",
+        "decision writing": "decision",
+        "codification": "codify",
+        "public/private boundary": "public/private",
+        "approval gates": "approval",
+        "checkpoint approval": "checkpoint",
+        "Codex slash-command boundary": "Do not tell Codex users to run Claude slash commands.",
+    },
+}
+CODEX_FORBIDDEN_PHRASES_BY_WORKFLOW: dict[str, tuple[str, ...]] = {
+    "mb-think": (
+        "Run `/mb-think`",
+        "Claude Code skills work in Codex",
+        "slash-command parity",
+    ),
+}
 PUBLIC_PRIVATE_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
     ("local user path", re.compile(r"/Users/[^\s`)]+")),
     ("private maintainer handle", re.compile(r"devonmeadows", re.I)),
@@ -214,6 +233,19 @@ def shell_drift_errors(workflow: WorkflowSource, shell_text: str) -> list[str]:
     for fact in workflow.json_facts:
         if not _has_exact_bullet_item(shell_text, fact):
             errors.append(f"shell missing required JSON fact path: {fact}")
+    for label, phrase in REQUIRED_SHELL_PHRASES_BY_WORKFLOW.get(workflow.name, {}).items():
+        if phrase.lower() not in shell_text.lower():
+            errors.append(f"shell missing required workflow rule: {label}")
+    return errors
+
+
+def codex_shell_policy_errors(workflow: WorkflowSource, shell_text: str) -> list[str]:
+    """Return Codex guidance phrases that would overclaim support."""
+
+    errors: list[str] = []
+    for phrase in CODEX_FORBIDDEN_PHRASES_BY_WORKFLOW.get(workflow.name, ()):
+        if phrase.lower() in shell_text.lower():
+            errors.append(f"Codex shell contains forbidden support phrase: {phrase}")
     return errors
 
 
@@ -246,6 +278,14 @@ def _display_path(path: Path) -> str:
 
 def render_claude_shell(workflow: WorkflowSource) -> str:
     """Render a Claude Code shell snapshot for a workflow source."""
+
+    if workflow.name == "mb-think":
+        return _render_think_claude_shell(workflow)
+    return _render_start_money_path_claude_shell(workflow)
+
+
+def _render_start_money_path_claude_shell(workflow: WorkflowSource) -> str:
+    """Render the start-to-MoneyPath Claude shell snapshot."""
 
     output = f"""# Generated Claude Shell: {workflow.title}
 
@@ -305,6 +345,14 @@ or will not convert.
 def render_codex_shell(workflow: WorkflowSource) -> str:
     """Render a Codex CLI guidance snapshot for a workflow source."""
 
+    if workflow.name == "mb-think":
+        return _render_think_codex_shell(workflow)
+    return _render_start_money_path_codex_shell(workflow)
+
+
+def _render_start_money_path_codex_shell(workflow: WorkflowSource) -> str:
+    """Render the start-to-MoneyPath Codex shell snapshot."""
+
     output = f"""# Generated Codex Workflow Guidance: {workflow.title}
 
 Source workflow: `{_display_path(workflow.path)}`
@@ -357,5 +405,133 @@ Approval needed before writes: yes.
 
 Runtime smoke is required before docs say this selected workflow is supported
 or available in Codex.
+"""
+    return output
+
+
+def _render_think_claude_shell(workflow: WorkflowSource) -> str:
+    """Render a Claude Code shell snapshot for the thinking workflow."""
+
+    output = f"""# Generated Claude Shell: {workflow.title}
+
+Source workflow: `{_display_path(workflow.path)}`
+Runtime support: `claude_code: supported_shell`
+
+Use from `/mb-think` when the operator asks to research, decide, figure out,
+compare, codify, sharpen an offer, or turn learning into durable business
+truth. Preserve slash-command-native language for Claude Code only.
+
+This snapshot does not replace shipped `.claude/skills/mb-think/SKILL.md`.
+
+## Required mb Commands
+
+{_bullet_list(workflow.required_mb_commands)}
+
+## Required JSON Fact Paths
+
+{_bullet_list(workflow.json_facts)}
+
+## Routing
+
+1. Run hard gates first: required updates, broken repo wiring, repair blockers,
+   validation blockers, unsafe provider operations, private-data boundaries,
+   and destructive-operation requests.
+2. Read deterministic `mb` facts before raw markdown. Then read only relevant
+   `core/`, `research/`, `decisions/`, `bets/`, `pushes/`, `log/`, and `docs/`
+   files.
+3. Give a Research Depth Recommendation from 0-5 before outside research:
+   memory, repo context, lightweight public/manual research, multi-source
+   synthesis, structured approved-source collection, or high-resolution market
+   analysis.
+4. Use parallel research files for multiple sources, then synthesize in the
+   main thread. Each source file records source quality, access/permission,
+   caveats, promotion limits, and public/private handling.
+5. Write a decision when durable business truth changes. Codify only after the
+   operator accepts the direction.
+6. Ask for approval before creating or editing business files, promoting
+   research into core truth, using structured collection, or saving a
+   checkpoint.
+
+## Handoff Shape
+
+```text
+Thinking task: <research, decision, codify, or full flow>.
+Repo facts read: <status/start/connect/repair/checkpoint facts used>.
+Current bottleneck: <MoneyPath, content strategy, readiness, drift, or user question>.
+Research depth recommendation: <0-5>, because <reason>.
+Useful sources: <repo files, public/manual sources, approved providers, or operator input>.
+Stop condition: <what is enough signal>.
+Durable targets: <research/, decisions/, core/, bets/, pushes/, log/, or documents/>.
+Approval needed before writes: yes.
+```
+
+Use business language. Do not say an offer is bad, will convert, or will not
+convert. Do not tell Codex users to run Claude slash commands.
+"""
+    return output
+
+
+def _render_think_codex_shell(workflow: WorkflowSource) -> str:
+    """Render Codex CLI guidance for the thinking workflow."""
+
+    output = f"""# Generated Codex Workflow Guidance: {workflow.title}
+
+Source workflow: `{_display_path(workflow.path)}`
+Runtime support: `codex_cli: experimental_shell`
+
+Codex remains experimental and CLI-first. This guidance tells Codex how to
+treat a natural-language request as a Main Branch thinking task through
+`AGENTS.md` posture and deterministic `mb` facts. It does not claim Claude
+Code slash commands work inside Codex or that all Main Branch workflows are
+available in Codex.
+
+## Required mb Commands
+
+{_bullet_list(workflow.required_mb_commands)}
+
+## Required JSON Fact Paths
+
+{_bullet_list(workflow.json_facts)}
+
+## Codex Route
+
+1. Use the business repo `AGENTS.md` bootstrap posture: read facts first, keep
+   writes approval-gated, and translate git/provider details into business
+   language.
+2. Run hard gates first: required updates, repair blockers, readiness
+   blockers, unsafe provider operations, private-data boundaries, and
+   destructive-operation requests.
+3. Read deterministic `mb` facts before raw markdown. Then read only relevant
+   `core/`, `research/`, `decisions/`, `bets/`, `pushes/`, `log/`, and `docs/`
+   files.
+4. Give a Research Depth Recommendation from 0-5 before outside research:
+   memory, repo context, lightweight public/manual research, multi-source
+   synthesis, structured approved-source collection, or high-resolution market
+   analysis.
+5. Use parallel research files for multiple sources, then synthesize in the
+   main thread. Each source file records source quality, access/permission,
+   caveats, promotion limits, and public/private handling.
+6. Write a decision when durable business truth changes. Codify only after the
+   operator accepts the direction.
+7. Ask for approval before creating or editing business files, promoting
+   research into core truth, using structured collection, opening public
+   issues, publishing, mutating providers, spending money, contacting
+   customers, or saving a checkpoint.
+
+## Handoff Shape
+
+```text
+Thinking task: <research, decision, codify, or full flow>.
+Repo facts read: <status/start/connect/repair/checkpoint facts used>.
+Current bottleneck: <MoneyPath, content strategy, readiness, drift, or user question>.
+Research depth recommendation: <0-5>, because <reason>.
+Useful sources: <repo files, public/manual sources, approved providers, or operator input>.
+Stop condition: <what is enough signal>.
+Durable targets: <research/, decisions/, core/, bets/, pushes/, log/, or documents/>.
+Approval needed before writes: yes.
+```
+
+Do not tell Codex users to run Claude slash commands. Runtime smoke is required
+before docs say this selected workflow is supported or available in Codex.
 """
     return output

--- a/mb/tests/fixtures/workflows/mb-think.claude.md
+++ b/mb/tests/fixtures/workflows/mb-think.claude.md
@@ -1,0 +1,76 @@
+# Generated Claude Shell: Think Research Decision Codify
+
+Source workflow: `workflows/mb-think/workflow.md`
+Runtime support: `claude_code: supported_shell`
+
+Use from `/mb-think` when the operator asks to research, decide, figure out,
+compare, codify, sharpen an offer, or turn learning into durable business
+truth. Preserve slash-command-native language for Claude Code only.
+
+This snapshot does not replace shipped `.claude/skills/mb-think/SKILL.md`.
+
+## Required mb Commands
+
+- `mb status --json --peek`
+- `mb start --json`
+- `mb doctor repair --plan`
+- `mb connect doctor --json`
+- `mb checkpoint --plan --json`
+
+## Required JSON Fact Paths
+
+- `money_path`
+- `money_path.objects.offer`
+- `money_path.objects.proof`
+- `money_path.objects.proof.quality`
+- `money_path.objects.product_ladder`
+- `money_path.objects.cta_path`
+- `money_path.objects.channel_strategy`
+- `money_path.objects.active_push`
+- `money_path.objects.outcome_feedback_loop`
+- `money_path.ranked_actions`
+- `content_strategy`
+- `ranked_actions`
+- `update`
+- `readiness`
+- `drift.items`
+- `books`
+- `runtime.codex`
+- `runtime.claude_code`
+
+## Routing
+
+1. Run hard gates first: required updates, broken repo wiring, repair blockers,
+   validation blockers, unsafe provider operations, private-data boundaries,
+   and destructive-operation requests.
+2. Read deterministic `mb` facts before raw markdown. Then read only relevant
+   `core/`, `research/`, `decisions/`, `bets/`, `pushes/`, `log/`, and `docs/`
+   files.
+3. Give a Research Depth Recommendation from 0-5 before outside research:
+   memory, repo context, lightweight public/manual research, multi-source
+   synthesis, structured approved-source collection, or high-resolution market
+   analysis.
+4. Use parallel research files for multiple sources, then synthesize in the
+   main thread. Each source file records source quality, access/permission,
+   caveats, promotion limits, and public/private handling.
+5. Write a decision when durable business truth changes. Codify only after the
+   operator accepts the direction.
+6. Ask for approval before creating or editing business files, promoting
+   research into core truth, using structured collection, or saving a
+   checkpoint.
+
+## Handoff Shape
+
+```text
+Thinking task: <research, decision, codify, or full flow>.
+Repo facts read: <status/start/connect/repair/checkpoint facts used>.
+Current bottleneck: <MoneyPath, content strategy, readiness, drift, or user question>.
+Research depth recommendation: <0-5>, because <reason>.
+Useful sources: <repo files, public/manual sources, approved providers, or operator input>.
+Stop condition: <what is enough signal>.
+Durable targets: <research/, decisions/, core/, bets/, pushes/, log/, or documents/>.
+Approval needed before writes: yes.
+```
+
+Use business language. Do not say an offer is bad, will convert, or will not
+convert. Do not tell Codex users to run Claude slash commands.

--- a/mb/tests/fixtures/workflows/mb-think.codex.md
+++ b/mb/tests/fixtures/workflows/mb-think.codex.md
@@ -1,0 +1,80 @@
+# Generated Codex Workflow Guidance: Think Research Decision Codify
+
+Source workflow: `workflows/mb-think/workflow.md`
+Runtime support: `codex_cli: experimental_shell`
+
+Codex remains experimental and CLI-first. This guidance tells Codex how to
+treat a natural-language request as a Main Branch thinking task through
+`AGENTS.md` posture and deterministic `mb` facts. It does not claim Claude
+Code slash commands work inside Codex or that all Main Branch workflows are
+available in Codex.
+
+## Required mb Commands
+
+- `mb status --json --peek`
+- `mb start --json`
+- `mb doctor repair --plan`
+- `mb connect doctor --json`
+- `mb checkpoint --plan --json`
+
+## Required JSON Fact Paths
+
+- `money_path`
+- `money_path.objects.offer`
+- `money_path.objects.proof`
+- `money_path.objects.proof.quality`
+- `money_path.objects.product_ladder`
+- `money_path.objects.cta_path`
+- `money_path.objects.channel_strategy`
+- `money_path.objects.active_push`
+- `money_path.objects.outcome_feedback_loop`
+- `money_path.ranked_actions`
+- `content_strategy`
+- `ranked_actions`
+- `update`
+- `readiness`
+- `drift.items`
+- `books`
+- `runtime.codex`
+- `runtime.claude_code`
+
+## Codex Route
+
+1. Use the business repo `AGENTS.md` bootstrap posture: read facts first, keep
+   writes approval-gated, and translate git/provider details into business
+   language.
+2. Run hard gates first: required updates, repair blockers, readiness
+   blockers, unsafe provider operations, private-data boundaries, and
+   destructive-operation requests.
+3. Read deterministic `mb` facts before raw markdown. Then read only relevant
+   `core/`, `research/`, `decisions/`, `bets/`, `pushes/`, `log/`, and `docs/`
+   files.
+4. Give a Research Depth Recommendation from 0-5 before outside research:
+   memory, repo context, lightweight public/manual research, multi-source
+   synthesis, structured approved-source collection, or high-resolution market
+   analysis.
+5. Use parallel research files for multiple sources, then synthesize in the
+   main thread. Each source file records source quality, access/permission,
+   caveats, promotion limits, and public/private handling.
+6. Write a decision when durable business truth changes. Codify only after the
+   operator accepts the direction.
+7. Ask for approval before creating or editing business files, promoting
+   research into core truth, using structured collection, opening public
+   issues, publishing, mutating providers, spending money, contacting
+   customers, or saving a checkpoint.
+
+## Handoff Shape
+
+```text
+Thinking task: <research, decision, codify, or full flow>.
+Repo facts read: <status/start/connect/repair/checkpoint facts used>.
+Current bottleneck: <MoneyPath, content strategy, readiness, drift, or user question>.
+Research depth recommendation: <0-5>, because <reason>.
+Useful sources: <repo files, public/manual sources, approved providers, or operator input>.
+Stop condition: <what is enough signal>.
+Durable targets: <research/, decisions/, core/, bets/, pushes/, log/, or documents/>.
+Approval needed before writes: yes.
+```
+
+Do not tell Codex users to run Claude slash commands. Runtime smoke is required
+before docs say this selected workflow is supported or available in Codex.

--- a/mb/tests/test_workflows.py
+++ b/mb/tests/test_workflows.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from mb.workflows import (
+    codex_shell_policy_errors,
     load_workflow,
     public_private_boundary_errors,
     render_claude_shell,
@@ -15,11 +16,21 @@ from mb.workflows import (
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW = REPO_ROOT / "workflows" / "mb-start-money-path" / "workflow.md"
+THINK_WORKFLOW = REPO_ROOT / "workflows" / "mb-think" / "workflow.md"
 FIXTURES = REPO_ROOT / "mb" / "tests" / "fixtures" / "workflows"
+WORKFLOW_PATHS = [
+    WORKFLOW,
+    THINK_WORKFLOW,
+]
 
 
 def test_start_money_path_workflow_source_validates() -> None:
     assert validate_workflow(WORKFLOW) == []
+
+
+def test_all_workflow_sources_validate() -> None:
+    for path in WORKFLOW_PATHS:
+        assert validate_workflow(path) == []
 
 
 def test_workflow_validation_flags_missing_required_section(tmp_path: Path) -> None:
@@ -47,7 +58,7 @@ def test_workflow_validation_flags_missing_required_json_fact(tmp_path: Path) ->
     assert any("money_path.objects.proof.quality" in error for error in errors)
 
 
-def test_generated_claude_and_codex_snapshots_match_fixtures() -> None:
+def test_generated_start_money_path_claude_and_codex_snapshots_match_fixtures() -> None:
     workflow = load_workflow(WORKFLOW)
 
     assert render_claude_shell(workflow) == (FIXTURES / "mb-start-money-path.claude.md").read_text(
@@ -58,15 +69,27 @@ def test_generated_claude_and_codex_snapshots_match_fixtures() -> None:
     )
 
 
-def test_supported_shells_preserve_required_commands_and_json_facts() -> None:
-    workflow = load_workflow(WORKFLOW)
-    shells = [
-        render_claude_shell(workflow),
-        render_codex_shell(workflow),
-    ]
+def test_generated_think_claude_and_codex_snapshots_match_fixtures() -> None:
+    workflow = load_workflow(THINK_WORKFLOW)
 
-    for shell in shells:
-        assert shell_drift_errors(workflow, shell) == []
+    assert render_claude_shell(workflow) == (FIXTURES / "mb-think.claude.md").read_text(
+        encoding="utf-8"
+    )
+    assert render_codex_shell(workflow) == (FIXTURES / "mb-think.codex.md").read_text(
+        encoding="utf-8"
+    )
+
+
+def test_supported_shells_preserve_required_commands_and_json_facts() -> None:
+    for path in WORKFLOW_PATHS:
+        workflow = load_workflow(path)
+        shells = [
+            render_claude_shell(workflow),
+            render_codex_shell(workflow),
+        ]
+
+        for shell in shells:
+            assert shell_drift_errors(workflow, shell) == []
 
 
 def test_drift_detection_flags_omitted_required_command_or_fact() -> None:
@@ -93,11 +116,58 @@ def test_drift_detection_requires_exact_bulleted_fact_paths() -> None:
     assert "shell missing required JSON fact path: ranked_actions" in errors
 
 
+def test_think_drift_detection_flags_missing_required_workflow_rules() -> None:
+    workflow = load_workflow(THINK_WORKFLOW)
+    shell = render_codex_shell(workflow)
+    drifted = shell.replace("Research Depth Recommendation", "research note")
+    drifted = drifted.replace("Research depth recommendation", "research note")
+    drifted = drifted.replace("parallel research files", "source notes")
+    drifted = drifted.replace("public/private handling", "handling")
+
+    errors = shell_drift_errors(workflow, drifted)
+
+    assert "shell missing required workflow rule: research-depth ladder" in errors
+    assert "shell missing required workflow rule: parallel research file pattern" in errors
+    assert "shell missing required workflow rule: public/private boundary" in errors
+
+
+def test_think_codex_shell_does_not_claim_slash_command_or_skill_parity() -> None:
+    workflow = load_workflow(THINK_WORKFLOW)
+    shell = render_codex_shell(workflow)
+
+    assert codex_shell_policy_errors(workflow, shell) == []
+    assert "Run `/mb-think`" not in shell
+    assert "Claude Code skills work in Codex" not in shell
+
+
+def test_think_codex_policy_flags_forbidden_support_language() -> None:
+    workflow = load_workflow(THINK_WORKFLOW)
+    shell = render_codex_shell(workflow) + "\nRun `/mb-think`.\nClaude Code skills work in Codex.\n"
+
+    errors = codex_shell_policy_errors(workflow, shell)
+
+    assert "Codex shell contains forbidden support phrase: Run `/mb-think`" in errors
+    assert (
+        "Codex shell contains forbidden support phrase: Claude Code skills work in Codex" in errors
+    )
+
+
+def test_think_runtime_shells_stay_thin_and_currently_named() -> None:
+    workflow = load_workflow(THINK_WORKFLOW)
+    shells = [
+        render_claude_shell(workflow),
+        render_codex_shell(workflow),
+    ]
+
+    for shell in shells:
+        assert len(shell.splitlines()) < 90
+        assert "workflow corpus" not in shell.lower()
+        assert "shared workflow source" not in shell.lower()
+
+
 def test_workflow_source_and_snapshots_stay_public_safe() -> None:
-    texts = [
-        WORKFLOW.read_text(encoding="utf-8"),
-        (FIXTURES / "mb-start-money-path.claude.md").read_text(encoding="utf-8"),
-        (FIXTURES / "mb-start-money-path.codex.md").read_text(encoding="utf-8"),
+    texts = [path.read_text(encoding="utf-8") for path in WORKFLOW_PATHS] + [
+        fixture.read_text(encoding="utf-8") for fixture in sorted(FIXTURES.glob("*.md"))
     ]
 
     errors = [error for text in texts for error in public_private_boundary_errors(text)]

--- a/workflows/mb-think/workflow.md
+++ b/workflows/mb-think/workflow.md
@@ -1,0 +1,262 @@
+---
+name: mb-think
+title: Think Research Decision Codify
+description: Research, decide, and codify durable Main Branch business truth from repo facts, source-backed synthesis, and explicit operator approval.
+loops: [sense, decide, ship]
+runtime_support:
+  claude_code: supported_shell
+  codex_cli: experimental_shell
+  future: planned
+required_mb_commands:
+  - mb status --json --peek
+  - mb start --json
+  - mb doctor repair --plan
+  - mb connect doctor --json
+  - mb checkpoint --plan --json
+json_facts:
+  - money_path
+  - money_path.objects.offer
+  - money_path.objects.proof
+  - money_path.objects.proof.quality
+  - money_path.objects.product_ladder
+  - money_path.objects.cta_path
+  - money_path.objects.channel_strategy
+  - money_path.objects.active_push
+  - money_path.objects.outcome_feedback_loop
+  - money_path.ranked_actions
+  - content_strategy
+  - ranked_actions
+  - update
+  - readiness
+  - drift.items
+  - books
+  - runtime.codex
+  - runtime.claude_code
+writes_business_files: true
+provider_mutation: false
+publishing_or_spend: false
+---
+
+# Think Research Decision Codify
+
+This workflow source is the portable contract for Main Branch thinking work:
+research a question, make or document a decision, and codify approved learning
+into durable business files.
+
+## Intent And Triggers
+
+Use this workflow when the operator asks to think through an offer, research a
+market, compare providers, pressure-test positioning, choose a direction, turn
+source material into a decision, or codify what was learned.
+
+Trigger phrases include think through, research, decide, figure out, explore,
+codify, enrich, sharpen this offer, improve the offer, compare providers,
+market research, customer language, proof, objections, guarantees, keyword
+gate, sales video research, script teardown, and decision.
+
+Do not use this workflow for a site build, ads generation, organic post
+production, provider mutation, publishing, spend, customer contact, or model
+execution from `mb`.
+
+## Required Mb Commands
+
+Run or preserve these deterministic facts before interpreting business files:
+
+- `mb status --json --peek`
+- `mb start --json`
+- `mb doctor repair --plan`
+- `mb connect doctor --json`
+- `mb checkpoint --plan --json`
+
+`mb status --json --peek` is the normal first read for repo, MoneyPath, content
+strategy, provider, books, drift, readiness, and ranked-action facts.
+`mb start --json` is the compact daily-start handoff when the workflow begins
+from a new session. `mb doctor repair --plan` supplies repair blockers when
+status reports drift or broken wiring. `mb connect doctor --json` supplies
+provider-readiness and repair language when a research path needs a provider.
+`mb checkpoint --plan --json` is read before recommending a saved checkpoint,
+not permission to save one.
+
+## Required JSON Fact Paths
+
+The runtime shell must preserve these paths from the workflow source:
+
+- `money_path`
+- `money_path.objects.offer`
+- `money_path.objects.proof`
+- `money_path.objects.proof.quality`
+- `money_path.objects.product_ladder`
+- `money_path.objects.cta_path`
+- `money_path.objects.channel_strategy`
+- `money_path.objects.active_push`
+- `money_path.objects.outcome_feedback_loop`
+- `money_path.ranked_actions`
+- `content_strategy`
+- `ranked_actions`
+- `update`
+- `readiness`
+- `drift.items`
+- `books`
+- `runtime.codex`
+- `runtime.claude_code`
+
+Treat these as facts, not strategy. The CLI reports legibility, connection,
+readiness, and repair state. The runtime may recommend a research or decision
+route, but it must not claim that an offer will or will not convert.
+
+## Routing Rules
+
+Hard gates win before research or codification: required updates, broken repo
+wiring, repair blockers, validation blockers, relationship-health blockers,
+unsafe provider operations, private-data boundaries, and destructive-operation
+requests.
+
+After hard gates, resolve the active business context from `mb` facts and the
+business repo before outside research. Read only the files needed for the
+question:
+
+- `core/`
+- `research/`
+- `decisions/`
+- `bets/`
+- `pushes/`
+- `log/`
+- `docs/`
+
+Choose the smallest research depth that can make the next decision honest:
+
+- Level 0: operator memory is enough for a low-risk move.
+- Level 1: existing repo context and `mb` facts are enough.
+- Level 2: lightweight public or operator-provided research is needed.
+- Level 3: multi-source synthesis is needed.
+- Level 4: structured approved-source collection is justified.
+- Level 5: high-resolution market analysis or field evidence is needed.
+
+For multiple source types, split collection into source-specific research files
+and synthesize in the main thread. Source files should record the question,
+source type, access/permission note, collection method, source quality, key
+patterns, counter-signals, caveats, promotion limits, and public/private
+handling.
+
+Use decisions when the work changes durable business truth. A decision should
+name options, rationale, tradeoffs, consequences, and the specific files that
+would change. Codify only after the operator accepts the direction.
+
+## Read Boundaries
+
+Read deterministic `mb` facts before raw markdown. After the fact pass, read
+only business files needed for the current research, decision, or codify route:
+
+- active offer, audience, proof, product ladder, CTA, content strategy, and
+  relevant marketing layers;
+- relevant research, decisions, bets, pushes, logs, documents, and safe docs;
+- safe provider-readiness summaries from `mb connect` when a source path needs
+  provider context.
+
+Do not inspect secrets, raw provider exports, raw finance/legal records,
+customer/member records, private DMs, gated communities, local runtime
+settings, private maintainer notes, or credentials unless the operator gives
+explicit permission and the source is appropriate for the business repo.
+
+## Write Boundaries
+
+The workflow may write business files only after the operator approves the
+research, decision, codify, or checkpoint action. Valid write targets live in
+the business repo:
+
+- `research/`
+- `decisions/`
+- `core/`
+- `bets/`
+- `pushes/`
+- `log/`
+- `documents/`
+
+Research preserves evidence, source quality, caveats, and open questions.
+Core files preserve accepted operating truth. Proof files preserve permission,
+offer linkage, outcome, timeframe, metric, and typicality facts. Pushes and
+playbooks preserve bounded execution plans and approval records. Decisions
+explain accepted rationale and what changes because of it.
+
+The workflow source does not authorize writes to provider accounts, public
+sites, ad accounts, customer systems, release surfaces, runtime adapter files,
+or the Main Branch engine repo.
+
+## Approval Gates
+
+Ask before:
+
+- applying updates, repairs, migrations, or provider setup;
+- creating, editing, moving, deleting, or archiving business files;
+- marking a decision accepted or codified;
+- promoting research into `core/`, proof, pushes, playbooks, or logs;
+- saving a checkpoint;
+- using structured collection for Level 4 or Level 5 research;
+- publishing, opening a public issue, submitting a proposal, spending money,
+  mutating provider state, or contacting customers;
+- reading or moving private, restricted, local-only, finance, legal, customer,
+  member, credential, or raw provider data.
+
+Never ask the operator to paste secrets into repo files or workflow sources.
+Never commit raw dumps, full transcripts, private customer/member data,
+credential material, session cookies, or unsupported provider exports.
+
+## Handoff Format
+
+When entering thinking work, include a compact snapshot:
+
+```text
+Thinking task: <research, decision, codify, or full flow>.
+Repo facts read: <status/start/connect/repair/checkpoint facts used>.
+Current bottleneck: <MoneyPath, content strategy, readiness, drift, or user question>.
+Research depth recommendation: <0-5>, because <reason>.
+Useful sources: <repo files, public/manual sources, approved providers, or operator input>.
+Stop condition: <what is enough signal>.
+Durable targets: <research/, decisions/, core/, bets/, pushes/, log/, or documents/>.
+Approval needed before writes: yes.
+```
+
+Use business language. Avoid subjective conversion judgment such as "your offer
+is bad," "this will convert," or "this will not convert." Do not tell Codex
+users to run Claude Code slash commands.
+
+## Validation Commands
+
+Minimum validation for this port:
+
+- workflow schema tests;
+- generated Claude and Codex shell snapshot tests;
+- drift tests that fail when a supported shell omits a required `mb` command,
+  JSON fact path, research-depth rule, public/private rule, approval gate, or
+  Codex support boundary;
+- `python3 -m mb skill validate --all --json`;
+- `scripts/check.sh`.
+
+Run read-only Codex smoke before docs claim selected `/mb-think` workflow
+support in Codex. The smoke should start from a fresh or fixture business repo,
+ask a natural thinking prompt, require read-only `mb` facts first, require a
+research-depth recommendation, and leave `git status --short` clean.
+
+## Runtime-Specific Notes
+
+### Claude Code
+
+Claude Code remains the supported runtime. Rendered Claude shell snapshots must
+preserve slash-command-native language, direct `/mb-think` invocation, re-invoke
+guidance after compaction, research-depth routing, source-specific research
+files, decision writing, codification approval, and checkpoint approval.
+
+This shared workflow source does not replace
+`.claude/skills/mb-think/SKILL.md` unless a branch explicitly chooses that
+replacement and includes skill validation plus runtime evidence.
+
+### Codex CLI
+
+Codex remains experimental and CLI-first. Rendered Codex shell snapshots must
+start from generated `AGENTS.md` style grounding, deterministic `mb` facts, and
+natural-language workflow routing.
+
+Do not say `/mb-think` works inside Codex. Do not say "Run `/mb-think`." Do
+not claim selected Codex workflow support until a fresh fixture repo and
+read-only `codex exec --json --ephemeral --sandbox read-only -C <repo>` smoke
+prove the guidance is actually used.


### PR DESCRIPTION
## Summary

Ports the `/mb-think` workflow to Codex through shared workflow source, adds thin Claude/Codex runtime shell fixtures, and records the architecture decision that workflow semantics live under `workflows/<workflow>/workflow.md` while runtime shells stay thin.

## Linked issue

Closes #583
Refs #125
Refs #549
Refs #453
Refs #451

## Why

MAIN-368 needs Codex-native `/mb-think` guidance without copying Claude Code skill trees or overclaiming slash-command parity. This gives future workflow ports a tested shared-source pattern while keeping runtime support language gated by actual smoke evidence.

## Commits by concern

- [ ] Each commit body bullet-lists the changes in that commit; these commits use subject-only bodies.
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work.
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`.

Commits:

- `5beb9b6 [add] MAIN-368 record workflow shell architecture`
- `29b560d [add] MAIN-368 port think workflow source`

## Validation

Pre-push gate from repo root:

```bash
scripts/check.sh
```

- [x] Level 1 static: `scripts/check.sh` passes.
- [x] Level 2 CLI contract: focused workflow rendering, snapshot, drift, and policy tests passed.
- [ ] Level 3 package/install smoke was not required; packaging, entrypoints, init/onboard, and packaged data behavior were not changed.
- [ ] Level 4 fixture repo was not required; generated business repo files and command behavior were not changed.
- [x] Level 5 runtime smoke / dogfood harness / simulation-tier: read-only Codex smoke ran against a clean fresh business repo with generated Codex guidance loaded explicitly.
- [x] SKILL.md <=500 lines; no bundled `SKILL.md` file was changed.
- [ ] Package-visible release gate evidence before tag/publish was not required; this is not a release PR.
- [ ] Supply-chain review was not required; no workflow, dependency, `id-token`, or permissions files changed.

Evidence:

- Level 1 static: `scripts/check.sh` — runtime: local repo Python environment — exit: 0 — log: terminal excerpt showed full gate passing, including formatting, ruff, mypy, 666 pytest items, coverage gate, skill validation, and docs checks.
- Level 2 CLI contract: `cd mb && pytest tests/test_workflows.py -q` — runtime: local repo Python environment — exit: 0 — log: `14 passed`.
- Level 2 skill validation: `PYTHONPATH=mb python3 -m mb skill validate --all --json` — runtime: `python3` — exit: 0 — log: `15 skills`, `0 errors`.
- Level 5 runtime smoke: `codex exec --json --ephemeral --sandbox read-only -c 'approval_policy="never"'` from a clean fresh business repo — runtime: `codex-cli 0.129.0` — exit: 0 — log: Codex read deterministic `mb` facts, gave a research depth recommendation, kept approval before writes, and the repo stayed clean before and after.

## Success metric

`/mb-think` has a canonical shared workflow source and Codex-native runtime guidance can be drift-tested against required `mb` facts and rules without changing shipped Claude behavior or overclaiming Codex parity.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [ ] N/A — change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [x] No
- [ ] Yes — migration note below

## Public / private boundary

Raw Grok/Codex scratch stayed in `.context`; committed files are public-safe and contain no private operator strategy, machine-specific paths, secrets, credentials, or customer/member data.

Follow-up, not blocking this PR: decide the runtime skill distribution layer after shared workflow source prototypes, including `.agents/skills`, symlinks, generated runtime files, package behavior, generated business repos, Windows/WSL, and future runtime workflow discovery.
