### PR TITLE
[update] Prepare v0.3.21 release

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mainbranch",
-  "version": "0.3.20",
+  "version": "0.3.21",
   "description": "Main Branch Claude Code skills for running a business from markdown files in git.",
   "author": {
     "name": "Noontide"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,20 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+## [0.3.21] - 2026-05-13
+
+v0.3.21 packages the first compact read-only Meta Ads readiness and summary
+rail, the hledger-backed sample monthly books report, shared `/mb-think`
+workflow shells for Claude and Codex, provider wrapper boundary guidance, and
+release-simulation owner-language hardening.
+
 ### Added
 
+- Added an accepted creative media generation rails decision for MAIN-282,
+  classifying static image providers, deterministic motion/export rails, AI
+  video providers, and platform creative tools as recommended, candidate, or
+  refused while keeping provider support claims behind setup detection,
+  approval gates, smoke evidence, and artifact metadata. Refs #409.
 - Added a durable provider CLI/API vs `mb` wrapper boundary decision, including
   `mb connect`, skill/playbook UX, SecretStore/Keychain, privacy/redaction,
   JSON envelope, support-claim, Meta Ads, and image-generation guidance for
@@ -53,6 +65,15 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ### Changed
 
+- Refreshed always-read cold-start docs after v0.3.20 so README, roadmap,
+  ethos, and operator-loop language stay aligned with package-visible books
+  readiness while leaving sample reporting under `[Unreleased]`, and use
+  saved-checkpoint language where normal owner copy should avoid raw git
+  wording. Refs MAIN-365, #577.
+- Updated release-simulation scoring and `/mb-start` owner-language guidance so
+  normal answers translate raw git/GitHub status phrases before speaking, while
+  allowing ordinary phrasing such as "only commit summaries." Refs MAIN-364,
+  #575.
 - Updated `/mb-ads` Meta account guidance so agents ask before pulling a
   compact read-only account summary, continue from repo files, screenshots, or
   manual Ads Manager notes when Meta is not ready, and avoid implying raw
@@ -67,6 +88,10 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   OpenAI-first ad-volume cost math, and a deterministic video/motion CLI
   boundary that keeps raw generative video out of the first rail. Refs
   MAIN-362, #569.
+- Updated `/mb-ads` image-generation guidance to stop hard-coding a single
+  Gemini model or private local environment path, require provider/model
+  metadata in image indexes, and fall back to saved prompts when no approved
+  image provider is configured. Refs MAIN-282, #409.
 
 ## [0.3.20] - 2026-05-13
 
@@ -80,11 +105,6 @@ guidance.
 
 ### Added
 
-- Added an accepted creative media generation rails decision for MAIN-282,
-  classifying static image providers, deterministic motion/export rails, AI
-  video providers, and platform creative tools as recommended, candidate, or
-  refused while keeping provider support claims behind setup detection,
-  approval gates, smoke evidence, and artifact metadata. Refs #409.
 - Added a `/mb-think` research-depth ladder for offer, audience, proof,
   product-ladder, CTA, content strategy, ads/page launch, market positioning,
   and influence/playbook work, including enough-signal thresholds, stop rules,
@@ -135,19 +155,6 @@ guidance.
 
 ### Changed
 
-- Refreshed always-read cold-start docs after v0.3.20 so README, roadmap,
-  ethos, and operator-loop language stay aligned with package-visible books
-  readiness while leaving sample reporting under `[Unreleased]`, and use
-  saved-checkpoint language where normal owner copy should avoid raw git
-  wording. Refs MAIN-365, #577.
-- Updated release-simulation scoring and `/mb-start` owner-language guidance so
-  normal answers translate raw git/GitHub status phrases before speaking, while
-  allowing ordinary phrasing such as "only commit summaries." Refs MAIN-364,
-  #575.
-- Updated `/mb-ads` image-generation guidance to stop hard-coding a single
-  Gemini model or private local environment path, require provider/model
-  metadata in image indexes, and fall back to saved prompts when no approved
-  image provider is configured. Refs MAIN-282, #409.
 - Refreshed the README, roadmap, and ethos around the chat-first, CLI-backed
   operating loop: repo truth feeds deterministic `mb` facts, skills/agents
   explain and route in chat, operators approve sensitive action, and accepted

--- a/mb/mb/__init__.py
+++ b/mb/mb/__init__.py
@@ -7,6 +7,6 @@ file stays a thin dispatcher.
 
 from __future__ import annotations
 
-__version__ = "0.3.20"
+__version__ = "0.3.21"
 
 __all__ = ["__version__"]

--- a/mb/pyproject.toml
+++ b/mb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mainbranch"
-version = "0.3.20"
+version = "0.3.21"
 description = "Main Branch engine umbrella - scaffolds, validates, and graphs business-as-files repos. Claude Code first, runtime-agnostic by design."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
<!--
  Thanks for contributing to Main Branch.

  See CONTRIBUTING.md for branch + PR shape, concern-based commit
  organization, and pre-push gates. Keep PRs scoped — one logical
  change per PR, ideally 3–5 commits by concern.
-->

## Summary

Prepares the v0.3.21 package release by moving included post-v0.3.20 work into a dated changelog section and bumping the package, module, and Claude plugin version metadata to `0.3.21`.

## Linked issue

Refs #590
Refs #591

## Why

The latest published GitHub Release, tag, and PyPI package are still `0.3.20`, while `main` now contains completed work that should ship in v0.3.21. This PR makes the release candidate explicit without tagging or publishing before the release-prep commit lands on `main`.

## Commits by concern

- [ ] Each commit body bullet-lists the changes in that commit
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`

Commits:

- `5a0a257 [update] MAIN-371 prepare v0.3.21 release`

## Validation

Pre-push gate from repo root:

```bash
scripts/check.sh
```

Level 0 release truth: verified latest published GitHub Release/tag/PyPI state is `0.3.20` / `oe-v0.3.20`; inspected merged PRs since `oe-v0.3.20`: #571, #572, #574, #576, #578, #579, #580, #584, #586, #588, #589.

Level 1 release-file preflight: `cd mb && python3 -m pytest tests/test_smoke_coverage.py::test_claude_plugin_manifest_points_at_prefixed_skills -q` — runtime: `python3` — exit: 0 — log: `.agent/release-evidence/0.3.21/release-preflight.out` (`1 passed`).

Level 1 static: `scripts/check.sh` — runtime: `python3` — exit: 0 — log: `.agent/release-evidence/0.3.21/check.out` (repo gate and bundled skill validation passed).

Level 2 installed CLI smoke: `mb --version`, `mb skill list`, `mb skill validate --all`, `mb books report monthly --sample --month 2026-01 --json`, `mb books check --fixture --json`, `mb ads meta summary --repo <fixture> --window 7d --json`, and `mb connect test meta --repo <fixture> --json` from the fresh wheel install — runtime: fresh venv Python — exit: 0 for successful commands, with the Meta summary returning the expected safe not-connected error state — logs: `.agent/release-evidence/0.3.21/installed-*.out`.

Level 3 package/install: `cd mb && python3 -m build` plus fresh venv install of `mainbranch-0.3.21-py3-none-any.whl` — runtime: `python3` / fresh venv Python — exit: 0 — logs: `.agent/release-evidence/0.3.21/build.out`, `.agent/release-evidence/0.3.21/install.out`.

Level 4 fixture repo: installed-package `mb onboard --yes`, `mb doctor`, `mb status`, `mb start --json`, and `mb validate` on a disposable business repo — runtime: fresh venv `mb` — exit: 0 — log: `.agent/release-evidence/0.3.21/fixture-smoke.out`.

Level 5 release simulation: `scripts/claude-runtime-dogfood.py --install-mode wheel --wheel mb/dist/mainbranch-0.3.21-py3-none-any.whl --run-claude-print --simulation-tier prerelease_candidate --max-budget-usd 0.75` — runtime: `python3`, Claude Code 2.1.140 print-mode proxy — exit: 0 — log/evidence: `.agent/release-evidence/0.3.21/prerelease-candidate.log` and `prerelease-candidate/evidence-template.md` (no permission denials, no read-only `mb` grounding denials, no engine repo boundary violation, 11/11 heuristic checks).

Level 5 release acceptance candidate: `scripts/claude-runtime-dogfood.py --install-mode wheel --wheel mb/dist/mainbranch-0.3.21-py3-none-any.whl --run-claude-print --simulation-tier release_acceptance --max-budget-usd 0.75` — runtime: `python3`, Claude Code 2.1.140 print-mode proxy — exit: 0 — log/evidence: `.agent/release-evidence/0.3.21/release-acceptance-candidate.log` and `release-acceptance-candidate/evidence-template.md` (no permission denials, no read-only `mb` grounding denials, no engine repo boundary violation, 11/11 heuristic checks).

Supply-chain review: workflow permission scan unchanged; Dependabot open alerts returned `[]`; `pypi` GitHub Environment has required reviewer protection. Post-publish PyPI install and release-acceptance verification are not run yet because v0.3.21 is not published until after this release-prep commit is merged and the GitHub Release workflow completes.

Manual transcript review: print-mode proxy runs still show owner-language quality leaks around phrases like `repo is clean`, `on main`, `origin remote`, plus one vague checkpoint note example. No write/privacy/runtime/provider/repo-boundary failure occurred; follow-up routed to #591.

- [x] Level 1 static: `scripts/check.sh` passes
- [x] Level 2 CLI contract: focused Typer/CliRunner tests, exit codes, `--json` behavior, TTY vs non-TTY (if CLI behavior touched)
- [x] Level 3 package/install smoke (if packaging touched)
- [x] Level 4 fixture repo (if init/onboard/status/start/update touched)
- [x] Level 5 runtime smoke / dogfood harness / simulation-tier (if runtime, first-run, skill discovery, or release validation touched)
- [x] SKILL.md ≤500 lines (if any skill touched)
- [x] Package-visible release gate evidence before tag/publish (if preparing a release)
- [x] Supply-chain review (if `.github/workflows/`, `.github/dependabot.yml`, `mb/pyproject.toml` deps, or `id-token`/`permissions` blocks touched — see [docs/supply-chain-policy.md](../docs/supply-chain-policy.md))

## Success metric

After merge, `main` has a coherent v0.3.21 release candidate: version metadata agrees, the changelog describes only merged post-v0.3.20 work, local package-visible gates pass, and the release owner can create `oe-v0.3.21` from the merged commit.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section into the dated `0.3.21` release section, OR
- [ ] N/A — change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [x] No
- [ ] Yes — migration note below

## Public / private boundary

No private operator strategy, machine-specific paths, credentials, account data, raw provider payloads, raw transcripts, or private business context were committed. Release evidence is summarized in public-safe form; detailed local artifacts remain under ignored `.agent/` evidence paths.
