### PR TITLE
[add] Privacy-bounded bet exposure

### DIFF
--- a/.claude/skills/mb-bet/SKILL.md
+++ b/.claude/skills/mb-bet/SKILL.md
@@ -20,7 +20,7 @@ For the full offer/bet/push/proof routing rubric, use
 
 Use `/mb-bet` for five modes:
 
-- `new` - open a bet with hypothesis, appetite, metric, target, deadline, and links.
+- `new` - open a bet with hypothesis, appetite, MoneyPath anchor, metric, target, deadline, and links.
 - `update` - add progress and link new evidence.
 - `close` - record result, verdict, learning, and follow-up links.
 - `list` - summarize active bets and deadlines.
@@ -64,10 +64,33 @@ status: open
 opened: YYYY-MM-DD
 deadline: YYYY-MM-DD
 appetite: "2 weeks"
+appetite_tier: small
 hypothesis: "If we do X for Y, Z will happen because..."
 metric: "qualified calls booked"
 target: "10 qualified calls by deadline"
 result: ""
+owner: ""
+money_path:
+  required: true
+  bet_id: YYYY-MM-DD-slug
+  exposure_cap:
+    amount: 500
+    currency: USD
+  anchor_required_before: execution
+kill_rubric:
+  failure_signals:
+    - id: no-qualified-calls
+      metric: qualified_calls
+      comparator: <
+      threshold: 3
+      by: YYYY-MM-DD
+      action: kill
+  double_down_signals:
+    - id: profitable-signal
+      metric: cost_per_qualified_call
+      comparator: <=
+      threshold: 150
+      action: double_down
 linked_decisions: []
 linked_research: []
 linked_pushes: []
@@ -80,6 +103,35 @@ tags: []
 ```
 
 Allowed statuses: `open`, `paused`, `closed`, `canceled`.
+Allowed `appetite_tier` values: `trivial`, `small`, `material`, `strategic`.
+Keep `appetite` human-readable, and use `appetite_tier` for rough financial
+weight. The tier should match the operator's appetite thresholds in
+`core/finance/books.md` when that file exists.
+
+When an owner is known, use the team member slug that will map to
+`core/team/<slug>.md`; do not invent team files before that primitive exists.
+
+For financially material bets, use `money_path.bet_id` equal to the filename
+stem and tag private hledger transactions with `bet:<id>`. Check exposure with:
+
+```bash
+mb books exposure --repo . --bet bets/YYYY-MM-DD-slug.md --json
+```
+
+For active bets:
+
+```bash
+mb books exposure --repo . --active --json
+```
+
+Treat the exposure output as safe aggregate evidence only. Do not ask for or
+paste raw ledger rows, payees, account names, account numbers, private vault
+paths, or transaction memos into bet files.
+
+Use `kill_rubric.failure_signals` and `kill_rubric.double_down_signals` for
+pre-committed exit and scale criteria. `mb status --json` evaluates only
+declared rubrics against explicit `metrics:` or `metric_values:` frontmatter;
+it does not infer kill criteria from prose.
 
 Use repo-relative paths in link fields:
 
@@ -111,13 +163,17 @@ docs/business-connections.md and do not invent relationships from body links.
 
 Use when the operator says they want to try, launch, test, prove, or make a bet.
 
-1. Ask only for missing essentials: hypothesis, appetite, deadline, metric,
-   target, public/private posture, channels, and any known linked files.
+1. Ask only for missing essentials: hypothesis, appetite, appetite tier,
+   exposure cap or MoneyPath anchor requirement, deadline, metric, target,
+   kill/double-down signals, public/private posture, channels, and any known
+   linked files.
 2. If the idea also sounds like a new offer, ask whether it is only a wager for
    now or whether the operator wants to preserve a durable offer candidate too.
    Do not create, rename, delete, or move `core/offers/` folders without an
    accepted decision, approved migration plan, or explicit instruction.
 3. Create `bets/YYYY-MM-DD-slug.md`.
+   If `money_path.required` is true, set `money_path.bet_id` to
+   `YYYY-MM-DD-slug`; do not invent private ledger details.
 4. Add reverse `linked_bets` frontmatter to linked decisions, research,
    pushes (or legacy campaigns), and outcome files when those files already
    exist and the edit is clearly safe.
@@ -193,6 +249,9 @@ Summarize active bets from `mb status --json --peek` and direct file reads:
 - status
 - target
 - metric
+- appetite tier and exposure cap when declared
+- missing MoneyPath or missing exit criteria
+- triggered kill or double-down signals
 - public/private posture
 - blocked or overdue signals
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   source material, claims, offer details, proof usage, or messaging angles;
   `/mb-start` now routes stale-source cleanup requests into the reconcile,
   decision, codify, and checkpoint loop. Refs MAIN-393, #630.
+- Added bet MoneyPath metadata, appetite-tier, kill-rubric, and double-down
+  validation warnings plus `mb status --json` exit-signal facts for declared
+  active bet rubrics. Refs MAIN-399, #644.
+- Added `mb books exposure --repo . --bet ... --json` and
+  `mb books exposure --repo . --active --json` for privacy-bounded hledger bet
+  exposure totals without raw ledger rows, payees, account names, account
+  numbers, private vault paths, or transaction memos. Refs MAIN-399, #644.
 
 ### Changed
 

--- a/docs/books.md
+++ b/docs/books.md
@@ -14,6 +14,11 @@ function is bookkeeping.
 - Main Branch also ships a fake-data sample monthly report:
   `mb books report monthly --sample --month YYYY-MM`. It uses packaged fixture
   data, not the operator's private books.
+- Main Branch ships privacy-bounded bet exposure checks:
+  `mb books exposure --repo . --bet bets/YYYY-MM-DD-slug.md --json` and
+  `mb books exposure --repo . --active --json`. Exposure checks read the
+  configured private hledger journal through hledger only to return aggregate
+  bet totals, cap state, and transaction counts.
 - **Main Branch uses hledger as the bookkeeping engine for `mb books`.**
   The hledger journal is the only authoritative ledger.
 - hledger is **optional** for base `mb` installs, but it is the chosen
@@ -219,6 +224,13 @@ The shipped sample reporting surface is:
 mb books report monthly --sample --month YYYY-MM [--json]
 ```
 
