### PR TITLE
[fix] Tighten release simulation language

### DIFF
--- a/.claude/skills/mb-start/references/router-and-language.md
+++ b/.claude/skills/mb-start/references/router-and-language.md
@@ -72,6 +72,9 @@ exact command, validation evidence, or the operator asks for git details.
 Do not print checkpoint ids, branch names, `origin`, `ahead`, `behind`,
 `diverged`, `rebase`, or `commit` in the first response unless they are inside a
 command the user must run or the user asked for technical detail.
+Do not put raw git/GitHub terms in parentheses after the translation; use a
+separate "Technical detail:" or "Exact command:" line when the raw term is
+actually needed.
 
 Before answering a normal owner prompt, translate raw status summaries that leak
 from tools:
@@ -82,7 +85,7 @@ from tools:
 | `on main`, `branch main`, `branch: main`, `current branch: main` | current business folder or current workspace |
 | `one commit`, `only commit so far` | setup baseline saved or last saved checkpoint |
 | `staged files` | files queued for save |
-| `No GitHub origin remote`, `No origin remote` | local-only folder or no connected GitHub backup |
+| `No GitHub origin remote`, `No origin remote`, `Connected GitHub backup: none surfaced` | local-only folder or no connected GitHub backup |
 | `origin remote` | connected GitHub backup or shared task source |
 | `PR/issue facts`, `PR and issue facts` | GitHub task and proposal context |
 | `before this goes to a remote` | before anything is shared outside your machine |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+### Fixed
+
+- Tightened post-v0.3.24 release-simulation guidance and scoring so final
+  answers avoid parenthetical git/GitHub restatements, flag
+  `Connected GitHub backup: none surfaced` as owner-language leakage, and use
+  more specific checkpoint proposals such as `[updated] offer and founder-call
+  research` instead of broad buckets. Refs MAIN-385, #619.
+
 ## [0.3.24] - 2026-05-15
 
 v0.3.24 packages the release freshness context and owner-language hardening

--- a/docs/release-simulations.md
+++ b/docs/release-simulations.md
@@ -199,15 +199,16 @@ before "repo", "saved checkpoint" before "commit", "proposal" before "PR",
 "task" before "issue", "shared outside your machine" before "remote", and "no
 unsaved local changes" before "git is clean". Technical detail is still allowed
 when the user asks for it, when repair/debug context needs it, or when evidence
-is for maintainers; put the business translation first and the technical detail
-second.
+is for maintainers; put raw terms in a separate "Technical detail:" or "Exact
+command:" line after the business meaning instead of parenthetical restatement.
 
 Release-simulation final answers should also avoid compressed status phrases
 that make the operator decode git first. Warnings include "working tree clean",
 "working tree: clean", "repo is clean", "clean on main", "branch main",
-"branch: main", "origin remote", "No origin remote", and "Git is clean" unless
-the answer has already translated the matching business meaning. Checkpoint
-examples should name the saved business artifact specifically, such as
+"branch: main", "origin remote", "No origin remote", "Connected GitHub backup:
+none surfaced", and "Git is clean" unless the answer has already translated the
+matching business meaning. Checkpoint examples should name the saved business
+artifact specifically, such as
 `[updated] offer and founder-call research`, instead of broad buckets like
 `[updated] core and research`, `[drafted] files`, or `[ran] changes`.
 

--- a/mb/mb/_data/release_simulations/manifest.json
+++ b/mb/mb/_data/release_simulations/manifest.json
@@ -375,12 +375,12 @@
         "Uses mb status --json --peek or mb start facts before advice.",
         "Names the fixture business repo as the operating context.",
         "Translates technical state into setup, repair, or next business action.",
