### PR TITLE
[fix] Block unpermissioned public proof

### DIFF
--- a/.claude/skills/mb-ads/SKILL.md
+++ b/.claude/skills/mb-ads/SKILL.md
@@ -354,6 +354,8 @@ matching files under `core/offers/[active]/proof/`. Read older offer
 testimonial files as compatibility context only.
 Before outcome-claim or substantiation recommendations, read `money_path.objects.proof.quality`.
 Treat proof fields as factual signals, not scores; generic testimonials are proof material but not specific, offer-linked, typicality-aware, or outcome-backed unless those signals exist.
+If `quality.public_marketing.status` is `blocked`, do not draft proof-backed public ad claims from those testimonials.
+Route to `/mb-think` to collect permission or reframe the proof as internal strategy unless the operator explicitly approves an internal-only use.
 
 **Offer argument:** `/mb-ads [mode] [offer] [campaign]` — e.g., `/mb-ads static community january-launch`
 If offer specified, it selects the offer for this run only.

--- a/.claude/skills/mb-site/references/site-context.md
+++ b/.claude/skills/mb-site/references/site-context.md
@@ -62,6 +62,10 @@ Before using proof in page claims, read `money_path.objects.proof.quality` from
 `mb status --json --peek`. Use it to distinguish generic proof, specific
 outcomes, offer-linked proof, typicality-aware proof, and outcome-backed proof.
 These are factual page-support signals, not conversion or persuasion scores.
+If `quality.public_marketing.status` is `blocked`, do not use those
+testimonials in public page copy. Route to permission collection first, or use
+the proof only as internal strategy if the operator explicitly reframes the
+work that way.
 
 ## Required Business Context
 

--- a/.claude/skills/mb-start/references/readiness-assessment.md
+++ b/.claude/skills/mb-start/references/readiness-assessment.md
@@ -15,6 +15,9 @@ connected, and instrumented. For proof, prefer
 generic testimonials, specific outcomes, permissioned public signals, offer
 linkage, typicality context, and outcome feedback are factual signals, not
 proof scores.
+Use `quality.public_marketing` for public ads/pages readiness. Specific
+testimonials with no permissioned public signal are internal strategy proof,
+not public marketing proof; route to permission collection before public claims.
 
 ---
 

--- a/.claude/skills/mb-start/references/router-and-language.md
+++ b/.claude/skills/mb-start/references/router-and-language.md
@@ -25,6 +25,9 @@ first.
 3. Use status facts as evidence: `ranked_actions`, `update`, `readiness`,
    `onboarding`, `drift`, `integrations`, `github`, `brain`, `checkpoint`,
    `since_last_check`, `journal`, and `money_path`.
+   When `money_path.objects.proof.quality.public_marketing.status` is
+   `blocked`, route public ads/pages/claim work to proof permission collection
+   before recommending proof-backed campaigns.
 4. Choose the smallest useful next workflow. Do not present the full route menu
    when a clear intent maps to one route.
 5. If two routes are plausible, ask one business question that separates them.

--- a/.claude/skills/mb-think/SKILL.md
+++ b/.claude/skills/mb-think/SKILL.md
@@ -116,7 +116,8 @@ both.
 **Proof files:** company-wide proof uses `core/proof/testimonials.md`,
 `core/proof/typicality.md`, and `core/proof/angles/`; offer-specific proof
 uses matching files under `core/offers/<slug>/proof/`.
-When codifying proof, make permission, offer-link, outcome, timeframe, metric, and typicality facts explicit so `money_path.objects.proof.quality` can see them.
+When codifying proof, make permission, offer-link, outcome, timeframe, metric, and typicality facts explicit so `money_path.objects.proof.quality` can see them; use `permissioned_public: false` for internal proof awaiting public permission.
+If status reports `money_path.objects.proof.quality.public_marketing.status: blocked`, collect permission before ads, pages, or public claims use that proof.
 
 For a live idea, ask whether it is something to keep selling or something to
 test before deciding. Use `bets/` for the time-boxed wager, offer files for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   plain-language save/checkpoint/update/runtime boundaries and strongly
   recommended GitHub backup, sync, connector, and account-check guidance. Refs
   MAIN-388, #625; MAIN-395, #632; MAIN-394, #631.
