### PR TITLE
[add] mb onboard GitHub setup

### DIFF
--- a/.claude/skills/mb-setup/SKILL.md
+++ b/.claude/skills/mb-setup/SKILL.md
@@ -83,6 +83,18 @@ If no business repo exists yet:
 mb onboard plan --team-size solo --success-stage working
 ```
 
+If the operator wants the folder created, saved, synced to GitHub, and ready
+for Claude Code in one first-run pass, prefer the first-class onboarding path
+over hand-rolled `git` / `gh` glue:
+
+```bash
+mb onboard --yes --name "[Business Name]" --path "[repo-path]" --github "[owner/repo]" --github-visibility private --push
+```
+
+End setup answers in owner language first: created, saved, synced to GitHub
+when requested, and ready to open in Claude Code. Put git, remote, branch,
+validation, and wiring details second as the technical receipt.
+
 **Visibility default for business repos: private.** A business repo holds
 offer experiments, strategy, drafts, client work, screenshots, and
 operating notes. Default to a private repo and only switch to public when

--- a/.claude/skills/mb-setup/references/git-workflow.md
+++ b/.claude/skills/mb-setup/references/git-workflow.md
@@ -120,9 +120,18 @@ Check readiness from the business repo:
 mb connect doctor --json
 ```
 
+For a brand-new business repo, prefer `mb onboard` to create, save, push, and
+report the setup receipt in one flow:
+
+```bash
+mb onboard --yes --name "[Business Name]" --path "[repo-path]" --github "[owner/repo]" --github-visibility private --push
+```
+
 Creating a private GitHub repo is a setup/provider step, not a substitute for
 checkpointing approved business changes. Prefer private visibility unless the
