### PR TITLE
[add] source ingestion privacy rails

### DIFF
--- a/.claude/skills/mb-think/SKILL.md
+++ b/.claude/skills/mb-think/SKILL.md
@@ -162,14 +162,12 @@ Detect mode from user's natural language:
 | "decide", "we chose", "document decision" | Decide | [decide-phase.md](references/decide-phase.md) |
 | "codify", "apply", "update reference files" | Codify | [codify-phase.md](references/codify-phase.md) |
 | "add context", "enrich", "I have new info" | Codify | [codify-phase.md](references/codify-phase.md) |
+| "mine these transcripts", "ingest community posts", "process call recordings", "use Drive/provider exports", "mixed account sources" | Source ingestion privacy rail | [source-ingestion.md](references/source-ingestion.md) |
 | "this source/claim/angle is stale", "old source", "obsolete claim", "retire this", "stop using that proof" | Stale-source cleanup | [stale-source-cleanup.md](references/stale-source-cleanup.md) |
 | "content strategy", "pillars", "what platforms", "content plan", "cadence", "channel strategy", "account strategy", "founder voice", "weekly content plan" | Full Flow (codify to the right content strategy layer) | [codify-phase.md](references/codify-phase.md) |
 | "where was I", "continue", "pick up" | Recovery | [recovery.md](references/recovery.md) |
 | "here's a PDF", "ingest this", "convert this document", file path (.pdf/.docx/.pptx) | Document Ingestion | [document-ingestion.md](references/document-ingestion.md) |
-For offer, audience, proof, CTA, content strategy, ads/pages, and positioning
-requests, use [research-depth-ladder.md](references/research-depth-ladder.md)
-before selecting source tools. The ladder chooses how much research is enough;
-the routing references choose which tools to use.
+For offer, audience, proof, CTA, content strategy, ads/pages, and positioning requests, use [research-depth-ladder.md](references/research-depth-ladder.md) before selecting source tools.
 
 If unclear, ask: "Are you exploring a question, documenting a decision, or updating reference files?"
 
@@ -301,6 +299,7 @@ Gather from codebase, web, user input, local recordings.
 | X/Twitter sentiment | Grok X Insights MCP ([grok-social.md](references/grok-social.md)) | `-x-social.md` |
 | Local video/audio | whisper-cpp ([local-transcription.md](references/local-transcription.md)) | `-local-mining.md` |
 | Voice memos | whisper-cpp | `-voice-mining.md` |
+| Authenticated community, calls, Drive/provider exports, mixed private sources | Source inventory + manifest-first filters ([source-ingestion.md](references/source-ingestion.md)) | `-source-mining.md` |
 | Instagram mining | Apify or manual | `-ig-mining.md` |
 | Ad account data | Verified Meta Ads account context | `-ad-account.md` |
 | Competitor sites | Browser MCP or web fetch | `-competitor-mining.md` |
@@ -318,7 +317,7 @@ Every research output needs:
 - Implications for reference files
 - Open questions
 
-Synthesis works best when the main conversation is clean — which is exactly what subagents provide. Heavy raw content (transcripts, mined posts) lives in the subagent context windows, and only distilled summaries return to main.
+Synthesis works best when the main conversation is clean — which is exactly what subagents provide. Heavy raw content (transcripts, mined posts) lives in the subagent context windows, and only distilled summaries return to main. For authenticated or private sources, run the source-ingestion rail first and keep raw transcripts/provider payloads out of committed files by default.
 
 **For content mining specifically:** AI shows WHAT worked. You must judge WHY.
 

--- a/.claude/skills/mb-think/references/document-ingestion.md
+++ b/.claude/skills/mb-think/references/document-ingestion.md
@@ -8,6 +8,12 @@ How /mb-think handles non-markdown files: PDFs, DOCX, PPTX, and other documents.
 
 The repo is a precision instrument, not a dumping ground. Documents get **converted to markdown** during /mb-think — the originals stay where they are. Only the extracted, synthesized knowledge enters the repo.
 
+If the document comes from an authenticated provider, mixed private/business
+account, cloud drive, CRM, classroom, community, call recorder, or other source
+that may contain customer/member or restricted data, use the source-ingestion
+privacy rail first: [`source-ingestion.md`](source-ingestion.md).
+Inventory and manifest review happen before conversion or content reads.
+
 ---
 
 ## Detection
@@ -88,7 +94,7 @@ pdftotext input.pdf output.txt
 
 ## Output Format
 
-Converted documents save to research/ with extraction metadata:
+Synthesized document findings save to `research/` with extraction metadata:
 
 ```yaml
 ---
@@ -103,6 +109,11 @@ status: complete
 ```
 
 Filename: `research/YYYY-MM-DD-topic-doc-extraction.md`
+
+Raw conversions should stay in OS temp or ignored local scratch unless the
+operator explicitly approves a sanitized excerpt. Do not commit full extracted
+documents, provider payloads, private transcripts, or copied source archives by
+default.
 
 ---
 

--- a/.claude/skills/mb-think/references/local-transcription.md
+++ b/.claude/skills/mb-think/references/local-transcription.md
@@ -2,6 +2,11 @@
 
 When user has local media files to mine, use whisper.
 
+If the recording comes from a meeting provider, phone-call system,
+authenticated community, shared drive, mixed private/business account, or other
+source that may contain restricted data, run the source-ingestion privacy rail
+before transcription or content reads: [`source-ingestion.md`](source-ingestion.md).
+
 ---
 
 ## Prerequisites Check