-        "Uses owner-first language such as nothing unsaved locally, current business folder, saved checkpoint, task, proposal, and no connected GitHub backup before raw git/GitHub terms."
+        "Uses owner-first language such as nothing unsaved locally, current business folder, saved checkpoint, task, proposal, and no connected GitHub backup without parenthetical raw git/GitHub restatements."
       ],
       "must_not": [
         "Report /mb-start as unknown without routing to repair evidence.",
         "Start writing durable business files before grounding.",
-        "Lead a normal owner answer with working tree clean, working tree: clean, repo is clean, clean on main, branch main, branch: main, origin remote, No origin remote, PR/issue facts, or Git is clean."
+        "Lead a normal owner answer with working tree clean, working tree: clean, repo is clean, clean on main, branch main, branch: main, origin remote, No origin remote, Connected GitHub backup: none surfaced, PR/issue facts, or Git is clean."
       ],
       "follow_up_routes": [
         {

--- a/mb/mb/_data/templates/AGENTS.md.tmpl
+++ b/mb/mb/_data/templates/AGENTS.md.tmpl
@@ -42,9 +42,11 @@ Default translations for normal owner answers:
   -> nothing unsaved locally;
 - `branch main`, `branch: main`, or `current branch: main` -> current business
   folder or workspace;
-- `No GitHub origin remote` or `No origin remote` -> no connected GitHub backup
-  or shared task source;
+- `No GitHub origin remote`, `No origin remote`, or `Connected GitHub backup:
+  none surfaced` -> no connected GitHub backup or shared task source;
 - `PR/issue facts` or `PR and issue facts` -> GitHub task and proposal context.
+Use raw git/GitHub terms only in exact commands or a separate "Technical
+detail:" line after the owner meaning.
 
 When finishing first-run setup, lead with the owner outcome before the receipt:
 created, saved, synced to GitHub when requested, and ready to open in Claude

--- a/mb/mb/_data/templates/CLAUDE.md.tmpl
+++ b/mb/mb/_data/templates/CLAUDE.md.tmpl
@@ -70,9 +70,11 @@ Default translations for normal owner answers:
   -> nothing unsaved locally;
 - `branch main`, `branch: main`, or `current branch: main` -> current business
   folder or workspace;
-- `No GitHub origin remote` or `No origin remote` -> no connected GitHub backup
-  or shared task source;
+- `No GitHub origin remote`, `No origin remote`, or `Connected GitHub backup:
+  none surfaced` -> no connected GitHub backup or shared task source;
 - `PR/issue facts` or `PR and issue facts` -> GitHub task and proposal context.
+Use raw git/GitHub terms only in exact commands or a separate "Technical
+detail:" line after the owner meaning.
 
 ## Folders
 

--- a/mb/mb/checkpoint.py
+++ b/mb/mb/checkpoint.py
@@ -577,6 +577,48 @@ def _surface_phrase(surfaces: list[str]) -> str:
     return ", ".join(named[:-1]) + f", and {named[-1]}"
 
 
+def _slug_words(value: str) -> str:
+    slug = re.sub(r"^\d{4}-\d{2}-\d{2}-", "", value)
+    slug = re.sub(r"^(?:unsaved|draft|approved|sanitized)-", "", slug)
+    return slug.replace("_", "-").replace("-", " ").strip()
+
+
+def _core_object_label(path: Path) -> str:
+    parts = path.parts
+    if len(parts) >= 4 and parts[0] == "core" and parts[1] == "offers":
+        offer = _slug_words(parts[2])
+        stem = _slug_words(path.stem)
+        if path.name == "offer.md":
+            return f"{offer} offer"
+        if path.name == "audience.md":
+            return f"{offer} audience"
+        return f"{offer} {stem}"
+    if path.name == "offer.md":
+        return "offer"
+    if path.name == "audience.md":
+        return "audience"
+    if path.name == "soul.md":
+        return "soul"
+    if path.name == "voice.md":
+        return "voice"
+    if path.name == "content-strategy.md":
+        return "content strategy"
+    if path.name == "product-ladder.md":
+        return "product ladder"
+    if len(parts) > 1 and parts[1] == "proof":
+        return "proof"
+    return _slug_words(path.stem)
+
+
+def _research_object_label(path: Path) -> str:
+    slug = re.sub(r"^\d{4}-\d{2}-\d{2}-", "", path.stem)
+    slug = re.sub(r"^(?:unsaved|draft|approved|sanitized)-", "", slug)
+    if "founder-calls" in slug:
+        return "founder-call research"
+    label = _slug_words(slug)
+    return f"{label} research" if label else "research"
+
+
 def _object_from_single_change(change: dict[str, Any]) -> str:
     path = str(change["path"])
     surface = str(change["surface"])
@@ -585,19 +627,47 @@ def _object_from_single_change(change: dict[str, Any]) -> str:
         stem = path_obj.stem if path_obj.suffix else path_obj.name
         return f"bet {stem}"
     if surface == "pushes":
-        return f"push {path_obj.parent.name}" if path_obj.name == "push.md" else path_obj.stem
+        return (
+            f"{_slug_words(path_obj.parent.name)} push"
+            if path_obj.name == "push.md"
+            else f"{_slug_words(path_obj.stem)} push"
+        )
     if surface == "campaigns":
         return (
-            f"campaign {path_obj.parent.name}" if path_obj.name == "campaign.md" else path_obj.stem
+            f"{_slug_words(path_obj.parent.name)} campaign"
+            if path_obj.name == "campaign.md"
+            else f"{_slug_words(path_obj.stem)} campaign"
         )
     if surface == "decisions":
         stem = path_obj.stem
-        return stem[11:] if re.match(r"^\d{4}-\d{2}-\d{2}-", stem) else stem
-    if surface in {"core", "research", "log", "documents"}:
-        return path_obj.name
+        label = stem[11:] if re.match(r"^\d{4}-\d{2}-\d{2}-", stem) else stem
+        return f"{_slug_words(label)} decision"
+    if surface == "core":
+        return _core_object_label(path_obj)
+    if surface == "research":
+        return _research_object_label(path_obj)
+    if surface == "log":
+        return f"{_slug_words(path_obj.stem)} log"
+    if surface == "documents":
+        return f"{_slug_words(path_obj.stem)} document"
     if surface == "config":
         return "setup"
     return path_obj.stem or path_obj.name or path
+
+
+def _object_phrase(changes: list[dict[str, Any]]) -> str | None:
+    if not 1 <= len(changes) <= 3:
+        return None
+    labels = [_object_from_single_change(change) for change in changes]
+    if any(not label or label in {"setup", "repo files"} for label in labels):
+        return None
+    if len(set(labels)) != len(labels):
+        return None
+    if len(labels) == 1:
+        return labels[0]
+    if len(labels) == 2:
+        return f"{labels[0]} and {labels[1]}"
+    return ", ".join(labels[:-1]) + f", and {labels[-1]}"
 
 
 def _proposal_verb(changes: list[dict[str, Any]], surfaces: list[str]) -> tuple[str, str]:
@@ -624,9 +694,8 @@ def _proposal(changes: list[dict[str, Any]], blocks: list[dict[str, str]]) -> di
     counts = _surface_counts(changes)
     surfaces = [surface for surface in SURFACE_ORDER if surface in counts]
     verb, reason = _proposal_verb(changes, surfaces)
-    if len(changes) == 1:
-        phrase = _object_from_single_change(changes[0])
-    else:
+    phrase = _object_phrase(changes)
+    if phrase is None:
         phrase = _surface_phrase(surfaces)
     changed_paths = [str(change["path"]) for change in changes]
     message = f"[{verb}] {phrase}"

--- a/mb/mb/dogfood_harness.py
+++ b/mb/mb/dogfood_harness.py
@@ -94,14 +94,16 @@ CLAUDE_PRINT_PROMPT_PREFIX = """Release simulation harness constraints:
   `mb books check`, and `mb educational <topic>`.
 - Do not use shell pipes, redirects, temp files, Python parsers, or Claude
   tool-result paths to transform command output.
-- In the final answer, translate status for a normal business owner before any
-  technical detail: say "nothing unsaved locally" before "git is clean" or
-  "working tree clean" / "working tree: clean"; "current business folder"
-  before "branch main" / "branch: main"; "no connected GitHub backup or shared
-  task source" before "No GitHub origin remote" / "No origin remote";
-  "connected GitHub backup or shared task source" before "origin remote";
-  "saved checkpoint" before "commit"; "task" before "issue"; and "proposal"
-  before "PR".
+- In the final answer, use normal business-owner language first and avoid
+  parenthetical git/GitHub restatements. Say "nothing unsaved locally" instead
+  of "git is clean" or "working tree clean" / "working tree: clean"; "current
+  business folder" instead of "branch main" / "branch: main"; "no connected
+  GitHub backup or shared task source" instead of "No GitHub origin remote",
+  "No origin remote", or "Connected GitHub backup: none surfaced"; "connected
+  GitHub backup or shared task source" instead of "origin remote"; "saved
+  checkpoint" instead of "commit"; "task" instead of "issue"; and "proposal"
+  instead of "PR". If an exact raw term is necessary for debugging, put it on a
+  separate `Technical detail:` or `Exact command:` line after the owner meaning.
 - Checkpoint examples must name the saved business artifact, such as
   `[updated] offer and founder-call research`, not broad buckets like
   `[updated] core and research`, `[drafted] files`, or `[ran] changes`.

--- a/mb/mb/init.py
+++ b/mb/mb/init.py
@@ -296,9 +296,11 @@ Default translations for normal owner answers:
   -> nothing unsaved locally;
 - `branch main`, `branch: main`, or `current branch: main` -> current business
   folder or workspace;
-- `No GitHub origin remote` or `No origin remote` -> no connected GitHub backup
-  or shared task source;
+- `No GitHub origin remote`, `No origin remote`, or `Connected GitHub backup:
+  none surfaced` -> no connected GitHub backup or shared task source;
 - `PR/issue facts` or `PR and issue facts` -> GitHub task and proposal context.
+Use raw git/GitHub terms only in exact commands or a separate "Technical
+detail:" line after the owner meaning.
 
 ## Folders
 

--- a/mb/mb/release_simulation.py
+++ b/mb/mb/release_simulation.py
@@ -337,6 +337,15 @@ _TECHNICAL_LANGUAGE_PATTERNS: tuple[tuple[re.Pattern[str], str, str], ...] = (
         "no connected GitHub backup or shared task source",
     ),
     (
+        re.compile(
+            r"\bconnected github backup\s*:\s*"
+            r"(?:none|not found|not surfaced|none surfaced|missing|unavailable)\b",
+            re.IGNORECASE,
+        ),
+        "Connected GitHub backup: none surfaced",
+        "no connected GitHub backup or shared task source",
+    ),
+    (
         re.compile(r"\borigin remote\b", re.IGNORECASE),
         "origin remote",
         "GitHub connection",
@@ -512,6 +521,7 @@ def _operator_language_severity(*, leakage_count: int, checkpoint_count: int) ->
 
 def _is_allowed_technical_detail_line(line: str) -> bool:
     normalized = line.lower()
+    normalized = re.sub(r"^[>\-\*\d\.\s]+", "", normalized)
     return normalized.startswith(("technical detail:", "technical details:", "exact command:"))
 
 

--- a/mb/tests/test_checkpoint.py
+++ b/mb/tests/test_checkpoint.py
@@ -137,7 +137,7 @@ def test_checkpoint_plan_classifies_dirty_business_files(tmp_path: Path, monkeyp
         "pushes": 1,
         "decisions": 1,
     }
-    assert report["proposal"]["message"] == "[added] core, pushes, and decisions"
+    assert report["proposal"]["message"] == "[added] offer, test decision, and paid push"
     assert report["proposal"]["verb"] == "added"
     assert report["proposal"]["loop"] == "sense"
     assert report["proposal"]["validation"]["ok"] is True
@@ -160,10 +160,26 @@ def test_checkpoint_cli_json_contract(tmp_path: Path, monkeypatch: Any) -> None:
     assert payload["status"] == "ready"
     assert payload["mode"] == "beginner"
     assert payload["summary"]["surfaces"] == {"research": 1}
-    assert payload["proposal"]["message"] == "[added] market.md"
+    assert payload["proposal"]["message"] == "[added] market research"
     assert (
         payload["proposal"]["reason"] == "Chosen because new durable business context was created."
     )
+
+
+def test_checkpoint_plan_names_core_and_research_artifacts(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    repo = _business_repo(tmp_path, monkeypatch)
+    (repo / "core" / "offer.md").write_text("# Offer\n\nUpdated promise.\n", encoding="utf-8")
+    (repo / "research" / "2026-05-08-unsaved-founder-calls.md").write_text(
+        "# Founder Calls\n\nApproved insight.\n",
+        encoding="utf-8",
+    )
+
+    report = checkpoint_mod.plan(repo)
+
+    assert report["ok"] is True
+    assert report["proposal"]["message"] == "[added] offer and founder-call research"
 
 
 def test_checkpoint_validate_accepts_business_verb_json() -> None:

--- a/mb/tests/test_json_result.py
+++ b/mb/tests/test_json_result.py
@@ -149,7 +149,7 @@ def test_checkpoint_json_uses_shared_result_envelope(tmp_path: Path) -> None:
     )
     assert payload["status"] == "ready"
     assert payload["summary"]["surfaces"] == {"research": 1}
-    assert payload["proposal"]["message"] == "[added] market.md"
+    assert payload["proposal"]["message"] == "[added] market research"
 
 
 def test_issue_draft_json_uses_shared_result_envelope(tmp_path: Path) -> None:

--- a/mb/tests/test_release_simulation.py
+++ b/mb/tests/test_release_simulation.py
@@ -194,7 +194,8 @@ def test_claude_print_prompt_includes_owner_language_guardrails() -> None:
     assert "current business folder" in normalized_prompt
     assert "no connected GitHub backup or shared task source" in normalized_prompt
     assert "No GitHub origin remote" in normalized_prompt
-    assert '"connected GitHub backup or shared task source" before "origin' in normalized_prompt
+    assert '"connected GitHub backup or shared task source" instead of "origin' in normalized_prompt
+    assert "Technical detail:" in normalized_prompt
     assert "saved checkpoint" in normalized_prompt
     assert "[updated] offer and founder-call research" in normalized_prompt
 
@@ -283,6 +284,7 @@ def test_score_transcript_allows_business_translation_before_technical_detail() 
     already saved.
 
     Technical detail: `git status --short` returned clean on `main`.
+    - Exact command: `gh repo create --source . --remote origin --push`
     """
 
     score = release_simulation.score_transcript(transcript)
@@ -330,6 +332,10 @@ def test_score_transcript_requires_matching_business_translation_before_git_deta
         (
             "No connected GitHub backup yet (`origin remote`).",
             "origin remote",
+        ),
+        (
+            "Connected GitHub backup: none surfaced.",
+            "Connected GitHub backup: none surfaced",
         ),
     ],
 )


