### PR TITLE
[add] stale-source cleanup workflow

### DIFF
--- a/.claude/skills/mb-start/references/router-and-language.md
+++ b/.claude/skills/mb-start/references/router-and-language.md
@@ -275,6 +275,18 @@ strategy, positioning, offer, audience, voice, soul check, vendor choice.
 Route to `/mb-think`, with `codify` when the task is to turn known context into
 durable repo truth.
 
+### Stale source, claim, or angle cleanup
+
+Signals: stale source, old source, outdated file, obsolete claim, retire this
+claim, retire this angle, stop using that proof, not true anymore, old offer
+detail, old SOP.
+
+Route to `/mb-think` stale-source cleanup. Start from `mb status --json --peek`,
+then have the worker identify the stale item, find downstream usage, reconcile
+current `core/` and per-offer files, record a decision when durable truth
+changes, and offer a business-readable checkpoint. Do not ask the operator to
+inspect a git diff as the primary workflow.
+
 ### Bets, pushes, sites, ads, organic, wiki
 
 Signals and routes:

--- a/.claude/skills/mb-think/SKILL.md
+++ b/.claude/skills/mb-think/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mb-think
-description: "Combined research, decision, and codification workflow. Use when: (1) Exploring a question before committing (2) Making a decision that needs documentation (3) User says research, decide, figure out, explore, codify, enrich, sharpen this offer, improve the offer, add context, keyword gate, analyze this VSL, extract the pitch, script teardown, objection mining, or sales video research (4) Updating reference files based on decisions (5) User wants to add testimonials, angles, proof, mechanisms, objections, guarantees, or pitch context. Supports modes: full flow, research-only, keyword-gate, decide-only, codify."
+description: "Combined research, decision, and codification workflow. Use when: (1) Exploring a question before committing (2) Making a decision that needs documentation (3) User says research, decide, figure out, explore, codify, enrich, retire stale source, sharpen this offer, improve the offer, add context, keyword gate, analyze this VSL, extract the pitch, script teardown, objection mining, or sales video research (4) Updating reference files based on decisions (5) User wants to add testimonials, angles, proof, mechanisms, objections, guarantees, or pitch context. Supports modes: full flow, research-only, keyword-gate, decide-only, codify."
 loops: [sense, decide, ship]
 ---
 
@@ -162,10 +162,10 @@ Detect mode from user's natural language:
 | "decide", "we chose", "document decision" | Decide | [decide-phase.md](references/decide-phase.md) |
 | "codify", "apply", "update reference files" | Codify | [codify-phase.md](references/codify-phase.md) |
 | "add context", "enrich", "I have new info" | Codify | [codify-phase.md](references/codify-phase.md) |
+| "this source/claim/angle is stale", "old source", "obsolete claim", "retire this", "stop using that proof" | Stale-source cleanup | [stale-source-cleanup.md](references/stale-source-cleanup.md) |
 | "content strategy", "pillars", "what platforms", "content plan", "cadence", "channel strategy", "account strategy", "founder voice", "weekly content plan" | Full Flow (codify to the right content strategy layer) | [codify-phase.md](references/codify-phase.md) |
 | "where was I", "continue", "pick up" | Recovery | [recovery.md](references/recovery.md) |
 | "here's a PDF", "ingest this", "convert this document", file path (.pdf/.docx/.pptx) | Document Ingestion | [document-ingestion.md](references/document-ingestion.md) |
-
 For offer, audience, proof, CTA, content strategy, ads/pages, and positioning
 requests, use [research-depth-ladder.md](references/research-depth-ladder.md)
 before selecting source tools. The ladder chooses how much research is enough;

--- a/.claude/skills/mb-think/references/codify-phase.md
+++ b/.claude/skills/mb-think/references/codify-phase.md
@@ -145,6 +145,14 @@ When user has new information to add:
 - "Any client calls or DMs that show how you talk?"
 - "What's changed since you last updated these files?"
 
+## Retiring Stale Source
+
+When the new context says old source material, a claim, an offer detail, proof
+usage, or an angle is stale, switch to
+[stale-source-cleanup.md](stale-source-cleanup.md). Reconcile current truth,
+keep historical source auditable, write or update the decision that explains
+the change, and checkpoint only after approval.
+
 ---
 
 ## Change Report

