### PR TITLE
[update] Tighten Codex think route guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+### Changed
+
+- Tightened generated Codex `AGENTS.md` thinking-route guidance so fresh
+  business repos treat the rendered route as the Codex shell for the
+  `mb-think` shared workflow source instead of chasing engine-only workflow
+  paths. Refs MAIN-418, #671.
+
 ## [0.3.27] - 2026-05-18
 
 v0.3.27 packages the shared-workflow and customer-call cleanup batch after

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -145,7 +145,7 @@ smoke evidence exist.
 | Runtime surface | Status | Invocation | Skill/workflow discovery | Routing and automation | Observability and packaging |
 |---|---|---|---|---|---|
 | Claude Code | Supported | `mb start --repo "$repo"` prints the `claude` handoff; `mb start --launch` may launch after readiness checks. | `mb skill link --repo "$repo"` writes project-local `.claude/skills/mb-*` bridge links and `.claude/settings.local.json`. | Slash commands such as `/mb-start` and `/mb-think` own conversation and judgment; they call deterministic `mb` commands for facts. | `mb doctor`, `mb status --json`, `mb start --json`, `mb skill repair`, and runtime dogfood evidence gate release claims. Skills ship inside the Python package today. |
-| Codex CLI | Experimental | Can call deterministic `mb` commands as a subprocess when pointed at a business repo. `AGENTS.md` gives Codex a CLI-first lifecycle discovery surface for start, status, and thinking/codification routes. | Fresh `mb onboard` repos include tracked `AGENTS.md`; `mb doctor repair --plan` / `--apply` can report and refresh it. No `.agents/skills` or plugin parity is claimed yet. | Codex should run `mb status --json --peek`, `mb start --json`, and `mb doctor repair --plan` before advice, translate facts into business language, route status/thinking work through the generated lifecycle index, and ask before writes. | `mb doctor`, `mb status --json`, and `mb start --json` expose Codex readiness. Support remains experimental; generated lifecycle guidance is checked against the `mb-think` shared workflow source, but no Codex slash-command or selected-workflow support is claimed without fresh smoke evidence. |
+| Codex CLI | Experimental | Can call deterministic `mb` commands as a subprocess when pointed at a business repo. `AGENTS.md` gives Codex a CLI-first lifecycle discovery surface for start, status, and thinking/codification routes. | Fresh `mb onboard` repos include tracked `AGENTS.md`; `mb doctor repair --plan` / `--apply` can report and refresh it. No `.agents/skills` or plugin parity is claimed yet. | Codex should run `mb status --json --peek`, `mb start --json`, and `mb doctor repair --plan` before advice, translate facts into business language, route status/thinking work through the generated lifecycle index, and ask before writes. | `mb doctor`, `mb status --json`, and `mb start --json` expose Codex readiness. Support remains experimental. The natural-language thinking/codification route has fresh read-only smoke evidence through generated `AGENTS.md` guidance checked against the `mb-think` shared workflow source; this is not slash-command or skill parity. |
 | Cursor | Roadmap | Can call deterministic `mb` commands from terminal/tasks when pointed at a business repo. | No supported Cursor rules/package adapter yet. | No supported Main Branch routing contract. | Needs adapter docs, install/update rules, conflict handling, and smoke evidence. |
 | OpenClaw | Roadmap | Target public runtime surface. It should call `mb` through stable CLI/JSON commands rather than clone-era paths. | No supported OpenClaw adapter yet. | Main Branch should coexist with OpenClaw as the business repo/GitHub memory layer, not replace it. | Needs explicit adapter shape, migration notes, generated-file rules, and smoke evidence. |
 | Hermes | Roadmap | Target runtime/memory surface. It may supervise or host workflows that call packaged `mb` commands. | No supported Hermes adapter yet. | Hermes-specific routing belongs in the Hermes adapter, while `mb` remains deterministic and non-conversational. | Docs may describe internal-package expectations generically, but not as the only blessed public path. Smoke evidence is required before support claims. |
@@ -192,9 +192,10 @@ implementation is the experimental CLI-first slice: generated `AGENTS.md`,
 deterministic readiness facts, doctor repair coverage, and compact lifecycle
 discovery for start, status, and thinking/codification. The think route is
 checked against `workflows/mb-think/workflow.md` as the first official shared
