### PR TITLE
[update] Prepare mainbranch 0.3.24

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mainbranch",
-  "version": "0.3.23",
+  "version": "0.3.24",
   "description": "Main Branch Claude Code skills for running a business from markdown files in git.",
   "author": {
     "name": "Noontide"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+## [0.3.24] - 2026-05-15
+
+v0.3.24 packages the release freshness context and owner-language hardening
+that landed after v0.3.23. It helps agents explain update availability from
+fresh facts and keeps normal business-owner answers from leading with
+git/GitHub mechanics.
+
 ### Changed
 
 - Added release-note context and freshness evidence to update checks:

--- a/mb/mb/__init__.py
+++ b/mb/mb/__init__.py
@@ -7,6 +7,6 @@ file stays a thin dispatcher.
 
 from __future__ import annotations
 
-__version__ = "0.3.23"
+__version__ = "0.3.24"
 
 __all__ = ["__version__"]

--- a/mb/pyproject.toml
+++ b/mb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mainbranch"
-version = "0.3.23"
+version = "0.3.24"
 description = "Main Branch engine umbrella - scaffolds, validates, and graphs business-as-files repos. Claude Code first, runtime-agnostic by design."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Prepares the package-visible `mainbranch` / `mb` 0.3.24 release. The release packages the MAIN-384 release freshness/update context and the MAIN-377 owner-language release-simulation hardening that landed after 0.3.23.

## Linked issue

Refs #604
Refs #616
Refs #619

## Why

The merged work is user-visible in `mb status`, `mb update --check`, generated business-repo guidance, bundled skill guidance, and release-simulation scoring, so it needs a dated changelog section and synchronized package/plugin versions before publishing. Release evidence also found non-blocking simulation wording quality concerns, routed to #619 for post-release cleanup.

## Commits by concern

- [x] `5592273 [update] Prepare mainbranch 0.3.24` — version files and dated changelog section only.
- [x] Each commit body bullet-lists the changes in that commit
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`

## Validation

Pre-push gate from repo root:

```bash
scripts/check.sh
```

- [x] Level 1 static: `scripts/check.sh` passes
- [x] Level 2 CLI contract: focused Typer/CliRunner tests, exit codes, `--json` behavior, TTY vs non-TTY (if CLI behavior touched)
- [x] Level 3 package/install smoke (if packaging touched)
- [x] Level 4 fixture repo (if init/onboard/status/start/update touched)
- [x] Level 5 runtime smoke / dogfood harness / simulation-tier (if runtime, first-run, skill discovery, or release validation touched)
- [x] SKILL.md ≤500 lines (if any skill touched)
- [x] Package-visible release gate evidence before tag/publish (if preparing a release)
- [x] Supply-chain review (if `.github/workflows/`, `.github/dependabot.yml`, `mb/pyproject.toml` deps, or `id-token`/`permissions` blocks touched — see [docs/supply-chain-policy.md](../docs/supply-chain-policy.md))

Level 0 release-file preflight: `cd mb && python3 -m pytest tests/test_smoke_coverage.py::test_claude_plugin_manifest_points_at_prefixed_skills -q` plus version/changelog parser — runtime: `python3` — exit: 0 — log: terminal capture (`1 passed`, changelog section found).
Level 1 static: `scripts/check.sh` — runtime: `python3` — exit: 0 — log: `.agent/release-evidence/0.3.24/check.out` (`711 passed`, 84% coverage, mypy clean, skill validation clean).
Level 3 package/install: `(cd mb && python3 -m build)`, fresh venv install of `mainbranch-0.3.24`, `mb --version`, `mb skill list` — runtime: `/tmp/mainbranch-0.3.24-wheel-smoke/bin/python3.13` — exit: 0 — log: `.agent/release-evidence/0.3.24/wheel-smoke.out`.
Level 4 fixture repo: wheel-installed `mb onboard`, `mb doctor`, `mb status --json --peek`, `mb start --json`, `mb validate` — runtime: `/tmp/mainbranch-0.3.24-wheel-smoke/bin/mb` — exit: 0 — log: `.agent/release-evidence/0.3.24/wheel-smoke.out`.
Level 5 release candidate: `scripts/claude-runtime-dogfood.py --install-mode wheel --wheel mb/dist/mainbranch-0.3.24-py3-none-any.whl --run-claude-print --simulation-tier prerelease_candidate --max-budget-usd 0.75` — runtime: `python3` / Claude Code 2.1.140 — exit: 0 — log: `.agent/release-evidence/0.3.24/prerelease-candidate.log`; 11/11 heuristic checks, no read-only `mb` grounding denials, operator-language quality concerns routed to #619.
Level 5 release acceptance: `scripts/claude-runtime-dogfood.py --install-mode wheel --wheel mb/dist/mainbranch-0.3.24-py3-none-any.whl --run-claude-print --simulation-tier release_acceptance --max-budget-usd 0.75` — runtime: `python3` / Claude Code 2.1.140 — exit: 0 — log: `.agent/release-evidence/0.3.24/release-acceptance-wheel.log`; 10/11 heuristic checks, one read-only `mb` grounding denial with deterministic fallback, operator-language quality concerns routed to #619.
Books fixture modes: wheel-installed `mb books check --fixture --json` with hledger on PATH and with hledger removed from PATH — runtime: `/tmp/mainbranch-0.3.24-wheel-smoke/bin/mb` — exit: 0 — log: `.agent/release-evidence/0.3.24/books-fixture-modes.out`; hledger mode returned `fixture-valid`, no-hledger mode returned informational `hledger-missing`, both `result_status: ok`.
Supply-chain review: release-time checks from `docs/supply-chain-policy.md` — runtime: `gh` / shell — exit: 0 — logs: `.agent/release-evidence/0.3.24/supply-chain-preflight.out`, `dependabot-alert-count.out`, `pypi-environment.out`; `[Unreleased]` empty, one pyproject version-bump commit, no open Dependabot alerts, `pypi` environment has required reviewers.

Interactive Claude Code TUI smoke was not run; this release changes packaged scoring/guidance/update output and does not claim new slash-command discovery behavior. The required release simulations ran as print-mode proxy evidence and are explicitly labeled as such.

## Success metric

`mainbranch` 0.3.24 can be tagged from a release-only diff, the publish workflow can extract the matching changelog section, and the candidate wheel proves install, fixture, books, release-simulation, and supply-chain gates before PyPI approval.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [ ] N/A — change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [x] No
- [ ] Yes — migration note below

## Public / private boundary

No private operator strategy, customer data, tokens, provider payloads, raw transcripts, or machine-specific paths were committed. Release evidence remains in ignored `.agent/`; the PR summarizes only public-safe behavior and links the post-release quality follow-up as #619.
