### PR TITLE
[fix] mb status JSON date serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   keeping `.agents/skills`, plugin packaging, site/ads/provider workflows, and
   slash-command parity out of scope. Refs MAIN-387, #624.
 
+### Fixed
+
+- Fixed `mb status --json --peek` so date-valued status facts serialize as ISO
+  strings and status failures return the shared JSON error envelope instead of
+  leaking Python tracebacks. Refs MAIN-391, #628.
+
 ## [0.3.25] - 2026-05-16
 
 v0.3.25 packages the post-v0.3.24 release-simulation language fix. It makes

--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -40,7 +40,7 @@ from mb import think as think_mod
 from mb import update as update_mod
 from mb import validate as validate_mod
 from mb.freshness import format_update_alert, looks_like_business_repo, package_update_status
-from mb.json_result import envelope
+from mb.json_result import envelope, json_default
 
 app = typer.Typer(
     name="mb",
@@ -147,7 +147,29 @@ def _version_callback(value: bool) -> None:
 
 
 def _json_payload(payload: dict[str, Any], *, command: str, schema_name: str) -> str:
-    return json.dumps(envelope(payload, command=command, schema_name=schema_name), indent=2)
+    return json.dumps(
+        envelope(payload, command=command, schema_name=schema_name),
+        indent=2,
+        default=json_default,
+    )
+
+
+def _json_error_payload(
+    *,
+    command: str,
+    schema_name: str,
+    code: str,
+    message: str,
+) -> str:
+    return _json_payload(
+        {
+            "ok": False,
+            "errors": [{"code": code, "message": message}],
+            "safe_to_share": True,
+        },
+        command=command,
+        schema_name=schema_name,
+    )
 
 
 def _is_interactive_terminal() -> bool:
@@ -989,9 +1011,35 @@ def status_cmd(
     ),
 ) -> None:
     """Show a cheap daily briefing for a Main Branch repo."""
-    report = status_mod.run(path=path, update_marker=not peek, validation_cross_refs=not peek)
+    try:
+        report = status_mod.run(path=path, update_marker=not peek, validation_cross_refs=not peek)
+    except Exception as exc:
+        message = status_mod._safe_exception_message(exc)
+        if json_out:
+            typer.echo(
+                _json_error_payload(
+                    command="mb status",
+                    schema_name="mainbranch.status",
+                    code="status_unavailable",
+                    message=message,
+                )
+            )
+        else:
+            typer.echo(f"mb status: {message}", err=True)
+        raise typer.Exit(1) from exc
     if json_out:
-        typer.echo(_json_payload(report, command="mb status", schema_name="mainbranch.status"))
+        try:
+            typer.echo(_json_payload(report, command="mb status", schema_name="mainbranch.status"))
+        except TypeError as exc:
+            typer.echo(
+                _json_error_payload(
+                    command="mb status",
+                    schema_name="mainbranch.status",
+                    code="status_json_serialization_failed",
+                    message=status_mod._safe_exception_message(exc),
+                )
+            )
+            raise typer.Exit(1) from exc
     else:
         status_mod.render_human(report, verbose=verbose, no_color=no_color)
 

--- a/mb/mb/json_result.py
+++ b/mb/mb/json_result.py
@@ -2,9 +2,19 @@
 
 from __future__ import annotations
 
+from datetime import date, datetime
 from typing import Any
 
 JSON_RESULT_ENVELOPE_VERSION = "1.0"
+
+
+def json_default(value: Any) -> str:
+    """Normalize scalar values that common parsers return but JSON rejects."""
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, date):
+        return value.isoformat()
+    raise TypeError(f"Object of type {value.__class__.__name__} is not JSON serializable")
 
 
 def _coerce_list(value: Any) -> list[Any]:

--- a/mb/mb/status.py
+++ b/mb/mb/status.py
@@ -26,6 +26,7 @@ from mb import topology as topology_mod
 from mb import validate as validate_mod
 from mb.engine import install_mode, link_status
 from mb.freshness import format_update_alert, package_update_status
