### PR TITLE
[fix] Repair Claude start wiring in worktrees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,10 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   `mb connect test` validation results, and tightened setup references so
   provider smoke evidence records readiness without printing credential values.
   Refs MAIN-413, #658.
+- Tightened Claude Code worktree repair so missing project-local `/mb-start`
+  wiring is reported as missing Main Branch start wiring, `mb start --json`
+  points to `mb doctor repair --plan` / `--apply`, and doctor repair restores
+  the bridge in a fresh worktree fixture. Refs MAIN-410, #655.
 
 ## [0.3.26] - 2026-05-16
 

--- a/mb/mb/_data/templates/CLAUDE.md.tmpl
+++ b/mb/mb/_data/templates/CLAUDE.md.tmpl
@@ -70,8 +70,8 @@ If `/mb-start` is not discoverable or Claude Code reports `Unknown command:
 repair options with `mb doctor repair --plan`, then ask before running any
 write/apply command such as `mb skill link --repo .`, `mb skill repair --repo .
 --apply`, `mb doctor repair --apply`, or `mb update`. After repairing skill
-wiring, tell the operator to restart Claude Code from this repo and try
-`/mb-start` again.
+wiring, tell the operator: "I repaired missing Main Branch start wiring in this
+business folder; restart Claude Code from this repo and try `/mb-start` again."
 
 If `mb status --json --peek` reports `update.severity` as `recommended` or
 `required`, make that the only recommendation before business routing. Name the

--- a/mb/mb/doctor.py
+++ b/mb/mb/doctor.py
@@ -1404,8 +1404,8 @@ def run(path: str) -> dict[str, Any]:
                 f"mb-start skill linked via {wiring['engine_root']}"
                 if wiring_ok
                 else (
-                    "Claude Code skill links missing or shadowed. Run "
-                    "`mb skill repair --repo .`, then `mb skill link --repo .`."
+                    "Missing Main Branch start wiring for Claude Code. Run "
+                    "`mb doctor repair --plan`, then `mb doctor repair --apply`."
                 )
             ),
             "severity": "ok"
@@ -1931,8 +1931,9 @@ def repair_plan(
             "summary": (
                 "Claude Code can discover mb-start"
                 if wiring.get("ok")
-                else "project-local skill wiring is missing or shadowed"
+                else str(wiring.get("summary") or "missing Main Branch start wiring")
             ),
+            "fallback_commands": wiring.get("fallback_commands", []),
         },
         {
             "name": "personal-skill-shadowing",
@@ -1961,12 +1962,15 @@ def repair_plan(
         actions.append(
             _action(
                 id="skill-link",
-                title="Refresh project-local Claude Code skill wiring",
+                title="Restore Main Branch start wiring for Claude Code",
                 state="error",
                 mode="write",
-                command="mb skill link --repo . --json",
+                command="mb doctor repair --apply",
                 safe_to_apply=True,
-                reason="relinks bundled skills and repairs Main Branch local gitignore entries",
+                reason=(
+                    "restores project-local Main Branch start wiring so Claude Code "
+                    "can discover /mb-start from this repo or worktree"
+                ),
                 writes=[
                     ".claude/settings.local.json",
                     ".claude/skills/",
@@ -2348,12 +2352,15 @@ def repair_apply(repo: str | Path = ".", *, include_migration: bool = False) -> 
         applied.append(
             _action(
                 id="skill-link",
-                title="Refreshed project-local Claude Code skill wiring",
+                title="Restored Main Branch start wiring for Claude Code",
                 state="ok" if linked["ok"] else "error",
                 mode="write",
                 command="mb skill link --repo . --json",
                 safe_to_apply=True,
-                reason="refreshed Main Branch skill links and local settings",
+                reason=(
+                    "restored project-local Main Branch start wiring so Claude Code "
+                    "can discover /mb-start"
+                ),
                 writes=[".claude/settings.local.json", ".claude/skills/", ".gitignore"],
                 applied=True,
                 result=linked,

--- a/mb/mb/engine.py
+++ b/mb/mb/engine.py
@@ -668,6 +668,18 @@ def link_status(repo: str | Path) -> dict[str, Any]:
     shadow_report = inspect_personal_skill_conflicts(target, apply=False)
     install_diagnostics = mb_install_diagnostics()
     stale_from_other_install = bool(stale_engine_paths and install_diagnostics["multiple_installs"])
+    missing: list[str] = []
+    if not settings_has_engine:
+        missing.append("Main Branch engine access")
+    if not start_link_ok:
+        missing.append("project-local /mb-start bridge")
+    if not shadow_report["ok"]:
+        missing.append("personal Claude skill shadow")
+    summary = (
+        "Main Branch start wiring is ready."
+        if not missing
+        else "Missing Main Branch start wiring: " + ", ".join(missing) + "."
+    )
 
     return {
         "ok": settings_has_engine and start_link_ok and shadow_report["ok"],
@@ -691,6 +703,13 @@ def link_status(repo: str | Path) -> dict[str, Any]:
         "start_link_ok": start_link_ok,
         "start_link": str(start_link),
         "shadow_report": shadow_report,
+        "missing": missing,
+        "summary": summary,
+        "fallback_commands": [
+            "mb start --json",
+            "mb doctor repair --plan",
+            "mb doctor repair --apply",
+        ],
         "repair_command": "mb skill link --repo .",
     }
 

--- a/mb/mb/init.py
+++ b/mb/mb/init.py
@@ -296,8 +296,8 @@ If `/mb-start` is not discoverable or Claude Code reports `Unknown command:
 repair options with `mb doctor repair --plan`, then ask before running any
 write/apply command such as `mb skill link --repo .`, `mb skill repair --repo .
 --apply`, `mb doctor repair --apply`, or `mb update`. After repairing skill
