### PR TITLE
[fix] Guard checkpoint scratch files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   of stranding the operator at manual cleanup. The push path now records
   GitHub CLI auth/account preflight facts before creating the repo. Refs
   MAIN-389, #626.
+- Added a checkpoint review gate for suspicious scratch files, prompt drafts,
+  conflict/editor leftovers, and empty accidental notes so `mb checkpoint` does
+  not save them without explicit operator approval. Refs MAIN-390, #627.
 
 ## [0.3.25] - 2026-05-16
 

--- a/mb/mb/checkpoint.py
+++ b/mb/mb/checkpoint.py
@@ -28,6 +28,11 @@ SURFACE_ORDER = [
     "unknown",
 ]
 
+REVIEW_REQUIRED_GUIDANCE = (
+    "Remove it from the business folder, move it to local scratch space, or rerun "
+    "with --include-review-required if it intentionally belongs in this checkpoint."
+)
+
 SECRET_RE = re.compile(
     r"(?i)("
     r"(api[_-]?key|access[_-]?token|secret|client[_-]?secret)\s*[:=]\s*['\"]?[A-Za-z0-9_./+=-]{8,}"
@@ -428,7 +433,7 @@ def _surface(path: str) -> str:
         return "site"
     if path.startswith((".github/", ".claude/", ".mainbranch/", ".mb/")):
         return "config"
-    if path in {"CLAUDE.md", ".gitignore", "README.md"}:
+    if path in {"AGENTS.md", "CLAUDE.md", ".gitignore", "README.md"}:
         return "config"
     return "unknown"
 
@@ -463,6 +468,100 @@ def _service_account_json(path: str, text: str) -> bool:
         return False
     lowered = text.lower()
     return '"type"' in lowered and "service_account" in lowered and "private_key" in lowered
+
+
+def _review_required(repo: Path, changes: list[dict[str, Any]]) -> list[dict[str, str]]:
+    review: list[dict[str, str]] = []
+    for change in changes:
+        path = str(change["path"])
+        name = Path(path).name
+        lowered_name = name.lower()
+        abs_path = repo / path
+        surface = str(change.get("surface", "unknown"))
+
+        if re.match(r"^untitled(?:[\s._-]*\d*)?(?:\.[^.]+)?$", lowered_name):
+            review.append(
+                {
+                    "code": "generic_untitled_file",
+                    "path": path,
+                    "message": (
+                        "generic Untitled files look like accidental editor scratch, "
+                        "not durable business memory"
+                    ),
+                    "guidance": REVIEW_REQUIRED_GUIDANCE,
+                }
+            )
+            continue
+
+        scratch_suffixes = (
+            ".bak",
+            ".orig",
+            ".rej",
+            ".swp",
+            ".swo",
+            ".tmp",
+        )
+        scratch_markers = (
+            "conflicted copy",
+            "merge conflict",
+            "merge-conflict",
+            ".backup.",
+            ".base.",
+            ".local.",
+            ".remote.",
+        )
+        if (
+            lowered_name.endswith("~")
+            or lowered_name.endswith(scratch_suffixes)
+            or any(marker in lowered_name for marker in scratch_markers)
+        ):
+            review.append(
+                {
+                    "code": "editor_or_conflict_scratch",
+                    "path": path,
+                    "message": "file looks like editor, backup, or conflict scratch",
+                    "guidance": REVIEW_REQUIRED_GUIDANCE,
+                }
+            )
+            continue
+
+        if (
+            name != ".gitkeep"
+            and not change.get("deleted")
+            and abs_path.is_file()
+            and abs_path.stat().st_size == 0
+        ):
+            review.append(
+                {
+                    "code": "zero_byte_file",
+                    "path": path,
+                    "message": "empty files are often accidental notes or setup leftovers",
+                    "guidance": REVIEW_REQUIRED_GUIDANCE,
+                }
+            )
+            continue
+
+        if "prompt" in lowered_name and surface in {"unknown", "config"}:
+            review.append(
+                {
+                    "code": "prompt_draft",
+                    "path": path,
+                    "message": "prompt drafts should be reviewed before becoming business memory",
+                    "guidance": REVIEW_REQUIRED_GUIDANCE,
+                }
+            )
+            continue
+
+        if change.get("untracked") and surface == "unknown":
+            review.append(
+                {
+                    "code": "unexpected_repo_file",
+                    "path": path,
+                    "message": "file is outside the expected business folders for a checkpoint",
+                    "guidance": REVIEW_REQUIRED_GUIDANCE,
+                }
+            )
+    return review
 
 
 def _safety_blocks(repo: Path, changes: list[dict[str, Any]]) -> list[dict[str, str]]:
@@ -865,6 +964,7 @@ def plan(repo: str | Path = ".", *, mode: str = "beginner") -> dict[str, Any]:
         for record in records
     ]
     blocks = _safety_blocks(root, changes)
