### PR TITLE
[update] First-run setup contract

### DIFF
--- a/.claude/skills/mb-setup/SKILL.md
+++ b/.claude/skills/mb-setup/SKILL.md
@@ -12,10 +12,11 @@ reference prose.
 
 **CLI facts first:** Run `mb doctor`, `mb start --json`, and
 `mb status --json --peek` when a repo exists or can be identified. Use
-`mb onboard status --json` and `mb onboard plan` as the durable progress
-contract; do not keep onboarding state only in chat prose. If there is no repo
-yet, use `mb onboard plan` / `mb onboard` to create one instead of hand-rolling
-repo-shape checks.
+`mb onboard status --json` as the read-only progress check for existing repos.
+Use `mb onboard plan` only after the operator approves writing setup progress;
+do not keep onboarding state only in chat prose. If there is no repo yet,
+inspect `mb onboard --help`, explain the target folder, ask for approval, then
+use `mb onboard` to create one instead of hand-rolling repo-shape checks.
 
 For provider setup, use `mb connect plan` and `mb connect doctor --json` as the
 durable readiness contract. Explain providers as business capabilities, not
@@ -25,14 +26,15 @@ developer config, and end with exact commands.
 beginner setup guide, or a bootstrap prompt with business/folder intent, treat
 it as setup intent, not as a document to save. Do not offer to save it as a
 document. Check `mb --version`; if missing, stop with `pipx install
-mainbranch`. If present, inspect `mb onboard --help` or `mb onboard plan`,
-explain the target folder, and ask before any write.
+mainbranch`. If present, inspect `mb onboard --help`, explain the target
+folder, and ask before any write.
 
 **GitHub-backed setup preflight.** GitHub is strongly recommended because it
 gives Main Branch a free cloud backup, shared history, task/proposal layer, and
 connector-friendly copy of the business brain. Main Branch can start locally
 without GitHub. If the user wants backup, sync, collaboration, or `mb onboard
---github --push`, check `gh auth status` and `gh api user --jq .login` first.
+--github <owner/repo> --push`, check `gh auth status` and
+`gh api user --jq .login` first.
 Confirm the account is the one they expect before running a writing setup
 command.
 
@@ -95,7 +97,7 @@ pwd
 
 If no business repo exists yet:
 ```bash
-mb onboard plan --team-size solo --success-stage working
+mb onboard --help
 ```
 
 If the operator wants the folder created, saved, synced to GitHub, and ready
@@ -187,7 +189,7 @@ mb onboard status --repo "$REPO_PATH" --json
 ```
 
 If business type, team size, success stage, or desired outcome are missing, ask
-briefly and save them:
+briefly. After the operator approves saving setup progress, write the plan:
 
 ```bash
 mb onboard plan --repo "$REPO_PATH" --team-size solo --success-stage working

--- a/.claude/skills/mb-setup/SKILL.md
+++ b/.claude/skills/mb-setup/SKILL.md
@@ -21,6 +21,21 @@ For provider setup, use `mb connect plan` and `mb connect doctor --json` as the
 durable readiness contract. Explain providers as business capabilities, not
 developer config, and end with exact commands.
 
+**Pasted setup guide = setup intent.** If the user pastes this guide, the
+beginner setup guide, or a bootstrap prompt with business/folder intent, treat
+it as setup intent, not as a document to save. Do not offer to save it as a
+document. Check `mb --version`; if missing, stop with `pipx install
+mainbranch`. If present, inspect `mb onboard --help` or `mb onboard plan`,
+explain the target folder, and ask before any write.
+
+**GitHub-backed setup preflight.** GitHub is strongly recommended because it
+gives Main Branch a free cloud backup, shared history, task/proposal layer, and
+connector-friendly copy of the business brain. Main Branch can start locally
+without GitHub. If the user wants backup, sync, collaboration, or `mb onboard
+--github --push`, check `gh auth status` and `gh api user --jq .login` first.
+Confirm the account is the one they expect before running a writing setup
+command.
+
 ---
 
 ## Before We Begin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   `AGENTS.md`, covering start, status, and thinking/codification routes while
   keeping `.agents/skills`, plugin packaging, site/ads/provider workflows, and
   slash-command parity out of scope. Refs MAIN-387, #624.
+- Added a folder-first first-run setup contract across beginner docs, README,
+  generated runtime guidance, and `/mb-setup`: pasted setup guides now route to
+  deterministic `mb onboard` setup intent instead of document creation, with
+  plain-language save/checkpoint/update/runtime boundaries and strongly
+  recommended GitHub backup, sync, connector, and account-check guidance. Refs
+  MAIN-388, #625; MAIN-395, #632; MAIN-394, #631.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ Mobile thought capture, team views, finance/fulfillment roll-ups, broader Ops/bo
 
 ## Quickstart
 
+Start with the folder that should become your business brain:
+
 ```bash
 pipx install mainbranch
 mb onboard --name "My Business" --path my-business
@@ -164,6 +166,22 @@ claude
 ```
 
 That's it. `mb onboard` creates the folder, wires Claude Code, and shows the next step. `/mb-start` reads the folder and tells you what to do.
