### PR TITLE
[add] MAIN-369 provider wrapper boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ### Added
 
+- Added a durable provider CLI/API vs `mb` wrapper boundary decision, including
+  `mb connect`, skill/playbook UX, SecretStore/Keychain, privacy/redaction,
+  JSON envelope, support-claim, Meta Ads, and image-generation guidance for
+  provider cold starts. Refs MAIN-369, #585.
 - Added a MAIN-366 design for the first compact read-only Meta Ads account
   summary surface, keeping `mb connect` as the readiness rail and routing the
   next paid-channel summary shape toward `mb ads meta summary --json` with raw

--- a/decisions/2026-05-13-provider-cli-api-wrapper-boundary.md
+++ b/decisions/2026-05-13-provider-cli-api-wrapper-boundary.md
@@ -1,0 +1,212 @@
+---
+type: decision
+date: 2026-05-13
+status: accepted
+topic: Provider CLI/API and mb wrapper boundary
+linked_issues:
+  - https://github.com/noontide-co/mainbranch/issues/585
+linked_decisions:
+  - decisions/2026-05-04-sidecar-enrichment-cli-contract.md
+  - decisions/2026-05-04-workspace-repo-sensitive-data-boundaries.md
+  - decisions/2026-05-12-meta-ads-cli-readiness.md
+  - decisions/2026-05-13-creative-media-generation-rails.md
+linked_docs:
+  - docs/dependency-choices.md
+  - docs/agent-cold-start.md
+participants: [Devon, Codex]
+tags: [providers, integrations, cli, connect, privacy, product-boundary]
+---
+
+# Provider CLI/API And mb Wrapper Boundary
+
+## Decision
+
+Use provider CLIs, APIs, MCP servers, SDKs, and dashboards as raw capability.
+Use `mb` wrappers only when Main Branch needs to turn that capability into a
+safe, stable business primitive. Use skills and playbooks for the
+human-friendly workflow on top.
+
+The default path is:
+
+```text
+provider CLI/API = raw capability
+mb wrapper = safe, stable business primitive
+agent skill/playbook = human-friendly workflow
+```
+
+Provider tools are right for discovery, dogfood, debugging, and one-off
+operator smoke. Build an `mb` wrapper when the workflow needs repeatability,
+privacy boundaries, stable JSON, approval gates, tests, cross-runtime behavior,
+or product support claims.
+
+## Wrapper Rule
+
+Build an `mb` wrapper when **three or more** of these are true:
+
+- the workflow will be repeated;
+- agents need to consume the output;
+- raw provider output may leak private data;
+- the result needs stable JSON;
+- the workflow should work across Claude Code, Codex, and future runtimes;
+- the workflow needs approval gates;
+- the workflow will show up in docs, skills, or release claims;
+- the command is part of the product promise.
+
+Use the provider CLI/API directly when:
+
+- the team is still discovering what data exists;
+- it is a one-off debug or dogfood check;
+- the provider output is small and safe;
+- there is no stable product workflow yet;
+- only a developer or operator will run it;
+- Main Branch is not ready to own support for the surface.
+
+This rule is a decision aid, not an automatic promotion. A wrapper still needs
+the validation evidence appropriate to its risk: focused CLI tests, safe
+fixtures, read-only or mutation smoke, package/fixture/runtime checks when the
+changed surface requires them, and public-safe evidence in the PR.
+
+## Relationship To mb connect
+
+`mb connect` owns setup, credential routing, readiness, repair, and safe
+connection metadata. It should answer:
+
+1. Is the provider path known?
+2. Is the local tool installed when one is required?
+3. Are credentials available without exposing secret values?
+4. Can the safest health check or read smoke pass?
+5. What exact next command repairs the first missing requirement?
+
+Do not overload `mb connect` with every provider workflow. Once a provider is
+ready, repeated domain work should move into a specific wrapper such as
+`mb ads meta summary`, `mb books ...`, `mb site check`, or a future narrow
+command family. `mb connect` should keep reporting readiness and repair facts
+that those wrappers can trust.
+
+Safe repo metadata may record provider ids, setup state, non-sensitive labels,
+credential backend names, and readiness timestamps. It must not record tokens,
+refresh tokens, API keys, service-account JSON, raw account exports, raw
+customer/member data, or private local paths.
+
+## Relationship To Skills And Playbooks
+
+Skills and playbooks are the chat UX and judgment layer. They may call `mb`
+wrappers for facts, then translate those facts into plain business guidance.
+They should not reimplement provider readiness, auth checks, raw-output
+redaction, or JSON normalization in prose.
+
+A skill may call a provider CLI/API directly when the work is exploratory,
+operator-approved for the current run, and not a Main Branch support claim.
+When that direct call starts appearing in repeatable docs, skill prose,
+release evidence, or cross-runtime workflows, the wrapper rule applies.
+
+Provider mutation, publishing, spending, customer contact, and account changes
+need explicit operator approval at the workflow boundary. Repo files can
+record intent or approval notes, but authority comes from the provider account,
+the operator, and the local secret/session context.
+
+## Secrets And Privacy
+
+Credentials never belong in chat, markdown, GitHub issues, PR bodies, fixtures,
+committed `.mb/` files, or public evidence.
+
+Supported credential homes are:
+
+- `SecretStore` / OS keychain when `mb` owns the setup path;
+- provider-native local auth stores when the provider CLI owns auth;
+- environment variables for the current local process;
+- GitHub Actions secrets only when a hosted-runner workflow is explicitly
+  accepted for that provider.
+
+Raw provider payloads, raw account exports, account-private IDs, customer or
+member rows, private analytics, raw ledgers, screenshots containing private
+account context, and local absolute paths should stay in ignored scratch,
+private operator storage, or the provider system. Public docs and PRs should
+record sanitized summaries, exit codes, result shapes, redaction behavior, and
+safe next commands.
+
+## JSON Envelope Expectations
+
+An `mb` wrapper that emits machine-readable provider facts should use the
+shared `mb.json_result` envelope pattern unless a more specific accepted
+contract says otherwise. Keep command-specific payloads small and stable, and
+include enough metadata for agents and future dashboards to decide whether the
+output can be reused.
+
+Provider wrapper JSON should usually include:
+
+- command and schema metadata through the shared result envelope;
+- `ok`, `result_status`, `errors`, `warnings`, and `actions`;
+- provider id and checked timestamp;
+- readiness state and repair command when not ready;
+- privacy flags such as whether raw payloads were written, tracked files were
+  changed, ids were redacted, or exact private values were included;
+- `safe_to_share` when the output could be copied into chat, issues, docs, or
+  tracked files;
+- bounded domain facts rather than raw provider dumps;
+- provenance for direct provider reads when useful.
+
+`safe_to_share: false` is valid and often correct. It means the output may be
+useful in the operator's local session after approval, but should not be copied
+into public issues, PRs, docs, or committed business files.
+
+## Support Claims
+
+Main Branch may describe a provider path as:
+
+- **direct/provider-native** when operators or agents can use the provider tool
+  outside Main Branch, with no Main Branch support claim;
+- **readiness** when `mb connect` can identify setup state and repair path;
+- **read-only wrapper** when `mb` owns a bounded safe read with stable JSON and
+  smoke evidence;
+- **mutation-gated wrapper** only when preview/dry-run behavior, approval
+  gates, provider authority, failure handling, tests, and safe-account smoke
+  exist;
+- **unsupported, planned, candidate, or reference** when the evidence is not
+  enough for a stronger claim.
+
+Do not promote support language because a provider CLI exists, a maintainer ran
+a local smoke, or a skill can paste a command. Promote only when Main Branch
+owns the wrapper contract, docs, tests, and public-safe evidence for the exact
+surface being claimed.
+
+## Examples
+
+### Meta Ads
+
+Direct Meta CLI use was right for MAIN-366 / #581 dogfood. It proved the
+official `meta-ads` / `meta` path, setup requirements, auth status behavior,
+and read-only command surface without making Main Branch own account summaries
+yet.
+
+`mb connect meta` is right for readiness because the user needs safe credential
+storage, setup state, repair commands, and read-smoke status. It should store
+tokens through `SecretStore`, keep `.mb/connect.yaml` to safe metadata, and
+surface the same provider state to `mb status --json --peek`.
+
+`mb ads meta summary --json` is right for MAIN-367 because agents need a
+compact, safe, repeatable, privacy-bounded account summary across runtimes. The
+wrapper should ask before live reads, avoid raw payloads and tracked caches,
+redact account IDs, keep `safe_to_share: false`, and use the shared JSON result
+envelope.
+
+Meta campaign, ad set, ad, creative, budget, pixel, catalog, page, or audience
+mutation remains unsupported until a separate mutation-gated wrapper has
+approval gates, authority checks, tests, and safe-account smoke.
+
+### Image Generation
+
+Direct provider calls are fine for fake-asset smoke and current-run creative
+experiments. They are not enough for a Main Branch image-generation support
+claim.
+
+Main Branch should only claim a supported image rail once artifact records,
+media storage boundaries, credential handling, approval language, cost
+visibility, provider/model metadata, and smoke evidence exist. Until then,
+skills may write prompts and output records, use prompt-only/manual fallback,
+or call an approved provider for the current run without presenting it as a
+stable Main Branch provider wrapper.
+
+OpenAI GPT Image 2 is the first static-image readiness target from the creative
+media decision, but that target still needs setup detection, approval copy, and
+fixture-safe smoke before support language moves beyond candidate/readiness.

