### PR TITLE
[fix] Redact provider smoke secrets

### DIFF
--- a/.claude/skills/mb-setup/references/nano-banana-setup.md
+++ b/.claude/skills/mb-setup/references/nano-banana-setup.md
@@ -41,8 +41,12 @@ If you don't have `env.sh` yet, run `/mb-setup` first or create it manually:
 
 ```bash
 mkdir -p ~/.config/vip
-echo 'export GOOGLE_API_KEY="your-key"' >> ~/.config/vip/env.sh
+chmod 700 ~/.config/vip
+$EDITOR ~/.config/vip/env.sh
 ```
+
+Add the `export GOOGLE_API_KEY="..."` line in the editor. Do not paste API keys
+into chat, screenshots, or terminal output.
 
 ### 3. Add MCP Server
 
@@ -122,7 +126,7 @@ Free tier includes limited image generation. Paid credits scale to hundreds of i
 
 **"MCP not found"** — Run `claude mcp add` command again. Make sure npx is available (`which npx`).
 
-**"Invalid API key"** — Check `echo $GOOGLE_API_KEY`. Verify at [aistudio.google.com](https://aistudio.google.com).
+**"Invalid API key"** — Check presence without printing the value: `test -n "$GOOGLE_API_KEY" && echo "GOOGLE_API_KEY is set" || echo "GOOGLE_API_KEY is not set"`. Verify at [aistudio.google.com](https://aistudio.google.com).
 
 **"Rate limited"** — Free tier has limits. Wait or upgrade to paid credits.
 

--- a/.claude/skills/mb-think/references/gemini-setup.md
+++ b/.claude/skills/mb-think/references/gemini-setup.md
@@ -97,10 +97,10 @@ echo 'source ~/.config/vip/env.sh' >> ~/.zshrc
 ## Verify It's Working
 
 ```bash
-echo $GOOGLE_API_KEY
+test -n "$GOOGLE_API_KEY" && echo "GOOGLE_API_KEY is set" || echo "GOOGLE_API_KEY is not set"
 ```
 
-Should show your key (not empty).
+This should confirm the key is set without printing the value.
 
 **In Claude Code:**
 
@@ -123,7 +123,8 @@ Gemini Deep Research is now available in /mb-think.
 **"Key not found"**
 - Did you `source ~/.config/vip/env.sh`?
 - Or restart your terminal?
-- Check: `echo $GOOGLE_API_KEY`
+- Check presence without printing the value:
+  `test -n "$GOOGLE_API_KEY" && echo "GOOGLE_API_KEY is set" || echo "GOOGLE_API_KEY is not set"`
 
 **"Invalid API key"**
 - Verify key at [aistudio.google.com/apikey](https://aistudio.google.com/apikey)

--- a/.claude/skills/mb-think/references/grok-setup.md
+++ b/.claude/skills/mb-think/references/grok-setup.md
@@ -226,7 +226,9 @@ Still useful for finding popular/viral posts that have been indexed.
 
 **SDK: "ModuleNotFoundError: xai_sdk"** — Run `pip install xai-sdk`
 
-**SDK: "Invalid API key"** — Check `echo $XAI_API_KEY` and verify at [console.x.ai](https://console.x.ai)
+**SDK: "Invalid API key"** — Check presence without printing the value:
+`test -n "$XAI_API_KEY" && echo "XAI_API_KEY is set" || echo "XAI_API_KEY is not set"`,
+then verify at [console.x.ai](https://console.x.ai)
 
 **SDK: "num_sources_used: 0"** — You're using REST API, not SDK. Make sure you're using `x_search()` tool.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,13 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   `AGENTS.md` alignment while keeping Codex support experimental and
   CLI-first. Refs MAIN-397, #636.
 
+### Fixed
+
+- Redacted provider upstream error messages before storing or printing
+  `mb connect test` validation results, and tightened setup references so
+  provider smoke evidence records readiness without printing credential values.
+  Refs MAIN-413, #658.
+
 ## [0.3.26] - 2026-05-16
 
 v0.3.26 packages the first-run trust batch after v0.3.25. It tightens setup,

--- a/docs/session-excavation.md
+++ b/docs/session-excavation.md
@@ -93,6 +93,8 @@ Read the session in passes. Do not start with broad product wishes.
    restart requirements, OAuth scope confusion, direct provider writes, secret
    handling, account mutation, and whether a provider path is `mb`-native,
    runtime-native, plugin-based, CLI/API-key-based, or unsupported.
+   Provider smoke evidence should record presence, exit status, and readiness
+   facts, never credential values or token prefixes.
 8. **Roadmap signal:** useful future direction that should not become an
    immediate support claim.
 

--- a/mb/mb/connect.py
+++ b/mb/mb/connect.py
@@ -7,6 +7,7 @@ import importlib
 import json
 import os
 import platform
+import re
 import shutil
 import subprocess
 import sys
@@ -29,8 +30,22 @@ SENSITIVE_KEY_PARTS = ("token", "secret", "password", "credential", "api_key", "
 SAFE_METADATA_KEYS = {"token_type", "token_scope", "api_token_type"}
 CONNECT_SCOPES = {"repo", "user"}
 VALIDATION_TIMEOUT_SECONDS = 8
+SECRET_REPLACEMENT = "<redacted>"
 CommandRunner = Callable[..., dict[str, Any]]
 Which = Callable[[str], str | None]
+
+SECRET_ASSIGNMENT_RE = re.compile(
+    r"(?i)\b"
+    r"(api[_ -]?key|access[_ -]?token|refresh[_ -]?token|token|secret|password|"
+    r"credential|authorization)"
+    r"([ \t]*[:=][ \t]*)(bearer[ \t]+)?([^\s,;]+)"
+)
+SECRET_PHRASE_RE = re.compile(
+    r"(?i)\b"
+    r"((?:api[_ -]?key|access[_ -]?token|refresh[_ -]?token|authorization)[ \t]+)"
+    r"(bearer[ \t]+)?([A-Za-z0-9._~+/=-]{12,})"
+)
+BEARER_SECRET_RE = re.compile(r"(?i)\bbearer[ \t]+[^\s,;]+")
 
 
 class ConfigBoundaryError(ValueError):
@@ -1306,7 +1321,45 @@ def _provider_error_summary(provider_name: str, upstream: dict[str, Any]) -> str
     return f"{provider_name} validation could not complete."
 
 
-def _extract_upstream_errors(payload: Any) -> tuple[list[str], list[str]]:
+def _header_secret_candidates(headers: dict[str, str] | None) -> list[str]:
+    if not headers:
+        return []
+    candidates: list[str] = []
+    for key, value in headers.items():
+        key_text = str(key).lower()
+        value_text = str(value)
+        if not value_text:
+            continue
+        if key_text == "authorization":
+            candidates.append(value_text)
+            parts = value_text.split()
+            if len(parts) >= 2 and parts[0].lower() == "bearer":
+                candidates.append(parts[1])
+        elif any(part in key_text for part in SENSITIVE_KEY_PARTS):
+            candidates.append(value_text)
+    return candidates
+
+
+def _redact_sensitive_text(value: Any, secret_values: tuple[str, ...] = ()) -> str:
+    text = str(value)
+    for secret in sorted(set(secret_values), key=len, reverse=True):
+        if len(secret) >= 4:
+            text = text.replace(secret, SECRET_REPLACEMENT)
+    text = BEARER_SECRET_RE.sub(f"Bearer {SECRET_REPLACEMENT}", text)
+    text = SECRET_ASSIGNMENT_RE.sub(
+        lambda match: f"{match.group(1)}{match.group(2)}{match.group(3) or ''}{SECRET_REPLACEMENT}",
+        text,
+    )
+    text = SECRET_PHRASE_RE.sub(
+        lambda match: f"{match.group(1)}{match.group(2) or ''}{SECRET_REPLACEMENT}",
+        text,
+    )
+    return text
+
+
+def _extract_upstream_errors(
+    payload: Any, secret_values: tuple[str, ...] = ()
+) -> tuple[list[str], list[str]]:
     if not isinstance(payload, dict):
         return [], []
     codes: list[str] = []
@@ -1323,7 +1376,7 @@ def _extract_upstream_errors(payload: Any) -> tuple[list[str], list[str]]:
             if code not in {None, ""}:
                 codes.append(str(code))
             if message:
-                messages.append(str(message))
+                messages.append(_redact_sensitive_text(message, secret_values))
     return codes, messages
 
 
@@ -1335,6 +1388,7 @@ def _http_get_json(
     endpoint_family: str = "unknown",
 ) -> dict[str, Any]:
     request = urllib.request.Request(url, headers=headers or {})
+    secret_values = tuple(_header_secret_candidates(headers))
     upstream: dict[str, Any] = {
         "endpoint_family": endpoint_family,
         "http_status": None,
@@ -1355,7 +1409,7 @@ def _http_get_json(
         if body:
             with suppress(json.JSONDecodeError, UnicodeDecodeError):
                 payload = json.loads(body.decode("utf-8"))
-        codes, messages = _extract_upstream_errors(payload)
+        codes, messages = _extract_upstream_errors(payload, secret_values)
         upstream.update(
             {
                 "http_status": int(exc.code),
@@ -1384,7 +1438,7 @@ def _http_get_json(
     if body:
         with suppress(json.JSONDecodeError, UnicodeDecodeError):
             payload = json.loads(body.decode("utf-8"))
-    codes, messages = _extract_upstream_errors(payload)
+    codes, messages = _extract_upstream_errors(payload, secret_values)
     upstream.update(
         {
             "http_status": status,

--- a/mb/tests/test_connect.py
+++ b/mb/tests/test_connect.py
@@ -895,7 +895,7 @@ def test_connect_test_records_invalid_provider_without_leaking_secret(
                 "http_status": 403,
                 "response_received": True,
                 "error_codes": ["9109"],
-                "error_messages": ["Invalid access token"],
+                "error_messages": ["Invalid access token <redacted>"],
                 "safe_to_share": True,
             },
         },
@@ -912,7 +912,36 @@ def test_connect_test_records_invalid_provider_without_leaking_secret(
     assert payload["validation"]["upstream"]["endpoint_family"] == "cloudflare_user_token_verify"
     assert payload["validation"]["upstream"]["http_status"] == 403
     assert payload["validation"]["upstream"]["error_codes"] == ["9109"]
+    assert payload["validation"]["upstream"]["error_messages"] == [
+        "Invalid access token <redacted>"
+    ]
     assert "cf-secret-token" not in result.stdout
+
+
+def test_connect_redacts_secret_material_from_provider_errors() -> None:
+    codes, messages = connect_mod._extract_upstream_errors(
+        {
+            "errors": [
+                {
+                    "code": "bad_auth",
+                    "message": "Invalid access token cf-secret-token for request",
+                },
+                {"message": "Authorization: Bearer sk-live-secret"},
+                {"message": "api_key=plain-secret-value"},
+            ]
+        },
+        secret_values=("cf-secret-token", "sk-live-secret", "plain-secret-value"),
+    )
+
+    serialized = json.dumps({"codes": codes, "messages": messages})
+    assert "cf-secret-token" not in serialized
+    assert "sk-live-secret" not in serialized
+    assert "plain-secret-value" not in serialized
+    assert messages == [
+        "Invalid access token <redacted> for request",
+        "Authorization: Bearer <redacted>",
+        "api_key=<redacted>",
+    ]
 
 
 def test_connect_test_routes_cloudflare_account_tokens_to_account_endpoint(


### PR DESCRIPTION
## Summary

- Redact secret-like provider upstream error messages before `mb connect test` stores or prints validation results.
- Remove setup guidance that told users to echo provider API keys into terminal output.
- Add session-excavation guidance that provider smoke evidence should record readiness facts without credential values or token prefixes.

## Scope

In scope: MAIN-413 secret-safe provider smoke cleanup, provider setup references, and regression coverage.

Out of scope: new provider adapters, provider mutation flows, and connector implementation.

## Validation

- `cd mb && pytest tests/test_connect.py -q`
- `scripts/check.sh`
- secret echo scan: `rg` found no remaining direct API-key echo guidance in public docs/skills.

## Public / Private Boundary

No private provider credentials, local paths, transcript content, or customer/member details were added.

Closes #658
Refs MAIN-413