--- a/.claude/skills/mb-think/references/stale-source-cleanup.md
+++ b/.claude/skills/mb-think/references/stale-source-cleanup.md
@@ -1,0 +1,137 @@
+# Stale-Source Cleanup
+
+Use this when the operator says old source material, a claim, an offer detail,
+a testimonial usage, or a messaging angle is stale, obsolete, retired, no
+longer true, or should stop being used.
+
+The goal is not to erase history. The goal is to reconcile current business
+truth so future sessions do not keep using the stale material.
+
+Scope boundary: this workflow starts after a specific stale item is named. If
+the operator needs to inventory or ingest transcripts, authenticated community
+content, cloud-drive uploads, provider recordings, or mixed private sources,
+route to the ingestion/privacy rail first; do not expand stale-source cleanup
+into transcript ingestion, provider connectors, newsletter implementation, or
+dashboard work.
+
+## Trigger Phrases
+
+- "That source is old."
+- "This claim is not true anymore."
+- "We do not sell that offer now."
+- "Retire this angle."
+- "Stop using that proof."
+- "This was tested and did not work."
+- "The file came from an old SOP."
+
+## Workflow
+
+1. **Name the stale item.** Ask for the smallest exact claim, source, angle,
+   offer detail, or file path that should stop guiding future work.
+2. **Name the replacement truth.** Ask what should be true now. If the operator
+   only knows "not that," record that and keep replacement wording conservative.
+3. **Read facts first.** Run `mb status --json --peek`. If save state matters,
+   run `mb checkpoint --plan --json` before proposing a saved checkpoint.
+4. **Find downstream usage.** Search exact phrases and nearby terms across
+   `core/`, `research/`, `decisions/`, `bets/`, `pushes/`, `log/`, and
+   `documents/`. Read the files before editing.
+5. **Map impact.** Group findings as current truth, source/evidence,
+   generated output, decision history, or stale artifact. Current truth lives
+   in `core/` and active offer files; source/evidence may stay for audit with
+   a stale note.
+6. **Propose reconciliation.** Tell the operator which files should change and
+   which files should stay as historical evidence.
+7. **Record a decision when truth changes.** Use
+   `decisions/YYYY-MM-DD-retire-<slug>.md` with `status: accepted` after the
+   operator confirms. `## What Changes` must name every affected `core/` or
+   per-offer file and describe the removal, replacement, or retirement.
+8. **Codify after approval.** Update current truth files. Mark retired angles,
+   proof usage, or claims as retired instead of deleting them unless the
+   operator explicitly asks for deletion and destructive-operation guardrails
+   have been read.
+9. **Mark the decision codified.** In the same cleanup pass, flip the cleanup
+   decision from `status: accepted` to `status: codified` after the current
+   truth files are updated.
+10. **Verify read-back.** Re-open edited files and the cleanup decision. Confirm
+   the stale phrasing no longer appears in active current-truth sections and
+   the decision has exactly one `status:` field set to `codified`.
+11. **Checkpoint.** Run `mb checkpoint --plan --json`, show the proposed
+   business-readable message, validate it, and save only after approval.
+
+## File Handling
+
+| Finding | Default handling |
+| --- | --- |
+| Stale claim in `core/offer.md` | Replace or remove from current offer truth. |
+| Stale offer detail in `core/offers/<slug>/offer.md` | Update the offer-specific file and any brand-level summary it affected. |
+| Retired audience language in `core/audience.md` | Remove from current audience truth or move to "Do not use" language. |
+| Retired angle in `core/proof/angles/` | Mark as retired with reason, date, and replacement angle if known. |
+| Source research that caused the mistake | Keep it as historical source and add a stale note. |
+| Generated push/ad/site copy using the stale claim | Mark for revision; do not publish or reuse until updated. |
+| Prior accepted decision now superseded | Add a new decision that supersedes it instead of rewriting history. |
+
+## Decision Shape
+
+```markdown
+---
+type: decision
+date: YYYY-MM-DD
+status: accepted
+supersedes:
+  - decisions/YYYY-MM-DD-older-decision.md
+---
+
+# Retire old offer detail
+
+## Decision
+
+We are retiring the old offer detail from current business truth.
+
+## Why
+
+The source was from an older version of the business and no longer matches what
+we sell.
+
+## What Changes
+
+Reference files affected:
+- `core/offer.md` - remove the old detail and replace it with the current
+  promise.
+- `core/offers/workshop/offer.md` - update the deliverables section.
+- `core/proof/angles/old-angle.md` - mark the angle retired and point to the
+  replacement angle.
+
+Outside reference: revise any draft campaign or page copy before publishing.
+```
+
+After approved reconciliation, update the same decision to `status: codified`.
+
+## Operator-Facing Summary
+
+Use this shape after reconciliation:
+
+```text
+I found the stale claim in three places.
+
+Current truth updated:
+- core/offer.md
+- core/offers/workshop/offer.md
+
+Historical source kept with a stale note:
+- research/YYYY-MM-DD-old-source.md
+
+Decision recorded:
+- decisions/YYYY-MM-DD-retire-old-offer-detail.md
+
+Next checkpoint proposal:
+- [updated] offer truth after stale-source cleanup
+```
+
+Do not require the operator to inspect a git diff. Offer the exact files and
+plain-language changes first; technical detail can be shown on request.
+
+## Manual Smoke Path
+
+The sanitized fixture path is `mb/tests/fixtures/stale-source-cleanup/manual-smoke.md`.
+It covers obsolete source material, downstream active truth cleanup, an accepted
+decision, and a checkpoint message proposal.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   gates, secret-safe smoke checks, transcript/source-ingestion privacy,
   connector readiness, dashboard direction, repo boundaries, and stale-source
   cleanup. Refs MAIN-408, #653.
