### PR TITLE
[add] mb image smoke-openai rail

### DIFF
--- a/.claude/skills/mb-ads/SKILL.md
+++ b/.claude/skills/mb-ads/SKILL.md
@@ -146,10 +146,10 @@ Display the readiness report, then proceed. See [references/preflight-algorithm.
 mb connect doctor --json
 ```
 
-Use status/connect facts first for Google/Workspace readiness. Only check local
-environment variables when image generation is actually selected and the CLI
-does not report that capability. Never ask the operator to paste API keys into
-chat or public issue text.
+Use status/connect facts first for Google/Workspace readiness. For the first
+OpenAI rail smoke, use `mb image smoke-openai --repo "$BUSINESS_REPO" --json`; see [references/image-generation-workflow.md](references/image-generation-workflow.md)
+for the `--generate`, credential, media-storage, and `image-index.md` boundary.
+Never ask the operator to paste API keys into chat or public issue text.
 
 ### 0e. Paid-Traffic Measurement Gate
 

--- a/.claude/skills/mb-ads/references/image-generation-workflow.md
+++ b/.claude/skills/mb-ads/references/image-generation-workflow.md
@@ -106,16 +106,28 @@ mb image edit --prompt "..." --ref-image mb-media://brand/logo.png --out mb-medi
 mb image edit --prompt "..." --ref-image mb-media://pushes/2026-05-ad-test/references/product.webp --mask mb-media://pushes/2026-05-ad-test/references/mask.png --out mb-media://pushes/2026-05-ad-test/images/hero-003.png
 ```
 
-This shape is a decision recommendation, not a shipped command claim.
+This generate/edit shape is a decision recommendation, not a shipped command
+claim. The first shipped smoke surface is narrower:
+
+```bash
+mb image smoke-openai --repo "$BUSINESS_REPO" --json
+mb image smoke-openai --repo "$BUSINESS_REPO" --generate --json
+```
+
+Run without `--generate` to create a safe blocked record. Add `--generate` only
+after the operator approves one fixture-safe provider call and local OpenAI
+credentials are available outside chat and tracked repo files.
 
 ---
 
 ## Generation via Python SDK
 
-The OpenAI Python SDK is the first implementation pattern to smoke for
-MAIN-362. MCP servers, runtime-native image tools, or another SDK can be used
-only when they are configured for the run and the artifact metadata records the
-provider/model.
+The `mb image smoke-openai` command owns the first fixture-safe smoke path.
+When generation is approved, it uses the OpenAI Python SDK shape below and
+writes the binary to configured media storage while committing only the
+push-local `image-index.md` record. MCP servers, runtime-native image tools, or
+another SDK can be used only when they are configured for the run and the
+artifact metadata records the provider/model.
 
 ```python
 import base64

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,12 @@ release-simulation owner-language hardening.
   keeping Google Gemini / Nano Banana, BFL FLUX.2, xAI Imagine, ComfyUI, and
   raw video providers as candidate rails behind separate smoke evidence. Refs
   #569, #409.
+- Added `mb image smoke-openai` as the first fixture-safe OpenAI GPT Image 2
+  rail smoke: it writes a push-local `image-index.md`, records generated or
+  sanitized blocked state, stores binaries only in configured media storage
+  when `--generate` is approved, and keeps `.mb/media/` gitignored by default.
+  The package now depends on the official OpenAI Python SDK for that direct
+  rail. Refs MAIN-370, #587.
 
 ### Changed
 
@@ -90,6 +96,9 @@ release-simulation owner-language hardening.
   OpenAI GPT Image 2 as the first smoke target, configurable media storage
   with safe logical media URIs, reference-image roles, and prompt-only fallback
   when no approved provider is configured. Refs MAIN-362, #569.
+- Updated `/mb-ads` image-generation guidance to route the first real provider
+  proof through `mb image smoke-openai`, including the approved-generation and
+  no-secrets credential boundary. Refs MAIN-370, #587.
 - Added verified MAIN-362 implementation research patterns to the creative
   media decision, including a GitHub reference-repo pattern table,
   OpenAI-first ad-volume cost math, and a deterministic video/motion CLI

--- a/mb/mb/_data/templates/.gitignore.tmpl
+++ b/mb/mb/_data/templates/.gitignore.tmpl
@@ -16,6 +16,7 @@ node_modules/
 .mb/private/
 .mb/backups/
 .mb/connect.yaml
+.mb/media/
 .mb/onboarding.json
 .mb/last-status-seen.json
 .mb/issue-drafts/

--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import json
 import os
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, NoReturn
 
@@ -23,6 +24,7 @@ from mb import connect as connect_mod
 from mb import doctor as doctor_mod
 from mb import educational as educational_mod
 from mb import graph as graph_mod
+from mb import image_rail as image_rail_mod
 from mb import init as init_mod
 from mb import issue as issue_mod
 from mb import migrate as migrate_mod
@@ -116,6 +118,13 @@ ads_meta_app = typer.Typer(
 )
 ads_app.add_typer(ads_meta_app, name="meta")
 
+image_app = typer.Typer(
+    name="image",
+    help="Smoke fixture-safe creative image rails.",
+    no_args_is_help=True,
+)
+app.add_typer(image_app, name="image")
+
 suggest_app = typer.Typer(
     name="suggest",
     help="Suggest read-only business repo improvements.",
@@ -174,6 +183,10 @@ def _render_launch_screen() -> None:
         ]
     )
     typer.echo("\n".join(lines))
+
+
+def _today_utc() -> str:
+    return datetime.now(timezone.utc).date().isoformat()
 
 
 @app.callback()
@@ -1267,6 +1280,64 @@ def site_check_cmd(
     else:
         site_mod.render_check(result)
     raise typer.Exit(0 if result["ok"] else 1)
+
+
+@image_app.command("smoke-openai")
+def image_smoke_openai_cmd(
+    repo: str = typer.Option(
+        ".",
+        "--repo",
+        help="Business repo where the fake push-local image-index.md should be written.",
+    ),
+    push_slug: str = typer.Option(
+        image_rail_mod.DEFAULT_PUSH_SLUG,
+        "--push-slug",
+        help="Fake push slug for the fixture-safe smoke record.",
+    ),
+    docs_checked: str = typer.Option(
+        "",
+        "--docs-checked",
+        help="Provider docs checked date. Defaults to today in UTC.",
+    ),
+    media_root: str = typer.Option(
+        ".mb/media",
+        "--media-root",
+        help="Private media storage root used only when --generate writes a binary.",
+    ),
+    generate: bool = typer.Option(
+        False,
+        "--generate",
+        help="Call OpenAI only when local credentials exist and the operator approved generation.",
+    ),
+    json_out: bool = typer.Option(False, "--json", help="Machine-readable output."),
+) -> None:
+    """Smoke the narrow OpenAI GPT Image 2 rail with fake fixture context."""
+    result = image_rail_mod.smoke_openai(
+        repo=repo,
+        push_slug=push_slug,
+        docs_checked=docs_checked or _today_utc(),
+        media_root=media_root,
+        generate=generate,
+    )
+    if json_out:
+        typer.echo(
+            _json_payload(
+                result,
+                command="image smoke-openai",
+                schema_name="mainbranch.image.smoke_openai.v1",
+            )
+        )
+    elif result["state"] == "generated":
+        typer.echo("OpenAI image rail smoke generated a fixture-safe asset.")
+        typer.echo(f"record: {result['record_path']}")
+        typer.echo(f"media:  {result['output_reference']}")
+        typer.echo("binary committed: false")
+    else:
+        typer.echo("OpenAI image rail smoke blocked safely.")
+        typer.echo(f"record: {result['record_path']}")
+        typer.echo(f"reason: {result['blocker_code']}")
+        typer.echo("I will not ask you to paste provider keys into chat or repo files.")
+    raise typer.Exit(0)
 
 
 @app.command("validate")

--- a/mb/mb/image_rail.py
+++ b/mb/mb/image_rail.py
@@ -6,6 +6,7 @@ import base64
 import importlib
 import importlib.util
 import os
+import struct
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Literal
@@ -91,6 +92,17 @@ def _generate_openai_image(prompt: str, *, model: str, size: str, quality: str) 
     return base64.b64decode(encoded)
 
 
+def _png_dimensions(image_bytes: bytes) -> dict[str, int] | None:
+    if len(image_bytes) < 24:
+        return None
+    if not image_bytes.startswith(b"\x89PNG\r\n\x1a\n"):
+        return None
+    if image_bytes[12:16] != b"IHDR":
+        return None
+    width, height = struct.unpack(">II", image_bytes[16:24])
+    return {"width": width, "height": height}
+
+
 def _asset_record(
     *,
     push_slug: str,
@@ -106,6 +118,7 @@ def _asset_record(
     model: str,
     size: str,
     quality: str,
+    generated_dimensions: dict[str, int] | None,
 ) -> dict[str, Any]:
     return {
         "asset_id": asset_id,
@@ -139,6 +152,12 @@ def _asset_record(
             "aspect_ratio": "2:3",
             "format": "png",
             "quality": quality,
+            "generated_width": (
+                generated_dimensions["width"] if generated_dimensions is not None else None
+            ),
+            "generated_height": (
+                generated_dimensions["height"] if generated_dimensions is not None else None
+            ),
         },
         "output_reference": output_reference,
         "storage_backend": "mb-media",
@@ -196,6 +215,7 @@ def smoke_openai(
     state: SmokeState = "blocked" if blocker_code else "generated"
 
     binary_written = False
+    generated_dimensions: dict[str, int] | None = None
     if state == "generated":
         out_path = _media_path(repo_path, media_root, push_slug, DEFAULT_ASSET_ID)
         out_path.parent.mkdir(parents=True, exist_ok=True)
@@ -215,6 +235,7 @@ def smoke_openai(
                 f"organization verification, quota, model access, and network state."
             )
         else:
+            generated_dimensions = _png_dimensions(image_bytes)
             out_path.write_bytes(image_bytes)
             binary_written = True
 
@@ -239,6 +260,7 @@ def smoke_openai(
                 model=DEFAULT_MODEL,
                 size=DEFAULT_SIZE,
                 quality=DEFAULT_QUALITY,
+                generated_dimensions=generated_dimensions,
             )
         ],
     }
@@ -254,6 +276,13 @@ def smoke_openai(
         "record_path": _repo_relative(index_path, repo_path),
         "output_reference": output_reference,
         "storage_backend": "mb-media",
+        "dimensions": {
+            "requested_size": DEFAULT_SIZE,
+            "aspect_ratio": "2:3",
+            "format": "png",
+            "quality": DEFAULT_QUALITY,
+        },
+        "generated_dimensions": generated_dimensions,
         "binary_written": binary_written,
         "binary_committed": False,
         "safe_to_share": True,

--- a/mb/mb/image_rail.py
+++ b/mb/mb/image_rail.py
@@ -1,0 +1,261 @@
+"""Fixture-safe image rail smoke helpers."""
+
+from __future__ import annotations
+
+import base64
+import importlib
+import importlib.util
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Literal
+
+import yaml
+
+DEFAULT_PUSH_SLUG = "2026-05-13-openai-image-rail-smoke"
+DEFAULT_ASSET_ID = "fake-openai-image-001"
+DEFAULT_MODEL = "gpt-image-2"
+DEFAULT_MODEL_SNAPSHOT = "gpt-image-2-2026-04-21"
+DEFAULT_SIZE = "1024x1536"
+DEFAULT_QUALITY = "medium"
+DEFAULT_TIMEOUT_SECONDS = 60
+DEFAULT_PROMPT = """\
+Create a fixture-safe static ad concept for a fictional business called
+Northstar Ledger. Show an abstract desk scene with a clean notebook, simple
+charts, and warm natural light. Do not include real brands, real people,
+customer data, logos, screenshots, account details, or private information.
+Leave open space near the upper center for a later deterministic text overlay.
+"""
+
+SmokeState = Literal["generated", "blocked"]
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _logical_output(push_slug: str, asset_id: str, extension: str = "png") -> str:
+    return f"mb-media://pushes/{push_slug}/images/{asset_id}.{extension}"
+
+
+def _repo_relative(path: Path, repo: Path) -> str:
+    return path.resolve().relative_to(repo.resolve()).as_posix()
+
+
+def _media_path(repo: Path, media_root: str, push_slug: str, asset_id: str) -> Path:
+    root = Path(media_root).expanduser()
+    if not root.is_absolute():
+        root = repo / root
+    return root / "pushes" / push_slug / "images" / f"{asset_id}.png"
+
+
+def _provider_blocker(generate: bool) -> tuple[str, str]:
+    if not generate:
+        return (
+            "generation_not_approved",
+            (
+                "Provider generation was not requested. Re-run with --generate only after "
+                "the operator approves the provider call and local credential boundary."
+            ),
+        )
+    if not os.environ.get("OPENAI_API_KEY"):
+        return (
+            "missing_openai_api_key",
+            (
+                "OPENAI_API_KEY is not set in the local runtime. Do not paste provider "
+                "keys into chat or committed repo files."
+            ),
+        )
+    if importlib.util.find_spec("openai") is None:
+        return (
+            "missing_openai_package",
+            "The optional openai Python package is not installed in the local runtime.",
+        )
+    return "", ""
+
+
+def _generate_openai_image(prompt: str, *, model: str, size: str, quality: str) -> bytes:
+    openai_mod: Any = importlib.import_module("openai")
+    client = openai_mod.OpenAI()
+
+    response = client.images.generate(
+        model=model,
+        prompt=prompt,
+        size=size,
+        quality=quality,
+        n=1,
+    )
+    encoded = response.data[0].b64_json
+    if not encoded:
+        raise RuntimeError("OpenAI image response did not include b64_json output")
+    return base64.b64decode(encoded)
+
+
+def _asset_record(
+    *,
+    push_slug: str,
+    asset_id: str,
+    docs_checked: str,
+    generated_at: str,
+    state: SmokeState,
+    blocker_code: str,
+    blocker: str,
+    credential_state: str,
+    output_reference: str,
+    prompt: str,
+    model: str,
+    size: str,
+    quality: str,
+) -> dict[str, Any]:
+    return {
+        "asset_id": asset_id,
+        "rail": "provider",
+        "provider": "openai",
+        "model": model,
+        "model_snapshot": DEFAULT_MODEL_SNAPSHOT,
+        "endpoint": "v1/images/generations",
+        "docs_checked": docs_checked,
+        "state": state,
+        "blocker_code": blocker_code or None,
+        "blocker": blocker or None,
+        "credential_ref": "openai:image-generation",
+        "credential_state": credential_state,
+        "prompt": prompt.strip(),
+        "source_context": [
+            {
+                "path": f"pushes/{push_slug}/image-index.md",
+                "role": "fake_push_context",
+                "safe_to_share": True,
+            },
+            {
+                "path": "fixture:fictional-northstar-ledger",
+                "role": "source_brief",
+                "safe_to_share": True,
+            },
+        ],
+        "references": [],
+        "dimensions": {
+            "requested_size": size,
+            "aspect_ratio": "2:3",
+            "format": "png",
+            "quality": quality,
+        },
+        "output_reference": output_reference,
+        "storage_backend": "mb-media",
+        "committed_binary": False,
+        "retries": 0,
+        "timeout_seconds": DEFAULT_TIMEOUT_SECONDS,
+        "cost": {
+            "estimate": "unknown_token_metered",
+            "actual": "unknown",
+            "usage": None,
+        },
+        "review_status": "unreviewed",
+        "safe_to_share": True,
+        "generated_at": generated_at,
+        "operator_notes": (
+            "Fixture-safe OpenAI image rail smoke. Commit this record only; keep any "
+            "generated binary in configured private media storage."
+        ),
+    }
+
+
+def _render_index(record: dict[str, Any]) -> str:
+    yaml_text = yaml.safe_dump(record, sort_keys=False, allow_unicode=False)
+    return (
+        "# Image Index - OpenAI Image Rail Smoke\n\n"
+        "This fixture-safe record proves the first narrow OpenAI image rail "
+        "without committing generated binaries, secrets, private paths, or "
+        "provider request credentials.\n\n"
+        "```yaml\n"
+        f"{yaml_text}"
+        "```\n"
+    )
+
+
+def smoke_openai(
+    *,
+    repo: str,
+    push_slug: str = DEFAULT_PUSH_SLUG,
+    docs_checked: str,
+    media_root: str = ".mb/media",
+    generate: bool = False,
+) -> dict[str, Any]:
+    """Run or block the narrow OpenAI image rail smoke and write an asset record."""
+
+    repo_path = Path(repo).resolve()
+    push_dir = repo_path / "pushes" / push_slug
+    push_dir.mkdir(parents=True, exist_ok=True)
+
+    index_path = push_dir / "image-index.md"
+    generated_at = _utc_now()
+    output_reference = _logical_output(push_slug, DEFAULT_ASSET_ID)
+
+    blocker_code, blocker = _provider_blocker(generate)
+    credential_state = "configured_env" if os.environ.get("OPENAI_API_KEY") else "missing_env"
+    state: SmokeState = "blocked" if blocker_code else "generated"
+
+    binary_written = False
+    if state == "generated":
+        out_path = _media_path(repo_path, media_root, push_slug, DEFAULT_ASSET_ID)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            image_bytes = _generate_openai_image(
+                DEFAULT_PROMPT,
+                model=DEFAULT_MODEL,
+                size=DEFAULT_SIZE,
+                quality=DEFAULT_QUALITY,
+            )
+        except Exception as exc:  # noqa: BLE001 - provider errors must become sanitized records.
+            state = "blocked"
+            blocker_code = "provider_request_failed"
+            blocker = (
+                f"OpenAI image generation failed before a usable image was written "
+                f"({exc.__class__.__name__}). Check the local provider account, "
+                f"organization verification, quota, model access, and network state."
+            )
+        else:
+            out_path.write_bytes(image_bytes)
+            binary_written = True
+
+    record = {
+        "schema": "mainbranch.image_index.v0",
+        "push_slug": push_slug,
+        "docs_checked": docs_checked,
+        "output_record_written": True,
+        "binary_committed": False,
+        "assets": [
+            _asset_record(
+                push_slug=push_slug,
+                asset_id=DEFAULT_ASSET_ID,
+                docs_checked=docs_checked,
+                generated_at=generated_at,
+                state=state,
+                blocker_code=blocker_code,
+                blocker=blocker,
+                credential_state=credential_state,
+                output_reference=output_reference,
+                prompt=DEFAULT_PROMPT,
+                model=DEFAULT_MODEL,
+                size=DEFAULT_SIZE,
+                quality=DEFAULT_QUALITY,
+            )
+        ],
+    }
+    index_path.write_text(_render_index(record), encoding="utf-8")
+
+    return {
+        "ok": True,
+        "provider": "openai",
+        "model": DEFAULT_MODEL,
+        "state": state,
+        "blocker_code": blocker_code or None,
+        "output_record_written": True,
+        "record_path": _repo_relative(index_path, repo_path),
+        "output_reference": output_reference,
+        "storage_backend": "mb-media",
+        "binary_written": binary_written,
+        "binary_committed": False,
+        "safe_to_share": True,
+        "docs_checked": docs_checked,
+    }