@@ -90,15 +95,21 @@ Trigger phrases:
 
 ## Output
 
-Save transcripts to:
-- `research/YYYY-MM-DD-[topic]-transcript.txt` (raw)
-- Or synthesize directly into `research/YYYY-MM-DD-[topic]-mining.md`
+Save raw transcripts to OS temp or ignored local scratch first. Commit the
+synthesis by default:
+
+- `research/YYYY-MM-DD-[topic]-mining.md`
 
 **Always synthesize.** Raw transcripts are rarely useful. Extract:
 - Key insights and frameworks
 - Quotable moments
 - Messaging patterns
 - Action items mentioned
+
+Do not commit full transcripts, phone-call payloads, meeting exports,
+authenticated-community content, customer/member data, or provider raw output
+unless the operator explicitly approves a short sanitized excerpt and the
+public/private boundary is safe.
 
 ---
 

--- a/.claude/skills/mb-think/references/research-phase.md
+++ b/.claude/skills/mb-think/references/research-phase.md
@@ -75,7 +75,7 @@ the output with `brief_format: grok-8` and include all eight categories.
 | `-voice-mining.md` | Voice memo transcription |
 | `-competitor-mining.md` | Competitor site mining |
 | `-internal-mining.md` | Internal data (emails, DMs, reviews) |
-| `-transcript.txt` | Raw transcript (use specific `-mining.md` for synthesized) |
+| `-source-mining.md` | Authenticated/private source synthesis after manifest-first review |
 | `-audit.md` | Site or system audit |
 | (none) | General or mixed sources |
 
@@ -156,6 +156,14 @@ comment dumps, customer records, full tweet threads, and copyrighted page
 copies do not belong in committed research files. Cite source URLs and keep
 only concise excerpts needed to support the synthesis.
 
+For transcripts, authenticated community content, connected-provider
+recordings, cloud-drive files, call notes, exported chats, or mixed
+private/business sources, use the source-ingestion privacy rail before reading
+content: [`source-ingestion.md`](source-ingestion.md).
+Inventory sources, review a manifest, apply allow/skip filters, then read only
+the smallest approved slice. Commit synthesized findings, not raw provider
+payloads or transcripts.
+
 ### Provider Routing
 
 - Use Apify only as optional read-only enrichment, preferably through MCP for
@@ -186,6 +194,9 @@ only concise excerpts needed to support the synthesis.
 6. **Local video/audio** — User's own recordings, voice memos, Loom exports (see [local-transcription.md](local-transcription.md))
 7. **Customer/review/comment evidence** — When researching ad or organic angles,
    use [winning-ad-research.md](winning-ad-research.md)
+8. **Authenticated/private source sets** — Use `source-ingestion.md` first for
+   manifest-first review, skip filters, proof-permission gates, and private
+   evidence handling
 
 ---
 
@@ -258,6 +269,8 @@ Then fetch results with `mcp__apify__get-actor-output` using the returned datase
 2. Extract quotable moments
 3. Note messaging patterns
 4. Save to `research/YYYY-MM-DD-[topic]-mining.md`
+5. For private or authenticated sources, keep raw output in ignored scratch and
+   record proof candidates with permission fields before public use
 
 **Example workflow:**
 > User: "Research what Alex Hormozi says about pricing"