+
+If you open Claude Code or Codex CLI in an empty folder first, paste the
+folder-first bootstrap from [beginner setup](docs/beginner-setup.md#folder-first-bootstrap).
+It tells the agent this is setup intent, not a document to save, and routes it
+to deterministic `mb onboard` checks before anything writes.
+
+GitHub backup/sync is strongly recommended for almost everyone. It does not
+need to cost anything, and it gives the business brain cloud backup, readable
+saved history, shared tasks/proposals, and a repo that AI tools with GitHub
+connectors can read. Before choosing the GitHub-backed setup path, install
+GitHub CLI and confirm it is signed in to the account you expect:
+
+```bash
+gh auth status
+gh api user --jq .login
+```
 
 After the first session, the daily flow is:
 

--- a/docs/beginner-setup.md
+++ b/docs/beginner-setup.md
@@ -37,7 +37,7 @@ readiness checks, and Claude Code skills.
   use Anthropic's current Claude Code plan details as the source of truth.
 - **GitHub CLI (`gh`)** — strongly recommended for almost everyone, and
   required when you want GitHub backup, sync, collaboration, or
-  `mb onboard --github --push`.
+  `mb onboard --github <owner/repo> --push`.
 
 GitHub does not need to cost anything, and it is the highest-leverage
 connection after your local folder. It gives you cloud backup, readable saved
@@ -80,7 +80,7 @@ authenticated, and signed in to the account I expect. GitHub is strongly
 recommended because it gives Main Branch a free cloud backup, shared history,
 task/proposal layer, and connector-friendly copy of the business brain. Main
 Branch can start locally without GitHub, but GitHub is needed for sync,
-collaboration, and `mb onboard --github --push`.
+collaboration, and `mb onboard --github <owner/repo> --push`.
 
 After setup, run the read-only health/status checks, summarize what was created
 in business language, and tell me the next safest action.

--- a/docs/beginner-setup.md
+++ b/docs/beginner-setup.md
@@ -28,10 +28,66 @@ readiness checks, and Claude Code skills.
 
 ---
 
-## Required Accounts
+## What You Need
 
-- **GitHub** — where the code lives. Free signup at [github.com/signup](https://github.com/signup).
-- **Anthropic Pro or Max** — your Claude subscription. Required for Claude Code. Sign up at [claude.ai](https://claude.ai). Pro is $20/month.
+- **A folder on your computer** — this becomes the business brain.
+- **Main Branch (`mb`)** — creates and checks that folder.
+- **Claude Code** — the first supported chat runtime for Main Branch skills.
+- **A Claude plan that includes Claude Code** — pricing and limits can change;
+  use Anthropic's current Claude Code plan details as the source of truth.
+- **GitHub CLI (`gh`)** — strongly recommended for almost everyone, and
+  required when you want GitHub backup, sync, collaboration, or
+  `mb onboard --github --push`.
+
+GitHub does not need to cost anything, and it is the highest-leverage
+connection after your local folder. It gives you cloud backup, readable saved
+history, shared tasks and proposals, and a repo that other AI tools with GitHub
+connectors can read as your business brain. Main Branch can start locally
+before GitHub is ready, but most users should connect it during first setup.
+
+Before using GitHub-backed setup, install GitHub CLI and confirm it is signed in
+to the account you expect:
+
+```bash
+gh auth status
+gh api user --jq .login
+```
+
+If that account is wrong, stop before creating the GitHub-backed setup and run
+`gh auth login` or `gh auth switch`.
+
+## Folder-First Bootstrap
+
+If you are starting from an empty folder with Claude Code, Codex CLI, or another
+agent-like runtime, open that runtime in the folder where the business brain
+should live and paste this prompt:
+
+```text
+I want to set up Main Branch for this business in the current folder.
+
+Treat this as setup intent, not as a document to save.
+
+First, check whether `mb` is available. If it is not installed, stop and tell me
+the exact install step. If it is installed, inspect the available setup/onboard
+command before running it.
+
+Use this folder as the business repo location unless I say otherwise. Before any
+write, explain the folder or repo that will be created or modified and ask for
+approval.
+
+If I ask for GitHub backup or sync, first check whether GitHub CLI is installed,
+authenticated, and signed in to the account I expect. GitHub is strongly
+recommended because it gives Main Branch a free cloud backup, shared history,
+task/proposal layer, and connector-friendly copy of the business brain. Main
+Branch can start locally without GitHub, but GitHub is needed for sync,
+collaboration, and `mb onboard --github --push`.
+
+After setup, run the read-only health/status checks, summarize what was created
+in business language, and tell me the next safest action.
+```
+
+Do not save that prompt as a markdown document. It is the instruction that tells
+the agent to start setup.
 
 ---
 
@@ -49,11 +105,19 @@ pipx ensurepath
 
 # 3. Install Main Branch
 pipx install mainbranch
+
+# 4. Strongly recommended, for GitHub backup/sync/collaboration
+brew install gh
+gh auth login
 ```
 
 ### Linux
 
-Same flow as macOS — use `apt install pipx` (Debian/Ubuntu) or `dnf install pipx` (Fedora) instead of `brew install pipx`. Then `pipx ensurepath && pipx install mainbranch`.
+Same flow as macOS — use `apt install pipx` (Debian/Ubuntu) or `dnf install
+pipx` (Fedora) instead of `brew install pipx`. Then `pipx ensurepath && pipx
+install mainbranch`. For GitHub backup/sync/collaboration, install GitHub CLI
+from [cli.github.com](https://cli.github.com/) and run
+`gh auth login`.
 
 ### Windows
 
@@ -72,6 +136,10 @@ python -m pipx ensurepath
 
 # 4. Install Main Branch
 pipx install mainbranch
+
+# 5. Strongly recommended, for GitHub backup/sync/collaboration
+# Download GitHub CLI from: https://cli.github.com/
+gh auth login
 ```
 
 After install, verify:
@@ -85,11 +153,18 @@ claude doctor   # should report Claude Code is healthy
 
 ## Step 2: Create Your Business Repo
 
-Pick a name and a folder. Then:
+Pick a name and a folder. Local-only setup:
 
 ```bash
 cd ~/Documents/GitHub          # or wherever you keep code
 mb onboard --name "My Business" --path my-business
+cd my-business
+```
+
+GitHub-backed setup, after `gh auth status` shows the expected account:
+
+```bash
+mb onboard --name "My Business" --path my-business --github your-gh-username/my-business --github-visibility private --push
 cd my-business
 ```
 
@@ -103,6 +178,21 @@ You may also see a `.mb/` folder. That is normal. It stores Main Branch's local
 operational state for that business repo, such as onboarding progress, safe
 provider metadata, backups, and issue drafts. You do not need a `.mb-vip/`
 folder; that name comes from the old clone-based setup.
+
+### What Gets Saved
+
+- Saving a file writes it on your computer.
+- A checkpoint is an approved saved point in the business history.
+- GitHub backup/sync means the approved history is also available from GitHub,
+  where AI tools with GitHub connectors can read the business brain.
+- Main Branch updates change the engine and skills; they do not rewrite your
+  business files without an approved repair, migration, or edit.
+
+Use one business repo when brand, team, voice, access, and operating history are
+shared. Create a separate business repo for a separate entity or independent
+operating history. Use linked child repos for sites, products, finance/legal,
+client work, or private ops when access or lifecycle differs. The full model
+lives in [system architecture](system-architecture.md#repo-topology).
 
 ---
 

--- a/docs/reports/2026-05-16-first-customer-setup-excavation.md
+++ b/docs/reports/2026-05-16-first-customer-setup-excavation.md
@@ -115,7 +115,7 @@ P0 and P1 findings now have concrete public issues:
 | Issue | Owner Loop | Validation Need |
 |---|---|---|
 | [#625](https://github.com/noontide-co/mainbranch/issues/625) | Sense / Decide | Runtime or fixture prompt for full-guide paste recognition |
-| [#626](https://github.com/noontide-co/mainbranch/issues/626) | Ship | Fixture repo smoke for `mb onboard --github --push` |
+| [#626](https://github.com/noontide-co/mainbranch/issues/626) | Ship | Fixture repo smoke for `mb onboard --github <owner/repo> --push` |
 | [#627](https://github.com/noontide-co/mainbranch/issues/627) | Ship / Reflect | Checkpoint plan/hook tests with suspicious scratch files |
 | [#628](https://github.com/noontide-co/mainbranch/issues/628) | Sense | Status JSON regression test with date-valued facts |
 | [#629](https://github.com/noontide-co/mainbranch/issues/629) | Decide / Ship | MoneyPath/proof fixture plus skill routing review |

--- a/mb/mb/_data/templates/AGENTS.md.tmpl
+++ b/mb/mb/_data/templates/AGENTS.md.tmpl
@@ -38,11 +38,11 @@ description into an empty or uninitialized folder, treat it as setup intent,
 not as a document to save. Do not ask what file format to save the prompt in. First
 check `mb --version`. If `mb` is missing, stop and give the exact install step:
 `pipx install mainbranch`. If `mb` is available, inspect the setup path with
-`mb onboard --help` or `mb onboard plan`, then explain which folder will become
-the business brain and ask before running a writing command.
+`mb onboard --help`, then explain which folder will become the business brain
+and ask before running any command that writes files.
 
 If the operator asks for GitHub backup, sync, collaboration, or
-`mb onboard --github --push`, check GitHub CLI before any setup write:
+`mb onboard --github <owner/repo> --push`, check GitHub CLI before any setup write:
 `gh auth status` and `gh api user --jq .login`. Confirm the signed-in account
 matches the operator's expected account. GitHub is strongly recommended because
 it gives Main Branch a free cloud backup, shared history, task/proposal layer,

--- a/mb/mb/_data/templates/AGENTS.md.tmpl
+++ b/mb/mb/_data/templates/AGENTS.md.tmpl
@@ -31,6 +31,30 @@ refresh local runtime wiring, update packages, migrate business files, create
 checkpoints, publish, spend money, contact customers, email, or mutate provider
 accounts require explicit operator approval before applying.
 
+## First-run setup intent
+
+When the operator pastes a setup guide, bootstrap prompt, or business/folder
+description into an empty or uninitialized folder, treat it as setup intent,
+not as a document to save. Do not ask what file format to save the prompt in. First
+check `mb --version`. If `mb` is missing, stop and give the exact install step:
+`pipx install mainbranch`. If `mb` is available, inspect the setup path with
+`mb onboard --help` or `mb onboard plan`, then explain which folder will become
+the business brain and ask before running a writing command.
+
+If the operator asks for GitHub backup, sync, collaboration, or
+`mb onboard --github --push`, check GitHub CLI before any setup write:
+`gh auth status` and `gh api user --jq .login`. Confirm the signed-in account
+matches the operator's expected account. GitHub is strongly recommended because
+it gives Main Branch a free cloud backup, shared history, task/proposal layer,
+and connector-friendly copy of the business brain. Main Branch can start
+locally without GitHub; GitHub is needed for sync, collaboration, and the
+GitHub-backed onboarding path.
+
+After setup, run `mb status --json --peek` and `mb start --json`. Summarize the
+outcome in business language first: folder created, business brain ready,
+baseline saved, GitHub backup connected when requested, checkpoint state, and
+next safe action. Put commands and git/GitHub details second.
+
 Do the technical work in technical commands, then translate the result back into
 business-owner language. Speak first in terms of bets, goals, offers, pushes,
 playbooks, outcomes, decisions, next actions, and saved checkpoints. Treat git,

--- a/mb/mb/_data/templates/CLAUDE.md.tmpl
+++ b/mb/mb/_data/templates/CLAUDE.md.tmpl
@@ -40,6 +40,30 @@ mb doctor repair --apply
 mb update
 ```
 
+## First-run setup intent
+
+When the operator pastes a setup guide, bootstrap prompt, or business/folder
+description into an empty or uninitialized folder, treat it as setup intent,
+not as a document to save. Do not ask what file format to save the prompt in. First
+check `mb --version`. If `mb` is missing, stop and give the exact install step:
+`pipx install mainbranch`. If `mb` is available, inspect the setup path with
+`mb onboard --help` or `mb onboard plan`, then explain which folder will become
+the business brain and ask before running a writing command.
+
+If the operator asks for GitHub backup, sync, collaboration, or
+`mb onboard --github --push`, check GitHub CLI before any setup write:
+`gh auth status` and `gh api user --jq .login`. Confirm the signed-in account
+matches the operator's expected account. GitHub is strongly recommended because
+it gives Main Branch a free cloud backup, shared history, task/proposal layer,
+and connector-friendly copy of the business brain. Main Branch can start
+locally without GitHub; GitHub is needed for sync, collaboration, and the
+GitHub-backed onboarding path.
+
+After setup, run `mb status --json --peek` and `mb start --json`. Summarize the
+outcome in business language first: folder created, business brain ready,
+baseline saved, GitHub backup connected when requested, checkpoint state, and
+next safe action. Put commands and git/GitHub details second.
+
 If `/mb-start` is not discoverable or Claude Code reports `Unknown command:
 /mb-start`, do not improvise from memory. From this business repo, check
 `mb --version`, run `mb start --json` and `mb status --json --peek`, inspect

--- a/mb/mb/_data/templates/CLAUDE.md.tmpl
+++ b/mb/mb/_data/templates/CLAUDE.md.tmpl
@@ -47,11 +47,11 @@ description into an empty or uninitialized folder, treat it as setup intent,
 not as a document to save. Do not ask what file format to save the prompt in. First
 check `mb --version`. If `mb` is missing, stop and give the exact install step:
 `pipx install mainbranch`. If `mb` is available, inspect the setup path with
-`mb onboard --help` or `mb onboard plan`, then explain which folder will become
-the business brain and ask before running a writing command.
+`mb onboard --help`, then explain which folder will become the business brain
+and ask before running any command that writes files.
 
 If the operator asks for GitHub backup, sync, collaboration, or
-`mb onboard --github --push`, check GitHub CLI before any setup write:
+`mb onboard --github <owner/repo> --push`, check GitHub CLI before any setup write:
 `gh auth status` and `gh api user --jq .login`. Confirm the signed-in account
 matches the operator's expected account. GitHub is strongly recommended because
 it gives Main Branch a free cloud backup, shared history, task/proposal layer,

--- a/mb/mb/_data/templates/README.md.tmpl
+++ b/mb/mb/_data/templates/README.md.tmpl
@@ -28,6 +28,16 @@ mb status --json --peek
 mb start --json
 ```
 
+## Save, Checkpoint, Backup
+
+- Saving a file keeps it on this computer.
+- A checkpoint is an approved saved point in the business history.
+- GitHub backup/sync is strongly recommended for almost everyone. It gives the
+  approved history a free cloud backup and connector-friendly copy of the
+  business brain.
+- Main Branch updates change the engine and skills; they do not rewrite this
+  business folder without an approved repair, migration, or edit.
+
 ## Safety
 
 Commit business-readable files. Do not commit API keys, OAuth tokens,

--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -308,6 +308,13 @@ def _render_onboard_human(result: dict[str, Any]) -> None:
         console.print("  Git remembers how the business changed.")
         console.print("  GitHub turns tasks and proposals into a team surface.")
         console.print("  Claude Code is the first runtime that can act on the repo.\n")
+    console.print("[bold]Save model[/bold]")
+    console.print("  Files save locally first.")
+    console.print("  Checkpoints are approved saved points in the business history.")
+    console.print(
+        "  GitHub backup/sync is strongly recommended for cloud backup, "
+        "collaboration, and AI connector access.\n"
+    )
 
     tools = result["tools"]
     skill_wiring = result["skill_wiring"]

--- a/mb/mb/codex.py
+++ b/mb/mb/codex.py
@@ -64,6 +64,30 @@ refresh local runtime wiring, update packages, migrate business files, create
 checkpoints, publish, spend money, contact customers, email, or mutate provider
 accounts require explicit operator approval before applying.
 
+## First-run setup intent
+
+When the operator pastes a setup guide, bootstrap prompt, or business/folder
+description into an empty or uninitialized folder, treat it as setup intent,
+not as a document to save. Do not ask what file format to save the prompt in. First
+check `mb --version`. If `mb` is missing, stop and give the exact install step:
+`pipx install mainbranch`. If `mb` is available, inspect the setup path with
+`mb onboard --help` or `mb onboard plan`, then explain which folder will become
+the business brain and ask before running a writing command.
+
+If the operator asks for GitHub backup, sync, collaboration, or
+`mb onboard --github --push`, check GitHub CLI before any setup write:
+`gh auth status` and `gh api user --jq .login`. Confirm the signed-in account
+matches the operator's expected account. GitHub is strongly recommended because
+it gives Main Branch a free cloud backup, shared history, task/proposal layer,
+and connector-friendly copy of the business brain. Main Branch can start
+locally without GitHub; GitHub is needed for sync, collaboration, and the
+GitHub-backed onboarding path.
+
+After setup, run `mb status --json --peek` and `mb start --json`. Summarize the
+outcome in business language first: folder created, business brain ready,
+baseline saved, GitHub backup connected when requested, checkpoint state, and
+next safe action. Put commands and git/GitHub details second.
+
 Do the technical work in technical commands, then translate the result back into
 business-owner language. Speak first in terms of bets, goals, offers, pushes,
 playbooks, outcomes, decisions, next actions, and saved checkpoints. Treat git,

--- a/mb/mb/codex.py
+++ b/mb/mb/codex.py
@@ -71,11 +71,11 @@ description into an empty or uninitialized folder, treat it as setup intent,
 not as a document to save. Do not ask what file format to save the prompt in. First
 check `mb --version`. If `mb` is missing, stop and give the exact install step:
 `pipx install mainbranch`. If `mb` is available, inspect the setup path with
-`mb onboard --help` or `mb onboard plan`, then explain which folder will become
-the business brain and ask before running a writing command.
+`mb onboard --help`, then explain which folder will become the business brain
+and ask before running any command that writes files.
 
 If the operator asks for GitHub backup, sync, collaboration, or
-`mb onboard --github --push`, check GitHub CLI before any setup write:
+`mb onboard --github <owner/repo> --push`, check GitHub CLI before any setup write:
 `gh auth status` and `gh api user --jq .login`. Confirm the signed-in account
 matches the operator's expected account. GitHub is strongly recommended because
 it gives Main Branch a free cloud backup, shared history, task/proposal layer,

--- a/mb/mb/init.py
+++ b/mb/mb/init.py
@@ -266,6 +266,30 @@ mb doctor repair --apply
 mb update
 ```
 
+## First-run setup intent
+
+When the operator pastes a setup guide, bootstrap prompt, or business/folder
+description into an empty or uninitialized folder, treat it as setup intent,
+not as a document to save. Do not ask what file format to save the prompt in. First
+check `mb --version`. If `mb` is missing, stop and give the exact install step:
+`pipx install mainbranch`. If `mb` is available, inspect the setup path with
+`mb onboard --help` or `mb onboard plan`, then explain which folder will become
+the business brain and ask before running a writing command.
+
+If the operator asks for GitHub backup, sync, collaboration, or
+`mb onboard --github --push`, check GitHub CLI before any setup write:
+`gh auth status` and `gh api user --jq .login`. Confirm the signed-in account
+matches the operator's expected account. GitHub is strongly recommended because
+it gives Main Branch a free cloud backup, shared history, task/proposal layer,
+and connector-friendly copy of the business brain. Main Branch can start
+locally without GitHub; GitHub is needed for sync, collaboration, and the
+GitHub-backed onboarding path.
+
+After setup, run `mb status --json --peek` and `mb start --json`. Summarize the
+outcome in business language first: folder created, business brain ready,
+baseline saved, GitHub backup connected when requested, checkpoint state, and
+next safe action. Put commands and git/GitHub details second.
+
 If `/mb-start` is not discoverable or Claude Code reports `Unknown command:
 /mb-start`, do not improvise from memory. From this business repo, check
 `mb --version`, run `mb start --json` and `mb status --json --peek`, inspect

--- a/mb/mb/init.py
+++ b/mb/mb/init.py
@@ -273,11 +273,11 @@ description into an empty or uninitialized folder, treat it as setup intent,
 not as a document to save. Do not ask what file format to save the prompt in. First
 check `mb --version`. If `mb` is missing, stop and give the exact install step:
 `pipx install mainbranch`. If `mb` is available, inspect the setup path with
-`mb onboard --help` or `mb onboard plan`, then explain which folder will become
-the business brain and ask before running a writing command.
+`mb onboard --help`, then explain which folder will become the business brain
+and ask before running any command that writes files.
 
 If the operator asks for GitHub backup, sync, collaboration, or
-`mb onboard --github --push`, check GitHub CLI before any setup write:
+`mb onboard --github <owner/repo> --push`, check GitHub CLI before any setup write:
 `gh auth status` and `gh api user --jq .login`. Confirm the signed-in account
 matches the operator's expected account. GitHub is strongly recommended because
 it gives Main Branch a free cloud backup, shared history, task/proposal layer,

--- a/mb/tests/test_first_run_setup_contract.py
+++ b/mb/tests/test_first_run_setup_contract.py
@@ -15,6 +15,11 @@ def _normalize(text: str) -> str:
     return " ".join(text.split())
 
 
+def _setup_section(text: str) -> str:
+    start = text.index("setup intent")
+    return text[start : start + 1400]
+
+
 def test_beginner_setup_uses_folder_first_bootstrap_prompt() -> None:
     text = _read("docs/beginner-setup.md")
     normalized = _normalize(text)
@@ -29,6 +34,7 @@ def test_beginner_setup_uses_folder_first_bootstrap_prompt() -> None:
         "GitHub is strongly recommended",
         "connector-friendly copy of the business brain",
         "Main Branch can start locally without GitHub",
+        "mb onboard --github <owner/repo> --push",
         "Do not save that prompt as a markdown document.",
         "A checkpoint is an approved saved point in the business history.",
         "Main Branch updates change the engine and skills",
@@ -36,13 +42,13 @@ def test_beginner_setup_uses_folder_first_bootstrap_prompt() -> None:
     ]
     for phrase in required:
         assert phrase in normalized
+    assert "mb onboard --github --push" not in normalized
 
 
 def test_runtime_guidance_routes_pasted_setup_to_onboarding() -> None:
     for relative in (
         "mb/mb/_data/templates/CLAUDE.md.tmpl",
         "mb/mb/_data/templates/AGENTS.md.tmpl",
-        ".claude/skills/mb-setup/SKILL.md",
     ):
         text = _read(relative)
         normalized = _normalize(text)
@@ -50,11 +56,27 @@ def test_runtime_guidance_routes_pasted_setup_to_onboarding() -> None:
         assert "not as a document to save" in normalized
         assert "mb --version" in normalized
         assert "pipx install mainbranch" in normalized
-        assert "mb onboard" in normalized
+        assert "mb onboard --help" in normalized
+        assert "mb onboard plan" not in _normalize(_setup_section(text))
         assert "gh auth status" in normalized
         assert "gh api user --jq .login" in normalized
         assert "GitHub is strongly recommended" in normalized
         assert "connector-friendly copy of the business brain" in normalized
+        assert "mb onboard --github <owner/repo> --push" in normalized
+        assert "mb onboard --github --push" not in normalized
+
+
+def test_setup_skill_keeps_onboard_plan_after_approval() -> None:
+    text = _read(".claude/skills/mb-setup/SKILL.md")
+    normalized = _normalize(text)
+
+    assert "setup intent" in normalized
+    assert "not as a document to save" in normalized
+    assert "mb onboard --help" in normalized
+    assert "Use `mb onboard plan` only after the operator approves" in normalized
+    assert "After the operator approves saving setup progress" in normalized
+    assert "mb onboard --github <owner/repo> --push" in normalized
+    assert "mb onboard --github --push" not in normalized
 
 
 def test_readme_points_empty_folder_users_to_bootstrap() -> None:
@@ -68,3 +90,4 @@ def test_readme_points_empty_folder_users_to_bootstrap() -> None:
     assert "AI tools with GitHub connectors can read" in normalized
     assert "gh auth status" in normalized
     assert "gh api user --jq .login" in normalized
+    assert "mb onboard --github --push" not in normalized

--- a/mb/tests/test_first_run_setup_contract.py
+++ b/mb/tests/test_first_run_setup_contract.py
@@ -1,0 +1,70 @@
+"""Regression guards for first-run setup intent guidance."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _read(relative: str) -> str:
+    return (REPO_ROOT / relative).read_text(encoding="utf-8")
+
+
+def _normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def test_beginner_setup_uses_folder_first_bootstrap_prompt() -> None:
+    text = _read("docs/beginner-setup.md")
+    normalized = _normalize(text)
+
+    required = [
+        "## Folder-First Bootstrap",
+        "I want to set up Main Branch for this business in the current folder.",
+        "Treat this as setup intent, not as a document to save.",
+        "check whether `mb` is available",
+        "Use this folder as the business repo location unless I say otherwise.",
+        "GitHub CLI is installed, authenticated, and signed in to the account I expect",
+        "GitHub is strongly recommended",
+        "connector-friendly copy of the business brain",
+        "Main Branch can start locally without GitHub",
+        "Do not save that prompt as a markdown document.",
+        "A checkpoint is an approved saved point in the business history.",
+        "Main Branch updates change the engine and skills",
+        "system-architecture.md#repo-topology",
+    ]
+    for phrase in required:
+        assert phrase in normalized
+
+
+def test_runtime_guidance_routes_pasted_setup_to_onboarding() -> None:
+    for relative in (
+        "mb/mb/_data/templates/CLAUDE.md.tmpl",
+        "mb/mb/_data/templates/AGENTS.md.tmpl",
+        ".claude/skills/mb-setup/SKILL.md",
+    ):
+        text = _read(relative)
+        normalized = _normalize(text)
+        assert "setup intent" in normalized
+        assert "not as a document to save" in normalized
+        assert "mb --version" in normalized
+        assert "pipx install mainbranch" in normalized
+        assert "mb onboard" in normalized
+        assert "gh auth status" in normalized
+        assert "gh api user --jq .login" in normalized
+        assert "GitHub is strongly recommended" in normalized
+        assert "connector-friendly copy of the business brain" in normalized
+
+
+def test_readme_points_empty_folder_users_to_bootstrap() -> None:
+    text = _read("README.md")
+    normalized = _normalize(text)
+
+    assert "Start with the folder that should become your business brain" in normalized
+    assert "folder-first bootstrap" in normalized
+    assert "setup intent, not a document to save" in normalized
+    assert "GitHub backup/sync is strongly recommended" in normalized
+    assert "AI tools with GitHub connectors can read" in normalized
+    assert "gh auth status" in normalized
+    assert "gh api user --jq .login" in normalized

--- a/mb/tests/test_init.py
+++ b/mb/tests/test_init.py
@@ -15,7 +15,12 @@ def _section(text: str, start: str, end: str) -> str:
     return text[start_index:end_index]
 
 
+def _normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
 def _assert_claude_md_cli_first_contract(text: str) -> None:
+    normalized = _normalize(text)
     assert "## Claude operating contract" in text
     assert "Main Branch CLI facts are the source of truth" in text
     assert "run `claude`" in text
@@ -34,6 +39,14 @@ def _assert_claude_md_cli_first_contract(text: str) -> None:
     assert "mb skill link --repo .          # writes project-local Claude skill wiring" in text
     assert "mb skill repair --repo . --apply" in text
     assert "mb doctor repair --apply" in text
+    assert "## First-run setup intent" in text
+    assert "setup intent, not as a document to save" in normalized
+    assert "pipx install mainbranch" in normalized
+    assert "gh auth status" in normalized
+    assert "gh api user --jq .login" in normalized
+    assert "GitHub is strongly recommended" in normalized
+    assert "connector-friendly copy of the business brain" in normalized
+    assert "business brain" in normalized
     assert "If `/mb-start` is not discoverable" in text
     assert "restart Claude Code from this repo and try" in text
     assert "business-owner language" in text
@@ -83,6 +96,7 @@ def _assert_claude_md_primitive_routing_contract(text: str) -> None:
 
 
 def _assert_agents_md_codex_start_contract(text: str) -> None:
+    normalized = _normalize(text)
     assert "## Codex Operating Contract" in text
     assert "Do not pretend Claude" in text
     assert "slash commands exist in Codex." in text
@@ -106,6 +120,14 @@ def _assert_agents_md_codex_start_contract(text: str) -> None:
     assert "mb start --json" in text
     assert "mb doctor repair --plan" in text
     assert "explicit operator approval" in text
+    assert "## First-run setup intent" in text
+    assert "setup intent, not as a document to save" in normalized
+    assert "pipx install mainbranch" in normalized
+    assert "gh auth status" in normalized
+    assert "gh api user --jq .login" in normalized
+    assert "GitHub is strongly recommended" in normalized
+    assert "connector-friendly copy of the business brain" in normalized
+    assert "business brain" in normalized
     assert "business-owner language" in text
     assert "bets, goals, offers, pushes" in text
     assert "`working tree: clean`" in text
@@ -201,6 +223,9 @@ def test_init_scaffolds_folders(tmp_path: Path) -> None:
     assert "Acme Brewing" in agents_md
     assert "Acme Brewing" in readme_md
     assert "/mb-start" in readme_md
+    assert "## Save, Checkpoint, Backup" in readme_md
+    assert "A checkpoint is an approved saved point" in readme_md
+    assert "GitHub backup/sync is strongly recommended" in readme_md
     assert ".mb/onboarding.json" in readme_md
     assert "## Connected accounts" in claude_md
     assert "Stripe account IDs" in claude_md

--- a/mb/tests/test_onboard.py
+++ b/mb/tests/test_onboard.py
@@ -27,7 +27,12 @@ def _tool_path(name: str) -> str:
     return ""
 
 
+def _normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
 def _assert_onboard_claude_md_cli_first_contract(text: str) -> None:
+    normalized = _normalize(text)
     assert "## Claude operating contract" in text
     assert "Main Branch CLI facts are the source of truth" in text
     assert "mb status --json --peek" in text
@@ -37,6 +42,10 @@ def _assert_onboard_claude_md_cli_first_contract(text: str) -> None:
     assert "require explicit operator approval before applying" in text
     assert "If `/mb-start` is not discoverable" in text
     assert "business-owner language" in text
+    assert "## First-run setup intent" in text
+    assert "setup intent, not as a document to save" in normalized
+    assert "gh auth status" in normalized
+    assert "business brain" in normalized
     assert "## Business primitive routing" in text
     assert "multi-offer repo, `core/offer.md` is the portfolio thesis" in text
     assert "offer-specific proof belongs in `core/offers/<slug>/proof/`" in text


### PR DESCRIPTION
## Summary

Makes first-run setup folder-first and trust-preserving: pasted setup guides now route to Main Branch onboarding instead of document creation, with explicit approval before writes and clearer GitHub backup guidance.

## Linked issue

Closes #625
Refs #631
Refs #632

## Why

A founder starting from an empty folder could paste the beginner setup guide and get asked where to save the prompt, which breaks the first-run trust boundary before the business repo exists. This PR makes the docs, generated runtime guidance, and `/mb-setup` agree on read-only inspection, owner-language explanation, GitHub account preflight, and checkpoint/save/sync basics.

## Commits by concern

- [x] Each commit body bullet-lists the changes in that commit
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`

Commits:

- `69b66e0 [update] MAIN-388 first-run setup contract`
- `60c9f15 [fix] MAIN-388 review setup guidance`

## Validation

Pre-push gate from repo root:

```bash
scripts/check.sh
```

- [x] Level 1 static: `scripts/check.sh` passes
- [x] Level 2 CLI contract: focused Typer/CliRunner tests, exit codes, `--json` behavior, TTY vs non-TTY (if CLI behavior touched)
- [x] Level 3 package/install smoke (if packaging touched)
- [x] Level 4 fixture repo (if init/onboard/status/start/update touched)
- [ ] Level 5 runtime smoke / dogfood harness / simulation-tier (if runtime, first-run, skill discovery, or release validation touched)
- [x] SKILL.md <=500 lines (if any skill touched)
- [ ] Package-visible release gate evidence before tag/publish (if preparing a release)
- [ ] Supply-chain review (if `.github/workflows/`, `.github/dependabot.yml`, `mb/pyproject.toml` deps, or `id-token`/`permissions` blocks touched - see [docs/supply-chain-policy.md](../docs/supply-chain-policy.md))

Evidence:

- Level 1 static: `scripts/check.sh` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: format, ruff, mypy, 727 tests, skill validation passed after rebasing on `origin/main`.
- Level 2 CLI contract: `pytest tests/test_first_run_setup_contract.py tests/test_init.py tests/test_onboard.py tests/test_runtime_command_references.py -q` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: `30 passed in 31.62s` after rebasing on `origin/main`.
- Level 3 package/install: `(cd mb && python3 -m build) && python3 -m venv /tmp/mainbranch-smoke-review && /tmp/mainbranch-smoke-review/bin/pip install mb/dist/*.whl && /tmp/mainbranch-smoke-review/bin/mb --version && /tmp/mainbranch-smoke-review/bin/mb skill list` — runtime: `/tmp/mainbranch-smoke-review/bin/python3.13` — exit: 0 — log: built `mainbranch-0.3.25`, installed wheel, `mb --version` returned `mb 0.3.25`, bundled skills listed.
- Level 4 fixture repo: `python3 -m mb onboard --yes --name "First Run Trust" --path <tmp>/first-run-trust --json`, then `mb status --json --peek`, `mb start --json`, `mb validate`, `mb doctor` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: generated `CLAUDE.md`, `AGENTS.md`, and README include setup-intent, GitHub, save/checkpoint guidance.
- Level 5 runtime smoke: interactive Claude Code/Codex TUI smoke was not run — runtime: n/a — exit: n/a — log: closest verified fallback is fixture-generated guidance plus CLI start/status validation.

Not required:

- Package-visible release gate evidence: this is not a tag/publish prep PR.
- Supply-chain review: no workflow, dependency, Dependabot, `id-token`, or permissions files changed.

## Success metric

A founder can start in an empty folder, paste the setup guide/bootstrap prompt, and get routed to read-only inspection plus approved Main Branch onboarding, with GitHub backup explained as recommended but not required.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [ ] N/A - change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [x] No
- [ ] Yes - migration note below

## Public / private boundary

Only sanitized public setup findings are included. No raw transcript, customer details, local paths, private repo names, private business strategy, credentials, or runtime internals were committed.