--- a/mb/mb/init.py
+++ b/mb/mb/init.py
@@ -59,6 +59,7 @@ node_modules/
 .mb/private/
 .mb/backups/
 .mb/connect.yaml
+.mb/media/
 .mb/onboarding.json
 .mb/last-status-seen.json
 .mb/issue-drafts/

--- a/mb/pyproject.toml
+++ b/mb/pyproject.toml
@@ -33,6 +33,7 @@ classifiers = [
   "Topic :: Utilities",
 ]
 dependencies = [
+  "openai>=1.0",
   "typer>=0.12",
   "pyyaml>=6.0",
   "rich>=13.0",

--- a/mb/tests/fixtures/pushes/2026-05-13-openai-image-rail-smoke/image-index.md
+++ b/mb/tests/fixtures/pushes/2026-05-13-openai-image-rail-smoke/image-index.md
@@ -41,6 +41,8 @@ assets:
     aspect_ratio: '2:3'
     format: png
     quality: medium
+    generated_width: 1024
+    generated_height: 1536
   output_reference: mb-media://pushes/2026-05-13-openai-image-rail-smoke/images/fake-openai-image-001.png
   storage_backend: mb-media
   committed_binary: false

--- a/mb/tests/fixtures/pushes/2026-05-13-openai-image-rail-smoke/image-index.md
+++ b/mb/tests/fixtures/pushes/2026-05-13-openai-image-rail-smoke/image-index.md
@@ -1,0 +1,58 @@
+# Image Index - OpenAI Image Rail Smoke
+
+This fixture-safe record proves the first narrow OpenAI image rail without
+committing generated binaries, secrets, private paths, or provider request
+credentials.
+
+```yaml
+schema: mainbranch.image_index.v0
+push_slug: 2026-05-13-openai-image-rail-smoke
+docs_checked: '2026-05-13'
+output_record_written: true
+binary_committed: false
+assets:
+- asset_id: fake-openai-image-001
+  rail: provider
+  provider: openai
+  model: gpt-image-2
+  model_snapshot: gpt-image-2-2026-04-21
+  endpoint: v1/images/generations
+  docs_checked: '2026-05-13'
+  state: generated
+  blocker_code: null
+  blocker: null
+  credential_ref: openai:image-generation
+  credential_state: configured_env
+  prompt: Create a fixture-safe static ad concept for a fictional business called
+    Northstar Ledger. Show an abstract desk scene with a clean notebook, simple
+    charts, and warm natural light. Do not include real brands, real people, customer
+    data, logos, screenshots, account details, or private information. Leave open
+    space near the upper center for a later deterministic text overlay.
+  source_context:
+  - path: pushes/2026-05-13-openai-image-rail-smoke/image-index.md
+    role: fake_push_context
+    safe_to_share: true
+  - path: fixture:fictional-northstar-ledger
+    role: source_brief
+    safe_to_share: true
+  references: []
+  dimensions:
+    requested_size: 1024x1536
+    aspect_ratio: '2:3'
+    format: png
+    quality: medium
+  output_reference: mb-media://pushes/2026-05-13-openai-image-rail-smoke/images/fake-openai-image-001.png
+  storage_backend: mb-media
+  committed_binary: false
+  retries: 0
+  timeout_seconds: 60
+  cost:
+    estimate: unknown_token_metered
+    actual: unknown
+    usage: null
+  review_status: unreviewed
+  safe_to_share: true
+  generated_at: '2026-05-13T17:20:50+00:00'
+  operator_notes: Fixture-safe OpenAI image rail smoke. Commit this record only;
+    keep any generated binary in configured private media storage.
+```

--- a/mb/tests/test_image_rail.py
+++ b/mb/tests/test_image_rail.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, cast
+
+import yaml
+from typer.testing import CliRunner
+
+from mb import image_rail as image_rail_mod
+from mb.cli import app
+
+runner = CliRunner()
+
+
+def _record_from_index(path: Path) -> dict[str, Any]:
+    text = path.read_text(encoding="utf-8")
+    _, fenced = text.split("```yaml\n", 1)
+    yaml_text, _ = fenced.split("\n```", 1)
+    return cast(dict[str, Any], yaml.safe_load(yaml_text))
+
+
+def test_openai_image_smoke_writes_safe_blocked_record(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    repo = tmp_path / "biz"
+    repo.mkdir()
+
+    result = runner.invoke(
+        app,
+        [
+            "image",
+            "smoke-openai",
+            "--repo",
+            str(repo),
+            "--push-slug",
+            "2026-05-13-fake-openai-smoke",
+            "--docs-checked",
+            "2026-05-13",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["provider"] == "openai"
+    assert payload["model"] == "gpt-image-2"
+    assert payload["state"] == "blocked"
+    assert payload["blocker_code"] == "generation_not_approved"
+    assert payload["output_record_written"] is True
+    assert payload["binary_committed"] is False
+
+    index_path = repo / "pushes" / "2026-05-13-fake-openai-smoke" / "image-index.md"
+    assert index_path.exists()
+    record = _record_from_index(index_path)
+    asset = record["assets"][0]
+
+    assert record["schema"] == "mainbranch.image_index.v0"
+    assert asset["provider"] == "openai"
+    assert asset["model"] == "gpt-image-2"
+    assert asset["model_snapshot"] == "gpt-image-2-2026-04-21"
+    assert asset["credential_state"] == "missing_env"
+    assert asset["output_reference"].startswith("mb-media://pushes/")
+    assert asset["storage_backend"] == "mb-media"
+    assert asset["committed_binary"] is False
+    assert asset["safe_to_share"] is True
+
+    text = index_path.read_text(encoding="utf-8")
+    assert str(tmp_path) not in text
+    assert "OPENAI_API_KEY=" not in text
+    assert not (repo / ".mb" / "media").exists()
+
+
+def test_openai_image_smoke_generate_without_key_records_missing_key(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    repo = tmp_path / "biz"
+    repo.mkdir()
+
+    result = runner.invoke(
+        app,
+        [
+            "image",
+            "smoke-openai",
+            "--repo",
+            str(repo),
+            "--push-slug",
+            "2026-05-13-fake-openai-smoke",
+            "--docs-checked",
+            "2026-05-13",
+            "--generate",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["state"] == "blocked"
+    assert payload["blocker_code"] == "missing_openai_api_key"
+
+    index_path = repo / "pushes" / "2026-05-13-fake-openai-smoke" / "image-index.md"
+    record = _record_from_index(index_path)
+    asset = record["assets"][0]
+    assert asset["blocker_code"] == "missing_openai_api_key"
+    assert "Do not paste provider keys" in asset["blocker"]
+
+
+def test_openai_image_smoke_generated_path_keeps_binary_in_media_cache(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    repo = tmp_path / "biz"
+    repo.mkdir()
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key-not-written")
+    monkeypatch.setattr(image_rail_mod, "_provider_blocker", lambda generate: ("", ""))
+    monkeypatch.setattr(
+        image_rail_mod,
+        "_generate_openai_image",
+        lambda prompt, *, model, size, quality: b"fake-png-bytes",
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "image",
+            "smoke-openai",
+            "--repo",
+            str(repo),
+            "--push-slug",
+            "2026-05-13-fake-openai-smoke",
+            "--docs-checked",
+            "2026-05-13",
+            "--generate",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["state"] == "generated"
+    assert payload["binary_written"] is True
+    assert payload["binary_committed"] is False
+
+    media_path = (
+        repo
+        / ".mb"
+        / "media"
+        / "pushes"
+        / "2026-05-13-fake-openai-smoke"
+        / "images"
+        / "fake-openai-image-001.png"
+    )
+    assert media_path.read_bytes() == b"fake-png-bytes"
+
+    index_path = repo / "pushes" / "2026-05-13-fake-openai-smoke" / "image-index.md"
+    text = index_path.read_text(encoding="utf-8")
+    assert str(media_path) not in text
+    assert "test-key-not-written" not in text
+
+
+def test_openai_image_smoke_provider_failure_writes_sanitized_blocker(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    repo = tmp_path / "biz"
+    repo.mkdir()
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key-not-written")
+    monkeypatch.setattr(image_rail_mod, "_provider_blocker", lambda generate: ("", ""))
+
+    def fail_generation(prompt: str, *, model: str, size: str, quality: str) -> bytes:
+        raise RuntimeError("secret-bearing provider details should not be recorded")
+
+    monkeypatch.setattr(image_rail_mod, "_generate_openai_image", fail_generation)
+
+    result = runner.invoke(
+        app,
+        [
+            "image",
+            "smoke-openai",
+            "--repo",
+            str(repo),
+            "--push-slug",
+            "2026-05-13-fake-openai-smoke",
+            "--docs-checked",
+            "2026-05-13",
+            "--generate",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["state"] == "blocked"
+    assert payload["blocker_code"] == "provider_request_failed"
+
+    index_path = repo / "pushes" / "2026-05-13-fake-openai-smoke" / "image-index.md"
+    text = index_path.read_text(encoding="utf-8")
+    assert "RuntimeError" in text
+    assert "secret-bearing provider details" not in text
+    assert "test-key-not-written" not in text
+
+
+def test_init_gitignore_keeps_media_cache_out_of_git(tmp_path: Path) -> None:
+    result = runner.invoke(app, ["init", str(tmp_path / "biz"), "--name", "Acme"])
+
+    assert result.exit_code == 0
+    gitignore = (tmp_path / "biz" / ".gitignore").read_text(encoding="utf-8")
+    assert ".mb/media/" in gitignore

--- a/mb/tests/test_image_rail.py
+++ b/mb/tests/test_image_rail.py
@@ -120,7 +120,9 @@ def test_openai_image_smoke_generated_path_keeps_binary_in_media_cache(
     monkeypatch.setattr(
         image_rail_mod,
         "_generate_openai_image",
-        lambda prompt, *, model, size, quality: b"fake-png-bytes",
+        lambda prompt, *, model, size, quality: (
+            b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x04\x00\x00\x00\x06\x00fake-png-tail"
+        ),
     )
 
     result = runner.invoke(
@@ -142,6 +144,7 @@ def test_openai_image_smoke_generated_path_keeps_binary_in_media_cache(
     assert result.exit_code == 0
     payload = json.loads(result.stdout)
     assert payload["state"] == "generated"
+    assert payload["generated_dimensions"] == {"width": 1024, "height": 1536}
     assert payload["binary_written"] is True
     assert payload["binary_committed"] is False
 
@@ -154,9 +157,13 @@ def test_openai_image_smoke_generated_path_keeps_binary_in_media_cache(
         / "images"
         / "fake-openai-image-001.png"
     )
-    assert media_path.read_bytes() == b"fake-png-bytes"
+    assert media_path.read_bytes().startswith(b"\x89PNG\r\n\x1a\n")
 
     index_path = repo / "pushes" / "2026-05-13-fake-openai-smoke" / "image-index.md"
+    record = _record_from_index(index_path)
+    dimensions = record["assets"][0]["dimensions"]
+    assert dimensions["generated_width"] == 1024
+    assert dimensions["generated_height"] == 1536
     text = index_path.read_text(encoding="utf-8")
     assert str(media_path) not in text
     assert "test-key-not-written" not in text

--- a/mb/tests/test_start.py
+++ b/mb/tests/test_start.py
@@ -334,6 +334,7 @@ def test_start_surfaces_recent_checkpoint_history(tmp_path: Path, monkeypatch) -
     subprocess_result = start_mod._run_command(
         ["git", "commit", "-m", "[added] business scaffold"],
         cwd=repo,
+        timeout=15,
     )
     assert subprocess_result["ok"] is True
     (repo / "core" / "offer.md").write_text("# Offer\n", encoding="utf-8")


### PR DESCRIPTION
## Summary

Adds a narrow OpenAI `gpt-image-2` image smoke rail that writes a safe push-local `image-index.md` record, keeps generated binaries in ignored private media storage, and proves installed-package generation without committing secrets, raw provider payloads, or private paths.

This proves the provider and artifact boundary; ad-specific concept generation, review rubrics, placement presets, and Meta outcome linkage remain follow-up work.

## Linked issue

Closes #587 / MAIN-370
Refs #569 / MAIN-362
Refs #585 / MAIN-369

## Why

MAIN-370 needed actual generation evidence for the first OpenAI image rail, while keeping the public repo safe from keys, generated binaries, raw provider payloads, request IDs, and machine-local paths.

## Commits by concern

- `9874999 [add] MAIN-370 OpenAI image rail smoke`
- `286e1b8 [update] MAIN-370 report image smoke dimensions`

- [ ] Each commit body bullet-lists the changes in that commit
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`

## Validation

Pre-push gate from repo root:

```bash
scripts/check.sh
```

- [x] Level 1 static: `scripts/check.sh` passes
- [x] Level 2 CLI contract: focused Typer/CliRunner tests, exit codes, `--json` behavior, TTY vs non-TTY (if CLI behavior touched)
- [x] Level 3 package/install smoke (if packaging touched)
- [x] Level 4 fixture repo (if init/onboard/status/start/update touched)
- [ ] Level 5 runtime smoke / dogfood harness / simulation-tier (if runtime, first-run, skill discovery, or release validation touched)
- [x] SKILL.md <=500 lines (if any skill touched)
- [ ] Package-visible release gate evidence before tag/publish (if preparing a release)
- [x] Supply-chain review (if `.github/workflows/`, `.github/dependabot.yml`, `mb/pyproject.toml` deps, or `id-token`/`permissions` blocks touched - see [docs/supply-chain-policy.md](../docs/supply-chain-policy.md))

Level 1 static: `scripts/check.sh` - runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` - exit: 0 - log: excerpt `88 files already formatted; All checks passed!; Success: no issues found in 87 source files; 677 tests collected; skill validation passed 15/15`.

Level 2 CLI contract: `cd mb && python3 -m pytest tests/test_image_rail.py -q` - runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` - exit: 0 - log: excerpt `5 passed in 0.80s`.

Level 3 package/install smoke: `(cd mb && python3 -m build) && /tmp/mainbranch-smoke-main370-dimensions/bin/pip install dist/*.whl && /tmp/mainbranch-smoke-main370-dimensions/bin/mb --version && /tmp/mainbranch-smoke-main370-dimensions/bin/mb skill list` - runtime: `/tmp/mainbranch-smoke-main370-dimensions/bin/python3.13` - exit: 0 - log: excerpt `openai_package=available; mb 0.3.21`.

Level 3 provider smoke: `/tmp/mainbranch-smoke-main370-dimensions/bin/mb image smoke-openai --repo "$tmpdir/biz" --docs-checked 2026-05-13 --generate --json` with a local Keychain-sourced `OPENAI_API_KEY` - runtime: `/tmp/mainbranch-smoke-main370-dimensions/bin/python3.13` - exit: 0 - log: excerpt `provider=openai; model=gpt-image-2; state=generated; generated_dimensions={width: 1024, height: 1536}; binary_written=true; binary_committed=false`.

Level 4 fixture repo: `/tmp/mainbranch-smoke-main370-dimensions/bin/mb init "$tmpdir/biz" --name "Smoke Business"` plus missing-key and generated `mb image smoke-openai` runs in that repo - runtime: `/tmp/mainbranch-smoke-main370-dimensions/bin/python3.13` - exit: 0 - log: excerpt `missing_openai_api_key` blocked safely without traceback; generated run wrote only `mb-media://...` in command output.

Level 5 runtime smoke was not required because this PR adds a CLI/package provider smoke rail and updates `/mb-ads` guidance, but does not change runtime discovery, slash-command wiring, first-run runtime behavior, or release validation.

Supply-chain review: `mb/pyproject.toml` adds only `openai>=1.0`; no workflow, `id-token`, or permissions block changed.

## Success metric

From an installed package, `mb image smoke-openai --generate --json` can produce a fixture-safe OpenAI `gpt-image-2` PNG while committing only an `image-index.md` record with `binary_committed=false`, `generated_dimensions`, and an `mb-media://...` output reference.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [ ] N/A - change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [x] No
- [ ] Yes - migration note below

## Public / private boundary

No OpenAI key, generated binary, raw provider payload, request ID, temp path, provider key path, or private absolute media path is committed. Generated images stay in ignored `.mb/media/`, and the committed fixture uses only the logical `mb-media://pushes/2026-05-13-openai-image-rail-smoke/images/fake-openai-image-001.png` reference.
