### PR TITLE
[fix] mb onboard push schema marker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 - Fixed `mb status --json --peek` so date-valued status facts serialize as ISO
   strings and status failures return the shared JSON error envelope instead of
   leaking Python tracebacks. Refs MAIN-391, #628.
+- Fixed `mb onboard --github <owner/repo> --push` so first-run GitHub backup
+  includes generated `.mb/schema_version` state in the saved baseline instead
+  of stranding the operator at manual cleanup. The push path now records
+  GitHub CLI auth/account preflight facts before creating the repo. Refs
+  MAIN-389, #626.
 
 ## [0.3.25] - 2026-05-16
 

--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -312,13 +312,26 @@ def _render_onboard_human(result: dict[str, Any]) -> None:
     tools = result["tools"]
     skill_wiring = result["skill_wiring"]
     checkpoint_hook = result.get("checkpoint_hook") or {}
+    raw_github = result.get("github")
+    github_result: dict[str, Any] = raw_github if isinstance(raw_github, dict) else {}
+    raw_github_preflight = github_result.get("preflight")
+    github_preflight: dict[str, Any] = (
+        raw_github_preflight if isinstance(raw_github_preflight, dict) else {}
+    )
     git = tools["git"]
     github = tools["github_cli"]
     claude = tools["claude_code"]
     console.print("[bold]Checks[/bold]")
     console.print(f"  {'ok' if git['found'] else 'warn'}  git")
     github_state = "ok" if github["found"] and github["authenticated"] else "warn"
-    console.print(f"  {github_state}  GitHub CLI")
+    github_label = "GitHub CLI"
+    account = str(github_preflight.get("authenticated_account") or "")
+    expected_owner = str(github_preflight.get("expected_owner") or "")
+    if account and expected_owner:
+        github_label = f"GitHub CLI signed in as {account}; backup target {expected_owner}"
+    elif account:
+        github_label = f"GitHub CLI signed in as {account}"
+    console.print(f"  {github_state}  {github_label}")
     console.print(f"  {'ok' if claude['found'] else 'warn'}  Claude Code")
     console.print(f"  {'ok' if skill_wiring['ok'] else 'fail'}  Claude Code skill discovery")
     if checkpoint_hook:

--- a/mb/mb/onboard.py
+++ b/mb/mb/onboard.py
@@ -46,6 +46,9 @@ LOCAL_SETUP_PATH_PREFIXES = (
     ".claude/worktrees/",
     ".claude/skills/",
 )
+TRACKED_LOCAL_SETUP_PATHS = {
+    ".mb/schema_version",
+}
 
 
 def _which(name: str) -> str:
@@ -113,7 +116,7 @@ def _durable_generated_paths(paths: list[str]) -> list[str]:
         path = Path(rel)
         if path.is_absolute() or ".." in path.parts:
             continue
