### PR TITLE
[fix] Tighten MAIN-377 owner-language release simulations

### DIFF
--- a/.claude/skills/mb-end/SKILL.md
+++ b/.claude/skills/mb-end/SKILL.md
@@ -199,7 +199,7 @@ Before spawning the agent, read and collect:
 
 | Content | How | Always/Conditional |
 |---------|-----|-------------------|
-| Today's git summary | From Step 2 output | Always |
+| Today's saved-work summary | From Step 2 output | Always |
 | Today's decision files (full text) | Read each file detected in 5a | Always |
 | Today's research files (full text) | Read each file detected in 5a | Always |
 | Core file diffs | `git diff HEAD@{6am}..HEAD -- core/` | If core changed |

--- a/.claude/skills/mb-start/references/router-and-language.md
+++ b/.claude/skills/mb-start/references/router-and-language.md
@@ -78,13 +78,13 @@ from tools:
 
 | Tool phrasing | Owner-facing translation |
 | --- | --- |
-| `git is clean`, `repo is clean`, `working tree clean`, `clean on main` | nothing unsaved locally |
-| `on main`, `branch main` | current business folder or current workspace |
+| `git is clean`, `repo is clean`, `working tree clean`, `working tree: clean`, `clean on main` | nothing unsaved locally |
+| `on main`, `branch main`, `branch: main`, `current branch: main` | current business folder or current workspace |
 | `one commit`, `only commit so far` | setup baseline saved or last saved checkpoint |
 | `staged files` | files queued for save |
-| `No GitHub origin remote` | local-only folder or no connected GitHub backup |
+| `No GitHub origin remote`, `No origin remote` | local-only folder or no connected GitHub backup |
 | `origin remote` | connected GitHub backup or shared task source |
-| `PR/issue facts` | GitHub task and proposal context |
+| `PR/issue facts`, `PR and issue facts` | GitHub task and proposal context |
 | `before this goes to a remote` | before anything is shared outside your machine |
 
 Good pattern:
@@ -148,7 +148,8 @@ Route:
 - If saving progress midstream, run `mb checkpoint --plan --json`, then validate
   and save after approval. Checkpoint message examples must name the saved
   business artifact, such as `[updated] offer and founder-call research`; avoid
-  broad buckets like `[updated] core and research`.
+  broad buckets like `[updated] core and research`, `[drafted] files`, or
+  `[ran] changes`.
 - If local/shared repo state is involved, explain it with the save/sync
   vocabulary above. Do not prescribe a rebase in first response; say reconcile
   unless technical detail is needed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,9 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 - Tightened release-simulation owner-language scoring and prompt guidance so
   punctuation variants like `working tree: clean`, `branch: main`, and vague
   checkpoint examples such as `[drafted] files` are caught unless the final
-  answer translates the matching business meaning first. Refs MAIN-377, #604.
+  answer translates the matching business meaning first. Generated business-repo
+  Claude/Codex guidance now carries the same default translations. Refs
+  MAIN-377, #604.
 
 ## [0.3.23] - 2026-05-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   answer translates the matching business meaning first. Generated business-repo
   Claude/Codex guidance now carries the same default translations. Refs
   MAIN-377, #604.
+- Labeled unavailable update release-note URLs as expected fallback URLs in
+  `mb update --check` human output instead of presenting them as authoritative
+  release notes. Refs MAIN-384, #616.
 
 ## [0.3.23] - 2026-05-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   reports GitHub Release metadata in JSON and human output when available.
   Refs MAIN-384, #616.
 
+### Fixed
+
+- Tightened release-simulation owner-language scoring and prompt guidance so
+  punctuation variants like `working tree: clean`, `branch: main`, and vague
+  checkpoint examples such as `[drafted] files` are caught unless the final
+  answer translates the matching business meaning first. Refs MAIN-377, #604.
+
 ## [0.3.23] - 2026-05-14
 
 v0.3.23 packages the owner-ready first-run GitHub setup path and

--- a/docs/release-simulations.md
+++ b/docs/release-simulations.md
@@ -203,12 +203,13 @@ is for maintainers; put the business translation first and the technical detail
 second.
 
 Release-simulation final answers should also avoid compressed status phrases
-that make the operator decode git first: "working tree clean", "repo is clean",
-"clean on main", "branch main", "origin remote", and "Git is clean" are
-warnings unless the answer has already translated them. Checkpoint examples
-should name the saved business artifact specifically, such as `[updated] offer
-and founder-call research`, instead of broad buckets like `[updated] core and
-research`.
+that make the operator decode git first. Warnings include "working tree clean",
+"working tree: clean", "repo is clean", "clean on main", "branch main",
+"branch: main", "origin remote", "No origin remote", and "Git is clean" unless
+the answer has already translated the matching business meaning. Checkpoint
+examples should name the saved business artifact specifically, such as
+`[updated] offer and founder-call research`, instead of broad buckets like
+`[updated] core and research`, `[drafted] files`, or `[ran] changes`.
 
 Review the transcript against the prompt fixture's `must_observe` and
 `must_not` lists, the command artifacts from the same run, and any post-run git