-wiring, tell the operator to restart Claude Code from this repo and try
-`/mb-start` again.
+wiring, tell the operator: "I repaired missing Main Branch start wiring in this
+business folder; restart Claude Code from this repo and try `/mb-start` again."
 
 If `mb status --json --peek` reports `update.severity` as `recommended` or
 `required`, make that the only recommendation before business routing. Name the

--- a/mb/mb/start.py
+++ b/mb/mb/start.py
@@ -140,7 +140,7 @@ def _build_checks(
     skill_detail = (
         "mb-start skill discoverable"
         if wiring["ok"]
-        else "Claude Code mb-start skill is not wired or is shadowed"
+        else str(wiring.get("summary") or "Missing Main Branch start wiring.")
     )
     if wiring.get("stale_engine_paths"):
         current = wiring.get("current_mb") or {}
@@ -199,8 +199,8 @@ def _build_checks(
             "severity": "error",
             "detail": skill_detail,
             "repair": (
-                "Run `mb skill repair --repo .`, then `mb skill link --repo .` "
-                "from the business repo."
+                "Run `mb doctor repair --plan`, review it, then run "
+                "`mb doctor repair --apply` from the business repo."
             ),
         },
         {

--- a/mb/mb/status.py
+++ b/mb/mb/status.py
@@ -3289,7 +3289,10 @@ def _runtime(repo: Path) -> dict[str, Any]:
                 wiring_summary += " Multiple mb installs are active on PATH."
             wiring_repair = "Run `mb skill link --repo .`."
         else:
-            wiring_summary = "Claude Code skill wiring is missing or unhealthy."
+            wiring_summary = str(wiring.get("summary") or "Missing Main Branch start wiring.")
+            wiring_repair = (
+                "Run `mb doctor repair --plan`, review it, then run `mb doctor repair --apply`."
+            )
     return {
         "claude_code": {
             "found": bool(claude_path),

--- a/mb/tests/test_doctor.py
+++ b/mb/tests/test_doctor.py
@@ -9,6 +9,7 @@ from typing import Any
 from typer.testing import CliRunner
 
 from mb import doctor as doctor_mod
+from mb import engine as engine_mod
 from mb import migration_lint
 from mb.cli import app
 from mb.doctor import _detect_cloud_paths, _repo_layout_check, run
@@ -261,6 +262,48 @@ def test_doctor_repair_plan_reports_missing_checkpoint_hook(tmp_path: Path) -> N
     assert section["state"] == "warn"
     actions = {action["id"]: action for action in payload["actions"]}
     assert actions["checkpoint-hook-install"]["safe_to_apply"] is True
+
+
+def test_doctor_repair_apply_restores_missing_claude_worktree_start_wiring(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "biz"
+    init_run(path=str(repo), name="Acme")
+    doctor_mod._run_git(repo, ["config", "user.email", "test@example.com"])
+    doctor_mod._run_git(repo, ["config", "user.name", "Test User"])
+    doctor_mod._run_git(repo, ["add", "AGENTS.md", "CLAUDE.md", "README.md", "core"])
+    commit = doctor_mod._run_git(repo, ["commit", "-m", "[updated] setup -- baseline"])
+    assert commit["ok"], commit["stderr"]
+    worktree = repo / ".claude" / "worktrees" / "repair-start"
+    added = doctor_mod._run_git(repo, ["worktree", "add", "-b", "repair-start", str(worktree)])
+    assert added["ok"], added["stderr"]
+
+    assert not (worktree / ".claude" / "skills" / "mb-start" / "SKILL.md").exists()
+
+    plan = doctor_mod.repair_plan(repo=worktree)
+    section = next(section for section in plan["sections"] if section["id"] == "claude-wiring")
+    start_check = next(
+        check for check in section["checks"] if check["name"] == "project-local-skills"
+    )
+    actions = {action["id"]: action for action in plan["actions"]}
+
+    assert section["state"] == "error"
+    assert "Missing Main Branch start wiring" in start_check["summary"]
+    assert "project-local /mb-start bridge" in start_check["summary"]
+    assert start_check["fallback_commands"] == [
+        "mb start --json",
+        "mb doctor repair --plan",
+        "mb doctor repair --apply",
+    ]
+    assert actions["skill-link"]["command"] == "mb doctor repair --apply"
+    assert "/mb-start" in actions["skill-link"]["reason"]
+
+    applied = doctor_mod.repair_apply(repo=worktree)
+    applied_actions = {action["id"]: action for action in applied["applied_actions"]}
+
+    assert "skill-link" in applied_actions
+    assert (worktree / ".claude" / "skills" / "mb-start" / "SKILL.md").is_file()
+    assert engine_mod.link_status(worktree)["ok"] is True
 
 
 def test_doctor_repair_plan_reports_missing_codex_agents_md(tmp_path: Path) -> None:

--- a/mb/tests/test_start.py
+++ b/mb/tests/test_start.py
@@ -131,6 +131,26 @@ def test_start_json_omits_codex_command_when_codex_is_missing(
     assert "Install Codex CLI" not in report["next_actions"]
 
 
+def test_start_json_names_doctor_repair_when_start_wiring_is_missing(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(start_mod, "_which", _with_claude)
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+    shutil.rmtree(repo / ".claude" / "skills")
+
+    result = runner.invoke(app, ["start", "--repo", str(repo), "--json"])
+
+    assert result.exit_code == 1
+    report = json.loads(result.stdout)
+    wiring = report["runtime"]["skill_wiring"]
+    assert report["handoff_ready"] is False
+    assert "Missing Main Branch start wiring" in wiring["summary"]
+    assert "project-local /mb-start bridge" in wiring["missing"]
+    assert any("mb doctor repair --plan" in action for action in report["next_actions"])
+    assert any("mb doctor repair --apply" in action for action in report["next_actions"])
+
+
 def test_start_json_exposes_push_and_legacy_campaign_facts(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(start_mod, "_which", _with_claude)
     repo = tmp_path / "acme"


### PR DESCRIPTION
## Summary

- Report missing project-local `/mb-start` bridges as missing Main Branch start wiring.
- Point `mb start --json` and generated Claude guidance to the `mb doctor repair --plan` / `--apply` fallback.
- Add a real git worktree regression proving doctor repair restores `.claude/skills/mb-start` in a fresh Claude worktree.

## Scope

In scope: MAIN-410 Claude Code worktree wiring detection, repair copy, and regression coverage.

Out of scope: shared-skill architecture, Codex parity, and new runtime adapters.

## Validation

- `cd mb && pytest tests/test_doctor.py::test_doctor_repair_apply_restores_missing_claude_worktree_start_wiring tests/test_start.py::test_start_json_names_doctor_repair_when_start_wiring_is_missing tests/test_engine.py::test_link_status_explains_stale_engine_path_from_other_install -q`
- `cd mb && pytest tests/test_doctor.py tests/test_start.py tests/test_status.py tests/test_engine.py tests/test_json_result.py -q`
- `scripts/check.sh`

## Public / Private Boundary

No private session transcript, local customer path, member identity, or machine-specific evidence was added. The regression fixture is synthetic.

Closes #655
Refs MAIN-410