### PR TITLE
[docs] Record v0.3.22 post-release review

### DIFF
--- a/docs/release-simulations.md
+++ b/docs/release-simulations.md
@@ -271,6 +271,10 @@ with print-mode proxy limits and follow-up routing:
 The v0.3.19 post-release review shows the same shape after MoneyPath,
 proof-quality, content-strategy, and start-update-posture changes shipped:
 [reports/2026-05-12-v0-3-19-post-release-transcript-review.md](reports/2026-05-12-v0-3-19-post-release-transcript-review.md).
+The v0.3.22 post-release review shows the package-visible acceptance shape
+after the OpenAI image rail and owner-language hardening release, including the
+route for repeated owner-language leakage:
+[reports/2026-05-14-v0-3-22-post-release-transcript-review.md](reports/2026-05-14-v0-3-22-post-release-transcript-review.md).
 
 ## Evidence Rules
 

--- a/docs/release-simulations.md
+++ b/docs/release-simulations.md
@@ -274,8 +274,8 @@ The v0.3.19 post-release review shows the same shape after MoneyPath,
 proof-quality, content-strategy, and start-update-posture changes shipped:
 [reports/2026-05-12-v0-3-19-post-release-transcript-review.md](reports/2026-05-12-v0-3-19-post-release-transcript-review.md).
 The v0.3.22 post-release review shows the package-visible acceptance shape
-after the OpenAI image rail and owner-language hardening release, including the
-route for repeated owner-language leakage:
+after the OpenAI image rail release, including the historical route that led to
+the later owner-language hardening:
 [reports/2026-05-14-v0-3-22-post-release-transcript-review.md](reports/2026-05-14-v0-3-22-post-release-transcript-review.md).
 
 ## Evidence Rules