+- Added public-marketing proof permission readiness to MoneyPath status facts
+  and tightened start/ads/site/think guidance so specific internal proof routes
+  to permission collection before proof-backed public campaigns. Refs MAIN-392,
+  #629.
 
 ### Fixed
 

--- a/docs/json-output-contract.md
+++ b/docs/json-output-contract.md
@@ -81,6 +81,7 @@ When no proof files exist, `quality` contains the baseline empty shape:
     "generic": 0,
     "specific": 0,
     "permissioned_public": 0,
+    "specific_permissioned_public": 0,
     "linked_to_offer": 0,
     "with_before_state": 0,
     "with_outcome": 0,
@@ -99,6 +100,13 @@ When no proof files exist, `quality` contains the baseline empty shape:
   "claim_links": {
     "linked_offers": [],
     "unsupported_offer_claims": []
+  },
+  "public_marketing": {
+    "ready": false,
+    "status": "missing",
+    "summary": "No testimonial proof is available for public marketing.",
+    "missing": ["testimonials"],
+    "next_action": "collect_testimonials"
   }
 }
 ```
@@ -121,16 +129,24 @@ When proof files exist and status can inspect them, `quality` also includes:
 Generic testimonials are real proof material, but they are not treated as
 specific, offer-linked, typicality-aware, or outcome-backed unless the relevant
 fields say so. Skills and dashboards should cite facts such as
-`permissioned_public`, `linked_to_offer`, `with_outcome`, `with_timeframe`,
-`with_metric`, `typicality.exists`, and, when present,
+`permissioned_public`, `specific_permissioned_public`, `linked_to_offer`,
+`with_outcome`, `with_timeframe`, `with_metric`, `typicality.exists`, and, when present,
 `instrumentation.outcome_feedback`; those are factual signals, not persuasion
 scores.
+
+`quality.public_marketing` distinguishes internal proof from proof that can be
+used in public campaigns. If testimonials have specific outcomes but none are
+permissioned for public use, `public_marketing.status` is `blocked` and
+`ready` is `false`; skills should route to permission collection before
+drafting proof-backed public ads, pages, or claims.
 
 Dashboard-safe proof categories can be derived from these facts:
 
 - Missing proof: component `status` is `missing`.
 - Generic proof: testimonials exist, but `specific` is `0`.
 - Specific proof: `testimonials.specific` is greater than `0`.
+- Public marketing proof: `public_marketing.ready` is `true`.
+- Permission-blocked public proof: `public_marketing.status` is `blocked`.
 - Offer-linked proof: `testimonials.linked_to_offer` is greater than `0`.
 - Typicality-aware proof: `typicality.exists` is `true`.
 - Outcome-backed proof: `instrumentation.outcome_feedback` is present and

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -138,6 +138,12 @@ lives under `core/offers/<slug>/proof/` or when a testimonial entry uses
 the operator, but `mb status` only treats path placement and those structured
 fields as offer-link signals.
 
+Use `permissioned_public: false` for specific proof that is useful internally
+but not approved for public marketing yet. `mb status --json --peek` reports
+that as blocked public-marketing proof under
+`money_path.objects.proof.quality.public_marketing`; skills should collect
+permission before using it in public ads, pages, or claims.
+
 Generic testimonials are still proof material. They should not be described as
 specific, offer-linked, typicality-aware, or outcome-backed unless the
 corresponding MoneyPath facts say so. `typicality.md` should record

--- a/mb/mb/_data/templates/AGENTS.md.tmpl
+++ b/mb/mb/_data/templates/AGENTS.md.tmpl
@@ -241,7 +241,9 @@ customers.
 - `core/offers/` - per-offer specifics when this is a multi-offer repo.
 - `core/proof/` - testimonials, typicality, and reusable proof. Use
   structured permission and offer-link fields when proof should be detectable
-  by `mb status`.
+  by `mb status`. If specific proof is not approved for public marketing, use
+  `permissioned_public: false` and collect permission before public ads, pages,
+  or claims use it.
 - `core/content-strategy.md` - business-level content strategy and index.
 - `core/marketing/` - optional distribution, channel, and account strategy.
 - `core/people/` - optional founder/person voice source material, beliefs,

--- a/mb/mb/_data/templates/CLAUDE.md.tmpl
+++ b/mb/mb/_data/templates/CLAUDE.md.tmpl
@@ -173,8 +173,10 @@ Use standard proof files such as `testimonials.md`, `typicality.md`, and
 `angles/` inside those proof folders. Make proof status-detectable with
 structured testimonial fields such as `public`, `permissioned_public`,
 `approved_for_public`, `safe_to_share`, `offer`, `linked_offer`, and
-`linked_offers`. Use `typicality.md` for average-case outcomes, caveats,
-common failure context, and time-to-outcome when available.
+`linked_offers`. Use `permissioned_public: false` for specific internal proof
+that is not approved for public marketing yet. Use `typicality.md` for
+average-case outcomes, caveats, common failure context, and time-to-outcome
+when available.
 Content strategy starts at `core/content-strategy.md`. Keep it as the simple
 business-level strategy and index: what the business wants to be known for, who
 the content is for, pillars, content jobs, non-publishing rules, and links to
@@ -193,7 +195,9 @@ and outcome feedback are legible and connected. Use MoneyPath from
 `mb status --json --peek` for routing when the path needs to be legible,
 supported, connected, and instrumented. Treat proof-quality fields as factual
 signals for badges or gaps, not persuasion scores; do not claim proof or offers
-are good, bad, high-converting, or likely to convert.
+are good, bad, high-converting, or likely to convert. If
+`money_path.objects.proof.quality.public_marketing.status` is `blocked`,
+collect permission before using that proof in public ads, pages, or claims.
 A live idea can be both a bet and an offer candidate: open the bet first, then
 create or update the offer only when the operator wants durable sellable truth.
 

--- a/mb/mb/init.py
+++ b/mb/mb/init.py
@@ -399,8 +399,10 @@ Use standard proof files such as `testimonials.md`, `typicality.md`, and
 `angles/` inside those proof folders. Make proof status-detectable with
 structured testimonial fields such as `public`, `permissioned_public`,
 `approved_for_public`, `safe_to_share`, `offer`, `linked_offer`, and
-`linked_offers`. Use `typicality.md` for average-case outcomes, caveats,
-common failure context, and time-to-outcome when available.
+`linked_offers`. Use `permissioned_public: false` for specific internal proof
+that is not approved for public marketing yet. Use `typicality.md` for
+average-case outcomes, caveats, common failure context, and time-to-outcome
+when available.
 Content strategy starts at `core/content-strategy.md`. Keep it as the simple
 business-level strategy and index: what the business wants to be known for, who
 the content is for, pillars, content jobs, non-publishing rules, and links to
@@ -419,7 +421,9 @@ and outcome feedback are legible and connected. Use MoneyPath from
 `mb status --json --peek` for routing when the path needs to be legible,
 supported, connected, and instrumented. Treat proof-quality fields as factual
 signals for badges or gaps, not persuasion scores; do not claim proof or offers
-are good, bad, high-converting, or likely to convert.
+are good, bad, high-converting, or likely to convert. If
+`money_path.objects.proof.quality.public_marketing.status` is `blocked`,
+collect permission before using that proof in public ads, pages, or claims.
 A live idea can be both a bet and an offer candidate: open the bet first, then
 create or update the offer only when the operator wants durable sellable truth.
 

--- a/mb/mb/status.py
+++ b/mb/mb/status.py
@@ -195,6 +195,12 @@ PROOF_PERMISSION_KEYWORDS = (
     "public: true",
     "safe to share",
 )
+PROOF_PERMISSION_NEGATIVE_RE = re.compile(
+    r"\b(?:not|no|without|pending|needs?|awaiting|unapproved)\b.{0,40}"
+    r"\b(?:permission|permissioned|approved|public|share|sharing)\b"
+    r"|\b(?:permission|permissioned|approved|public|share|sharing)\b.{0,40}"
+    r"\b(?:not|no|without|pending|needed|awaiting|unapproved|false)\b"
+)
 PROOF_AVERAGE_CASE_KEYWORDS = (
     "average",
     "median",
@@ -842,9 +848,25 @@ def _truthy_structured_value(value: Any) -> bool:
     return False
 
 
-def _testimonial_structured_permission(entry: TestimonialEntry) -> bool:
+def _falsey_structured_value(value: Any) -> bool:
+    if isinstance(value, bool):
+        return not value
+    if isinstance(value, str):
+        return value.strip().lower() in {
+            "false",
+            "no",
+            "not approved",
+            "not permissioned",
+            "pending",
+            "private",
+            "internal",
+        }
+    return False
+
+
+def _testimonial_structured_permission_signal(entry: TestimonialEntry) -> bool | None:
     if not isinstance(entry, dict):
-        return False
+        return None
     permission_fields = {
         "public",
         "permissioned_public",
@@ -852,11 +874,24 @@ def _testimonial_structured_permission(entry: TestimonialEntry) -> bool:
         "safe_to_share",
         "public_approved",
     }
+    explicit_false = False
     for key, value in entry.items():
         normalized = str(key).strip().lower().replace("-", "_")
-        if normalized in permission_fields and _truthy_structured_value(value):
+        if normalized not in permission_fields:
+            continue
+        if _truthy_structured_value(value):
             return True
-    return False
+        explicit_false = explicit_false or _falsey_structured_value(value)
+    if explicit_false:
+        return False
+    return None
+
+
+def _testimonial_text_permission_signal(text: str) -> bool:
+    lowered = text.lower()
+    if PROOF_PERMISSION_NEGATIVE_RE.search(lowered):
+        return False
+    return _contains_any(lowered, PROOF_PERMISSION_KEYWORDS)
 
 
 def _testimonial_structured_offer_refs(entry: TestimonialEntry) -> list[str]:
@@ -903,6 +938,7 @@ def _testimonial_signal_counts(
         "generic": 0,
         "specific": 0,
         "permissioned_public": 0,
+        "specific_permissioned_public": 0,
         "linked_to_offer": 0,
         "with_before_state": 0,
         "with_outcome": 0,
@@ -921,8 +957,11 @@ def _testimonial_signal_counts(
         has_metric = _proof_text_has_metric(lowered)
         has_mechanism = _contains_any(lowered, PROOF_MECHANISM_KEYWORDS)
         has_objection = _contains_any(lowered, PROOF_OBJECTION_KEYWORDS)
-        has_permission = _testimonial_structured_permission(entry) or _contains_any(
-            lowered, PROOF_PERMISSION_KEYWORDS
+        structured_permission = _testimonial_structured_permission_signal(entry)
+        has_permission = (
+            structured_permission
+            if structured_permission is not None
+            else _testimonial_text_permission_signal(entry_text)
         )
         explicit_offer_refs = _testimonial_structured_offer_refs(entry)
         explicit_offer_refs.extend(_testimonial_explicit_offer_refs(entry_text))
@@ -945,6 +984,7 @@ def _testimonial_signal_counts(
         counts["with_mechanism"] += int(has_mechanism)
         counts["with_objection"] += int(has_objection)
         counts["permissioned_public"] += int(has_permission)
+        counts["specific_permissioned_public"] += int(has_permission and any(signals))
         counts["linked_to_offer"] += int(has_offer_link)
         if any(signals):
             counts["specific"] += 1
@@ -960,6 +1000,7 @@ def _empty_proof_quality() -> dict[str, Any]:
             "generic": 0,
             "specific": 0,
             "permissioned_public": 0,
+            "specific_permissioned_public": 0,
             "linked_to_offer": 0,
             "with_before_state": 0,
             "with_outcome": 0,
@@ -979,6 +1020,61 @@ def _empty_proof_quality() -> dict[str, Any]:
             "linked_offers": [],
             "unsupported_offer_claims": [],
         },
+        "public_marketing": {
+            "ready": False,
+            "status": "missing",
+            "summary": "No testimonial proof is available for public marketing.",
+            "missing": ["testimonials"],
+            "next_action": "collect_testimonials",
+        },
+    }
+
+
+def _proof_public_marketing_readiness(quality: dict[str, Any]) -> dict[str, Any]:
+    testimonial_quality = quality.get("testimonials") or {}
+    total = int(testimonial_quality.get("total") or 0)
+    specific = int(testimonial_quality.get("specific") or 0)
+    permissioned = int(testimonial_quality.get("permissioned_public") or 0)
+    specific_permissioned = int(testimonial_quality.get("specific_permissioned_public") or 0)
+    if total == 0:
+        return {
+            "ready": False,
+            "status": "missing",
+            "summary": "No testimonial proof is available for public marketing.",
+            "missing": ["testimonials"],
+            "next_action": "collect_testimonials",
+        }
+    if specific > 0 and specific_permissioned == 0:
+        return {
+            "ready": False,
+            "status": "blocked",
+            "summary": (
+                "Specific proof exists for internal strategy, but no specific "
+                "testimonial is permissioned for public marketing."
+            ),
+            "missing": ["permissioned_public_testimonials"],
+            "next_action": "collect_public_permission",
+        }
+    if specific == 0:
+        missing = ["specific_testimonials"]
+        if permissioned == 0:
+            missing.append("permissioned_public_testimonials")
+        return {
+            "ready": False,
+            "status": "incomplete",
+            "summary": (
+                "Testimonials exist, but public marketing proof needs "
+                "specific permissioned evidence."
+            ),
+            "missing": missing,
+            "next_action": "strengthen_testimonials",
+        }
+    return {
+        "ready": True,
+        "status": "ready",
+        "summary": "At least one specific testimonial is permissioned for public marketing.",
+        "missing": [],
+        "next_action": None,
     }
 
 
@@ -1871,6 +1967,7 @@ def _proof_quality(
         )
         or any(playbook.get("linked_outcomes") for playbook in playbooks),
     }
+    quality["public_marketing"] = _proof_public_marketing_readiness(quality)
     return quality
 
 
@@ -2504,6 +2601,28 @@ def _money_path_ranked_actions(
             typicality_quality = quality.get("typicality") or {}
             claim_links = quality.get("claim_links") or {}
             instrumentation = quality.get("instrumentation") or {}
+            public_marketing = quality.get("public_marketing") or {}
+            if public_marketing.get("status") == "blocked":
+                actions.append(
+                    {
+                        "id": "collect-proof-permission",
+                        "title": "Collect proof permission",
+                        "reason": str(
+                            public_marketing.get("summary")
+                            or "Specific proof exists, but public marketing permission is missing."
+                        ),
+                        "route": "/mb-think",
+                        "source": "money_path.objects.proof.quality.public_marketing",
+                        "component": "proof",
+                        "confidence": "high",
+                        "effort_hint": "low",
+                        "missing": [
+                            str(item) for item in (public_marketing.get("missing") or [])[:5]
+                        ],
+                        "safe_to_share": True,
+                    }
+                )
+                continue
             proof_quality_gaps: list[str] = []
             if int(testimonial_quality.get("generic") or 0) > 0:
                 proof_quality_gaps.append("specific_testimonials")

--- a/mb/tests/fixtures/proof/specific-unpermissioned-testimonials.md
+++ b/mb/tests/fixtures/proof/specific-unpermissioned-testimonials.md
@@ -1,0 +1,17 @@
+---
+testimonials:
+  - permissioned_public: false
+    linked_offer: core/offer.md
+    before: Stuck rebuilding launch context every week
+    outcome: Booked 3 sales calls within 2 weeks
+    mechanism: Used the repo-backed setup sprint
+    objection: Worried the setup would take too much time
+  - permissioned_public: false
+    linked_offer: core/offer.md
+    before: Customer notes were scattered across tools
+    outcome: Saved 5 hours in 10 days
+    mechanism: Used daily checkpoints and proof files
+    objection: Unsure whether the new folder would stick
+---
+
+# Testimonials

--- a/mb/tests/test_init.py
+++ b/mb/tests/test_init.py
@@ -84,6 +84,8 @@ def _assert_claude_md_primitive_routing_contract(text: str) -> None:
     assert "`core/proof/`" in text
     assert "offer-specific proof belongs in `core/offers/<slug>/proof/`" in text
     assert "Use standard proof files such as `testimonials.md`" in text
+    assert "`permissioned_public: false`" in text
+    assert "`money_path.objects.proof.quality.public_marketing.status` is `blocked`" in text
     assert "`typicality.md`" in text
     assert "`angles/`" in text
     assert "Content strategy starts at `core/content-strategy.md`" in text
@@ -143,6 +145,7 @@ def _assert_agents_md_codex_start_contract(text: str) -> None:
     assert "`vocabulary` block from `mb status --json --peek`" in text
     assert "MoneyPath" in text
     assert "Use `money_path` when the next move depends on customer progress" in text
+    assert "`permissioned_public: false`" in text
     assert "current paths, frontmatter, JSON keys" in text
     assert "If `ranked_actions` has entries" in text
     assert "Do not pretend" in text

--- a/mb/tests/test_start_router_contract.py
+++ b/mb/tests/test_start_router_contract.py
@@ -8,6 +8,9 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 START_SKILL = REPO_ROOT / ".claude" / "skills" / "mb-start" / "SKILL.md"
 ROUTER_REF = REPO_ROOT / ".claude" / "skills" / "mb-start" / "references" / "router-and-language.md"
 UPDATE_REF = REPO_ROOT / ".claude" / "skills" / "mb-start" / "references" / "pull-engine-updates.md"
+ADS_SKILL = REPO_ROOT / ".claude" / "skills" / "mb-ads" / "SKILL.md"
+SITE_CONTEXT_REF = REPO_ROOT / ".claude" / "skills" / "mb-site" / "references" / "site-context.md"
+THINK_SKILL = REPO_ROOT / ".claude" / "skills" / "mb-think" / "SKILL.md"
 
 
 def _read(path: Path) -> str:
@@ -99,6 +102,8 @@ def test_start_router_routes_money_intent_from_moneypath_facts() -> None:
         "`money_path.overall_label`",
         "`money_path.objects.offer`",
         "`money_path.objects.proof`",
+        "`money_path.objects.proof.quality.public_marketing.status`",
+        "permission collection",
         "`money_path.objects.product_ladder`",
         "`money_path.objects.cta_path`",
         "`money_path.objects.channel_strategy`",
@@ -130,3 +135,16 @@ def test_start_router_no_longer_blindly_pulls_business_repo() -> None:
     combined = f"{start}\n{update}"
     assert 'git -C "$REPO_PATH" pull origin main' not in combined
     assert "blindly pull or rebase the business repo" in start
+
+
+def test_public_marketing_proof_permission_guidance_is_shared() -> None:
+    combined = "\n".join(
+        _read(path) for path in [START_SKILL, ROUTER_REF, ADS_SKILL, SITE_CONTEXT_REF, THINK_SKILL]
+    )
+
+    assert "quality.public_marketing.status" in combined
+    assert "permission collection" in combined
+    assert "ads, pages, or public claims" in combined
+    assert "do not draft proof-backed public ad claims" in combined
+    assert "do not use those\ntestimonials in public page copy" in combined
+    assert "`permissioned_public: false`" in combined

--- a/mb/tests/test_status.py
+++ b/mb/tests/test_status.py
@@ -763,6 +763,54 @@ def test_status_json_peek_handles_date_valued_testimonial_frontmatter(
     assert testimonials["permissioned_public"] == 1
 
 
+def test_status_money_path_specific_unpermissioned_proof_blocks_public_marketing(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+    _write_money_path_core(repo)
+    proof = repo / "core" / "proof"
+    proof.mkdir(parents=True, exist_ok=True)
+    (proof / "testimonials.md").write_text(
+        (FIXTURES / "proof" / "specific-unpermissioned-testimonials.md").read_text(
+            encoding="utf-8"
+        ),
+        encoding="utf-8",
+    )
+    (proof / "typicality.md").write_text(
+        (
+            "# Typicality\n\n"
+            "Average case: most users need one setup week. Caveat: outcomes vary. "
+            "Common failure context: no clear offer. Time to outcome is usually 2 weeks.\n"
+        ),
+        encoding="utf-8",
+    )
+
+    report = status_mod.run(path=str(repo), update_marker=False)
+
+    proof_object = report["money_path"]["objects"]["proof"]
+    quality = proof_object["quality"]
+    testimonials = quality["testimonials"]
+    assert testimonials["specific"] == 2
+    assert testimonials["permissioned_public"] == 0
+    assert testimonials["specific_permissioned_public"] == 0
+    assert quality["public_marketing"] == {
+        "ready": False,
+        "status": "blocked",
+        "summary": (
+            "Specific proof exists for internal strategy, but no specific "
+            "testimonial is permissioned for public marketing."
+        ),
+        "missing": ["permissioned_public_testimonials"],
+        "next_action": "collect_public_permission",
+    }
+    assert report["money_path"]["ranked_actions"][0]["id"] == "collect-proof-permission"
+    assert report["money_path"]["ranked_actions"][0]["source"] == (
+        "money_path.objects.proof.quality.public_marketing"
+    )
+
+
 def test_status_money_path_proof_cannot_reach_field_tested_without_level_three(
     tmp_path: Path, monkeypatch
 ) -> None:


### PR DESCRIPTION
## Summary

Adds a public-marketing proof readiness signal to MoneyPath so specific internal testimonials without public permission block proof-backed public campaign guidance. Updates start, ads, site, think, and generated repo guidance to route those cases to permission collection first.

## Linked issue

Closes #629
Refs #622

## Why

Specific proof can be strategically useful while still unusable for ads, pages, or other public claims. Without a deterministic readiness fact, runtime guidance can treat unpermissioned proof as campaign-ready and create trust risk.

## Commits by concern

- `857779b [fix] MAIN-392 block unpermissioned public proof`
  - Adds `quality.public_marketing` and `collect-proof-permission`.
  - Adds synthetic fixture coverage for `permissioned_public: false`.
  - Updates runtime/generated guidance and public docs.

- [x] Each commit body bullet-lists the changes in that commit
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`