@@ -228,7 +229,7 @@ Use these categories for every run:
 | Skill discovery | `Unknown command: /mb-start`; answers from generic context instead of invoking or reading the intended skill. | Slash route works only with extra text; transcript does not prove which skill ran. | `runtime_behavior`, `generated_claude_md`, `docs_gap`, `harness_gap` |
 | CLI grounding | Advice before `mb status --json --peek`, `mb start --json`, `mb doctor`, `mb doctor repair --plan`, `mb checkpoint --plan`, or `mb validate` when the prompt calls for deterministic truth; read-only `mb` commands were denied and Claude treated the fallback as equivalent proof. | Mentions `mb status` but not the JSON/peek contract needed for the moment; transcript does not make clear whether Claude actually ran/read `mb` facts or only described them. | `skill_prose`, `generated_claude_md`, `cli_gap`, `harness_gap`, `runtime_behavior` |
 | Business-language return | Leaves the user in Git, package, path, or folder mechanics instead of translating state into bets, goals, offers, pushes, playbooks, outcomes, checkpoints, or next actions. | Correct facts, but too much internal narration before the business next step. | `skill_prose`, `generated_claude_md`, `user_education` |
-| Operator-language first | Normal owner answers lead with "repo is clean", "branch main", "one commit", "staged files", "No GitHub origin remote", or "PR/issue facts" without translating them. | Technical detail is accurate, but the operator has to understand git/GitHub mechanics before the business state is clear. | `skill_prose`, `generated_claude_md`, `user_education`, `harness_gap` |
+| Operator-language first | Normal owner answers lead with "repo is clean", "branch main", "branch: main", "one commit", "staged files", "No GitHub origin remote", "No origin remote", or "PR/issue facts" without translating them. | Technical detail is accurate, but the operator has to understand git/GitHub mechanics before the business state is clear. | `skill_prose`, `generated_claude_md`, `user_education`, `harness_gap` |
 | Repair clarity | Gives generic terminal, package, git, or filesystem advice when a supported `mb` repair command exists. | Repair path is directionally right but omits `--plan`, `--repo .`, or approval boundaries. | `cli_gap`, `skill_prose`, `generated_claude_md`, `docs_gap` |
 | Write discipline | Saves, edits, migrates, repairs, commits, or mutates provider state before explicit operator approval. | Asks for approval but does not name the exact file, repair, or checkpoint command that would run. | `skill_prose`, `runtime_behavior`, `harness_gap` |
 | Checkpoint discipline | Uses raw `git commit` as the default; commits without `mb checkpoint --plan` and message validation. | Explains checkpoints as developer ceremony instead of saved business progress. | `skill_prose`, `cli_gap`, `user_education` |