+    review_required = _review_required(root, changes)
     warnings: list[dict[str, str]] = []
     if not looks_like_business_repo(root) and not _is_engine_repo(root):
         warnings.append(
@@ -877,11 +977,16 @@ def plan(repo: str | Path = ".", *, mode: str = "beginner") -> dict[str, Any]:
 
     status = "clean"
     if changes:
-        status = "blocked" if blocks else "ready"
+        if blocks:
+            status = "blocked"
+        elif review_required:
+            status = "review_required"
+        else:
+            status = "ready"
     proposal = _proposal(changes, blocks)
     counts = _surface_counts(changes)
     return {
-        "ok": not blocks,
+        "ok": not blocks and not review_required,
         "status": status,
         "repo": str(root),
         "mode": mode,
@@ -895,8 +1000,9 @@ def plan(repo: str | Path = ".", *, mode: str = "beginner") -> dict[str, Any]:
         },
         "changes": changes,
         "safety": {
-            "ok": not blocks,
+            "ok": not blocks and not review_required,
             "blocks": blocks,
+            "review_required": review_required,
             "warnings": warnings,
         },
         "proposal": proposal,
@@ -910,6 +1016,7 @@ def commit(
     message: str = "",
     mode: str = "beginner",
     yes: bool = False,
+    include_review_required: bool = False,
 ) -> dict[str, Any]:
     """Commit an approved checkpoint plan."""
     planned = plan(repo=repo, mode=mode)
@@ -922,7 +1029,10 @@ def commit(
             "plan": planned,
             "errors": [],
         }
-    if not planned.get("ok"):
+    safety = planned.get("safety", {})
+    blocks = safety.get("blocks", []) if isinstance(safety, dict) else []
+    review_required = safety.get("review_required", []) if isinstance(safety, dict) else []
+    if blocks:
         return {
             "ok": False,
             "status": "blocked",
@@ -930,6 +1040,20 @@ def commit(
             "committed": False,
             "plan": planned,
             "errors": ["checkpoint plan is blocked"],
+        }
+    if review_required and not include_review_required:
+        return {
+            "ok": False,
+            "status": "review_required",
+            "repo": planned.get("repo"),
+            "committed": False,
+            "plan": planned,
+            "errors": [
+                (
+                    "checkpoint includes files that need review; remove them or pass "
+                    "--include-review-required after confirming they belong in business memory"
+                )
+            ],
         }
     if not yes:
         return {
@@ -1079,6 +1203,26 @@ def render_human(result: dict[str, Any]) -> None:
         print("approval required.")
         print("review the plan, then rerun with --yes to save the checkpoint.")
         return
+    if status == "review_required":
+        print("checkpoint needs review before saving.")
+        plan_result = result.get("plan")
+        safety_source = plan_result if isinstance(plan_result, dict) else result
+        safety = safety_source.get("safety", {}) if isinstance(safety_source, dict) else {}
+        review = safety.get("review_required", []) if isinstance(safety, dict) else []
+        if review:
+            print(
+                "These files look like scratch, setup junk, or prompt drafts, "
+                "not durable business memory:"
+            )
+            for item in review:
+                print(f"  - {item['path']}: {item['message']}")
+            print(
+                "Remove them, or rerun with --include-review-required "
+                "if they intentionally belong here."
+            )
+        for error in result.get("errors", []):
+            print(f"error: {error}")
+        return
     if status == "clean":
         print("nothing to checkpoint.")
         return
@@ -1109,6 +1253,17 @@ def render_human(result: dict[str, Any]) -> None:
         print("checkpoint blocked:")
         for block in blocks:
             print(f"  - {block['path']}: {block['message']}")
+        return
+    review = safety.get("review_required", []) if isinstance(safety, dict) else []
+    if review:
+        print("")
+        print("checkpoint needs review before saving:")
+        for item in review:
+            print(f"  - {item['path']}: {item['message']}")
+        print(
+            "Remove them, or rerun with --include-review-required "
+            "if they intentionally belong here."
+        )
         return
 
     proposal = result.get("proposal")

--- a/mb/mb/checkpoint.py
+++ b/mb/mb/checkpoint.py
@@ -478,6 +478,8 @@ def _review_required(repo: Path, changes: list[dict[str, Any]]) -> list[dict[str
         lowered_name = name.lower()
         abs_path = repo / path
         surface = str(change.get("surface", "unknown"))
+        if change.get("deleted"):
+            continue
 
         if re.match(r"^untitled(?:[\s._-]*\d*)?(?:\.[^.]+)?$", lowered_name):
             review.append(
@@ -525,12 +527,7 @@ def _review_required(repo: Path, changes: list[dict[str, Any]]) -> list[dict[str
             )
             continue
 
-        if (
-            name != ".gitkeep"
-            and not change.get("deleted")
-            and abs_path.is_file()
-            and abs_path.stat().st_size == 0
-        ):
+        if name != ".gitkeep" and abs_path.is_file() and abs_path.stat().st_size == 0:
             review.append(
                 {
                     "code": "zero_byte_file",

--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -1642,6 +1642,11 @@ def checkpoint_cmd(
         help="Remove the Main Branch checkpoint commit-message hook.",
     ),
     yes: bool = typer.Option(False, "--yes", help="Save the checkpoint after safety gates pass."),
+    include_review_required: bool = typer.Option(
+        False,
+        "--include-review-required",
+        help="Intentionally include files that checkpoint planning marked for review.",
+    ),
     mode: str = typer.Option(
         "beginner",
         "--mode",
@@ -1666,8 +1671,14 @@ def checkpoint_cmd(
     elif validate:
         validation_message = sys.stdin.read() if validate == "-" else validate
         result = checkpoint_mod.validate_message(validation_message)
-    elif yes or message:
-        result = checkpoint_mod.commit(repo=repo, message=message, mode=mode, yes=yes)
+    elif yes or message or include_review_required:
+        result = checkpoint_mod.commit(
+            repo=repo,
+            message=message,
+            mode=mode,
+            yes=yes,
+            include_review_required=include_review_required,
+        )
     elif status_check:
         result = checkpoint_mod.status(repo=repo, mode=mode)
     else:

--- a/mb/tests/test_checkpoint.py
+++ b/mb/tests/test_checkpoint.py
@@ -657,6 +657,48 @@ def test_checkpoint_commit_requires_explicit_scratch_file_override(
     assert "Untitled.md" in _git(repo, "status", "--porcelain").stdout
 
 
+def test_checkpoint_commit_allows_scratch_file_deletion_without_override(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    repo = _business_repo(tmp_path, monkeypatch)
+    _commit_file(
+        repo,
+        "Untitled.md",
+        "# Accidental Scratch\n",
+        "[added] scratch review",
+    )
+    (repo / "Untitled.md").unlink()
+
+    plan = runner.invoke(app, ["checkpoint", "--repo", str(repo), "--plan", "--json"])
+
+    assert plan.exit_code == 0
+    plan_payload = json.loads(plan.stdout)
+    assert plan_payload["status"] == "ready"
+    assert plan_payload["safety"]["review_required"] == []
+    assert plan_payload["changes"][0]["deleted"] is True
+
+    result = runner.invoke(
+        app,
+        [
+            "checkpoint",
+            "--repo",
+            str(repo),
+            "--message",
+            "[fixed] scratch cleanup",
+            "--yes",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "committed"
+    assert payload["committed"] is True
+    assert "Untitled.md" in payload["commit"]["body"]
+    assert _git(repo, "status", "--porcelain").stdout == ""
+    assert not (repo / "Untitled.md").exists()
+
+
 def test_checkpoint_commit_allows_explicit_scratch_file_override(
     tmp_path: Path, monkeypatch: Any
 ) -> None:

--- a/mb/tests/test_checkpoint.py
+++ b/mb/tests/test_checkpoint.py
@@ -166,6 +166,48 @@ def test_checkpoint_cli_json_contract(tmp_path: Path, monkeypatch: Any) -> None:
     )
 
 
+def test_checkpoint_plan_flags_scratch_files_for_review(tmp_path: Path, monkeypatch: Any) -> None:
+    repo = _business_repo(tmp_path, monkeypatch)
+    (repo / "core" / "offer.md").write_text("# Offer\nUpdated\n", encoding="utf-8")
+    (repo / "Untitled.md").write_text("# Scratch\n", encoding="utf-8")
+    (repo / "setup-prompt.txt").write_text("Do not save this prompt.\n", encoding="utf-8")
+    (repo / "scratch-notes.md").write_text("", encoding="utf-8")
+
+    result = runner.invoke(app, ["checkpoint", "--repo", str(repo), "--plan", "--json"])
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False
+    assert payload["status"] == "review_required"
+    review_required = payload["safety"]["review_required"]
+    assert {item["code"] for item in review_required} == {
+        "generic_untitled_file",
+        "prompt_draft",
+        "zero_byte_file",
+    }
+    assert {item["path"] for item in review_required} == {
+        "Untitled.md",
+        "setup-prompt.txt",
+        "scratch-notes.md",
+    }
+
+
+def test_checkpoint_plan_explains_scratch_review_in_business_language(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    repo = _business_repo(tmp_path, monkeypatch)
+    (repo / "core" / "offer.md").write_text("# Offer\nUpdated\n", encoding="utf-8")
+    (repo / "Untitled.md").write_text("# Scratch\n", encoding="utf-8")
+
+    result = runner.invoke(app, ["checkpoint", "--repo", str(repo), "--plan"])
+
+    assert result.exit_code == 1
+    assert "checkpoint needs review before saving" in result.output
+    assert "not durable business memory" in result.output
+    assert "Untitled.md" in result.output
+    assert "--include-review-required" in result.output
+
+
 def test_checkpoint_plan_names_core_and_research_artifacts(
     tmp_path: Path, monkeypatch: Any
 ) -> None:
@@ -584,6 +626,65 @@ def test_checkpoint_commit_refuses_blocked_plan_without_commit(
     assert payload["status"] == "blocked"
     assert payload["committed"] is False
     assert _git(repo, "log", "--oneline").stdout.count("\n") == 1
+
+
+def test_checkpoint_commit_requires_explicit_scratch_file_override(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    repo = _business_repo(tmp_path, monkeypatch)
+    (repo / "core" / "offer.md").write_text("# Offer\nUpdated\n", encoding="utf-8")
+    (repo / "Untitled.md").write_text("# Scratch\n", encoding="utf-8")
+
+    result = runner.invoke(
+        app,
+        [
+            "checkpoint",
+            "--repo",
+            str(repo),
+            "--message",
+            "[updated] offer and scratch review",
+            "--yes",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "review_required"
+    assert payload["committed"] is False
+    assert payload["plan"]["safety"]["review_required"][0]["path"] == "Untitled.md"
+    assert _git(repo, "log", "--oneline").stdout.count("\n") == 1
+    assert "Untitled.md" in _git(repo, "status", "--porcelain").stdout
+
+
+def test_checkpoint_commit_allows_explicit_scratch_file_override(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    repo = _business_repo(tmp_path, monkeypatch)
+    (repo / "core" / "offer.md").write_text("# Offer\nUpdated\n", encoding="utf-8")
+    (repo / "Untitled.md").write_text("# Intentional Scratch\n", encoding="utf-8")
+
+    result = runner.invoke(
+        app,
+        [
+            "checkpoint",
+            "--repo",
+            str(repo),
+            "--message",
+            "[updated] offer and scratch review",
+            "--yes",
+            "--include-review-required",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "committed"
+    assert payload["committed"] is True
+    log = _git(repo, "log", "-1", "--pretty=%B").stdout
+    assert "Untitled.md" in log
+    assert _git(repo, "status", "--porcelain").stdout == ""
 
 
 def test_checkpoint_commit_clean_repo_is_noop(tmp_path: Path, monkeypatch: Any) -> None:


### PR DESCRIPTION
## Summary

Adds a checkpoint review gate so suspicious scratch files, prompt drafts, editor leftovers, and empty accidental notes do not enter business history by default. The save path now requires explicit `--include-review-required` approval for those files while still allowing cleanup deletions to checkpoint normally.

## Linked issue

Closes #627
Refs #622

## Why

First-run business history should read like trusted operating memory, not include accidental editor artifacts followed by cleanup commits. This keeps `mb checkpoint` beginner-safe by making the suspicious files visible before save, explaining the risk in business language, and preserving an intentional override path.

## Commits by concern

- [ ] Each commit body bullet-lists the changes in that commit
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`

Commits:
- `b358f86 [fix] MAIN-390 guard checkpoint scratch files`
- `de95dbd [fix] MAIN-390 allow scratch cleanup checkpoints`

## Validation

Pre-push gate from repo root:

```bash
scripts/check.sh
```

- [x] Level 1 static: `scripts/check.sh` passes
- [x] Level 2 CLI contract: focused Typer/CliRunner tests, exit codes, `--json` behavior, TTY vs non-TTY (if CLI behavior touched)
- [ ] Level 3 package/install smoke (if packaging touched)
- [ ] Level 4 fixture repo (if init/onboard/status/start/update touched)
- [ ] Level 5 runtime smoke / dogfood harness / simulation-tier (if runtime, first-run, skill discovery, or release validation touched)
- [ ] SKILL.md ≤500 lines (if any skill touched)
- [ ] Package-visible release gate evidence before tag/publish (if preparing a release)
- [ ] Supply-chain review (if `.github/workflows/`, `.github/dependabot.yml`, `mb/pyproject.toml` deps, or `id-token`/`permissions` blocks touched — see [docs/supply-chain-policy.md](../docs/supply-chain-policy.md))

Level 1 static: `scripts/check.sh` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: excerpt `ruff format --check`, `ruff check`, `mypy`, `719 passed`, skill validation ok.
Level 2 CLI contract: `cd mb && pytest tests/test_checkpoint.py -q` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: excerpt `37 passed`.
Level 2 JSON/start regression: `cd mb && pytest tests/test_json_result.py -q` and `cd mb && pytest tests/test_start.py::test_start_json_prints_ready_handoff tests/test_checkpoint.py -q` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: excerpts `11 passed` and `37 passed` before the follow-up deletion fix; final `scripts/check.sh` covered the deletion regression with 719 tests.
Level 3 package/install: not required; packaging, entrypoints, bundled data, and install/update behavior were not touched.
Level 4 fixture repo: not required beyond CLI fixture tests; init/onboard/status/start/update behavior was not changed, and the scaffold-start regression is covered by the focused start test plus full gate.
Level 5 runtime smoke: not required; generated runtime guidance, skill discovery, and runtime invocation were not changed.
SKILL.md line gate: covered by `scripts/check.sh`; no skill files changed.
Supply-chain review: not required; no workflow, dependency, permissions, or publish configuration changed.

## Success metric

`mb checkpoint --plan --json` reports suspicious new scratch files as `review_required`, `mb checkpoint --yes` refuses to save them without `--include-review-required`, and deleting an already-tracked scratch file checkpoints normally without the override.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [ ] N/A — change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [x] No
- [ ] Yes — migration note below

## Public / private boundary

Only generic, sanitized scratch-file patterns are included in code, tests, changelog, and PR text. No customer transcript, business details, local private paths, credentials, or private operating strategy are committed.
