### PR TITLE
[update] expose release and direction context

### DIFF
--- a/.claude/skills/mb-start/SKILL.md
+++ b/.claude/skills/mb-start/SKILL.md
@@ -197,7 +197,7 @@ updates inside a general status wall.** Users on stale code get broken
 features, and normal operators will miss a one-line version note.
 
 If `update.severity` is `required` or the top ranked action is an update action,
-run the cited command. When status does not cite a narrower command, use:
+run the cited update command. When status does not cite one, use:
 
 ```bash
 mb update --repo . --json
@@ -205,10 +205,10 @@ mb update --repo . --json
 
 Then run `mb status --json --peek` again before routing.
 
-If `update.severity` is `recommended`, stop there. Do not show ranked actions
-or business recommendations yet; those may change after the update. Ask whether
-to update now, then rerun `mb status --json --peek` before routing. Use
-[references/router-and-language.md](references/router-and-language.md) for
+If `update.severity` is `recommended`, stop there. Use `update.release_notes_url`
+or `update.update_check_command` to answer what changed or run a fresh dry-run.
+Ask whether to update now, then rerun `mb status --json --peek` before routing.
+Use [references/router-and-language.md](references/router-and-language.md) for
 operator-facing wording and fallback details.
 
 ---

--- a/.claude/skills/mb-start/references/router-and-language.md
+++ b/.claude/skills/mb-start/references/router-and-language.md
@@ -107,9 +107,12 @@ updates or explicitly chooses to continue. Name the installed and latest
 versions if present and say how many version steps are behind when the numbers
 are obvious.
 
-If the status report includes release highlights or ranked update actions, use
-those highlights. If not, say the user may be missing recent routing, repair,
-or skill fixes; do not invent exact release notes.
+If the status report includes `update.release_notes_url`, release highlights, or
+ranked update actions, use those facts. If the user asks what changed and status
+includes `update.update_check_command`, run that dry-run and use its
+`release.summary` or `release.url`. If no release context is available, say the
+user may be missing recent routing, repair, or skill fixes; do not invent exact
+release notes.
 
 Use direct, non-technical language:
 

--- a/.claude/skills/mb-update/SKILL.md
+++ b/.claude/skills/mb-update/SKILL.md
@@ -67,21 +67,27 @@ Do not continue as if the update worked.
 
 ## Step 3: Restart If Skill Links Changed
 
-If `skills_relinked_count` is greater than zero, tell the user:
+If `skills_relinked_count` is greater than zero after an actual update, tell
+the user:
 
 > "Skill links were refreshed. If a slash command does not appear in Claude
 > Code, restart Claude from this repo and run `/mb-start`."
 
 Claude Code loads slash commands at session start, so a restart can be required
-after repairing links.
+after repairing links. In `--check --json` output, treat
+`planned_skills_relink_count` as a dry-run preview, not proof that links already
+changed.
 
 ---
 
 ## Step 4: What Changed
 
-After a successful update, read `CHANGELOG.md` from the active Main Branch
-engine if available and summarize only the most recent "What this means for
-you" section. Keep it short: 3-5 bullets max.
+After a successful update, use `release.summary` and `release.url` from the
+JSON result when present. Keep it short: 3-5 bullets max, and include the
+release URL when the user asks what changed.
+
+If the JSON result has no release summary, read `CHANGELOG.md` from the active
+Main Branch engine if available and summarize only the matching version section.
 
 If no changelog is available, do not guess. Say:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+### Changed
+
+- Added release-note context and freshness evidence to update checks:
+  `mb status --json --peek` now names the fresh check command, latest-version
+  source, check timestamp, and release notes URL, while `mb update --check`
+  reports GitHub Release metadata in JSON and human output when available.
+  Refs MAIN-384, #616.
+
 ## [0.3.23] - 2026-05-14
 
 v0.3.23 packages the owner-ready first-run GitHub setup path and

--- a/README.md
+++ b/README.md
@@ -119,12 +119,12 @@ You don't run any of these commands yourself. You ask the agent. It runs them.
 Main Branch v0.3 has three layers:
 
 - **Your folder is the source of truth.** Offer, audience, voice, decisions, research, bets, launches, logs, documents, links to other repos. Plain markdown files you can read on any computer.
-- **The CLI is the fact and safety layer.** It scaffolds the folder, validates the shape, draws the relationship graph, briefs the agent on what's changed, walks through repairs, saves readable checkpoints, and checks that connected providers are wired up safely. It also exposes shipped facts for MoneyPath readiness, proof quality, content strategy health, books readiness, provider readiness, status, start, graph, and checkpoint workflows. The agent runs it. You don't have to learn it.
+- **The CLI is the fact and safety layer.** It scaffolds the folder, validates the shape, maps how the business pieces connect, briefs the agent on what's changed, walks through repairs, saves readable checkpoints, and checks that connected accounts are wired up safely. It also exposes shipped facts for MoneyPath readiness, proof quality, content strategy health, books readiness, connected-account health, status, start, graph, and checkpoint workflows. The agent runs it. You don't have to learn it.
 - **The skills are the chat UX and judgment layer.** The agent reads your folder and `mb` facts, asks you the right questions, drafts work, reviews it, and routes approved artifacts back into files.
 
 Agent recommends. You decide what gets shipped, spent, published, or saved.
 
-The longer-arc operating-system model — where multiple business repos, GitHub teams, structured data, and runtime adapters compose into a full team operating system — is direction, not the v0.3 shape. See [`decisions/2026-05-02-github-native-business-os.md`](decisions/2026-05-02-github-native-business-os.md).
+The longer-arc operating-memory model — where multiple business repos, GitHub teams, structured data, and runtime adapters compose into a full team operating system — is direction, not the v0.3 shape. See [`decisions/2026-05-15-repo-owned-operating-memory.md`](decisions/2026-05-15-repo-owned-operating-memory.md).
 
 ---
 

--- a/decisions/2026-04-29-mb-vip-v0-1-0-master.md
+++ b/decisions/2026-04-29-mb-vip-v0-1-0-master.md
@@ -1,9 +1,11 @@
 ---
 type: decision
 date: 2026-04-29
-status: proposed
+status: superseded
 topic: mb-vip v0.1.0 — engine-side master decision (skill composition, repo shape, PyPI packaging, /mb-site upgrade, conductor preferences)
 mirrors: noontide-projects/decisions/2026-04-29-main-branch-v0-1-0-master.md
+superseded_by:
+  - decisions/2026-05-15-repo-owned-operating-memory.md
 linked_research:
   - noontide-projects/research/2026-04-29-marketing-site-brief-framework-yt-mining.md
   - noontide-projects/research/2026-04-29-marketing-skills-repo-mining.md
@@ -16,6 +18,16 @@ tags: [v0-1-0, mb-vip, engine, /mb-site, pypi, conductor-preferences]
 
 # mb-vip v0.1.0 — Engine Master Decision
 
+> Superseded. This is a historical launch-planning mirror from before the public
+> repo, package, folder model, operator language, and current runtime support
+> stance settled. Current product truth lives in
+> [2026-05-15 Repo-Owned Operating Memory](2026-05-15-repo-owned-operating-memory.md),
+> [README](../README.md), [AGENTS](../AGENTS.md),
+> [docs/roadmap.md](../docs/roadmap.md), and
+> [docs/system-architecture.md](../docs/system-architecture.md). Do not use this
+> file for current branch naming, setup, packaging, pricing, paid/private
+> content, or runtime-support guidance.
+
 ## Context
 
 This file is the engine-side mirror of the noontide-projects master decision (`noontide-projects/decisions/2026-04-29-main-branch-v0-1-0-master.md`). The noontide-projects master sets the business-level locks: vocabulary (tool/skill/playbook), folder shape, OSS-vs-paid mechanism, pricing, dashboard commitment, and the 8-item v0.1.0 ship list at the conceptual level. This file lands the same locks on the **engine repo (`mb-vip`)** with concrete file paths, package shape, and per-skill change lists.
@@ -24,7 +36,8 @@ It exists because Devon already acked the noontide-projects master on 2026-04-29
 
 There is no relitigation here. Vocabulary, folder shape, dial naming, archetype catalog, OSS/paid mechanism, PyPI commitment, and conductor-preferences-for-mb-vip are all decided in the noontide-projects master or in the linked research files. This file translates them into engine-repo execution.
 
-The decision is `status: proposed` because it has not yet been opened as a PR. It graduates to `status: accepted` when Devon merges the v0.1.0-rc1 PR on this branch.
+This decision started as `status: proposed` during v0.1 launch planning. It is
+now `status: superseded`; see the notice above for current product truth.
 
 ---
 
@@ -922,7 +935,9 @@ Mirrors the noontide-projects master.
 
 Engine-side ships:
 
-- This decision file lands as `decisions/2026-04-29-mb-vip-v0-1-0-master.md`, status `proposed` → `accepted` on merge.
+- This historical plan expected the decision file to land as
+  `decisions/2026-04-29-mb-vip-v0-1-0-master.md`, status `proposed` →
+  `accepted` on merge. That path has since been superseded.
 - Repo reorg: skills stay flat, playbooks dir created flat, educational dir created.
 - Vocabulary sweep (any remaining `atom-*` / `molecule` / `compound` mentions in skill files → `tool-*` / `skill` / `playbook`).
 - /mb-site skill upgrade *outline only*: brief schema doc'd in `SKILL.md`, `archetypes.md` index file lands, 3 archetype detail files land, Seven Sweeps lands in `review.md`, AI-tells lands in `anti-patterns.md`. Remaining 6 archetypes are `status: stub` placeholders that load but say "detail coming v0.1.1."

--- a/decisions/2026-05-02-github-native-business-os.md
+++ b/decisions/2026-05-02-github-native-business-os.md
@@ -1,11 +1,20 @@
 ---
 title: Main Branch as GitHub-native business operating system
 date: 2026-05-02
-status: proposed
+status: superseded
 tags: [product-direction, github, cli, integrations, graph, business-os]
+superseded_by:
+  - decisions/2026-05-15-repo-owned-operating-memory.md
 ---
 
 # Main Branch as GitHub-Native Business Operating System
+
+> Superseded by
+> [2026-05-15 Repo-Owned Operating Memory](2026-05-15-repo-owned-operating-memory.md).
+> This proposal was useful direction for v0.2, but it predates the current
+> chat-first daily loop, push primitive, hidden GitOps layer, user-scoped
+> provider connection model, and experimental Codex CLI-first adapter. Use it as
+> historical context, not current product truth.
 
 ## Decision
 

--- a/decisions/2026-05-08-codex-adapter-plan.md
+++ b/decisions/2026-05-08-codex-adapter-plan.md
@@ -1,7 +1,7 @@
 ---
 type: decision
 date: 2026-05-08
-status: proposed
+status: accepted
 topic: Codex adapter plan without duplicating the skill system
 linked_decisions:
   - decisions/2026-05-01-mb-cli-vs-agent-workflows-boundary.md
@@ -14,6 +14,12 @@ tags: [runtime-adapters, codex, skills, cli, decision-needed]
 ---
 
 # Codex Adapter Plan
+
+> Status note: Stage 1 has shipped as the experimental CLI-first Codex adapter.
+> Fresh business repos include `AGENTS.md`, and `mb doctor`, `mb status`, and
+> `mb start` expose Codex readiness. This decision remains the staging plan;
+> current public support wording lives in
+> [docs/compatibility.md](../docs/compatibility.md).
 
 ## Decision
 
@@ -49,16 +55,17 @@ does not mean identical runtime behavior.
 Main Branch facts:
 
 - Claude Code is the only supported runtime today.
-- `docs/compatibility.md` already says Codex is a roadmap surface until adapter
-  docs/code and fresh-repo smoke evidence exist.
-- `mb start --json`, `mb status --json`, and generated business `CLAUDE.md`
-  are Claude-first today.
+- Codex CLI has an experimental CLI-first adapter for power users. Fresh
+  business repos include generated `AGENTS.md`; `mb doctor`, `mb status`, and
+  `mb start` expose Codex readiness; no slash-command or workflow parity is
+  claimed.
+- `mb start --json`, `mb status --json`, generated business `CLAUDE.md`, and
+  generated business `AGENTS.md` are the current runtime handoff surfaces.
 - Claude Code discovery depends on project-local `.claude/skills/mb-*` bridge
   links. `.claude/settings.local.json` grants engine file access but does not
   by itself prove slash-command discovery.
-- There is no generated business `AGENTS.md`, Codex handoff envelope, Codex
-  skill-link command, Codex conflict/shadow repair, or Codex fresh-repo smoke
-  evidence in this repository today.
+- There is no Codex skill-link command or broad Codex workflow parity in this
+  repository today.
 
 Codex facts from official docs:
 

--- a/decisions/2026-05-15-repo-owned-operating-memory.md
+++ b/decisions/2026-05-15-repo-owned-operating-memory.md
@@ -1,0 +1,164 @@
+---
+type: decision
+date: 2026-05-15
+status: accepted
+topic: Repo-owned operating memory and current product language
+linked_decisions:
+  - decisions/2026-05-01-mb-cli-vs-agent-workflows-boundary.md
+  - decisions/2026-05-04-workspace-repo-sensitive-data-boundaries.md
+  - decisions/2026-05-05-operator-loops-taxonomy.md
+  - decisions/2026-05-06-main-branch-operating-spine.md
+  - decisions/2026-05-07-work-continuity-hidden-technical-memory.md
+  - decisions/2026-05-11-repo-setup-visibility-and-checks-model.md
+  - decisions/2026-05-13-provider-cli-api-wrapper-boundary.md
+supersedes:
+  - decisions/2026-05-02-github-native-business-os.md
+tags: [product-direction, architecture, language, state-model, providers]
+---
+
+# Repo-Owned Operating Memory
+
+## Decision
+
+Main Branch is repo-owned operating memory for AI-assisted businesses.
+
+The current product shape is:
+
+1. The business folder is the durable memory.
+2. `mb` is the fact, safety, repair, update, and connected-account readiness
+   layer.
+3. Agent runtimes and skills are the judgment and workflow layer.
+4. Git and GitHub are the hidden technical memory layer.
+5. Provider rails, sidecars, Obsidian, and future dashboards are inputs or
+   views, not source of truth.
+
+This supersedes the older "GitHub-native business operating system" proposal as
+the current direction anchor. The old proposal was directionally useful, but it
+was written before the daily loop, push primitive, hidden GitOps layer, provider
+connection model, and experimental Codex adapter had settled.
+
+## Current Architecture
+
+The business repo owns durable business truth:
+
+- `core/` for evergreen offer, audience, voice, proof, strategy, operations,
+  finance policy, and connected-account boundaries;
+- `research/`, `decisions/`, `bets/`, `pushes/`, `log/`, and `documents/` for
+  operating memory;
+- safe connected-account refs, data-source records, and approved summaries when
+  they are useful to future work;
+- git history, checkpoints, GitHub issues, and pull requests as inspectable
+  history and coordination.
+
+`mb` owns deterministic facts and safe mechanics:
+
+- repo shape, validation, graph, status, start, doctor/repair, migration,
+  update, connected-account readiness, skill wiring, and checkpoint planning;
+- stable JSON and exit codes for agents, CI, dashboards, and power users;
+- privacy and secret boundaries for local state, provider connections, and
+  public issue drafting.
+
+Skills and runtimes own judgment:
+
+- routing messy operator requests into business primitives;
+- asking the missing question;
+- drafting, reviewing, and improving work;
+- translating `mb` facts into business-owner language;
+- asking before durable writes, publishing, spend, provider mutation, or
+  customer contact.
+
+## Provider And Secret Model
+
+Durable safe refs live in git. Secrets do not.
+
+Provider setup has three layers:
+
+- tracked repo files can hold non-secret intent, account labels,
+  connected-account refs, public-safe ids, and approved summaries;
+- local ignored workspace state can hold hydration markers, repair evidence,
+  and caches;
+- user-scoped or provider-native secret stores hold tokens, refresh tokens,
+  service-account material, and private account access.
+
+`mb connect` may own credential routing, readiness checks, safe metadata, and
+workspace hydration. The OS keychain, environment, provider-native auth store,
+or GitHub Actions secrets own the secret values.
+
+Disposable workspaces should hydrate from user/local state when the repo identity
+matches. A different business repo must not inherit another repo's provider
+credentials simply because it shares a machine.
+
+Provider mutation is not a blanket product capability. A rail can mutate
+external systems only when that specific workflow has preview behavior,
+operator approval, readiness checks, tests, and smoke evidence.
+
+## Language Contract
+
+Normal operators should not have to reason in git or schema terms.
+
+Use business language first:
+
+- task, blocker, follow-up, proposal, saved checkpoint, connected account,
+  business map, proof, offer, push, playbook, outcome, and what changed;
+- "the system checked..." before raw command names;
+- "saved progress" before "commit";
+- "proposal" before "pull request";
+- "connected account" before "provider readiness";
+- "public site from private source" before GitHub/Cloudflare mechanics.
+
+Keep technical language available where it belongs:
+
+- contributor docs;
+- command references;
+- JSON contracts;
+- troubleshooting;
+- architecture and decision records.
+
+The rule is not to hide the machinery. The rule is to let the user meet the
+business outcome before the machinery.
+
+## Dashboard And Sidecar Stance
+
+Dashboards, Obsidian, scheduled sync, local databases, and sidecars are useful
+only when they make repo truth easier to see or safe external facts easier to
+use.
+
+They must not become the canonical business memory. A future dashboard may have
+state, indexes, and server process state, but that state is explicit local or
+self-hosted operational state. It reads from business repos, GitHub, `mb` JSON,
+provider-safe summaries, and approved sidecars.
+
+No dashboard is required for the current daily loop.
+
+## Consequences
+
+- README and roadmap should link this decision for the current long-arc model.
+- Historical v0.1/v0.2 planning decisions remain useful context, but they are
+  not current product truth when they conflict with README, AGENTS, roadmap,
+  architecture, compatibility, or this decision.
+- Provider and workspace docs should say that `mb` owns routing and readiness,
+  while secret stores own secret values.
+- Operator-facing copy should keep improving away from unexplained terms such
+  as provider refs, sidecars, topology, schema, runtime adapter, and smoke
+  evidence unless the user is in a technical or contributor context.
+
+## Review Trigger
+
+Revisit this decision if Main Branch ships any of these:
+
+- a dashboard that writes durable business truth;
+- provider mutation without a specific accepted rail;
+- a supported non-Claude runtime;
+- a hosted service that changes the repo-owned memory model;
+- background sync or scheduled jobs that become default rather than explicit.
+
+## Related links
+
+- [The mb CLI vs Portable Agent Workflows](2026-05-01-mb-cli-vs-agent-workflows-boundary.md)
+- [Workspace, Repo, and Sensitive Data Boundaries](2026-05-04-workspace-repo-sensitive-data-boundaries.md)
+- [Operator Loops Taxonomy](2026-05-05-operator-loops-taxonomy.md)
+- [Main Branch Operating Spine](2026-05-06-main-branch-operating-spine.md)
+- [Work Continuity and Hidden Technical Memory](2026-05-07-work-continuity-hidden-technical-memory.md)
+- [Repo Setup, Visibility, and Checks Model](2026-05-11-repo-setup-visibility-and-checks-model.md)
+- [Provider CLI/API and mb Wrapper Boundary](2026-05-13-provider-cli-api-wrapper-boundary.md)
+- [Superseded: GitHub-Native Business Operating System](2026-05-02-github-native-business-os.md)

--- a/docs/architecture/system-map.md
+++ b/docs/architecture/system-map.md
@@ -199,7 +199,7 @@ flowchart TB
 
 | Surface | Owns | Does not own | Source |
 | --- | --- | --- | --- |
-| `mb` CLI | Deterministic facts, repo shape, validation, migration, status, graph, provider readiness, updates, skill wiring, checkpoint planning. | Judgment-heavy writing, model conversations, broad provider products, secret storage. | [Ethos](../ethos.md), [README](../../README.md#for-contributors-and-power-users) |
+| `mb` CLI | Deterministic facts, repo shape, validation, migration, status, graph, provider readiness, credential routing, safe connection metadata, updates, skill wiring, checkpoint planning. | Judgment-heavy writing, model conversations, broad provider products, secret values. | [Ethos](../ethos.md), [README](../../README.md#for-contributors-and-power-users) |
 | Skills | Judgment, routing, synthesis, drafting, review, explanation, session flow. | Structural invariants that `mb` can check, raw provider mutation without approval, repo-health probes in prose. | [AGENTS](../../AGENTS.md#product-shape), [Operator loops](../operator-loops.md) |
 | Business repo | Durable business memory: core files, research, decisions, bets, pushes, logs, documents, safe data records, approved summaries. | Secrets, raw finance/legal/account data, rebuildable caches as source of truth. | [System architecture](../system-architecture.md), [OSS checklist](../oss-operating-checklist.md) |
 | Git and GitHub | History, issues, proposals, checks, releases, public coordination. | Private operational notes or customer/member/account details. | [Checks and review model](../checks-and-review-model.md), [Issue drafting](../issue-drafting.md) |
@@ -228,7 +228,7 @@ flowchart TB
 | Provider metrics | `data/<provider>/` records, SQLite, snapshots, and reports when the rows are safe for the repo audience. | `data/<provider>/source.md`, `linked_data_sources`, reports. |
 | Scheduled sync state | `.mb/private/sync/` and scheduler logs; ignored local state or hosted-runner logs. | `source.md` freshness and sanitized run summaries. |
 | Real bookkeeping | Private bookkeeping vault using hledger; separate private repo for teams when needed. | `core/finance/books.md`, sanitized finance summaries, bookkeeping policy. |
-| Credentials | OS keychain, environment, provider-native auth, GitHub Actions secrets. | `mb connect` safe metadata and readiness state. |
+| Credentials | OS keychain, environment, provider-native auth, GitHub Actions secrets. | `mb connect` safe metadata, user-scoped routing, and readiness state. |
 | Raw customer, member, legal, account, or transcript data | Provider systems, private repos, private vaults, or explicit local ignored storage. | Sanitized summaries, approved excerpts, or no pointer. |
 
 Sources: [Data-source registry](../data-source-registry.md),

--- a/docs/checks-and-review-model.md
+++ b/docs/checks-and-review-model.md
@@ -170,7 +170,7 @@ in a skill or in an action is a workaround, not a check.
   validation evidence.
 - **Hosted dashboard state model** is out of scope until a dashboard surface
   is accepted. See
-  [`decisions/2026-05-02-github-native-business-os.md`](../decisions/2026-05-02-github-native-business-os.md).
+  [`decisions/2026-05-15-repo-owned-operating-memory.md`](../decisions/2026-05-15-repo-owned-operating-memory.md).
 
 ## Related links
 

--- a/docs/operator-loops.md
+++ b/docs/operator-loops.md
@@ -37,15 +37,15 @@ The normal Main Branch day is a compact Sense -> Decide -> Ship -> Reflect
 chain:
 
 - **Sense:** `/mb-start`, `/mb-status`, or `mb status --json --peek` reads
-  repo health, graph links, provider readiness, recent activity, update state,
-  GitHub task/proposal signals, and MoneyPath readiness for the path from
+  repo health, graph links, connected-account readiness, recent activity,
+  update state, GitHub task/proposal signals, and MoneyPath readiness for the path from
   customer progress to offer, proof, CTA, channel, push, playbook, page, and
   outcome feedback.
 - **Decide:** the agent and operator choose the next business move: a bet to
   frame, a piece of research to run, a decision to codify, a push to advance, a
   playbook to draft, or a repair to approve.
 - **Ship:** the skill creates or updates the artifact, while `mb` supplies
-  deterministic checks, repair commands, validation, provider readiness, and
+  deterministic checks, repair commands, validation, connected-account readiness, and
   checkpoint plans.
 - **Reflect:** `/mb-end`, bet close/narrate behavior, push review notes, or
   checkpoint guidance records what changed and what the next Sense pass should
@@ -55,8 +55,8 @@ The user-facing nouns are business nouns: bets, goals, offers, pushes,
 playbooks, outcomes, and checkpoints. The technical nouns underneath are still
 part of the architecture, but they serve the loop: issues are durable work
 threads, pull requests are proposals/reviews, commits are saved checkpoints,
-graph links are relationship memory, and provider refs are safe handles to
-external systems.
+graph links are relationship memory, and connected-account handles point to
+external systems without copying private account data into the repo.
 
 ## 1. Sense
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,13 +2,16 @@
 
 This roadmap is direction, not a promise. GitHub issues and release notes are
 the detailed execution record. This file explains the product shape so users,
-contributors, and agents understand where Main Branch is going.
+contributors, and agents understand where Main Branch is going. The current
+direction anchor is
+[Repo-owned operating memory](../decisions/2026-05-15-repo-owned-operating-memory.md).
 
 Main Branch is not only a marketing-growth context folder. Growth is the first
 high-value wedge because ads, pages, content, and launches expose the memory
 problem quickly. The broader product is durable operating memory for
 AI-assisted businesses: meetings, fulfillment, bookkeeping summaries, provider
-refs, decisions, bets, pushes, logs, and lessons in repos the team owns.
+safe account refs, decisions, bets, pushes, logs, and lessons in repos the team
+owns.
 
 ## Shipped Foundation
 
@@ -86,10 +89,11 @@ In one pass, the loop is:
 3. **Use the right layer.** Claude Code skills are the chat UX and judgment
    layer. `mb` is the fact and safety layer: repo shape, graph links, status
    health, MoneyPath, proof quality, content strategy health, books readiness,
-   provider readiness, updates, repairs, validation, and guarded commits.
+   connected-account readiness, updates, repairs, validation, and guarded commits.
 4. **Hide the plumbing, preserve the memory.** Issues, branches, pull requests,
-   commits, graph links, and provider refs exist so the business can inspect
-   what happened later. The user-facing language should stay business-readable.
+   commits, graph links, and connected-account handles exist so the business
+   can inspect what happened later. The user-facing language should stay
+   business-readable.
 5. **Keep approval explicit.** Writing durable files, publishing, spending,
    provider mutation, and customer contact should stay operator-approved.
 6. **Close the loop.** `/mb-end` and checkpoint guidance turn the session into
@@ -99,7 +103,7 @@ The work clusters into a few durable buckets:
 
 - **Start and status.** `/mb-start`, `/mb-status`, and `mb status` should read
   the same facts: since-last-check changes, ranked next actions, drift,
-  onboarding progress, update severity, provider readiness, GitHub
+  onboarding progress, update severity, connected-account readiness, GitHub
   tasks/proposals, MoneyPath readiness, proof quality, content strategy health,
   books readiness, and recent business activity.
 - **Repair and migration.** `mb doctor`, `mb doctor repair`, `mb update`, and
@@ -135,7 +139,7 @@ Current public implementation anchors are GitHub issues, not promises in this
 roadmap. Check live issues before using any anchor as current scope. For this
 phase, the durable topic cluster is generated repo guidance, migration lint,
 topology/status/graph facts, child repo descriptors, reusable playbooks,
-runtime dogfood, provider readiness, and issue/friction capture. Link specific
+runtime dogfood, connected-account readiness, and issue/friction capture. Link specific
 issue numbers only after verifying their state on GitHub.
 
 Anti-scope for v0.3.x:

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -522,11 +522,11 @@ Provider systems record live operational facts. Sidecars can enrich Main
 Branch with structured data. A future local dashboard could render repo and
 provider truth without owning it. None of these replace the main business record.
 
-Main Branch does not mutate provider accounts today. Provider mutation
-requires a shipped adapter with approval gates, readiness checks, and smoke
-evidence; until then, playbooks are plans and approvals, not execution. See
-[roadmap.md](roadmap.md) and [dependency-choices.md](dependency-choices.md)
-for direction.
+Main Branch does not claim blanket provider mutation. A provider rail can mutate
+external systems only when that exact workflow has preview behavior, operator
+approval, readiness checks, tests, and smoke evidence. Until then, playbooks are
+plans and approvals, not execution. See [roadmap.md](roadmap.md) and
+[dependency-choices.md](dependency-choices.md) for direction.
 
 Correct pattern:
 

--- a/mb/mb/_data/templates/AGENTS.md.tmpl
+++ b/mb/mb/_data/templates/AGENTS.md.tmpl
@@ -67,10 +67,9 @@ command.
 5. If status says an update is required, route to the cited `mb update` command
    and ask before running it. If status says an update is recommended, make that
    the only recommendation before business routing: name installed/latest
-   versions, say the update brings recent routing, repair, and skill
-   improvements when release highlights are unavailable, then ask whether to
-   update now. Do not show ranked actions until
-   after the operator updates or explicitly chooses to continue. After an
+   versions, use `update.release_notes_url` or `update.update_check_command`
+   when present, and ask whether to update now. Do not show ranked actions
+   until after the operator updates or explicitly chooses to continue. After an
    approved update, rerun `mb status --json --peek`.
 6. Resume onboarding from status facts. In rich repos, read existing `core/`
    files before asking bounded missing-profile questions.

--- a/mb/mb/_data/templates/CLAUDE.md.tmpl
+++ b/mb/mb/_data/templates/CLAUDE.md.tmpl
@@ -51,13 +51,13 @@ wiring, tell the operator to restart Claude Code from this repo and try
 
 If `mb status --json --peek` reports `update.severity` as `recommended` or
 `required`, make that the only recommendation before business routing. Name the
-installed/latest versions when present. For recommended updates, say the update
-brings recent routing, repair, and skill improvements when release highlights
-are unavailable, then ask whether to update now. Do not show ranked actions
-until after the operator updates or explicitly chooses to continue. For required
-updates, route to the cited
-`mb update` command before business work. After an approved update, rerun the
-status briefing.
+installed/latest versions when present. Use `update.release_notes_url` or
+`update.update_check_command` when present to answer what changed. If release
+context is unavailable, say the update brings recent routing, repair, and skill
+improvements, then ask whether to update now. Do not show ranked actions until
+after the operator updates or explicitly chooses to continue. For required
+updates, route to the cited `mb update` command before business work. After an
+approved update, rerun the status briefing.
 
 Do the technical work in technical commands, then translate the result back into
 business-owner language. Speak first in terms of bets, goals, offers, pushes,

--- a/mb/mb/freshness.py
+++ b/mb/mb/freshness.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import urllib.error
 import urllib.request
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -15,6 +16,7 @@ MINIMUM_SUPPORTED_VERSION = "0.2.0"
 # `mb update` first shipped in the same release as the current support floor.
 MB_UPDATE_AVAILABLE_VERSION = "0.2.0"
 PYPI_PACKAGE_URL = "https://pypi.org/pypi/mainbranch/json"
+GITHUB_RELEASE_URL_TEMPLATE = "https://github.com/noontide-co/mainbranch/releases/tag/oe-v{version}"
 _LATEST_AUTO = object()
 
 
@@ -39,6 +41,11 @@ def latest_pypi_version(timeout: float = 3.0) -> str | None:
     info = data.get("info", {})
     version = info.get("version") if isinstance(info, dict) else None
     return version if isinstance(version, str) and version else None
+
+
+def release_notes_url(version: str) -> str:
+    version = version.strip()
+    return GITHUB_RELEASE_URL_TEMPLATE.format(version=version) if version else ""
 
 
 def looks_like_business_repo(repo: Path) -> bool:
@@ -70,6 +77,12 @@ def package_update_status(
         if latest_version is _LATEST_AUTO and mode not in {"clone", "source"}
         else latest_version
     )
+    checked_at = (
+        datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    )
+    latest_source = "not_applicable" if mode in {"clone", "source"} else "provided"
+    if latest_version is _LATEST_AUTO and mode not in {"clone", "source"}:
+        latest_source = "pypi_json" if latest else "unavailable"
     if latest is _LATEST_AUTO:
         latest = None
     latest_text = latest if isinstance(latest, str) else ""
@@ -107,8 +120,14 @@ def package_update_status(
         "minimum_supported": minimum_supported,
         "severity": severity,
         "command": command,
+        "update_check_command": "mb update --check --json"
+        if mode not in {"clone", "source"}
+        else "",
         "post_update_commands": _post_update_commands(repo),
         "reason": reason,
+        "latest_source": latest_source,
+        "checked_at": checked_at,
+        "release_notes_url": release_notes_url(latest_text) if latest_text else "",
     }
 
 

--- a/mb/mb/init.py
+++ b/mb/mb/init.py
@@ -277,13 +277,13 @@ wiring, tell the operator to restart Claude Code from this repo and try
 
 If `mb status --json --peek` reports `update.severity` as `recommended` or
 `required`, make that the only recommendation before business routing. Name the
-installed/latest versions when present. For recommended updates, say the update
-brings recent routing, repair, and skill improvements when release highlights
-are unavailable, then ask whether to update now. Do not show ranked actions
-until after the operator updates or explicitly chooses to continue. For required
-updates, route to the cited
-`mb update` command before business work. After an approved update, rerun the
-status briefing.
+installed/latest versions when present. Use `update.release_notes_url` or
+`update.update_check_command` when present to answer what changed. If release
+context is unavailable, say the update brings recent routing, repair, and skill
+improvements, then ask whether to update now. Do not show ranked actions until
+after the operator updates or explicitly chooses to continue. For required
+updates, route to the cited `mb update` command before business work. After an
+approved update, rerun the status briefing.
 
 Do the technical work in technical commands, then translate the result back into
 business-owner language. Speak first in terms of bets, goals, offers, pushes,

--- a/mb/mb/update.py
+++ b/mb/mb/update.py
@@ -6,15 +6,23 @@ import json
 import re
 import shutil
 import subprocess
+import urllib.error
+import urllib.request
 from pathlib import Path
 from typing import Any
 
 from mb import __version__
 from mb.engine import bundled_skills, engine_root, install_mode
-from mb.freshness import latest_pypi_version as _latest_pypi_version
+from mb.freshness import (
+    latest_pypi_version as _latest_pypi_version,
+)
+from mb.freshness import release_notes_url, version_key
 
 VERSION_RE = re.compile(r'__version__\s*=\s*["\']([^"\']+)["\']')
 CLONE_UPDATE_COMMAND = ["git", "pull", "--ff-only", "origin", "main"]
+GITHUB_RELEASE_API_URL_TEMPLATE = (
+    "https://api.github.com/repos/noontide-co/mainbranch/releases/tags/oe-v{version}"
+)
 
 
 def _run_command(args: list[str], *, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
@@ -88,6 +96,58 @@ def _skill_count_from_link_result(result: dict[str, Any]) -> int:
     return total
 
 
+def _release_summary(body: str) -> str:
+    lines: list[str] = []
+    for raw_line in body.splitlines():
+        line = raw_line.strip()
+        if not line:
+            if lines:
+                break
+            continue
+        if line.startswith("#"):
+            continue
+        lines.append(line)
+    return " ".join(lines)
+
+
+def _release_context(version: str, *, timeout: float = 3.0) -> dict[str, Any]:
+    version = version.strip()
+    context: dict[str, Any] = {
+        "version": version,
+        "tag": f"oe-v{version}" if version else "",
+        "url": release_notes_url(version),
+        "name": "",
+        "published_at": "",
+        "summary": "",
+        "available": False,
+        "source": "github_release",
+    }
+    if not version:
+        return context
+    url = GITHUB_RELEASE_API_URL_TEMPLATE.format(version=version)
+    try:
+        request = urllib.request.Request(url, headers={"Accept": "application/vnd.github+json"})
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            data = json.loads(response.read().decode("utf-8"))
+    except (OSError, TimeoutError, urllib.error.URLError, json.JSONDecodeError):
+        context["source"] = "github_release_unavailable"
+        return context
+    if not isinstance(data, dict):
+        context["source"] = "github_release_unavailable"
+        return context
+    body = str(data.get("body") or "")
+    context.update(
+        {
+            "url": str(data.get("html_url") or context["url"]),
+            "name": str(data.get("name") or ""),
+            "published_at": str(data.get("published_at") or ""),
+            "summary": _release_summary(body),
+            "available": True,
+        }
+    )
+    return context
+
+
 def _link_warnings(payload: dict[str, Any]) -> list[str]:
     skipped = _list_field(payload, "skipped")
     if not skipped:
@@ -130,6 +190,8 @@ def _base_result(repo: Path, *, check: bool, mode: str, root: Path | None) -> di
         "old_version": _engine_version(root),
         "new_version": None,
         "skills_relinked_count": 0,
+        "planned_skills_relink_count": 0,
+        "release": {},
         "actions": [],
         "warnings": [],
         "errors": [],
@@ -180,7 +242,24 @@ def run(repo: str | Path = ".", *, check: bool = False) -> dict[str, Any]:
                     f"would run `mb skill link --repo {target_repo} --json`",
                 ]
             )
-        result["skills_relinked_count"] = len(bundled_skills())
+        planned_count = len(bundled_skills())
+        result["skills_relinked_count"] = planned_count
+        result["planned_skills_relink_count"] = planned_count
+        new_version = str(result.get("new_version") or "")
+        old_version = str(result.get("old_version") or "")
+        if new_version and version_key(new_version) > version_key(old_version):
+            result["release"] = _release_context(new_version)
+        elif new_version:
+            result["release"] = {
+                "version": new_version,
+                "tag": f"oe-v{new_version}",
+                "url": release_notes_url(new_version),
+                "name": "",
+                "published_at": "",
+                "summary": "",
+                "available": False,
+                "source": "not_newer",
+            }
         return result
 
     if mode == "pipx":
@@ -232,6 +311,14 @@ def render_human(result: dict[str, Any]) -> None:
     if result.get("check"):
         print(f"install mode: {mode}")
         print(f"version: {old} -> {new}")
+        raw_release = result.get("release")
+        release = raw_release if isinstance(raw_release, dict) else {}
+        release_url = str(release.get("url") or "")
+        release_summary = str(release.get("summary") or "")
+        if release_url:
+            print(f"release notes: {release_url}")
+        if release_summary:
+            print(f"release summary: {release_summary}")
         for action in result.get("actions", []):
             print(action)
         if count:

--- a/mb/tests/fixtures/status/schema-v1-basic.json
+++ b/mb/tests/fixtures/status/schema-v1-basic.json
@@ -55,13 +55,17 @@
       "version"
     ],
     "update": [
+      "checked_at",
       "command",
       "installed",
       "latest",
+      "latest_source",
       "minimum_supported",
       "post_update_commands",
       "reason",
-      "severity"
+      "release_notes_url",
+      "severity",
+      "update_check_command"
     ],
     "runtime": [
       "claude_code",

--- a/mb/tests/test_freshness.py
+++ b/mb/tests/test_freshness.py
@@ -15,15 +15,18 @@ def test_required_update_status_for_version_below_minimum(tmp_path: Path) -> Non
         mode="pipx",
     )
 
-    assert update == {
-        "installed": "0.1.2",
-        "latest": "0.2.1",
-        "minimum_supported": "0.2.0",
-        "severity": "required",
-        "command": "pipx upgrade mainbranch",
-        "post_update_commands": ["mb skill link --repo .", "mb doctor"],
-        "reason": "Installed version predates mb update and the current skill-link repair flow.",
-    }
+    assert update["installed"] == "0.1.2"
+    assert update["latest"] == "0.2.1"
+    assert update["minimum_supported"] == "0.2.0"
+    assert update["severity"] == "required"
+    assert update["command"] == "pipx upgrade mainbranch"
+    assert update["update_check_command"] == "mb update --check --json"
+    assert update["post_update_commands"] == ["mb skill link --repo .", "mb doctor"]
+    assert update["latest_source"] == "provided"
+    assert update["release_notes_url"].endswith("/oe-v0.2.1")
+    assert update["reason"] == (
+        "Installed version predates mb update and the current skill-link repair flow."
+    )
 
     alert = format_update_alert(update)
     assert "Update required." in alert
@@ -59,9 +62,12 @@ def test_recommended_update_status_for_supported_stale_version(tmp_path: Path) -
 
     assert update["severity"] == "recommended"
     assert update["command"] == "mb update"
+    assert update["update_check_command"] == "mb update --check --json"
     assert update["installed"] == "0.2.0"
     assert update["latest"] == "0.2.1"
     assert update["minimum_supported"] == "0.2.0"
+    assert update["latest_source"] == "provided"
+    assert update["release_notes_url"].endswith("/oe-v0.2.1")
 
     alert = format_update_alert(update)
     assert "Update recommended." in alert
@@ -79,4 +85,6 @@ def test_current_source_install_does_not_render_alert(tmp_path: Path) -> None:
 
     assert update["severity"] == "current"
     assert update["latest"] == "0.2.1"
+    assert update["latest_source"] == "not_applicable"
+    assert update["update_check_command"] == ""
     assert format_update_alert(update) == ""

--- a/mb/tests/test_update.py
+++ b/mb/tests/test_update.py
@@ -40,7 +40,21 @@ def test_update_check_pipx_does_not_run_commands(monkeypatch: Any, tmp_path: Pat
 
     monkeypatch.setattr(update_mod, "install_mode", lambda: "pipx")
     monkeypatch.setattr(update_mod, "engine_root", lambda: tmp_path / "_engine")
-    monkeypatch.setattr(update_mod, "_latest_pypi_version", lambda: "0.2.0")
+    monkeypatch.setattr(update_mod, "_latest_pypi_version", lambda: "9.9.9")
+    monkeypatch.setattr(
+        update_mod,
+        "_release_context",
+        lambda version: {
+            "version": version,
+            "tag": f"oe-v{version}",
+            "url": f"https://github.com/noontide-co/mainbranch/releases/tag/oe-v{version}",
+            "name": f"Main Branch {version}",
+            "published_at": "2026-05-15T00:00:00Z",
+            "summary": "Test release summary.",
+            "available": True,
+            "source": "github_release",
+        },
+    )
     monkeypatch.setattr(update_mod, "bundled_skills", lambda: ["mb-start", "mb-update"])
     monkeypatch.setattr(update_mod, "_run_command", fake_run)
 
@@ -48,8 +62,11 @@ def test_update_check_pipx_does_not_run_commands(monkeypatch: Any, tmp_path: Pat
 
     assert result["ok"] is True
     assert result["old_version"] == __version__
-    assert result["new_version"] == "0.2.0"
+    assert result["new_version"] == "9.9.9"
     assert result["skills_relinked_count"] == 2
+    assert result["planned_skills_relink_count"] == 2
+    assert result["release"]["url"].endswith("/oe-v9.9.9")
+    assert result["release"]["summary"] == "Test release summary."
     assert calls == []
 
 
@@ -195,7 +212,21 @@ def test_update_clone_pulls_engine_root_then_relinks(monkeypatch: Any, tmp_path:
 def test_update_json_cli_envelope(monkeypatch: Any, tmp_path: Path) -> None:
     monkeypatch.setattr(update_mod, "install_mode", lambda: "pipx")
     monkeypatch.setattr(update_mod, "engine_root", lambda: tmp_path / "_engine")
-    monkeypatch.setattr(update_mod, "_latest_pypi_version", lambda: "0.2.0")
+    monkeypatch.setattr(update_mod, "_latest_pypi_version", lambda: "9.9.9")
+    monkeypatch.setattr(
+        update_mod,
+        "_release_context",
+        lambda version: {
+            "version": version,
+            "tag": f"oe-v{version}",
+            "url": f"https://github.com/noontide-co/mainbranch/releases/tag/oe-v{version}",
+            "name": "",
+            "published_at": "",
+            "summary": "Release notes from GitHub.",
+            "available": True,
+            "source": "github_release",
+        },
+    )
     monkeypatch.setattr(update_mod, "bundled_skills", lambda: ["mb-start"])
 
     result = runner.invoke(app, ["update", "--repo", str(tmp_path / "biz"), "--check", "--json"])
@@ -204,9 +235,28 @@ def test_update_json_cli_envelope(monkeypatch: Any, tmp_path: Path) -> None:
     payload = json.loads(result.stdout)
     assert payload["mode"] == "pipx"
     assert payload["old_version"] == __version__
-    assert payload["new_version"] == "0.2.0"
+    assert payload["new_version"] == "9.9.9"
     assert payload["skills_relinked_count"] == 1
+    assert payload["planned_skills_relink_count"] == 1
+    assert payload["release"]["summary"] == "Release notes from GitHub."
+    assert payload["release"]["url"].endswith("/oe-v9.9.9")
     assert payload["errors"] == []
+
+
+def test_update_check_current_release_still_exposes_notes_url(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(update_mod, "install_mode", lambda: "pipx")
+    monkeypatch.setattr(update_mod, "engine_root", lambda: tmp_path / "_engine")
+    monkeypatch.setattr(update_mod, "_latest_pypi_version", lambda: __version__)
+    monkeypatch.setattr(update_mod, "bundled_skills", lambda: ["mb-start"])
+
+    result = update_mod.run(repo=tmp_path / "biz", check=True)
+
+    assert result["ok"] is True
+    assert result["new_version"] == __version__
+    assert result["release"]["source"] == "not_newer"
+    assert result["release"]["url"].endswith(f"/oe-v{__version__}")
 
 
 def test_update_rejects_unknown_install_mode(monkeypatch: Any, tmp_path: Path) -> None:
@@ -310,6 +360,10 @@ def test_update_render_human_check_and_error(capsys: Any) -> None:
             "old_version": "0.1.2",
             "new_version": "0.2.0",
             "skills_relinked_count": 3,
+            "release": {
+                "url": "https://github.com/noontide-co/mainbranch/releases/tag/oe-v0.2.0",
+                "summary": "Release context.",
+            },
             "actions": ["would run `git pull`"],
             "errors": ["boom"],
             "warnings": ["careful"],
@@ -320,6 +374,10 @@ def test_update_render_human_check_and_error(capsys: Any) -> None:
 
     assert "install mode: clone" in output
     assert "version: 0.1.2 -> 0.2.0" in output
+    assert (
+        "release notes: https://github.com/noontide-co/mainbranch/releases/tag/oe-v0.2.0" in output
+    )
+    assert "release summary: Release context." in output
     assert "would refresh 3 skill link(s)" in output
     assert "error: boom" in output
     assert "warning: careful" in output


### PR DESCRIPTION
## Summary

Adds explicit release and freshness context to the `mb status` update payload and `mb update --check` output so agents can distinguish cached status from a fresh update check and point operators at the matching release notes. Updates bundled/generator guidance, current direction docs, architecture wording, and stale decision status so cold-start agents read the current product reality.

## Linked issue

Closes #616
Refs MAIN-384

## Why

During the `0.3.23` rollout, `mb status --json --peek` could report the installed version as current while `mb update --check --json` found a newer PyPI package. The dry-run update path also did not expose release notes or a changelog summary, leaving agents unable to explain what the update contained.

The follow-up docs pass fixes the conceptual layer around that behavior: current cold-start docs now point to repo-owned operating memory, user-scoped provider connection boundaries, connected-account language, and the experimental Codex adapter state instead of stale v0.1/v0.2 proposals.

## Commits by concern

- [ ] Each commit body bullet-lists the changes in that commit
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`

