### PR TITLE
[update] Shared workflow source contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   connector readiness, dashboard direction, repo boundaries, and stale-source
   cleanup. Refs MAIN-408, #653.
 
+### Changed
+
+- Made `workflows/mb-think/workflow.md` the first official shared workflow
+  source pattern by adding checked runtime surfaces, approval gates,
+  public/private boundary metadata, generated shell drift checks, and Codex
+  `AGENTS.md` alignment while keeping Codex support experimental and
+  CLI-first. Refs MAIN-397, #636.
+
 ## [0.3.26] - 2026-05-16
 
 v0.3.26 packages the first-run trust batch after v0.3.25. It tightens setup,

--- a/decisions/2026-05-13-shared-workflow-corpus-and-native-runtime-renderers.md
+++ b/decisions/2026-05-13-shared-workflow-corpus-and-native-runtime-renderers.md
@@ -17,6 +17,11 @@ tags: [runtime-adapters, codex, claude-code, skills, workflows, renderer]
 
 # Shared Workflow Corpus And Native Runtime Renderers
 
+Historical naming note: this decision used "workflow corpus" while the adapter
+shape was being chosen. Current product language is **shared workflow source**,
+with **runtime shells**, **runtime guidance**, and **runtime adapters** over
+that source.
+
 ## Decision
 
 Main Branch should introduce a runtime-neutral workflow corpus under

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -144,7 +144,7 @@ smoke evidence exist.
 | Runtime surface | Status | Invocation | Skill/workflow discovery | Routing and automation | Observability and packaging |
 |---|---|---|---|---|---|
 | Claude Code | Supported | `mb start --repo "$repo"` prints the `claude` handoff; `mb start --launch` may launch after readiness checks. | `mb skill link --repo "$repo"` writes project-local `.claude/skills/mb-*` bridge links and `.claude/settings.local.json`. | Slash commands such as `/mb-start` and `/mb-think` own conversation and judgment; they call deterministic `mb` commands for facts. | `mb doctor`, `mb status --json`, `mb start --json`, `mb skill repair`, and runtime dogfood evidence gate release claims. Skills ship inside the Python package today. |
-| Codex CLI | Experimental | Can call deterministic `mb` commands as a subprocess when pointed at a business repo. `AGENTS.md` gives Codex a CLI-first lifecycle discovery surface for start, status, and thinking/codification routes. | Fresh `mb onboard` repos include tracked `AGENTS.md`; `mb doctor repair --plan` / `--apply` can report and refresh it. No `.agents/skills` or plugin parity is claimed yet. | Codex should run `mb status --json --peek`, `mb start --json`, and `mb doctor repair --plan` before advice, translate facts into business language, route status/thinking work through the generated lifecycle index, and ask before writes. | `mb doctor`, `mb status --json`, and `mb start --json` expose Codex readiness. Support remains experimental; only the generated lifecycle guidance and `/mb-think` shared workflow guidance have smoke-backed coverage. |
+| Codex CLI | Experimental | Can call deterministic `mb` commands as a subprocess when pointed at a business repo. `AGENTS.md` gives Codex a CLI-first lifecycle discovery surface for start, status, and thinking/codification routes. | Fresh `mb onboard` repos include tracked `AGENTS.md`; `mb doctor repair --plan` / `--apply` can report and refresh it. No `.agents/skills` or plugin parity is claimed yet. | Codex should run `mb status --json --peek`, `mb start --json`, and `mb doctor repair --plan` before advice, translate facts into business language, route status/thinking work through the generated lifecycle index, and ask before writes. | `mb doctor`, `mb status --json`, and `mb start --json` expose Codex readiness. Support remains experimental; generated lifecycle guidance is checked against the `mb-think` shared workflow source, but no Codex slash-command or selected-workflow support is claimed without fresh smoke evidence. |
 | Cursor | Roadmap | Can call deterministic `mb` commands from terminal/tasks when pointed at a business repo. | No supported Cursor rules/package adapter yet. | No supported Main Branch routing contract. | Needs adapter docs, install/update rules, conflict handling, and smoke evidence. |
 | OpenClaw | Roadmap | Target public runtime surface. It should call `mb` through stable CLI/JSON commands rather than clone-era paths. | No supported OpenClaw adapter yet. | Main Branch should coexist with OpenClaw as the business repo/GitHub memory layer, not replace it. | Needs explicit adapter shape, migration notes, generated-file rules, and smoke evidence. |
 | Hermes | Roadmap | Target runtime/memory surface. It may supervise or host workflows that call packaged `mb` commands. | No supported Hermes adapter yet. | Hermes-specific routing belongs in the Hermes adapter, while `mb` remains deterministic and non-conversational. | Docs may describe internal-package expectations generically, but not as the only blessed public path. Smoke evidence is required before support claims. |
@@ -183,9 +183,11 @@ For the Codex staging plan, see
 [Codex Adapter Plan](../decisions/2026-05-08-codex-adapter-plan.md). The current
 implementation is the experimental CLI-first slice: generated `AGENTS.md`,
 deterministic readiness facts, doctor repair coverage, and compact lifecycle