--- a/.claude/skills/mb-think/references/source-ingestion.md
+++ b/.claude/skills/mb-think/references/source-ingestion.md
@@ -1,0 +1,103 @@
+# Source Ingestion Privacy Rail
+
+Use this before reading transcripts, authenticated community content,
+connected-provider recordings, cloud-drive files, call notes, exported chats,
+or mixed private/business sources into business memory.
+
+The goal is to get useful signal without copying raw private material into git.
+Raw sources are evidence. Durable output is synthesized research, decisions,
+proof candidates, push inputs, logs, or stale-source cleanup notes.
+
+## Triggers
+
+- "mine these transcripts"
+- "ingest community posts"
+- "process call recordings"
+- "use these Drive files"
+- "look through provider exports"
+- "some of this account is personal/private"
+- "find proof or audience language in member/customer content"
+
+Public web research and public YouTube transcript mining still need synthesis,
+but use this full rail when the source may contain private, restricted, mixed,
+customer, member, finance, legal, credential, or account-specific material.
+
+## Workflow
+
+1. **Inventory before content.** List source type, private location/provider,
+   owner/account, access posture, business reason, skip rules, allowed use, and
+   expected durable destination. Keep private paths and account names in
+   ignored scratch.
+2. **Review a manifest.** Use metadata first: safe label, title or sanitized
+   title, date/date range, type, provider, owner/account category, privacy
+   posture, allowed/skip decision, read reason, and destination. Do not include
+   raw comments, transcript excerpts, customer details, account ids, or private
+   URLs in public artifacts.
+3. **Apply allow/skip filters.** Filter by account/workspace, source type,
+   people, date range, topic, and permission. Skip personal accounts, unrelated
+   clients, billing/legal/health/finance, private DMs, credentials, and anything
+   outside the approved business reason.
+4. **Read the smallest useful slice.** Prefer title-only search, manifests,
+   excerpts, topic/speaker segments, or operator-approved files over full raw
+   dumps.
+5. **Route synthesized output.** Save findings into the right business
+   artifact, not a raw source archive.
+
+## Durable Routes
+
+| Signal | Destination |
+| --- | --- |
+| Audience language, objections, jobs, market signal | `research/YYYY-MM-DD-<topic>-source-mining.md` |
+| Accepted offer, audience, positioning, operations, or source-policy change | `decisions/` plus approved `core/` edits |
+| Testimonial, win, result, case detail, or claim | `core/proof/` or offer proof as a proof candidate |
+| Launch, ad, organic, page, email, or provider-action input | `pushes/<YYYY-MM-DD-slug>/` or a playbook |
+| Session lesson, fulfillment note, or operating lesson | `log/` or `documents/`, sanitized |
+| Old claim, retired angle, obsolete offer detail, or contradiction | `stale-source-cleanup.md` |
+| Product friction or workflow gap | `mb issue draft` after public/private review |
+
+## Proof Permission Gate
+
+Treat wins, quotes, screenshots, and outcomes as proof candidates first.
+Specific proof is not public proof until permission is recorded.
+
+- Record offer linkage, outcome, timeframe, metric, typicality, and caveats
+  when known.
+- Use `permissioned_public: false` until the operator confirms public use.
+- Do not place private quotes in ads, pages, public issues, docs, or examples
+  before permission is explicit.
+- If proof is useful internally but not public, keep that boundary visible and
+  route public work to permission collection.
+
+## Never Commit By Default
+
+- raw transcripts;
+- full chat exports;
+- provider payloads;
+- scrape dumps;
+- CRM rows;
+- customer/member names;
+- private community content;
+- DMs, emails, phone numbers, account ids, screenshots, credentials, or local
+  paths;
+- private proof quotes or testimonials before permission is recorded.
+
+Raw transcription output belongs in OS temp or ignored scratch first. Commit
+only synthesized findings unless the operator explicitly approves a short,
+sanitized excerpt and the public/private boundary is safe.
+
+## Handoff Shape
+
+```text
+Source inventory reviewed: <count and categories>.
+Allowed sources: <safe labels>.
+Skipped sources: <count and generic reasons>.
+Content read: <smallest useful slice>.
+Durable output proposed: <research/decision/proof/push/log/issue>.
+Private evidence kept out of git: yes.
+Permission gates: <proof/public quote/customer data/account boundaries>.
+Next approval needed: <read more, codify, collect proof permission, stale-source cleanup, checkpoint>.
+```
+
+This rail does not make a provider supported. Connector availability is not
+proof that Main Branch supports authenticated scraping, provider mutation, bulk
+export, or background monitoring.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+### Added
+
+- Added source-ingestion privacy rails for transcripts, authenticated
+  community/provider sources, mixed-account manifests, skip filters, proof
+  permission gates, and `/mb-think` routing. Refs MAIN-409, #657.
+
 ## [0.3.27] - 2026-05-18
 
 v0.3.27 packages the shared-workflow and customer-call cleanup batch after

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,6 +34,7 @@ Pick the route that matches what you are doing.
 - [`onboarding-progress.md`](onboarding-progress.md) — lifecycle skill resume surface.
 - [`business-connections.md`](business-connections.md) — when to use frontmatter links, inline links, tags, data refs, or context.
 - [`markdown-link-conventions.md`](markdown-link-conventions.md) — markdown and link rules.
+- [`source-ingestion.md`](source-ingestion.md) — manifest-first privacy rail for transcripts, authenticated sources, and provider exports.
 - [`issue-drafting.md`](issue-drafting.md) — privacy-safe `mb issue` flow.
 - [`session-excavation.md`](session-excavation.md) — turn transcripts, chat exports, and session logs into prioritized public-safe follow-ups.
 

--- a/docs/session-excavation.md
+++ b/docs/session-excavation.md
@@ -20,6 +20,13 @@ Use session excavation for:
 - generated business-repo history after a live session;
 - repeated support conversations that expose the same friction.
 
+When the goal is to mine transcripts, authenticated community content,
+connected-provider recordings, cloud-drive files, or mixed private/business
+sources into business memory, use [`source-ingestion.md`](source-ingestion.md)
+before reading source content. Session excavation turns a session into public
+product follow-ups; source ingestion controls whether and how source material
+may be read and routed.
+
 For release-bearing runtime validation, use
 [`release-simulations.md`](release-simulations.md) and
 [`release-agent-contract.md`](release-agent-contract.md) first. This document
@@ -167,7 +174,7 @@ After the table is drafted, route each P0 and P1 row.
 | Stale business source handling | Workflow issue, skill update, or decision if it changes repo primitives |
 | Provider write or secret handling risk | Provider mutation, approval-gate, or secret-redaction issue with a validation target |
 | Connector bridge confusion | Connector-readiness issue or shared-workflow source issue; do not claim runtime support from directory availability alone |
-| Transcript or authenticated-community ingestion | Ingestion/privacy issue with manifest-first, skip-filter, and proof-permission requirements |
+| Transcript or authenticated-community ingestion | Use `source-ingestion.md`; open or link an ingestion/privacy issue when the rail itself needs product work |
 | Connector/provider request | Provider-readiness issue only after support claim and smoke boundary are clear |
 | Roadmap pull | Roadmap note or backlog issue; do not claim support |
 

