### PR TITLE
[docs] Align docs after v0.3.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+### Changed
+
+- Aligned post-v0.3.21 roadmap and bookkeeping docs so the sample monthly books
+  report and Meta Ads read-only summary are described as shipped, while
+  private-vault reporting, imports, reconciliation, and provider mutation remain
+  deferred. Refs #590.
+
 ## [0.3.21] - 2026-05-13
 
 v0.3.21 packages the first compact read-only Meta Ads readiness and summary

--- a/docs/books.md
+++ b/docs/books.md
@@ -11,6 +11,9 @@ function is bookkeeping.
 - Main Branch ships the first safe `mb books` setup surfaces:
   `check`, `status`, and `doctor --plan`. They validate and explain
   bookkeeping safety without reading any real ledger contents.
+- Main Branch also ships a fake-data sample monthly report:
+  `mb books report monthly --sample --month YYYY-MM`. It uses packaged fixture
+  data, not the operator's private books.
 - **Main Branch uses hledger as the bookkeeping engine for `mb books`.**
   The hledger journal is the only authoritative ledger.
 - hledger is **optional** for base `mb` installs, but it is the chosen
@@ -210,6 +213,12 @@ mb books status [REPO] [--json]
 mb books doctor [REPO] --plan [--json]
 ```
 
+The shipped sample reporting surface is:
+
+```bash
+mb books report monthly --sample --month YYYY-MM [--json]
+```
+
 `mb books check` runs read-only checks against a business repo. It:
 
 - detects whether `core/finance/books.md` exists and parses (including
@@ -272,6 +281,12 @@ It does not apply repairs yet. The plan is designed for operator
 review and avoids printing private external vault paths or real
 financial data.
 
+`mb books report monthly --sample` generates a beginner-safe monthly report
+from packaged fake hledger data. It validates the bundled fixture with hledger
+when available, emits stable JSON with `--json`, redacts fixture internals that
+should not train operators to paste private paths or account identifiers, and
+keeps `safe_to_share: true` because the data is synthetic.
+
 Exit codes:
 
 - `mb books check`: `0` when there are no error findings (info or
@@ -283,6 +298,8 @@ Exit codes:
 - `mb books doctor --plan`: `0` after printing a plan. Running
   `mb books doctor` without `--plan` exits `2` because applying
   repairs is not implemented.
+- `mb books report monthly --sample`: `0` when the sample report is generated;
+  `1` for report-generation errors such as an invalid month or missing fixture.
 
 It does **not**:
 
@@ -294,8 +311,8 @@ It does **not**:
 - mutate any file.
 
 Later slices may add real imports, reconciliation, month close, or
-fixture-safe reporting only after separate decisions and smoke
-evidence. They are not part of the current command surface.
+private-vault reporting only after separate decisions and smoke evidence. They
+are not part of the current command surface.
 
 The full first-surface spec lives in
 [the mb books foundation decision](../decisions/2026-05-11-mb-books-foundation.md).

--- a/docs/books.md
+++ b/docs/books.md
@@ -282,8 +282,9 @@ review and avoids printing private external vault paths or real
 financial data.
 
 `mb books report monthly --sample` generates a beginner-safe monthly report
-from packaged fake hledger data. It validates the bundled fixture with hledger
-when available, emits stable JSON with `--json`, redacts fixture internals that
+from packaged fake hledger data through hledger. If hledger is unavailable, the
+command fails with install guidance instead of falling back to a non-hledger
+report. It emits stable JSON with `--json`, redacts fixture internals that
 should not train operators to paste private paths or account identifiers, and
 keeps `safe_to_share: true` because the data is synthetic.
 
@@ -299,7 +300,9 @@ Exit codes:
   `mb books doctor` without `--plan` exits `2` because applying
   repairs is not implemented.
 - `mb books report monthly --sample`: `0` when the sample report is generated;
-  `1` for report-generation errors such as an invalid month or missing fixture.
+  `1` for generation failures such as missing hledger or missing fixture;
+  `2` for usage errors such as missing `--sample`, missing `--month`, or an
+  invalid month.
 
 It does **not**:
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -38,6 +38,13 @@ Main Branch already ships:
   plus `mb books check`, `mb books status`, and `mb books doctor --plan` for
   privacy-bounded setup checks without reading ledgers or exposing private
   vault paths;
+- the first hledger-backed sample monthly books report through
+  `mb books report monthly --sample --month YYYY-MM`, using packaged fake data
+  so operators can see the report shape without exposing real books;
+- Meta Ads read-only readiness through `mb connect meta` /
+  `mb connect test meta --json`, plus compact `mb ads meta summary --json`
+  account context after the operator has configured the official Meta Ads CLI
+  path;
 - privacy-safe GitHub issue drafting and submission (`mb issue draft`,
   `mb issue open`) for user friction;
 - push, reusable playbook, and per-push run-record vocabulary for coordinated
@@ -112,12 +119,14 @@ The work clusters into a few durable buckets:
   synthesis only when the decision justifies the time, tokens, and permissions.
 - **Books readiness and reporting.** hledger is the accounting engine, `mb
   books` is the privacy, JSON, and workflow wrapper, and skills are the chat UX.
-  Next direction is fake-data sample reporting before private-vault reports,
-  imports, reconciliation, or close workflows.
-- **Provider rails.** Cloudflare, GitHub, Google/Workspace, ads providers,
-  Apify, Postiz-style social scheduling, and future sidecars should enter
-  through explicit, tested rails with approval gates where money, publishing,
-  account mutation, or customer contact is involved.
+  Fake-data sample monthly reporting is shipped; next direction is
+  private-vault reports, imports, reconciliation, or close workflows only after
+  separate privacy and smoke evidence.
+- **Provider rails.** Cloudflare, GitHub, Google/Workspace, Meta Ads, Apify,
+  Postiz-style social scheduling, and future sidecars should enter through
+  explicit, tested rails with approval gates where money, publishing, account
+  mutation, or customer contact is involved. Meta Ads has read-only readiness
+  and compact summary rails; broader provider mutation remains out of scope.
 - **Issue and friction capture.** Confusing errors, missing workflows, and
   repeated repair steps should turn into privacy-safe issue drafts so real use
   improves the public engine.


### PR DESCRIPTION
<!--
  Thanks for contributing to Main Branch.

  See CONTRIBUTING.md for branch + PR shape, concern-based commit
  organization, and pre-push gates. Keep PRs scoped — one logical
  change per PR, ideally 3–5 commits by concern.
-->

## Summary

Aligns post-v0.3.21 docs so the shipped sample monthly books report and Meta Ads read-only summary are described in present tense, while private-vault reporting, imports, reconciliation, and provider mutation stay deferred.

## Linked issue

Refs #590

## Why

The v0.3.21 release shipped a fake-data books report and Meta Ads read-only summary rails, but the durable roadmap and bookkeeping docs still carried pre-release wording. This sweep keeps the always-read product surfaces aligned with the published package without widening release scope.

## Commits by concern

- [ ] Each commit body bullet-lists the changes in that commit
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`

