### PR TITLE
[update] Prepare v0.3.27 release

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mainbranch",
-  "version": "0.3.26",
+  "version": "0.3.27",
   "description": "Main Branch Claude Code skills for running a business from markdown files in git.",
   "author": {
     "name": "Noontide"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+## [0.3.27] - 2026-05-18
+
+v0.3.27 packages the shared-workflow and customer-call cleanup batch after
+v0.3.26. It makes `/mb-think` the first official runtime-agnostic workflow
+source, adds Codex-aligned generated guidance for that workflow, tightens
+Claude Code worktree repair and provider smoke privacy, and adds MoneyPath bet
+exit/exposure facts plus a second public-safe session excavation report.
+
 ### Added
 
 - Added the second sanitized member session excavation report, with public

--- a/mb/mb/__init__.py
+++ b/mb/mb/__init__.py
@@ -7,6 +7,6 @@ file stays a thin dispatcher.
 
 from __future__ import annotations
 
-__version__ = "0.3.26"
+__version__ = "0.3.27"
 
 __all__ = ["__version__"]

--- a/mb/pyproject.toml
+++ b/mb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mainbranch"
-version = "0.3.26"
+version = "0.3.27"
 description = "Main Branch engine umbrella - scaffolds, validates, and graphs business-as-files repos. Claude Code first, runtime-agnostic by design."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- Prepare v0.3.27 by moving the current `[Unreleased]` changelog batch into a dated release section.
- Bump package, module, and Claude plugin manifest versions from 0.3.26 to 0.3.27.

## Linked Issue
Closes #669
Refs MAIN-417

## Why
This release packages the shared-workflow and customer-call cleanup batch after v0.3.26: stale-source cleanup, shared `/mb-think` workflow source, bet exit/exposure facts, the second sanitized session excavation, Claude worktree start repair, provider smoke redaction, and pre-release alignment docs.

## Commits By Concern
- `15ca007 [update] MAIN-417 prepare v0.3.27 release`

## Validation
- Level 0 release-file preflight: `cd mb && python3 -m pytest tests/test_smoke_coverage.py::test_claude_plugin_manifest_points_at_prefixed_skills -q` — exit 0 — log `.agent/release-evidence/0.3.27/preflight.out`.
- Level 1 static: `scripts/check.sh` — exit 0 — log `.agent/release-evidence/0.3.27/check.out`; 748 tests and skill validation passed.
- Level 3 package/install: `(cd mb && python3 -m build)` + fresh venv wheel install — exit 0 — logs `.agent/release-evidence/0.3.27/build.out` and `wheel-install.out`; `mb --version` returned `mb 0.3.27`, and `mb skill list` showed all 15 bundled skills.
- Level 3 books fixture: `mb books check --fixture --json` with hledger available and with hledger hidden from PATH — both exit 0; hledger mode returned `fixture-valid`, base mode returned the documented `hledger-missing` informational fallback.
- Level 4 fixture repo: wheel-installed `mb onboard --yes`, `mb doctor`, `mb status --json --peek`, `mb start --json`, and `mb validate` — exit 0 — log `.agent/release-evidence/0.3.27/fixture-smoke.out`.
- Level 5 release-candidate dogfood: `scripts/claude-runtime-dogfood.py --install-mode wheel --wheel mb/dist/mainbranch-0.3.27-py3-none-any.whl --run-claude-print --simulation-tier prerelease_candidate --max-budget-usd 0.75` — exit 0; 11/11 heuristic checks; one shell-wrapped `mb status` permission denial, with deterministic fixture facts captured as fallback.
- Level 5 release-acceptance dogfood before tag: same wheel with `--simulation-tier release_acceptance` — exit 0; 10/11 heuristic checks; failed heuristic was evidence-capture due one shell-wrapped `mb status` permission denial; operator language passed and deterministic fixture facts were captured as fallback.

Interactive Claude Code TUI smoke was not run in this automated pass. The release evidence uses deterministic CLI, fixture, wheel, and Claude print-mode proxy evidence; print-mode is not claimed as slash-command TUI proof.

## Success Metric
v0.3.27 release files are coherent before tagging, and the release candidate wheel passes static, package, fixture, and release dogfood gates. Post-merge success is GitHub Release `oe-v0.3.27`, PyPI `mainbranch==0.3.27`, fresh PyPI install, first-run smoke, post-publish dogfood, and Linear release sync.

## CHANGELOG
Updated: `CHANGELOG.md` now has `[0.3.27] - 2026-05-18`.

## Breaking Changes
None.

## Public/Private Boundary
Release notes and validation evidence are public-safe. No raw transcript/session exports, local private paths, credentials, customer/member context, or private maintainer preference details were committed.