--- a/docs/source-ingestion.md
+++ b/docs/source-ingestion.md
@@ -1,0 +1,178 @@
+# Source Ingestion Privacy Rail
+
+Use this workflow when transcripts, authenticated community content, connected
+provider recordings, cloud-drive files, call notes, or exported chats may become
+business memory.
+
+The goal is to mine useful signal without copying raw private material into
+git, public docs, GitHub issues, or agent-visible contexts that do not need it.
+Raw sources are evidence. Durable Main Branch output is synthesized research,
+decisions, proof candidates, push inputs, logs, or stale-source cleanup notes.
+
+## When To Use This
+
+Use this rail before reading source content from:
+
+- meeting, webinar, sales-call, phone-call, voice memo, Loom, or video
+  transcripts;
+- authenticated community posts, comments, DMs, member wins, classroom
+  discussions, or support conversations;
+- Google Drive, Dropbox, Notion, CRM, call-recorder, calendar, email, or other
+  provider exports;
+- mixed personal/business accounts where some material must be skipped;
+- any source that may contain customer/member data, private proof, credentials,
+  account names, billing, legal, health, finance, or internal team context.
+
+Public web research, public YouTube transcript mining, and operator-pasted
+snippets still need synthesis and copyright care, but they do not need the full
+manifest workflow unless the source contains private or restricted material.
+
+## Step 1: Inventory Before Content
+
+List sources before opening or transcribing content. The inventory can live in
+ignored local scratch space when it names private paths, provider accounts, or
+people. Commit only a sanitized version when it is useful as public evidence.
+
+| Field | Purpose |
+| --- | --- |
+| Source type | Transcript, authenticated community, Drive file, CRM export, call recording, chat log, provider manifest. |
+| Location | Private path, provider UI, connector query, or operator-supplied file. Keep private locations out of public artifacts. |
+| Owner/account | Which business, account, workspace, or operator owns the source. Use generic public labels. |
+| Access posture | Public, team private, restricted, local only, mixed account, or unknown. |
+| Business reason | Offer research, proof review, content mining, workflow improvement, fulfillment, support, or stale-source check. |
+| Skip rules | Accounts, folders, date ranges, people, channels, tags, topics, or source types to exclude. |
+| Allowed use | Internal synthesis, proof candidate, public quote after permission, push input, decision evidence, or do not use. |
+
+If the source set is mixed or ambiguous, stop at inventory and ask the operator
+to approve allow/skip filters before content reads.
+
+## Step 2: Manifest-First Review
+
+Create or request a manifest before opening raw content. A manifest is metadata
+only: enough to decide what to read, not the source itself.
+
+Good manifest fields:
+
+- source id or safe short label;
+- title or sanitized title;
+- source type and provider;
+- date or date range;
+- duration, file size, or item count when useful;
+- owner/account/workspace category;
+- privacy posture;
+- allowed/skip decision;
+- reason for reading or skipping;
+- expected durable destination.
+
+Avoid manifest fields that expose private value by themselves: full names,
+emails, phone numbers, account ids, exact provider account names, private
+community URLs, raw comments, transcript excerpts, credential material, or
+customer-specific details.
+
+## Step 3: Allow And Skip Filters
+
+Use explicit filters before content reads.
+
+| Filter | Examples |
+| --- | --- |
+| Account/workspace | Only the business workspace; skip personal or unrelated client accounts. |
+| Source type | Include sales calls and webinar chats; skip billing, legal, support inbox, or private DMs. |
+| People | Include operator-owned recordings; skip unrelated customers, team members, or family/personal contacts. |
+| Date range | Include the launch window; skip older sources unless stale-source cleanup needs them. |
+| Topic | Include offer/audience/proof language; skip credentials, billing, health, legal, HR, or finance details. |
+| Permission | Include internal proof candidates; skip public testimonial usage until permission is recorded. |
+
+When a source fails a filter, record the skip reason in private notes or a
+sanitized manifest. Do not read it just because a connector can access it.
+
+## Step 4: Read The Smallest Useful Slice
+
+Read only the content needed for the decision. Prefer title-only search,
+metadata manifests, excerpts, speaker/topic segments, or operator-approved
+files over full raw dumps.
+
+Do not commit:
+
+- raw transcripts, full chat exports, provider payloads, scrape dumps, or CRM
+  rows;
+- gated-community content copied from authenticated spaces;
+- customer/member names, private community content, DMs, emails, phone numbers,
+  account ids, screenshots, credentials, or local paths;
+- private proof quotes or testimonials before permission is recorded;
+- copied source material that would make the repo a shadow database for another
+  provider.
+
+If raw transcription is required, write raw output to OS temp or ignored local
+scratch first. Commit only synthesized findings unless the operator explicitly
+approves a short, sanitized excerpt and the public/private boundary is safe.
+
+## Step 5: Route Durable Output
+
+Route synthesized output by business use:
+
+| Signal | Durable destination |
+| --- | --- |
+| Audience language, objections, jobs, market signal | `research/YYYY-MM-DD-<topic>-source-mining.md` |
+| Accepted change to offer, audience, positioning, operations, or source policy | `decisions/YYYY-MM-DD-<slug>.md` plus approved `core/` edits |
+| Testimonial, win, result, case detail, or claim | `core/proof/` or offer-specific proof as a proof candidate with permission fields |
+| Launch, ad, organic, page, email, or provider-action input | `pushes/<YYYY-MM-DD-slug>/` or a playbook, with source limits noted |
+| Session lesson, fulfillment note, or internal operating lesson | `log/` or `documents/`, sanitized |
+| Old claim, retired angle, obsolete offer detail, or source contradiction | `/mb-think` stale-source cleanup |
+| Product friction or workflow gap | `mb issue draft` or a public-safe GitHub issue after review |
+
+## Proof Permission Gate
+
+Specific proof is not public proof until permission is recorded. When mining
+private or authenticated sources:
+
+- classify wins, quotes, screenshots, and outcomes as proof candidates first;
+- record offer linkage, outcome, timeframe, metric, typicality, and caveats
+  when known;
+- use `permissioned_public: false` until the operator confirms public use;
+- do not place private quotes in ads, pages, public issues, docs, or examples
+  before permission is explicit;
+- if proof is useful internally but not public, keep that boundary visible in
+  the proof file and route public work to permission collection.
+
+This gate complements MoneyPath proof-quality facts and the `/mb-start` route
+for public-marketing proof collection.
+
+## Stale-Source Handoff
+
+Use this ingestion rail to inventory and filter source material. Use
+[`stale-source-cleanup.md`](../.claude/skills/mb-think/references/stale-source-cleanup.md)
+after a specific stale claim, source, offer detail, proof usage, or angle is
+named.
+
+Do not turn stale-source cleanup into broad transcript ingestion. Do not turn
+source ingestion into broad reconciliation across every current-truth file
+unless the operator accepts that cleanup scope.
+
+## Provider Boundary
+
+This rail does not make a provider supported. It defines how to handle source
+material when the operator has already provided access or a runtime connector
+is available.
+
+Provider-specific support still needs its own decision, setup path, smoke
+evidence, approval gates, privacy handling, and fallback. Connector availability
+is not proof that Main Branch supports authenticated scraping, provider
+mutation, bulk export, or background monitoring.
+
+## Handoff Shape
+
+Use this summary when handing work back to the operator:
+
+```text
+Source inventory reviewed: <count and categories>.
+Allowed sources: <safe labels>.
+Skipped sources: <count and generic reasons>.
+Content read: <smallest useful slice>.
+Durable output proposed: <research/decision/proof/push/log/issue>.
+Private evidence kept out of git: yes.
+Permission gates: <proof/public quote/customer data/account boundaries>.
+Next approval needed: <read more, codify, collect proof permission, stale-source cleanup, checkpoint>.
+```
+
+The operator should know what was read, what was skipped, where the synthesis
+will land, and what private material stayed out of durable public history.