## Validation

Level 1 static: `scripts/check.sh` - runtime: Python 3.13 - exit: 0 - log: formatting, ruff, mypy, 729 pytest items, coverage gate, and `mb skill validate --all --json` passed after rebasing on `origin/main`.

Level 2 CLI contract: focused status, router, and init tests - runtime: Python 3.13 - exit: 0 - log: `test_status_money_path_specific_unpermissioned_proof_blocks_public_marketing`, shared public-marketing guidance, and generated guidance assertions passed.

Level 3 package/install smoke: `(cd mb && python3 -m build)`, install wheel into a fresh temp venv, `mb --version`, and `mb skill list` - runtime: fresh temp venv Python - exit: 0 - log: built and installed `mainbranch-0.3.25`; `mb 0.3.25`; bundled skills listed.

Level 4 fixture repo: `mb onboard --yes` fixture plus synthetic unpermissioned proof and `mb status --json --peek` - runtime: local checkout via `PYTHONPATH` - exit: 0 - log: `public_marketing.status: blocked`; `collect-proof-permission` present in `money_path.ranked_actions`.

Level 5 runtime smoke: `scripts/claude-runtime-dogfood.py --install-mode editable --run-claude-print --simulation-tier pr_smoke --max-budget-usd 1.00 --evidence-dir .agent/main392-dogfood-evidence --cleanup` - runtime: temp editable venv plus Claude Code 2.1.140 - exit: 0 - log: no permission denials, clean fixture/engine boundaries, print proxy manual review required.