-        if any(
+        if rel not in TRACKED_LOCAL_SETUP_PATHS and any(
             rel == prefix.rstrip("/") or rel.startswith(prefix)
             for prefix in LOCAL_SETUP_PATH_PREFIXES
         ):
@@ -143,14 +146,20 @@ def _commit_generated_scaffold(
         result["commands"].append("git add -- " + " ".join(durable_paths))
         if not add["ok"]:
             result["errors"].append(add["stderr"].strip() or "git add failed")
-            result["repair"] = "Review `git status`, then commit the scaffold manually."
+            result["repair"] = (
+                "Rerun `mb onboard --yes --path <repo> --github <owner/repo> --push` "
+                "after the folder is writable."
+            )
             return result
 
     staged = _git_output(repo, ["diff", "--cached", "--quiet", "--"])
     staged_changes = staged["returncode"] == 1
     if staged["returncode"] not in {0, 1}:
         result["errors"].append(staged["stderr"].strip() or "git staged diff failed")
-        result["repair"] = "Review `git status`, then commit the scaffold manually."
+        result["repair"] = (
+            "Rerun `mb onboard --yes --path <repo> --github <owner/repo> --push` "
+            "after the folder is writable."
+        )
         return result
     if staged_changes:
         commit = _git_output(repo, ["commit", "-m", commit_message], timeout=15.0)
@@ -165,18 +174,53 @@ def _commit_generated_scaffold(
         result["committed"] = True
     elif not _has_git_commit(repo):
         result["errors"].append("No durable scaffold files were staged for the first commit.")
-        result["repair"] = "Review `git status`, then commit the scaffold manually."
+        result["repair"] = (
+            "Rerun `mb onboard --yes --path <repo> --github <owner/repo> --push` "
+            "after the folder is writable."
+        )
         return result
 
     if _working_tree_dirty(repo):
-        result["errors"].append(
-            "Working tree has uncommitted files outside the generated Main Branch scaffold."
-        )
+        result["errors"].append("This folder has files Main Branch did not create.")
         result["repair"] = (
-            "Review `git status`; commit, ignore, or move private files before pushing."
+            "Move private or scratch files out of the business folder, then rerun "
+            "`mb onboard --yes --path <repo> --github <owner/repo> --push`."
         )
         return result
 
+    result["ok"] = True
+    return result
+
+
+def _github_owner(github_repo: str) -> str:
+    parts = github_repo.strip().split("/", maxsplit=1)
+    return parts[0].strip() if len(parts) == 2 else ""
+
+
+def _github_preflight(github_repo: str) -> dict[str, Any]:
+    owner = _github_owner(github_repo)
+    result: dict[str, Any] = {
+        "ok": False,
+        "authenticated": False,
+        "authenticated_account": "",
+        "expected_owner": owner,
+        "owner_matches_authenticated_account": False,
+        "commands": [],
+        "errors": [],
+        "repair": "",
+    }
+    auth = _run_command(["gh", "auth", "status"], timeout=5.0)
+    result["commands"].append("gh auth status")
+    user = _run_command(["gh", "api", "user", "--jq", ".login"], timeout=5.0)
+    result["commands"].append("gh api user --jq .login")
+    account = user["stdout"].strip() if user["ok"] else ""
+    result["authenticated_account"] = account
+    result["authenticated"] = bool(auth["ok"] or account)
+    result["owner_matches_authenticated_account"] = bool(owner and account and owner == account)
+    if not result["authenticated"]:
+        result["errors"].append("GitHub CLI is installed but not authenticated.")
+        result["repair"] = "Run `gh auth login`, then rerun onboarding."
+        return result
     result["ok"] = True
     return result
 
@@ -201,6 +245,7 @@ def _github_create_push(
         "remote_set": bool(_git_remote(repo)),
         "pushed": False,
         "tracking": _tracking_branch(repo),
+        "preflight": {},
         "commands": [],
         "errors": [],
         "repair": "",
@@ -218,6 +263,14 @@ def _github_create_push(
     if not _which("git"):
         result["errors"].append("git is not installed.")
         result["repair"] = "Install git before creating the GitHub repo."
+        return result
+
+    preflight = _github_preflight(github_repo.strip())
+    result["preflight"] = preflight
+    result["commands"].extend(preflight["commands"])
+    if not preflight["ok"]:
+        result["errors"].extend(str(item) for item in preflight["errors"])
+        result["repair"] = str(preflight["repair"])
         return result
 
     commit_result = _commit_generated_scaffold(

--- a/mb/tests/test_onboard.py
+++ b/mb/tests/test_onboard.py
@@ -3,9 +3,13 @@
 from __future__ import annotations
 
 import json
+import os
 import shutil
+import subprocess
+import sys
 from pathlib import Path
 
+import pytest
 from typer.testing import CliRunner
 
 from mb import graph as graph_mod
@@ -424,6 +428,8 @@ def test_onboard_github_create_push_commits_and_sets_tracking(tmp_path: Path, mo
             return {"ok": True, "stdout": "", "stderr": "", "returncode": 0}
         if args[:3] == ["gh", "auth", "status"]:
             return {"ok": True, "stdout": "", "stderr": "", "returncode": 0}
+        if args[:4] == ["gh", "api", "user", "--jq"]:
+            return {"ok": True, "stdout": "dmthepm\n", "stderr": "", "returncode": 0}
         if args[:3] == ["gh", "repo", "create"]:
             state["remote"] = "https://github.com/dmthepm/acme.git\n"
             state["tracking"] = "origin/main\n"
@@ -449,7 +455,10 @@ def test_onboard_github_create_push_commits_and_sets_tracking(tmp_path: Path, mo
     assert "." not in add_command
     assert "CLAUDE.md" in add_command
     assert ".gitignore" in add_command
+    assert ".mb/schema_version" in add_command
     assert result["github"]["pushed"] is True
+    assert result["github"]["preflight"]["authenticated_account"] == "dmthepm"
+    assert result["github"]["preflight"]["owner_matches_authenticated_account"] is True
     assert result["setup_complete"]["github_requested"] is True
     assert result["setup_complete"]["github_remote_connected"] is True
     assert result["setup_complete"]["pushed_tracking_remote"] is True
@@ -503,6 +512,8 @@ def test_onboard_github_push_commits_generated_scaffold_in_repo_with_head(
             return {"ok": True, "stdout": "", "stderr": "", "returncode": 0}
         if args[:3] == ["gh", "auth", "status"]:
             return {"ok": True, "stdout": "", "stderr": "", "returncode": 0}
+        if args[:4] == ["gh", "api", "user", "--jq"]:
+            return {"ok": True, "stdout": "dmthepm\n", "stderr": "", "returncode": 0}
         if args[:3] == ["gh", "repo", "create"]:
             state["remote"] = "https://github.com/dmthepm/existing.git\n"
             state["tracking"] = "origin/main\n"
@@ -577,6 +588,8 @@ def test_onboard_github_push_does_not_sweep_preexisting_untracked_files(
             return {"ok": True, "stdout": "", "stderr": "", "returncode": 0}
         if args[:3] == ["gh", "auth", "status"]:
             return {"ok": True, "stdout": "", "stderr": "", "returncode": 0}
+        if args[:4] == ["gh", "api", "user", "--jq"]:
+            return {"ok": True, "stdout": "dmthepm\n", "stderr": "", "returncode": 0}
         raise AssertionError(args)
 
     monkeypatch.setattr(onboard_mod, "_run_command", fake_run)
@@ -593,7 +606,7 @@ def test_onboard_github_push_does_not_sweep_preexisting_untracked_files(
 
     assert result["ok"] is False
     assert result["github"]["ok"] is False
-    assert any("uncommitted files outside" in error for error in result["github"]["errors"])
+    assert any("files Main Branch did not create" in error for error in result["github"]["errors"])
     assert not any(cmd[:3] == ["gh", "repo", "create"] for cmd in commands)
 
 
@@ -647,6 +660,8 @@ def test_onboard_github_success_uses_reachability_over_stale_auth_status(
             return {"ok": True, "stdout": "", "stderr": "", "returncode": 0}
         if args[:3] == ["gh", "auth", "status"]:
             return {"ok": False, "stdout": "", "stderr": "stale auth", "returncode": 1}
+        if args[:4] == ["gh", "api", "user", "--jq"]:
+            return {"ok": True, "stdout": "dmthepm\n", "stderr": "", "returncode": 0}
         if args[:3] == ["gh", "repo", "create"]:
             state["remote"] = "https://github.com/dmthepm/reachable.git\n"
             state["tracking"] = "origin/main\n"
@@ -676,3 +691,105 @@ def test_onboard_github_success_uses_reachability_over_stale_auth_status(
     assert result["tools"]["github_cli"]["authenticated"] is True
     assert result["tools"]["github_cli"]["state"] == "ready_reachable"
     assert not any("gh auth login" in warning for warning in result["warnings"])
+
+
+def test_onboard_cli_github_push_fixture_leaves_generated_mb_state_clean(
+    tmp_path: Path, monkeypatch
+) -> None:
+    if not shutil.which("git"):
+        pytest.skip("git is required for the fixture push smoke")
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_gh = fake_bin / "gh"
+    remote = tmp_path / "remote.git"
+    fake_gh.write_text(
+        f"""#!{sys.executable}
+import json
+import os
+import subprocess
+import sys
+
+args = sys.argv[1:]
+remote = os.environ["MB_TEST_REMOTE"]
+
+if args[:2] == ["auth", "status"]:
+    sys.exit(0)
+if args[:4] == ["api", "user", "--jq", ".login"]:
+    print("fixture-owner")
+    sys.exit(0)
+if args[:2] == ["repo", "view"]:
+    print(json.dumps({{"nameWithOwner": args[2]}}))
+    sys.exit(0)
+if args[:2] == ["repo", "create"]:
+    full_name = args[2]
+    if not os.path.exists(remote):
+        subprocess.run(["git", "init", "--bare", remote], check=True, stdout=subprocess.DEVNULL)
+    subprocess.run(["git", "remote", "remove", "origin"], stderr=subprocess.DEVNULL)
+    subprocess.run(["git", "remote", "add", "origin", remote], check=True)
+    if "--push" in args:
+        subprocess.run(["git", "push", "-u", "origin", "main"], check=True)
+    subprocess.run(
+        ["git", "remote", "set-url", "origin", "https://github.com/" + full_name + ".git"],
+        check=True,
+    )
+    sys.exit(0)
+
+print("unexpected gh command: " + " ".join(args), file=sys.stderr)
+sys.exit(2)
+""",
+        encoding="utf-8",
+    )
+    fake_gh.chmod(0o755)
+    monkeypatch.setenv("PATH", str(fake_bin) + os.pathsep + os.environ.get("PATH", ""))
+    monkeypatch.setenv("MB_TEST_REMOTE", str(remote))
+    monkeypatch.setenv("GIT_AUTHOR_NAME", "Main Branch Test")
+    monkeypatch.setenv("GIT_AUTHOR_EMAIL", "test@example.com")
+    monkeypatch.setenv("GIT_COMMITTER_NAME", "Main Branch Test")
+    monkeypatch.setenv("GIT_COMMITTER_EMAIL", "test@example.com")
+    monkeypatch.setattr(onboard_mod, "is_interactive", lambda: False)
+    repo = tmp_path / "acme"
+
+    result = runner.invoke(
+        app,
+        [
+            "onboard",
+            "--yes",
+            "--name",
+            "Acme",
+            "--path",
+            str(repo),
+            "--github",
+            "fixture-owner/acme",
+            "--push",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["github"]["ok"] is True
+    assert payload["github"]["committed"] is True
+    assert payload["github"]["pushed"] is True
+    assert payload["github"]["preflight"]["authenticated_account"] == "fixture-owner"
+    assert payload["setup_complete"]["committed_with_durable_files"] is True
+    assert payload["setup_complete"]["pushed_tracking_remote"] is True
+    assert ".mb/schema_version" in " ".join(payload["github"]["commands"])
+
+    status = subprocess.run(
+        ["git", "status", "--short"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert status.stdout == ""
+    schema_history = subprocess.run(
+        ["git", "log", "--oneline", "--", ".mb/schema_version"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert schema_history.stdout.strip()


### PR DESCRIPTION
## Summary

Fixes `mb onboard --github <owner/repo> --push` so first-run GitHub backup saves generated `.mb/schema_version` in the baseline commit instead of leaving the repo dirty. The push path now records GitHub CLI auth/account preflight facts and keeps repair copy out of raw git cleanup.

## Linked issue

Closes #626

## Why

First-run setup could create the business folder and baseline, then report repair needed because Main Branch-generated `.mb/` state was still untracked. A beginner should not have to inspect `.mb/`, manually commit a schema marker, or rerun setup before GitHub backup is trusted.

## Commits by concern

- [ ] Each commit body bullet-lists the changes in that commit
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`

Commit list:
- `c7c24f4 [fix] MAIN-389 preserve onboard schema marker on push`

## Validation

Pre-push gate from repo root:

```bash
scripts/check.sh
```

- [x] Level 1 static: `scripts/check.sh` passes
- [x] Level 2 CLI contract: focused Typer/CliRunner tests, exit codes, `--json` behavior, TTY vs non-TTY (if CLI behavior touched)
- [x] Level 3 package/install smoke (if packaging touched)
- [x] Level 4 fixture repo (if init/onboard/status/start/update touched)
- [ ] Level 5 runtime smoke / dogfood harness / simulation-tier (if runtime, first-run, skill discovery, or release validation touched)
- [ ] SKILL.md <=500 lines (if any skill touched)
- [ ] Package-visible release gate evidence before tag/publish (if preparing a release)
- [ ] Supply-chain review (if `.github/workflows/`, `.github/dependabot.yml`, `mb/pyproject.toml` deps, or `id-token`/`permissions` blocks touched — see [docs/supply-chain-policy.md](../docs/supply-chain-policy.md))

Level 1 static: `scripts/check.sh` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: formatting, lint, mypy, 715 tests with coverage, skill validation, and docs gates passed.
Level 2 CLI contract: `cd mb && pytest tests/test_onboard.py -q` — runtime: `python3` — exit: 0 — log: `19 passed in 33.10s`.
Level 3 package/install: `cd mb && python3 -m build && /tmp/mainbranch-smoke/bin/pip install mb/dist/*.whl && /tmp/mainbranch-smoke/bin/mb --version && /tmp/mainbranch-smoke/bin/mb skill list` — runtime: `/tmp/mainbranch-smoke/bin/python3.13` — exit: 0 — log: wheel built, `mb 0.3.25`, bundled skill list printed.
Level 4 fixture repo: installed `mb onboard --yes --github fixture-owner/acme --push --json` with fake `gh` and real git remote — runtime: `/tmp/mainbranch-smoke/bin/mb` — exit: 0 — log: pushed true, `git status --short` empty, `.mb/schema_version` present in scaffold commit.
Level 5 runtime: not required; generated runtime guidance and skill discovery did not change.
SKILL.md line gate: covered by `scripts/check.sh`; no skill files changed.
Package-visible release gate: not required; this prepares unreleased branch work, not a tag or publish.
Supply-chain review: not required; no workflow, dependency, Dependabot, `id-token`, or permissions files changed.

## Success metric

A no-user-files `mb onboard --yes --github <owner/repo> --push` run finishes with GitHub backup ready, a clean working tree, and `.mb/schema_version` in the generated scaffold history without any manual schema marker commit.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [ ] N/A — change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [x] No
- [ ] Yes — migration note below

## Public / private boundary

Only sanitized public issue context and disposable fixture repos were used. No private operator strategy, customer transcript, credentials, machine-specific setup, or runtime internals were committed.