Commit list:

- `d90f3c6 [update] MAIN-384 expose release update context`
- `c29b2fb [update] MAIN-384 align update guidance docs`
- `db7af3c [update] MAIN-384 align product direction docs`

Note: the commits have no bodies, so the first checklist item is left unchecked rather than rewriting pushed history.

## Validation

Pre-push gate from repo root:

```bash
scripts/check.sh
```

Level 0 docs/decisions: `cd mb && python3 -m mb validate --cross-refs ..` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: `0` — log: Conductor terminal excerpt; new `decisions/2026-05-15-repo-owned-operating-memory.md` reports `ok`; existing repo-wide warning-class related-link mirrors remain.

Level 1 static: `scripts/check.sh` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: `0` — log: `.context/check-doc-direction.out`; `88 files already formatted`; `All checks passed!`; `Success: no issues found in 87 source files`; `697 passed in 314.28s`; skill validation `passed: 15`, `failed: 0`.

Level 2 CLI contract: `cd mb && pytest tests/test_freshness.py tests/test_update.py tests/test_status.py::test_status_schema_v1_matches_golden_fixture tests/test_status.py::test_status_required_update_json_and_human_copy -q` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: `0` — log: Conductor terminal excerpt; `20 passed in 4.37s`.

Level 3 package/install: not run; this branch does not change packaging metadata, entrypoints, bundled skill data packaging, or install mutation behavior.