--- a/mb/mb/_data/templates/AGENTS.md.tmpl
+++ b/mb/mb/_data/templates/AGENTS.md.tmpl
@@ -211,8 +211,9 @@ Shared source gates: `updates_repairs_migrations`, `file_writes`,
 `public_issue_or_proposal`.
 
 Shared public/private boundaries: `no_secrets`, `no_raw_provider_exports`,
-`no_customer_member_data`, `no_private_runtime_settings`,
-`no_private_dms_or_gated_communities`, `no_raw_finance_legal_records`.
+`no_raw_transcripts`, `no_customer_member_data`,
+`no_private_runtime_settings`, `no_private_dms_or_gated_communities`,
+`no_raw_finance_legal_records`.
 
 Use it when the operator asks to think through an offer, research a market,
 compare providers, make a decision, or codify what was learned.
@@ -240,10 +241,14 @@ Choose the smallest honest research depth:
 
 Read only the business files needed for the question: `core/`, `research/`,
 `decisions/`, `bets/`, `pushes/`, `log/`, and `documents/`. Do not inspect
-secrets, raw provider exports, raw finance/legal records, customer/member
-records, private DMs, gated communities, local runtime settings, or credentials
-unless the operator gives explicit permission and the source belongs in the
-business repo.
+secrets, raw provider exports, raw transcripts, raw finance/legal records,
+customer/member records, private DMs, gated communities, local runtime
+settings, or credentials unless the operator gives explicit permission and the
+source belongs in the business repo. For transcripts, authenticated community
+content, provider recordings, cloud-drive files, exported chats, or mixed
+private/business sources, inventory sources and apply manifest-first
+allow/skip filters before reading content; commit synthesized findings, not raw
+payloads.
 
 Ask before creating, editing, moving, deleting, archiving, codifying, or
 checkpointing business files. Ask before publishing, opening a public issue,