Commits:

- `f0fda9b [docs] Align docs after v0.3.21 release`

## Validation

Pre-push gate from repo root:

```bash
scripts/check.sh
```

Level 0 docs/release-truth review: `git diff origin/main... --stat` and targeted diff review — runtime: shell — exit: 0 — log: 3 docs files changed (`CHANGELOG.md`, `docs/books.md`, `docs/roadmap.md`) and no code/package files touched.

Level 0 whitespace: `git diff --check` — runtime: shell — exit: 0 — log: no whitespace errors.

Level 1 static: `scripts/check.sh` — runtime: `python3` — exit: 0 — log: `.agent/post-release-alignment-0.3.21/check.out` (repo gate and bundled skill validation passed).

Level 2 CLI contract: not required; this PR changes docs and changelog only, with no Typer behavior, exit codes, JSON output, or TTY/non-TTY behavior changed.

Level 3 package/install smoke: not required; no packaging, entrypoint, bundled data, update, or install behavior changed.

Level 4 fixture repo: not required; no init/onboard/status/start/update fixture behavior changed.

Level 5 runtime smoke / dogfood harness / simulation-tier: not required; no runtime discovery, first-run behavior, skill behavior, or release-validation behavior changed.

- [x] Level 1 static: `scripts/check.sh` passes
- [ ] Level 2 CLI contract: focused Typer/CliRunner tests, exit codes, `--json` behavior, TTY vs non-TTY (if CLI behavior touched)
- [ ] Level 3 package/install smoke (if packaging touched)
- [ ] Level 4 fixture repo (if init/onboard/status/start/update touched)
- [ ] Level 5 runtime smoke / dogfood harness / simulation-tier (if runtime, first-run, skill discovery, or release validation touched)
- [ ] SKILL.md ≤500 lines (if any skill touched)
- [ ] Package-visible release gate evidence before tag/publish (if preparing a release)
- [ ] Supply-chain review (if `.github/workflows/`, `.github/dependabot.yml`, `mb/pyproject.toml` deps, or `id-token`/`permissions` blocks touched — see [docs/supply-chain-policy.md](../docs/supply-chain-policy.md))

## Success metric

Agents and contributors reading the roadmap or bookkeeping docs after v0.3.21 see the sample books report and Meta Ads read-only summary as shipped surfaces, while still seeing private books reports and provider mutation as future work.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [ ] N/A — change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [x] No
- [ ] Yes — migration note below

## Public / private boundary

No private operator strategy, machine-specific paths, credentials, account data, raw provider payloads, raw transcripts, or private business context were committed. This is docs-only post-release alignment using public release facts.