Level 4 fixture repo: `tmpdir="$(mktemp -d)"; PYTHONPATH="$PWD/mb" python3 -m mb onboard --yes --name "Test Business" --path "$tmpdir/test-business"; cd "$tmpdir/test-business"; PYTHONPATH="$OLDPWD/mb" python3 -m mb doctor; PYTHONPATH="$OLDPWD/mb" python3 -m mb status --json --peek; PYTHONPATH="$OLDPWD/mb" python3 -m mb start --json; PYTHONPATH="$OLDPWD/mb" python3 -m mb validate` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: `0` — log: `.context/fixture-main384.out`; fresh repo created, doctor/status/start returned JSON successfully, and validate printed `nothing to check yet`.

Level 5 runtime: not run; no runtime discovery, slash-command registration, or adapter execution behavior changed. Bundled skill prose changed, but the changes only teach existing agent flows to consume additive CLI fields and were covered by skill validation plus fixture guidance smoke.

- [x] Level 1 static: `scripts/check.sh` passes
- [x] Level 2 CLI contract: focused Typer/CliRunner tests, exit codes, `--json` behavior, TTY vs non-TTY (if CLI behavior touched)
- [ ] Level 3 package/install smoke (if packaging touched)
- [x] Level 4 fixture repo (if init/onboard/status/start/update touched)
- [ ] Level 5 runtime smoke / dogfood harness / simulation-tier (if runtime, first-run, skill discovery, or release validation touched)
- [x] SKILL.md ≤500 lines (if any skill touched)
- [ ] Package-visible release gate evidence before tag/publish (if preparing a release)
- [ ] Supply-chain review (if `.github/workflows/`, `.github/dependabot.yml`, `mb/pyproject.toml` deps, or `id-token`/`permissions` blocks touched — see [docs/supply-chain-policy.md](../docs/supply-chain-policy.md))

## Success metric

When a newer release exists, `mb update --check --json` exposes release context and `mb status --json --peek` gives agents enough freshness evidence to recommend a fresh update check instead of reporting contradictory readiness. Cold-start agents also see the current repo-owned operating-memory model instead of stale v0.1/v0.2 direction proposals.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [ ] N/A — change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [x] No
- [ ] Yes — migration note below

## Public / private boundary

No private operator strategy, customer data, tokens, provider payloads, local transcript bodies, or machine-specific paths were committed. The only external URLs added are public GitHub Release links for `noontide-co/mainbranch`. Local validation logs stayed under ignored `.context/` and are summarized without private business data.