-repo is intentionally public:
+repo is intentionally public. If an older installed `mb` does not expose the
+GitHub onboarding option yet, use the raw GitHub CLI fallback only after
+approval:
 
 ```bash
 gh repo create [business-name] --private --source=. --push

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,22 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+### Added
+
+- Added a first-run setup completion envelope and optional `mb onboard --github
+  ... --push` path so fresh business repos can be scaffolded, saved, connected
+  to a private/public GitHub repo, pushed, and reported in owner-facing
+  language. Fresh business repos now include a small tracked `README.md`.
+  Refs MAIN-378, #606.
+
+### Changed
+
+- Improved stale Claude wiring diagnostics to show the current `mb` path and
+  version, stale wired engine path, multiple-install signal, and repair command.
+  GitHub readiness now treats successful `gh repo view owner/repo` reachability
+  as stronger evidence than stale `gh auth status` metadata. Refs MAIN-378,
+  #606.
+
 ## [0.3.22] - 2026-05-14
 
 v0.3.22 packages the first fixture-safe OpenAI GPT Image 2 smoke rail, the

--- a/mb/mb/_data/templates/AGENTS.md.tmpl
+++ b/mb/mb/_data/templates/AGENTS.md.tmpl
@@ -37,6 +37,11 @@ playbooks, outcomes, decisions, next actions, and saved checkpoints. Treat git,
 branches, pull requests, provider refs, and local wiring as the hidden memory
 layer unless the operator asks for the plumbing.
 
+When finishing first-run setup, lead with the owner outcome before the receipt:
+created, saved, synced to GitHub when requested, and ready to open in Claude
+Code. Put commands, remotes, branches, validation checks, and local wiring in a
+short technical receipt after that outcome.
+
 Use the `vocabulary` block from `mb status --json --peek` when present. If
 `core/vocabulary.md` says this business calls pushes drops, launches,
 challenges, or promos, use that word in operator-facing prose while preserving

--- a/mb/mb/_data/templates/README.md.tmpl
+++ b/mb/mb/_data/templates/README.md.tmpl
@@ -1,0 +1,39 @@
+# {{BUSINESS_NAME}}
+
+This is the Main Branch business folder for {{BUSINESS_NAME}}.
+
+The durable business memory lives here: offer, audience, voice, proof,
+decisions, bets, pushes, logs, research, and approved summaries. Claude Code
+reads this folder before advising, so work starts from the business context
+instead of a blank chat.
+
+## Start
+
+Open a terminal in this folder:
+
+```bash
+claude
+```
+
+Then run:
+
+```text
+/mb-start
+```
+
+For a terminal-only check:
+
+```bash
+mb status --json --peek
+mb start --json
+```
+
+## Safety
+
+Commit business-readable files. Do not commit API keys, OAuth tokens,
+service-account JSON, customer exports, raw finance/legal records, or local
+runtime settings.
+
+Local setup files such as `.claude/settings.local.json`, `.mb/onboarding.json`,
+`.mb/connect.yaml`, and `.mb/private/` stay on this machine and are ignored by
+git.

--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -275,6 +275,10 @@ def _render_onboard_human(result: dict[str, Any]) -> None:
     console.print(f"\n[bold]mb onboard[/bold]  {mark}")
     console.print(f"repo: {result['path']}")
     console.print(f"level / action: {result['level']} / {result['action']}\n")
+    setup_complete = result.get("setup_complete") or {}
+    if setup_complete:
+        console.print(f"[bold]Outcome[/bold] {setup_complete.get('owner_outcome')}")
+        console.print()
 
     if result["level"] != "power":
         console.print("[bold]Why this stack[/bold]")
@@ -297,6 +301,15 @@ def _render_onboard_human(result: dict[str, Any]) -> None:
     console.print(f"  {'ok' if skill_wiring['ok'] else 'fail'}  Claude Code skill discovery")
     if checkpoint_hook:
         console.print(f"  {'ok' if checkpoint_hook.get('ok') else 'warn'}  checkpoint save hook")
+    if setup_complete:
+        console.print(
+            f"  {'ok' if setup_complete.get('committed_with_durable_files') else 'warn'}  "
+            "saved baseline"
+        )
+        if setup_complete.get("github_requested"):
+            console.print(
+                f"  {'ok' if setup_complete.get('pushed_tracking_remote') else 'warn'}  GitHub sync"
+            )
 
     warnings = result["warnings"]
     errors = result["errors"]
@@ -359,6 +372,21 @@ def onboard_cmd(
         "--desired-outcome",
         help="Short target outcome for onboarding progress.",
     ),
+    github_repo: str = typer.Option(
+        "",
+        "--github",
+        help="Create/connect a GitHub repo such as owner/name or name.",
+    ),
+    github_visibility: str = typer.Option(
+        "private",
+        "--github-visibility",
+        help="GitHub repo visibility when --github is used: private or public.",
+    ),
+    github_push: bool = typer.Option(
+        False,
+        "--push",
+        help="Push main and set origin tracking after creating the GitHub repo.",
+    ),
     yes: bool = typer.Option(False, "--yes", "-y", help="Use defaults and never prompt."),
     json_out: bool = typer.Option(False, "--json", help="Machine-readable output."),
 ) -> None:
@@ -406,6 +434,9 @@ def onboard_cmd(
             business_type=business_type,
             success_stage=success_stage,
             desired_outcome=desired_outcome,
+            github_repo=github_repo,
+            github_visibility=github_visibility,
+            github_push=github_push,
         )
     except ValueError as exc:
         typer.echo(f"mb onboard: {exc}", err=True)

--- a/mb/mb/codex.py
+++ b/mb/mb/codex.py
@@ -62,6 +62,11 @@ playbooks, outcomes, decisions, next actions, and saved checkpoints. Treat git,
 branches, pull requests, provider refs, and local wiring as the hidden memory
 layer unless the operator asks for the plumbing.
 
+When finishing first-run setup, lead with the owner outcome before the receipt:
+created, saved, synced to GitHub when requested, and ready to open in Claude
+Code. Put commands, remotes, branches, validation checks, and local wiring in a
+short technical receipt after that outcome.
+
 Use the `vocabulary` block from `mb status --json --peek` when present. If
 `core/vocabulary.md` says this business calls pushes drops, launches,
 challenges, or promos, use that word in operator-facing prose while preserving

--- a/mb/mb/connect.py
+++ b/mb/mb/connect.py
@@ -381,6 +381,18 @@ def _normalized_remote(value: str) -> str:
     return remote.removesuffix(".git")
 
 
+def _github_repo_full_name(remote: str) -> str:
+    normalized = _normalized_remote(remote)
+    parsed = urllib.parse.urlparse(normalized)
+    if parsed.hostname != "github.com":
+        return ""
+    path = parsed.path.strip("/")
+    if path.count("/") < 1:
+        return ""
+    owner, repo_name, *_ = path.split("/")
+    return f"{owner}/{repo_name.removesuffix('.git')}" if owner and repo_name else ""
+
+
 def _repo_identity(repo: Path) -> dict[str, str]:
     remote = _git_output(repo, ["config", "--get", "remote.origin.url"])
     if remote:
@@ -1681,17 +1693,6 @@ def github_context(
             "safe_to_share": True,
         }
 
-    auth = run(["gh", "auth", "status"], target, 5.0)
-    if not auth["ok"]:
-        return {
-            "ok": False,
-            "state": "unauthenticated",
-            "summary": "GitHub CLI is installed but not authenticated.",
-            "repair": "Run `gh auth login`.",
-            "repair_command": "gh auth login",
-            "safe_to_share": True,
-        }
-
     git = run(["git", "rev-parse", "--is-inside-work-tree"], target, 3.0)
     if not git["ok"] or git["stdout"].strip() != "true":
         return {
@@ -1715,12 +1716,47 @@ def github_context(
             "safe_to_share": True,
         }
 
+    auth = run(["gh", "auth", "status"], target, 5.0)
+    if not auth["ok"]:
+        full_name = _github_repo_full_name(remote_value)
+        reachable = (
+            run(["gh", "repo", "view", full_name, "--json", "nameWithOwner"], target, 5.0)
+            if full_name
+            else {"ok": False, "stdout": "", "stderr": ""}
+        )
+        if reachable["ok"]:
+            return {
+                "ok": True,
+                "state": "ready_reachable",
+                "summary": (
+                    "GitHub repo is reachable even though `gh auth status` reports stale "
+                    "auth metadata."
+                ),
+                "repair": "",
+                "repair_command": "",
+                "repo": full_name,
+                "auth_status_ok": False,
+                "repo_view_ok": True,
+                "safe_to_share": True,
+            }
+        return {
+            "ok": False,
+            "state": "unauthenticated",
+            "summary": "GitHub CLI is installed but not authenticated.",
+            "repair": "Run `gh auth login`.",
+            "repair_command": "gh auth login",
+            "safe_to_share": True,
+        }
+
     return {
         "ok": True,
         "state": "ready",
         "summary": "GitHub CLI auth and repo remote are ready.",
         "repair": "",
         "repair_command": "",
+        "repo": _github_repo_full_name(remote_value),
+        "auth_status_ok": True,
+        "repo_view_ok": False,
         "safe_to_share": True,
     }
 

--- a/mb/mb/engine.py
+++ b/mb/mb/engine.py
@@ -19,10 +19,13 @@ from __future__ import annotations
 import json
 import os
 import shutil
+import subprocess
 from datetime import datetime, timezone
 from importlib import resources
 from pathlib import Path
 from typing import Any
+
+from mb import __version__
 
 SKILL_PREFIX = "mb-"
 PRIMARY_SKILL = "mb-start"
@@ -122,6 +125,75 @@ def _read_settings(path: Path) -> dict[str, Any]:
     except json.JSONDecodeError:
         return {}
     return data if isinstance(data, dict) else {}
+
+
+def _iter_mb_binaries(path_value: str | None = None) -> list[str]:
+    """Return executable `mb` binaries on PATH, preserving PATH order."""
+    path_text = path_value if path_value is not None else os.environ.get("PATH", "")
+    binaries: list[str] = []
+    seen: set[str] = set()
+    for raw_dir in path_text.split(os.pathsep):
+        if not raw_dir:
+            continue
+        candidate = Path(raw_dir).expanduser() / "mb"
+        if not candidate.is_file() or not os.access(candidate, os.X_OK):
+            continue
+        try:
+            key = str(candidate.resolve())
+        except OSError:
+            key = str(candidate)
+        if key in seen:
+            continue
+        seen.add(key)
+        binaries.append(str(candidate))
+    return binaries
+
+
+def _mb_binary_version(path: str, *, timeout: float = 3.0) -> dict[str, Any]:
+    try:
+        result = subprocess.run(
+            [path, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return {"ok": False, "version": "", "output": "", "error": str(exc)}
+    output = (result.stdout or result.stderr).strip()
+    version = output.removeprefix("mb ").strip() if output.startswith("mb ") else output
+    return {
+        "ok": result.returncode == 0,
+        "version": version if result.returncode == 0 else "",
+        "output": output,
+        "error": "" if result.returncode == 0 else output,
+    }
+
+
+def mb_install_diagnostics(path_value: str | None = None) -> dict[str, Any]:
+    """Describe active `mb` binaries on PATH for runtime wiring diagnostics."""
+    active = shutil.which("mb") or ""
+    installs: list[dict[str, Any]] = []
+    for binary in _iter_mb_binaries(path_value):
+        version = _mb_binary_version(binary)
+        installs.append(
+            {
+                "path": binary,
+                "version": version["version"],
+                "ok": version["ok"],
+                "error": version["error"],
+                "active": bool(active and Path(binary) == Path(active)),
+            }
+        )
+    versions = {str(item["version"]) for item in installs if item.get("version")}
+    return {
+        "active_path": active,
+        "current_version": __version__,
+        "installs": installs,
+        "multiple_installs": len(installs) > 1,
+        "multiple_versions": len(versions) > 1,
+        "repair_command": "mb skill link --repo .",
+    }
 
 
 def _looks_like_engine_root_path(path: Path) -> bool:
@@ -571,10 +643,31 @@ def link_status(repo: str | Path) -> dict[str, Any]:
 
     root_str = str(root) if root is not None else ""
     settings_has_engine = bool(root_str and root_str in dirs)
+    stale_engine_paths = [
+        value
+        for value in dirs
+        if isinstance(value, str) and root is not None and _is_stale_engine_path(value, root)
+    ]
+    configured_engine_paths = [
+        value
+        for value in dirs
+        if isinstance(value, str) and _looks_like_engine_root_path(Path(value).expanduser())
+    ]
+    wired_engine_path = (
+        root_str
+        if settings_has_engine
+        else (
+            stale_engine_paths[0]
+            if stale_engine_paths
+            else (configured_engine_paths[0] if configured_engine_paths else "")
+        )
+    )
     start_link = target / ".claude" / "skills" / PRIMARY_SKILL
     start_skill = start_link / "SKILL.md"
     start_link_ok = start_skill.is_file()
     shadow_report = inspect_personal_skill_conflicts(target, apply=False)
+    install_diagnostics = mb_install_diagnostics()
+    stale_from_other_install = bool(stale_engine_paths and install_diagnostics["multiple_installs"])
 
     return {
         "ok": settings_has_engine and start_link_ok and shadow_report["ok"],
@@ -582,12 +675,23 @@ def link_status(repo: str | Path) -> dict[str, Any]:
         "engine_root": root_str or None,
         "settings_path": str(settings_path),
         "settings_has_engine": settings_has_engine,
+        "settings_additional_directories": [str(item) for item in dirs if isinstance(item, str)],
+        "wired_engine_path": wired_engine_path,
+        "stale_engine_paths": stale_engine_paths,
+        "stale_from_other_install": stale_from_other_install,
+        "current_mb": {
+            "path": install_diagnostics["active_path"],
+            "version": install_diagnostics["current_version"],
+            "engine_root": root_str or "",
+        },
+        "mb_installs": install_diagnostics,
         "primary_skill": PRIMARY_SKILL,
         "primary_link_ok": start_link_ok,
         "primary_link": str(start_link),
         "start_link_ok": start_link_ok,
         "start_link": str(start_link),
         "shadow_report": shadow_report,
+        "repair_command": "mb skill link --repo .",
     }
 
 

--- a/mb/mb/init.py
+++ b/mb/mb/init.py
@@ -156,6 +156,11 @@ def run(path: str, name: str) -> dict[str, Any]:
     (target / "CLAUDE.md").write_text(_render(claude_tmpl, mapping), encoding="utf-8")
     created.append("CLAUDE.md")
 
+    readme_tmpl = _read_template("README.md.tmpl")
+    if readme_tmpl:
+        (target / "README.md").write_text(_render(readme_tmpl, mapping), encoding="utf-8")
+        created.append("README.md")
+
     agents_result = codex_mod.write_agents_md(
         target,
         name=business_name,

--- a/mb/mb/migration_lint.py
+++ b/mb/mb/migration_lint.py
@@ -377,23 +377,40 @@ def _lint_settings(repo: Path, findings: list[dict[str, Any]]) -> None:
     root = engine_mod.engine_root()
     if root is None:
         return
+    install = engine_mod.mb_install_diagnostics()
     stale = [
         value
         for value in dirs
         if isinstance(value, str) and engine_mod.is_stale_engine_path(value, root)
     ]
     if stale:
+        other_install = (
+            " This often happens when multiple `mb` installs are active on PATH."
+            if install.get("multiple_installs")
+            else ""
+        )
         findings.append(
-            _finding(
-                code="stale-claude-settings-engine-path",
-                path=".claude/settings.local.json",
-                category="runtime-settings",
-                message=(
-                    f".claude/settings.local.json has {len(stale)} stale Main Branch engine "
-                    "path(s). Refresh project-local skill wiring before trusting runtime discovery."
+            {
+                **_finding(
+                    code="stale-claude-settings-engine-path",
+                    path=".claude/settings.local.json",
+                    category="runtime-settings",
+                    message=(
+                        f".claude/settings.local.json has {len(stale)} stale Main Branch "
+                        "engine path(s). Refresh project-local skill wiring before trusting "
+                        f"runtime discovery. Current mb: {install.get('active_path') or 'unknown'} "
+                        f"{install.get('current_version') or ''}; wired engine: {stale[0]}."
+                        f"{other_install}"
+                    ),
+                    repair_command="mb skill link --repo . --json",
                 ),
-                repair_command="mb skill link --repo . --json",
-            )
+                "current_mb_path": install.get("active_path") or "",
+                "current_mb_version": install.get("current_version") or "",
+                "current_engine_path": str(root),
+                "wired_engine_paths": stale,
+                "multiple_mb_installs": bool(install.get("multiple_installs")),
+                "mb_installs": install.get("installs") or [],
+            }
         )
 
 

--- a/mb/mb/onboard.py
+++ b/mb/mb/onboard.py
@@ -67,6 +67,144 @@ def _run_command(args: list[str], cwd: Path | None = None, timeout: float = 5.0)
     }
 
 
+def _git_output(repo: Path, args: list[str], timeout: float = 5.0) -> dict[str, Any]:
+    return _run_command(["git", *args], cwd=repo, timeout=timeout)
+
+
+def _has_git_commit(repo: Path) -> bool:
+    head = _git_output(repo, ["rev-parse", "--verify", "HEAD"])
+    return bool(head["ok"])
+
+
+def _git_remote(repo: Path) -> str:
+    remote = _git_output(repo, ["config", "--get", "remote.origin.url"])
+    return remote["stdout"].strip() if remote["ok"] else ""
+
+
+def _git_branch(repo: Path) -> str:
+    branch = _git_output(repo, ["branch", "--show-current"])
+    return branch["stdout"].strip() if branch["ok"] else ""
+
+
+def _tracking_branch(repo: Path) -> str:
+    tracking = _git_output(repo, ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"])
+    return tracking["stdout"].strip() if tracking["ok"] else ""
+
+
+def _working_tree_dirty(repo: Path) -> bool:
+    status = _git_output(repo, ["status", "--porcelain"])
+    return bool(status["ok"] and status["stdout"].strip())
+
+
+def _github_create_push(
+    repo: Path,
+    *,
+    business_name: str,
+    github_repo: str,
+    visibility: str,
+    push: bool,
+) -> dict[str, Any]:
+    requested = bool(github_repo.strip())
+    result: dict[str, Any] = {
+        "requested": requested,
+        "ok": not requested,
+        "repo": github_repo.strip(),
+        "visibility": visibility,
+        "committed": False,
+        "remote_set": bool(_git_remote(repo)),
+        "pushed": False,
+        "tracking": _tracking_branch(repo),
+        "commands": [],
+        "errors": [],
+        "repair": "",
+    }
+    if not requested:
+        return result
+    if visibility not in {"private", "public"}:
+        result["errors"].append("github visibility must be private or public")
+        result["repair"] = "Use `--github-visibility private` or `--github-visibility public`."
+        return result
+    if not _which("gh"):
+        result["errors"].append("GitHub CLI is not installed.")
+        result["repair"] = "Install GitHub CLI, then run `gh auth login`."
+        return result
+    if not _which("git"):
+        result["errors"].append("git is not installed.")
+        result["repair"] = "Install git before creating the GitHub repo."
+        return result
+    if not _has_git_commit(repo):
+        add = _git_output(repo, ["add", "."])
+        result["commands"].append("git add .")
+        if not add["ok"]:
+            result["errors"].append(add["stderr"].strip() or "git add failed")
+            result["repair"] = "Review `git status`, then commit the scaffold manually."
+            return result
+        commit_message = f"[opened] Main Branch scaffold for {business_name or repo.name}"
+        commit = _git_output(repo, ["commit", "-m", commit_message], timeout=15.0)
+        result["commands"].append(f"git commit -m {commit_message!r}")
+        if not commit["ok"]:
+            result["errors"].append(commit["stderr"].strip() or commit["stdout"].strip())
+            result["repair"] = (
+                "Configure git author identity if needed, then run "
+                f'`git commit -m "{commit_message}"`.'
+            )
+            return result
+        result["committed"] = True
+
+    args = ["gh", "repo", "create", github_repo.strip(), f"--{visibility}", "--source", "."]
+    if not _git_remote(repo):
+        args.extend(["--remote", "origin"])
+    if push:
+        args.append("--push")
+    create = _run_command(args, cwd=repo, timeout=30.0)
+    result["commands"].append(" ".join(args))
+    if not create["ok"]:
+        result["errors"].append(create["stderr"].strip() or create["stdout"].strip())
+        result["repair"] = (
+            "Run `gh auth login`, then rerun onboarding or create the GitHub repo manually."
+        )
+        return result
+    result["remote_set"] = bool(_git_remote(repo))
+    result["tracking"] = _tracking_branch(repo)
+    result["pushed"] = bool(push and result["tracking"])
+    result["ok"] = True
+    return result
+
+
+def _setup_complete(repo: Path, *, github_requested: bool = False) -> dict[str, Any]:
+    markers = _repo_markers(repo)
+    git_repo = _git_output(repo, ["rev-parse", "--is-inside-work-tree"])
+    branch = _git_branch(repo)
+    remote = _git_remote(repo)
+    tracking = _tracking_branch(repo)
+    checkpoint_hook = checkpoint_mod.hook_status(repo)
+    wiring = link_status(repo)
+    committed = _has_git_commit(repo)
+    dirty = _working_tree_dirty(repo)
+    return {
+        "scaffolded": _looks_initialized(markers),
+        "initialized_on_main": bool(git_repo["ok"] and branch == "main"),
+        "checkpoint_hook_ready": bool(checkpoint_hook.get("ok")),
+        "checkpoint_hook_repair": ""
+        if checkpoint_hook.get("ok")
+        else "mb checkpoint --install-hook",
+        "committed_with_durable_files": bool(committed and not dirty),
+        "github_remote_connected": bool(remote),
+        "github_remote": remote,
+        "pushed_tracking_remote": bool(tracking),
+        "tracking_branch": tracking,
+        "github_requested": github_requested,
+        "claude_code_handoff_ready": bool(wiring.get("ok")),
+        "codex_instructions_present": (repo / "AGENTS.md").is_file(),
+        "owner_outcome": (
+            "This business folder is created, saved, synced to GitHub, and ready to open "
+            "in Claude Code."
+            if github_requested and remote and tracking and wiring.get("ok") and committed
+            else "This business folder is created and ready for the next setup step."
+        ),
+    }
+
+
 def _slug(value: str) -> str:
     slug = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
     return slug or "my-business"
@@ -553,6 +691,9 @@ def run(
     business_type: str = "",
     success_stage: str = "unknown",
     desired_outcome: str = "",
+    github_repo: str = "",
+    github_visibility: str = "private",
+    github_push: bool = False,
 ) -> dict[str, Any]:
     """Create or connect a business repo and verify the Claude Code handoff."""
     target = Path(path).expanduser().resolve()
@@ -566,6 +707,7 @@ def run(
     result_business_name = name.strip() if normalized_mode == "connect" else ""
     init_result: dict[str, Any] | None = None
     link_result: dict[str, Any] | None = None
+    github_result: dict[str, Any] | None = None
 
     if normalized_mode == "connect" and not target.exists():
         errors.append(f"cannot connect missing repo: {target}")
@@ -617,6 +759,19 @@ def run(
     if isinstance(checkpoint_hook, dict) and not checkpoint_hook.get("ok"):
         warnings.append(str(checkpoint_hook.get("summary") or "Checkpoint hook needs repair."))
 
+    if github_repo.strip() and target.exists() and not errors:
+        github_result = _github_create_push(
+            target,
+            business_name=result_business_name,
+            github_repo=github_repo,
+            visibility=github_visibility.strip().lower(),
+            push=github_push,
+        )
+        if not github_result.get("ok"):
+            errors.extend(str(item) for item in github_result.get("errors", []))
+            if github_result.get("repair"):
+                warnings.append(str(github_result["repair"]))
+
     ok = not errors and wiring["ok"] and after["claude_md"]
     progress = (
         write_plan(
@@ -650,6 +805,17 @@ def run(
         "errors": errors,
         "doctor_command": f"mb doctor {target}",
         "checkpoint_hook": checkpoint_hook,
+        "github": github_result
+        or _github_create_push(
+            target,
+            business_name=result_business_name,
+            github_repo="",
+            visibility=github_visibility.strip().lower(),
+            push=False,
+        ),
+        "setup_complete": _setup_complete(target, github_requested=bool(github_repo.strip()))
+        if target.exists()
+        else {},
         "onboarding": progress,
         "next_steps": _next_steps(target),
         "init": init_result,

--- a/mb/mb/onboard.py
+++ b/mb/mb/onboard.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any
 
 from mb import checkpoint as checkpoint_mod
+from mb import connect as connect_mod
 from mb import init as init_mod
 from mb.engine import link_skills, link_status
 
@@ -38,6 +39,13 @@ BOUNDARIES = {
 }
 
 ONBOARDING_GITIGNORE_ENTRY = ".mb/onboarding.json"
+LOCAL_SETUP_PATH_PREFIXES = (
+    ".git/",
+    ".mb/",
+    ".claude/settings.local.json",
+    ".claude/worktrees/",
+    ".claude/skills/",
+)
 
 
 def _which(name: str) -> str:
@@ -96,6 +104,83 @@ def _working_tree_dirty(repo: Path) -> bool:
     return bool(status["ok"] and status["stdout"].strip())
 
 
+def _durable_generated_paths(paths: list[str]) -> list[str]:
+    durable: list[str] = []
+    for raw in paths:
+        rel = raw.strip().replace("\\", "/").strip("/")
+        if not rel or rel == ".git":
+            continue
+        path = Path(rel)
+        if path.is_absolute() or ".." in path.parts:
+            continue
+        if any(
+            rel == prefix.rstrip("/") or rel.startswith(prefix)
+            for prefix in LOCAL_SETUP_PATH_PREFIXES
+        ):
+            continue
+        if rel not in durable:
+            durable.append(rel)
+    return durable
+
+
+def _commit_generated_scaffold(
+    repo: Path,
+    *,
+    business_name: str,
+    generated_paths: list[str],
+) -> dict[str, Any]:
+    commit_message = f"[opened] Main Branch scaffold for {business_name or repo.name}"
+    result: dict[str, Any] = {
+        "ok": False,
+        "committed": False,
+        "commands": [],
+        "errors": [],
+        "repair": "",
+    }
+    durable_paths = _durable_generated_paths(generated_paths)
+    if durable_paths:
+        add = _git_output(repo, ["add", "--", *durable_paths])
+        result["commands"].append("git add -- " + " ".join(durable_paths))
+        if not add["ok"]:
+            result["errors"].append(add["stderr"].strip() or "git add failed")
+            result["repair"] = "Review `git status`, then commit the scaffold manually."
+            return result
+
+    staged = _git_output(repo, ["diff", "--cached", "--quiet", "--"])
+    staged_changes = staged["returncode"] == 1
+    if staged["returncode"] not in {0, 1}:
+        result["errors"].append(staged["stderr"].strip() or "git staged diff failed")
+        result["repair"] = "Review `git status`, then commit the scaffold manually."
+        return result
+    if staged_changes:
+        commit = _git_output(repo, ["commit", "-m", commit_message], timeout=15.0)
+        result["commands"].append(f"git commit -m {commit_message!r}")
+        if not commit["ok"]:
+            result["errors"].append(commit["stderr"].strip() or commit["stdout"].strip())
+            result["repair"] = (
+                "Configure git author identity if needed, then run "
+                f'`git commit -m "{commit_message}"`.'
+            )
+            return result
+        result["committed"] = True
+    elif not _has_git_commit(repo):
+        result["errors"].append("No durable scaffold files were staged for the first commit.")
+        result["repair"] = "Review `git status`, then commit the scaffold manually."
+        return result
+
+    if _working_tree_dirty(repo):
+        result["errors"].append(
+            "Working tree has uncommitted files outside the generated Main Branch scaffold."
+        )
+        result["repair"] = (
+            "Review `git status`; commit, ignore, or move private files before pushing."
+        )
+        return result
+
+    result["ok"] = True
+    return result
+
+
 def _github_create_push(
     repo: Path,
     *,
@@ -103,6 +188,7 @@ def _github_create_push(
     github_repo: str,
     visibility: str,
     push: bool,
+    generated_paths: list[str] | None = None,
 ) -> dict[str, Any]:
     requested = bool(github_repo.strip())
     result: dict[str, Any] = {
@@ -111,6 +197,7 @@ def _github_create_push(
         "repo": github_repo.strip(),
         "visibility": visibility,
         "committed": False,
+        "clean_tree": not _working_tree_dirty(repo),
         "remote_set": bool(_git_remote(repo)),
         "pushed": False,
         "tracking": _tracking_branch(repo),
@@ -132,24 +219,19 @@ def _github_create_push(
         result["errors"].append("git is not installed.")
         result["repair"] = "Install git before creating the GitHub repo."
         return result
-    if not _has_git_commit(repo):
-        add = _git_output(repo, ["add", "."])
-        result["commands"].append("git add .")
-        if not add["ok"]:
-            result["errors"].append(add["stderr"].strip() or "git add failed")
-            result["repair"] = "Review `git status`, then commit the scaffold manually."
-            return result
-        commit_message = f"[opened] Main Branch scaffold for {business_name or repo.name}"
-        commit = _git_output(repo, ["commit", "-m", commit_message], timeout=15.0)
-        result["commands"].append(f"git commit -m {commit_message!r}")
-        if not commit["ok"]:
-            result["errors"].append(commit["stderr"].strip() or commit["stdout"].strip())
-            result["repair"] = (
-                "Configure git author identity if needed, then run "
-                f'`git commit -m "{commit_message}"`.'
-            )
-            return result
-        result["committed"] = True
+
+    commit_result = _commit_generated_scaffold(
+        repo,
+        business_name=business_name,
+        generated_paths=generated_paths or [],
+    )
+    result["commands"].extend(commit_result["commands"])
+    result["committed"] = bool(commit_result["committed"])
+    result["clean_tree"] = commit_result["ok"]
+    if not commit_result["ok"]:
+        result["errors"].extend(str(item) for item in commit_result["errors"])
+        result["repair"] = str(commit_result["repair"])
+        return result
 
     args = ["gh", "repo", "create", github_repo.strip(), f"--{visibility}", "--source", "."]
     if not _git_remote(repo):
@@ -167,6 +249,7 @@ def _github_create_push(
     result["remote_set"] = bool(_git_remote(repo))
     result["tracking"] = _tracking_branch(repo)
     result["pushed"] = bool(push and result["tracking"])
+    result["clean_tree"] = not _working_tree_dirty(repo)
     result["ok"] = True
     return result
 
@@ -199,7 +282,12 @@ def _setup_complete(repo: Path, *, github_requested: bool = False) -> dict[str, 
         "owner_outcome": (
             "This business folder is created, saved, synced to GitHub, and ready to open "
             "in Claude Code."
-            if github_requested and remote and tracking and wiring.get("ok") and committed
+            if github_requested
+            and remote
+            and tracking
+            and wiring.get("ok")
+            and committed
+            and not dirty
             else "This business folder is created and ready for the next setup step."
         ),
     }
@@ -397,19 +485,31 @@ def _looks_initialized(markers: dict[str, bool]) -> bool:
     return markers["claude_md"] and shaped_dirs >= 2
 
 
-def _tool_readiness(repo: Path) -> dict[str, Any]:
+def _tool_readiness(
+    repo: Path,
+    *,
+    github_context: dict[str, Any] | None = None,
+) -> dict[str, Any]:
     git_path = _which("git")
     gh_path = _which("gh")
     claude_path = _which("claude")
     gh_auth = False
+    gh_repair = ""
+    gh_state = "missing_cli"
     git_repo = False
 
     if git_path:
         git_probe = _run_command(["git", "rev-parse", "--is-inside-work-tree"], cwd=repo)
         git_repo = git_probe["ok"] and git_probe["stdout"].strip() == "true"
-    if gh_path:
+    if github_context is not None:
+        gh_auth = bool(github_context.get("ok"))
+        gh_state = str(github_context.get("state") or ("ready" if gh_auth else "unknown"))
+        gh_repair = str(github_context.get("repair") or github_context.get("repair_command") or "")
+    elif gh_path:
         gh_probe = _run_command(["gh", "auth", "status"], cwd=repo)
         gh_auth = gh_probe["ok"]
+        gh_state = "ready" if gh_auth else "unauthenticated"
+        gh_repair = "" if gh_auth else "Run `gh auth login` to connect GitHub tasks and proposals."
 
     return {
         "git": {
@@ -421,10 +521,12 @@ def _tool_readiness(repo: Path) -> dict[str, Any]:
         "github_cli": {
             "found": bool(gh_path),
             "authenticated": gh_auth,
+            "state": gh_state,
             "path": gh_path,
             "repair": ""
             if gh_path and gh_auth
-            else (
+            else gh_repair
+            or (
                 "Install GitHub CLI: https://cli.github.com/ and run `gh auth login`."
                 if not gh_path
                 else "Run `gh auth login` to connect GitHub tasks and proposals."
@@ -738,17 +840,9 @@ def run(
     wiring = link_status(target)
     tools = _tool_readiness(target)
     selected_level = _normalize_level(level)
-    if selected_level == "auto":
-        selected_level = _infer_level(tools)
 
     if not after["git"]:
         warnings.append("Repo is not a git work tree. Run `git init` or `mb doctor` for repair.")
-    if not tools["github_cli"]["found"] or not tools["github_cli"]["authenticated"]:
-        warnings.append(str(tools["github_cli"]["repair"]))
-    if not tools["claude_code"]["found"]:
-        warnings.append(str(tools["claude_code"]["repair"]))
-    if not wiring["ok"]:
-        warnings.append("Claude Code skill discovery is not wired. Run `mb doctor` for details.")
     checkpoint_hook = (
         init_result.get("checkpoint_hook")
         if init_result
@@ -766,11 +860,29 @@ def run(
             github_repo=github_repo,
             visibility=github_visibility.strip().lower(),
             push=github_push,
+            generated_paths=created,
         )
         if not github_result.get("ok"):
             errors.extend(str(item) for item in github_result.get("errors", []))
             if github_result.get("repair"):
                 warnings.append(str(github_result["repair"]))
+        else:
+            github_context = connect_mod.github_context(
+                target,
+                which_func=_which,
+                command_runner=_run_command,
+            )
+            tools = _tool_readiness(target, github_context=github_context)
+
+    if selected_level == "auto":
+        selected_level = _infer_level(tools)
+
+    if not tools["github_cli"]["found"] or not tools["github_cli"]["authenticated"]:
+        warnings.append(str(tools["github_cli"]["repair"]))
+    if not tools["claude_code"]["found"]:
+        warnings.append(str(tools["claude_code"]["repair"]))
+    if not wiring["ok"]:
+        warnings.append("Claude Code skill discovery is not wired. Run `mb doctor` for details.")
 
     ok = not errors and wiring["ok"] and after["claude_md"]
     progress = (

--- a/mb/mb/start.py
+++ b/mb/mb/start.py
@@ -137,6 +137,21 @@ def _build_checks(
     shadow_summary = wiring.get("shadow_report", {}).get("summary", {})
     active_shadows = int(shadow_summary.get("active_shadows", 0) or 0)
     legacy_globals = int(shadow_summary.get("legacy_globals", 0) or 0)
+    skill_detail = (
+        "mb-start skill discoverable"
+        if wiring["ok"]
+        else "Claude Code mb-start skill is not wired or is shadowed"
+    )
+    if wiring.get("stale_engine_paths"):
+        current = wiring.get("current_mb") or {}
+        wired = str(wiring.get("wired_engine_path") or wiring["stale_engine_paths"][0])
+        skill_detail = (
+            "Claude Code wiring points at a different Main Branch engine. "
+            f"Current mb: {current.get('path') or 'unknown'} "
+            f"{current.get('version') or ''}; wired engine: {wired}."
+        )
+        if wiring.get("stale_from_other_install"):
+            skill_detail += " Multiple mb installs are active on PATH."
     checks = [
         {
             "name": "mainbranch_repo",
@@ -182,9 +197,7 @@ def _build_checks(
             "name": "skill_wiring",
             "ok": bool(wiring["ok"]),
             "severity": "error",
-            "detail": "mb-start skill discoverable"
-            if wiring["ok"]
-            else "Claude Code mb-start skill is not wired or is shadowed",
+            "detail": skill_detail,
             "repair": (
                 "Run `mb skill repair --repo .`, then `mb skill link --repo .` "
                 "from the business repo."

--- a/mb/mb/status.py
+++ b/mb/mb/status.py
@@ -2946,6 +2946,22 @@ def _runtime(repo: Path) -> dict[str, Any]:
     claude_path = _which("claude")
     wiring = link_status(repo)
     codex = codex_mod.readiness(repo)
+    wiring_repair = "Run `mb skill repair --repo .`, then `mb skill link --repo .`."
+    wiring_summary = "Claude Code skill wiring is ready."
+    if not wiring["ok"]:
+        if wiring.get("stale_engine_paths"):
+            current = wiring.get("current_mb") or {}
+            wired = str(wiring.get("wired_engine_path") or wiring["stale_engine_paths"][0])
+            wiring_summary = (
+                "Claude Code wiring points at a different Main Branch engine. "
+                f"Current mb: {current.get('path') or 'unknown'} "
+                f"{current.get('version') or ''}; wired engine: {wired}."
+            )
+            if wiring.get("stale_from_other_install"):
+                wiring_summary += " Multiple mb installs are active on PATH."
+            wiring_repair = "Run `mb skill link --repo .`."
+        else:
+            wiring_summary = "Claude Code skill wiring is missing or unhealthy."
     return {
         "claude_code": {
             "found": bool(claude_path),
@@ -2954,9 +2970,8 @@ def _runtime(repo: Path) -> dict[str, Any]:
         },
         "skill_wiring": {
             **wiring,
-            "repair": ""
-            if wiring["ok"]
-            else "Run `mb skill repair --repo .`, then `mb skill link --repo .`.",
+            "summary": wiring_summary,
+            "repair": "" if wiring["ok"] else wiring_repair,
         },
         "codex_cli": codex,
     }
@@ -3459,7 +3474,10 @@ def _drift(report: dict[str, Any]) -> dict[str, Any]:
             {
                 "id": "broken_skill_wiring",
                 "severity": "error",
-                "summary": "Claude Code skill wiring is missing or unhealthy.",
+                "summary": str(
+                    skill_wiring.get("summary")
+                    or "Claude Code skill wiring is missing or unhealthy."
+                ),
                 "evidence": list(skill_wiring.get("missing") or [])[:5],
                 "repair": str(skill_wiring.get("repair") or "Run `mb skill link --repo .`."),
                 "safe_to_share": True,

--- a/mb/tests/test_connect.py
+++ b/mb/tests/test_connect.py
@@ -1108,6 +1108,47 @@ def test_github_context_distinguishes_missing_remote(monkeypatch, tmp_path: Path
     assert context["repair_command"] == "gh repo create --source . --remote origin --push"
 
 
+def test_github_context_trusts_repo_view_when_auth_status_is_stale(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(
+        connect_mod.shutil,  # type: ignore[attr-defined]
+        "which",
+        lambda name: "/usr/bin/gh" if name == "gh" else "/usr/bin/git",
+    )
+
+    def fake_run(args: list[str], cwd: Path | None = None, timeout: float = 5.0) -> dict[str, Any]:
+        if args[:3] == ["git", "rev-parse", "--is-inside-work-tree"]:
+            return {"ok": True, "returncode": 0, "stdout": "true\n", "stderr": ""}
+        if args[:4] == ["git", "config", "--get", "remote.origin.url"]:
+            return {
+                "ok": True,
+                "returncode": 0,
+                "stdout": "https://github.com/dmthepm/acme.git\n",
+                "stderr": "",
+            }
+        if args[:3] == ["gh", "auth", "status"]:
+            return {"ok": False, "returncode": 1, "stdout": "", "stderr": "stale token"}
+        if args[:3] == ["gh", "repo", "view"]:
+            return {
+                "ok": True,
+                "returncode": 0,
+                "stdout": '{"nameWithOwner":"dmthepm/acme"}\n',
+                "stderr": "",
+            }
+        raise AssertionError(args)
+
+    monkeypatch.setattr(connect_mod, "_run_command", fake_run)
+
+    context = connect_mod.github_context(tmp_path)
+
+    assert context["ok"] is True
+    assert context["state"] == "ready_reachable"
+    assert context["repo"] == "dmthepm/acme"
+    assert context["auth_status_ok"] is False
+    assert context["repo_view_ok"] is True
+
+
 def test_status_all_reuses_supplied_github_context(monkeypatch, tmp_path: Path) -> None:
     context = {
         "ok": True,

--- a/mb/tests/test_engine.py
+++ b/mb/tests/test_engine.py
@@ -236,3 +236,64 @@ def test_link_skills_removes_stale_mainbranch_engine_paths(tmp_path: Path) -> No
     assert str(tmp_path / "mb-vip") not in dirs
     assert str(unrelated_missing) in dirs
     assert str(other_dir) in dirs
+
+
+def test_mb_install_diagnostics_reports_multiple_versions(tmp_path: Path, monkeypatch) -> None:
+    bin_a = tmp_path / "a"
+    bin_b = tmp_path / "b"
+    bin_a.mkdir()
+    bin_b.mkdir()
+    mb_a = bin_a / "mb"
+    mb_b = bin_b / "mb"
+    mb_a.write_text("#!/bin/sh\necho 'mb 0.3.22'\n", encoding="utf-8")
+    mb_b.write_text("#!/bin/sh\necho 'mb 0.3.18'\n", encoding="utf-8")
+    mb_a.chmod(0o755)
+    mb_b.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{bin_a}:{bin_b}")
+
+    result = engine_mod.mb_install_diagnostics()
+
+    assert result["active_path"] == str(mb_a)
+    assert result["multiple_installs"] is True
+    assert result["multiple_versions"] is True
+    assert [item["version"] for item in result["installs"]] == ["0.3.22", "0.3.18"]
+    assert result["repair_command"] == "mb skill link --repo ."
+
+
+def test_link_status_explains_stale_engine_path_from_other_install(
+    tmp_path: Path, monkeypatch
+) -> None:
+    repo = tmp_path / "biz"
+    stale_engine = tmp_path / "mb-vip"
+    _write_skill(stale_engine, "start")
+    (stale_engine / "CHANGELOG.md").write_text("# Changelog\n", encoding="utf-8")
+    settings = repo / ".claude" / "settings.local.json"
+    settings.parent.mkdir(parents=True)
+    settings.write_text(
+        json.dumps({"permissions": {"additionalDirectories": [str(stale_engine)]}}) + "\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        engine_mod,
+        "mb_install_diagnostics",
+        lambda: {
+            "active_path": "/tmp/new/mb",
+            "current_version": "0.3.22",
+            "multiple_installs": True,
+            "multiple_versions": True,
+            "installs": [
+                {"path": "/tmp/new/mb", "version": "0.3.22"},
+                {"path": "/tmp/old/mb", "version": "0.3.18"},
+            ],
+            "repair_command": "mb skill link --repo .",
+        },
+    )
+
+    result = engine_mod.link_status(repo)
+
+    assert result["ok"] is False
+    assert str(stale_engine) in result["stale_engine_paths"]
+    assert result["stale_from_other_install"] is True
+    assert result["current_mb"]["path"] == "/tmp/new/mb"
+    assert result["repair_command"] == "mb skill link --repo ."

--- a/mb/tests/test_init.py
+++ b/mb/tests/test_init.py
@@ -86,6 +86,8 @@ def _assert_agents_md_codex_start_contract(text: str) -> None:
     assert "explicit operator approval" in text
     assert "business-owner language" in text
     assert "bets, goals, offers, pushes" in text
+    assert "created, saved, synced to GitHub when requested" in text
+    assert "short technical receipt" in text
     assert "`vocabulary` block from `mb status --json --peek`" in text
     assert "MoneyPath" in text
     assert "Use `money_path` when the next move depends on customer progress" in text
@@ -130,6 +132,7 @@ def test_init_scaffolds_folders(tmp_path: Path) -> None:
     assert "terms:" in vocab
     assert "singular: push" in vocab
     assert (target / "CLAUDE.md").exists()
+    assert (target / "README.md").exists()
     assert (target / "AGENTS.md").exists()
     assert (target / ".github" / "CODEOWNERS").exists()
     assert (target / ".gitignore").exists()
@@ -163,8 +166,12 @@ def test_init_scaffolds_folders(tmp_path: Path) -> None:
     assert ".vip/local.yaml" in gitignore
     claude_md = (target / "CLAUDE.md").read_text()
     agents_md = (target / "AGENTS.md").read_text()
+    readme_md = (target / "README.md").read_text()
     assert "Acme Brewing" in claude_md
     assert "Acme Brewing" in agents_md
+    assert "Acme Brewing" in readme_md
+    assert "/mb-start" in readme_md
+    assert ".mb/onboarding.json" in readme_md
     assert "## Connected accounts" in claude_md
     assert "Stripe account IDs" in claude_md
     assert "Google Ads customer IDs" in claude_md

--- a/mb/tests/test_migration_lint.py
+++ b/mb/tests/test_migration_lint.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from mb import engine as engine_mod
 from mb import migration_lint
 
 
@@ -104,18 +105,35 @@ def test_migration_lint_does_not_flag_negated_reference_write_guidance(
 
 
 def test_migration_lint_reports_stale_claude_settings_engine_path(
-    tmp_path: Path,
+    tmp_path: Path, monkeypatch
 ) -> None:
     stale_engine = tmp_path / "mb-vip"
     _write(
         tmp_path / ".claude" / "settings.local.json",
         json.dumps({"permissions": {"additionalDirectories": [str(stale_engine)]}}),
     )
+    monkeypatch.setattr(
+        engine_mod,
+        "mb_install_diagnostics",
+        lambda: {
+            "active_path": "/tmp/current/mb",
+            "current_version": "0.3.22",
+            "multiple_installs": True,
+            "installs": [{"path": "/tmp/current/mb", "version": "0.3.22"}],
+        },
+    )
 
     report = migration_lint.run(tmp_path)
 
     codes = {finding["code"] for finding in report["findings"]}
     assert "stale-claude-settings-engine-path" in codes
+    finding = next(
+        item for item in report["findings"] if item["code"] == "stale-claude-settings-engine-path"
+    )
+    assert finding["current_mb_path"] == "/tmp/current/mb"
+    assert finding["current_mb_version"] == "0.3.22"
+    assert finding["wired_engine_paths"] == [str(stale_engine)]
+    assert "multiple `mb` installs" in finding["message"]
 
 
 def test_migration_lint_reuses_push_frontmatter_reads(tmp_path: Path, monkeypatch) -> None:

--- a/mb/tests/test_onboard.py
+++ b/mb/tests/test_onboard.py
@@ -61,6 +61,11 @@ def test_onboard_yes_creates_repo_and_reports_next_steps(tmp_path: Path, monkeyp
     assert (repo / ".git" / "hooks" / "commit-msg").exists()
     assert result["checkpoint_hook"]["state"] == "installed"
     assert result["skill_wiring"]["ok"] is True
+    assert result["setup_complete"]["scaffolded"] is True
+    assert result["setup_complete"]["initialized_on_main"] is True
+    assert result["setup_complete"]["checkpoint_hook_ready"] is True
+    assert result["setup_complete"]["claude_code_handoff_ready"] is True
+    assert result["setup_complete"]["codex_instructions_present"] is True
     assert result["next_steps"] == [f"cd {repo.resolve()}", "claude", "/mb-start"]
     assert any("Claude Code" in warning for warning in result["warnings"])
     assert any(
@@ -165,6 +170,8 @@ def test_onboard_cli_yes_json_smoke(tmp_path: Path, monkeypatch) -> None:
     assert payload["ok"] is True
     assert payload["path"] == str(repo.resolve())
     assert payload["next_steps"][-1] == "/mb-start"
+    assert payload["setup_complete"]["scaffolded"] is True
+    assert payload["setup_complete"]["github_requested"] is False
     assert (repo / ".mb" / "onboarding.json").exists()
     assert payload["onboarding"]["summary"]["status"] == "in_progress"
     assert ".mb/onboarding.json" in (repo / ".gitignore").read_text(encoding="utf-8")
@@ -359,5 +366,78 @@ def test_onboard_cli_interactive_path_renders_clear_labels(tmp_path: Path, monke
     assert "level / action: beginner / created" in result.stdout
     assert "path: beginner / created" not in result.stdout
     assert "Connected accounts" in result.stdout
+    assert "Outcome" in result.stdout
     assert "CLAUDE.md -> Connected accounts" in result.stdout
     assert "Show the short why" not in result.stdout
+
+
+def test_onboard_github_create_push_commits_and_sets_tracking(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(onboard_mod, "_which", lambda name: f"/usr/bin/{name}")
+    repo = tmp_path / "acme"
+    state = {"commit": False, "remote": "", "tracking": ""}
+    commands: list[list[str]] = []
+
+    def fake_run(
+        args: list[str], cwd: Path | None = None, timeout: float = 5.0
+    ) -> dict[str, object]:
+        commands.append(args)
+        if args[:2] == ["git", "init"]:
+            return {"ok": True, "stdout": "", "stderr": "", "returncode": 0}
+        if args[:3] == ["git", "rev-parse", "--is-inside-work-tree"]:
+            return {"ok": True, "stdout": "true\n", "stderr": "", "returncode": 0}
+        if args[:3] == ["git", "branch", "--show-current"]:
+            return {"ok": True, "stdout": "main\n", "stderr": "", "returncode": 0}
+        if args[:4] == ["git", "config", "--get", "remote.origin.url"]:
+            ok = bool(state["remote"])
+            return {"ok": ok, "stdout": state["remote"], "stderr": "", "returncode": 0 if ok else 1}
+        if args[:5] == ["git", "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"]:
+            ok = bool(state["tracking"])
+            return {
+                "ok": ok,
+                "stdout": state["tracking"],
+                "stderr": "",
+                "returncode": 0 if ok else 1,
+            }
+        if args[:3] == ["git", "rev-parse", "--verify"]:
+            return {
+                "ok": state["commit"],
+                "stdout": "abc123\n" if state["commit"] else "",
+                "stderr": "",
+                "returncode": 0 if state["commit"] else 1,
+            }
+        if args[:2] == ["git", "status"]:
+            return {"ok": True, "stdout": "", "stderr": "", "returncode": 0}
+        if args[:2] == ["git", "add"]:
+            return {"ok": True, "stdout": "", "stderr": "", "returncode": 0}
+        if args[:2] == ["git", "commit"]:
+            state["commit"] = True
+            return {"ok": True, "stdout": "", "stderr": "", "returncode": 0}
+        if args[:3] == ["gh", "auth", "status"]:
+            return {"ok": True, "stdout": "", "stderr": "", "returncode": 0}
+        if args[:3] == ["gh", "repo", "create"]:
+            state["remote"] = "https://github.com/dmthepm/acme.git\n"
+            state["tracking"] = "origin/main\n"
+            return {"ok": True, "stdout": "", "stderr": "", "returncode": 0}
+        raise AssertionError(args)
+
+    monkeypatch.setattr(onboard_mod, "_run_command", fake_run)
+
+    result = onboard_mod.run(
+        path=str(repo),
+        name="Acme",
+        mode="new",
+        level="power",
+        github_repo="dmthepm/acme",
+        github_visibility="private",
+        github_push=True,
+    )
+
+    assert result["ok"] is True
+    assert result["github"]["ok"] is True
+    assert result["github"]["committed"] is True
+    assert result["github"]["pushed"] is True
+    assert result["setup_complete"]["github_requested"] is True
+    assert result["setup_complete"]["github_remote_connected"] is True
+    assert result["setup_complete"]["pushed_tracking_remote"] is True
+    assert "created, saved, synced to GitHub" in result["setup_complete"]["owner_outcome"]
+    assert any(cmd[:3] == ["gh", "repo", "create"] and "--private" in cmd for cmd in commands)

--- a/mb/tests/test_onboard.py
+++ b/mb/tests/test_onboard.py
@@ -374,7 +374,7 @@ def test_onboard_cli_interactive_path_renders_clear_labels(tmp_path: Path, monke
 def test_onboard_github_create_push_commits_and_sets_tracking(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(onboard_mod, "_which", lambda name: f"/usr/bin/{name}")
     repo = tmp_path / "acme"
-    state = {"commit": False, "remote": "", "tracking": ""}
+    state = {"commit": False, "remote": "", "tracking": "", "staged": False, "dirty": False}
     commands: list[list[str]] = []
 
     def fake_run(
@@ -406,11 +406,21 @@ def test_onboard_github_create_push_commits_and_sets_tracking(tmp_path: Path, mo
                 "returncode": 0 if state["commit"] else 1,
             }
         if args[:2] == ["git", "status"]:
-            return {"ok": True, "stdout": "", "stderr": "", "returncode": 0}
+            stdout = "?? private.txt\n" if state["dirty"] else ""
+            return {"ok": True, "stdout": stdout, "stderr": "", "returncode": 0}
         if args[:2] == ["git", "add"]:
+            state["staged"] = True
             return {"ok": True, "stdout": "", "stderr": "", "returncode": 0}
+        if args[:3] == ["git", "diff", "--cached"]:
+            return {
+                "ok": not state["staged"],
+                "stdout": "",
+                "stderr": "",
+                "returncode": 1 if state["staged"] else 0,
+            }
         if args[:2] == ["git", "commit"]:
             state["commit"] = True
+            state["staged"] = False
             return {"ok": True, "stdout": "", "stderr": "", "returncode": 0}
         if args[:3] == ["gh", "auth", "status"]:
             return {"ok": True, "stdout": "", "stderr": "", "returncode": 0}
@@ -435,9 +445,234 @@ def test_onboard_github_create_push_commits_and_sets_tracking(tmp_path: Path, mo
     assert result["ok"] is True
     assert result["github"]["ok"] is True
     assert result["github"]["committed"] is True
+    add_command = next(cmd for cmd in commands if cmd[:3] == ["git", "add", "--"])
+    assert "." not in add_command
+    assert "CLAUDE.md" in add_command
+    assert ".gitignore" in add_command
     assert result["github"]["pushed"] is True
     assert result["setup_complete"]["github_requested"] is True
     assert result["setup_complete"]["github_remote_connected"] is True
     assert result["setup_complete"]["pushed_tracking_remote"] is True
     assert "created, saved, synced to GitHub" in result["setup_complete"]["owner_outcome"]
     assert any(cmd[:3] == ["gh", "repo", "create"] and "--private" in cmd for cmd in commands)
+
+
+def test_onboard_github_push_commits_generated_scaffold_in_repo_with_head(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(onboard_mod, "_which", lambda name: f"/usr/bin/{name}")
+    repo = tmp_path / "existing"
+    state = {"commit": True, "remote": "", "tracking": "", "staged": False, "dirty": False}
+    commands: list[list[str]] = []
+
+    def fake_run(
+        args: list[str], cwd: Path | None = None, timeout: float = 5.0
+    ) -> dict[str, object]:
+        commands.append(args)
+        if args[:3] == ["git", "rev-parse", "--is-inside-work-tree"]:
+            return {"ok": True, "stdout": "true\n", "stderr": "", "returncode": 0}
+        if args[:3] == ["git", "branch", "--show-current"]:
+            return {"ok": True, "stdout": "main\n", "stderr": "", "returncode": 0}
+        if args[:4] == ["git", "config", "--get", "remote.origin.url"]:
+            ok = bool(state["remote"])
+            return {"ok": ok, "stdout": state["remote"], "stderr": "", "returncode": 0 if ok else 1}
+        if args[:5] == ["git", "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"]:
+            ok = bool(state["tracking"])
+            return {
+                "ok": ok,
+                "stdout": state["tracking"],
+                "stderr": "",
+                "returncode": 0 if ok else 1,
+            }
+        if args[:3] == ["git", "rev-parse", "--verify"]:
+            return {"ok": True, "stdout": "abc123\n", "stderr": "", "returncode": 0}
+        if args[:2] == ["git", "status"]:
+            return {"ok": True, "stdout": "", "stderr": "", "returncode": 0}
+        if args[:2] == ["git", "add"]:
+            state["staged"] = True
+            return {"ok": True, "stdout": "", "stderr": "", "returncode": 0}
+        if args[:3] == ["git", "diff", "--cached"]:
+            return {
+                "ok": not state["staged"],
+                "stdout": "",
+                "stderr": "",
+                "returncode": 1 if state["staged"] else 0,
+            }
+        if args[:2] == ["git", "commit"]:
+            state["staged"] = False
+            return {"ok": True, "stdout": "", "stderr": "", "returncode": 0}
+        if args[:3] == ["gh", "auth", "status"]:
+            return {"ok": True, "stdout": "", "stderr": "", "returncode": 0}
+        if args[:3] == ["gh", "repo", "create"]:
+            state["remote"] = "https://github.com/dmthepm/existing.git\n"
+            state["tracking"] = "origin/main\n"
+            return {"ok": True, "stdout": "", "stderr": "", "returncode": 0}
+        raise AssertionError(args)
+
+    monkeypatch.setattr(onboard_mod, "_run_command", fake_run)
+
+    result = onboard_mod.run(
+        path=str(repo),
+        name="Existing",
+        mode="new",
+        level="power",
+        github_repo="dmthepm/existing",
+        github_visibility="private",
+        github_push=True,
+    )
+
+    assert result["ok"] is True
+    assert result["github"]["ok"] is True
+    assert result["github"]["committed"] is True
+    assert any(cmd[:2] == ["git", "commit"] for cmd in commands)
+    assert any(cmd[:3] == ["gh", "repo", "create"] for cmd in commands)
+
+
+def test_onboard_github_push_does_not_sweep_preexisting_untracked_files(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(onboard_mod, "_which", lambda name: f"/usr/bin/{name}")
+    repo = tmp_path / "private-folder"
+    repo.mkdir()
+    (repo / "private-notes.txt").write_text("do not publish\n", encoding="utf-8")
+    state = {"commit": False, "remote": "", "tracking": "", "staged": False, "dirty": True}
+    commands: list[list[str]] = []
+
+    def fake_run(
+        args: list[str], cwd: Path | None = None, timeout: float = 5.0
+    ) -> dict[str, object]:
+        commands.append(args)
+        if args[:3] == ["git", "rev-parse", "--is-inside-work-tree"]:
+            return {"ok": True, "stdout": "true\n", "stderr": "", "returncode": 0}
+        if args[:3] == ["git", "branch", "--show-current"]:
+            return {"ok": True, "stdout": "main\n", "stderr": "", "returncode": 0}
+        if args[:4] == ["git", "config", "--get", "remote.origin.url"]:
+            return {"ok": False, "stdout": "", "stderr": "", "returncode": 1}
+        if args[:5] == ["git", "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"]:
+            return {"ok": False, "stdout": "", "stderr": "", "returncode": 1}
+        if args[:3] == ["git", "rev-parse", "--verify"]:
+            return {
+                "ok": state["commit"],
+                "stdout": "abc123\n" if state["commit"] else "",
+                "stderr": "",
+                "returncode": 0 if state["commit"] else 1,
+            }
+        if args[:2] == ["git", "status"]:
+            return {"ok": True, "stdout": "?? private-notes.txt\n", "stderr": "", "returncode": 0}
+        if args[:2] == ["git", "add"]:
+            assert "private-notes.txt" not in args
+            assert "." not in args
+            state["staged"] = True
+            return {"ok": True, "stdout": "", "stderr": "", "returncode": 0}
+        if args[:3] == ["git", "diff", "--cached"]:
+            return {
+                "ok": not state["staged"],
+                "stdout": "",
+                "stderr": "",
+                "returncode": 1 if state["staged"] else 0,
+            }
+        if args[:2] == ["git", "commit"]:
+            state["commit"] = True
+            state["staged"] = False
+            return {"ok": True, "stdout": "", "stderr": "", "returncode": 0}
+        if args[:3] == ["gh", "auth", "status"]:
+            return {"ok": True, "stdout": "", "stderr": "", "returncode": 0}
+        raise AssertionError(args)
+
+    monkeypatch.setattr(onboard_mod, "_run_command", fake_run)
+
+    result = onboard_mod.run(
+        path=str(repo),
+        name="Private Folder",
+        mode="new",
+        level="power",
+        github_repo="dmthepm/private-folder",
+        github_visibility="private",
+        github_push=True,
+    )
+
+    assert result["ok"] is False
+    assert result["github"]["ok"] is False
+    assert any("uncommitted files outside" in error for error in result["github"]["errors"])
+    assert not any(cmd[:3] == ["gh", "repo", "create"] for cmd in commands)
+
+
+def test_onboard_github_success_uses_reachability_over_stale_auth_status(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(onboard_mod, "_which", lambda name: f"/usr/bin/{name}")
+    repo = tmp_path / "reachable"
+    state = {"commit": False, "remote": "", "tracking": "", "staged": False}
+
+    def fake_run(
+        args: list[str], cwd: Path | None = None, timeout: float = 5.0
+    ) -> dict[str, object]:
+        if args[:3] == ["git", "rev-parse", "--is-inside-work-tree"]:
+            return {"ok": True, "stdout": "true\n", "stderr": "", "returncode": 0}
+        if args[:3] == ["git", "branch", "--show-current"]:
+            return {"ok": True, "stdout": "main\n", "stderr": "", "returncode": 0}
+        if args[:4] == ["git", "config", "--get", "remote.origin.url"]:
+            ok = bool(state["remote"])
+            return {"ok": ok, "stdout": state["remote"], "stderr": "", "returncode": 0 if ok else 1}
+        if args[:5] == ["git", "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"]:
+            ok = bool(state["tracking"])
+            return {
+                "ok": ok,
+                "stdout": state["tracking"],
+                "stderr": "",
+                "returncode": 0 if ok else 1,
+            }
+        if args[:3] == ["git", "rev-parse", "--verify"]:
+            return {
+                "ok": state["commit"],
+                "stdout": "abc123\n" if state["commit"] else "",
+                "stderr": "",
+                "returncode": 0 if state["commit"] else 1,
+            }
+        if args[:2] == ["git", "status"]:
+            return {"ok": True, "stdout": "", "stderr": "", "returncode": 0}
+        if args[:2] == ["git", "add"]:
+            state["staged"] = True
+            return {"ok": True, "stdout": "", "stderr": "", "returncode": 0}
+        if args[:3] == ["git", "diff", "--cached"]:
+            return {
+                "ok": not state["staged"],
+                "stdout": "",
+                "stderr": "",
+                "returncode": 1 if state["staged"] else 0,
+            }
+        if args[:2] == ["git", "commit"]:
+            state["commit"] = True
+            state["staged"] = False
+            return {"ok": True, "stdout": "", "stderr": "", "returncode": 0}
+        if args[:3] == ["gh", "auth", "status"]:
+            return {"ok": False, "stdout": "", "stderr": "stale auth", "returncode": 1}
+        if args[:3] == ["gh", "repo", "create"]:
+            state["remote"] = "https://github.com/dmthepm/reachable.git\n"
+            state["tracking"] = "origin/main\n"
+            return {"ok": True, "stdout": "", "stderr": "", "returncode": 0}
+        if args[:3] == ["gh", "repo", "view"]:
+            return {
+                "ok": True,
+                "stdout": '{"nameWithOwner":"dmthepm/reachable"}\n',
+                "stderr": "",
+                "returncode": 0,
+            }
+        raise AssertionError(args)
+
+    monkeypatch.setattr(onboard_mod, "_run_command", fake_run)
+
+    result = onboard_mod.run(
+        path=str(repo),
+        name="Reachable",
+        mode="new",
+        level="auto",
+        github_repo="dmthepm/reachable",
+        github_visibility="private",
+        github_push=True,
+    )
+
+    assert result["ok"] is True
+    assert result["tools"]["github_cli"]["authenticated"] is True
+    assert result["tools"]["github_cli"]["state"] == "ready_reachable"
+    assert not any("gh auth login" in warning for warning in result["warnings"])


### PR DESCRIPTION
## Summary

Adds an owner-ready first-run setup path for `mb onboard` that can scaffold a business repo, save the baseline, create or connect GitHub, push `main`, and return setup-complete facts. Fresh business repos now include a tracked README, runtime/GitHub diagnostics explain duplicate `mb` installs, stale Claude wiring, and reachable GitHub remotes more clearly, and GitHub setup now only commits generated durable scaffold files before push success.

## Linked issue

Closes #606
Refs MAIN-378
Follow-up: #608

## Why

The real first-run Codex setup reached the desired outcome only because the agent stitched together lower-level `mb`, `git`, and `gh` commands and diagnosed stale local wiring by hand. This makes that path first-class while protecting non-generated local files from accidental baseline commits.

## Commits by concern

- [ ] Each commit body bullet-lists the changes in that commit
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`