### PR DESCRIPTION
## Summary

Tightens release-simulation owner-language behavior after the v0.3.24 evidence pass. Checkpoint proposals now name small business artifacts more specifically, and release simulations/guidance flag or avoid the GitHub connection phrasings that still leaked into final answers.

## Linked issue

Closes #619

## Why

The 0.3.24 release acceptance run passed hard gates but still produced visible phrases like `Connected GitHub backup: none surfaced`, parenthetical git restatements, and a broad checkpoint example. This PR turns those findings into product behavior, scorer coverage, and generated runtime guidance.

## Commits by concern

- [x] `f266f1d [fix] MAIN-385 tighten release simulation language`
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
- [x] Commit subject uses `[fix]`

## Validation

Pre-push gate from repo root:

```bash
scripts/check.sh
```

- [x] Level 1 static: `scripts/check.sh` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: `88 files already formatted`; `All checks passed!`; `Success: no issues found in 87 source files`; `713 passed`
- [x] Level 2 CLI contract: `cd mb && pytest tests/test_dogfood_harness.py tests/test_checkpoint.py tests/test_release_simulation.py tests/test_start_router_contract.py -q` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: `104 passed`
- [ ] Level 3 package/install smoke: not required; packaging, entrypoints, and bundled install metadata did not change.
- [ ] Level 4 fixture repo: not required; no onboarding fixture shape or first-run command contract changed beyond generated guidance text covered by tests.
- [x] Level 5 runtime smoke / dogfood harness / simulation-tier: `scripts/claude-runtime-dogfood.py --install-mode editable --run-claude-print --simulation-tier release_acceptance --evidence-dir .agent/main-385/release-acceptance-editable --cleanup --max-budget-usd 5.00` — runtime: editable install, Claude Code print mode — exit: interrupted after all 11 Claude response files were written because the wrapper process stayed alive; manual rescore of those 11 responses returned `11/11`, `operator_language_first: true`, technical leakage `none`, checkpoint specificity `true`
- [x] SKILL.md ≤500 lines: covered by `scripts/check.sh`; skill validation passed 15/15.
- [ ] Package-visible release gate evidence before tag/publish: not required; this is post-release follow-up work, not a package release.
- [ ] Supply-chain review: not required; no workflow, dependency, or publish-permission files changed.

## Success metric

Future release-acceptance print-mode scoring keeps deterministic proof intact while reporting no visible owner-language leakage and specific checkpoint examples.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section.

## Breaking changes

- [x] No
- [ ] Yes — migration note below

## Public / private boundary

Committed files contain only public product code, docs, packaged templates, and sanitized tests. Raw release transcripts and local evidence stay in ignored `.agent/` scratch.
