### PR TITLE
[update] Tighten release simulation owner language

### DIFF
--- a/.claude/skills/mb-start/references/router-and-language.md
+++ b/.claude/skills/mb-start/references/router-and-language.md
@@ -78,11 +78,12 @@ from tools:
 
 | Tool phrasing | Owner-facing translation |
 | --- | --- |
-| `git is clean`, `repo is clean`, `working tree clean` | nothing unsaved locally |
+| `git is clean`, `repo is clean`, `working tree clean`, `clean on main` | nothing unsaved locally |
 | `on main`, `branch main` | current business folder or current workspace |
 | `one commit`, `only commit so far` | setup baseline saved or last saved checkpoint |
 | `staged files` | files queued for save |
 | `No GitHub origin remote` | local-only folder or no connected GitHub backup |
+| `origin remote` | connected GitHub backup or shared task source |
 | `PR/issue facts` | GitHub task and proposal context |
 | `before this goes to a remote` | before anything is shared outside your machine |
 
@@ -142,7 +143,9 @@ Route:
 
 - If ending the session, use `/mb-end`.
 - If saving progress midstream, run `mb checkpoint --plan --json`, then validate
-  and save after approval.
+  and save after approval. Checkpoint message examples must name the saved
+  business artifact, such as `[updated] offer and founder-call research`; avoid
+  broad buckets like `[updated] core and research`.
 - If local/shared repo state is involved, explain it with the save/sync
   vocabulary above. Do not prescribe a rebase in first response; say reconcile
   unless technical detail is needed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   generation produced nine fixture-safe candidates, binaries stayed ignored,
   and manual review rejected the full batch for generic AI image feel, weak
   native-feed fit, and no clear Facebook ad click reason. Refs MAIN-376, #600.
+- Tightened release-simulation owner-language guidance, scoring, and `/mb-start`
+  wording so normal final answers translate git/GitHub/checkpoint state before
+  technical terms and use specific saved-checkpoint examples. Refs MAIN-372,
+  #591.
 
 ## [0.3.21] - 2026-05-13
 

--- a/docs/release-simulations.md
+++ b/docs/release-simulations.md
@@ -202,6 +202,14 @@ when the user asks for it, when repair/debug context needs it, or when evidence
 is for maintainers; put the business translation first and the technical detail
 second.
 
+Release-simulation final answers should also avoid compressed status phrases
+that make the operator decode git first: "working tree clean", "repo is clean",
+"clean on main", "branch main", "origin remote", and "Git is clean" are
+warnings unless the answer has already translated them. Checkpoint examples
+should name the saved business artifact specifically, such as `[updated] offer
+and founder-call research`, instead of broad buckets like `[updated] core and
+research`.
+
 Review the transcript against the prompt fixture's `must_observe` and
 `must_not` lists, the command artifacts from the same run, and any post-run git
 state. Use this severity scale:

