### PR TITLE
[update] Prepare v0.3.22 release

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mainbranch",
-  "version": "0.3.21",
+  "version": "0.3.22",
   "description": "Main Branch Claude Code skills for running a business from markdown files in git.",
   "author": {
     "name": "Noontide"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,27 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+## [0.3.22] - 2026-05-14
+
+v0.3.22 packages the first fixture-safe OpenAI GPT Image 2 smoke rail, the
+ad-creative review-board and creative playbook hardening from dogfood,
+post-v0.3.21 roadmap/bookkeeping alignment, and tighter owner-language
+release-simulation guidance.
+
+### Added
+
+- Added `mb image smoke-openai` as the first fixture-safe OpenAI GPT Image 2
+  rail smoke: it writes a push-local `image-index.md`, records generated or
+  sanitized blocked state, stores binaries only in configured media storage
+  when `--generate` is approved, and keeps `.mb/media/` gitignored by default.
+  The package now depends on the official OpenAI Python SDK for that direct
+  rail. Refs MAIN-370, #587.
+
 ### Changed
 
+- Updated `/mb-ads` image-generation guidance to route the first real provider
+  proof through `mb image smoke-openai`, including the approved-generation and
+  no-secrets credential boundary. Refs MAIN-370, #587.
 - Aligned post-v0.3.21 roadmap and bookkeeping docs so the sample monthly books
   report and Meta Ads read-only summary are described as shipped, while
   private-vault reporting, imports, reconciliation, and provider mutation remain
@@ -90,12 +109,6 @@ release-simulation owner-language hardening.
   keeping Google Gemini / Nano Banana, BFL FLUX.2, xAI Imagine, ComfyUI, and
   raw video providers as candidate rails behind separate smoke evidence. Refs
   #569, #409.
-- Added `mb image smoke-openai` as the first fixture-safe OpenAI GPT Image 2
-  rail smoke: it writes a push-local `image-index.md`, records generated or
-  sanitized blocked state, stores binaries only in configured media storage
-  when `--generate` is approved, and keeps `.mb/media/` gitignored by default.
-  The package now depends on the official OpenAI Python SDK for that direct
-  rail. Refs MAIN-370, #587.
 
 ### Changed
 
@@ -117,9 +130,6 @@ release-simulation owner-language hardening.
   OpenAI GPT Image 2 as the first smoke target, configurable media storage
   with safe logical media URIs, reference-image roles, and prompt-only fallback
   when no approved provider is configured. Refs MAIN-362, #569.
-- Updated `/mb-ads` image-generation guidance to route the first real provider
-  proof through `mb image smoke-openai`, including the approved-generation and
-  no-secrets credential boundary. Refs MAIN-370, #587.
 - Added verified MAIN-362 implementation research patterns to the creative
   media decision, including a GitHub reference-repo pattern table,
   OpenAI-first ad-volume cost math, and a deterministic video/motion CLI

--- a/mb/mb/__init__.py
+++ b/mb/mb/__init__.py
@@ -7,6 +7,6 @@ file stays a thin dispatcher.
 
 from __future__ import annotations
 
-__version__ = "0.3.21"
+__version__ = "0.3.22"
 
 __all__ = ["__version__"]

--- a/mb/pyproject.toml
+++ b/mb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mainbranch"
-version = "0.3.21"
+version = "0.3.22"
 description = "Main Branch engine umbrella - scaffolds, validates, and graphs business-as-files repos. Claude Code first, runtime-agnostic by design."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Prepares the `0.3.22` package-visible release by moving the current unreleased notes into a dated changelog section and bumping the Python package plus Claude plugin version sites to `0.3.22`.

## Linked issue

Refs #587, #590, #591, #595, #596, #600, #604.

## Why

The latest shipped release is `0.3.21`; the post-tag image rail, creative review, roadmap/books alignment, and owner-language simulation hardening need a release-prep branch before tagging and publishing `0.3.22`.

## Commits by concern

- [ ] Each commit body bullet-lists the changes in that commit
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`

Commit list:

- `f692ecd [update] Prepare v0.3.22 release`

## Validation

Pre-push gate from repo root:

```bash
scripts/check.sh
```

- [x] Level 1 static: `scripts/check.sh` passes
- [x] Level 2 CLI contract: focused Typer/CliRunner tests, exit codes, `--json` behavior, TTY vs non-TTY (if CLI behavior touched)
- [x] Level 3 package/install smoke (if packaging touched)
- [x] Level 4 fixture repo (if init/onboard/status/start/update touched)
- [x] Level 5 runtime smoke / dogfood harness / simulation-tier (if runtime, first-run, skill discovery, or release validation touched)
- [x] SKILL.md ≤500 lines (if any skill touched)
- [x] Package-visible release gate evidence before tag/publish (if preparing a release)
- [x] Supply-chain review (if `.github/workflows/`, `.github/dependabot.yml`, `mb/pyproject.toml` deps, or `id-token`/`permissions` blocks touched — see [docs/supply-chain-policy.md](../docs/supply-chain-policy.md))

Evidence lines:

- Level 0 release-file preflight: version/changelog grep — runtime: `python3` 3.13.7 — exit: 0 — log: `.agent/release-evidence/0.3.22/release-file-preflight.out`.
- Level 1 static: `scripts/check.sh` — runtime: `python3` 3.13.7 — exit: 0 — log: `.agent/release-evidence/0.3.22/check.out`.
- Level 1 plugin manifest preflight: `cd mb && python3 -m pytest tests/test_smoke_coverage.py::test_claude_plugin_manifest_points_at_prefixed_skills -q` — runtime: `python3` 3.13.7 — exit: 0 — log: `.agent/release-evidence/0.3.22/preflight-plugin-manifest.out`.
- Level 3 package/build: `cd mb && python3 -m build` — runtime: `python3` 3.13.7 — exit: 0 — log: `.agent/release-evidence/0.3.22/build.out`.
- Level 3 package/install: fresh venv install of `mb/dist/mainbranch-0.3.22-py3-none-any.whl`, `mb --version`, `mb skill list` — runtime: `/tmp/mainbranch-smoke-0.3.22-captured/bin/python` — exit: 0 — log: `.agent/release-evidence/0.3.22/install.out`.
- Level 3 books fixture: `mb books check --fixture --json` with hledger available and with hledger hidden from `PATH` — runtime: `/tmp/mainbranch-smoke-0.3.22-captured/bin/mb` — exit: 0 — log: `.agent/release-evidence/0.3.22/books-fixture.out`.
- Level 4 fixture repo: `mb onboard --yes`, `mb doctor`, `mb status`, `mb start --json`, `mb validate` from a fresh temporary business repo — runtime: `/tmp/mainbranch-smoke-0.3.22-captured/bin/mb` — exit: 0 — log: `.agent/release-evidence/0.3.22/fixture-repo.out`.
- Level 5 prerelease candidate: `scripts/claude-runtime-dogfood.py --install-mode wheel --wheel mb/dist/mainbranch-0.3.22-py3-none-any.whl --run-claude-print --simulation-tier prerelease_candidate --max-budget-usd 0.75` — runtime: `python3` 3.13.7 / Claude Code 2.1.140 — exit: 0 — evidence: `.agent/release-evidence/0.3.22/prerelease_candidate/`; print-mode proxy only, no interactive TUI proof.
- Level 5 release acceptance: `scripts/claude-runtime-dogfood.py --install-mode wheel --wheel mb/dist/mainbranch-0.3.22-py3-none-any.whl --run-claude-print --simulation-tier release_acceptance --max-budget-usd 0.75` — runtime: `python3` 3.13.7 / Claude Code 2.1.140 — exit: 0 — evidence: `.agent/release-evidence/0.3.22/release_acceptance_wheel/`; print-mode proxy only, no interactive TUI proof.
- Supply-chain review: release surfaces, dependency/workflow diff, workflow permission scan, Dependabot PR/security state, and `pypi` environment reviewer check — runtime: `gh` 2.89.0 / `python3` 3.13.7 — exit: 0 — log: `.agent/release-evidence/0.3.22/supply-chain.out`.

Manual transcript review note: both dogfood runs preserved permission, write, grounding, and repo-boundary safety; repeated owner-language leakage remains a quality follow-up in #604 and is not treated as interactive TUI evidence.

## Success metric

After merge, maintainers can tag `oe-v0.3.22`, publish through the existing GitHub Release/PyPI trusted-publisher path, and verify a fresh PyPI install reports `mb 0.3.22` with the packaged skill bundle.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [ ] N/A — change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [x] No
- [ ] Yes — migration note below

## Public / private boundary

Only public release metadata, package version sites, and changelog entries are committed. Local release evidence stayed under ignored `.agent/`, and no private operator strategy, machine-specific paths, secrets, credentials, raw account data, or runtime internals were committed.