-workflow source pattern. It does not claim supported Codex parity,
-slash-command parity, selected workflow support, `.agents/skills` distribution,
-or provider/publishing workflow support.
+workflow source pattern, and fresh read-only Codex smoke has covered a natural
+thinking/codification prompt from a business repo. It does not claim supported
+Codex parity, slash-command parity, `.agents/skills` distribution, or
+provider/publishing workflow support.
 
 ## Recommended setup
 

--- a/mb/mb/_data/templates/AGENTS.md.tmpl
+++ b/mb/mb/_data/templates/AGENTS.md.tmpl
@@ -174,7 +174,10 @@ This is Codex-native guidance for the existing `mb-think` shared workflow
 source. It is not a slash command, and it does not mean all Main Branch skills
 work in Codex.
 
-Engine source workflow: `workflows/mb-think/workflow.md`
+Engine source workflow: `workflows/mb-think/workflow.md`. This business repo
+does not need to contain that engine source file. Treat this generated
+`AGENTS.md` section as the Codex shell for that source unless you are explicitly
+working inside the Main Branch engine repo.
 
 Shared source required `mb` commands:
 

--- a/mb/mb/codex.py
+++ b/mb/mb/codex.py
@@ -260,7 +260,10 @@ This is Codex-native guidance for the existing `mb-think` shared workflow
 source. It is not a slash command, and it does not mean all Main Branch skills
 work in Codex.
 
-Engine source workflow: `workflows/mb-think/workflow.md`
+Engine source workflow: `workflows/mb-think/workflow.md`. This business repo
+does not need to contain that engine source file. Treat this generated
+`AGENTS.md` section as the Codex shell for that source unless you are explicitly
+working inside the Main Branch engine repo.
 
 Shared source required `mb` commands:
 

