### PR TITLE
[add] Meta Ads account summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   `mb connect`, skill/playbook UX, SecretStore/Keychain, privacy/redaction,
   JSON envelope, support-claim, Meta Ads, and image-generation guidance for
   provider cold starts. Refs MAIN-369, #585.
+- Added `mb ads meta summary --repo <BUSINESS_REPO> --window 7d --json` for
+  compact read-only Meta Ads account summaries after `mb connect` readiness,
+  with bounded windows, redacted account/business IDs, coarse spend by default,
+  current-run flags for campaign names and exact spend, and no raw payload or
+  cache writes. Refs MAIN-367, #582, MAIN-366, #581, MAIN-352, #550.
 - Added a MAIN-366 design for the first compact read-only Meta Ads account
   summary surface, keeping `mb connect` as the readiness rail and routing the
   next paid-channel summary shape toward `mb ads meta summary --json` with raw

--- a/mb/mb/ads.py
+++ b/mb/mb/ads.py
@@ -1,0 +1,393 @@
+"""Read-only ads account summaries."""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Callable
+from contextlib import suppress
+from datetime import date, datetime, timedelta, timezone
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import Any
+
+from mb import connect as connect_mod
+
+CommandRunner = Callable[..., dict[str, Any]]
+
+SUMMARY_SCHEMA_VERSION = "1.0"
+MAX_WINDOW_DAYS = 90
+
+
+class AdsSummaryError(ValueError):
+    """Raised for invalid summary arguments."""
+
+
+def _today() -> date:
+    return datetime.now(timezone.utc).date()
+
+
+def _checked_at() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def _parse_iso_date(value: str, *, option: str) -> date:
+    try:
+        return date.fromisoformat(value)
+    except ValueError as exc:
+        raise AdsSummaryError(f"{option} must be YYYY-MM-DD") from exc
+
+
+def _window_from_args(
+    *, window: str = "7d", since: str = "", until: str = "", today: date | None = None
+) -> dict[str, Any]:
+    current = today or _today()
+    if since or until:
+        if not since or not until:
+            raise AdsSummaryError("--since and --until must be provided together")
+        since_date = _parse_iso_date(since, option="--since")
+        until_date = _parse_iso_date(until, option="--until")
+        label = f"{since_date.isoformat()}..{until_date.isoformat()}"
+    else:
+        match = re.fullmatch(r"([1-9][0-9]*)d", window.strip().lower())
+        if not match:
+            raise AdsSummaryError("--window must use a day window like 7d")
+        days = int(match.group(1))
+        if days > MAX_WINDOW_DAYS:
+            raise AdsSummaryError(f"--window must be {MAX_WINDOW_DAYS}d or less")
+        until_date = current
+        since_date = current - timedelta(days=days)
+        label = f"{days}d"
+
+    days_inclusive = (until_date - since_date).days
+    if days_inclusive <= 0:
+        raise AdsSummaryError("--until must be after --since")
+    if days_inclusive > MAX_WINDOW_DAYS:
+        raise AdsSummaryError(f"date range must be {MAX_WINDOW_DAYS} days or less")
+    return {
+        "label": label,
+        "since": since_date.isoformat(),
+        "until": until_date.isoformat(),
+        "days": days_inclusive,
+    }
+
+
+def _read_json(stdout: str) -> Any:
+    with suppress(json.JSONDecodeError):
+        return json.loads(stdout or "")
+    return {}
+
+
+def _items(payload: Any) -> list[dict[str, Any]]:
+    if isinstance(payload, list):
+        return [item for item in payload if isinstance(item, dict)]
+    if not isinstance(payload, dict):
+        return []
+    for key in ("data", "items", "results", "campaigns", "adaccounts", "datasets"):
+        value = payload.get(key)
+        if isinstance(value, list):
+            return [item for item in value if isinstance(item, dict)]
+    return [payload] if payload else []
+
+
+def _first_string(item: dict[str, Any], keys: tuple[str, ...]) -> str:
+    for key in keys:
+        value = item.get(key)
+        if value is not None and value != "":
+            return str(value)
+    return ""
+
+
+def _decimal(value: Any) -> Decimal:
+    if value is None or value == "":
+        return Decimal("0")
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, ValueError):
+        return Decimal("0")
+
+
+def _spend_range(amount: Decimal) -> str:
+    if amount <= 0:
+        return "no recent spend detected"
+    if amount < Decimal("100"):
+        return "recent spend under 100"
+    if amount < Decimal("1000"):
+        return "recent spend 100-999"
+    if amount < Decimal("10000"):
+        return "recent spend 1k-9.9k"
+    return "recent spend 10k+"
+
+
+def _active_campaigns(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    active: list[dict[str, Any]] = []
+    for item in items:
+        raw_status = (
+            item.get("effective_status")
+            or item.get("configured_status")
+            or item.get("status")
+            or ""
+        )
+        status = str(raw_status).strip().upper()
+        if status in {"ACTIVE", "ENABLED"}:
+            active.append(item)
+    return active
+
+
+def _empty_summary(
+    *,
+    ok: bool,
+    state: str,
+    readiness: dict[str, Any],
+    window_info: dict[str, Any],
+    checked_at: str,
+    errors: list[str] | None = None,
+    actions: list[str] | None = None,
+) -> dict[str, Any]:
+    repair_command = str(readiness.get("repair_command") or "")
+    return {
+        "ok": ok,
+        "schema_version": SUMMARY_SCHEMA_VERSION,
+        "safe_to_share": False,
+        "provider": "meta",
+        "command": "mb ads meta summary",
+        "state": state,
+        "checked_at": checked_at,
+        "window": {
+            "label": window_info["label"],
+            "since": window_info["since"],
+            "until": window_info["until"],
+        },
+        "privacy": {
+            "raw_payload_written": False,
+            "tracked_files_written": False,
+            "account_ids_redacted": True,
+            "business_ids_redacted": True,
+            "exact_spend_included": False,
+            "campaign_names_included": False,
+        },
+        "readiness": {
+            "state": str(readiness.get("state") or state),
+            "summary": str(readiness.get("summary") or ""),
+            "repair": str(readiness.get("repair") or ""),
+            "repair_command": repair_command,
+            "support_level": "meta_ads_cli_read_only",
+            "command_source": "mb connect",
+        },
+        "account": {
+            "label": str(readiness.get("account_label") or "Meta Ads"),
+            "currency": "",
+            "timezone": "",
+            "ad_account_id": "<redacted>",
+            "business_id": "<redacted>",
+        },
+        "campaigns": {"active_count": 0, "names": [], "names_redacted": True},
+        "spend": {"amount": "redacted", "range_label": "unknown", "currency": ""},
+        "performance_direction": {
+            "state": "unknown",
+            "summary": "Not enough prior-window context to compare direction.",
+        },
+        "datasets": {"state": "not_read", "count": None},
+        "creatives": {"state": "not_read", "count": None, "naming_patterns": []},
+        "findings": [],
+        "next_actions": [],
+        "errors": errors or [],
+        "actions": actions if actions is not None else ([repair_command] if repair_command else []),
+    }
+
+
+def _run_json(
+    run: CommandRunner,
+    args: list[str],
+    repo: Path,
+    env: dict[str, str],
+) -> tuple[dict[str, Any], Any]:
+    result = connect_mod._run_meta_command(run, args, repo, env)
+    return result, _read_json(str(result.get("stdout") or "")) if result.get("ok") else {}
+
+
+def _load_meta_secret_and_metadata(repo: Path) -> tuple[str, dict[str, Any]]:
+    config = connect_mod._read_config(repo)
+    entry = config.get("providers", {}).get("meta")
+    if not isinstance(entry, dict):
+        return "", {}
+    provider = connect_mod.normalize_provider("meta")
+    secret = connect_mod._stored_secret(provider, entry)
+    raw_metadata = entry.get("metadata")
+    metadata: dict[str, Any] = raw_metadata if isinstance(raw_metadata, dict) else {}
+    return secret, metadata
+
+
+def meta_summary(
+    *,
+    repo: str | Path = ".",
+    window: str = "7d",
+    since: str = "",
+    until: str = "",
+    include_campaign_names: bool = False,
+    include_exact_spend: bool = False,
+    command_runner: CommandRunner | None = None,
+) -> dict[str, Any]:
+    """Return a compact, read-only Meta Ads account summary."""
+
+    target = Path(repo).resolve()
+    window_info = _window_from_args(window=window, since=since, until=until)
+    checked_at = _checked_at()
+    readiness = connect_mod.status_provider("meta", target)
+    if readiness.get("state") != "ready":
+        state = str(readiness.get("state") or "not_ready")
+        summary = _empty_summary(
+            ok=False,
+            state=state,
+            readiness=readiness,
+            window_info=window_info,
+            checked_at=checked_at,
+            errors=[str(readiness.get("summary") or "Meta Ads is not ready.")],
+        )
+        summary["findings"] = [
+            "Meta Ads is not ready, so no live account data was read.",
+        ]
+        if readiness.get("repair_command"):
+            summary["next_actions"] = [str(readiness["repair_command"])]
+        else:
+            summary["next_actions"] = [
+                "Continue from repo files, exported screenshots, or manual Ads Manager notes.",
+            ]
+        return summary
+
+    secret, metadata = _load_meta_secret_and_metadata(target)
+    if not secret:
+        readiness = connect_mod.status_provider("meta", target)
+        return _empty_summary(
+            ok=False,
+            state="missing_secret",
+            readiness=readiness,
+            window_info=window_info,
+            checked_at=checked_at,
+            errors=["Meta Ads local token material is missing."],
+        )
+
+    run = command_runner or connect_mod._run_command
+    env = connect_mod._meta_env(secret, metadata)
+    account_args = ["meta", "-o", "json", "ads", "adaccount", "list"]
+    campaign_args = ["meta", "-o", "json", "ads", "campaign", "list"]
+    insights_args = [
+        "meta",
+        "-o",
+        "json",
+        "ads",
+        "insights",
+        "get",
+        "--fields",
+        "spend,impressions,clicks,ctr,cpc",
+        "--since",
+        window_info["since"],
+        "--until",
+        window_info["until"],
+    ]
+    dataset_args = ["meta", "-o", "json", "ads", "dataset", "list"]
+    business_id = str(metadata.get("business_id") or "").strip()
+
+    account_result, account_payload = _run_json(run, account_args, target, env)
+    campaign_result, campaign_payload = _run_json(run, campaign_args, target, env)
+    insights_result, insights_payload = _run_json(run, insights_args, target, env)
+    if business_id:
+        dataset_result, dataset_payload = _run_json(run, dataset_args, target, env)
+        dataset_skipped = False
+    else:
+        dataset_result = {"ok": True, "skipped": True, "reason": "business_id metadata not set"}
+        dataset_payload = {}
+        dataset_skipped = True
+
+    upstream = {
+        "account": account_result,
+        "campaigns": campaign_result,
+        "insights": insights_result,
+        "datasets": dataset_result,
+    }
+    failed = [name for name, result in upstream.items() if not result.get("ok")]
+    if failed:
+        summary = _empty_summary(
+            ok=False,
+            state="read_failed",
+            readiness=readiness,
+            window_info=window_info,
+            checked_at=checked_at,
+            errors=[f"Meta Ads read-only summary failed for: {', '.join(failed)}"],
+            actions=["mb connect test meta"],
+        )
+        summary["findings"] = [
+            "Meta Ads readiness was ready, but one or more read-only summary calls failed.",
+        ]
+        summary["next_actions"] = [
+            "Run `mb connect test meta --json` to refresh the readiness state.",
+        ]
+        return summary
+
+    account_items = _items(account_payload)
+    account = account_items[0] if account_items else {}
+    currency = _first_string(account, ("currency", "account_currency"))
+    timezone = _first_string(account, ("timezone_name", "timezone", "account_timezone"))
+    campaign_items = _items(campaign_payload)
+    active = _active_campaigns(campaign_items)
+    insight_items = _items(insights_payload)
+    exact_spend = sum((_decimal(item.get("spend")) for item in insight_items), Decimal("0"))
+    dataset_items = _items(dataset_payload)
+    dataset_count = len(dataset_items) if not dataset_skipped else None
+
+    summary = _empty_summary(
+        ok=True,
+        state="ready",
+        readiness=readiness,
+        window_info=window_info,
+        checked_at=checked_at,
+    )
+    summary["privacy"]["exact_spend_included"] = bool(include_exact_spend)
+    summary["privacy"]["campaign_names_included"] = bool(include_campaign_names)
+    summary["readiness"]["command_source"] = "Meta Ads CLI"
+    summary["account"]["currency"] = currency
+    summary["account"]["timezone"] = timezone
+    summary["campaigns"] = {
+        "active_count": len(active),
+        "names": [
+            str(item.get("name") or "") for item in active if str(item.get("name") or "").strip()
+        ]
+        if include_campaign_names
+        else [],
+        "names_redacted": not include_campaign_names,
+    }
+    summary["spend"] = {
+        "amount": str(exact_spend) if include_exact_spend else "redacted",
+        "range_label": _spend_range(exact_spend),
+        "currency": currency,
+    }
+    summary["datasets"] = {
+        "state": "not_configured"
+        if dataset_skipped
+        else "readable"
+        if dataset_count
+        else "none_detected",
+        "count": dataset_count,
+    }
+    summary["findings"] = [
+        "Meta account context is readable for a bounded summary.",
+    ]
+    if active:
+        summary["findings"].append("Active campaign context is present.")
+    else:
+        summary["findings"].append("No active campaign context was detected.")
+    summary["next_actions"] = [
+        (
+            "Use this summary to choose whether to generate new creative, audit active "
+            "campaigns, or work from repo reference files."
+        ),
+    ]
+    return summary
+
+
+def render_meta_summary_human(summary: dict[str, Any]) -> None:
+    print(f"Meta Ads summary: {summary['state']}")
+    for finding in summary.get("findings", []):
+        print(f"- {finding}")
+    for action in summary.get("next_actions", []):
+        print(f"next: {action}")

--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -16,6 +16,7 @@ from typing import Any, NoReturn
 import typer
 
 from mb import __version__
+from mb import ads as ads_mod
 from mb import books as books_mod
 from mb import checkpoint as checkpoint_mod
 from mb import connect as connect_mod
@@ -100,6 +101,20 @@ books_report_app = typer.Typer(
     no_args_is_help=True,
 )
 books_app.add_typer(books_report_app, name="report")
+
+ads_app = typer.Typer(
+    name="ads",
+    help="Read paid-channel account summaries.",
+    no_args_is_help=True,
+)
+app.add_typer(ads_app, name="ads")
+
+ads_meta_app = typer.Typer(
+    name="meta",
+    help="Read privacy-bounded Meta Ads account summaries.",
+    no_args_is_help=True,
+)
+ads_app.add_typer(ads_meta_app, name="meta")
 
 suggest_app = typer.Typer(
     name="suggest",
@@ -1154,6 +1169,84 @@ def books_report_monthly_cmd(
     else:
         books_mod.render_sample_monthly_report(report)
     raise typer.Exit(0 if report["ok"] else 1)
+
+
+@ads_meta_app.command("summary")
+def ads_meta_summary_cmd(
+    repo: str = typer.Option(".", "--repo", help="Business repo with Meta readiness metadata."),
+    window: str = typer.Option("7d", "--window", help="Recent bounded window, such as 7d."),
+    since: str = typer.Option("", "--since", help="Start date as YYYY-MM-DD."),
+    until: str = typer.Option("", "--until", help="End date as YYYY-MM-DD."),
+    include_campaign_names: bool = typer.Option(
+        False,
+        "--include-campaign-names",
+        help="Include campaign names for this run only.",
+    ),
+    include_exact_spend: bool = typer.Option(
+        False,
+        "--include-exact-spend",
+        help="Include exact spend for this run only.",
+    ),
+    json_out: bool = typer.Option(False, "--json", help="Machine-readable output."),
+) -> None:
+    """Pull a compact read-only Meta Ads account summary."""
+    command_parts = ["mb ads meta summary"]
+    if window:
+        command_parts.extend(["--window", window])
+    if since:
+        command_parts.extend(["--since", since])
+    if until:
+        command_parts.extend(["--until", until])
+    if include_campaign_names:
+        command_parts.append("--include-campaign-names")
+    if include_exact_spend:
+        command_parts.append("--include-exact-spend")
+    command = " ".join(command_parts)
+    try:
+        result = ads_mod.meta_summary(
+            repo=repo,
+            window=window,
+            since=since,
+            until=until,
+            include_campaign_names=include_campaign_names,
+            include_exact_spend=include_exact_spend,
+        )
+    except ads_mod.AdsSummaryError as exc:
+        message = f"mb ads meta summary: {exc}"
+        payload = {
+            "ok": False,
+            "schema_version": ads_mod.SUMMARY_SCHEMA_VERSION,
+            "safe_to_share": False,
+            "provider": "meta",
+            "command": "mb ads meta summary",
+            "state": "invalid_arguments",
+            "summary": message,
+            "errors": [message],
+            "actions": [],
+        }
+        if json_out:
+            typer.echo(
+                _json_payload(
+                    payload,
+                    command=command,
+                    schema_name="mainbranch.ads.meta.summary.v1",
+                )
+            )
+        else:
+            typer.echo(message, err=True)
+        raise typer.Exit(2) from exc
+
+    if json_out:
+        typer.echo(
+            _json_payload(
+                result,
+                command=command,
+                schema_name="mainbranch.ads.meta.summary.v1",
+            )
+        )
+    else:
+        ads_mod.render_meta_summary_human(result)
+    raise typer.Exit(0 if result["ok"] else 1)
 
 
 @site_app.command("check")

--- a/mb/tests/test_ads.py
+++ b/mb/tests/test_ads.py
@@ -1,0 +1,318 @@
+"""``mb ads`` read-only account summaries."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+from typer.testing import CliRunner
+
+from mb import connect as connect_mod
+from mb.cli import app
+
+runner = CliRunner()
+
+
+def _local_secret_env(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("MB_CONNECT_SECRET_BACKEND", "local-file")
+    monkeypatch.setenv("MAINBRANCH_HOME", str(tmp_path / "home"))
+    for provider in connect_mod.PROVIDERS:
+        for env_var in provider.env_vars:
+            monkeypatch.delenv(env_var, raising=False)
+
+
+def _ready_meta_repo(tmp_path: Path, monkeypatch, *, include_business_id: bool = True) -> Path:
+    _local_secret_env(monkeypatch, tmp_path)
+    monkeypatch.setattr(connect_mod, "_meta_prerequisite_state", lambda **kwargs: "")
+    repo = tmp_path / "biz"
+    repo.mkdir()
+    metadata_pairs = ["ad_account_id=act_123456789"]
+    if include_business_id:
+        metadata_pairs.append("business_id=biz_987654321")
+    connect_mod.connect_provider(
+        "meta",
+        repo=repo,
+        token="meta-secret-token",
+        account_label="Primary Meta",
+        metadata_pairs=metadata_pairs,
+    )
+    config_path = repo / ".mb" / "connect.yaml"
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    meta = config["providers"]["meta"]
+    meta["validation"] = {
+        "state": "ready",
+        "checked_at": "2026-05-13T00:00:00Z",
+        "summary": "Meta read-only account smoke passed.",
+        "safe_to_share": True,
+    }
+    config_path.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
+    return repo
+
+
+def _fake_meta_runner(calls: list[list[str]]):
+    def fake_run(
+        args: list[str],
+        cwd: Path | None = None,
+        timeout: float = 5.0,
+        *,
+        env: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        calls.append(args)
+        assert env is not None
+        assert env["ACCESS_TOKEN"] == "meta-secret-token"
+        assert env["AD_ACCOUNT_ID"] == "act_123456789"
+        if "BUSINESS_ID" in env:
+            assert env["BUSINESS_ID"] == "biz_987654321"
+        if args[:4] == ["meta", "-o", "json", "ads"] and args[4:6] == [
+            "adaccount",
+            "list",
+        ]:
+            stdout = json.dumps(
+                {
+                    "data": [
+                        {
+                            "id": "act_123456789",
+                            "name": "Private account name",
+                            "currency": "USD",
+                            "timezone_name": "America/Los_Angeles",
+                        }
+                    ]
+                }
+            )
+        elif args[:4] == ["meta", "-o", "json", "ads"] and args[4:6] == [
+            "campaign",
+            "list",
+        ]:
+            stdout = json.dumps(
+                {
+                    "data": [
+                        {
+                            "id": "111",
+                            "name": "Spring private campaign",
+                            "effective_status": "ACTIVE",
+                        },
+                        {
+                            "id": "222",
+                            "name": "Old private campaign",
+                            "effective_status": "PAUSED",
+                        },
+                    ]
+                }
+            )
+        elif args[:4] == ["meta", "-o", "json", "ads"] and args[4:6] == [
+            "insights",
+            "get",
+        ]:
+            stdout = json.dumps({"data": [{"spend": "123.45"}]})
+        elif args[:4] == ["meta", "-o", "json", "ads"] and args[4:6] == [
+            "dataset",
+            "list",
+        ]:
+            stdout = json.dumps({"data": [{"id": "dataset-private"}]})
+        else:
+            raise AssertionError(f"unexpected Meta command: {args}")
+        return {"ok": True, "returncode": 0, "stdout": stdout, "stderr": ""}
+
+    return fake_run
+
+
+def _repo_snapshot(repo: Path) -> dict[str, str]:
+    return {
+        str(path.relative_to(repo)): path.read_text(encoding="utf-8")
+        for path in repo.rglob("*")
+        if path.is_file()
+    }
+
+
+def test_ads_meta_summary_command_exists_and_reports_not_ready_without_probe(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(connect_mod, "_meta_prerequisite_state", lambda **kwargs: "")
+    repo = tmp_path / "biz"
+    repo.mkdir()
+    calls: list[list[str]] = []
+    monkeypatch.setattr(connect_mod, "_run_command", _fake_meta_runner(calls))
+
+    result = runner.invoke(app, ["ads", "meta", "summary", "--repo", str(repo), "--json"])
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["result_schema"]["name"] == "mainbranch.ads.meta.summary.v1"
+    assert payload["mb_command"] == "mb ads meta summary --window 7d"
+    assert payload["provider"] == "meta"
+    assert payload["state"] == "not_connected"
+    assert payload["readiness"]["repair_command"].startswith("mb connect meta")
+    assert payload["safe_to_share"] is False
+    assert calls == []
+
+
+def test_ads_meta_summary_ready_uses_read_only_commands_and_redacts_defaults(
+    tmp_path: Path, monkeypatch
+) -> None:
+    repo = _ready_meta_repo(tmp_path, monkeypatch)
+    calls: list[list[str]] = []
+    monkeypatch.setattr(connect_mod, "_run_command", _fake_meta_runner(calls))
+
+    result = runner.invoke(app, ["ads", "meta", "summary", "--repo", str(repo), "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert [call[:6] for call in calls] == [
+        ["meta", "-o", "json", "ads", "adaccount", "list"],
+        ["meta", "-o", "json", "ads", "campaign", "list"],
+        ["meta", "-o", "json", "ads", "insights", "get"],
+        ["meta", "-o", "json", "ads", "dataset", "list"],
+    ]
+    assert all("create" not in " ".join(call).lower() for call in calls)
+    assert all("update" not in " ".join(call).lower() for call in calls)
+    assert all("delete" not in " ".join(call).lower() for call in calls)
+    assert payload["ok"] is True
+    assert payload["safe_to_share"] is False
+    assert payload["privacy"]["raw_payload_written"] is False
+    assert payload["privacy"]["tracked_files_written"] is False
+    assert payload["privacy"]["account_ids_redacted"] is True
+    assert payload["privacy"]["business_ids_redacted"] is True
+    assert payload["account"]["ad_account_id"] == "<redacted>"
+    assert payload["account"]["business_id"] == "<redacted>"
+    assert payload["account"]["label"] == "Primary Meta"
+    assert payload["account"]["currency"] == "USD"
+    assert payload["account"]["timezone"] == "America/Los_Angeles"
+    assert payload["campaigns"]["active_count"] == 1
+    assert payload["campaigns"]["names"] == []
+    assert payload["campaigns"]["names_redacted"] is True
+    assert payload["spend"]["amount"] == "redacted"
+    assert payload["spend"]["range_label"] == "recent spend 100-999"
+    assert payload["datasets"]["state"] == "readable"
+    assert "act_123456789" not in result.stdout
+    assert "biz_987654321" not in result.stdout
+    assert "Spring private campaign" not in result.stdout
+    assert "123.45" not in result.stdout
+    assert "meta-secret-token" not in result.stdout
+
+
+def test_ads_meta_summary_skips_datasets_without_business_id(tmp_path: Path, monkeypatch) -> None:
+    repo = _ready_meta_repo(tmp_path, monkeypatch, include_business_id=False)
+    calls: list[list[str]] = []
+    monkeypatch.setattr(connect_mod, "_run_command", _fake_meta_runner(calls))
+
+    result = runner.invoke(app, ["ads", "meta", "summary", "--repo", str(repo), "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert [call[:6] for call in calls] == [
+        ["meta", "-o", "json", "ads", "adaccount", "list"],
+        ["meta", "-o", "json", "ads", "campaign", "list"],
+        ["meta", "-o", "json", "ads", "insights", "get"],
+    ]
+    assert all(call[4:6] != ["dataset", "list"] for call in calls)
+    assert payload["state"] == "ready"
+    assert payload["datasets"] == {"state": "not_configured", "count": None}
+    assert payload["campaigns"]["active_count"] == 1
+    assert payload["spend"]["amount"] == "redacted"
+
+
+def test_ads_meta_summary_includes_campaign_names_and_exact_spend_only_with_flags(
+    tmp_path: Path, monkeypatch
+) -> None:
+    repo = _ready_meta_repo(tmp_path, monkeypatch)
+    calls: list[list[str]] = []
+    monkeypatch.setattr(connect_mod, "_run_command", _fake_meta_runner(calls))
+
+    result = runner.invoke(
+        app,
+        [
+            "ads",
+            "meta",
+            "summary",
+            "--repo",
+            str(repo),
+            "--include-campaign-names",
+            "--include-exact-spend",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["privacy"]["campaign_names_included"] is True
+    assert payload["privacy"]["exact_spend_included"] is True
+    assert payload["safe_to_share"] is False
+    assert payload["campaigns"]["names"] == ["Spring private campaign"]
+    assert payload["campaigns"]["names_redacted"] is False
+    assert payload["spend"]["amount"] == "123.45"
+    assert "act_123456789" not in result.stdout
+    assert "biz_987654321" not in result.stdout
+
+
+def test_ads_meta_summary_supports_since_until_and_validates_windows(
+    tmp_path: Path, monkeypatch
+) -> None:
+    repo = _ready_meta_repo(tmp_path, monkeypatch)
+    calls: list[list[str]] = []
+    monkeypatch.setattr(connect_mod, "_run_command", _fake_meta_runner(calls))
+
+    result = runner.invoke(
+        app,
+        [
+            "ads",
+            "meta",
+            "summary",
+            "--repo",
+            str(repo),
+            "--since",
+            "2026-05-01",
+            "--until",
+            "2026-05-08",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["window"] == {
+        "label": "2026-05-01..2026-05-08",
+        "since": "2026-05-01",
+        "until": "2026-05-08",
+    }
+    insights_call = next(call for call in calls if call[4:6] == ["insights", "get"])
+    assert "--since" in insights_call
+    assert "2026-05-01" in insights_call
+    assert "--until" in insights_call
+    assert "2026-05-08" in insights_call
+
+    invalid = runner.invoke(
+        app,
+        [
+            "ads",
+            "meta",
+            "summary",
+            "--repo",
+            str(repo),
+            "--window",
+            "365d",
+            "--json",
+        ],
+    )
+
+    assert invalid.exit_code == 2
+    invalid_payload = json.loads(invalid.stdout)
+    assert invalid_payload["state"] == "invalid_arguments"
+    assert invalid_payload["result_status"] == "error"
+
+
+def test_ads_meta_summary_does_not_write_raw_payloads_or_cache_files(
+    tmp_path: Path, monkeypatch
+) -> None:
+    repo = _ready_meta_repo(tmp_path, monkeypatch)
+    before = _repo_snapshot(repo)
+    calls: list[list[str]] = []
+    monkeypatch.setattr(connect_mod, "_run_command", _fake_meta_runner(calls))
+
+    result = runner.invoke(app, ["ads", "meta", "summary", "--repo", str(repo), "--json"])
+
+    assert result.exit_code == 0
+    assert _repo_snapshot(repo) == before
+    assert not (repo / ".mb" / "ads").exists()
+    assert not (repo / ".mb" / "cache").exists()


### PR DESCRIPTION
## Summary

Adds `mb ads meta summary --repo <BUSINESS_REPO> --window 7d --json` as the first compact read-only Meta Ads account summary. The command stays behind `mb connect` readiness, redacts account/business IDs, keeps campaign names and exact spend behind current-run flags, and writes no raw payloads or caches.

## Linked issue

Closes #582 / MAIN-367
Refs #581 / MAIN-366
Refs #550 / MAIN-352

## Why

Operators need enough live Meta Ads context to inform the next ad recommendation without importing raw performance data, exposing account IDs, or overloading `mb connect` beyond setup/readiness/repair.

## Commits by concern

- [x] `cbe82ca [add] Meta Ads account summary`
  - Adds `mb/mb/ads.py` for readiness-gated read-only Meta summary generation.
  - Wires `mb ads meta summary` through Typer.
  - Adds focused fake-payload tests for JSON shape, redaction, not-ready behavior, flags, windows, and no writes.
  - Updates `CHANGELOG.md` `[Unreleased]`.
- [x] Each commit body bullet-lists the changes in that commit
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`

## Validation

Pre-push gate from repo root:

```bash
scripts/check.sh
```

- [x] Level 1 static: `scripts/check.sh` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: `ruff format` clean, `ruff check` clean, `mypy mb tests` clean, `665 passed`, coverage above 79%, skill validation all ok.
- [x] Level 2 CLI contract: `pytest tests/test_ads.py -q` — runtime: Python 3.13.7 pytest environment — exit: 0 — log: `5 passed in 0.35s`.
- [x] Level 2 CLI contract: `pytest tests/test_connect.py -q` — runtime: Python 3.13.7 pytest environment — exit: 0 — log: `42 passed in 7.41s`.
- [x] Skill validation: `python3 -m mb skill validate mb-ads` — runtime: `python3` — exit: 0 — log: `1 skill(s) validated`.
- [x] Skill validation: `python3 -m mb skill validate --all` — runtime: `python3` — exit: 0 — log: `15 skill(s) validated`.
- [x] Level 3 package/install smoke not required; packaging and entrypoints were not changed.
- [x] Level 4 fixture repo smoke not required; init/onboard/status/start/update repo-shape flows were not changed.
- [x] Level 5 runtime smoke not required; skill discovery and runtime invocation were not changed.
- [x] SKILL.md <=500 lines; `mb skill validate --all` passed.
- [x] Package-visible release gate evidence before tag/publish not required; this is not a release PR.
- [x] Supply-chain review not required; workflows, dependency metadata, and permissions were not changed.

Real-account smoke not run on this branch; command is covered with fake Meta payload tests and should be smoke-tested before or during release validation.

## Success metric

A business repo with Meta `ready` can run `mb ads meta summary --repo <BUSINESS_REPO> --window 7d --json` and receive a compact privacy-bounded account summary; a repo without Meta readiness gets the existing `mb connect` repair state without any live account probe.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [ ] N/A — change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [x] No
- [ ] Yes — migration note below

## Public / private boundary

No private operator strategy, machine-specific paths, raw Meta payloads, account IDs, business IDs, tokens, customer/member data, or real-account evidence were committed. The summary output remains `safe_to_share: false` because compact account context can still be private even when IDs and exact spend are redacted.
