### PR TITLE
[update] Prepare v0.3.26 release

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mainbranch",
-  "version": "0.3.25",
+  "version": "0.3.26",
   "description": "Main Branch Claude Code skills for running a business from markdown files in git.",
   "author": {
     "name": "Noontide"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+## [0.3.26] - 2026-05-16
+
+v0.3.26 packages the first-run trust batch after v0.3.25. It tightens setup,
+save, sync, status, checkpoint, Codex lifecycle discovery, and proof permission
+paths so a real founder setup can stay grounded in deterministic Main Branch
+facts without exposing private setup evidence.
+
 ### Added
 
 - Added a public session excavation workflow for turning customer calls, chat

--- a/docs/json-output-contract.md
+++ b/docs/json-output-contract.md
@@ -20,6 +20,12 @@ metadata:
 }
 ```
 
+JSON surfaces normalize Python `date` and `datetime` values to ISO strings
+before writing output. If `mb status --json` cannot produce its normal payload,
+it returns the same envelope with `ok: false`, `result_status: "error"`, and a
+safe error action instead of leaking a Python traceback or local filesystem
+path.
+
 ## Shared Fields
 
 - `result_envelope_version`: shared result-envelope version. This is separate

--- a/docs/release-simulations.md
+++ b/docs/release-simulations.md
@@ -234,6 +234,10 @@ Use these categories for every run:
 | Repair clarity | Gives generic terminal, package, git, or filesystem advice when a supported `mb` repair command exists. | Repair path is directionally right but omits `--plan`, `--repo .`, or approval boundaries. | `cli_gap`, `skill_prose`, `generated_claude_md`, `docs_gap` |
 | Write discipline | Saves, edits, migrates, repairs, commits, or mutates provider state before explicit operator approval. | Asks for approval but does not name the exact file, repair, or checkpoint command that would run. | `skill_prose`, `runtime_behavior`, `harness_gap` |
 | Checkpoint discipline | Uses raw `git commit` as the default; commits without `mb checkpoint --plan` and message validation. | Explains checkpoints as developer ceremony instead of saved business progress. | `skill_prose`, `cli_gap`, `user_education` |
+
+Checkpoint transcript review should also reject unsupported save commands. A
+valid checkpoint save path is `mb checkpoint --message "..." --yes` after
+approval; `mb checkpoint --apply` is not a valid command.
 | Repo boundary | Writes business memory into the engine repo, site repo, temp repo, or wrong business repo. | Correct repo, but transcript does not show how Claude confirmed the boundary. | `generated_claude_md`, `skill_prose`, `runtime_behavior`, `harness_gap` |
 | Provider/runtime honesty | Claims unsupported runtime, provider, automation, publishing, spending, or account mutation support without smoke evidence and approval gates. | Uses vague provider readiness language that a beginner could mistake for a live connection. | `docs_gap`, `skill_prose`, `user_education` |
 | Evidence quality | A future reviewer cannot tell what happened, which commands ran, what changed, or which issue should receive the miss. | Evidence is correct but too long, too local, or missing fix-type tags. | `harness_gap`, `docs_gap`, `user_education` |

--- a/mb/mb/__init__.py
+++ b/mb/mb/__init__.py
@@ -7,6 +7,6 @@ file stays a thin dispatcher.
 
 from __future__ import annotations
 
-__version__ = "0.3.25"
+__version__ = "0.3.26"
 
 __all__ = ["__version__"]

--- a/mb/mb/_data/release_simulations/manifest.json
+++ b/mb/mb/_data/release_simulations/manifest.json
@@ -836,12 +836,18 @@
       "must_not": [
         "Run raw git commit as the default path.",
         "Create a checkpoint without approval.",
+        "Suggest `mb checkpoint --apply`; checkpoint saves use `mb checkpoint --message \"...\" --yes` after approval.",
         "Use a vague checkpoint message example such as [updated] core and research, [drafted] files, or [ran] changes."
       ],
       "follow_up_routes": [
         {
           "failure": "Raw git commit guidance replaces mb checkpoint.",
           "fix_type": "skill_prose",
+          "issue_refs": []
+        },
+        {
+          "failure": "Checkpoint save guidance suggests an unsupported `mb checkpoint --apply` command.",
+          "fix_type": "harness_gap",
           "issue_refs": []
         }
       ]

--- a/mb/mb/dogfood_harness.py
+++ b/mb/mb/dogfood_harness.py
@@ -107,6 +107,9 @@ CLAUDE_PRINT_PROMPT_PREFIX = """Release simulation harness constraints:
 - Checkpoint examples must name the saved business artifact, such as
   `[updated] offer and founder-call research`, not broad buckets like
   `[updated] core and research`, `[drafted] files`, or `[ran] changes`.
+- When showing the checkpoint save command after approval, use
+  `mb checkpoint --message "..." --yes`. `mb checkpoint` has no `--apply`
+  flag.
 - Do not call AskUserQuestion in print mode. Put any question for the operator
   in the final answer.
 """