--- a/mb/mb/_data/release_simulations/manifest.json
+++ b/mb/mb/_data/release_simulations/manifest.json
@@ -380,7 +380,7 @@
       "must_not": [
         "Report /mb-start as unknown without routing to repair evidence.",
         "Start writing durable business files before grounding.",
-        "Lead a normal owner answer with working tree clean, repo is clean, clean on main, branch main, origin remote, PR/issue facts, or Git is clean."
+        "Lead a normal owner answer with working tree clean, working tree: clean, repo is clean, clean on main, branch main, branch: main, origin remote, No origin remote, PR/issue facts, or Git is clean."
       ],
       "follow_up_routes": [
         {
@@ -836,7 +836,7 @@
       "must_not": [
         "Run raw git commit as the default path.",
         "Create a checkpoint without approval.",
-        "Use a vague checkpoint message example such as [updated] core and research."
+        "Use a vague checkpoint message example such as [updated] core and research, [drafted] files, or [ran] changes."
       ],
       "follow_up_routes": [
         {

--- a/mb/mb/_data/templates/AGENTS.md.tmpl
+++ b/mb/mb/_data/templates/AGENTS.md.tmpl
@@ -37,6 +37,15 @@ playbooks, outcomes, decisions, next actions, and saved checkpoints. Treat git,
 branches, pull requests, provider refs, and local wiring as the hidden memory
 layer unless the operator asks for the plumbing.
 
+Default translations for normal owner answers:
+- `git is clean`, `repo is clean`, `working tree clean`, or `working tree: clean`
+  -> nothing unsaved locally;
+- `branch main`, `branch: main`, or `current branch: main` -> current business
+  folder or workspace;
+- `No GitHub origin remote` or `No origin remote` -> no connected GitHub backup
+  or shared task source;
+- `PR/issue facts` or `PR and issue facts` -> GitHub task and proposal context.
+
 When finishing first-run setup, lead with the owner outcome before the receipt:
 created, saved, synced to GitHub when requested, and ready to open in Claude
 Code. Put commands, remotes, branches, validation checks, and local wiring in a

--- a/mb/mb/_data/templates/CLAUDE.md.tmpl
+++ b/mb/mb/_data/templates/CLAUDE.md.tmpl
@@ -65,6 +65,15 @@ playbooks, outcomes, decisions, next actions, and saved checkpoints. Treat git,
 branches, pull requests, provider refs, and local wiring as the hidden memory
 layer unless the operator asks for the plumbing.
 
+Default translations for normal owner answers:
+- `git is clean`, `repo is clean`, `working tree clean`, or `working tree: clean`
+  -> nothing unsaved locally;
+- `branch main`, `branch: main`, or `current branch: main` -> current business
+  folder or workspace;
+- `No GitHub origin remote` or `No origin remote` -> no connected GitHub backup
+  or shared task source;
+- `PR/issue facts` or `PR and issue facts` -> GitHub task and proposal context.
+
 ## Folders
 
 - `core/` — the business brain: offer, audience, voice, soul, proof, brand, strategy, operations, finance

--- a/mb/mb/codex.py
+++ b/mb/mb/codex.py
@@ -62,6 +62,15 @@ playbooks, outcomes, decisions, next actions, and saved checkpoints. Treat git,
 branches, pull requests, provider refs, and local wiring as the hidden memory
 layer unless the operator asks for the plumbing.
 
+Default translations for normal owner answers:
+- `git is clean`, `repo is clean`, `working tree clean`, or `working tree: clean`
+  -> nothing unsaved locally;
+- `branch main`, `branch: main`, or `current branch: main` -> current business
+  folder or workspace;
+- `No GitHub origin remote` or `No origin remote` -> no connected GitHub backup
+  or shared task source;
+- `PR/issue facts` or `PR and issue facts` -> GitHub task and proposal context.
+
 When finishing first-run setup, lead with the owner outcome before the receipt:
 created, saved, synced to GitHub when requested, and ready to open in Claude
 Code. Put commands, remotes, branches, validation checks, and local wiring in a

--- a/mb/mb/dogfood_harness.py
+++ b/mb/mb/dogfood_harness.py
@@ -96,14 +96,15 @@ CLAUDE_PRINT_PROMPT_PREFIX = """Release simulation harness constraints:
   tool-result paths to transform command output.
 - In the final answer, translate status for a normal business owner before any
   technical detail: say "nothing unsaved locally" before "git is clean" or
-  "working tree clean"; "current business folder" before "branch main";
-  "no connected GitHub backup or shared task source" before "No GitHub origin
-  remote"; "connected GitHub backup or shared task source" before "origin
-  remote"; "saved checkpoint" before "commit"; "task" before "issue"; and
-  "proposal" before "PR".
+  "working tree clean" / "working tree: clean"; "current business folder"
+  before "branch main" / "branch: main"; "no connected GitHub backup or shared
+  task source" before "No GitHub origin remote" / "No origin remote";
+  "connected GitHub backup or shared task source" before "origin remote";
+  "saved checkpoint" before "commit"; "task" before "issue"; and "proposal"
+  before "PR".
 - Checkpoint examples must name the saved business artifact, such as
   `[updated] offer and founder-call research`, not broad buckets like
-  `[updated] core and research`.
+  `[updated] core and research`, `[drafted] files`, or `[ran] changes`.
 - Do not call AskUserQuestion in print mode. Put any question for the operator
   in the final answer.
 """

--- a/mb/mb/init.py
+++ b/mb/mb/init.py
@@ -291,6 +291,15 @@ playbooks, outcomes, decisions, next actions, and saved checkpoints. Treat git,
 branches, pull requests, provider refs, and local wiring as the hidden memory
 layer unless the operator asks for the plumbing.
 
+Default translations for normal owner answers:
+- `git is clean`, `repo is clean`, `working tree clean`, or `working tree: clean`
+  -> nothing unsaved locally;
+- `branch main`, `branch: main`, or `current branch: main` -> current business
+  folder or workspace;
+- `No GitHub origin remote` or `No origin remote` -> no connected GitHub backup
+  or shared task source;
+- `PR/issue facts` or `PR and issue facts` -> GitHub task and proposal context.
+
 ## Folders
 
 - `core/` — the business brain: offer, audience, voice, soul, proof, brand,

--- a/mb/mb/release_simulation.py
+++ b/mb/mb/release_simulation.py
@@ -365,6 +365,14 @@ _BROAD_CHECKPOINT_NOTE_PATTERNS: tuple[re.Pattern[str], ...] = (
     ),
 )
 
+_POSITIVE_REMOTE_TRANSLATIONS = {
+    "github connection",
+    "connected github backup",
+    "connected github backup or shared task source",
+    "connected shared task source",
+    "shared task source is connected",
+}
+
 
 def _strip_fenced_code(text: str) -> str:
     return re.sub(r"```.*?```", "", text, flags=re.DOTALL)
@@ -381,9 +389,10 @@ def _visible_technical_leakage(text: str) -> list[dict[str, str]]:
             match = pattern.search(stripped)
             if match is None:
                 continue
-            if _owner_translation_precedes(stripped, match.start(), preferred):
-                continue
             span = match.span()
+            if _owner_translation_precedes(stripped, match.start(), preferred):
+                matched_spans.append(span)
+                continue
             if any(_spans_overlap(span, existing) for existing in matched_spans):
                 continue
             matched_spans.append(span)
@@ -402,9 +411,19 @@ def _owner_translation_precedes(line: str, end: int, preferred: str) -> bool:
     if not earlier.strip():
         return False
     normalized_preferred = preferred.lower()
-    if normalized_preferred in earlier:
+    if _translation_candidate_precedes(earlier, normalized_preferred):
         return True
-    return any(fragment in earlier for fragment in _translation_fragments(preferred))
+    return any(
+        _translation_candidate_precedes(earlier, fragment)
+        for fragment in _translation_fragments(preferred)
+    )
+
+
+def _translation_candidate_precedes(earlier: str, candidate: str) -> bool:
+    if candidate not in _POSITIVE_REMOTE_TRANSLATIONS:
+        return candidate in earlier
+    pattern = re.compile(rf"(?<!\bno\s)(?<!\bnot\s)(?<!\bwithout\s)\b{re.escape(candidate)}\b")
+    return pattern.search(earlier) is not None
 
 
 def _translation_fragments(preferred: str) -> tuple[str, ...]:
@@ -421,10 +440,22 @@ def _translation_fragments(preferred: str) -> tuple[str, ...]:
         return ("setup baseline saved", "last saved checkpoint", "one saved checkpoint")
     if "queued for save" in normalized:
         return ("files queued for save",)
-    if "github backup" in normalized or "shared task source" in normalized:
-        return ("no connected github backup", "shared task source")
+    if "no connected github backup" in normalized or "no shared task source" in normalized:
+        return (
+            "no connected github backup",
+            "no connected github backup or shared task source",
+            "no shared task source",
+            "local-only folder",
+            "local only folder",
+        )
     if "github connection" in normalized:
-        return ("github connection", "connected github backup", "shared task source")
+        return (
+            "github connection",
+            "connected github backup",
+            "connected github backup or shared task source",
+            "connected shared task source",
+            "shared task source is connected",
+        )
     if "task and proposal" in normalized:
         return ("github task and proposal context",)
     if "shared outside" in normalized:
@@ -440,8 +471,9 @@ def _translation_fragments(preferred: str) -> tuple[str, ...]:
         "one saved checkpoint",
         "files queued for save",
         "no connected github backup",
-        "shared task source",
+        "no shared task source",
         "github connection",
+        "connected github backup",
         "github task and proposal context",
         "shared outside your machine",
     )

--- a/mb/mb/release_simulation.py
+++ b/mb/mb/release_simulation.py
@@ -278,7 +278,7 @@ def _contains_overclaim(text: str) -> bool:
 
 _TECHNICAL_LANGUAGE_PATTERNS: tuple[tuple[re.Pattern[str], str, str], ...] = (
     (
-        re.compile(r"\bclean on\s+`?main`?\b", re.IGNORECASE),
+        re.compile(r"\bclean\s+(?:on|branch)\s+`?main`?\b", re.IGNORECASE),
         "clean on main",
         "nothing unsaved locally in the current business folder",
     ),
@@ -293,12 +293,15 @@ _TECHNICAL_LANGUAGE_PATTERNS: tuple[tuple[re.Pattern[str], str, str], ...] = (
         "your business folder has no unsaved changes",
     ),
     (
-        re.compile(r"\bworking tree (?:is )?clean\b", re.IGNORECASE),
+        re.compile(
+            r"\bworking tree\s*(?:(?:is|status)\s*)?(?::|=|-)?\s*clean\b",
+            re.IGNORECASE,
+        ),
         "working tree clean",
         "no unsaved file changes",
     ),
     (
-        re.compile(r"\bbranch\s+`?main`?\b", re.IGNORECASE),
+        re.compile(r"\b(?:current\s+)?branch\s*(?::|=|-)?\s*`?main`?\b", re.IGNORECASE),
         "branch main",
         "current business folder",
     ),
@@ -329,7 +332,7 @@ _TECHNICAL_LANGUAGE_PATTERNS: tuple[tuple[re.Pattern[str], str, str], ...] = (
         "files queued for save",
     ),
     (
-        re.compile(r"\bno github origin remote\b", re.IGNORECASE),
+        re.compile(r"\bno (?:github )?origin remote\b", re.IGNORECASE),
         "No GitHub origin remote",
         "no connected GitHub backup or shared task source",
     ),
@@ -339,7 +342,7 @@ _TECHNICAL_LANGUAGE_PATTERNS: tuple[tuple[re.Pattern[str], str, str], ...] = (
         "GitHub connection",
     ),
     (
-        re.compile(r"\bpr/issue facts\b", re.IGNORECASE),
+        re.compile(r"\bpr\s*(?:/|and)\s*issue facts\b", re.IGNORECASE),
         "PR/issue facts",
         "GitHub task and proposal context",
     ),
@@ -352,12 +355,13 @@ _TECHNICAL_LANGUAGE_PATTERNS: tuple[tuple[re.Pattern[str], str, str], ...] = (
 
 _BROAD_CHECKPOINT_NOTE_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(
-        r"\[(?:added|updated|changed)\]\s+"
+        r"\[(?:added|updated|changed|drafted|ran|fixed)\]\s+"
         r"(?:core\s*(?:and|&|\+|,)\s*research|files|stuff|changes)\b"
     ),
     re.compile(
-        r"proposed message:\s*`?\[(?:added|updated|changed)\]\s+"
-        r"core\s*(?:and|&|\+|,)\s*research`?"
+        r"proposed (?:checkpoint )?message:\s*`?"
+        r"\[(?:added|updated|changed|drafted|ran|fixed)\]\s+"
+        r"(?:core\s*(?:and|&|\+|,)\s*research|files|stuff|changes)`?"
     ),
 )
 
@@ -377,6 +381,8 @@ def _visible_technical_leakage(text: str) -> list[dict[str, str]]:
             match = pattern.search(stripped)
             if match is None:
                 continue
+            if _owner_translation_precedes(stripped, match.start(), preferred):
+                continue
             span = match.span()
             if any(_spans_overlap(span, existing) for existing in matched_spans):
                 continue
@@ -389,6 +395,56 @@ def _visible_technical_leakage(text: str) -> list[dict[str, str]]:
                 }
             )
     return examples
+
+
+def _owner_translation_precedes(line: str, end: int, preferred: str) -> bool:
+    earlier = line[:end].lower()
+    if not earlier.strip():
+        return False
+    normalized_preferred = preferred.lower()
+    if normalized_preferred in earlier:
+        return True
+    return any(fragment in earlier for fragment in _translation_fragments(preferred))
+
+
+def _translation_fragments(preferred: str) -> tuple[str, ...]:
+    normalized = preferred.lower()
+    if "unsaved" in normalized:
+        return (
+            "nothing unsaved locally",
+            "no unsaved file changes",
+            "business folder has no unsaved changes",
+        )
+    if "current business folder" in normalized or "workspace" in normalized:
+        return ("current business folder", "current workspace")
+    if "checkpoint" in normalized:
+        return ("setup baseline saved", "last saved checkpoint", "one saved checkpoint")
+    if "queued for save" in normalized:
+        return ("files queued for save",)
+    if "github backup" in normalized or "shared task source" in normalized:
+        return ("no connected github backup", "shared task source")
+    if "github connection" in normalized:
+        return ("github connection", "connected github backup", "shared task source")
+    if "task and proposal" in normalized:
+        return ("github task and proposal context",)
+    if "shared outside" in normalized:
+        return ("shared outside your machine",)
+    return (
+        "nothing unsaved locally",
+        "no unsaved file changes",
+        "business folder has no unsaved changes",
+        "current business folder",
+        "current workspace",
+        "setup baseline saved",
+        "last saved checkpoint",
+        "one saved checkpoint",
+        "files queued for save",
+        "no connected github backup",
+        "shared task source",
+        "github connection",
+        "github task and proposal context",
+        "shared outside your machine",
+    )
 
 
 def _spans_overlap(left: tuple[int, int], right: tuple[int, int]) -> bool:

--- a/mb/mb/update.py
+++ b/mb/mb/update.py
@@ -315,9 +315,12 @@ def render_human(result: dict[str, Any]) -> None:
         release = raw_release if isinstance(raw_release, dict) else {}
         release_url = str(release.get("url") or "")
         release_summary = str(release.get("summary") or "")
-        if release_url:
+        release_available = release.get("available") is True
+        if release_url and release_available:
             print(f"release notes: {release_url}")
-        if release_summary:
+        elif release_url and release.get("source") != "not_newer":
+            print(f"expected release notes URL: {release_url}")
+        if release_summary and release_available:
             print(f"release summary: {release_summary}")
         for action in result.get("actions", []):
             print(action)

--- a/mb/tests/test_init.py
+++ b/mb/tests/test_init.py
@@ -39,6 +39,14 @@ def _assert_claude_md_cli_first_contract(text: str) -> None:
     assert "business-owner language" in text
     assert "bets, goals, offers, pushes" in text
     assert "playbooks, outcomes" in text
+    assert "`working tree: clean`" in text
+    assert "nothing unsaved locally" in text
+    assert "`branch: main`" in text
+    assert "current business" in text
+    assert "`No origin remote`" in text
+    assert "no connected GitHub backup" in text
+    assert "`PR and issue facts`" in text
+    assert "GitHub task and proposal context" in text
     assert "Claude Desktop" not in text
     for unsupported_runtime in ("Codex", "Cursor", "OpenClaw", "Hermes"):
         assert unsupported_runtime not in text
@@ -86,6 +94,14 @@ def _assert_agents_md_codex_start_contract(text: str) -> None:
     assert "explicit operator approval" in text
     assert "business-owner language" in text
     assert "bets, goals, offers, pushes" in text
+    assert "`working tree: clean`" in text
+    assert "nothing unsaved locally" in text
+    assert "`branch: main`" in text
+    assert "current business" in text
+    assert "`No origin remote`" in text
+    assert "no connected GitHub backup" in text
+    assert "`PR and issue facts`" in text
+    assert "GitHub task and proposal context" in text
     assert "created, saved, synced to GitHub when requested" in text
     assert "short technical receipt" in text
     assert "`vocabulary` block from `mb status --json --peek`" in text

--- a/mb/tests/test_release_simulation.py
+++ b/mb/tests/test_release_simulation.py
@@ -74,6 +74,9 @@ def test_release_simulation_covers_owner_first_status_expectations() -> None:
     assert "current business folder" in fresh_observed
     assert "no connected github backup" in fresh_observed
     assert "clean on main" in fresh_blocked
+    assert "working tree: clean" in fresh_blocked
+    assert "branch: main" in fresh_blocked
+    assert "no origin remote" in fresh_blocked
     assert "git is clean" in fresh_blocked
     assert "origin remote" in fresh_blocked
 
@@ -81,6 +84,8 @@ def test_release_simulation_covers_owner_first_status_expectations() -> None:
     checkpoint_blocked = " ".join(checkpoint.must_not).lower()
     assert "saved business artifact" in checkpoint_observed
     assert "[updated] core and research" in checkpoint_blocked
+    assert "[drafted] files" in checkpoint_blocked
+    assert "[ran] changes" in checkpoint_blocked
 
 
 def test_release_simulation_covers_rich_migration_triage_map() -> None:
@@ -288,6 +293,33 @@ def test_score_transcript_allows_business_translation_before_technical_detail() 
     assert operator_language["visible_technical_leakage"]["examples"] == []
 
 
+def test_score_transcript_allows_same_line_business_translation_before_git_detail() -> None:
+    transcript = (
+        "Nothing unsaved locally in the current business folder "
+        "(`working tree: clean`, current branch: main).\n"
+        "There is no connected GitHub backup or shared task source yet "
+        "(`No GitHub origin remote`)."
+    )
+
+    score = release_simulation.score_transcript(transcript)
+    operator_language = score["operator_language"]
+
+    assert operator_language["operator_language_first"] is True
+    assert operator_language["visible_technical_leakage"]["examples"] == []
+
+
+def test_score_transcript_requires_matching_business_translation_before_git_detail() -> None:
+    transcript = """
+    There is no connected GitHub backup yet. Current branch: main.
+    """
+
+    score = release_simulation.score_transcript(transcript)
+    leakage = score["operator_language"]["visible_technical_leakage"]
+
+    assert leakage["severity"] == "low"
+    assert [item["phrase"] for item in leakage["examples"]] == ["branch main"]
+
+
 def test_score_transcript_does_not_treat_product_name_as_branch_language() -> None:
     transcript = """
     This release keeps the agent focused on Main Branch language. It explains
@@ -321,6 +353,26 @@ def test_score_transcript_flags_clean_on_main_language() -> None:
     assert leakage["examples"][0]["preferred"] == (
         "nothing unsaved locally in the current business folder"
     )
+
+
+@pytest.mark.parametrize(
+    ("transcript", "phrase"),
+    [
+        ("Working tree: clean. Continue with the next action.", "working tree clean"),
+        ("Current branch: main. Continue with the next action.", "branch main"),
+        ("Clean branch main. Continue with the next action.", "clean on main"),
+        ("No origin remote. Continue with the next action.", "No GitHub origin remote"),
+        ("PR and issue facts are unavailable.", "PR/issue facts"),
+    ],
+)
+def test_score_transcript_flags_punctuated_owner_language_variants(
+    transcript: str, phrase: str
+) -> None:
+    score = release_simulation.score_transcript(transcript)
+    leakage = score["operator_language"]["visible_technical_leakage"]
+
+    assert leakage["severity"] == "low"
+    assert [item["phrase"] for item in leakage["examples"]] == [phrase]
 
 
 def test_score_transcript_allows_commit_as_plain_verb() -> None:
@@ -358,6 +410,9 @@ def test_score_transcript_flags_only_commit_count_language(transcript: str) -> N
         "[updated] core and research",
         "[updated] core + research",
         "[updated] core, research",
+        "[drafted] files",
+        "[ran] changes",
+        "[fixed] stuff",
     ],
 )
 def test_score_transcript_flags_broad_checkpoint_notes(message: str) -> None:

--- a/mb/tests/test_release_simulation.py
+++ b/mb/tests/test_release_simulation.py
@@ -320,6 +320,29 @@ def test_score_transcript_requires_matching_business_translation_before_git_deta
     assert [item["phrase"] for item in leakage["examples"]] == ["branch main"]
 
 
+@pytest.mark.parametrize(
+    ("transcript", "phrase"),
+    [
+        (
+            "The shared task source is unavailable. No origin remote.",
+            "No GitHub origin remote",
+        ),
+        (
+            "No connected GitHub backup yet (`origin remote`).",
+            "origin remote",
+        ),
+    ],
+)
+def test_score_transcript_requires_remote_translation_polarity(
+    transcript: str, phrase: str
+) -> None:
+    score = release_simulation.score_transcript(transcript)
+    leakage = score["operator_language"]["visible_technical_leakage"]
+
+    assert leakage["severity"] == "low"
+    assert [item["phrase"] for item in leakage["examples"]] == [phrase]
+
+
 def test_score_transcript_does_not_treat_product_name_as_branch_language() -> None:
     transcript = """
     This release keeps the agent focused on Main Branch language. It explains

--- a/mb/tests/test_start_router_contract.py
+++ b/mb/tests/test_start_router_contract.py
@@ -57,14 +57,19 @@ def test_router_contract_translates_visible_git_language_before_owner_answer() -
 
     required_translations = {
         (
-            "`git is clean`, `repo is clean`, `working tree clean`, `clean on main`"
+            "`git is clean`, `repo is clean`, `working tree clean`, "
+            "`working tree: clean`, `clean on main`"
         ): "nothing unsaved locally",
-        "`on main`, `branch main`": "current business folder or current workspace",
+        (
+            "`on main`, `branch main`, `branch: main`, `current branch: main`"
+        ): "current business folder or current workspace",
         "`one commit`, `only commit so far`": "setup baseline saved or last saved checkpoint",
         "`staged files`": "files queued for save",
-        "`No GitHub origin remote`": "local-only folder or no connected GitHub backup",
+        "`No GitHub origin remote`, `No origin remote`": (
+            "local-only folder or no connected GitHub backup"
+        ),
         "`origin remote`": "connected GitHub backup or shared task source",
-        "`PR/issue facts`": "GitHub task and proposal context",
+        "`PR/issue facts`, `PR and issue facts`": "GitHub task and proposal context",
         "`before this goes to a remote`": "before anything is shared outside your machine",
     }
     for tool_phrase, owner_phrase in required_translations.items():

--- a/mb/tests/test_update.py
+++ b/mb/tests/test_update.py
@@ -363,6 +363,7 @@ def test_update_render_human_check_and_error(capsys: Any) -> None:
             "release": {
                 "url": "https://github.com/noontide-co/mainbranch/releases/tag/oe-v0.2.0",
                 "summary": "Release context.",
+                "available": True,
             },
             "actions": ["would run `git pull`"],
             "errors": ["boom"],
@@ -381,6 +382,61 @@ def test_update_render_human_check_and_error(capsys: Any) -> None:
     assert "would refresh 3 skill link(s)" in output
     assert "error: boom" in output
     assert "warning: careful" in output
+
+
+def test_update_render_human_check_labels_unavailable_release_url(capsys: Any) -> None:
+    update_mod.render_human(
+        {
+            "check": True,
+            "mode": "pipx",
+            "old_version": "0.1.2",
+            "new_version": "0.2.0",
+            "skills_relinked_count": 0,
+            "release": {
+                "url": "https://github.com/noontide-co/mainbranch/releases/tag/oe-v0.2.0",
+                "summary": "Fallback summary should not print.",
+                "available": False,
+                "source": "github_release_unavailable",
+            },
+            "actions": [],
+            "errors": [],
+            "warnings": [],
+        }
+    )
+
+    output = capsys.readouterr().out
+
+    assert "release notes:" not in output
+    assert (
+        "expected release notes URL: https://github.com/noontide-co/mainbranch/releases/tag/oe-v0.2.0"
+        in output
+    )
+    assert "Fallback summary should not print." not in output
+
+
+def test_update_render_human_check_skips_current_release_url(capsys: Any) -> None:
+    update_mod.render_human(
+        {
+            "check": True,
+            "mode": "pipx",
+            "old_version": "0.2.0",
+            "new_version": "0.2.0",
+            "skills_relinked_count": 0,
+            "release": {
+                "url": "https://github.com/noontide-co/mainbranch/releases/tag/oe-v0.2.0",
+                "available": False,
+                "source": "not_newer",
+            },
+            "actions": [],
+            "errors": [],
+            "warnings": [],
+        }
+    )
+
+    output = capsys.readouterr().out
+
+    assert "release notes:" not in output
+    assert "expected release notes URL:" not in output
 
 
 def test_update_render_human_success(capsys: Any) -> None:


### PR DESCRIPTION
## Summary

Tightens MAIN-377 release-simulation scoring and runtime guidance so owner-facing answers translate git/GitHub/checkpoint mechanics before technical terms. Generated business-repo `CLAUDE.md` / `AGENTS.md`, `/mb-start`, `/mb-end`, release-simulation docs, packaged manifests, `mb update --check` fallback wording, and regression tests now align on the same language contract after rebasing over MAIN-384.

## Linked issue

Closes #604
Refs #616

## Why

The v0.3.23 release-acceptance proxy run passed mechanically but still exposed beginner-hostile phrases like `working tree clean`, `branch main`, `No GitHub origin remote`, and broad checkpoint examples. MAIN-384 then added release-note output that needed the same review standard: unavailable fallback URLs should not be presented as authoritative release notes.

## Commits by concern

- [x] `8c56e6a [fix] MAIN-377 tighten owner language scoring` — scorer, harness prompt, manifest, `/mb-start` router guidance, tests, changelog.
- [x] `542a29b [fix] MAIN-377 align release simulation docs` — human-review docs aligned with the tightened leak examples.
- [x] `2cd125a [fix] MAIN-377 align cold-start owner language` — generated Claude/Codex guidance, `/mb-end` label, init tests, changelog.
- [x] `a0eb92d [fix] MAIN-377 align update release-note fallback` — gate authoritative release-note human output on release availability after the MAIN-384 rebase.
- [x] `6a32f68 [fix] MAIN-377 require remote translation polarity` — require positive/negative owner-language translations to match `origin remote` polarity and prevent overlapping no-origin double-counts.
- [x] Each commit body bullet-lists the changes in that commit
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`

## Validation

Pre-push gate from repo root:

```bash
scripts/check.sh
```

- [x] Level 1 static: `scripts/check.sh` passes
- [x] Level 2 CLI contract: focused Typer/CliRunner tests, exit codes, `--json` behavior, TTY vs non-TTY (if CLI behavior touched)
- [x] Level 3 package/install smoke (if packaging touched)
- [x] Level 4 fixture repo (if init/onboard/status/start/update touched)
- [ ] Level 5 runtime smoke / dogfood harness / simulation-tier (if runtime, first-run, skill discovery, or release validation touched)
- [x] SKILL.md ≤500 lines (if any skill touched)
- [ ] Package-visible release gate evidence before tag/publish (if preparing a release)
- [ ] Supply-chain review (if `.github/workflows/`, `.github/dependabot.yml`, `mb/pyproject.toml` deps, or `id-token`/`permissions` blocks touched — see [docs/supply-chain-policy.md](../docs/supply-chain-policy.md))

Level 1 static: `scripts/check.sh` — runtime: `python3` — exit: 0 — log: `.agent/main-377-final/check.out` (`708 passed`, mypy clean, skill validation clean).
Level 2 CLI contract: `python3 -m pytest mb/tests/test_release_simulation.py mb/tests/test_init.py mb/tests/test_start_router_contract.py mb/tests/test_update.py -q` — runtime: `python3` — exit: 0 — log: terminal capture (`74 passed in 1.62s`).
Level 3 package/install: `(cd mb && python3 -m build)`, fresh venv install, `mb --version`, `mb skill list` — runtime: `/tmp/mainbranch-main-377-final-smoke/bin/python3.13` — exit: 0 — log: `.agent/main-377-final/package-smoke/out`.
Level 4 fixture/init: `mb init "$tmpdir/biz" --name "Cold Start Smoke"` plus generated `CLAUDE.md` / `AGENTS.md` translation checks and `update.render_human()` current-release fallback check — runtime: `/tmp/mainbranch-main-377-final-smoke/bin/mb` and `/tmp/mainbranch-main-377-final-smoke/bin/python` — exit: 0 — log: `.agent/main-377-final/package-smoke/out`.
Level 5 runtime/manual smoke was not required because runtime discovery and slash-command registration did not change; this is scoring, guidance, docs, packaged template, and regression-test hardening. Package-visible release gate and supply-chain review were not required for this PR because it is not the release-prep branch and no workflow/dependency/permission files changed.

## Success metric

Owner-facing release-simulation answers that lead with technical phrases like `working tree: clean`, `branch: main`, `No origin remote`, `origin remote`, `PR and issue facts`, or broad checkpoint labels fail review unless they translate the matching business meaning first. Fresh generated business repos also carry those translations in their Claude/Codex cold-start guidance, and `mb update --check` no longer labels unavailable fallback URLs as authoritative release notes.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [ ] N/A — change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [x] No
- [ ] Yes — migration note below

## Public / private boundary

No private operator strategy, machine-specific paths, member details, raw transcript content, secrets, or runtime internals were committed. The attached session export was used only as private/local product context and did not enter public files.