+The shipped privacy-bounded exposure surface is:
+
+```bash
+mb books exposure --repo . --bet bets/YYYY-MM-DD-slug.md [--json]
+mb books exposure --repo . --active [--json]
+```
+
 `mb books check` runs read-only checks against a business repo. It:
 
 - detects whether `core/finance/books.md` exists and parses (including
@@ -288,6 +300,21 @@ report. It emits stable JSON with `--json`, redacts fixture internals that
 should not train operators to paste private paths or account identifiers, and
 keeps `safe_to_share: true` because the data is synthetic.
 
+`mb books exposure` checks whether bet spending is anchored in the private
+hledger journal:
+
+- resolves the private journal from `vault_location` in
+  `core/finance/books.md`;
+- runs `hledger -f <journal> check` before querying exposure;
+- queries `tag:bet=<id>` for one bet or all active bets;
+- returns aggregate gross outflow, exposure cap, remaining cap, anchor
+  presence, and transaction count;
+- withholds private hledger stderr/stdout on failures because hledger can print
+  transaction context;
+- keeps `safe_to_share: true` by omitting raw rows, payees, descriptions,
+  account names, account numbers, transaction memos, provider payloads, private
+  vault paths, and absolute business-repo paths.
+
 Exit codes:
 
 - `mb books check`: `0` when there are no error findings (info or
@@ -303,6 +330,10 @@ Exit codes:
   `1` for generation failures such as missing hledger or missing fixture;
   `2` for usage errors such as missing `--sample`, missing `--month`, or an
   invalid month.
+- `mb books exposure`: `0` when hledger can check the private journal and return
+  aggregate exposure facts, including warning states such as a missing anchor;
+  `1` for hledger, policy, journal, bet, or query errors; `2` when the operator
+  does not choose exactly one of `--bet` or `--active`.
 
 It does **not**:
 
@@ -310,7 +341,11 @@ It does **not**:
   cash-flow, or tax claims;
 - import the hledger library directly into `mb`;
 - scrape human terminal output when structured output exists;
-- read the real ledger contents inside the vault;
+- read the real ledger contents inside the vault except for the explicit
+  `mb books exposure` hledger query, which returns only aggregate bet exposure
+  facts;
+- print raw ledger rows, payees, descriptions, account details, transaction
+  memos, provider payloads, private vault paths, or finance/legal records;
 - mutate any file.
 
 Later slices may add real imports, reconciliation, month close, or

--- a/mb/mb/books.py
+++ b/mb/mb/books.py
@@ -57,6 +57,7 @@ NON_LOCAL_STORAGE_MODES = frozenset({"team-private-repo", "advanced-vault"})
 BUNDLED_FIXTURE_NAME = "acme-fixture.journal"
 DOCS_BOOKS_PATH = "docs/books.md"
 BOOKS_REPORT_SCHEMA = "1.0"
+BOOKS_EXPOSURE_SCHEMA = "1.0"
 SAMPLE_FIXTURE_LABEL = "acme-fixture"
 SAMPLE_REPORT_WARNING = "This is sample data only. It is not reading your private books."
 GITHUB_PRIVATE_WARNING = (
@@ -845,6 +846,11 @@ def _sanitize_hledger_detail(text: str, journal: Path) -> str:
     return detail[:2000]
 
 
+def _sanitize_private_journal_detail(text: str, journal: Path) -> str:
+    detail = text.strip().replace(str(journal), "private journal")
+    return detail[:2000]
+
+
 def _hledger_missing_finding() -> dict[str, Any]:
     return _finding(
         id="hledger-missing",
@@ -946,6 +952,521 @@ def _run_hledger_check(journal: Path) -> dict[str, Any] | None:
             operator_summary="The packaged sample journal did not pass hledger check.",
         )
     return None
+
+
+def _run_private_hledger_check(journal: Path) -> dict[str, Any] | None:
+    try:
+        proc = subprocess.run(
+            ["hledger", "-f", str(journal), "check"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.SubprocessError) as exc:
+        return _finding(
+            id="hledger-check-error",
+            title="hledger check could not run",
+            state="error",
+            detail=str(exc),
+            audience="informational",
+            operator_summary="Main Branch found hledger on PATH but could not run its check.",
+        )
+    if proc.returncode != 0:
+        return _finding(
+            id="hledger-check-failed",
+            title="Private books journal failed hledger check",
+            state="error",
+            detail=_sanitize_private_journal_detail(proc.stderr or proc.stdout, journal),
+            audience="operator_decision",
+            operator_summary="hledger check failed for the configured private journal.",
+        )
+    return None
+
+
+def _journal_from_policy(
+    repo: Path, fm: dict[str, Any]
+) -> tuple[Path | None, dict[str, Any] | None]:
+    raw_location = str(fm.get("vault_location") or "").strip()
+    if not raw_location:
+        raw_location = DEFAULT_BOOKS_VAULT_RELATIVE.as_posix()
+    candidate = Path(raw_location).expanduser()
+    location = candidate if candidate.is_absolute() else repo / candidate
+    journal = location if location.suffix in LEDGER_EXTENSIONS else location / "main.journal"
+    if not journal.exists():
+        return None, _finding(
+            id="books-journal-missing",
+            title="Private books journal is missing",
+            state="error",
+            detail=(
+                "The configured books vault does not contain a readable main.journal. "
+                "The private path is intentionally not shown."
+            ),
+            audience="operator_decision",
+            operator_summary="Create the private hledger journal before checking bet exposure.",
+            repair="Create main.journal inside the configured private books vault.",
+        )
+    return journal, None
+
+
+def _bet_frontmatter(repo: Path, bet_path: Path) -> tuple[dict[str, Any], dict[str, Any] | None]:
+    if not bet_path.is_absolute():
+        bet_path = repo / bet_path
+    try:
+        resolved = bet_path.resolve()
+        resolved.relative_to(repo.resolve())
+    except (OSError, ValueError):
+        return {}, _finding(
+            id="bet-path-outside-repo",
+            title="Bet path is outside the business repo",
+            state="error",
+            detail="The --bet path must point to a bet file inside the business repo.",
+            audience="operator_decision",
+            operator_summary="Choose a bet file inside this business repo.",
+        )
+    if not resolved.exists():
+        return {}, _finding(
+            id="bet-file-missing",
+            title="Bet file does not exist",
+            state="error",
+            detail="The requested bet file does not exist.",
+            audience="operator_decision",
+            operator_summary="Choose an existing bet file.",
+        )
+    fm, err = _read_frontmatter(resolved)
+    if err:
+        return {}, _finding(
+            id="bet-frontmatter-error",
+            title="Bet frontmatter does not parse",
+            state="error",
+            detail=err,
+            audience="operator_decision",
+            operator_summary="Fix the bet frontmatter before checking exposure.",
+            repair=f"Fix YAML frontmatter in {resolved.relative_to(repo).as_posix()}.",
+        )
+    return fm, None
+
+
+def _active_bet_paths(repo: Path) -> list[Path]:
+    paths: list[Path] = []
+    for path in sorted((repo / "bets").glob("*.md")):
+        fm, err = _read_frontmatter(path)
+        if err or str(fm.get("status") or "").lower() not in {"open", "paused"}:
+            continue
+        paths.append(path)
+    return paths
+
+
+def _money_path_for_bet(path: Path, fm: dict[str, Any]) -> dict[str, Any]:
+    raw = fm.get("money_path")
+    money_path = raw if isinstance(raw, dict) else {}
+    cap = money_path.get("exposure_cap")
+    exposure_cap = cap if isinstance(cap, dict) else {}
+    return {
+        "declared": isinstance(raw, dict),
+        "required": _safe_bool(money_path.get("required")),
+        "bet_id": str(money_path.get("bet_id") or path.stem).strip(),
+        "expected_bet_id": path.stem,
+        "anchor_required_before": str(money_path.get("anchor_required_before") or "").strip(),
+        "exposure_cap": {
+            "amount": exposure_cap.get("amount"),
+            "currency": str(exposure_cap.get("currency") or "").strip(),
+        }
+        if exposure_cap
+        else None,
+    }
+
+
+def _decimal_mantissa_from_number(value: Any, places: int = 2) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int | float):
+        return int(round(float(value) * (10**places)))
+    if isinstance(value, str):
+        try:
+            return int(round(float(value.replace(",", "").strip()) * (10**places)))
+        except ValueError:
+            return None
+    return None
+
+
+def _amount_parts(raw: Any) -> tuple[str, int, int] | None:
+    if not isinstance(raw, dict):
+        return None
+    quantity = raw.get("aquantity")
+    if not isinstance(quantity, dict):
+        return None
+    return (
+        str(raw.get("acommodity") or "USD"),
+        int(quantity.get("decimalMantissa") or 0),
+        int(quantity.get("decimalPlaces") or 0),
+    )
+
+
+def _posting_amounts(posting: dict[str, Any]) -> list[tuple[str, int, int]]:
+    raw_amounts = posting.get("pamount")
+    amounts: list[tuple[str, int, int]] = []
+    if isinstance(raw_amounts, list):
+        for raw in raw_amounts:
+            parts = _amount_parts(raw)
+            if parts is not None:
+                amounts.append(parts)
+    else:
+        parts = _amount_parts(raw_amounts)
+        if parts is not None:
+            amounts.append(parts)
+    return amounts
+
+
+def _transaction_postings(txn: Any) -> list[dict[str, Any]]:
+    if isinstance(txn, dict):
+        postings = txn.get("tpostings") or txn.get("postings") or []
+        if isinstance(postings, list):
+            return [posting for posting in postings if isinstance(posting, dict)]
+    return []
+
+
+def _gross_outflow_from_transactions(transactions: list[Any]) -> tuple[str, int, int, bool]:
+    expenses: list[tuple[str, int, int]] = []
+    negative_fallback: list[tuple[str, int, int]] = []
+    for txn in transactions:
+        for posting in _transaction_postings(txn):
+            account = str(posting.get("paccount") or posting.get("account") or "").lower()
+            for commodity, mantissa, places in _posting_amounts(posting):
+                if account.startswith("expenses") and mantissa > 0:
+                    expenses.append((commodity, mantissa, places))
+                elif mantissa < 0:
+                    negative_fallback.append((commodity, abs(mantissa), places))
+    selected = expenses or negative_fallback
+    if not selected:
+        return "USD", 0, 2, False
+    commodity = selected[0][0]
+    places = selected[0][2]
+    mixed = any(item[0] != commodity or item[2] != places for item in selected)
+    total = sum(item[1] for item in selected if item[0] == commodity and item[2] == places)
+    return commodity, total, places, mixed
+
+
+def _run_hledger_print(
+    journal: Path, bet_id: str
+) -> tuple[list[Any] | None, dict[str, Any] | None]:
+    try:
+        proc = subprocess.run(
+            ["hledger", "-n", "-f", str(journal), "print", f"tag:bet={bet_id}", "-O", "json"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.SubprocessError) as exc:
+        return None, _finding(
+            id="hledger-exposure-query-error",
+            title="hledger exposure query could not run",
+            state="error",
+            detail=str(exc),
+            audience="informational",
+            operator_summary="Main Branch found hledger on PATH but could not query bet exposure.",
+        )
+    if proc.returncode != 0:
+        return None, _finding(
+            id="hledger-exposure-query-failed",
+            title="hledger exposure query failed",
+            state="error",
+            detail=_sanitize_private_journal_detail(proc.stderr or proc.stdout, journal),
+            audience="operator_decision",
+            operator_summary="hledger could not query transactions for this bet anchor.",
+        )
+    try:
+        parsed = json.loads(proc.stdout or "[]")
+    except json.JSONDecodeError as exc:
+        return None, _finding(
+            id="hledger-exposure-json-invalid",
+            title="hledger exposure query returned invalid JSON",
+            state="error",
+            detail=f"hledger returned invalid JSON: {exc}",
+            audience="informational",
+            operator_summary="hledger returned output Main Branch could not parse.",
+        )
+    if not isinstance(parsed, list):
+        return None, _finding(
+            id="hledger-exposure-json-shape",
+            title="hledger exposure query returned an unexpected shape",
+            state="error",
+            detail="Expected a JSON list of transactions.",
+            audience="informational",
+            operator_summary="hledger returned an unexpected JSON shape.",
+        )
+    return parsed, None
+
+
+def _exposure_error(
+    *,
+    repo: Path,
+    mode: str,
+    findings: list[dict[str, Any]],
+) -> dict[str, Any]:
+    state = _max_state([finding["state"] for finding in findings])
+    return {
+        "ok": False,
+        "state": state,
+        "schema_version": BOOKS_EXPOSURE_SCHEMA,
+        "safe_to_share": True,
+        "repo": str(repo),
+        "mode": mode,
+        "summary": findings[0]["operator_summary"] if findings else "Exposure check failed.",
+        "exposures": [],
+        "findings": findings,
+        "errors": [
+            finding["operator_summary"] for finding in findings if finding["state"] == "error"
+        ],
+        "warnings": [
+            finding["operator_summary"] for finding in findings if finding["state"] == "warn"
+        ],
+        "redactions": {
+            "private_paths": True,
+            "account_identifiers": True,
+            "payees": True,
+            "transaction_memos": True,
+            "raw_rows": True,
+        },
+    }
+
+
+def _bet_exposure(
+    repo: Path, journal: Path, bet_path: Path
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    fm, frontmatter_error = _bet_frontmatter(repo, bet_path)
+    if frontmatter_error is not None:
+        return {}, [frontmatter_error]
+    resolved = bet_path if bet_path.is_absolute() else repo / bet_path
+    rel = resolved.resolve().relative_to(repo.resolve()).as_posix()
+    money_path = _money_path_for_bet(resolved, fm)
+    bet_id = str(money_path.get("bet_id") or resolved.stem)
+    findings: list[dict[str, Any]] = []
+    if not money_path["declared"]:
+        findings.append(
+            _finding(
+                id="bet-money-path-missing",
+                title="Bet has no MoneyPath metadata",
+                state="warn",
+                detail=f"{rel} does not declare money_path metadata.",
+                audience="operator_decision",
+                operator_summary=(
+                    "Add money_path metadata to the bet before treating exposure as committed."
+                ),
+            )
+        )
+    elif money_path["bet_id"] != money_path["expected_bet_id"]:
+        findings.append(
+            _finding(
+                id="bet-money-path-id-mismatch",
+                title="Bet MoneyPath id does not match filename",
+                state="warn",
+                detail=f"{rel} declares a bet_id that does not match the file stem.",
+                audience="operator_decision",
+                operator_summary="Align money_path.bet_id with the bet filename stem.",
+            )
+        )
+    transactions, query_error = _run_hledger_print(journal, bet_id)
+    if query_error is not None:
+        return {}, [*findings, query_error]
+    assert transactions is not None
+    commodity, gross_mantissa, places, mixed = _gross_outflow_from_transactions(transactions)
+    if mixed:
+        findings.append(
+            _finding(
+                id="bet-exposure-mixed-commodities",
+                title="Bet exposure uses mixed commodities",
+                state="warn",
+                detail="The anchored hledger transactions use multiple commodities or precisions.",
+                audience="operator_decision",
+                operator_summary=(
+                    "Review the private journal; Main Branch is reporting the first commodity only."
+                ),
+            )
+        )
+    if not transactions and money_path["required"]:
+        findings.append(
+            _finding(
+                id="bet-anchor-missing",
+                title="No hledger transactions carry the bet anchor",
+                state="warn",
+                detail=f"No private journal transactions matched tag:bet={bet_id}.",
+                audience="operator_decision",
+                operator_summary=(
+                    "Add the bet tag to private ledger transactions before execution spend."
+                ),
+            )
+        )
+    cap = money_path.get("exposure_cap")
+    remaining = None
+    cap_amount = None
+    if isinstance(cap, dict):
+        cap_currency = str(cap.get("currency") or commodity or "USD")
+        cap_places = places or 2
+        cap_mantissa = _decimal_mantissa_from_number(cap.get("amount"), cap_places)
+        if cap_mantissa is not None:
+            cap_amount = _amount_from_parts(
+                commodity=cap_currency,
+                mantissa=cap_mantissa,
+                places=cap_places,
+            )
+            if cap_currency == commodity:
+                remaining = _amount_from_parts(
+                    commodity=commodity,
+                    mantissa=cap_mantissa - gross_mantissa,
+                    places=cap_places,
+                )
+            else:
+                findings.append(
+                    _finding(
+                        id="bet-exposure-cap-currency-mismatch",
+                        title="Bet exposure cap currency does not match ledger commodity",
+                        state="warn",
+                        detail="Exposure cap currency differs from the anchored ledger commodity.",
+                        audience="operator_decision",
+                        operator_summary=(
+                            "Review the cap currency before relying on remaining exposure."
+                        ),
+                    )
+                )
+    exposure = {
+        "path": rel,
+        "title": str(fm.get("title") or resolved.stem),
+        "status": str(fm.get("status") or ""),
+        "money_path": money_path,
+        "anchor": {
+            "tag": f"bet:{bet_id}",
+            "query": f"tag:bet={bet_id}",
+            "present": bool(transactions),
+            "transaction_count": len(transactions),
+        },
+        "totals": {
+            "gross_outflow": _amount_from_parts(
+                commodity=commodity,
+                mantissa=gross_mantissa,
+                places=places or 2,
+            ),
+            "exposure_cap": cap_amount,
+            "remaining_cap": remaining,
+        },
+    }
+    return exposure, findings
+
+
+def exposure(
+    *,
+    repo: str | Path = ".",
+    bet: str | Path | None = None,
+    active: bool = False,
+) -> dict[str, Any]:
+    """Return privacy-bounded bet exposure totals from a private hledger journal."""
+    repo_path = Path(repo).resolve()
+    mode = "active" if active else "single"
+    fm, policy_findings = _detect_books_policy(repo_path)
+    error_findings = [finding for finding in policy_findings if finding["state"] == "error"]
+    if error_findings:
+        return _exposure_error(repo=repo_path, mode=mode, findings=error_findings)
+    if not _has_books_policy(repo_path):
+        return _exposure_error(
+            repo=repo_path,
+            mode=mode,
+            findings=[
+                _finding(
+                    id="books-policy-missing",
+                    title="No bookkeeping policy file",
+                    state="error",
+                    detail="core/finance/books.md is required for exposure checks.",
+                    audience="operator_decision",
+                    operator_summary="Add core/finance/books.md before checking bet exposure.",
+                )
+            ],
+        )
+    if not shutil.which("hledger"):
+        return _exposure_error(
+            repo=repo_path,
+            mode=mode,
+            findings=[
+                _finding(
+                    id="hledger-missing",
+                    title="hledger is not installed",
+                    state="error",
+                    detail="hledger is required for private books exposure checks.",
+                    audience="informational",
+                    operator_summary="Install hledger before checking bet exposure.",
+                    repair="Install hledger from https://hledger.org/install.html",
+                )
+            ],
+        )
+    journal, journal_error = _journal_from_policy(repo_path, fm)
+    if journal_error is not None or journal is None:
+        return _exposure_error(
+            repo=repo_path, mode=mode, findings=[journal_error] if journal_error else []
+        )
+    check_error = _run_private_hledger_check(journal)
+    if check_error is not None:
+        return _exposure_error(repo=repo_path, mode=mode, findings=[check_error])
+    bet_paths = _active_bet_paths(repo_path) if active else [Path(bet)] if bet else []
+    if not bet_paths:
+        return _exposure_error(
+            repo=repo_path,
+            mode=mode,
+            findings=[
+                _finding(
+                    id="bet-selection-missing",
+                    title="No bet selected",
+                    state="error",
+                    detail="Pass --bet bets/YYYY-MM-DD-slug.md or --active.",
+                    audience="operator_decision",
+                    operator_summary="Choose one bet or request active bet exposure.",
+                )
+            ],
+        )
+    exposures: list[dict[str, Any]] = []
+    findings: list[dict[str, Any]] = [
+        _finding(
+            id="hledger-check-passed",
+            title="Private books journal passed hledger check",
+            state="ok",
+            detail="hledger check passed for the configured private journal.",
+            audience="informational",
+            operator_summary="Private journal passed hledger check.",
+        )
+    ]
+    for bet_path in bet_paths:
+        exposure_item, bet_findings = _bet_exposure(repo_path, journal, bet_path)
+        if exposure_item:
+            exposures.append(exposure_item)
+        findings.extend(bet_findings)
+    state = _max_state([finding["state"] for finding in findings])
+    errors = [finding["operator_summary"] for finding in findings if finding["state"] == "error"]
+    warnings = [finding["operator_summary"] for finding in findings if finding["state"] == "warn"]
+    transaction_count = sum(
+        int((item.get("anchor") or {}).get("transaction_count") or 0) for item in exposures
+    )
+    return {
+        "ok": state != "error",
+        "state": state,
+        "schema_version": BOOKS_EXPOSURE_SCHEMA,
+        "safe_to_share": True,
+        "repo": str(repo_path),
+        "mode": mode,
+        "summary": (
+            f"Checked {len(exposures)} bet exposure record(s); "
+            f"{transaction_count} anchored transaction(s) found."
+        ),
+        "exposures": exposures,
+        "findings": findings,
+        "errors": errors,
+        "warnings": warnings,
+        "redactions": {
+            "private_paths": True,
+            "account_identifiers": True,
+            "payees": True,
+            "transaction_memos": True,
+            "raw_rows": True,
+        },
+    }
 
 
 def _hledger_amount(raw: Any, *, owed: bool = False) -> dict[str, Any]:
@@ -1812,6 +2333,36 @@ def render_status(report: dict[str, Any]) -> None:
             typer.echo(f"           - {item}")
     typer.echo("")
     typer.echo("Run `mb books doctor --plan` for safe setup repair guidance.")
+
+
+def render_exposure(report: dict[str, Any]) -> None:
+    """Print ``mb books exposure`` for humans."""
+    import typer
+
+    typer.echo(f"mb books exposure — {report.get('summary', '')}")
+    for item in report.get("exposures") or []:
+        anchor = item.get("anchor") or {}
+        totals = item.get("totals") or {}
+        gross = totals.get("gross_outflow") or {}
+        remaining = totals.get("remaining_cap") or {}
+        typer.echo(
+            f"  - {item.get('path')}: {anchor.get('transaction_count', 0)} transaction(s), "
+            f"gross outflow {gross.get('display', '$0.00')}"
+        )
+        if remaining:
+            typer.echo(f"    remaining cap: {remaining.get('display')}")
+    if report.get("warnings"):
+        typer.echo("")
+        typer.echo("Warnings:")
+        for warning in report["warnings"]:
+            typer.echo(f"  - {warning}")
+    if report.get("errors"):
+        typer.echo("")
+        typer.echo("Errors:")
+        for error in report["errors"]:
+            typer.echo(f"  - {error}")
+    typer.echo("")
+    typer.echo("Private paths, payees, account names, memos, and raw rows are redacted.")
 
 
 def render_sample_monthly_report(report: dict[str, Any]) -> None:

--- a/mb/mb/books.py
+++ b/mb/mb/books.py
@@ -846,11 +846,6 @@ def _sanitize_hledger_detail(text: str, journal: Path) -> str:
     return detail[:2000]
 
 
-def _sanitize_private_journal_detail(text: str, journal: Path) -> str:
-    detail = text.strip().replace(str(journal), "private journal")
-    return detail[:2000]
-
-
 def _hledger_missing_finding() -> dict[str, Any]:
     return _finding(
         id="hledger-missing",
@@ -963,23 +958,38 @@ def _run_private_hledger_check(journal: Path) -> dict[str, Any] | None:
             timeout=15,
             check=False,
         )
-    except (FileNotFoundError, subprocess.SubprocessError) as exc:
+    except (FileNotFoundError, subprocess.SubprocessError):
         return _finding(
             id="hledger-check-error",
             title="hledger check could not run",
             state="error",
-            detail=str(exc),
+            detail=(
+                "hledger could not run the private journal check. Private command output "
+                "is withheld because it can contain ledger context."
+            ),
             audience="informational",
             operator_summary="Main Branch found hledger on PATH but could not run its check.",
+            repair=(
+                "Run hledger check inside the private books vault and keep details out "
+                "of the business repo."
+            ),
         )
     if proc.returncode != 0:
         return _finding(
             id="hledger-check-failed",
             title="Private books journal failed hledger check",
             state="error",
-            detail=_sanitize_private_journal_detail(proc.stderr or proc.stdout, journal),
+            detail=(
+                "hledger check failed for the configured private journal. Private command "
+                "output is withheld because it can contain payees, account names, memos, "
+                "or raw ledger rows."
+            ),
             audience="operator_decision",
             operator_summary="hledger check failed for the configured private journal.",
+            repair=(
+                "Run hledger check inside the private books vault and repair the private "
+                "journal there."
+            ),
         )
     return None
 
@@ -1158,23 +1168,35 @@ def _run_hledger_print(
             timeout=15,
             check=False,
         )
-    except (FileNotFoundError, subprocess.SubprocessError) as exc:
+    except (FileNotFoundError, subprocess.SubprocessError):
         return None, _finding(
             id="hledger-exposure-query-error",
             title="hledger exposure query could not run",
             state="error",
-            detail=str(exc),
+            detail=(
+                "hledger could not run the private exposure query. Private command output "
+                "is withheld because it can contain ledger context."
+            ),
             audience="informational",
             operator_summary="Main Branch found hledger on PATH but could not query bet exposure.",
+            repair=(
+                "Run the tag query inside the private books vault and keep details out "
+                "of the business repo."
+            ),
         )
     if proc.returncode != 0:
         return None, _finding(
             id="hledger-exposure-query-failed",
             title="hledger exposure query failed",
             state="error",
-            detail=_sanitize_private_journal_detail(proc.stderr or proc.stdout, journal),
+            detail=(
+                "hledger could not query transactions for this bet anchor. Private command "
+                "output is withheld because it can contain payees, account names, memos, "
+                "or raw ledger rows."
+            ),
             audience="operator_decision",
             operator_summary="hledger could not query transactions for this bet anchor.",
+            repair="Check the bet tag and journal syntax inside the private books vault.",
         )
     try:
         parsed = json.loads(proc.stdout or "[]")
@@ -1211,7 +1233,7 @@ def _exposure_error(
         "state": state,
         "schema_version": BOOKS_EXPOSURE_SCHEMA,
         "safe_to_share": True,
-        "repo": str(repo),
+        "repo": {"label": "business repo", "path_exposed": False},
         "mode": mode,
         "summary": findings[0]["operator_summary"] if findings else "Exposure check failed.",
         "exposures": [],
@@ -1449,7 +1471,7 @@ def exposure(
         "state": state,
         "schema_version": BOOKS_EXPOSURE_SCHEMA,
         "safe_to_share": True,
-        "repo": str(repo_path),
+        "repo": {"label": "business repo", "path_exposed": False},
         "mode": mode,
         "summary": (
             f"Checked {len(exposures)} bet exposure record(s); "

--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -1201,6 +1201,53 @@ def books_doctor_cmd(
     raise typer.Exit(0)
 
 
+@books_app.command("exposure")
+def books_exposure_cmd(
+    repo: str = typer.Option(".", "--repo", help="Business repo to inspect."),
+    bet: str = typer.Option("", "--bet", help="Repo-relative bet file to check."),
+    active: bool = typer.Option(False, "--active", help="Check all active bets."),
+    json_out: bool = typer.Option(False, "--json", help="Machine-readable output."),
+) -> None:
+    """Check privacy-bounded hledger exposure totals for bet anchors."""
+    if bool(bet) == active:
+        message = "mb books exposure: choose exactly one of --bet or --active"
+        payload = {
+            "ok": False,
+            "state": "error",
+            "schema_version": books_mod.BOOKS_EXPOSURE_SCHEMA,
+            "safe_to_share": True,
+            "summary": message,
+            "exposures": [],
+            "errors": [message],
+            "warnings": [],
+            "findings": [],
+        }
+        if json_out:
+            typer.echo(
+                _json_payload(
+                    payload,
+                    command="mb books exposure",
+                    schema_name="mainbranch.books.exposure.result",
+                )
+            )
+        else:
+            typer.echo(message, err=True)
+        raise typer.Exit(2)
+
+    report = books_mod.exposure(repo=repo, bet=bet or None, active=active)
+    if json_out:
+        typer.echo(
+            _json_payload(
+                report,
+                command="mb books exposure",
+                schema_name="mainbranch.books.exposure.result",
+            )
+        )
+    else:
+        books_mod.render_exposure(report)
+    raise typer.Exit(0 if report["ok"] else 1)
+
+
 @books_report_app.command("monthly")
 def books_report_monthly_cmd(
     sample: bool = typer.Option(

--- a/mb/mb/status.py
+++ b/mb/mb/status.py
@@ -45,6 +45,8 @@ LAST_STATUS_SEEN_GITIGNORE_ENTRY = ".mb/last-status-seen.json"
 STALE_DECISION_DAYS = 14
 STALE_RESEARCH_DAYS = 45
 ACTIVE_BET_STATUSES = {"open", "paused"}
+BET_APPETITE_TIERS = {"trivial", "small", "material", "strategic"}
+BET_SIGNAL_COMPARATORS = {"<", "<=", "==", ">=", ">", "!="}
 ACTIVE_PUSH_STATUSES = {"planned", "active", "paused"}
 COMPLETED_PUSH_STATUSES = {"completed"}
 LIVE_OFFER_STATUSES = {"accepted", "graduated", "running", "scaling"}
@@ -1226,6 +1228,8 @@ def _bet_summary(repo: Path, path: Path) -> dict[str, Any]:
     channels = meta.get("channels")
     if not isinstance(channels, list):
         channels = []
+    money_path = _bet_money_path_summary(meta, path)
+    exit_criteria = _bet_exit_criteria(meta, today=date.today())
     return {
         "path": rel,
         "title": _title_from_markdown(path),
@@ -1233,13 +1237,187 @@ def _bet_summary(repo: Path, path: Path) -> dict[str, Any]:
         "opened": opened.isoformat() if opened else "",
         "deadline": deadline.isoformat() if deadline else "",
         "appetite": str(meta.get("appetite", "") or ""),
+        "appetite_tier": _bet_appetite_tier(meta),
         "hypothesis": str(meta.get("hypothesis", "") or ""),
         "metric": str(meta.get("metric", "") or ""),
         "target": str(meta.get("target", "") or ""),
         "result": str(meta.get("result", "") or ""),
+        "money_path": money_path,
+        "exit_criteria": exit_criteria,
         "public": bool(meta.get("public", False)),
         "channels": [str(channel) for channel in channels if isinstance(channel, str)],
         "updated_at": datetime.fromtimestamp(path.stat().st_mtime).isoformat(timespec="seconds"),
+    }
+
+
+def _bet_appetite_tier(meta: dict[str, Any]) -> str:
+    tier = meta.get("appetite_tier")
+    if isinstance(tier, str) and tier.strip().lower() in BET_APPETITE_TIERS:
+        return tier.strip().lower()
+    appetite = meta.get("appetite")
+    if isinstance(appetite, str) and appetite.strip().lower() in BET_APPETITE_TIERS:
+        return appetite.strip().lower()
+    return ""
+
+
+def _bet_money_path_summary(meta: dict[str, Any], path: Path) -> dict[str, Any]:
+    raw = meta.get("money_path")
+    if not isinstance(raw, dict):
+        return {
+            "declared": False,
+            "required": False,
+            "bet_id": "",
+            "expected_bet_id": path.stem,
+            "anchor_required_before": "",
+            "exposure_cap": None,
+        }
+    exposure_cap = raw.get("exposure_cap")
+    cap: dict[str, Any] | None = None
+    if isinstance(exposure_cap, dict):
+        amount = exposure_cap.get("amount")
+        currency = exposure_cap.get("currency")
+        cap = {
+            "amount": amount
+            if isinstance(amount, int | float) and not isinstance(amount, bool)
+            else None,
+            "currency": str(currency or "").strip(),
+        }
+    return {
+        "declared": True,
+        "required": bool(raw.get("required")),
+        "bet_id": str(raw.get("bet_id") or "").strip(),
+        "expected_bet_id": path.stem,
+        "anchor_required_before": str(raw.get("anchor_required_before") or "").strip(),
+        "exposure_cap": cap,
+    }
+
+
+def _bet_metric_values(meta: dict[str, Any]) -> dict[str, Any]:
+    for key in ("metrics", "metric_values"):
+        value = meta.get(key)
+        if isinstance(value, dict):
+            return {str(metric): current for metric, current in value.items()}
+    return {}
+
+
+def _coerce_signal_number(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int | float):
+        return float(value)
+    if isinstance(value, str):
+        cleaned = value.strip().replace(",", "")
+        if not cleaned:
+            return None
+        try:
+            return float(cleaned)
+        except ValueError:
+            return None
+    return None
+
+
+def _compare_signal(current: Any, comparator: str, threshold: Any) -> bool | None:
+    current_number = _coerce_signal_number(current)
+    threshold_number = _coerce_signal_number(threshold)
+    if current_number is not None and threshold_number is not None:
+        if comparator == "<":
+            return current_number < threshold_number
+        if comparator == "<=":
+            return current_number <= threshold_number
+        if comparator == "==":
+            return current_number == threshold_number
+        if comparator == ">=":
+            return current_number >= threshold_number
+        if comparator == ">":
+            return current_number > threshold_number
+        if comparator == "!=":
+            return current_number != threshold_number
+    if comparator == "==":
+        return str(current) == str(threshold)
+    if comparator == "!=":
+        return str(current) != str(threshold)
+    return None
+
+
+def _evaluate_bet_signal(
+    signal: dict[str, Any],
+    *,
+    metrics: dict[str, Any],
+    today: date,
+) -> dict[str, Any]:
+    metric = str(signal.get("metric") or "").strip()
+    comparator = str(signal.get("comparator") or "").strip()
+    threshold = signal.get("threshold")
+    by_date = _parse_explicit_date(signal.get("by"))
+    current_value = metrics.get(metric) if metric else None
+    base = {
+        "id": str(signal.get("id") or metric or "unnamed-signal"),
+        "metric": metric,
+        "comparator": comparator,
+        "threshold": threshold,
+        "current_value": current_value,
+        "by": by_date.isoformat() if by_date else str(signal.get("by") or ""),
+        "action": str(signal.get("action") or ""),
+        "triggered": False,
+        "status": "not_triggered",
+    }
+    if not metric or comparator not in BET_SIGNAL_COMPARATORS:
+        base["status"] = "invalid"
+        return base
+    if metric not in metrics:
+        base["status"] = "missing_metric"
+        return base
+    matched = _compare_signal(current_value, comparator, threshold)
+    if matched is None:
+        base["status"] = "invalid"
+        return base
+    if by_date is not None and by_date > today:
+        base["status"] = "pending"
+        return base
+    base["triggered"] = bool(matched)
+    base["status"] = "triggered" if matched else "not_triggered"
+    return base
+
+
+def _bet_exit_criteria(meta: dict[str, Any], *, today: date) -> dict[str, Any]:
+    rubric = meta.get("kill_rubric")
+    if not isinstance(rubric, dict):
+        return {
+            "declared": False,
+            "missing": True,
+            "failure_signals": [],
+            "double_down_signals": [],
+            "triggered_failure_signals": [],
+            "triggered_double_down_signals": [],
+            "metrics_source": "",
+        }
+    metrics = _bet_metric_values(meta)
+    failure_signals = [
+        _evaluate_bet_signal(signal, metrics=metrics, today=today)
+        for signal in rubric.get("failure_signals") or []
+        if isinstance(signal, dict)
+    ]
+    double_down_signals = [
+        _evaluate_bet_signal(signal, metrics=metrics, today=today)
+        for signal in rubric.get("double_down_signals") or []
+        if isinstance(signal, dict)
+    ]
+    return {
+        "declared": True,
+        "missing": False,
+        "failure_signals": failure_signals,
+        "double_down_signals": double_down_signals,
+        "triggered_failure_signals": [
+            signal for signal in failure_signals if signal.get("triggered")
+        ],
+        "triggered_double_down_signals": [
+            signal for signal in double_down_signals if signal.get("triggered")
+        ],
+        "metrics_source": "frontmatter.metrics"
+        if "metrics" in meta
+        else "frontmatter.metric_values"
+        if "metric_values" in meta
+        else "",
     }
 
 
@@ -1270,11 +1448,37 @@ def _bets(repo: Path) -> dict[str, Any]:
             due_item = dict(item)
             due_item["days_until_deadline"] = days_until
             due_soon.append(due_item)
+    missing_exit_criteria = [
+        item for item in active if (item.get("exit_criteria") or {}).get("missing")
+    ]
+    triggered_failure_signals = [
+        {
+            "path": item.get("path"),
+            "title": item.get("title"),
+            "signal": signal,
+        }
+        for item in active
+        for signal in (item.get("exit_criteria") or {}).get("triggered_failure_signals", [])
+    ]
+    triggered_double_down_signals = [
+        {
+            "path": item.get("path"),
+            "title": item.get("title"),
+            "signal": signal,
+        }
+        for item in active
+        for signal in (item.get("exit_criteria") or {}).get("triggered_double_down_signals", [])
+    ]
     return {
         "active": active[:5],
         "due_soon": due_soon[:5],
         "overdue": overdue[:5],
         "recent": bet_items[:5],
+        "exit_criteria": {
+            "missing": missing_exit_criteria[:5],
+            "triggered_failure_signals": triggered_failure_signals[:10],
+            "triggered_double_down_signals": triggered_double_down_signals[:10],
+        },
     }
 
 

--- a/mb/mb/validate.py
+++ b/mb/mb/validate.py
@@ -375,7 +375,7 @@ def _check_one(path: Path, schema: dict[str, Any]) -> dict[str, Any]:
     if primitive == "push":
         _check_push_frontmatter(path, fm, errors)
     elif primitive == "bet":
-        _check_bet_frontmatter(fm, errors)
+        _check_bet_frontmatter(path, fm, errors, warnings)
     elif primitive == "playbook":
         _check_playbook_frontmatter(path, fm, errors)
     elif primitive == "legacy-campaign":
@@ -388,9 +388,125 @@ def _check_one(path: Path, schema: dict[str, Any]) -> dict[str, Any]:
     return {"path": str(path), "ok": not errors, "errors": errors, "warnings": warnings}
 
 
-def _check_bet_frontmatter(fm: dict[str, Any], errors: list[str]) -> None:
+BET_APPETITE_TIERS = {"trivial", "small", "material", "strategic"}
+BET_ANCHOR_REQUIRED_BEFORE = {"planning", "execution", "spend", "launch", "none"}
+BET_SIGNAL_COMPARATORS = {"<", "<=", "==", ">=", ">", "!="}
+BET_SIGNAL_ACTIONS = {"kill", "double_down", "review"}
+BET_OWNER_REF_RE = re.compile(r"^core/team/[a-z0-9][a-z0-9-]*\.md$")
+
+
+def _check_bet_frontmatter(
+    path: Path,
+    fm: dict[str, Any],
+    errors: list[str],
+    warnings: list[str],
+) -> None:
     if "linked_pushes" not in fm and "linked_campaigns" not in fm:
         errors.append("missing key: linked_pushes or linked_campaigns")
+    appetite_tier = fm.get("appetite_tier")
+    if appetite_tier is not None and appetite_tier not in BET_APPETITE_TIERS:
+        warnings.append(
+            f"appetite_tier={appetite_tier!r} is not one of {sorted(BET_APPETITE_TIERS)}"
+        )
+    _check_bet_owner(fm, warnings)
+    _check_bet_money_path(path, fm, warnings)
+    _check_bet_kill_rubric(fm, warnings)
+
+
+def _check_bet_owner(fm: dict[str, Any], warnings: list[str]) -> None:
+    owner = fm.get("owner")
+    if owner is None:
+        return
+    if not isinstance(owner, str) or not owner.strip():
+        warnings.append("owner should be a team member slug matching core/team/<slug>.md")
+        return
+    owner_ref = owner.strip()
+    if "/" in owner_ref and not BET_OWNER_REF_RE.fullmatch(owner_ref):
+        warnings.append("owner path references should use core/team/<slug>.md")
+
+
+def _check_bet_money_path(path: Path, fm: dict[str, Any], warnings: list[str]) -> None:
+    money_path = fm.get("money_path")
+    if money_path is None:
+        return
+    if not isinstance(money_path, dict):
+        warnings.append("money_path must be a mapping when declared")
+        return
+    required = money_path.get("required")
+    if required is not None and not isinstance(required, bool):
+        warnings.append("money_path.required should be true or false")
+    bet_id = money_path.get("bet_id")
+    if bet_id is not None:
+        if not isinstance(bet_id, str) or not bet_id.strip():
+            warnings.append("money_path.bet_id must be a non-empty string")
+        elif bet_id.strip() != path.stem:
+            warnings.append("money_path.bet_id should match the bet filename stem")
+    elif required is True:
+        warnings.append("money_path.required is true but money_path.bet_id is missing")
+    anchor_required_before = money_path.get("anchor_required_before")
+    if (
+        anchor_required_before is not None
+        and anchor_required_before not in BET_ANCHOR_REQUIRED_BEFORE
+    ):
+        warnings.append(
+            "money_path.anchor_required_before should be one of "
+            f"{sorted(BET_ANCHOR_REQUIRED_BEFORE)}"
+        )
+    exposure_cap = money_path.get("exposure_cap")
+    if exposure_cap is None:
+        return
+    if not isinstance(exposure_cap, dict):
+        warnings.append("money_path.exposure_cap must be a mapping with amount and currency")
+        return
+    amount = exposure_cap.get("amount")
+    if not isinstance(amount, int | float) or isinstance(amount, bool) or amount < 0:
+        warnings.append("money_path.exposure_cap.amount must be a non-negative number")
+    currency = exposure_cap.get("currency")
+    if not isinstance(currency, str) or not currency.strip():
+        warnings.append("money_path.exposure_cap.currency must be a non-empty string")
+
+
+def _check_bet_kill_rubric(fm: dict[str, Any], warnings: list[str]) -> None:
+    rubric = fm.get("kill_rubric")
+    if rubric is None:
+        return
+    if not isinstance(rubric, dict):
+        warnings.append("kill_rubric must be a mapping when declared")
+        return
+    for key, expected_action in (
+        ("failure_signals", "kill"),
+        ("double_down_signals", "double_down"),
+    ):
+        signals = rubric.get(key)
+        if signals is None:
+            continue
+        if not isinstance(signals, list):
+            warnings.append(f"kill_rubric.{key} must be a list")
+            continue
+        for index, signal in enumerate(signals):
+            prefix = f"kill_rubric.{key}[{index}]"
+            if not isinstance(signal, dict):
+                warnings.append(f"{prefix} must be a mapping")
+                continue
+            for field in ("id", "metric", "comparator", "threshold", "action"):
+                if field not in signal:
+                    warnings.append(f"{prefix}.{field} is missing")
+            comparator = signal.get("comparator")
+            if comparator is not None and comparator not in BET_SIGNAL_COMPARATORS:
+                warnings.append(
+                    f"{prefix}.comparator={comparator!r} is not one of "
+                    f"{sorted(BET_SIGNAL_COMPARATORS)}"
+                )
+            action = signal.get("action")
+            if action is not None and action not in BET_SIGNAL_ACTIONS:
+                warnings.append(
+                    f"{prefix}.action={action!r} is not one of {sorted(BET_SIGNAL_ACTIONS)}"
+                )
+            elif action is not None and action != expected_action:
+                warnings.append(f"{prefix}.action is usually {expected_action!r}")
+            threshold = signal.get("threshold")
+            if threshold is not None and not isinstance(threshold, int | float | str):
+                warnings.append(f"{prefix}.threshold should be a number or string")
 
 
 def _require_non_empty_string(fm: dict[str, Any], key: str, errors: list[str]) -> None:

--- a/mb/tests/test_books.py
+++ b/mb/tests/test_books.py
@@ -354,6 +354,11 @@ def _hledger_report_dispatcher(monkeypatch: pytest.MonkeyPatch) -> list[list[str
 def _hledger_exposure_dispatcher(
     monkeypatch: pytest.MonkeyPatch,
     transactions: list[dict[str, Any]],
+    *,
+    check_returncode: int = 0,
+    check_stderr: str = "",
+    query_returncode: int = 0,
+    query_stderr: str = "",
 ) -> list[list[str]]:
     real_run = subprocess.run
     seen: list[list[str]] = []
@@ -369,9 +374,13 @@ def _hledger_exposure_dispatcher(
         seen.append(argv)
         if argv and Path(str(argv[0])).name == "hledger":
             if "check" in argv:
-                return _FakeCompleted()
+                return _FakeCompleted(returncode=check_returncode, stderr=check_stderr)
             if "print" in argv:
-                return _FakeCompleted(json.dumps(transactions))
+                return _FakeCompleted(
+                    json.dumps(transactions),
+                    returncode=query_returncode,
+                    stderr=query_stderr,
+                )
             raise AssertionError(f"unexpected hledger command: {argv}")
         return real_run(args, *rest, **kwargs)
 
@@ -558,6 +567,7 @@ tags: []
     assert "PRIVATE PAYEE" not in result.output
     assert "PRIVATE_ACCOUNT" not in result.output
     assert "PRIVATE_LEDGER_CONTENT" not in result.output
+    assert str(repo) not in result.output
     assert str(repo / ".mb/private/books") not in result.output
 
 
@@ -600,6 +610,121 @@ tags: []
         "Add the bet tag to private ledger transactions before execution spend."
         in payload["warnings"]
     )
+
+
+def test_books_exposure_redacts_private_hledger_check_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _init_business_repo(tmp_path)
+    _write_books_policy_with_private_journal(repo)
+    _write(
+        repo / "bets/2026-05-16-private.md",
+        """---
+status: open
+opened: 2026-05-16
+deadline: 2026-05-30
+appetite: small
+money_path:
+  required: true
+  bet_id: 2026-05-16-private
+linked_decisions: []
+linked_research: []
+linked_pushes: []
+linked_outcomes: []
+public: false
+channels: []
+tags: []
+---
+# Private
+""",
+    )
+    private_stderr = (
+        "PRIVATE PAYEE\nAssets:Bank:PRIVATE_ACCOUNT\nmemo: PRIVATE_MEMO\n2026-05-16 raw ledger row"
+    )
+    monkeypatch.setattr("mb.books.shutil.which", lambda name: "/fake/hledger")
+    _hledger_exposure_dispatcher(monkeypatch, [], check_returncode=1, check_stderr=private_stderr)
+
+    result = runner.invoke(
+        app,
+        [
+            "books",
+            "exposure",
+            "--repo",
+            str(repo),
+            "--bet",
+            "bets/2026-05-16-private.md",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 1, result.output
+    payload = json.loads(result.output)
+    assert payload["findings"][0]["id"] == "hledger-check-failed"
+    assert "Private command output is withheld" in payload["findings"][0]["detail"]
+    assert "PRIVATE PAYEE" not in result.output
+    assert "PRIVATE_ACCOUNT" not in result.output
+    assert "PRIVATE_MEMO" not in result.output
+    assert "2026-05-16 raw ledger row" not in result.output
+    assert str(repo) not in result.output
+
+
+def test_books_exposure_redacts_private_hledger_query_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _init_business_repo(tmp_path)
+    _write_books_policy_with_private_journal(repo)
+    _write(
+        repo / "bets/2026-05-16-private.md",
+        """---
+status: open
+opened: 2026-05-16
+deadline: 2026-05-30
+appetite: small
+money_path:
+  required: true
+  bet_id: 2026-05-16-private
+linked_decisions: []
+linked_research: []
+linked_pushes: []
+linked_outcomes: []
+public: false
+channels: []
+tags: []
+---
+# Private
+""",
+    )
+    private_stderr = (
+        "PRIVATE PAYEE\n"
+        "Expenses:Marketing:PRIVATE_ACCOUNT\n"
+        "memo: PRIVATE_MEMO\n"
+        "2026-05-16 raw ledger row"
+    )
+    monkeypatch.setattr("mb.books.shutil.which", lambda name: "/fake/hledger")
+    _hledger_exposure_dispatcher(monkeypatch, [], query_returncode=1, query_stderr=private_stderr)
+
+    result = runner.invoke(
+        app,
+        [
+            "books",
+            "exposure",
+            "--repo",
+            str(repo),
+            "--bet",
+            "bets/2026-05-16-private.md",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 1, result.output
+    payload = json.loads(result.output)
+    assert payload["findings"][1]["id"] == "hledger-exposure-query-failed"
+    assert "Private command output is withheld" in payload["findings"][1]["detail"]
+    assert "PRIVATE PAYEE" not in result.output
+    assert "PRIVATE_ACCOUNT" not in result.output
+    assert "PRIVATE_MEMO" not in result.output
+    assert "2026-05-16 raw ledger row" not in result.output
+    assert str(repo) not in result.output
 
 
 def test_books_status_json_reports_missing_hledger_and_vault(

--- a/mb/tests/test_books.py
+++ b/mb/tests/test_books.py
@@ -351,6 +351,50 @@ def _hledger_report_dispatcher(monkeypatch: pytest.MonkeyPatch) -> list[list[str
     return seen
 
 
+def _hledger_exposure_dispatcher(
+    monkeypatch: pytest.MonkeyPatch,
+    transactions: list[dict[str, Any]],
+) -> list[list[str]]:
+    real_run = subprocess.run
+    seen: list[list[str]] = []
+
+    class _FakeCompleted:
+        def __init__(self, stdout: str = "", returncode: int = 0, stderr: str = "") -> None:
+            self.returncode = returncode
+            self.stdout = stdout
+            self.stderr = stderr
+
+    def _dispatch(args: Any, *rest: Any, **kwargs: Any) -> Any:
+        argv = list(args) if isinstance(args, (list, tuple)) else [args]
+        seen.append(argv)
+        if argv and Path(str(argv[0])).name == "hledger":
+            if "check" in argv:
+                return _FakeCompleted()
+            if "print" in argv:
+                return _FakeCompleted(json.dumps(transactions))
+            raise AssertionError(f"unexpected hledger command: {argv}")
+        return real_run(args, *rest, **kwargs)
+
+    monkeypatch.setattr("mb.books.subprocess.run", _dispatch)
+    return seen
+
+
+def _write_books_policy_with_private_journal(repo: Path) -> None:
+    _write(
+        repo / "core/finance/books.md",
+        """---
+type: books
+ledger: hledger
+storage_mode: solo-local
+vault_location: ".mb/private/books/"
+---
+
+# Books
+""",
+    )
+    _write(repo / ".mb/private/books/main.journal", "; PRIVATE_LEDGER_CONTENT\n")
+
+
 def test_books_check_fixture_runs_when_hledger_available(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -423,6 +467,139 @@ def test_books_check_unsafe_paths_warn_does_not_exit_one(tmp_path: Path) -> None
     result = runner.invoke(app, ["books", "check", str(repo)])
     assert result.exit_code == 0, result.output
     assert "WARN" in result.output
+
+
+def test_books_exposure_json_reports_safe_bet_totals(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _init_business_repo(tmp_path)
+    _write_books_policy_with_private_journal(repo)
+    _write(
+        repo / "bets/2026-05-16-offer-test.md",
+        """---
+status: open
+opened: 2026-05-16
+deadline: 2026-05-30
+appetite: 2 weeks
+appetite_tier: small
+hypothesis: If we sharpen the offer, calls will increase.
+metric: qualified_calls
+target: 3 qualified calls
+result: ''
+money_path:
+  required: true
+  bet_id: 2026-05-16-offer-test
+  exposure_cap:
+    amount: 500
+    currency: USD
+  anchor_required_before: execution
+linked_decisions: []
+linked_research: []
+linked_pushes: []
+linked_outcomes: []
+public: false
+channels: []
+tags: []
+---
+# Offer test
+""",
+    )
+    transactions = [
+        {
+            "tdescription": "PRIVATE PAYEE",
+            "tpostings": [
+                {
+                    "paccount": "Assets:Bank:PRIVATE_ACCOUNT",
+                    "pamount": [
+                        {
+                            "acommodity": "USD",
+                            "aquantity": {"decimalMantissa": -12500, "decimalPlaces": 2},
+                        }
+                    ],
+                },
+                {
+                    "paccount": "Expenses:Marketing",
+                    "pamount": [
+                        {
+                            "acommodity": "USD",
+                            "aquantity": {"decimalMantissa": 12500, "decimalPlaces": 2},
+                        }
+                    ],
+                },
+            ],
+        }
+    ]
+    monkeypatch.setattr("mb.books.shutil.which", lambda name: "/fake/hledger")
+    seen = _hledger_exposure_dispatcher(monkeypatch, transactions)
+
+    result = runner.invoke(
+        app,
+        [
+            "books",
+            "exposure",
+            "--repo",
+            str(repo),
+            "--bet",
+            "bets/2026-05-16-offer-test.md",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["mb_command"] == "mb books exposure"
+    assert payload["result_schema"]["name"] == "mainbranch.books.exposure.result"
+    exposure = payload["exposures"][0]
+    assert exposure["anchor"]["present"] is True
+    assert exposure["anchor"]["transaction_count"] == 1
+    assert exposure["totals"]["gross_outflow"]["display"] == "$125.00"
+    assert exposure["totals"]["remaining_cap"]["display"] == "$375.00"
+    assert any("tag:bet=2026-05-16-offer-test" in call for call in seen)
+    assert "PRIVATE PAYEE" not in result.output
+    assert "PRIVATE_ACCOUNT" not in result.output
+    assert "PRIVATE_LEDGER_CONTENT" not in result.output
+    assert str(repo / ".mb/private/books") not in result.output
+
+
+def test_books_exposure_active_warns_when_required_anchor_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _init_business_repo(tmp_path)
+    _write_books_policy_with_private_journal(repo)
+    _write(
+        repo / "bets/2026-05-16-anchor-missing.md",
+        """---
+status: open
+opened: 2026-05-16
+deadline: 2026-05-30
+appetite: small
+money_path:
+  required: true
+  bet_id: 2026-05-16-anchor-missing
+linked_decisions: []
+linked_research: []
+linked_pushes: []
+linked_outcomes: []
+public: false
+channels: []
+tags: []
+---
+# Anchor missing
+""",
+    )
+    monkeypatch.setattr("mb.books.shutil.which", lambda name: "/fake/hledger")
+    _hledger_exposure_dispatcher(monkeypatch, [])
+
+    result = runner.invoke(app, ["books", "exposure", "--repo", str(repo), "--active", "--json"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["state"] == "warn"
+    assert payload["exposures"][0]["anchor"]["present"] is False
+    assert (
+        "Add the bet tag to private ledger transactions before execution spend."
+        in payload["warnings"]
+    )
 
 
 def test_books_status_json_reports_missing_hledger_and_vault(

--- a/mb/tests/test_status.py
+++ b/mb/tests/test_status.py
@@ -2244,6 +2244,106 @@ def test_status_brain_includes_active_bets(tmp_path: Path) -> None:
     assert brain["bets"]["active"][0]["deadline"] == deadline.isoformat()
 
 
+def test_status_brain_evaluates_declared_bet_exit_signals(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    (repo / "bets").mkdir(parents=True)
+    (repo / "bets" / "2026-05-16-offer-test.md").write_text(
+        (
+            "---\n"
+            "status: open\n"
+            "opened: 2026-05-16\n"
+            "deadline: 2026-05-30\n"
+            "appetite: 2 weeks\n"
+            "appetite_tier: small\n"
+            "hypothesis: Offer sharpening creates qualified calls.\n"
+            "metric: qualified_calls\n"
+            "target: 3 qualified calls\n"
+            "result: ''\n"
+            "metrics:\n"
+            "  qualified_calls: 2\n"
+            "  cost_per_qualified_call: 120\n"
+            "money_path:\n"
+            "  required: true\n"
+            "  bet_id: 2026-05-16-offer-test\n"
+            "  exposure_cap:\n"
+            "    amount: 500\n"
+            "    currency: USD\n"
+            "  anchor_required_before: execution\n"
+            "kill_rubric:\n"
+            "  failure_signals:\n"
+            "    - id: no-qualified-calls\n"
+            "      metric: qualified_calls\n"
+            "      comparator: <\n"
+            "      threshold: 3\n"
+            "      by: 2026-05-01\n"
+            "      action: kill\n"
+            "  double_down_signals:\n"
+            "    - id: profitable-signal\n"
+            "      metric: cost_per_qualified_call\n"
+            "      comparator: <=\n"
+            "      threshold: 150\n"
+            "      action: double_down\n"
+            "linked_decisions: []\n"
+            "linked_research: []\n"
+            "linked_pushes: []\n"
+            "linked_outcomes: []\n"
+            "public: false\n"
+            "channels: []\n"
+            "tags: []\n"
+            "---\n\n"
+            "# Offer test\n"
+        ),
+        encoding="utf-8",
+    )
+
+    brain = status_mod._brain(repo)
+
+    bet = brain["bets"]["active"][0]
+    assert bet["appetite_tier"] == "small"
+    assert bet["money_path"]["required"] is True
+    assert bet["exit_criteria"]["declared"] is True
+    assert bet["exit_criteria"]["triggered_failure_signals"][0]["id"] == "no-qualified-calls"
+    assert bet["exit_criteria"]["triggered_double_down_signals"][0]["id"] == "profitable-signal"
+    assert brain["bets"]["exit_criteria"]["triggered_failure_signals"][0]["path"] == (
+        "bets/2026-05-16-offer-test.md"
+    )
+
+
+def test_status_brain_flags_active_bets_without_predeclared_exit_criteria(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    (repo / "bets").mkdir(parents=True)
+    (repo / "bets" / "2026-05-16-open.md").write_text(
+        (
+            "---\n"
+            "status: open\n"
+            "opened: 2026-05-16\n"
+            "deadline: 2026-05-30\n"
+            "appetite: 2 weeks\n"
+            "hypothesis: A test creates calls.\n"
+            "metric: calls\n"
+            "target: 3 calls\n"
+            "result: ''\n"
+            "linked_decisions: []\n"
+            "linked_research: []\n"
+            "linked_pushes: []\n"
+            "linked_outcomes: []\n"
+            "public: false\n"
+            "channels: []\n"
+            "tags: []\n"
+            "---\n\n"
+            "# Open bet\n"
+        ),
+        encoding="utf-8",
+    )
+
+    brain = status_mod._brain(repo)
+
+    assert brain["bets"]["active"][0]["exit_criteria"]["missing"] is True
+    assert brain["bets"]["exit_criteria"]["missing"][0]["path"] == "bets/2026-05-16-open.md"
+
+
 def test_status_frontmatter_reader_accepts_delimiter_whitespace(tmp_path: Path) -> None:
     path = tmp_path / "note.md"
     path.write_text("--- \nstatus: open\n--- \n# Note\n", encoding="utf-8")

--- a/mb/tests/test_validate.py
+++ b/mb/tests/test_validate.py
@@ -198,6 +198,112 @@ def test_validate_accepts_canonical_bet_linked_pushes_without_legacy_campaigns(
     assert bet["errors"] == []
 
 
+def test_validate_accepts_bet_money_path_and_kill_rubric(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "bets" / "2026-05-16-offer-test.md",
+        (
+            "---\n"
+            "status: open\n"
+            "opened: 2026-05-16\n"
+            "deadline: 2026-05-30\n"
+            "appetite: 2 weeks\n"
+            "appetite_tier: small\n"
+            "hypothesis: If we sharpen the offer, calls will increase.\n"
+            "metric: qualified_calls\n"
+            "target: 3 qualified calls\n"
+            "result: ''\n"
+            "money_path:\n"
+            "  required: true\n"
+            "  bet_id: 2026-05-16-offer-test\n"
+            "  exposure_cap:\n"
+            "    amount: 500\n"
+            "    currency: USD\n"
+            "  anchor_required_before: execution\n"
+            "kill_rubric:\n"
+            "  failure_signals:\n"
+            "    - id: no-qualified-calls\n"
+            "      metric: qualified_calls\n"
+            "      comparator: <\n"
+            "      threshold: 3\n"
+            "      by: 2026-05-30\n"
+            "      action: kill\n"
+            "  double_down_signals:\n"
+            "    - id: profitable-signal\n"
+            "      metric: cost_per_qualified_call\n"
+            "      comparator: <=\n"
+            "      threshold: 150\n"
+            "      action: double_down\n"
+            "linked_decisions: []\n"
+            "linked_research: []\n"
+            "linked_pushes: []\n"
+            "linked_outcomes: []\n"
+            "public: false\n"
+            "channels: []\n"
+            "tags: []\n"
+            "---\n"
+            "# Offer test\n"
+        ),
+    )
+
+    report = run(path=str(tmp_path))
+
+    assert report["ok"] is True
+    bet = next(file for file in report["files"] if file["schema"] == "bets")
+    assert bet["errors"] == []
+    assert bet["warnings"] == []
+
+
+def test_validate_warns_on_malformed_bet_money_path_without_failing(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "bets" / "2026-05-16-offer-test.md",
+        (
+            "---\n"
+            "status: open\n"
+            "opened: 2026-05-16\n"
+            "deadline: 2026-05-30\n"
+            "appetite: 2 weeks\n"
+            "appetite_tier: giant\n"
+            "hypothesis: If we sharpen the offer, calls will increase.\n"
+            "metric: qualified_calls\n"
+            "target: 3 qualified calls\n"
+            "result: ''\n"
+            "money_path:\n"
+            "  required: true\n"
+            "  bet_id: wrong-id\n"
+            "  exposure_cap:\n"
+            "    amount: -1\n"
+            "    currency: ''\n"
+            "kill_rubric:\n"
+            "  failure_signals:\n"
+            "    - id: no-qualified-calls\n"
+            "      metric: qualified_calls\n"
+            "      comparator: near\n"
+            "      threshold: 3\n"
+            "      action: kill\n"
+            "linked_decisions: []\n"
+            "linked_research: []\n"
+            "linked_pushes: []\n"
+            "linked_outcomes: []\n"
+            "public: false\n"
+            "channels: []\n"
+            "tags: []\n"
+            "---\n"
+            "# Offer test\n"
+        ),
+    )
+
+    report = run(path=str(tmp_path))
+
+    assert report["ok"] is True
+    bet = next(file for file in report["files"] if file["schema"] == "bets")
+    assert bet["errors"] == []
+    assert any("appetite_tier" in warning for warning in bet["warnings"])
+    assert any("money_path.bet_id should match" in warning for warning in bet["warnings"])
+    assert any(
+        "kill_rubric.failure_signals[0].comparator" in warning for warning in bet["warnings"]
+    )
+
+
 def test_validate_keeps_legacy_bet_campaign_links_readable(tmp_path: Path) -> None:
     _write(
         tmp_path / "bets" / "2026-05-08-legacy.md",


### PR DESCRIPTION
## Summary

Adds privacy-bounded bet exposure support so bets can declare appetite tiers, MoneyPath anchors, exposure caps, and pre-committed kill/double-down rubrics. `mb books exposure` reports aggregate hledger exposure totals only, and `mb status --json` surfaces declared bet exit-signal facts without inventing criteria.

## Linked issue

Closes #644

## Why

Bets need to be financially real without pulling private books into the public business repo. This gives agents and operators safe commitment metadata, cap checks, and status facts while preserving the existing finance privacy boundary.

## Commits by concern

- [ ] Each commit body bullet-lists the changes in that commit
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`

Commit list:
- `af4496a [add] MAIN-399 privacy-bounded bet exposure`
- `ac33bcf [fix] MAIN-399 redact private exposure failures`

## Validation

Pre-push gate from repo root:

```bash
scripts/check.sh
```

- [x] Level 1 static: `scripts/check.sh` passes
- [x] Level 2 CLI contract: focused Typer/CliRunner tests, exit codes, and `--json` behavior are covered by `scripts/check.sh`
- [ ] Level 3 package/install smoke (if packaging touched)
- [x] Level 4 fixture repo (if init/onboard/status/start/update touched)
- [ ] Level 5 runtime smoke / dogfood harness / simulation-tier (if runtime, first-run, skill discovery, or release validation touched)
- [x] SKILL.md <=500 lines (if any skill touched)
- [ ] Package-visible release gate evidence before tag/publish (if preparing a release)
- [ ] Supply-chain review (if `.github/workflows/`, `.github/dependabot.yml`, `mb/pyproject.toml` deps, or `id-token`/`permissions` blocks touched — see [docs/supply-chain-policy.md](../docs/supply-chain-policy.md))

Level 1 static: `scripts/check.sh` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: `ruff format/check passed; mypy reported no issues`.
Level 2 CLI contract: `pytest tests/test_books.py::test_books_exposure_json_reports_safe_bet_totals tests/test_books.py::test_books_exposure_active_warns_when_required_anchor_missing tests/test_books.py::test_books_exposure_redacts_private_hledger_check_failure tests/test_books.py::test_books_exposure_redacts_private_hledger_query_failure -q` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: `4 passed`.
Level 2 CLI contract: `pytest tests/test_books.py -q` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: `45 passed`.
Level 2 CLI contract: `scripts/check.sh` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: `737 passed`, including books exposure, validation, and status tests.
Level 4 fixture repo: `python3 -m mb onboard --yes ...; python3 -m mb doctor; python3 -m mb status --json --peek; python3 -m mb start --json; python3 -m mb validate` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` with source checkout on `PYTHONPATH` — exit: 0 — log: `mb start result_status=ok; mb validate: nothing to check yet`.
Level 3 package/install smoke: not required because package metadata, dependencies, bundled data, and console entrypoints did not change.
Level 5 runtime/manual note: no Claude Code TUI smoke was run because this branch changes CLI behavior and `/mb-bet` guidance text, not runtime discovery or first-run slash-command invocation; `mb skill validate --all --json` passed through `scripts/check.sh`.
Supply-chain review: not required because workflows, dependency metadata, Dependabot, and permissions blocks did not change.

## Success metric

An active bet can declare a MoneyPath anchor, exposure cap, appetite tier, and exit rubric; `mb validate` warns on malformed new fields without breaking legacy bets; `mb books exposure --json` returns only aggregate cap/exposure/count facts; and `mb status --json` surfaces missing or triggered declared exit criteria.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [ ] N/A — change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [x] No
- [ ] Yes — migration note below

## Public / private boundary

No private operator strategy, machine-specific paths, raw ledger rows, payees, descriptions, account details, provider payloads, or finance/legal records are committed or emitted by the new exposure result. Private hledger stdout/stderr is withheld from share-safe exposure errors, and the exposure payload does not include absolute business-repo paths. Owner/team validation remains soft until #633 lands, and the branch does not add newsletter-specific behavior.