-discovery for start, status, and thinking/codification. It does not claim
-supported Codex parity, slash-command parity, `.agents/skills` distribution, or
-provider/publishing workflow support.
+discovery for start, status, and thinking/codification. The think route is
+checked against `workflows/mb-think/workflow.md` as the first official shared
+workflow source pattern. It does not claim supported Codex parity,
+slash-command parity, selected workflow support, `.agents/skills` distribution,
+or provider/publishing workflow support.
 
 ## Recommended setup
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -54,9 +54,10 @@ Main Branch already ships:
   business work;
 - `bets/` and `/mb-bet` as the first Reflect primitive;
 - `mb checkpoint` as the first hidden GitOps save layer for long agent runs;
-- a shared workflow source prototype for the daily start -> MoneyPath
-  `/mb-think` handoff, with native Claude and Codex shell snapshots that avoid
-  overclaiming runtime parity;
+- the first official shared workflow source pattern in
+  `workflows/mb-think/workflow.md`, with checked Claude/Codex runtime shell
+  snapshots and generated Codex lifecycle guidance that avoids overclaiming
+  runtime parity;
 - materialized release-simulation fixtures and the package-visible release
   evidence ladder (PR smoke, pre-release candidate, release acceptance);
 - release and local-state boundary hardening for package publishing and

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -102,6 +102,25 @@ business language is direction, not current behavior; see
 
 ## Primitive Contracts
 
+### Shared Workflow Source
+
+Portable workflow semantics live in `workflows/<workflow>/workflow.md`.
+Runtime-specific files are runtime shells or runtime guidance over that source,
+not the canonical truth.
+
+The first official pattern is `workflows/mb-think/workflow.md`. It declares the
+workflow intent, operator loops, runtime support level, checked runtime
+surfaces, required `mb` fact commands, JSON fact paths, approval gates,
+public/private boundaries, routing rules, handoff shape, and validation
+expectations. Claude Code remains the first-class runtime shell through
+`.claude/skills/mb-think/SKILL.md`; Codex remains experimental and uses tracked
+`AGENTS.md` guidance checked against the shared source. Neither `.claude/skills`
+nor `.agents/skills` is the canonical source for cross-runtime workflow
+semantics.
+
+`mb` may validate, render snapshots for tests, and repair generated runtime
+guidance. It must not invoke Claude, Codex, or any model.
+
 ### `core/`
 
 Evergreen business truth: offer, audience, soul, voice, proof, brand systems,

--- a/mb/mb/_data/templates/AGENTS.md.tmpl
+++ b/mb/mb/_data/templates/AGENTS.md.tmpl
@@ -174,6 +174,46 @@ This is Codex-native guidance for the existing `mb-think` shared workflow
 source. It is not a slash command, and it does not mean all Main Branch skills
 work in Codex.
 
+Source workflow: `workflows/mb-think/workflow.md`
+
+Shared source required `mb` commands:
+
+- `mb status --json --peek`
+- `mb start --json`
+- `mb doctor repair --plan`
+- `mb connect doctor --json`
+- `mb checkpoint --plan --json`
+
+Shared source required JSON fact paths:
+
+- `money_path`
+- `money_path.objects.offer`
+- `money_path.objects.proof`
+- `money_path.objects.proof.quality`
+- `money_path.objects.product_ladder`
+- `money_path.objects.cta_path`
+- `money_path.objects.channel_strategy`
+- `money_path.objects.active_push`
+- `money_path.objects.outcome_feedback_loop`
+- `money_path.ranked_actions`
+- `content_strategy`
+- `ranked_actions`
+- `update`
+- `readiness`
+- `drift.items`
+- `books`
+- `runtime.codex`
+- `runtime.claude_code`
+
+Shared source gates: `updates_repairs_migrations`, `file_writes`,
+`checkpoint`, `provider_mutation`, `publishing_or_spend`, `customer_contact`,
+`private_data`, `destructive_operations`, `structured_collection`,
+`public_issue_or_proposal`.
+
+Shared public/private boundaries: `no_secrets`, `no_raw_provider_exports`,
+`no_customer_member_data`, `no_private_runtime_settings`,
+`no_private_dms_or_gated_communities`, `no_raw_finance_legal_records`.
+
 Use it when the operator asks to think through an offer, research a market,
 compare providers, make a decision, or codify what was learned.
 

--- a/mb/mb/_data/templates/AGENTS.md.tmpl
+++ b/mb/mb/_data/templates/AGENTS.md.tmpl
@@ -174,7 +174,7 @@ This is Codex-native guidance for the existing `mb-think` shared workflow
 source. It is not a slash command, and it does not mean all Main Branch skills
 work in Codex.
 
-Source workflow: `workflows/mb-think/workflow.md`
+Engine source workflow: `workflows/mb-think/workflow.md`
 
 Shared source required `mb` commands:
 

--- a/mb/mb/codex.py
+++ b/mb/mb/codex.py
@@ -19,23 +19,72 @@ REQUIRED_FACT_COMMANDS = (
     "mb start --json",
     "mb doctor repair --plan",
 )