- [x] Level 1 static: `scripts/check.sh` passes
- [x] Level 2 CLI contract: focused Typer/CliRunner tests, exit codes, `--json` behavior, TTY vs non-TTY (if CLI behavior touched)
- [x] Level 3 package/install smoke (if packaging touched)
- [x] Level 4 fixture repo (if init/onboard/status/start/update touched)
- [x] Level 5 runtime smoke / dogfood harness / simulation-tier (if runtime, first-run, skill discovery, or release validation touched)
- [x] SKILL.md <=500 lines (if any skill touched)
- [ ] Package-visible release gate evidence before tag/publish (if preparing a release) - N/A, not preparing a tag or publish.
- [ ] Supply-chain review (if `.github/workflows/`, `.github/dependabot.yml`, `mb/pyproject.toml` deps, or `id-token`/`permissions` blocks touched) - N/A, no supply-chain files touched.

## Success metric

When testimonials are specific but all public-permission fields are false, `mb status --json --peek` reports `money_path.objects.proof.quality.public_marketing.status: blocked` and skills route public proof-backed work to permission collection first.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [ ] N/A - change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [x] No
- [ ] Yes - migration note below

## Public / private boundary

Committed fixture and documentation use synthetic, generic proof only. No raw customer proof, names, quotes, private paths, account data, or private strategy from #622/#634 are included.
