### PR TITLE
[update] prepare mainbranch 0.3.23

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mainbranch",
-  "version": "0.3.22",
+  "version": "0.3.23",
   "description": "Main Branch Claude Code skills for running a business from markdown files in git.",
   "author": {
     "name": "Noontide"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+## [0.3.23] - 2026-05-14
+
+v0.3.23 packages the owner-ready first-run GitHub setup path and
+user-scoped provider hydration for disposable workspaces. Together they make a
+fresh business repo easier to set up, save, sync, and rehydrate from agent
+workspaces without re-entering provider tokens.
+
 ### Added
 
 - Added a first-run setup completion envelope and optional `mb onboard --github

--- a/mb/mb/__init__.py
+++ b/mb/mb/__init__.py
@@ -7,6 +7,6 @@ file stays a thin dispatcher.
 
 from __future__ import annotations
 
-__version__ = "0.3.22"
+__version__ = "0.3.23"
 
 __all__ = ["__version__"]

--- a/mb/pyproject.toml
+++ b/mb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mainbranch"
-version = "0.3.22"
+version = "0.3.23"
 description = "Main Branch engine umbrella - scaffolds, validates, and graphs business-as-files repos. Claude Code first, runtime-agnostic by design."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Prepares `mainbranch` / `mb` v0.3.23 by syncing all package/plugin version sites and moving the current unreleased setup and provider-hydration work into a dated changelog section. This is a release-only PR for the `oe-v0.3.23` publish path.

## Linked issue

Refs #610
Refs MAIN-380

## Why

MAIN-378 and MAIN-379 are merged, but users cannot install those changes until the package version, plugin manifest, changelog, release candidate evidence, and release supply-chain checks agree. This PR creates the reviewable release-prep commit before the GitHub Release / PyPI publish step.

## Commits by concern

- [ ] Each commit body bullet-lists the changes in that commit
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`

Commit list:

- `241ede6 [update] MAIN-380 prepare 0.3.23 release`

Note: the commit has no body, so the first checklist item is left unchecked rather than rewriting pushed history.

## Validation

Pre-push gate from repo root:

```bash
scripts/check.sh
```

Level 0 release preflight: version-file preflight and manifest guard — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: `0` — log: `.agent/release-evidence/0.3.23/preflight.out` shows all release version sites at `0.3.23` and `1 passed in 0.24s`.

Level 1 static: `scripts/check.sh` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: `0` — log: `.agent/release-evidence/0.3.23/check.out`; `88 files already formatted`; `All checks passed!`; `Success: no issues found in 87 source files`; `696 passed in 459.49s`; skill validation `passed: 15`, `failed: 0`.

Level 2 CLI contract: covered by the full gate and release-candidate smoke — runtime: `/tmp/mainbranch-smoke-0.3.23/bin/python3.13` — exit: `0` — log: `.agent/release-evidence/0.3.23/package-smoke.out` and `.agent/release-evidence/0.3.23/fixture-smoke.out`; installed `mb 0.3.23`, `mb skill list`, `mb status --json --peek`, `mb start --json`, and `mb validate --cross-refs` all completed.

Level 3 package/install: `(cd mb && python3 -m build)` plus fresh venv install of `mainbranch-0.3.23-py3-none-any.whl` — runtime: `/tmp/mainbranch-smoke-0.3.23/bin/python3.13` — exit: `0` — log: `.agent/release-evidence/0.3.23/package-smoke.out`; `Successfully built mainbranch-0.3.23...`; `mb 0.3.23`; dist and module versions both `0.3.23`; books fixture covered `hledger-missing` and `fixture-valid`, both `result_status: ok`.

Level 4 fixture repo: installed-wheel fresh repo smoke with `mb onboard`, `mb doctor`, `mb status --json --peek`, `mb start --json`, and `mb validate --cross-refs` — runtime: `/tmp/mainbranch-smoke-0.3.23/bin/python3.13` — exit: `0` — log: `.agent/release-evidence/0.3.23/fixture-smoke.out`; `all good — you're set to run claude`; `handoff_ready: true`; `nothing to check yet`.

Level 5 runtime: `scripts/claude-runtime-dogfood.py --install-mode wheel --wheel mb/dist/mainbranch-0.3.23-py3-none-any.whl --run-claude-print --simulation-tier release_acceptance --max-budget-usd 0.75` — runtime: `python3` + Claude Code `2.1.140` — exit: `0` — log: `.agent/release-evidence/0.3.23/dogfood.log`; evidence: `.agent/release-evidence/0.3.23/dogfood/evidence-template.md`; 11/11 heuristic checks, no permission denials, no repo-boundary changes, and no unknown command failures. Manual review routed the recurring operator-language quality concern to #604 as non-blocking.

Supply-chain review: release-time checks — runtime: `gh` CLI — exit: `0` — log: `.agent/release-evidence/0.3.23/supply-chain.out`; no dependency or workflow changes since `oe-v0.3.22`, no open Dependabot alerts, `id-token: write` remains isolated to the PyPI publish job, and the `pypi` environment still has required reviewers.

- [x] Level 1 static: `scripts/check.sh` passes
- [x] Level 2 CLI contract: focused Typer/CliRunner tests, exit codes, `--json` behavior, TTY vs non-TTY (if CLI behavior touched)
- [x] Level 3 package/install smoke (if packaging touched)
- [x] Level 4 fixture repo (if init/onboard/status/start/update touched)
- [x] Level 5 runtime smoke / dogfood harness / simulation-tier (if runtime, first-run, skill discovery, or release validation touched)
- [x] SKILL.md <=500 lines (if any skill touched)
- [x] Package-visible release gate evidence before tag/publish (if preparing a release)
- [x] Supply-chain review (if `.github/workflows/`, `.github/dependabot.yml`, `mb/pyproject.toml` deps, or `id-token`/`permissions` blocks touched — see [docs/supply-chain-policy.md](../docs/supply-chain-policy.md))

## Success metric

The release-prep branch proves `0.3.23` is internally consistent and ready for the maintainer release step: after this PR merges, creating GitHub Release `oe-v0.3.23` should publish `mainbranch 0.3.23`, then a fresh PyPI install should report `mb 0.3.23`.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [ ] N/A — change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [x] No
- [ ] Yes — migration note below

## Public / private boundary

No private operator strategy, customer data, tokens, raw provider payloads, local transcript bodies, or machine-specific paths were committed. Release evidence stayed under ignored `.agent/`; the public PR cites only sanitized command shapes and summary facts.