+CODEX_THINK_SOURCE_WORKFLOW = "workflows/mb-think/workflow.md"
+CODEX_THINK_REQUIRED_MB_COMMANDS = (
+    "mb status --json --peek",
+    "mb start --json",
+    "mb doctor repair --plan",
+    "mb connect doctor --json",
+    "mb checkpoint --plan --json",
+)
+CODEX_THINK_REQUIRED_JSON_FACTS = (
+    "money_path",
+    "money_path.objects.offer",
+    "money_path.objects.proof",
+    "money_path.objects.proof.quality",
+    "money_path.objects.product_ladder",
+    "money_path.objects.cta_path",
+    "money_path.objects.channel_strategy",
+    "money_path.objects.active_push",
+    "money_path.objects.outcome_feedback_loop",
+    "money_path.ranked_actions",
+    "content_strategy",
+    "ranked_actions",
+    "update",
+    "readiness",
+    "drift.items",
+    "books",
+    "runtime.codex",
+    "runtime.claude_code",
+)
+CODEX_THINK_APPROVAL_GATES = (
+    "updates_repairs_migrations",
+    "file_writes",
+    "checkpoint",
+    "provider_mutation",
+    "publishing_or_spend",
+    "customer_contact",
+    "private_data",
+    "destructive_operations",
+    "structured_collection",
+    "public_issue_or_proposal",
+)
+CODEX_THINK_PUBLIC_PRIVATE_BOUNDARIES = (
+    "no_secrets",
+    "no_raw_provider_exports",
+    "no_customer_member_data",
+    "no_private_runtime_settings",
+    "no_private_dms_or_gated_communities",
+    "no_raw_finance_legal_records",
+)
 REQUIRED_LIFECYCLE_GUIDANCE = (
     "## Codex Lifecycle Workflow Index",
     "## Codex Status Workflow",
     "## Codex Think Route",
-    "Source workflow: `workflows/mb-think/workflow.md`",
+    f"Source workflow: `{CODEX_THINK_SOURCE_WORKFLOW}`",
+    "Shared source required `mb` commands",
     "Shared source required JSON fact paths",
-    "money_path.objects.proof.quality",
-    "runtime.codex",
-    "mb checkpoint --plan --json",
     "Shared source gates",
-    "provider_mutation",
-    "publishing_or_spend",
     "Shared public/private boundaries",
-    "no_raw_provider_exports",
-    "no_customer_member_data",
     "Do not create `.agents/skills`",
     "do not claim these workflows are ported to",
+)
+REQUIRED_LIFECYCLE_GUIDANCE_MARKERS = (
+    *REQUIRED_LIFECYCLE_GUIDANCE,
+    *(f"- `{command}`" for command in CODEX_THINK_REQUIRED_MB_COMMANDS),
+    *(f"- `{fact}`" for fact in CODEX_THINK_REQUIRED_JSON_FACTS),
+    *(f"`{gate}`" for gate in CODEX_THINK_APPROVAL_GATES),
+    *(f"`{boundary}`" for boundary in CODEX_THINK_PUBLIC_PRIVATE_BOUNDARIES),
 )
 
 