Commit list:

- `754fa3e [add] MAIN-378 owner-ready onboarding setup`
- `10f1597 [fix] MAIN-378 guard onboarding GitHub push`

Note: the commits have no bodies, so the first checklist item is left unchecked rather than rewriting pushed history.

## Validation

Pre-push gate from repo root:

```bash
scripts/check.sh
```

Level 1 static: `scripts/check.sh` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: `0` — log: `88 files already formatted`; `All checks passed!`; `Success: no issues found in 87 source files`; full pytest `692 passed`; skill validation `passed: 15`, `failed: 0`.

Level 2 CLI contract: `cd mb && pytest tests/test_onboard.py -q` — runtime: local Python test env — exit: `0` — log: `18 passed in 28.96s`. Earlier focused suite for engine, migration lint, connect, onboard, init, start, and status also passed with `172 passed in 150.63s` before the review fix.

Level 3 package/install smoke: `cd mb && python3 -m build`; `/tmp/mainbranch-smoke-main378/bin/pip install mb/dist/*.whl`; `/tmp/mainbranch-smoke-main378/bin/mb --version`; `/tmp/mainbranch-smoke-main378/bin/mb skill list` — runtime: `/tmp/mainbranch-smoke-main378/bin/python3.13` — exit: `0` — log: `Successfully built mainbranch-0.3.22...`; `mb 0.3.22`; 15 bundled skills listed.