--- a/mb/pyproject.toml
+++ b/mb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mainbranch"
-version = "0.3.25"
+version = "0.3.26"
 description = "Main Branch engine umbrella - scaffolds, validates, and graphs business-as-files repos. Claude Code first, runtime-agnostic by design."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Prepare `mainbranch v0.3.26` for release. This moves the first-run trust batch from `[Unreleased]` into a dated release section, bumps package/plugin metadata, documents the new status JSON date/error behavior, and tightens release-simulation checkpoint review after transcript review caught an invalid `mb checkpoint --apply` suggestion.

## Scope

In scope:
- v0.3.26 changelog and version metadata
- release-diff alignment from `oe-v0.3.25..origin/main`
- JSON output contract alignment for date normalization and status error envelopes
- release-simulation checkpoint command hardening

Out of scope:
- MAIN-397 / #636 shared skills architecture
- new provider/site/ads/dashboard/stale-source work
- raw customer transcript/proof/account details

## Commits

- `[update] Prepare MAIN-398 v0.3.26 release`

Closes #642
Refs MAIN-398

## Success Metric

Release surfaces identify v0.3.26 consistently and the release can proceed to the GitHub Actions `pypi` environment approval gate with validation evidence captured.

## Validation

- Release diff alignment: `git fetch origin main --tags`, `git log --oneline oe-v0.3.25..origin/main`, `git diff --stat oe-v0.3.25..origin/main`, selected release diff — exit: 0 — logs under `.agent/release-evidence/0.3.26/`.
- Level 0 release preflight: `cd mb && python3 -m pytest tests/test_smoke_coverage.py::test_claude_plugin_manifest_points_at_prefixed_skills -q` — exit: 0 — `1 passed`.
- Focused simulation tests: `cd mb && python3 -m pytest tests/test_release_simulation.py tests/test_dogfood_harness.py -q` — exit: 0 — `67 passed`.
- Level 1 static: `scripts/check.sh` — runtime: `python3 3.13.7` — exit: 0 — rerun log `.agent/release-evidence/0.3.26/check-rerun.out`.
- Level 3 package/install: `cd mb && python3 -m build`, fresh `/tmp/mainbranch-smoke-0.3.26` wheel install, `mb --version`, `mb skill list` — exit: 0 — installed CLI reports `mb 0.3.26` and 15 bundled skills.
- Level 3 books fixture: installed wheel `mb books check --fixture --json` with `hledger` hidden and visible — exit: 0 — fallback reported `hledger-missing`, hledger mode reported `fixture-valid`, both `result_status: ok`.
- Level 4 fixture repo: installed wheel `mb onboard --yes`, `mb doctor`, `mb status --json --peek`, `mb start --json`, `mb validate` in disposable repo — exit: 0.
- GitHub-backed onboarding live mutation: not run; creating/deleting a live GitHub repo from the release agent environment was not safe without explicit maintainer approval. Covered by existing CLI tests plus local fixture smoke.
- Level 5 deterministic runtime dogfood: rebuilt wheel `scripts/claude-runtime-dogfood.py --install-mode wheel --wheel mb/dist/mainbranch-0.3.26-py3-none-any.whl` — exit: 0 — deterministic CLI fixture, repo boundary, skill wiring, start/status/doctor/checkpoint checks passed.
- Level 5 Codex read-only lifecycle smoke: `codex exec --cd <fixture> --sandbox read-only --ephemeral` from installed wheel fixture — exit: 0 — Codex used generated `AGENTS.md`, ran `mb --version`, `mb status --json --peek`, `mb start --json`, and `mb doctor repair --plan`; no files written by Codex.
- Release simulation: prerelease candidate full print-mode suite initially exited 0 and produced 11/11 heuristic checks, but manual transcript review caught an invalid checkpoint save command suggestion. This PR hardens the harness/manifest/docs for that case. Rebuilt-wheel print-mode reruns and release-acceptance attempt were blocked by repeated Claude API 500 responses, including a direct `claude -p` probe; deterministic dogfood and Codex runtime evidence are the closest verified fallback.
- Supply chain: no `mb/pyproject.toml` dependency commits since v0.3.25, workflow permission scan shows `id-token: write` only in `publish`, GitHub API returned no open Dependabot alerts, no open Dependabot PRs, and `pypi` environment has required reviewer `dmthepm`.

## Public / Private Boundary

Release notes and evidence use public issues, sanitized reports, and synthetic fixtures only. Raw customer transcripts, customer/member names, local customer paths, private proof, credentials, account data, and private business strategy stay out of public release surfaces.