@@ -457,7 +506,7 @@ def instructions_status(repo: str | Path) -> dict[str, Any]:
     approval_ok = "explicit operator approval" in text
     slash_ok = "Do not pretend Claude" in text and "slash commands exist in Codex." in text
     missing_lifecycle_guidance = [
-        phrase for phrase in REQUIRED_LIFECYCLE_GUIDANCE if phrase not in text
+        marker for marker in REQUIRED_LIFECYCLE_GUIDANCE_MARKERS if marker not in text
     ]
     lifecycle_discovery_ok = bool(exists and not missing_lifecycle_guidance)
     fact_grounding_ok = bool(

--- a/mb/mb/codex.py
+++ b/mb/mb/codex.py
@@ -23,7 +23,17 @@ REQUIRED_LIFECYCLE_GUIDANCE = (
     "## Codex Lifecycle Workflow Index",
     "## Codex Status Workflow",
     "## Codex Think Route",
+    "Source workflow: `workflows/mb-think/workflow.md`",
+    "Shared source required JSON fact paths",
+    "money_path.objects.proof.quality",
+    "runtime.codex",
     "mb checkpoint --plan --json",
+    "Shared source gates",
+    "provider_mutation",
+    "publishing_or_spend",
+    "Shared public/private boundaries",
+    "no_raw_provider_exports",
+    "no_customer_member_data",
     "Do not create `.agents/skills`",
     "do not claim these workflows are ported to",
 )
@@ -200,6 +210,46 @@ the daily check-in and wants it recorded.
 This is Codex-native guidance for the existing `mb-think` shared workflow
 source. It is not a slash command, and it does not mean all Main Branch skills
 work in Codex.
+
+Source workflow: `workflows/mb-think/workflow.md`
+
+Shared source required `mb` commands:
+
+- `mb status --json --peek`
+- `mb start --json`
+- `mb doctor repair --plan`
+- `mb connect doctor --json`
+- `mb checkpoint --plan --json`
+
+Shared source required JSON fact paths:
+
+- `money_path`
+- `money_path.objects.offer`
+- `money_path.objects.proof`
+- `money_path.objects.proof.quality`
+- `money_path.objects.product_ladder`
+- `money_path.objects.cta_path`
+- `money_path.objects.channel_strategy`
+- `money_path.objects.active_push`
+- `money_path.objects.outcome_feedback_loop`
+- `money_path.ranked_actions`
+- `content_strategy`
+- `ranked_actions`
+- `update`
+- `readiness`
+- `drift.items`
+- `books`
+- `runtime.codex`
+- `runtime.claude_code`
+
+Shared source gates: `updates_repairs_migrations`, `file_writes`,
+`checkpoint`, `provider_mutation`, `publishing_or_spend`, `customer_contact`,
+`private_data`, `destructive_operations`, `structured_collection`,
+`public_issue_or_proposal`.
+
+Shared public/private boundaries: `no_secrets`, `no_raw_provider_exports`,
+`no_customer_member_data`, `no_private_runtime_settings`,
+`no_private_dms_or_gated_communities`, `no_raw_finance_legal_records`.
 
 Use it when the operator asks to think through an offer, research a market,
 compare providers, make a decision, or codify what was learned.

--- a/mb/mb/codex.py
+++ b/mb/mb/codex.py
@@ -71,7 +71,7 @@ REQUIRED_LIFECYCLE_GUIDANCE = (
     "## Codex Lifecycle Workflow Index",
     "## Codex Status Workflow",
     "## Codex Think Route",
-    f"Source workflow: `{CODEX_THINK_SOURCE_WORKFLOW}`",
+    f"Engine source workflow: `{CODEX_THINK_SOURCE_WORKFLOW}`",
     "Shared source required `mb` commands",
     "Shared source required JSON fact paths",
     "Shared source gates",
@@ -260,7 +260,7 @@ This is Codex-native guidance for the existing `mb-think` shared workflow
 source. It is not a slash command, and it does not mean all Main Branch skills
 work in Codex.
 
-Source workflow: `workflows/mb-think/workflow.md`
+Engine source workflow: `workflows/mb-think/workflow.md`
 
 Shared source required `mb` commands:
 

--- a/mb/mb/workflows.py
+++ b/mb/mb/workflows.py
@@ -16,8 +16,11 @@ REQUIRED_FRONTMATTER_FIELDS = {
     "description",
     "loops",
     "runtime_support",
+    "runtime_surfaces",
     "required_mb_commands",
     "json_facts",
+    "approval_gates",
+    "public_private_boundaries",
     "writes_business_files",
     "provider_mutation",
     "publishing_or_spend",
@@ -51,6 +54,20 @@ MINIMUM_JSON_FACTS = {
     "update",
     "readiness",
     "drift.items",
+}
+MINIMUM_APPROVAL_GATES = {
+    "file_writes",
+    "checkpoint",
+    "provider_mutation",
+    "publishing_or_spend",
+    "customer_contact",
+    "private_data",
+}
+MINIMUM_PUBLIC_PRIVATE_BOUNDARIES = {
+    "no_secrets",
+    "no_raw_provider_exports",
+    "no_customer_member_data",
+    "no_private_runtime_settings",
 }
 REQUIRED_SHELL_PHRASES_BY_WORKFLOW: dict[str, dict[str, str]] = {
     "mb-think": {
@@ -107,6 +124,14 @@ class WorkflowSource:
     @property
     def json_facts(self) -> list[str]:
         return [str(item) for item in self.frontmatter["json_facts"]]
+
+    @property
+    def approval_gates(self) -> list[str]:
+        return [str(item) for item in self.frontmatter["approval_gates"]]
+
+    @property
+    def public_private_boundaries(self) -> list[str]:
+        return [str(item) for item in self.frontmatter["public_private_boundaries"]]
 
 
 class WorkflowValidationError(ValueError):
@@ -186,6 +211,15 @@ def validate_workflow(path: Path) -> list[str]:
             if actual != expected:
                 errors.append(f"runtime_support.{runtime} must be {expected!r}, got {actual!r}")
 
+    runtime_surfaces = frontmatter.get("runtime_surfaces")
+    if not isinstance(runtime_surfaces, dict):
+        errors.append("frontmatter field runtime_surfaces must be a mapping")
+    else:
+        for runtime in REQUIRED_RUNTIME_SUPPORT:
+            actual = runtime_surfaces.get(runtime)
+            if not isinstance(actual, str) or not actual.strip():
+                errors.append(f"runtime_surfaces.{runtime} must name the checked shell path")
+
     commands = _coerce_string_list(frontmatter.get("required_mb_commands"))
     if commands is None:
         errors.append("frontmatter field required_mb_commands must be a list of strings")
@@ -201,6 +235,24 @@ def validate_workflow(path: Path) -> list[str]:
         missing_facts = sorted(MINIMUM_JSON_FACTS - set(facts))
         if missing_facts:
             errors.append(f"json_facts missing minimum paths: {missing_facts}")
+
+    approval_gates = _coerce_string_list(frontmatter.get("approval_gates"))
+    if approval_gates is None:
+        errors.append("frontmatter field approval_gates must be a list of strings")
+    else:
+        missing_gates = sorted(MINIMUM_APPROVAL_GATES - set(approval_gates))
+        if missing_gates:
+            errors.append(f"approval_gates missing minimum gates: {missing_gates}")
+
+    boundaries = _coerce_string_list(frontmatter.get("public_private_boundaries"))
+    if boundaries is None:
+        errors.append("frontmatter field public_private_boundaries must be a list of strings")
+    else:
+        missing_boundaries = sorted(MINIMUM_PUBLIC_PRIVATE_BOUNDARIES - set(boundaries))
+        if missing_boundaries:
+            errors.append(
+                f"public_private_boundaries missing minimum boundaries: {missing_boundaries}"
+            )
 
     for field in ("writes_business_files", "provider_mutation", "publishing_or_spend"):
         if field in frontmatter and not isinstance(frontmatter[field], bool):
@@ -233,6 +285,12 @@ def shell_drift_errors(workflow: WorkflowSource, shell_text: str) -> list[str]:
     for fact in workflow.json_facts:
         if not _has_exact_bullet_item(shell_text, fact):
             errors.append(f"shell missing required JSON fact path: {fact}")
+    for gate in workflow.approval_gates:
+        if f"`{gate}`" not in shell_text:
+            errors.append(f"shell missing required approval gate: {gate}")
+    for boundary in workflow.public_private_boundaries:
+        if f"`{boundary}`" not in shell_text:
+            errors.append(f"shell missing required public/private boundary: {boundary}")
     for label, phrase in REQUIRED_SHELL_PHRASES_BY_WORKFLOW.get(workflow.name, {}).items():
         if phrase.lower() not in shell_text.lower():
             errors.append(f"shell missing required workflow rule: {label}")
@@ -268,6 +326,10 @@ def _bullet_list(items: list[str]) -> str:
     return "\n".join(f"- `{item}`" for item in items)
 
 
+def _inline_code_list(items: list[str]) -> str:
+    return ", ".join(f"`{item}`" for item in items)
+
+
 def _display_path(path: Path) -> str:
     parts = path.parts
     if "workflows" in parts:
@@ -291,6 +353,8 @@ def _render_start_money_path_claude_shell(workflow: WorkflowSource) -> str:
 
 Source workflow: `{_display_path(workflow.path)}`
 Runtime support: `claude_code: supported_shell`
+Approval gates: {_inline_code_list(workflow.approval_gates)}
+Public/private boundaries: {_inline_code_list(workflow.public_private_boundaries)}
 
 Use from `/mb-start` when the operator asks about revenue, offer readiness, the
 next dollar, or the path to money. Preserve slash-command-native language and
@@ -357,6 +421,8 @@ def _render_start_money_path_codex_shell(workflow: WorkflowSource) -> str:
 
 Source workflow: `{_display_path(workflow.path)}`
 Runtime support: `codex_cli: experimental_shell`
+Approval gates: {_inline_code_list(workflow.approval_gates)}
+Public/private boundaries: {_inline_code_list(workflow.public_private_boundaries)}
 
 Codex remains experimental and CLI-first. This guidance is a generated snapshot
 for validation; it does not mean `/mb-start` slash commands work inside Codex
@@ -416,6 +482,8 @@ def _render_think_claude_shell(workflow: WorkflowSource) -> str:
 
 Source workflow: `{_display_path(workflow.path)}`
 Runtime support: `claude_code: supported_shell`
+Approval gates: {_inline_code_list(workflow.approval_gates)}
+Public/private boundaries: {_inline_code_list(workflow.public_private_boundaries)}
 
 Use from `/mb-think` when the operator asks to research, decide, figure out,
 compare, codify, sharpen an offer, or turn learning into durable business
@@ -478,6 +546,8 @@ def _render_think_codex_shell(workflow: WorkflowSource) -> str:
 
 Source workflow: `{_display_path(workflow.path)}`
 Runtime support: `codex_cli: experimental_shell`
+Approval gates: {_inline_code_list(workflow.approval_gates)}
+Public/private boundaries: {_inline_code_list(workflow.public_private_boundaries)}
 
 Codex remains experimental and CLI-first. This guidance tells Codex how to
 treat a natural-language request as a Main Branch thinking task through

--- a/mb/tests/fixtures/workflows/mb-start-money-path.claude.md
+++ b/mb/tests/fixtures/workflows/mb-start-money-path.claude.md
@@ -2,6 +2,8 @@
 
 Source workflow: `workflows/mb-start-money-path/workflow.md`
 Runtime support: `claude_code: supported_shell`
+Approval gates: `updates_repairs_migrations`, `file_writes`, `checkpoint`, `provider_mutation`, `publishing_or_spend`, `customer_contact`, `private_data`, `destructive_operations`
+Public/private boundaries: `no_secrets`, `no_raw_provider_exports`, `no_customer_member_data`, `no_private_runtime_settings`, `no_private_maintainer_notes`
 
 Use from `/mb-start` when the operator asks about revenue, offer readiness, the
 next dollar, or the path to money. Preserve slash-command-native language and

--- a/mb/tests/fixtures/workflows/mb-start-money-path.codex.md
+++ b/mb/tests/fixtures/workflows/mb-start-money-path.codex.md
@@ -2,6 +2,8 @@
 
 Source workflow: `workflows/mb-start-money-path/workflow.md`
 Runtime support: `codex_cli: experimental_shell`
+Approval gates: `updates_repairs_migrations`, `file_writes`, `checkpoint`, `provider_mutation`, `publishing_or_spend`, `customer_contact`, `private_data`, `destructive_operations`
+Public/private boundaries: `no_secrets`, `no_raw_provider_exports`, `no_customer_member_data`, `no_private_runtime_settings`, `no_private_maintainer_notes`
 
 Codex remains experimental and CLI-first. This guidance is a generated snapshot
 for validation; it does not mean `/mb-start` slash commands work inside Codex

--- a/mb/tests/fixtures/workflows/mb-think.claude.md
+++ b/mb/tests/fixtures/workflows/mb-think.claude.md
@@ -2,6 +2,8 @@
 
 Source workflow: `workflows/mb-think/workflow.md`
 Runtime support: `claude_code: supported_shell`
+Approval gates: `updates_repairs_migrations`, `file_writes`, `checkpoint`, `provider_mutation`, `publishing_or_spend`, `customer_contact`, `private_data`, `destructive_operations`, `structured_collection`, `public_issue_or_proposal`
+Public/private boundaries: `no_secrets`, `no_raw_provider_exports`, `no_customer_member_data`, `no_private_runtime_settings`, `no_private_dms_or_gated_communities`, `no_raw_finance_legal_records`
 
 Use from `/mb-think` when the operator asks to research, decide, figure out,
 compare, codify, sharpen an offer, or turn learning into durable business

--- a/mb/tests/fixtures/workflows/mb-think.codex.md
+++ b/mb/tests/fixtures/workflows/mb-think.codex.md
@@ -2,6 +2,8 @@
 
 Source workflow: `workflows/mb-think/workflow.md`
 Runtime support: `codex_cli: experimental_shell`
+Approval gates: `updates_repairs_migrations`, `file_writes`, `checkpoint`, `provider_mutation`, `publishing_or_spend`, `customer_contact`, `private_data`, `destructive_operations`, `structured_collection`, `public_issue_or_proposal`
+Public/private boundaries: `no_secrets`, `no_raw_provider_exports`, `no_customer_member_data`, `no_private_runtime_settings`, `no_private_dms_or_gated_communities`, `no_raw_finance_legal_records`
 
 Codex remains experimental and CLI-first. This guidance tells Codex how to
 treat a natural-language request as a Main Branch thinking task through

--- a/mb/tests/test_doctor.py
+++ b/mb/tests/test_doctor.py
@@ -306,6 +306,31 @@ def test_doctor_repair_plan_reports_stale_codex_lifecycle_guidance(tmp_path: Pat
     assert "codex-agents-md" in actions
 
 
+def test_doctor_repair_plan_reports_custom_codex_agents_missing_source_item(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "biz"
+    init_run(path=str(repo), name="Acme")
+    agents = repo / "AGENTS.md"
+    agents.write_text(
+        agents.read_text(encoding="utf-8").replace("- `runtime.codex`\n", "", 1)
+        + "\n## Local Notes\n\nKeep this operator-specific note.\n",
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["doctor", "repair", "--repo", str(repo), "--plan", "--json"])
+
+    assert result.exit_code in {0, 1}
+    payload = json.loads(result.stdout)
+    section = next(section for section in payload["sections"] if section["id"] == "codex-wiring")
+    agents_check = next(check for check in section["checks"] if check["name"] == "AGENTS.md")
+    assert agents_check["state"] == "warn"
+    assert agents_check["lifecycle_discovery_ok"] is False
+    assert "- `runtime.codex`" in agents_check["missing_lifecycle_guidance"]
+    actions = {action["id"]: action for action in payload["actions"]}
+    assert "codex-agents-md" in actions
+
+
 def test_doctor_repair_apply_refreshes_codex_agents_md(tmp_path: Path) -> None:
     repo = tmp_path / "biz"
     init_run(path=str(repo), name="Acme")

--- a/mb/tests/test_workflows.py
+++ b/mb/tests/test_workflows.py
@@ -111,7 +111,7 @@ def test_codex_agents_think_route_preserves_shared_workflow_contract() -> None:
     workflow = load_workflow(THINK_WORKFLOW)
     text = AGENTS_TEMPLATE.read_text(encoding="utf-8")
 
-    assert "Source workflow: `workflows/mb-think/workflow.md`" in text
+    assert "Engine source workflow: `workflows/mb-think/workflow.md`" in text
     for command in workflow.required_mb_commands:
         assert f"- `{command}`" in text
     for fact in workflow.json_facts:

--- a/mb/tests/test_workflows.py
+++ b/mb/tests/test_workflows.py
@@ -18,6 +18,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW = REPO_ROOT / "workflows" / "mb-start-money-path" / "workflow.md"
 THINK_WORKFLOW = REPO_ROOT / "workflows" / "mb-think" / "workflow.md"
 FIXTURES = REPO_ROOT / "mb" / "tests" / "fixtures" / "workflows"
+AGENTS_TEMPLATE = REPO_ROOT / "mb" / "mb" / "_data" / "templates" / "AGENTS.md.tmpl"
 WORKFLOW_PATHS = [
     WORKFLOW,
     THINK_WORKFLOW,
@@ -58,6 +59,19 @@ def test_workflow_validation_flags_missing_required_json_fact(tmp_path: Path) ->
     assert any("money_path.objects.proof.quality" in error for error in errors)
 
 
+def test_workflow_validation_flags_missing_required_approval_gate(tmp_path: Path) -> None:
+    broken = tmp_path / "workflow.md"
+    broken.write_text(
+        THINK_WORKFLOW.read_text(encoding="utf-8").replace("  - checkpoint\n", "", 1),
+        encoding="utf-8",
+    )
+
+    errors = validate_workflow(broken)
+
+    assert any("approval_gates missing minimum gates" in error for error in errors)
+    assert any("checkpoint" in error for error in errors)
+
+
 def test_generated_start_money_path_claude_and_codex_snapshots_match_fixtures() -> None:
     workflow = load_workflow(WORKFLOW)
 
@@ -92,6 +106,21 @@ def test_supported_shells_preserve_required_commands_and_json_facts() -> None:
             assert shell_drift_errors(workflow, shell) == []
 
 
+def test_codex_agents_think_route_preserves_shared_workflow_contract() -> None:
+    workflow = load_workflow(THINK_WORKFLOW)
+    text = AGENTS_TEMPLATE.read_text(encoding="utf-8")
+
+    assert "Source workflow: `workflows/mb-think/workflow.md`" in text
+    for command in workflow.required_mb_commands:
+        assert f"- `{command}`" in text
+    for fact in workflow.json_facts:
+        assert f"- `{fact}`" in text
+    for gate in workflow.approval_gates:
+        assert f"`{gate}`" in text
+    for boundary in workflow.public_private_boundaries:
+        assert f"`{boundary}`" in text
+
+
 def test_drift_detection_flags_omitted_required_command_or_fact() -> None:
     workflow = load_workflow(WORKFLOW)
     shell = render_codex_shell(workflow)
@@ -122,6 +151,7 @@ def test_think_drift_detection_flags_missing_required_workflow_rules() -> None:
     drifted = shell.replace("Research Depth Recommendation", "research note")
     drifted = drifted.replace("Research depth recommendation", "research note")
     drifted = drifted.replace("parallel research files", "source notes")
+    drifted = drifted.replace("Public/private boundaries", "boundaries")
     drifted = drifted.replace("public/private handling", "handling")
 
     errors = shell_drift_errors(workflow, drifted)

--- a/mb/tests/test_workflows.py
+++ b/mb/tests/test_workflows.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from mb import codex as codex_mod
 from mb.workflows import (
     codex_shell_policy_errors,
     load_workflow,
@@ -119,6 +120,18 @@ def test_codex_agents_think_route_preserves_shared_workflow_contract() -> None:
         assert f"`{gate}`" in text
     for boundary in workflow.public_private_boundaries:
         assert f"`{boundary}`" in text
+
+
+def test_codex_contract_markers_match_think_workflow_source() -> None:
+    workflow = load_workflow(THINK_WORKFLOW)
+
+    assert codex_mod.CODEX_THINK_SOURCE_WORKFLOW == "workflows/mb-think/workflow.md"
+    assert tuple(workflow.required_mb_commands) == codex_mod.CODEX_THINK_REQUIRED_MB_COMMANDS
+    assert tuple(workflow.json_facts) == codex_mod.CODEX_THINK_REQUIRED_JSON_FACTS
+    assert tuple(workflow.approval_gates) == codex_mod.CODEX_THINK_APPROVAL_GATES
+    assert (
+        tuple(workflow.public_private_boundaries) == codex_mod.CODEX_THINK_PUBLIC_PRIVATE_BOUNDARIES
+    )
 
 
 def test_drift_detection_flags_omitted_required_command_or_fact() -> None:

--- a/workflows/mb-start-money-path/workflow.md
+++ b/workflows/mb-start-money-path/workflow.md
@@ -7,6 +7,9 @@ runtime_support:
   claude_code: supported_shell
   codex_cli: experimental_shell
   future: planned
+runtime_surfaces:
+  claude_code: .claude/skills/mb-start/SKILL.md
+  codex_cli: AGENTS.md#codex-lifecycle-workflow-index
 required_mb_commands:
   - mb status --json --peek
   - mb start --json
@@ -27,6 +30,21 @@ json_facts:
   - update
   - readiness
   - drift.items
+approval_gates:
+  - updates_repairs_migrations
+  - file_writes
+  - checkpoint
+  - provider_mutation
+  - publishing_or_spend
+  - customer_contact
+  - private_data
+  - destructive_operations
+public_private_boundaries:
+  - no_secrets
+  - no_raw_provider_exports
+  - no_customer_member_data
+  - no_private_runtime_settings
+  - no_private_maintainer_notes
 writes_business_files: true
 provider_mutation: false
 publishing_or_spend: false

--- a/workflows/mb-think/workflow.md
+++ b/workflows/mb-think/workflow.md
@@ -7,6 +7,9 @@ runtime_support:
   claude_code: supported_shell
   codex_cli: experimental_shell
   future: planned
+runtime_surfaces:
+  claude_code: .claude/skills/mb-think/SKILL.md
+  codex_cli: AGENTS.md#codex-think-route
 required_mb_commands:
   - mb status --json --peek
   - mb start --json
@@ -32,6 +35,24 @@ json_facts:
   - books
   - runtime.codex
   - runtime.claude_code
+approval_gates:
+  - updates_repairs_migrations
+  - file_writes
+  - checkpoint
+  - provider_mutation
+  - publishing_or_spend
+  - customer_contact
+  - private_data
+  - destructive_operations
+  - structured_collection
+  - public_issue_or_proposal
+public_private_boundaries:
+  - no_secrets
+  - no_raw_provider_exports
+  - no_customer_member_data
+  - no_private_runtime_settings
+  - no_private_dms_or_gated_communities
+  - no_raw_finance_legal_records
 writes_business_files: true
 provider_mutation: false
 publishing_or_spend: false


### PR DESCRIPTION
## Summary

Makes `workflows/mb-think/workflow.md` the first official shared workflow source pattern and checks Claude/Codex runtime guidance against that source. The branch keeps Codex experimental and CLI-first while adding drift coverage for fact commands, JSON paths, approval gates, and public/private boundaries.

## Linked issue

Closes #636

## Why

Main Branch needed one canonical workflow source so Claude skill prose, Codex `AGENTS.md`, compatibility docs, and renderer snapshots do not drift into separate product truths.

## Commits by concern

- [x] `d3c9a88 [update] MAIN-397 shared workflow source contract`: adds shared workflow metadata, renderer drift checks, generated Codex `AGENTS.md` alignment, docs, fixtures, and changelog coverage.
- [x] `85f7d5c [fix] MAIN-397 check full Codex workflow guidance`: checks Codex lifecycle freshness against the full `mb-think` source marker contract and adds repair regression coverage for a custom `AGENTS.md` missing a required fact.
- [x] `d6ab34f [fix] MAIN-397 label workflow source as engine path`: labels the `mb-think` source path in generated Codex guidance as an engine source workflow so fresh business repos do not imply the file exists locally.
- [x] Each commit body bullet-lists the changes in that commit
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`

## Validation

Pre-push gate from repo root:

```bash
scripts/check.sh
```

Level 1 static: `scripts/check.sh` — runtime: repo `python3` environment — exit: 0 — log: `.context/check-engine-source.out`, `733 passed in 344.76s`, mypy clean, skill validation clean.
Level 2 CLI contract: `cd mb && pytest tests/test_workflows.py tests/test_doctor.py::test_doctor_repair_plan_reports_custom_codex_agents_missing_source_item tests/test_doctor.py::test_doctor_repair_plan_reports_stale_codex_lifecycle_guidance tests/test_doctor.py::test_doctor_repair_preserves_custom_codex_agents_md_when_contract_is_current tests/test_init.py tests/test_first_run_setup_contract.py -q` — runtime: repo `python3` environment — exit: 0 — log: terminal excerpt, `28 passed in 11.09s`.
Level 3 package/install smoke: `(cd mb && python3 -m build) && python3 -m venv /tmp/mainbranch-smoke-rebase && /tmp/mainbranch-smoke-rebase/bin/pip install mb/dist/*.whl && /tmp/mainbranch-smoke-rebase/bin/mb --version && /tmp/mainbranch-smoke-rebase/bin/mb skill list` — runtime: `/tmp/mainbranch-smoke-rebase/bin/python3.13` — exit: 0 — log: `.context/package-rebase.out`, `mb 0.3.26` and skill list printed.
Level 4 fixture repo: `mb onboard --yes`, `mb doctor`, `mb status`, `mb start --json`, `mb validate`, plus generated `AGENTS.md` gate/boundary marker checks — runtime: `/tmp/mainbranch-smoke-rebase/bin/mb` — exit: 0 — log: `.context/fixture-rebase.out`, Codex wiring current and provider/privacy markers present.
Level 5 runtime smoke / dogfood harness / simulation-tier was not required because this PR does not add a selected Codex workflow, slash-command support claim, or provider/publishing support claim.

- [x] Level 1 static: `scripts/check.sh` passes
- [x] Level 2 CLI contract: focused Typer/CliRunner tests, exit codes, `--json` behavior, TTY vs non-TTY (if CLI behavior touched)
- [x] Level 3 package/install smoke (if packaging touched)
- [x] Level 4 fixture repo (if init/onboard/status/start/update touched)
- [x] Level 5 runtime smoke / dogfood harness / simulation-tier (if runtime, first-run, skill discovery, or release validation touched)
- [x] SKILL.md <=500 lines (if any skill touched)
- [x] Package-visible release gate evidence before tag/publish (if preparing a release)
- [x] Supply-chain review (if `.github/workflows/`, `.github/dependabot.yml`, `mb/pyproject.toml` deps, or `id-token`/`permissions` blocks touched — see [docs/supply-chain-policy.md](../docs/supply-chain-policy.md))

## Success metric

A reviewer can change `workflows/mb-think/workflow.md` and tests fail if Claude/Codex shell snapshots or generated Codex `AGENTS.md` guidance drop required fact commands, JSON fact paths, approval gates, or public/private boundaries.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [ ] N/A — change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [x] No
- [ ] Yes — migration note below

## Public / private boundary

No private operator strategy, machine-specific paths, secrets, credentials, customer/member data, or private runtime internals were committed. Codex support remains described as experimental and CLI-first; the PR does not claim slash-command parity, `.agents/skills` distribution, newsletter execution, Hermes support, or provider/publishing workflow support.