Level 4 fixture repo: installed-wheel fresh `mb onboard`, `mb doctor`, `mb status --json --peek`, `mb start --json`, `mb validate --cross-refs`, and `mb doctor repair --plan --json` — runtime: `/tmp/mainbranch-smoke-main378/bin/python3.13` — exit: `0` — log: `all good — you're set to run claude`; `nothing to check yet`; no required repair actions.

Level 5 runtime smoke: `codex exec --json --ephemeral --sandbox read-only -c 'approval_policy="never"' -C <fresh repo> ...` — runtime: `/opt/homebrew/bin/codex` with installed-wheel `mb` on PATH — exit: `0` — log: final answer used deterministic `mb 0.3.22` facts, reported readiness `100/ready`, validation clean, and no edits.

Claude Code interactive TUI smoke was not run because this branch changes setup guidance and CLI handoff facts but not slash-command discovery semantics; closest verified fallback was installed-wheel `mb start --json` with `handoff_ready: true`.

- [x] Level 1 static: `scripts/check.sh` passes
- [x] Level 2 CLI contract: focused Typer/CliRunner tests, exit codes, `--json` behavior, TTY vs non-TTY (if CLI behavior touched)
- [x] Level 3 package/install smoke (if packaging touched)
- [x] Level 4 fixture repo (if init/onboard/status/start/update touched)
- [x] Level 5 runtime smoke / dogfood harness / simulation-tier (if runtime, first-run, skill discovery, or release validation touched)
- [x] SKILL.md <=500 lines (if any skill touched)
- [ ] Package-visible release gate evidence before tag/publish (if preparing a release)
- [ ] Supply-chain review (if `.github/workflows/`, `.github/dependabot.yml`, `mb/pyproject.toml` deps, or `id-token`/`permissions` blocks touched — see [docs/supply-chain-policy.md](../docs/supply-chain-policy.md))

Package-visible release gate evidence before tag/publish was not required because this PR is not tagging or publishing a release. Supply-chain review was not required because no workflows, dependency files, or permissions blocks changed.

## Success metric

A fresh business-repo setup can end with one owner-readable outcome: the folder is created, saved, synced to GitHub when requested, and ready to open in Claude Code; the technical receipt exposes the setup-complete facts and repair commands without sweeping unrelated local files into the GitHub baseline.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [ ] N/A — change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [x] No
- [ ] Yes — migration note below

## Public / private boundary

No private operator strategy, customer data, tokens, raw local transcript, or machine-specific private paths were committed. New docs and templates describe the behavior generically, `.mb/onboarding.json`, `.claude/settings.local.json`, `.mb/connect.yaml`, and `.mb/private/` stay ignored, and the GitHub setup path now refuses push success when non-generated local files remain uncommitted.