--- a/mb/mb/codex.py
+++ b/mb/mb/codex.py
@@ -72,6 +72,7 @@ REQUIRED_LIFECYCLE_GUIDANCE = (
     "## Codex Status Workflow",
     "## Codex Think Route",
     f"Engine source workflow: `{CODEX_THINK_SOURCE_WORKFLOW}`",
+    "does not need to contain that engine source file",
     "Shared source required `mb` commands",
     "Shared source required JSON fact paths",
     "Shared source gates",

--- a/mb/mb/workflows.py
+++ b/mb/mb/workflows.py
@@ -554,11 +554,12 @@ Runtime support: `codex_cli: experimental_shell`
 Approval gates: {_inline_code_list(workflow.approval_gates)}
 Public/private boundaries: {_inline_code_list(workflow.public_private_boundaries)}
 
-Codex remains experimental and CLI-first. This guidance tells Codex how to
-treat a natural-language request as a Main Branch thinking task through
-`AGENTS.md` posture and deterministic `mb` facts. It does not claim Claude
-Code slash commands work inside Codex or that all Main Branch workflows are
-available in Codex.
+Codex remains experimental and CLI-first. This guidance is generated from the
+engine workflow source for business-repo `AGENTS.md`; the business repo does
+not need to contain `{_display_path(workflow.path)}`. Treat this rendered route
+as the Codex shell for natural-language thinking tasks. It does not claim
+Claude Code slash commands work inside Codex or that all Main Branch workflows
+are available in Codex.
 
 ## Required mb Commands
 

--- a/mb/tests/fixtures/workflows/mb-think.codex.md
+++ b/mb/tests/fixtures/workflows/mb-think.codex.md
@@ -5,11 +5,12 @@ Runtime support: `codex_cli: experimental_shell`
 Approval gates: `updates_repairs_migrations`, `file_writes`, `checkpoint`, `provider_mutation`, `publishing_or_spend`, `customer_contact`, `private_data`, `destructive_operations`, `structured_collection`, `public_issue_or_proposal`
 Public/private boundaries: `no_secrets`, `no_raw_provider_exports`, `no_customer_member_data`, `no_private_runtime_settings`, `no_private_dms_or_gated_communities`, `no_raw_finance_legal_records`
 
-Codex remains experimental and CLI-first. This guidance tells Codex how to
-treat a natural-language request as a Main Branch thinking task through
-`AGENTS.md` posture and deterministic `mb` facts. It does not claim Claude
-Code slash commands work inside Codex or that all Main Branch workflows are
-available in Codex.
+Codex remains experimental and CLI-first. This guidance is generated from the
+engine workflow source for business-repo `AGENTS.md`; the business repo does
+not need to contain `workflows/mb-think/workflow.md`. Treat this rendered route
+as the Codex shell for natural-language thinking tasks. It does not claim
+Claude Code slash commands work inside Codex or that all Main Branch workflows
+are available in Codex.
 
 ## Required mb Commands
 

--- a/mb/tests/test_doctor.py
+++ b/mb/tests/test_doctor.py
@@ -349,6 +349,38 @@ def test_doctor_repair_plan_reports_stale_codex_lifecycle_guidance(tmp_path: Pat
     assert "codex-agents-md" in actions
 
 
+def test_doctor_repair_plan_reports_pre_engine_source_boundary_codex_guidance(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "biz"
+    init_run(path=str(repo), name="Acme")
+    agents = repo / "AGENTS.md"
+    agents.write_text(
+        agents.read_text(encoding="utf-8").replace(
+            "does not need to contain that engine source file. ",
+            "",
+            1,
+        ),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["doctor", "repair", "--repo", str(repo), "--plan", "--json"])
+
+    assert result.exit_code in {0, 1}
+    payload = json.loads(result.stdout)
+    section = next(section for section in payload["sections"] if section["id"] == "codex-wiring")
+    agents_check = next(check for check in section["checks"] if check["name"] == "AGENTS.md")
+    assert agents_check["state"] == "warn"
+    assert agents_check["lifecycle_discovery_ok"] is False
+    assert (
+        "does not need to contain that engine source file"
+        in agents_check["missing_lifecycle_guidance"]
+    )
+    actions = {action["id"]: action for action in payload["actions"]}
+    assert actions["codex-agents-md"]["safe_to_apply"] is True
+    assert actions["codex-agents-md"]["writes"] == ["AGENTS.md"]
+
+
 def test_doctor_repair_plan_reports_custom_codex_agents_missing_source_item(
     tmp_path: Path,
 ) -> None:

--- a/mb/tests/test_workflows.py
+++ b/mb/tests/test_workflows.py
@@ -112,6 +112,8 @@ def test_codex_agents_think_route_preserves_shared_workflow_contract() -> None:
     text = AGENTS_TEMPLATE.read_text(encoding="utf-8")
 
     assert "Engine source workflow: `workflows/mb-think/workflow.md`" in text
+    assert "does not need to contain that engine source file" in text
+    assert "`AGENTS.md` section as the Codex shell" in text
     for command in workflow.required_mb_commands:
         assert f"- `{command}`" in text
     for fact in workflow.json_facts:
@@ -190,6 +192,8 @@ def test_think_codex_shell_does_not_claim_slash_command_or_skill_parity() -> Non
     assert codex_shell_policy_errors(workflow, shell) == []
     assert "Run `/mb-think`" not in shell
     assert "Claude Code skills work in Codex" not in shell
+    assert "not need to contain `workflows/mb-think/workflow.md`" in shell
+    assert "as the Codex shell for natural-language thinking tasks" in shell
 
 
 def test_think_codex_policy_flags_forbidden_support_language() -> None:


### PR DESCRIPTION
<!--
  Thanks for contributing to Main Branch.

  See CONTRIBUTING.md for branch + PR shape, concern-based commit
  organization, and pre-push gates. Keep PRs scoped — one logical
  change per PR, ideally 3–5 commits by concern.
-->

## Summary

Tightens the generated Codex think-route guidance so fresh business repos treat `AGENTS.md` as the rendered Codex shell for the `mb-think` shared workflow source. Updates the checked Codex workflow snapshot, drift tests, compatibility wording, and changelog to match fresh read-only Codex smoke evidence.

## Linked issue

Closes #671

## Why

The fresh Codex smoke showed that Codex could ground itself in `mb` facts and follow the natural-language think route, but it also tried to read the engine-only `workflows/mb-think/workflow.md` path from the business repo. The generated guidance now keeps the shared workflow source canonical without making business repos look like they should contain engine source files.

## Commits by concern

- `eaa318a [update] MAIN-418 tighten Codex think route guidance` — updates generated Codex guidance, checked snapshots/tests, compatibility docs, and changelog.

- [ ] Each commit body bullet-lists the changes in that commit
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`

## Validation

Pre-push gate from repo root:

```bash
scripts/check.sh
```

Level 1 static: `scripts/check.sh` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: excerpt `748 passed`, ruff format/check clean, mypy clean, bundled skill validation clean.

Level 2 CLI contract: `cd mb && pytest tests/test_workflows.py -q` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: excerpt `18 passed`.

Level 2 CLI/runtime-adapter contract: `cd mb && pytest tests/test_init.py tests/test_start.py tests/test_doctor.py tests/test_status.py -q` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: excerpt `161 passed`.

Level 3 package/install smoke: `cd mb && python3 -m build && /tmp/mainbranch-main418-smoke/bin/pip install --force-reinstall mb/dist/*.whl && /tmp/mainbranch-main418-smoke/bin/mb --version && /tmp/mainbranch-main418-smoke/bin/mb skill list` — runtime: `/tmp/mainbranch-main418-smoke/bin/python` — exit: 0 — log: excerpt `Successfully built mainbranch-0.3.27-py3-none-any.whl`, `mb 0.3.27`, bundled skills listed.

Level 4 fixture repo: `mb onboard --yes`, `mb doctor`, `mb status --json --peek`, `mb start --json`, `mb validate` against the wheel-installed smoke repo — runtime: `/tmp/mainbranch-main418-smoke/bin/mb` — exit: 0 — log: excerpt `all good — you're set to run claude`, `nothing to check yet`; expected warnings only for missing GitHub remote and incomplete onboarding.

Level 5 runtime smoke: `codex exec --json --ephemeral --sandbox read-only -c 'approval_policy="never"' -c 'shell_environment_policy.inherit="all"' -C <fixture-repo> <natural proof-strategy prompt>` — runtime: `/opt/homebrew/bin/codex` with wheel-installed `mb` first on `PATH` — exit: 0 — log: `.context/codex-smoke-fixed.jsonl` / `.context/codex-smoke-fixed-last.md`; Codex ran read-only `mb` facts, followed `AGENTS.md`, did not chase `workflows/mb-think/workflow.md`, recommended Level 1 research, asked before durable writes, skipped checkpoint/provider actions, and left `git status --short` clean.

- [x] Level 1 static: `scripts/check.sh` passes
- [x] Level 2 CLI contract: focused Typer/CliRunner tests, exit codes, `--json` behavior, TTY vs non-TTY (if CLI behavior touched)
- [x] Level 3 package/install smoke (if packaging touched)
- [x] Level 4 fixture repo (if init/onboard/status/start/update touched)
- [x] Level 5 runtime smoke / dogfood harness / simulation-tier (if runtime, first-run, skill discovery, or release validation touched)
- [x] SKILL.md ≤500 lines (if any skill touched)
- [ ] Package-visible release gate evidence before tag/publish (if preparing a release)
- [ ] Supply-chain review (if `.github/workflows/`, `.github/dependabot.yml`, `mb/pyproject.toml` deps, or `id-token`/`permissions` blocks touched — see [docs/supply-chain-policy.md](../docs/supply-chain-policy.md))

Package-visible release gate evidence was not required because this PR is not tagging or publishing a release. Supply-chain review was not required because no workflow, dependency, or permission surface changed.

## Success metric

A fresh business repo can run a natural-language Codex thinking/codification prompt from deterministic `mb` facts, use generated `AGENTS.md` as the Codex shell for the shared `mb-think` source, ask before durable writes, and leave the repo clean without claiming slash-command or skill parity.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [ ] N/A — change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [x] No
- [ ] Yes — migration note below

## Public / private boundary

Committed files contain only public-safe runtime guidance, docs, tests, and changelog language. Smoke transcripts, temp paths, and local evidence stayed in ignored `.context/` or OS temp space and were not committed.