+from mb.json_result import json_default
 
 IMPORTANT_DIRS = (
     "core",
@@ -801,7 +802,11 @@ def _testimonial_entries(text: str, meta: dict[str, Any]) -> list[TestimonialEnt
     deduped: list[TestimonialEntry] = []
     seen: set[str] = set()
     for entry in entries:
-        key = json.dumps(entry, sort_keys=True) if isinstance(entry, dict) else entry.strip()
+        key = (
+            json.dumps(entry, sort_keys=True, default=json_default)
+            if isinstance(entry, dict)
+            else entry.strip()
+        )
         if key and key not in seen:
             deduped.append(entry)
             seen.add(key)

--- a/mb/tests/test_json_result.py
+++ b/mb/tests/test_json_result.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import shutil
 import subprocess
+from datetime import date, datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -90,6 +91,57 @@ def test_status_json_uses_shared_result_envelope(tmp_path: Path, monkeypatch: An
     assert payload["schema"]["name"] == "mainbranch.status"
     assert payload["repo"]["looks_like_mainbranch_repo"] is True
     assert "ranked_actions" in payload
+
+
+def test_status_json_normalizes_date_values_in_payload(monkeypatch: Any) -> None:
+    def fake_status_run(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        return {
+            "ok": True,
+            "schema": {"name": "mainbranch.status"},
+            "generated_at": date(2026, 5, 16),
+            "money_path": {
+                "objects": {
+                    "proof": {
+                        "review_on": date(2026, 5, 20),
+                        "checked_at": datetime(2026, 5, 16, 12, 30, tzinfo=timezone.utc),
+                    }
+                }
+            },
+        }
+
+    monkeypatch.setattr(status_mod, "run", fake_status_run)
+
+    result = runner.invoke(app, ["status", ".", "--json", "--peek"])
+
+    assert result.exit_code == 0
+    payload = _load_json(result)
+    _assert_envelope(payload, command="mb status", schema_name="mainbranch.status")
+    assert payload["generated_at"] == "2026-05-16"
+    assert payload["money_path"]["objects"]["proof"]["review_on"] == "2026-05-20"
+    assert payload["money_path"]["objects"]["proof"]["checked_at"] == "2026-05-16T12:30:00+00:00"
+
+
+def test_status_json_failure_returns_error_envelope(monkeypatch: Any) -> None:
+    def fail_status_run(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        raise RuntimeError("cannot read /Users/devon/private/status-source.md")
+
+    monkeypatch.setattr(status_mod, "run", fail_status_run)
+
+    result = runner.invoke(app, ["status", ".", "--json", "--peek"])
+
+    assert result.exit_code == 1
+    assert "Traceback" not in result.stdout
+    assert "Traceback" not in result.stderr
+    payload = _load_json(result)
+    _assert_envelope(
+        payload,
+        command="mb status",
+        expected_result_status="error",
+        schema_name="mainbranch.status",
+    )
+    assert payload["errors"][0]["code"] == "status_unavailable"
+    assert "<local-path>" in payload["errors"][0]["message"]
+    assert "/Users/devon" not in json.dumps(payload)
 
 
 def test_start_json_uses_shared_result_envelope(tmp_path: Path, monkeypatch: Any) -> None:

--- a/mb/tests/test_status.py
+++ b/mb/tests/test_status.py
@@ -728,6 +728,41 @@ def test_status_money_path_frontmatter_public_true_counts_as_permission(
     assert testimonials["specific"] == 1
 
 
+def test_status_json_peek_handles_date_valued_testimonial_frontmatter(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+    _write_money_path_core(repo)
+    proof = repo / "core" / "proof"
+    proof.mkdir(parents=True, exist_ok=True)
+    (proof / "testimonials.md").write_text(
+        (
+            "---\n"
+            "testimonials:\n"
+            "  - public: true\n"
+            "    received_on: 2026-05-16\n"
+            "    before: stuck rebuilding context\n"
+            "    outcome: booked 3 calls\n"
+            "    timeframe: within 2 weeks\n"
+            "---\n\n"
+            "# Testimonials\n"
+        ),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["status", str(repo), "--json", "--peek"])
+
+    assert result.exit_code == 0
+    assert "Traceback" not in result.stdout
+    assert "Traceback" not in result.stderr
+    report = json.loads(result.stdout)
+    testimonials = report["money_path"]["objects"]["proof"]["quality"]["testimonials"]
+    assert testimonials["total"] == 1
+    assert testimonials["permissioned_public"] == 1
+
+
 def test_status_money_path_proof_cannot_reach_field_tested_without_level_three(
     tmp_path: Path, monkeypatch
 ) -> None:


### PR DESCRIPTION
<!--
  Thanks for contributing to Main Branch.

  See CONTRIBUTING.md for branch + PR shape, concern-based commit
  organization, and pre-push gates. Keep PRs scoped — one logical
  change per PR, ideally 3–5 commits by concern.
-->

## Summary

Fixes `mb status --json --peek` so parsed YAML `date` and `datetime` values serialize as ISO strings instead of breaking JSON output. Status assembly or serialization failures now return the shared JSON error envelope instead of leaking a Python traceback.

## Linked issue

Closes #628

## Why

`mb status --json --peek` is the deterministic fact source for runtime guidance, dashboards, and first-run routing. Date-valued structured proof/status fields could make the command return invalid JSON, which breaks the trust contract for agents and power users.

## Commits by concern

- `e2f9661 [fix] MAIN-391 status json date serialization`
- [ ] Each commit body bullet-lists the changes in that commit — N/A; this is a single small scoped commit and branch history was not rewritten during PR creation.
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`

## Validation

Pre-push gate from repo root:

```bash
scripts/check.sh
```

- [x] Level 1 static: `scripts/check.sh` passes
- [x] Level 2 CLI contract: focused Typer/CliRunner tests, exit codes, `--json` behavior, TTY vs non-TTY (if CLI behavior touched)
- [ ] Level 3 package/install smoke (if packaging touched)
- [x] Level 4 fixture repo (if init/onboard/status/start/update touched)
- [ ] Level 5 runtime smoke / dogfood harness / simulation-tier (if runtime, first-run, skill discovery, or release validation touched)
- [ ] SKILL.md ≤500 lines (if any skill touched)
- [ ] Package-visible release gate evidence before tag/publish (if preparing a release)
- [ ] Supply-chain review (if `.github/workflows/`, `.github/dependabot.yml`, `mb/pyproject.toml` deps, or `id-token`/`permissions` blocks touched — see [docs/supply-chain-policy.md](../docs/supply-chain-policy.md))

Level 1 static: `scripts/check.sh` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: excerpt `88 files already formatted`; `Success: no issues found in 87 source files`; `717 passed in 506.66s`; skill validation `errors: 0, warnings: 0`.

Level 2 CLI contract: `cd mb && pytest tests/test_json_result.py::test_status_json_normalizes_date_values_in_payload tests/test_json_result.py::test_status_json_failure_returns_error_envelope -q` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: excerpt `2 passed in 0.35s`.

Level 2 CLI contract: `cd mb && pytest tests/test_status.py::test_status_json_peek_handles_date_valued_testimonial_frontmatter -q` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: excerpt `1 passed in 2.60s`.

Level 2 CLI contract: `cd mb && pytest tests/test_json_result.py -q` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: excerpt `13 passed in 7.15s`.

Level 2 CLI contract: `cd mb && pytest tests/test_status.py -q` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: excerpt `82 passed in 115.01s`.

Level 4 fixture repo: disposable Typer fixture generated a business repo with date-valued testimonial frontmatter and ran `status --json --peek` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: excerpt `result_status: ok`, `permissioned_public: 1`.

Level 3 package/install smoke was not required because packaging, entrypoints, bundled data, and install/update paths did not change. Level 5 runtime smoke was not required because generated runtime guidance, skill discovery, and runtime invocation did not change. SKILL.md and supply-chain checks were not required because this PR does not touch skills, workflow permissions, dependency metadata, or release publishing.

## Success metric

`mb status --json --peek` returns valid JSON or a shared JSON error envelope when status facts contain date-like values, with no Python traceback visible to the operator.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [ ] N/A — change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [x] No
- [ ] Yes — migration note below

## Public / private boundary

No private operator strategy, customer data, raw transcript detail, credentials, machine-specific paths, or runtime internals were committed. Regression fixtures use sanitized synthetic business data only.
