### PR TITLE
[update] Prepare mainbranch 0.3.25

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mainbranch",
-  "version": "0.3.24",
+  "version": "0.3.25",
   "description": "Main Branch Claude Code skills for running a business from markdown files in git.",
   "author": {
     "name": "Noontide"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+## [0.3.25] - 2026-05-16
+
+v0.3.25 packages the post-v0.3.24 release-simulation language fix. It makes
+checkpoint suggestions more specific and keeps release-acceptance transcripts
+stricter about business-owner wording before git/GitHub details.
+
 ### Fixed
 
 - Tightened post-v0.3.24 release-simulation guidance and scoring so final

--- a/mb/mb/__init__.py
+++ b/mb/mb/__init__.py
@@ -7,6 +7,6 @@ file stays a thin dispatcher.
 
 from __future__ import annotations
 
-__version__ = "0.3.24"
+__version__ = "0.3.25"
 
 __all__ = ["__version__"]

--- a/mb/pyproject.toml
+++ b/mb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mainbranch"
-version = "0.3.24"
+version = "0.3.25"
 description = "Main Branch engine umbrella - scaffolds, validates, and graphs business-as-files repos. Claude Code first, runtime-agnostic by design."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Prepares Main Branch 0.3.25 as a patch release for the post-v0.3.24 release-simulation language fix. The release moves the MAIN-385 / #619 changelog entry into a dated version section and bumps the package plus Claude plugin version sites.

## Linked issue

Refs #619

## Why

The MAIN-385 fix is package-visible: it changes checkpoint proposal wording, generated runtime guidance, and release-simulation scoring. Publishing 0.3.25 makes the merged fix installable from PyPI instead of leaving it only on `main`.

## Commits by concern

- [x] `7b2afe7 [update] Prepare mainbranch 0.3.25`
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
- [x] Commit subject uses `[update]`

## Validation

Pre-push gate from repo root:

```bash
scripts/check.sh
```

- [x] Level 0 release-file preflight: version sites + `cd mb && python3 -m pytest tests/test_smoke_coverage.py::test_claude_plugin_manifest_points_at_prefixed_skills -q` — runtime: `python3` — exit: 0 — log: `.agent/release-evidence/0.3.25/preflight.out` (`1 passed`)
- [x] Level 1 static: `scripts/check.sh` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: `.agent/release-evidence/0.3.25/check.out` (`713 passed`; skill validation 15/15)
- [x] Level 3 package/install: `(cd mb && python3 -m build)` + fresh venv wheel install + `mb --version` + `mb skill list` + `mb books check --fixture --json` — runtime: `/tmp/mainbranch-0.3.25-smoke/bin/python3` — exit: 0 — log: `.agent/release-evidence/0.3.25/wheel-smoke.out` (`mb 0.3.25`, books fixture `result_status: ok`)
- [x] Level 4 fixture repo: wheel-installed `mb onboard`, `mb doctor`, `mb status --json --peek`, `mb start --json`, `mb validate` — runtime: `/tmp/mainbranch-0.3.25-smoke/bin/mb` — exit: 0 — log: `.agent/release-evidence/0.3.25/wheel-smoke.out`
- [x] Level 5 runtime/simulation proxy: `scripts/claude-runtime-dogfood.py --install-mode wheel --wheel mb/dist/mainbranch-0.3.25-py3-none-any.whl --run-claude-print --simulation-tier release_acceptance --max-budget-usd 5.00` — runtime: Claude Code 2.1.140 print mode — exit: 0 — evidence: `.agent/release-evidence/0.3.25/release-acceptance-wheel/`; rubric `10/11`, owner-language leakage `none`, checkpoint specificity `true`; manual review found the missed `loop_routing` heuristic is lexical-only because transcripts used routing language such as “Pick a route” / “Recommended route” rather than the scorer's narrower keywords.
- [x] Books fixture both modes: hledger available mode covered in `wheel-smoke.out`; no-hledger PATH mode — exit: 0 — log: `.agent/release-evidence/0.3.25/books-fixture-no-hledger.out` (`hledger-missing`, `result_status: ok`)
- [x] Package-visible release supply-chain checks: `[Unreleased]` empty, no pyproject dependency diff beyond version bump, workflow permissions scanned, Dependabot open alert count 0, `pypi` environment reviewer present — logs: `.agent/release-evidence/0.3.25/supply-chain-preflight.out`, `dependabot-alert-count.out`, `pypi-environment.out`

## Success metric

`mainbranch 0.3.25` can be installed from PyPI with the MAIN-385 owner-language and checkpoint specificity fixes present.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [ ] N/A — change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [x] No
- [ ] Yes — migration note below

## Public / private boundary

The release PR changes only public release/version files. Raw simulation transcripts and local evidence remain in ignored `.agent/` release evidence.