--- a/mb/mb/codex.py
+++ b/mb/mb/codex.py
@@ -62,6 +62,7 @@ CODEX_THINK_APPROVAL_GATES = (
 CODEX_THINK_PUBLIC_PRIVATE_BOUNDARIES = (
     "no_secrets",
     "no_raw_provider_exports",
+    "no_raw_transcripts",
     "no_customer_member_data",
     "no_private_runtime_settings",
     "no_private_dms_or_gated_communities",
@@ -297,8 +298,9 @@ Shared source gates: `updates_repairs_migrations`, `file_writes`,
 `public_issue_or_proposal`.
 
 Shared public/private boundaries: `no_secrets`, `no_raw_provider_exports`,
-`no_customer_member_data`, `no_private_runtime_settings`,
-`no_private_dms_or_gated_communities`, `no_raw_finance_legal_records`.
+`no_raw_transcripts`, `no_customer_member_data`,
+`no_private_runtime_settings`, `no_private_dms_or_gated_communities`,
+`no_raw_finance_legal_records`.
 
 Use it when the operator asks to think through an offer, research a market,
 compare providers, make a decision, or codify what was learned.
@@ -326,10 +328,14 @@ Choose the smallest honest research depth:
 
 Read only the business files needed for the question: `core/`, `research/`,
 `decisions/`, `bets/`, `pushes/`, `log/`, and `documents/`. Do not inspect
-secrets, raw provider exports, raw finance/legal records, customer/member
-records, private DMs, gated communities, local runtime settings, or credentials
-unless the operator gives explicit permission and the source belongs in the
-business repo.
+secrets, raw provider exports, raw transcripts, raw finance/legal records,
+customer/member records, private DMs, gated communities, local runtime
+settings, or credentials unless the operator gives explicit permission and the
+source belongs in the business repo. For transcripts, authenticated community
+content, provider recordings, cloud-drive files, exported chats, or mixed
+private/business sources, inventory sources and apply manifest-first
+allow/skip filters before reading content; commit synthesized findings, not raw
+payloads.
 
 Ask before creating, editing, moving, deleting, archiving, codifying, or
 checkpointing business files. Ask before publishing, opening a public issue,

--- a/mb/mb/workflows.py
+++ b/mb/mb/workflows.py
@@ -517,11 +517,14 @@ This snapshot does not replace shipped `.claude/skills/mb-think/SKILL.md`.
    caveats, promotion limits, and public/private handling.
 5. Write a decision when durable business truth changes. Codify only after the
    operator accepts the direction.
-6. For stale source, claim, proof, or angle cleanup, identify the stale item,
+6. For transcripts, authenticated community content, provider recordings, or
+   mixed private/business sources, use manifest-first allow/skip filters before
+   reading content. Route synthesized output, not raw payloads.
+7. For stale source, claim, proof, or angle cleanup, identify the stale item,
    find downstream usage, keep history auditable with a stale note, reconcile
    current truth after approval, record and codify the decision, then
    checkpoint only after approval.
-7. Ask for approval before creating or editing business files, promoting
+8. Ask for approval before creating or editing business files, promoting
    research into core truth, using structured collection, or saving a
    checkpoint.
 
@@ -588,11 +591,14 @@ available in Codex.
    caveats, promotion limits, and public/private handling.
 6. Write a decision when durable business truth changes. Codify only after the
    operator accepts the direction.
-7. For stale source, claim, proof, or angle cleanup, identify the stale item,
+7. For transcripts, authenticated community content, provider recordings, or
+   mixed private/business sources, use manifest-first allow/skip filters before
+   reading content. Route synthesized output, not raw payloads.
+8. For stale source, claim, proof, or angle cleanup, identify the stale item,
    find downstream usage, keep history auditable with a stale note, reconcile
    current truth after approval, record and codify the decision, then
    checkpoint only after approval.
-8. Ask for approval before creating or editing business files, promoting
+9. Ask for approval before creating or editing business files, promoting
    research into core truth, using structured collection, opening public
    issues, publishing, mutating providers, spending money, contacting
    customers, or saving a checkpoint.

--- a/mb/tests/fixtures/workflows/mb-think.claude.md
+++ b/mb/tests/fixtures/workflows/mb-think.claude.md
@@ -3,7 +3,7 @@
 Source workflow: `workflows/mb-think/workflow.md`
 Runtime support: `claude_code: supported_shell`
 Approval gates: `updates_repairs_migrations`, `file_writes`, `checkpoint`, `provider_mutation`, `publishing_or_spend`, `customer_contact`, `private_data`, `destructive_operations`, `structured_collection`, `public_issue_or_proposal`
-Public/private boundaries: `no_secrets`, `no_raw_provider_exports`, `no_customer_member_data`, `no_private_runtime_settings`, `no_private_dms_or_gated_communities`, `no_raw_finance_legal_records`
+Public/private boundaries: `no_secrets`, `no_raw_provider_exports`, `no_raw_transcripts`, `no_customer_member_data`, `no_private_runtime_settings`, `no_private_dms_or_gated_communities`, `no_raw_finance_legal_records`
 
 Use from `/mb-think` when the operator asks to research, decide, figure out,
 compare, codify, sharpen an offer, or turn learning into durable business
@@ -57,11 +57,14 @@ This snapshot does not replace shipped `.claude/skills/mb-think/SKILL.md`.
    caveats, promotion limits, and public/private handling.
 5. Write a decision when durable business truth changes. Codify only after the
    operator accepts the direction.
-6. For stale source, claim, proof, or angle cleanup, identify the stale item,
+6. For transcripts, authenticated community content, provider recordings, or
+   mixed private/business sources, use manifest-first allow/skip filters before
+   reading content. Route synthesized output, not raw payloads.
+7. For stale source, claim, proof, or angle cleanup, identify the stale item,
    find downstream usage, keep history auditable with a stale note, reconcile
    current truth after approval, record and codify the decision, then
    checkpoint only after approval.
-7. Ask for approval before creating or editing business files, promoting
+8. Ask for approval before creating or editing business files, promoting
    research into core truth, using structured collection, or saving a
    checkpoint.
 

--- a/mb/tests/fixtures/workflows/mb-think.codex.md
+++ b/mb/tests/fixtures/workflows/mb-think.codex.md
@@ -3,7 +3,7 @@
 Source workflow: `workflows/mb-think/workflow.md`
 Runtime support: `codex_cli: experimental_shell`
 Approval gates: `updates_repairs_migrations`, `file_writes`, `checkpoint`, `provider_mutation`, `publishing_or_spend`, `customer_contact`, `private_data`, `destructive_operations`, `structured_collection`, `public_issue_or_proposal`
-Public/private boundaries: `no_secrets`, `no_raw_provider_exports`, `no_customer_member_data`, `no_private_runtime_settings`, `no_private_dms_or_gated_communities`, `no_raw_finance_legal_records`
+Public/private boundaries: `no_secrets`, `no_raw_provider_exports`, `no_raw_transcripts`, `no_customer_member_data`, `no_private_runtime_settings`, `no_private_dms_or_gated_communities`, `no_raw_finance_legal_records`
 
 Codex remains experimental and CLI-first. This guidance tells Codex how to
 treat a natural-language request as a Main Branch thinking task through
@@ -60,11 +60,14 @@ available in Codex.
    caveats, promotion limits, and public/private handling.
 6. Write a decision when durable business truth changes. Codify only after the
    operator accepts the direction.
-7. For stale source, claim, proof, or angle cleanup, identify the stale item,
+7. For transcripts, authenticated community content, provider recordings, or
+   mixed private/business sources, use manifest-first allow/skip filters before
+   reading content. Route synthesized output, not raw payloads.
+8. For stale source, claim, proof, or angle cleanup, identify the stale item,
    find downstream usage, keep history auditable with a stale note, reconcile
    current truth after approval, record and codify the decision, then
    checkpoint only after approval.
-8. Ask for approval before creating or editing business files, promoting
+9. Ask for approval before creating or editing business files, promoting
    research into core truth, using structured collection, opening public
    issues, publishing, mutating providers, spending money, contacting
    customers, or saving a checkpoint.

--- a/mb/tests/test_source_ingestion_workflow.py
+++ b/mb/tests/test_source_ingestion_workflow.py
@@ -1,0 +1,84 @@
+"""Contract checks for source-ingestion privacy guidance."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOCS_README = REPO_ROOT / "docs" / "README.md"
+SOURCE_DOC = REPO_ROOT / "docs" / "source-ingestion.md"
+SESSION_EXCAVATION = REPO_ROOT / "docs" / "session-excavation.md"
+THINK_SKILL = REPO_ROOT / ".claude" / "skills" / "mb-think" / "SKILL.md"
+THINK_WORKFLOW = REPO_ROOT / "workflows" / "mb-think" / "workflow.md"
+THINK_REF = REPO_ROOT / ".claude" / "skills" / "mb-think" / "references" / "source-ingestion.md"
+RESEARCH_PHASE = REPO_ROOT / ".claude" / "skills" / "mb-think" / "references" / "research-phase.md"
+LOCAL_TRANSCRIPTION = (
+    REPO_ROOT / ".claude" / "skills" / "mb-think" / "references" / "local-transcription.md"
+)
+DOCUMENT_INGESTION = (
+    REPO_ROOT / ".claude" / "skills" / "mb-think" / "references" / "document-ingestion.md"
+)
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_source_ingestion_doc_defines_manifest_skip_and_routing_contract() -> None:
+    text = _read(SOURCE_DOC)
+
+    required = [
+        "Inventory Before Content",
+        "Manifest-First Review",
+        "Allow And Skip Filters",
+        "Read The Smallest Useful Slice",
+        "Route Durable Output",
+        "Proof Permission Gate",
+        "Stale-Source Handoff",
+        "Provider Boundary",
+        "raw transcripts, full chat exports, provider payloads",
+        "gated-community content",
+        "permissioned_public: false",
+        "This rail does not make a provider supported",
+    ]
+    for phrase in required:
+        assert phrase in text
+
+
+def test_source_ingestion_is_indexed_and_session_excavation_routes_to_it() -> None:
+    docs_readme = _read(DOCS_README)
+    session = _read(SESSION_EXCAVATION)
+
+    assert "source-ingestion.md" in docs_readme
+    assert "use [`source-ingestion.md`](source-ingestion.md)" in session
+    assert "Session excavation turns a session into public" in session
+    assert "source ingestion controls whether and how source material" in session
+
+
+def test_think_skill_routes_authenticated_sources_to_self_contained_reference() -> None:
+    skill = _read(THINK_SKILL)
+    workflow = _read(THINK_WORKFLOW)
+    ref = _read(THINK_REF)
+
+    assert "Source ingestion privacy rail" in skill
+    assert "[source-ingestion.md](references/source-ingestion.md)" in skill
+    assert "Authenticated community, calls, Drive/provider exports" in skill
+    assert "no_raw_transcripts" in workflow
+    assert "route through the source-ingestion privacy" in workflow
+    assert "Inventory before content" in ref
+    assert "Connector availability is not" in ref
+    assert "provider mutation, bulk" in ref
+
+
+def test_transcription_and_document_guidance_keep_raw_outputs_out_of_git() -> None:
+    research = _read(RESEARCH_PHASE)
+    transcription = _read(LOCAL_TRANSCRIPTION)
+    documents = _read(DOCUMENT_INGESTION)
+
+    for text in (research, transcription, documents):
+        assert "source-ingestion.md" in text
+
+    assert "Commit synthesized findings, not raw provider" in research
+    assert "Save raw transcripts to OS temp or ignored local scratch first" in transcription
+    assert "Do not commit full transcripts" in transcription
+    assert "Raw conversions should stay in OS temp or ignored local scratch" in documents

--- a/workflows/mb-think/workflow.md
+++ b/workflows/mb-think/workflow.md
@@ -49,6 +49,7 @@ approval_gates:
 public_private_boundaries:
   - no_secrets
   - no_raw_provider_exports
+  - no_raw_transcripts
   - no_customer_member_data
   - no_private_runtime_settings
   - no_private_dms_or_gated_communities
@@ -68,8 +69,8 @@ into durable business files.
 
 Use this workflow when the operator asks to think through an offer, research a
 market, compare providers, pressure-test positioning, choose a direction, turn
-source material into a decision, retire stale source, or codify what was
-learned.
+source material into a decision, mine approved source material, retire stale
+source, or codify what was learned.
 
 Trigger phrases include think through, research, decide, figure out, explore,
 codify, enrich, sharpen this offer, improve the offer, compare providers,
@@ -164,6 +165,15 @@ handling.
 Use decisions when the work changes durable business truth. A decision should
 name options, rationale, tradeoffs, consequences, and the specific files that
 would change. Codify only after the operator accepts the direction.
+
+When transcripts, authenticated community content, provider recordings,
+cloud-drive files, call notes, exported chats, or mixed private/business
+sources may become business memory, route through the source-ingestion privacy
+rail before reading content: inventory sources, review a metadata-only
+manifest, apply allow/skip filters, read the smallest approved slice, and route
+synthesized output into research, decisions, proof candidates, pushes, logs, or
+issue drafts. Raw transcripts, provider payloads, gated-community content, and
+private customer/member data stay out of committed files by default.
 
 When source material, a claim, an offer detail, proof usage, or an angle is
 stale, reconcile current truth instead of erasing history. Identify the stale


### PR DESCRIPTION
<!--
  Thanks for contributing to Main Branch.

  See CONTRIBUTING.md for branch + PR shape, concern-based commit
  organization, and pre-push gates. Keep PRs scoped — one logical
  change per PR, ideally 3–5 commits by concern.
-->

## Summary

Adds manifest-first source-ingestion privacy rails for transcripts, authenticated community content, provider recordings, and mixed private/business source sets. Routes `/mb-think`, generated Codex guidance, and workflow snapshots through the same raw-output boundary.

## Linked issue

Closes #657

## Why

Recent session excavation showed that transcript and authenticated-source mining is high leverage but privacy-sensitive. Main Branch needed a public, reusable rail for inventory, skip filters, proof-permission gates, durable routing, and private evidence handling before provider-specific ingestion work grows.

## Commits by concern

- [x] `da49ca6 [add] MAIN-409 source ingestion privacy rails`
- [ ] Each commit body bullet-lists the changes in that commit
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`

## Validation

Pre-push gate from repo root:

```bash
scripts/check.sh
```

Level 1 static: `scripts/check.sh` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: `0` — log: `91 files already formatted; All checks passed!; Success: no issues found in 90 source files; 752 passed; skill validation passed 15/15`.

Level 2 CLI contract: `cd mb && pytest tests/test_source_ingestion_workflow.py tests/test_workflows.py tests/test_skill_validate.py::test_skill_validate_all_envelope -q` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: `0` — log: `23 passed in 0.25s`.

Level 3 package/install smoke: `(cd mb && python3 -m build); python3 -m venv /tmp/mainbranch-smoke-main409; /tmp/mainbranch-smoke-main409/bin/pip install mb/dist/*.whl; /tmp/mainbranch-smoke-main409/bin/mb --version; /tmp/mainbranch-smoke-main409/bin/mb skill list` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` plus installed wheel CLI — exit: `0` — log: `Successfully built mainbranch-0.3.27.tar.gz and mainbranch-0.3.27-py3-none-any.whl; Successfully installed mainbranch-0.3.27; mb 0.3.27; mb skill list listed mb-think and the bundled skill set`.

Level 4 fixture repo: `/tmp/mainbranch-smoke-main409/bin/mb onboard --yes --name "Test Business" --path "$tmpdir/test-business"; cd "$tmpdir/test-business"; /tmp/mainbranch-smoke-main409/bin/mb doctor; /tmp/mainbranch-smoke-main409/bin/mb status; /tmp/mainbranch-smoke-main409/bin/mb start --json; /tmp/mainbranch-smoke-main409/bin/mb validate` — runtime: installed wheel CLI at `/tmp/mainbranch-smoke-main409/bin/mb` — exit: `0` — log: `mb onboard ready; mb doctor completed with expected no-origin/onboarding warnings; mb status ready 100/100; mb start --json returned ok=true and handoff_ready=true with current generated AGENTS.md; mb validate reported nothing to check yet`.

Level 5 runtime smoke: not run; this changes docs, shared workflow guidance, generated Codex guidance, and bundled skill prose, not runtime discovery or invocation.

- [x] Level 1 static: `scripts/check.sh` passes
- [x] Level 2 CLI contract: focused Typer/CliRunner tests, exit codes, `--json` behavior, TTY vs non-TTY (if CLI behavior touched)
- [x] Level 3 package/install smoke (if packaging touched)
- [x] Level 4 fixture repo (if init/onboard/status/start/update touched)
- [x] Level 5 runtime smoke / dogfood harness / simulation-tier (if runtime, first-run, skill discovery, or release validation touched)
- [x] SKILL.md ≤500 lines (if any skill touched)
- [x] Package-visible release gate evidence before tag/publish (if preparing a release)
- [x] Supply-chain review (if `.github/workflows/`, `.github/dependabot.yml`, `mb/pyproject.toml` deps, or `id-token`/`permissions` blocks touched — see [docs/supply-chain-policy.md](../docs/supply-chain-policy.md))

## Success metric

An agent asked to mine transcripts, authenticated community content, provider recordings, Drive/provider exports, or mixed account sources starts with inventory plus manifest-first allow/skip filters and commits synthesized findings, not raw transcripts or provider payloads.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [ ] N/A — change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [x] No
- [ ] Yes — migration note below

## Public / private boundary

No private operator strategy, machine-specific paths, raw transcripts, provider payloads, account names, customer/member data, credentials, or private runtime internals were committed. The new rail explicitly keeps raw evidence in OS temp or ignored scratch by default and routes only synthesized, permission-aware output into durable files.