--- a/mb/mb/_data/release_simulations/manifest.json
+++ b/mb/mb/_data/release_simulations/manifest.json
@@ -240,7 +240,7 @@
     {
       "id": "business_language_failure",
       "label": "Business-language failure",
-      "review_for": "Made the operator manage Git, package state, or folder trivia instead of translating to bets, pushes, outcomes, checkpoints, and next actions.",
+      "review_for": "Made the operator manage Git, package state, or folder trivia instead of translating to bets, pushes, outcomes, checkpoints, saved progress, and next actions.",
       "likely_fix_types": [
         "skill_prose",
         "generated_claude_md",
@@ -374,11 +374,13 @@
         "Recognizes /mb-start as a Main Branch skill.",
         "Uses mb status --json --peek or mb start facts before advice.",
         "Names the fixture business repo as the operating context.",
-        "Translates technical state into setup, repair, or next business action."
+        "Translates technical state into setup, repair, or next business action.",
+        "Uses owner-first language such as nothing unsaved locally, current business folder, saved checkpoint, task, proposal, and no connected GitHub backup before raw git/GitHub terms."
       ],
       "must_not": [
         "Report /mb-start as unknown without routing to repair evidence.",
-        "Start writing durable business files before grounding."
+        "Start writing durable business files before grounding.",
+        "Lead a normal owner answer with working tree clean, repo is clean, clean on main, branch main, origin remote, PR/issue facts, or Git is clean."
       ],
       "follow_up_routes": [
         {
@@ -828,11 +830,13 @@
         "Runs or recommends mb checkpoint --plan before saving.",
         "Validates the proposed message before save.",
         "Asks for explicit approval before mb checkpoint --message ... --yes.",
-        "Explains checkpoint as saved business progress."
+        "Explains checkpoint as saved business progress.",
+        "Uses a checkpoint message example that names the saved business artifact specifically."
       ],
       "must_not": [
         "Run raw git commit as the default path.",
-        "Create a checkpoint without approval."
+        "Create a checkpoint without approval.",
+        "Use a vague checkpoint message example such as [updated] core and research."
       ],
       "follow_up_routes": [
         {

--- a/mb/mb/dogfood_harness.py
+++ b/mb/mb/dogfood_harness.py
@@ -97,9 +97,10 @@ CLAUDE_PRINT_PROMPT_PREFIX = """Release simulation harness constraints:
 - In the final answer, translate status for a normal business owner before any
   technical detail: say "nothing unsaved locally" before "git is clean" or
   "working tree clean"; "current business folder" before "branch main";
-  "no connected GitHub backup or shared task source" before "origin remote";
-  "saved checkpoint" before "commit"; "task" before "issue"; and "proposal"
-  before "PR".
+  "no connected GitHub backup or shared task source" before "No GitHub origin
+  remote"; "connected GitHub backup or shared task source" before "origin
+  remote"; "saved checkpoint" before "commit"; "task" before "issue"; and
+  "proposal" before "PR".
 - Checkpoint examples must name the saved business artifact, such as
   `[updated] offer and founder-call research`, not broad buckets like
   `[updated] core and research`.

--- a/mb/mb/dogfood_harness.py
+++ b/mb/mb/dogfood_harness.py
@@ -94,6 +94,15 @@ CLAUDE_PRINT_PROMPT_PREFIX = """Release simulation harness constraints:
   `mb books check`, and `mb educational <topic>`.
 - Do not use shell pipes, redirects, temp files, Python parsers, or Claude
   tool-result paths to transform command output.
+- In the final answer, translate status for a normal business owner before any
+  technical detail: say "nothing unsaved locally" before "git is clean" or
+  "working tree clean"; "current business folder" before "branch main";
+  "no connected GitHub backup or shared task source" before "origin remote";
+  "saved checkpoint" before "commit"; "task" before "issue"; and "proposal"
+  before "PR".
+- Checkpoint examples must name the saved business artifact, such as
+  `[updated] offer and founder-call research`, not broad buckets like
+  `[updated] core and research`.
 - Do not call AskUserQuestion in print mode. Put any question for the operator
   in the final answer.
 """

--- a/mb/mb/release_simulation.py
+++ b/mb/mb/release_simulation.py
@@ -278,6 +278,11 @@ def _contains_overclaim(text: str) -> bool:
 
 _TECHNICAL_LANGUAGE_PATTERNS: tuple[tuple[re.Pattern[str], str, str], ...] = (
     (
+        re.compile(r"\bclean on\s+`?main`?\b", re.IGNORECASE),
+        "clean on main",
+        "nothing unsaved locally in the current business folder",
+    ),
+    (
         re.compile(r"\bgit (?:tree )?is clean\b", re.IGNORECASE),
         "git is clean",
         "nothing unsaved locally",
@@ -346,8 +351,14 @@ _TECHNICAL_LANGUAGE_PATTERNS: tuple[tuple[re.Pattern[str], str, str], ...] = (
 )
 
 _BROAD_CHECKPOINT_NOTE_PATTERNS: tuple[re.Pattern[str], ...] = (
-    re.compile(r"\[(?:added|updated|changed)\]\s+(?:core and research|files|stuff|changes)\b"),
-    re.compile(r"proposed message:\s*`?\[(?:added|updated|changed)\]\s+core and research`?"),
+    re.compile(
+        r"\[(?:added|updated|changed)\]\s+"
+        r"(?:core\s*(?:and|&|\+|,)\s*research|files|stuff|changes)\b"
+    ),
+    re.compile(
+        r"proposed message:\s*`?\[(?:added|updated|changed)\]\s+"
+        r"core\s*(?:and|&|\+|,)\s*research`?"
+    ),
 )
 
 

--- a/mb/tests/test_release_simulation.py
+++ b/mb/tests/test_release_simulation.py
@@ -183,12 +183,15 @@ def test_claude_print_prompt_includes_owner_language_guardrails() -> None:
 
     simulation = release_simulation.simulations_for_tier("pr_smoke")[0]
     prompt = dogfood_harness.claude_print_prompt(simulation)
+    normalized_prompt = " ".join(prompt.split())
 
-    assert "nothing unsaved locally" in prompt
-    assert "current business folder" in prompt
-    assert "no connected GitHub backup or shared task source" in prompt
-    assert "saved checkpoint" in prompt
-    assert "[updated] offer and founder-call research" in prompt
+    assert "nothing unsaved locally" in normalized_prompt
+    assert "current business folder" in normalized_prompt
+    assert "no connected GitHub backup or shared task source" in normalized_prompt
+    assert "No GitHub origin remote" in normalized_prompt
+    assert '"connected GitHub backup or shared task source" before "origin' in normalized_prompt
+    assert "saved checkpoint" in normalized_prompt
+    assert "[updated] offer and founder-call research" in normalized_prompt
 
 
 def test_score_transcript_flags_provider_overclaim() -> None:

--- a/mb/tests/test_release_simulation.py
+++ b/mb/tests/test_release_simulation.py
@@ -62,6 +62,27 @@ def test_release_simulation_covers_ambiguous_mb_start_offer_choice() -> None:
     assert "ask_before_write" in sim.expected_behaviors
 
 
+def test_release_simulation_covers_owner_first_status_expectations() -> None:
+    simulations = {sim.id: sim for sim in release_simulation.simulations()}
+
+    fresh = simulations["fresh_first_day"]
+    checkpoint = simulations["checkpoint_discipline"]
+
+    fresh_observed = " ".join(fresh.must_observe).lower()
+    fresh_blocked = " ".join(fresh.must_not).lower()
+    assert "nothing unsaved locally" in fresh_observed
+    assert "current business folder" in fresh_observed
+    assert "no connected github backup" in fresh_observed
+    assert "clean on main" in fresh_blocked
+    assert "git is clean" in fresh_blocked
+    assert "origin remote" in fresh_blocked
+
+    checkpoint_observed = " ".join(checkpoint.must_observe).lower()
+    checkpoint_blocked = " ".join(checkpoint.must_not).lower()
+    assert "saved business artifact" in checkpoint_observed
+    assert "[updated] core and research" in checkpoint_blocked
+
+
 def test_release_simulation_covers_rich_migration_triage_map() -> None:
     simulations = {
         sim.id: sim for sim in release_simulation.simulations_for_tier("prerelease_candidate")
@@ -155,6 +176,19 @@ def test_release_simulation_manifest_loads_from_package_data() -> None:
             "before writing anything durable.",
         ),
     )
+
+
+def test_claude_print_prompt_includes_owner_language_guardrails() -> None:
+    from mb import dogfood_harness
+
+    simulation = release_simulation.simulations_for_tier("pr_smoke")[0]
+    prompt = dogfood_harness.claude_print_prompt(simulation)
+
+    assert "nothing unsaved locally" in prompt
+    assert "current business folder" in prompt
+    assert "no connected GitHub backup or shared task source" in prompt
+    assert "saved checkpoint" in prompt
+    assert "[updated] offer and founder-call research" in prompt
 
 
 def test_score_transcript_flags_provider_overclaim() -> None:
@@ -273,6 +307,19 @@ def test_score_transcript_does_not_double_count_specific_origin_remote_phrase() 
     assert [item["phrase"] for item in leakage["examples"]] == ["No GitHub origin remote"]
 
 
+def test_score_transcript_flags_clean_on_main_language() -> None:
+    transcript = "Clean on main. Continue with the next action."
+
+    score = release_simulation.score_transcript(transcript)
+    leakage = score["operator_language"]["visible_technical_leakage"]
+
+    assert leakage["severity"] == "low"
+    assert [item["phrase"] for item in leakage["examples"]] == ["clean on main"]
+    assert leakage["examples"][0]["preferred"] == (
+        "nothing unsaved locally in the current business folder"
+    )
+
+
 def test_score_transcript_allows_commit_as_plain_verb() -> None:
     transcript = """
     Keep raw ledgers in the private books vault and only commit summaries that
@@ -302,11 +349,19 @@ def test_score_transcript_flags_only_commit_count_language(transcript: str) -> N
     assert [item["phrase"] for item in leakage["examples"]] == ["only commit so far"]
 
 
-def test_score_transcript_flags_broad_checkpoint_notes() -> None:
-    transcript = """
+@pytest.mark.parametrize(
+    "message",
+    [
+        "[updated] core and research",
+        "[updated] core + research",
+        "[updated] core, research",
+    ],
+)
+def test_score_transcript_flags_broad_checkpoint_notes(message: str) -> None:
+    transcript = f"""
     Checkpoint plan ready.
 
-    Proposed message: `[updated] core and research`
+    Proposed message: `{message}`
     """
 
     score = release_simulation.score_transcript(transcript)

--- a/mb/tests/test_start_router_contract.py
+++ b/mb/tests/test_start_router_contract.py
@@ -56,11 +56,14 @@ def test_router_contract_translates_visible_git_language_before_owner_answer() -
     router = _read(ROUTER_REF)
 
     required_translations = {
-        "`git is clean`, `repo is clean`, `working tree clean`": "nothing unsaved locally",
+        (
+            "`git is clean`, `repo is clean`, `working tree clean`, `clean on main`"
+        ): "nothing unsaved locally",
         "`on main`, `branch main`": "current business folder or current workspace",
         "`one commit`, `only commit so far`": "setup baseline saved or last saved checkpoint",
         "`staged files`": "files queued for save",
         "`No GitHub origin remote`": "local-only folder or no connected GitHub backup",
+        "`origin remote`": "connected GitHub backup or shared task source",
         "`PR/issue facts`": "GitHub task and proposal context",
         "`before this goes to a remote`": "before anything is shared outside your machine",
     }


### PR DESCRIPTION
<!--
  Thanks for contributing to Main Branch.

  See CONTRIBUTING.md for branch + PR shape, concern-based commit
  organization, and pre-push gates. Keep PRs scoped — one logical
  change per PR, ideally 3–5 commits by concern.
-->

## Summary

Tightens release-simulation owner-language guidance and scoring so normal final answers translate git/GitHub/checkpoint state before technical terms.
It also strengthens `/mb-start` router guidance and tests around specific saved-checkpoint examples.

## Linked issue

Closes #591

## Why

The v0.3.21 candidate simulations passed deterministic checks, but manual transcript review still found owner-facing phrases like "clean on main" and vague checkpoint examples.
This keeps maintainer evidence technical while making normal owner answers business-readable first.

## Commits by concern

- [x] `87752ee [update] MAIN-372 tighten release simulation owner language`
- [x] Each commit body bullet-lists the changes in that commit
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`

## Validation

Pre-push gate from repo root:

```bash
scripts/check.sh
```

Level 1 static: `scripts/check.sh` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: terminal excerpt, formatting/ruff/mypy passed; 685 tests passed; `mb skill validate --all --json` passed.
Level 2 CLI contract: `cd mb && pytest tests/test_release_simulation.py tests/test_start_router_contract.py tests/test_dogfood_harness.py -q` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: terminal excerpt, 59 passed.
Level 3 package/install smoke: not required; packaging, entrypoints, bundled install paths, and dependencies were not changed.
Level 4 fixture repo: not required; init/onboard/status/start/update repo behavior was not changed.
Level 5 runtime smoke / dogfood harness / simulation-tier: not run; this changes release-simulation guidance, prompt constraints, and scorer coverage, not a new shipped runtime claim.

- [x] Level 1 static: `scripts/check.sh` passes
- [x] Level 2 CLI contract: focused Typer/CliRunner tests, exit codes, `--json` behavior, TTY vs non-TTY (if CLI behavior touched)
- [x] Level 3 package/install smoke (if packaging touched)
- [x] Level 4 fixture repo (if init/onboard/status/start/update touched)
- [x] Level 5 runtime smoke / dogfood harness / simulation-tier (if runtime, first-run, skill discovery, or release validation touched)
- [x] SKILL.md ≤500 lines (if any skill touched)
- [x] Package-visible release gate evidence before tag/publish (if preparing a release)
- [x] Supply-chain review (if `.github/workflows/`, `.github/dependabot.yml`, `mb/pyproject.toml` deps, or `id-token`/`permissions` blocks touched — see [docs/supply-chain-policy.md](../docs/supply-chain-policy.md))

## Success metric

A future release-acceptance print-mode run no longer scores `operator_language.visible_technical_leakage.severity: high` for these status phrases, and checkpoint examples name the saved business artifact specifically enough for an operator to understand what was saved.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [ ] N/A — change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [x] No
- [ ] Yes — migration note below

## Public / private boundary

No private operator strategy, machine-specific paths, secrets, raw transcripts, or runtime internals were committed; changes are public-safe guidance, fixtures, scorer logic, and tests.