--- a/docs/agent-cold-start.md
+++ b/docs/agent-cold-start.md
@@ -80,6 +80,7 @@ you are changing.
 | Trigger | Read |
 | --- | --- |
 | Product direction, roadmap, workflow shape, dashboard, provider choice, dependency choice, setup policy | `docs/roadmap.md`, `docs/operator-loops.md`, relevant `decisions/`, relevant PRD under `docs/prd/`, `docs/dependency-choices.md` when dependencies or provider rails are in play |
+| Provider wrappers, connectors, media rails, external CLIs/APIs, or support claims | `decisions/2026-05-13-provider-cli-api-wrapper-boundary.md`, `docs/dependency-choices.md`, relevant provider decisions, and the relevant skill or playbook docs |
 | CLI/runtime boundary, runtime support claim, adapter behavior | `decisions/2026-05-01-mb-cli-vs-agent-workflows-boundary.md`, `docs/compatibility.md`, `docs/claude-code-runtime-dogfood.md` when Claude Code evidence matters |
 | Skills or generated runtime guidance | relevant `.claude/skills/<name>/SKILL.md`, its `references/`, generated templates under `templates/`, nearby skill validation tests or fixtures |
 | First-run, package install, skill discovery, `mb init`, `mb onboard`, `mb status`, `mb start`, `mb update` | `docs/release-simulations.md`, `docs/release-agent-contract.md`, package/install smoke contract in `AGENTS.md`, relevant CLI tests |