+- Added a `/mb-think` stale-source cleanup workflow for retiring obsolete
+  source material, claims, offer details, proof usage, or messaging angles;
+  `/mb-start` now routes stale-source cleanup requests into the reconcile,
+  decision, codify, and checkpoint loop. Refs MAIN-393, #630.
 
 ## [0.3.26] - 2026-05-16
 

--- a/mb/mb/workflows.py
+++ b/mb/mb/workflows.py
@@ -58,6 +58,7 @@ REQUIRED_SHELL_PHRASES_BY_WORKFLOW: dict[str, dict[str, str]] = {
         "parallel research file pattern": "parallel research files",
         "decision writing": "decision",
         "codification": "codify",
+        "stale-source cleanup": "stale source",
         "public/private boundary": "public/private",
         "approval gates": "approval",
         "checkpoint approval": "checkpoint",
@@ -448,7 +449,11 @@ This snapshot does not replace shipped `.claude/skills/mb-think/SKILL.md`.
    caveats, promotion limits, and public/private handling.
 5. Write a decision when durable business truth changes. Codify only after the
    operator accepts the direction.
-6. Ask for approval before creating or editing business files, promoting
+6. For stale source, claim, proof, or angle cleanup, identify the stale item,
+   find downstream usage, keep history auditable with a stale note, reconcile
+   current truth after approval, record and codify the decision, then
+   checkpoint only after approval.
+7. Ask for approval before creating or editing business files, promoting
    research into core truth, using structured collection, or saving a
    checkpoint.
 
@@ -513,7 +518,11 @@ available in Codex.
    caveats, promotion limits, and public/private handling.
 6. Write a decision when durable business truth changes. Codify only after the
    operator accepts the direction.
-7. Ask for approval before creating or editing business files, promoting
+7. For stale source, claim, proof, or angle cleanup, identify the stale item,
+   find downstream usage, keep history auditable with a stale note, reconcile
+   current truth after approval, record and codify the decision, then
+   checkpoint only after approval.
+8. Ask for approval before creating or editing business files, promoting
    research into core truth, using structured collection, opening public
    issues, publishing, mutating providers, spending money, contacting
    customers, or saving a checkpoint.

--- a/mb/tests/fixtures/stale-source-cleanup/manual-smoke.md
+++ b/mb/tests/fixtures/stale-source-cleanup/manual-smoke.md
@@ -1,0 +1,60 @@
+# Stale-Source Cleanup Manual Smoke
+
+This is a sanitized fixture path for MAIN-393 / #630. It uses generic offer
+language only.
+
+## Setup
+
+Create a temporary business repo with these files:
+
+```text
+core/offer.md
+core/audience.md
+core/offers/workshop/offer.md
+core/proof/angles/legacy-speed-angle.md
+research/2026-05-01-old-source-import.md
+```
+
+Seed the stale phrase in each file:
+
+```text
+legacy same-day guarantee
+```
+
+The research file should say the source came from an older import. The active
+truth files should treat the phrase as current before cleanup.
+
+## Operator Prompt
+
+```text
+That old source is stale. We no longer offer the legacy same-day guarantee.
+Retire that claim everywhere and keep the current offer conservative.
+```
+
+## Expected Workflow
+
+1. Run `mb status --json --peek`.
+2. Search active and source files for `legacy same-day guarantee`.
+3. Report downstream usage without asking the operator to inspect a git diff.
+4. Add a stale note to `research/2026-05-01-old-source-import.md`.
+5. Create `decisions/YYYY-MM-DD-retire-legacy-same-day-guarantee.md` with
+   `status: accepted` and `## What Changes` naming the active files.
+6. Remove the stale claim from:
+   - `core/offer.md`
+   - `core/audience.md`
+   - `core/offers/workshop/offer.md`
+7. Mark `core/proof/angles/legacy-speed-angle.md` as retired instead of deleting it.
+8. Flip the cleanup decision from `status: accepted` to `status: codified`.
+9. Re-open edited files and confirm the stale phrase no longer appears in
+   active current-truth sections.
+10. Re-open the decision and confirm it has exactly one `status:` field set to
+    `codified`.
+11. Run `mb checkpoint --plan --json`.
+12. Propose a business-readable checkpoint message such as
+   `[updated] offer truth after stale-source cleanup`.
+
+## Pass Condition
+
+The cleanup passes when current truth no longer uses the obsolete claim, the
+source remains auditable with a stale note, the codified decision explains what
+changed, and the checkpoint proposal is business-readable.

--- a/mb/tests/fixtures/workflows/mb-think.claude.md
+++ b/mb/tests/fixtures/workflows/mb-think.claude.md
@@ -55,7 +55,11 @@ This snapshot does not replace shipped `.claude/skills/mb-think/SKILL.md`.
    caveats, promotion limits, and public/private handling.
 5. Write a decision when durable business truth changes. Codify only after the
    operator accepts the direction.
-6. Ask for approval before creating or editing business files, promoting
+6. For stale source, claim, proof, or angle cleanup, identify the stale item,
+   find downstream usage, keep history auditable with a stale note, reconcile
+   current truth after approval, record and codify the decision, then
+   checkpoint only after approval.
+7. Ask for approval before creating or editing business files, promoting
    research into core truth, using structured collection, or saving a
    checkpoint.
 

--- a/mb/tests/fixtures/workflows/mb-think.codex.md
+++ b/mb/tests/fixtures/workflows/mb-think.codex.md
@@ -58,7 +58,11 @@ available in Codex.
    caveats, promotion limits, and public/private handling.
 6. Write a decision when durable business truth changes. Codify only after the
    operator accepts the direction.
-7. Ask for approval before creating or editing business files, promoting
+7. For stale source, claim, proof, or angle cleanup, identify the stale item,
+   find downstream usage, keep history auditable with a stale note, reconcile
+   current truth after approval, record and codify the decision, then
+   checkpoint only after approval.
+8. Ask for approval before creating or editing business files, promoting
    research into core truth, using structured collection, opening public
    issues, publishing, mutating providers, spending money, contacting
    customers, or saving a checkpoint.

--- a/mb/tests/test_stale_source_workflow.py
+++ b/mb/tests/test_stale_source_workflow.py
@@ -1,0 +1,78 @@
+"""Contract checks for stale-source cleanup guidance."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+THINK_SKILL = REPO_ROOT / ".claude" / "skills" / "mb-think" / "SKILL.md"
+STALE_REF = REPO_ROOT / ".claude" / "skills" / "mb-think" / "references" / "stale-source-cleanup.md"
+CODIFY_REF = REPO_ROOT / ".claude" / "skills" / "mb-think" / "references" / "codify-phase.md"
+ROUTER_REF = REPO_ROOT / ".claude" / "skills" / "mb-start" / "references" / "router-and-language.md"
+THINK_WORKFLOW = REPO_ROOT / "workflows" / "mb-think" / "workflow.md"
+SMOKE_FIXTURE = REPO_ROOT / "mb" / "tests" / "fixtures" / "stale-source-cleanup" / "manual-smoke.md"
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_stale_source_cleanup_is_routed_from_start_to_think() -> None:
+    think = _read(THINK_SKILL)
+    router = _read(ROUTER_REF)
+    workflow = _read(THINK_WORKFLOW)
+
+    assert "retire stale source" in think
+    assert "stale-source-cleanup.md" in think
+    assert '| "add context", "enrich", "I have new info" | Codify |' in think
+    assert "obsolete claim" in think
+    assert "Stale source, claim, or angle cleanup" in router
+    assert "Route to `/mb-think` stale-source cleanup" in router
+    assert "stale source" in workflow
+    assert "obsolete claim" in workflow
+
+
+def test_stale_source_cleanup_reference_covers_reconcile_decision_checkpoint_loop() -> None:
+    text = _read(STALE_REF)
+    codify = _read(CODIFY_REF)
+
+    required = [
+        "Name the stale item",
+        "Name the replacement truth",
+        "Find downstream usage",
+        "Record a decision when truth changes",
+        "Codify after approval",
+        "Mark the decision codified",
+        "Verify read-back",
+        "Checkpoint",
+        "Do not require the operator to inspect a git diff",
+        "ingestion/privacy rail",
+        "core/offers/<slug>/offer.md",
+        "decisions/YYYY-MM-DD-retire-<slug>.md",
+        "status: codified",
+        "[updated] offer truth after stale-source cleanup",
+    ]
+    for phrase in required:
+        assert phrase in text
+
+    assert "stale-source-cleanup.md" in codify
+
+
+def test_stale_source_manual_smoke_fixture_covers_full_acceptance_path() -> None:
+    text = _read(SMOKE_FIXTURE)
+
+    required = [
+        "legacy same-day guarantee",
+        "Run `mb status --json --peek`",
+        "Search active and source files",
+        "Add a stale note",
+        "status: accepted",
+        "Remove the stale claim",
+        "Mark `core/proof/angles/legacy-speed-angle.md` as retired",
+        "status: codified",
+        "Run `mb checkpoint --plan --json`",
+        "[updated] offer truth after stale-source cleanup",
+        "business-readable",
+    ]
+    for phrase in required:
+        assert phrase in text

--- a/mb/tests/test_workflows.py
+++ b/mb/tests/test_workflows.py
@@ -131,6 +131,15 @@ def test_think_drift_detection_flags_missing_required_workflow_rules() -> None:
     assert "shell missing required workflow rule: public/private boundary" in errors
 
 
+def test_think_runtime_shells_surface_stale_source_cleanup_route() -> None:
+    workflow = load_workflow(THINK_WORKFLOW)
+
+    for shell in (render_claude_shell(workflow), render_codex_shell(workflow)):
+        assert "stale source, claim, proof, or angle cleanup" in shell
+        assert "find downstream usage" in shell
+        assert "record and codify the decision" in shell
+
+
 def test_think_codex_shell_does_not_claim_slash_command_or_skill_parity() -> None:
     workflow = load_workflow(THINK_WORKFLOW)
     shell = render_codex_shell(workflow)

--- a/workflows/mb-think/workflow.md
+++ b/workflows/mb-think/workflow.md
@@ -47,12 +47,14 @@ into durable business files.
 
 Use this workflow when the operator asks to think through an offer, research a
 market, compare providers, pressure-test positioning, choose a direction, turn
-source material into a decision, or codify what was learned.
+source material into a decision, retire stale source, or codify what was
+learned.
 
 Trigger phrases include think through, research, decide, figure out, explore,
 codify, enrich, sharpen this offer, improve the offer, compare providers,
 market research, customer language, proof, objections, guarantees, keyword
-gate, sales video research, script teardown, and decision.
+gate, sales video research, script teardown, stale source, obsolete claim,
+retire this angle, and decision.
 
 Do not use this workflow for a site build, ads generation, organic post
 production, provider mutation, publishing, spend, customer contact, or model
@@ -141,6 +143,14 @@ handling.
 Use decisions when the work changes durable business truth. A decision should
 name options, rationale, tradeoffs, consequences, and the specific files that
 would change. Codify only after the operator accepts the direction.
+
+When source material, a claim, an offer detail, proof usage, or an angle is
+stale, reconcile current truth instead of erasing history. Identify the stale
+item, find downstream usage, keep source/evidence auditable with a stale note,
+update `core/` and per-offer files after approval, record a decision when
+durable truth changes, and checkpoint only after approval. Do not expand this
+cleanup route into transcript ingestion, provider connectors, newsletter
+implementation, or dashboard work.
 
 ## Read Boundaries
 


### PR DESCRIPTION
## Summary

Adds a first-class stale-source cleanup workflow so operators can retire obsolete source material, claims, offer details, proof usage, or messaging angles without inspecting git diffs.

## Linked issue

Closes #630
Refs #657

## Why

Real onboarding includes mixed old and current materials, and the existing system handled those corrections only through expert live operation. This PR gives `/mb-start` and `/mb-think` a named path for finding downstream usage, reconciling durable truth, recording the decision, and saving a business-readable checkpoint. After reviewing #659, #661, #657, and #660, the workflow explicitly stays out of transcript ingestion, provider connectors, newsletter implementation, and dashboard work.

## Commits by concern

- `07ab968 [add] MAIN-393 stale-source cleanup workflow`
- `3a7ca0b [fix] Align workflow shells with stale cleanup`
- [ ] Each commit body bullet-lists the changes in that commit: N/A; commit subjects and scoped diffs carry the concern split.
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`

## Validation

Pre-push gate from repo root:

```bash
scripts/check.sh
```

Level 1 static: `scripts/check.sh` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: `0` — log: `90 files already formatted`; `Success: no issues found in 89 source files`; `733 passed`; `mb skill validate --all` passed.

Level 2 workflow contract: `cd mb && pytest tests/test_workflows.py tests/test_stale_source_workflow.py -q` — runtime: `python3` — exit: `0` — log: `18 passed`.

Level 3 package/install: `(cd mb && python3 -m build) && python3 -m venv /tmp/mainbranch-smoke-main-393 && /tmp/mainbranch-smoke-main-393/bin/pip install mb/dist/*.whl && /tmp/mainbranch-smoke-main-393/bin/mb --version && /tmp/mainbranch-smoke-main-393/bin/mb skill list` — runtime: `/tmp/mainbranch-smoke-main-393/bin/python` — exit: `0` — log: `mb 0.3.26`; skill list includes `mb-think`.

Level 4 fixture repo: not required; this does not change init, onboard, status, start CLI behavior, update paths, or repo shape, and includes a manual stale-source smoke fixture.

Level 5 runtime smoke: not run; this changes LLM-facing workflow guidance and generated workflow shell text, not runtime discovery, invocation, first-run handoff, or packaging entrypoints.

- [x] Level 1 static: `scripts/check.sh` passes
- [x] Level 2 CLI contract: focused Typer/CliRunner tests, exit codes, `--json` behavior, TTY vs non-TTY (if CLI behavior touched)
- [x] Level 3 package/install smoke (if packaging touched)
- [x] Level 4 fixture repo (if init/onboard/status/start/update touched)
- [x] Level 5 runtime smoke / dogfood harness / simulation-tier (if runtime, first-run, skill discovery, or release validation touched)
- [x] SKILL.md <=500 lines (if any skill touched)
- [x] Package-visible release gate evidence before tag/publish (if preparing a release)
- [x] Supply-chain review (if `.github/workflows/`, `.github/dependabot.yml`, `mb/pyproject.toml` deps, or `id-token`/`permissions` blocks touched)

## Success metric

When an operator says source material, a claim, or an angle is stale, Main Branch routes them to a business-language cleanup loop that finds downstream files, reconciles current truth, records and codifies the durable decision, and proposes a readable checkpoint. The shared workflow source and generated Claude/Codex shell snapshots surface the same stale-source cleanup route.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [ ] N/A — change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [x] No
- [ ] Yes — migration note below

## Public / private boundary

Only sanitized generic examples were added. No private operator strategy, customer material, machine-specific paths, credentials, or runtime internals were committed.