--- a/docs/reports/2026-05-14-v0-3-22-post-release-transcript-review.md
+++ b/docs/reports/2026-05-14-v0-3-22-post-release-transcript-review.md
@@ -1,0 +1,99 @@
+# v0.3.22 Post-Release Transcript Review Note
+
+This is a public-safe review note for the v0.3.22 post-publish
+`release_acceptance` simulation run. It is not a raw Claude transcript. It
+avoids local paths, account data, private business context, and long excerpts.
+
+## Evidence Set
+
+- Date: 2026-05-14
+- Published package: `mainbranch 0.3.22` from PyPI
+- GitHub Release: `oe-v0.3.22`
+- Release workflow: publish, release-note sync, PyPI publish, and Linear
+  release sync succeeded
+- Evidence level: fresh PyPI install deterministic harness plus `claude -p`
+  print-mode proxy simulation
+- Simulation tier: `release_acceptance`
+- Claude Code version: 2.1.140
+- Public/private boundary: sanitized summary only
+
+## Deterministic Harness Result
+
+- PyPI latest: `mainbranch 0.3.22`
+- `pip install mainbranch==0.3.22`: ok
+- `mb --version`: `mb 0.3.22`
+- `mb skill list`: ok
+- `mb books check --fixture --json`: ok with hledger available
+- `mb books check --fixture --json`: ok with hledger hidden from `PATH`
+- `mb onboard --yes --json`: ok in the dogfood harness
+- `.claude/skills/mb-start/SKILL.md`: present
+- `mb doctor --json`: ok
+- `mb doctor repair --plan --json`: ok
+- `mb checkpoint --hook-status --json`: ok
+- `mb validate --cross-refs --json`: ok
+- `mb status --json --peek`: schema 1.0, skill wiring ok
+- `mb start --json`: handoff ready, follow-up `/mb-start`
+- Fixture business repo after run: clean
+- Engine repo unexpected changes: false
+
+## Claude Print-Mode Proxy Result
+
+- Print-mode ran: yes
+- Rubric score: 11/11 heuristic checks
+- Grounding verdict: print proxy, manual review required
+- Permission denials: 0
+- Read-only `mb` grounding denials: 0
+- Session ID preserved: yes
+- Interactive Claude Code TUI smoke: not run in this post-release pass
+
+The deterministic harness captured the required `mb` facts. The Claude
+print-mode run respected write boundaries, kept repo boundaries clean, and did
+not hit permission distortions. It remains proxy evidence, not proof of
+interactive slash-command behavior.
+
+## Manual Review Summary
+
+| Finding | Severity | Categories | Release lesson |
+|---|---|---|---|
+| GitHub Release, PyPI publish, fresh install, installed CLI version, bundled skills, books fixture checks, and Linear release sync all agreed on v0.3.22. | Pass | evidence quality, package/install | The package-visible release is installable and release surfaces agree. |
+| The post-publish proxy simulation preserved read-only grounding, write discipline, repo boundaries, and provider/runtime honesty. | Pass | CLI grounding, write discipline, repo boundary, provider honesty | v0.3.22 did not introduce a release-blocking runtime safety regression in the proxy harness. |
+| Owner-facing transcript excerpts still leaked raw git/GitHub words such as branch, working tree, and origin remote after the business translation appeared nearby. Checkpoint examples still included a broad folder-level phrase. | Quality concern | operator-language first, business-language return, skill prose, generated repo guidance | This is the next owner-language slice, not a v0.3.22 publish blocker. Route to #604. |
+
+## Release Decision
+
+v0.3.22 is acceptable as shipped. GitHub Release, PyPI publish, fresh PyPI
+install, fixture checks, Linear release sync, and post-publish
+release-acceptance proxy all succeeded. The transcript review found no hard
+failure in skill discovery, write discipline, repo boundary, provider honesty,
+or public/private handling.
+
+Do not overstate the runtime evidence. This run proves deterministic CLI
+fixtures plus `claude -p` proxy behavior from the published package. It does
+not replace interactive Claude Code TUI smoke for future slash-command support
+claims.
+
+## Alignment Sweep
+
+- CHANGELOG: v0.3.22 is a dated shipped section; current `[Unreleased]`
+  correctly carries post-release v0.3.23 work from #607 and #609.
+- GitHub Release: `oe-v0.3.22` exists and points at the release-prep merge
+  commit.
+- PyPI: `mainbranch 0.3.22` is available with wheel and sdist artifacts.
+- README: no change needed; current support and command language already
+  treats the shipped daily-loop, books readiness, Meta summary, and image rail
+  surfaces accurately.
+- Roadmap: no change needed; shipped foundation already includes the
+  release-simulation fixture ladder, sample books reporting, Meta read-only
+  summary, and image-rail direction while keeping private-vault reporting and
+  provider mutation deferred.
+- Release simulations: no process change needed; the existing transcript
+  rubric caught the owner-language leakage and routed it to #604.
+- Local preferences: no new private workflow protocol found; no update needed.
+
+## Follow-Up Route
+
+- Keep
+  [#604](https://github.com/noontide-co/mainbranch/issues/604) as the next
+  focused branch for owner-language leakage in release-simulation answers.
+- Keep the fix public-safe: no raw transcript dumps, private paths, local
+  machine details, account data, or private operator strategy.

--- a/docs/reports/2026-05-14-v0-3-22-post-release-transcript-review.md
+++ b/docs/reports/2026-05-14-v0-3-22-post-release-transcript-review.md
@@ -57,7 +57,7 @@ interactive slash-command behavior.
 |---|---|---|---|
 | GitHub Release, PyPI publish, fresh install, installed CLI version, bundled skills, books fixture checks, and Linear release sync all agreed on v0.3.22. | Pass | evidence quality, package/install | The package-visible release is installable and release surfaces agree. |
 | The post-publish proxy simulation preserved read-only grounding, write discipline, repo boundaries, and provider/runtime honesty. | Pass | CLI grounding, write discipline, repo boundary, provider honesty | v0.3.22 did not introduce a release-blocking runtime safety regression in the proxy harness. |
-| Owner-facing transcript excerpts still leaked raw git/GitHub words such as branch, working tree, and origin remote after the business translation appeared nearby. Checkpoint examples still included a broad folder-level phrase. | Quality concern | operator-language first, business-language return, skill prose, generated repo guidance | This is the next owner-language slice, not a v0.3.22 publish blocker. Route to #604. |
+| Owner-facing transcript excerpts still leaked raw git/GitHub words such as branch, working tree, and origin remote after the business translation appeared nearby. Checkpoint examples still included a broad folder-level phrase. | Quality concern | operator-language first, business-language return, skill prose, generated repo guidance | This was routed to #604 after v0.3.22 and resolved by the later owner-language hardening. |
 
 ## Release Decision
 
@@ -87,13 +87,15 @@ claims.
   summary, and image-rail direction while keeping private-vault reporting and
   provider mutation deferred.
 - Release simulations: no process change needed; the existing transcript
-  rubric caught the owner-language leakage and routed it to #604.
+  rubric caught the owner-language leakage and routed it to #604, which later
+  landed as the owner-language hardening follow-up.
 - Local preferences: no new private workflow protocol found; no update needed.
 
 ## Follow-Up Route
 
-- Keep
-  [#604](https://github.com/noontide-co/mainbranch/issues/604) as the next
-  focused branch for owner-language leakage in release-simulation answers.
+- Treat
+  [#604](https://github.com/noontide-co/mainbranch/issues/604) as the
+  historical route from this review. It has since landed; open a fresh focused
+  issue for any new owner-language misses.
 - Keep the fix public-safe: no raw transcript dumps, private paths, local
   machine details, account data, or private operator strategy.


### PR DESCRIPTION
## Summary

Records the public-safe v0.3.22 post-release transcript review and links it from the release simulation docs.

## Linked issue

Refs #604.

## Why

The v0.3.22 release has shipped through GitHub Release, PyPI, fresh install verification, Linear release sync, and post-publish release acceptance. The post-release sweep needs a durable public note that captures what the package-visible evidence proved, what remains proxy-only, and where the repeated owner-language transcript finding is routed.

## Commits by concern

- [ ] Each commit body bullet-lists the changes in that commit
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`

Commit list:

- `2781283 [docs] Record v0.3.22 post-release review`

## Validation

Pre-push gate from repo root:

```bash
scripts/check.sh
```

- [x] Level 1 static: `scripts/check.sh` passes
- [ ] Level 2 CLI contract: focused Typer/CliRunner tests, exit codes, `--json` behavior, TTY vs non-TTY (if CLI behavior touched)
- [ ] Level 3 package/install smoke (if packaging touched)
- [ ] Level 4 fixture repo (if init/onboard/status/start/update touched)
- [ ] Level 5 runtime smoke / dogfood harness / simulation-tier (if runtime, first-run, skill discovery, or release validation touched)
- [ ] SKILL.md ≤500 lines (if any skill touched)
- [ ] Package-visible release gate evidence before tag/publish (if preparing a release)
- [ ] Supply-chain review (if `.github/workflows/`, `.github/dependabot.yml`, `mb/pyproject.toml` deps, or `id-token`/`permissions` blocks touched — see [docs/supply-chain-policy.md](../docs/supply-chain-policy.md))

Evidence lines:

- Level 1 static: `scripts/check.sh` — runtime: `python3` 3.13.7 — exit: 0 — log: `.agent/post-release-0.3.22-check-rebased.out`.
- Level 2 CLI contract: not required; this branch changes docs only.
- Level 3 package/install smoke: not required for this docs-only branch; v0.3.22 post-publish install evidence is summarized in the report.
- Level 4 fixture repo: not required; no first-run or repo-shape code changed.
- Level 5 runtime smoke: not rerun for this branch; the report summarizes the existing v0.3.22 post-publish `release_acceptance` evidence and its print-mode proxy limit.
- SKILL.md line-count gate: not required by the changed files; still covered inside `scripts/check.sh`.
- Package-visible release gate: not required; this branch records the completed post-release evidence and does not prepare a new package release.
- Supply-chain review: not required; no workflow, dependency, or permissions files changed.

## Success metric

Future release reviewers can find the v0.3.22 post-publish acceptance result, its print-mode proxy boundary, and the #604 follow-up route from `docs/release-simulations.md` without reading local `.agent/` evidence.

## CHANGELOG

- [ ] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [x] N/A — change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [x] No
- [ ] Yes — migration note below

## Public / private boundary

The report is a sanitized public summary only. It does not commit raw transcripts, local paths, account data, private operator strategy, credentials, or `.agent/` release evidence.