--- a/docs/dependency-choices.md
+++ b/docs/dependency-choices.md
@@ -65,6 +65,13 @@ This keeps the daily loop coherent. Users think in bets, pushes, playbooks,
 outcomes, and checkpoints. `mb` checks whether the rails are ready. Provider
 tools and sidecars do narrow jobs behind explicit contracts.
 
+When the question is specifically whether an agent should call a provider
+CLI/API directly or Main Branch should build an `mb` wrapper, use the
+[provider CLI/API and `mb` wrapper boundary decision](../decisions/2026-05-13-provider-cli-api-wrapper-boundary.md).
+The short rule: provider tools are raw capability; `mb` wrappers are safe,
+stable business primitives; skills and playbooks are the human-friendly
+workflow layer.
+
 ## Decision Rubric
 
 Use this rubric before adding, promoting, replacing, or removing a dependency.
@@ -174,7 +181,7 @@ why a tool disappeared.
 | 2026-05-04 | Workspace docs and sheets | Google Workspace | Planned optional provider | Many operators already have Docs, Sheets, and Drive source material. Main Branch should ingest or reference that material without making Google the source of memory. | Treat Google Workspace as source/input and provider metadata; durable summaries and decisions flow back into the business repo. | Follow-up issue needed |
 | 2026-05-04 | GitHub-native task and release flow | GitHub CLI | Adopted core operational dependency | GitHub issues, pull requests, releases, and auth are central public primitives; `gh` is inspectable, scriptable, and already expected by contributor and issue-drafting flows. | Keep browser/manual fallbacks for user-facing issue submission where needed; use `gh` for GitHub truth and mutations in agent workflows. | [#264](https://github.com/noontide-co/mainbranch/issues/264) |
 | 2026-05-11 | Repo setup, visibility, and checks model | GitHub repo/PR/checks rail, Cloudflare site/DNS/deploy rail, `mb` local checks, no GitHub Pages | Adopted product stance | One clean default path beats every fallback. Setup, site, and dependency docs need to agree that GitHub is for source/history/collaboration/PRs/checks, Cloudflare is for site/DNS/deploy, `mb` owns local checks, and public deploy does not require public source. GitHub organizations can be free; org does not imply paid. | Apply the visibility rubric in `/mb-setup` and `/mb-site` (default private; ask one visibility question for site repos). Layer checks locally first via `mb`; reuse the same rules in GitHub Actions and branch protection when a team repo wants them. See [the setup-and-checks decision](../decisions/2026-05-11-repo-setup-visibility-and-checks-model.md). | [#477](https://github.com/noontide-co/mainbranch/issues/477) |
-| 2026-05-07 | Provider/tool boundary | Build vs wrap vs sidecar rule | Adopted docs rule | Main Branch needs one public rule for when to use an external CLI/API/MCP directly, wrap it through `mb`, build an optional sidecar, promote behavior into core, or leave the surface manual or declined. | Apply the rule above before adding provider dependencies, sidecars, or support claims. Create follow-up implementation issues only when concrete smoke evidence or a specific user loop justifies them. | [#366](https://github.com/noontide-co/mainbranch/issues/366) |
+| 2026-05-13 | Provider/tool boundary | Provider CLI/API vs `mb` wrapper rule | Adopted decision | Main Branch needs one public rule for when to use an external CLI/API/MCP directly, wrap it through `mb`, build an optional sidecar, promote behavior into core, or leave the surface manual or declined. | Apply the [provider wrapper boundary decision](../decisions/2026-05-13-provider-cli-api-wrapper-boundary.md) before adding provider dependencies, sidecars, or support claims. Create follow-up implementation issues only when concrete smoke evidence or a specific user loop justifies them. | [#585](https://github.com/noontide-co/mainbranch/issues/585) |
 
 ## Related Public Contracts
 
@@ -192,5 +199,8 @@ why a tool disappeared.
   roadmap runtime surfaces.
 - [Sidecar enrichment CLI contract](../decisions/2026-05-04-sidecar-enrichment-cli-contract.md)
   defines how optional sidecars should integrate.
+- [Provider CLI/API and `mb` wrapper boundary](../decisions/2026-05-13-provider-cli-api-wrapper-boundary.md)
+  defines when raw provider capability should stay direct and when Main Branch
+  should own a stable wrapper.
 - [Workspace, repo, and sensitive-data boundaries](../decisions/2026-05-04-workspace-repo-sensitive-data-boundaries.md)
   defines where secrets, finance/legal data, and provider authority belong.


### PR DESCRIPTION
## Summary

Adds an accepted provider CLI/API vs `mb` wrapper boundary decision so future provider, connector, media, and external CLI work has one findable rule. The change also links cold-start and dependency-choice guidance to that decision and records the workflow-doc update in the changelog.

## Linked issue

Closes #585 / MAIN-369
Refs #581 / MAIN-366
Refs #582 / MAIN-367
Refs #569 / MAIN-362

## Why

Agents keep needing to decide whether a workflow should call a provider surface directly or become an `mb` wrapper. This PR makes the rule durable: provider CLIs/APIs are raw capability, `mb` wrappers are safe stable business primitives, and skills/playbooks are the human workflow layer.

## Commits by concern

- [x] `6e50bb3 [add] MAIN-369 provider wrapper boundary`
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`

## Validation

Pre-push gate from repo root:

```bash
scripts/check.sh
```

Level 1 static: `scripts/check.sh` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: excerpt `660 passed in 231.23s`; formatting, type checks, coverage, and `mb skill validate` also passed.
Level 2 CLI contract: not required; no CLI behavior, exit-code, JSON, TTY, or non-TTY surface changed.
Level 3 package/install smoke: not required; no packaging, entrypoint, or bundled data behavior changed.
Level 4 fixture repo: not required; no init/onboard/status/start/update or repo-shape behavior changed.
Level 5 runtime smoke / dogfood harness / simulation-tier: not required; no runtime discovery, skill invocation, first-run, or release-validation behavior changed.
SKILL.md line gate: not required for changed files; `scripts/check.sh` still ran skill validation and passed.
Package-visible release gate evidence: not required; this is not a release-prep branch.
Supply-chain review: not required; no workflow, dependency, `id-token`, or permissions files changed.

- [x] Level 1 static: `scripts/check.sh` passes
- [x] Level 2 CLI contract: focused Typer/CliRunner tests, exit codes, `--json` behavior, TTY vs non-TTY (if CLI behavior touched)
- [x] Level 3 package/install smoke (if packaging touched)
- [x] Level 4 fixture repo (if init/onboard/status/start/update touched)
- [x] Level 5 runtime smoke / dogfood harness / simulation-tier (if runtime, first-run, skill discovery, or release validation touched)
- [x] SKILL.md ≤500 lines (if any skill touched)
- [x] Package-visible release gate evidence before tag/publish (if preparing a release)
- [x] Supply-chain review (if `.github/workflows/`, `.github/dependabot.yml`, `mb/pyproject.toml` deps, or `id-token`/`permissions` blocks touched — see [docs/supply-chain-policy.md](../docs/supply-chain-policy.md))

## Success metric

A future provider, connector, media, or external CLI cold start points agents to `decisions/2026-05-13-provider-cli-api-wrapper-boundary.md` before inventing a new `mb` surface or making a support claim.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [ ] N/A — change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [x] No
- [ ] Yes — migration note below

## Public / private boundary

No private operator strategy, machine-specific paths, secrets, provider credentials, raw account data, customer/member data, or Conductor private preferences were committed. The PR changes only public docs, one accepted decision, and the changelog.
