### PR TITLE
[add] Codex owner-loop runtime surface

### DIFF
--- a/.claude/educational/upgrading-mainbranch.md
+++ b/.claude/educational/upgrading-mainbranch.md
@@ -95,5 +95,6 @@ backup location, and no conflicts.
 ## What Main Branch does not claim
 
 Updating the engine is not the same as proving a runtime behavior. Claude Code
-is the supported runtime today. Other runtimes remain roadmap targets until
-adapter code and smoke evidence exist.
+is the supported slash-skill runtime today, and Codex CLI is supported for the
+owner loop. Other runtimes remain roadmap targets until adapter code and smoke
+evidence exist.

--- a/.claude/educational/why-mainbranch-not-saas.md
+++ b/.claude/educational/why-mainbranch-not-saas.md
@@ -47,9 +47,10 @@ you to paste the same offer, audience, proof, and decisions every session.
 regular git. Issues and pull requests are durable work threads and proposals,
 not hidden rows in a vendor database.
 
-**You can switch tools later.** Claude Code is the supported runtime today, but
-the repo shape is not trapped inside Claude Code. Future adapters should read
-the same files and deterministic `mb` commands.
+**You can switch tools later.** Claude Code is the supported slash-skill
+runtime today, and Codex CLI is supported for the owner loop. The repo shape is
+not trapped inside either runtime. Future adapters should read the same files
+and deterministic `mb` commands.
 
 **You keep SaaS tools as rails, not the brain.** GitHub, Cloudflare,
 Google/Workspace, ads tools, Apify, Stripe, Cal.com, and other providers can be
@@ -90,6 +91,7 @@ portable, inspectable, and compounding.
 Main Branch is not a hosted dashboard, chat client, background daemon, vector
 database, scheduler, marketplace, or model host today.
 
-Claude Code is the supported runtime today. Codex, Cursor, OpenClaw, Hermes,
-Paperclip-adjacent orchestration, and local runtimes are compatibility targets
-until adapter code and smoke evidence prove support.
+Claude Code is the supported slash-skill runtime today. Codex CLI is supported
+for the owner loop. Cursor, OpenClaw, Hermes, Paperclip-adjacent orchestration,
+and local runtimes are compatibility targets until adapter code and smoke
+evidence prove support.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,11 +19,13 @@ markdown files in git.
 - A user's business repo is the durable business brain.
 - A user is not met with git speak but instead business speak.
 
-Claude Code is the first-class runtime today. Codex CLI has an experimental
-CLI-first adapter for power users; it is not slash-command or workflow parity.
-Cursor, OpenClaw, Hermes, Paperclip-adjacent orchestration, and local runtimes
-remain compatibility targets until tested. Do not claim support before there is
-an adapter and smoke evidence for the exact surface.
+Claude Code is the first-class slash-skill runtime today. Codex CLI is
+first-class for the proven owner loop through generated `AGENTS.md`,
+`.agents/skills/main-branch-owner-loop`, deterministic `mb` facts, and
+workflow inventory. That is not slash-command parity or full production
+workflow parity. Cursor, OpenClaw, Hermes, Paperclip-adjacent orchestration,
+and local runtimes remain compatibility targets until tested. Do not claim
+support before there is an adapter and smoke evidence for the exact surface.
 
 The public product frame lives in `docs/ethos.md`, the operator loop taxonomy
 lives in `docs/operator-loops.md`, and release direction lives in
@@ -33,8 +35,9 @@ lives in `docs/operator-loops.md`, and release direction lives in
 
 The current product center is the daily owner loop:
 
-1. The operator opens the business repo and starts Claude Code.
-2. `/mb-start` or the generated repo instructions ground the agent in
+1. The operator opens the business repo and starts Claude Code or Codex CLI.
+2. `/mb-start`, the generated repo instructions, or the generated Codex
+   owner-loop skill ground the agent in
    deterministic `mb` facts before advice.
 3. The agent routes thought dumps and requests into business primitives:
    bets, goals, offers, research, decisions, pushes, playbooks, outcomes, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,22 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ### Added
 
+- Added a generated Codex owner-loop skill at
+  `.agents/skills/main-branch-owner-loop`, a generated workflow inventory, and
+  `mb workflow list --runtime codex` so Codex can discover supported,
+  pending, and intentionally unsupported Main Branch workflow surfaces. Refs
+  MAIN-421, #676.
 - Added source-ingestion privacy rails for transcripts, authenticated
   community/provider sources, mixed-account manifests, skip filters, proof
   permission gates, and `/mb-think` routing. Refs MAIN-409, #657.
 
 ### Changed
 
+- Promoted Codex narrowly from experimental CLI-first guidance to first-class
+  owner-loop support for start/status/setup/update/doctor, think/codify,
+  end/checkpoint/save, validate, and workflow discovery while keeping
+  slash-command, provider-write, publishing, spend, customer-contact, and
+  copied Claude skill parity out of scope. Refs MAIN-421, #676.
 - Tightened generated Codex `AGENTS.md` thinking-route guidance so fresh
   business repos treat the rendered route as the Codex shell for the
   `mb-think` shared workflow source instead of chasing engine-only workflow

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,9 @@ Bundled Claude Code skills live in `.claude/skills/`. If you edit a skill:
 - avoid private member data, private launch strategy, or machine-specific paths
   in examples.
 
-Claude Code is first-class today. Codex CLI has an experimental CLI-first
-adapter for power users, but no slash-command or workflow parity claim. Other
-runtimes are roadmap targets until an adapter and smoke evidence exist, so do
-not overclaim compatibility in docs.
+Claude Code is the first-class slash-skill runtime today. Codex CLI is
+first-class for the proven owner loop through generated `AGENTS.md`,
+`.agents/skills/main-branch-owner-loop`, deterministic `mb` facts, and workflow
+inventory. That is not slash-command parity or full production workflow parity.
+Other runtimes are roadmap targets until an adapter and smoke evidence exist,
+so do not overclaim compatibility in docs.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Open source. Lives on your machine. Bring your own Claude Code plan. That's it.
 ---
 
 <div align="center">
-  <em>Works with</em> <strong>Claude Code today</strong>. Codex CLI has an experimental CLI-first adapter for power users; Cursor, OpenClaw, Hermes, and local runtimes remain compatibility targets — see <a href="docs/compatibility.md">compatibility</a>.
+  <em>Works with</em> <strong>Claude Code</strong> and <strong>Codex CLI for the owner loop</strong>. Cursor, OpenClaw, Hermes, and local runtimes remain compatibility targets — see <a href="docs/compatibility.md">compatibility</a>.
 </div>
 
 ---
@@ -156,7 +156,7 @@ The longer-arc operating-memory model — where multiple business repos, GitHub 
 
 |                                  |                                                                                                |
 | -------------------------------- | ---------------------------------------------------------------------------------------------- |
-| **Not a chat app.**              | The supported chat surface is Claude Code; Codex CLI is experimental. Main Branch gives agents durable context to read from. |
+| **Not a chat app.**              | The supported chat surfaces are Claude Code and Codex CLI for the owner loop. Main Branch gives agents durable context to read from. |
 | **Not a SaaS dashboard.**        | Your business doesn't live on our servers. It lives in your folder.                            |
 | **Not a connect-every-tool hub.**| We pick boring, inspectable rails: GitHub, Cloudflare, official ads paths. Curated, not sprawl.|
 | **Not a model host.**            | We don't run models. We hand the agent the right context so the model you already use is sharper.|
@@ -217,16 +217,22 @@ claude
 
 You'll need a Claude plan that includes Claude Code. Install Claude Code from [claude.ai](https://claude.ai). Step-by-step beginner walkthrough: [docs/beginner-setup.md](docs/beginner-setup.md).
 
-### Trying Codex CLI
+### Using Codex CLI
 
-Codex CLI support is experimental and CLI-first. Fresh business folders include
-an `AGENTS.md` file that tells Codex how to start from Main Branch facts and
-routes the lifecycle basics: start the day, inspect status, and think through
-or codify a decision. Expect Codex to run `mb status --json --peek`,
-`mb start --json`, and `mb doctor repair --plan`, then translate those facts
-into a useful owner briefing. Do not expect Claude Code slash commands such as
-`/mb-start` to work inside Codex yet, and do not expect site, ads, publishing,
-provider mutation, spend, or customer-contact workflows to be ported there.
+Codex CLI is first-class for the Main Branch owner loop, not for Claude Code
+slash-command parity. Fresh business folders include a tracked `AGENTS.md`
+bootstrap plus `.agents/skills/main-branch-owner-loop`, so Codex can start the
+day, inspect status, route setup/update/doctor work, think through or codify a
+decision, plan an end/checkpoint/save closeout, validate the repo, and list
+workflow support.
+
+Expect Codex to run `mb status --json --peek`, `mb start --json`,
+`mb doctor repair --plan --json`, `mb checkpoint --plan --json`,
+`mb validate --json`, and `mb workflow list --runtime codex --json`, then
+translate those facts into a useful owner briefing. Do not expect Claude Code slash commands
+such as `/mb-start` to work inside Codex, and do not expect site, ads,
+publishing, provider mutation, spend, or customer-contact workflows to be
+ported there.
 
 After installing Codex CLI, test a new repo with:
 
@@ -324,6 +330,7 @@ The `mb` CLI is the deterministic control plane. The agent runs it for normal us
 | `mb graph`               | Build a folder graph from frontmatter links, wikilinks, and entity tags. Graphviz DOT, JSON, and PNG outputs. |
 | `mb suggest links`       | Suggest likely frontmatter, inline, tag, data, and context connections for a file without editing it. |
 | `mb checkpoint`          | Plan or save a business-readable git checkpoint during long agent runs. |
+| `mb workflow list`       | List Codex workflow support: supported owner-loop surfaces, pending shared-source migrations, and intentionally unsupported workflows. |
 | `mb skill list` / `path` / `validate` / `link` / `repair` | Manage and repair the bundled Claude Code skills. |
 | `mb update`              | Update Main Branch in place. |
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   <a href="https://github.com/noontide-co/mainbranch/actions/workflows/ci.yml"><img alt="CI" src="https://img.shields.io/github/actions/workflow/status/noontide-co/mainbranch/ci.yml?label=CI"></a>
   <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/license-MIT-blue"></a>
   <img alt="Runtime" src="https://img.shields.io/badge/Claude%20Code-first--class-black">
-  <img alt="Codex" src="https://img.shields.io/badge/Codex-experimental%20CLI--first-orange">
+  <img alt="Codex" src="https://img.shields.io/badge/Codex-first--class%20owner--loop-blue">
 </p>
 
 <p align="center">

--- a/docs/architecture/system-map.md
+++ b/docs/architecture/system-map.md
@@ -27,7 +27,7 @@ flowchart TB
 
   subgraph runtime["Agent runtime layer"]
     claude["Claude Code<br/>supported runtime"]
-    codex["Codex CLI<br/>experimental CLI-first adapter"]
+    codex["Codex CLI<br/>first-class owner loop"]
     future["Cursor / OpenClaw / Hermes / local runtimes<br/>roadmap until adapter + smoke evidence"]
     skills["Bundled mb-* skills<br/>judgment, routing, writing, review, explanation"]
   end
@@ -218,7 +218,7 @@ flowchart TB
 | GitHub is repo, checks, and history. | GitHub issues are durable tasks, PRs are proposals, Actions/checks gate changes, Releases mark package-visible publication. |
 | Cloudflare is site and deploy. | Cloudflare is the adopted site/DNS/Pages rail where evidence exists; GitHub Pages is not the default setup path. |
 | Real private data stays out of broad repos. | Secrets, raw ledgers, account exports, customer/member data, legal records, and machine-specific paths stay in secret stores, private vaults, provider systems, or local ignored state. |
-| Runtime support stays honest. | Claude Code is supported. Codex CLI is experimental and CLI-first. Other runtimes are roadmap until adapter and smoke evidence exist. |
+| Runtime support stays honest. | Claude Code is the first-class slash-skill runtime. Codex CLI is first-class for the proven owner loop only. Other runtimes are roadmap until adapter and smoke evidence exist. |
 
 ## Data And Privacy Boundaries
 
@@ -262,7 +262,7 @@ Sources: [Data-source registry](../data-source-registry.md),
 | Runtime | Status | Contract |
 | --- | --- | --- |
 | Claude Code | Supported. | Slash skills and `mb start` handoff are the reference runtime path. |
-| Codex CLI | Experimental CLI-first adapter. | Fresh business repos include `AGENTS.md`; Codex should run deterministic `mb` fact commands and ask before writes. |
+| Codex CLI | First-class owner loop. | Fresh business repos include `AGENTS.md` and `.agents/skills/main-branch-owner-loop`; Codex should run deterministic `mb` fact commands, use workflow inventory, and ask before writes. |
 | Cursor, OpenClaw, Hermes, Paperclip-adjacent orchestration, local runtimes | Roadmap. | No support claim until adapter code, docs, generated-file rules, and fresh-repo smoke evidence exist. |
 
 Source: [Compatibility](../compatibility.md).

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,7 +1,8 @@
 # Compatibility
 
-Main Branch is intentionally narrow today: `mb` plus bundled Claude Code skills as the first adapter for portable agent workflows.
-This page is the public compatibility contract for that surface.
+Main Branch is intentionally narrow today: `mb`, bundled Claude Code skills,
+and generated Codex owner-loop guidance. This page is the public compatibility
+contract for those surfaces.
 
 ## Supported matrix
 
@@ -13,8 +14,8 @@ This page is the public compatibility contract for that surface.
 | Python | 3.10, 3.11, 3.12 | CI gates all three versions. |
 | Install mode | `pipx install mainbranch` | Official public install path. |
 | Developer mode | Git clone | For contributors who want to edit the engine or skills. |
-| Agent runtime | Claude Code | First-class today. |
-| Codex CLI | Experimental CLI-first adapter | Fresh business repos include `AGENTS.md`; `mb status`, `mb start`, and `mb doctor repair` expose Codex readiness. This is not slash-command parity. |
+| Agent runtime | Claude Code | First-class slash-skill runtime today. |
+| Codex CLI | First-class owner loop | Fresh business repos include `AGENTS.md` and `.agents/skills/main-branch-owner-loop`; `mb workflow list --runtime codex` exposes supported, pending, and unsupported workflow surfaces. This is not slash-command parity or provider/publishing parity. |
 | Cursor, OpenClaw, Hermes, Paperclip-adjacent orchestration, local LLMs | Roadmap | `mb` is runtime-agnostic by design, but these adapters are not supported yet. |
 
 **Windows tip — try WSL2.** If you're on Windows and want a working setup today, use [Windows Subsystem for Linux 2 (WSL2)](https://learn.microsoft.com/en-us/windows/wsl/install). Inside WSL2, follow the supported Linux flow. The pipx install path works there.
@@ -145,7 +146,7 @@ smoke evidence exist.
 | Runtime surface | Status | Invocation | Skill/workflow discovery | Routing and automation | Observability and packaging |
 |---|---|---|---|---|---|
 | Claude Code | Supported | `mb start --repo "$repo"` prints the `claude` handoff; `mb start --launch` may launch after readiness checks. | `mb skill link --repo "$repo"` writes project-local `.claude/skills/mb-*` bridge links and `.claude/settings.local.json`. | Slash commands such as `/mb-start` and `/mb-think` own conversation and judgment; they call deterministic `mb` commands for facts. | `mb doctor`, `mb status --json`, `mb start --json`, `mb skill repair`, and runtime dogfood evidence gate release claims. Skills ship inside the Python package today. |
-| Codex CLI | Experimental | Can call deterministic `mb` commands as a subprocess when pointed at a business repo. `AGENTS.md` gives Codex a CLI-first lifecycle discovery surface for start, status, and thinking/codification routes. | Fresh `mb onboard` repos include tracked `AGENTS.md`; `mb doctor repair --plan` / `--apply` can report and refresh it. No `.agents/skills` or plugin parity is claimed yet. | Codex should run `mb status --json --peek`, `mb start --json`, and `mb doctor repair --plan` before advice, translate facts into business language, route status/thinking work through the generated lifecycle index, and ask before writes. | `mb doctor`, `mb status --json`, and `mb start --json` expose Codex readiness. Support remains experimental. The natural-language thinking/codification route has fresh read-only smoke evidence through generated `AGENTS.md` guidance checked against the `mb-think` shared workflow source; this is not slash-command or skill parity. |
+| Codex CLI | First-class owner loop | Can call deterministic `mb` commands as a subprocess when pointed at a business repo. `AGENTS.md` gives Codex the repo bootstrap and `.agents/skills/main-branch-owner-loop` gives Codex a native owner-loop discovery surface. | Fresh `mb onboard` repos include tracked `AGENTS.md`, `.agents/skills/main-branch-owner-loop/SKILL.md`, and a generated workflow inventory. `mb doctor repair --plan` / `--apply` can report and refresh them. | Codex should run `mb status --json --peek`, `mb start --json`, `mb doctor repair --plan --json`, `mb checkpoint --plan --json`, `mb validate --json`, and `mb workflow list --runtime codex --json` before owner-loop advice, translate facts into business language, and ask before writes. | `mb doctor`, `mb status --json`, `mb start --json`, and `mb workflow list` expose Codex readiness and workflow support. Support is first-class only for the proven owner loop: start/status/setup/update/doctor, think/codify, end/checkpoint/save, validate, and workflow discovery. This is not slash-command, ads/site/provider, publishing, spend, or customer-contact parity. |
 | Cursor | Roadmap | Can call deterministic `mb` commands from terminal/tasks when pointed at a business repo. | No supported Cursor rules/package adapter yet. | No supported Main Branch routing contract. | Needs adapter docs, install/update rules, conflict handling, and smoke evidence. |
 | OpenClaw | Roadmap | Target public runtime surface. It should call `mb` through stable CLI/JSON commands rather than clone-era paths. | No supported OpenClaw adapter yet. | Main Branch should coexist with OpenClaw as the business repo/GitHub memory layer, not replace it. | Needs explicit adapter shape, migration notes, generated-file rules, and smoke evidence. |
 | Hermes | Roadmap | Target runtime/memory surface. It may supervise or host workflows that call packaged `mb` commands. | No supported Hermes adapter yet. | Hermes-specific routing belongs in the Hermes adapter, while `mb` remains deterministic and non-conversational. | Docs may describe internal-package expectations generically, but not as the only blessed public path. Smoke evidence is required before support claims. |
@@ -158,17 +159,17 @@ The CLI/repo contract and the slash-skill workflow contract have different
 support levels:
 
 Shared workflow sources under `workflows/` are runtime-agnostic contracts.
-Runtime shells, Claude Code skills, generated `AGENTS.md`, and future adapter
-packages should stay thin over those sources. A checked shared workflow source
-does not by itself make every runtime supported; support still requires an
-adapter and smoke evidence for that runtime.
+Runtime shells, Claude Code skills, generated `AGENTS.md`, generated Codex
+skills, and future adapter packages should stay thin over those sources. A
+checked shared workflow source does not by itself make every runtime supported;
+support still requires an adapter and smoke evidence for that runtime.
 
 | Surface | Claude Code | Other runtimes and orchestrators |
 |---|---|---|
 | Deterministic CLI facts (`mb status --json`, `mb validate --json`, `mb graph --json`, `mb connect status --json`) | Supported when `mb` is installed and pointed at a business repo. | Callable as packaged CLI subprocesses, but this does not make the hosting runtime supported. |
-| Runtime handoff (`mb start --json`, `mb start --launch`) | Supported for Claude Code handoff and launch readiness. | Codex CLI handoff metadata is experimental and read-only: `mb start --json` reports Codex executable and `AGENTS.md` readiness. `mb` does not launch Codex. |
-| Lifecycle slash skills (`/mb-start`, `/mb-status`, `/mb-setup`, `/mb-update`, `/mb-end`, `/mb-help`) | Supported through Claude Code project-local skill discovery. | Codex has generated `AGENTS.md` lifecycle guidance for start, status, and thinking/codification routes. These are instructions over deterministic `mb` facts, not slash commands. Setup, update, end, and help parity remain roadmap. |
-| Production slash skills (`/mb-think`, `/mb-ads`, `/mb-organic`, `/mb-site`, `/mb-wiki`, `/mb-bet`) | Supported through Claude Code skills, subject to each skill's provider and workflow limits. Conversion scripts route through the owning workflow instead of a standalone primitive or skill. | Roadmap. Cursor rules, Codex prompts, OpenClaw workflows, Hermes packages, Paperclip routines, or local-runtime prompts need their own adapter/package contract before public support claims. |
+| Runtime handoff (`mb start --json`, `mb start --launch`) | Supported for Claude Code handoff and launch readiness. | Codex CLI handoff metadata is supported for owner-loop readiness: `mb start --json` reports Codex executable, `AGENTS.md`, and owner-loop skill readiness. `mb` does not launch Codex. |
+| Lifecycle slash skills (`/mb-start`, `/mb-status`, `/mb-setup`, `/mb-update`, `/mb-end`, `/mb-help`) | Supported through Claude Code project-local skill discovery. | Codex does not use slash commands. The generated owner-loop skill covers start/status/setup/update/doctor, end/checkpoint/save, validate, and workflow discovery through deterministic `mb` facts and approval gates. |
+| Production slash skills (`/mb-think`, `/mb-ads`, `/mb-organic`, `/mb-site`, `/mb-wiki`, `/mb-bet`) | Supported through Claude Code skills, subject to each skill's provider and workflow limits. Conversion scripts route through the owning workflow instead of a standalone primitive or skill. | Codex supports think/codify through `workflows/mb-think/workflow.md` and generated guidance. Ads, organic/newsletter, site, and bet workflows are pending shared-source migration. Wiki and skill-authoring workflows are intentionally unsupported for the owner-loop target. |
 | Automation routines | May call CLI commands before handing judgment work to Claude Code. | May call shipped deterministic CLI commands against an explicit repo path. Conversation, retries, routing, and model invocation belong to the runtime adapter, not `mb`. |
 
 ## Adapter checklist
@@ -188,14 +189,16 @@ write runtime state, credentials, or raw account data into tracked files.
 
 For the Codex staging plan, see
 [Codex Adapter Plan](../decisions/2026-05-08-codex-adapter-plan.md). The current
-implementation is the experimental CLI-first slice: generated `AGENTS.md`,
-deterministic readiness facts, doctor repair coverage, and compact lifecycle
-discovery for start, status, and thinking/codification. The think route is
-checked against `workflows/mb-think/workflow.md` as the first official shared
-workflow source pattern, and fresh read-only Codex smoke has covered a natural
-thinking/codification prompt from a business repo. It does not claim supported
-Codex parity, slash-command parity, `.agents/skills` distribution, or
-provider/publishing workflow support.
+implementation is the owner-loop slice: generated `AGENTS.md`, generated
+`.agents/skills/main-branch-owner-loop`, deterministic readiness facts, doctor
+repair coverage, `mb workflow list`, and compact workflow discovery for
+start/status/setup/update/doctor, think/codify, end/checkpoint/save, validate,
+and workflow inventory. The think route is checked against
+`workflows/mb-think/workflow.md` as the first official shared workflow source
+pattern, and fresh read-only Codex smoke covers the owner-loop surface from a
+business repo. It does not claim slash-command parity, copied Claude skill
+parity, provider/publishing workflow support, spend, or customer-contact
+support.
 
 ## Recommended setup
 
@@ -258,10 +261,10 @@ mb doctor
 
 ## Known Limits
 
-- Claude Code is the only first-class agent runtime today.
-- Codex CLI support is experimental and CLI-first: generated `AGENTS.md` can
-  orient Codex to `mb` facts, but Main Branch does not claim Codex slash-command
-  or workflow parity.
+- Claude Code is the first-class slash-skill runtime today.
+- Codex CLI is first-class for the proven owner loop. Main Branch does not
+  claim Codex slash-command parity, copied Claude skill parity, provider writes,
+  publishing, spend, or customer-contact workflows.
 - Windows is experimental.
 - Skills are bundled into the installed Python package, so public users update
   skills by upgrading `mainbranch`.
@@ -273,6 +276,6 @@ mb doctor
   `.claude/settings.local.json` `additionalDirectories` entry grants engine
   file access, but it is not enough by itself for reliable `/mb-start`
   discovery.
-- Codex, Cursor, OpenClaw, Hermes, Paperclip-adjacent orchestration, and local
+- Cursor, OpenClaw, Hermes, Paperclip-adjacent orchestration, and local
   runtimes remain roadmap surfaces until each has a documented adapter and
-  smoke evidence.
+  smoke evidence. Codex support is limited to the owner-loop surface above.

--- a/docs/dependency-choices.md
+++ b/docs/dependency-choices.md
@@ -83,7 +83,7 @@ Use this rubric before adding, promoting, replacing, or removing a dependency.
 | Can Main Branch test it? | Local tests, CI tests, read-only smoke, package smoke, fixture repo smoke, or runtime smoke as appropriate. |
 | Does it require paid access or hosted setup? | Document account requirements, OAuth/developer-app steps, billing assumptions, and no-account fallback behavior. |
 | Where do secrets live? | Credentials must stay outside tracked repos; repo metadata must be safe to share. |
-| Does it cross runtime boundaries? | Claude Code is first-class today; Codex CLI is experimental and CLI-first; other runtimes need adapters and smoke evidence before support claims. |
+| Does it cross runtime boundaries? | Claude Code is the first-class slash-skill runtime; Codex CLI is first-class for the proven owner loop only; other runtimes need adapters and smoke evidence before support claims. |
 | Can failures be explained? | `mb doctor`, `mb connect`, `mb status`, or provider docs should tell the user what failed and the next command. |
 | Does it mutate external accounts? | Spending, publishing, emailing, deploying, and customer/account mutation need explicit operator action and provider authority. |
 | What is the exit plan? | Record the replacement, fallback, deprecation path, or reason the dependency can stay optional. |

--- a/docs/ethos.md
+++ b/docs/ethos.md
@@ -99,9 +99,12 @@ and power users, but they should not be the default user experience.
 
 ### 5. Runtime Honesty
 
-Claude Code is the first supported runtime today. Codex, Cursor, OpenClaw,
-Hermes, Paperclip-adjacent orchestration, and local runtimes are compatibility
-targets only when adapter code and smoke evidence exist.
+Claude Code is the first supported slash-skill runtime today. Codex CLI is
+first-class for the proven owner loop through generated repo guidance,
+generated owner-loop skill discovery, deterministic `mb` facts, and smoke
+evidence. Cursor, OpenClaw, Hermes, Paperclip-adjacent orchestration, and local
+runtimes are compatibility targets only when adapter code and smoke evidence
+exist.
 
 Main Branch should meet operators where they already work, but it should not
 claim support before support is proven.

--- a/docs/post-release-alignment.md
+++ b/docs/post-release-alignment.md
@@ -254,9 +254,10 @@ truth lives in the linked doc or decision.
 - **Language**: plain business language first. Technical terms (canonical,
   schema, primitive) are fine in code comments and contributor docs, not in
   user-facing copy. See `docs/agent-writing-style.md`.
-- **Runtime claims**: Claude Code is first-class. Codex CLI has an
-  experimental CLI-first adapter. Other runtimes are compatibility targets
-  until smoke evidence exists. See `docs/compatibility.md`.
+- **Runtime claims**: Claude Code is first-class for slash skills. Codex CLI is
+  first-class for the proven owner loop through generated repo guidance and a
+  generated owner-loop skill. Other runtimes are compatibility targets until
+  smoke evidence exists. See `docs/compatibility.md`.
 
 If a PR or issue contradicts one of these, treat the contradiction as a
 stale-assumption finding and block until reconciled or a new decision file

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -68,9 +68,11 @@ Main Branch already ships:
   team daily log, bookkeeping, and multi-repo work;
 - initial paid-traffic site readiness checks through `mb site check`.
 
-Claude Code is the supported runtime today. Codex CLI has an experimental
-CLI-first adapter; other runtimes are compatibility targets until adapter code
-and smoke evidence exist.
+Claude Code is the supported slash-skill runtime today. Codex CLI is
+first-class for the proven owner loop through generated `AGENTS.md`,
+`.agents/skills/main-branch-owner-loop`, deterministic `mb` facts, and workflow
+inventory. Other runtimes are compatibility targets until adapter code and
+smoke evidence exist.
 
 ## Current Direction: Chat-First, CLI-Backed Daily Loop
 

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -112,11 +112,12 @@ The first official pattern is `workflows/mb-think/workflow.md`. It declares the
 workflow intent, operator loops, runtime support level, checked runtime
 surfaces, required `mb` fact commands, JSON fact paths, approval gates,
 public/private boundaries, routing rules, handoff shape, and validation
-expectations. Claude Code remains the first-class runtime shell through
-`.claude/skills/mb-think/SKILL.md`; Codex remains experimental and uses tracked
-`AGENTS.md` guidance checked against the shared source. Neither `.claude/skills`
-nor `.agents/skills` is the canonical source for cross-runtime workflow
-semantics.
+expectations. Claude Code remains the first-class slash-skill runtime shell
+through `.claude/skills/mb-think/SKILL.md`; Codex uses tracked `AGENTS.md` and
+generated `.agents/skills/main-branch-owner-loop` guidance for the proven owner
+loop, checked against shared workflow sources where migrated. Neither
+`.claude/skills` nor `.agents/skills` is the canonical source for cross-runtime
+workflow semantics.
 
 `mb` may validate, render snapshots for tests, and repair generated runtime
 guidance. It must not invoke Claude, Codex, or any model.
@@ -580,10 +581,11 @@ graph, status, doctor/repair, connect, update, migrate, skill management,
 and checkpoint. The full surface lives in
 [the README](../README.md#for-contributors-and-power-users).
 
-Skills own judgment-heavy work — synthesis, writing, review, routing — and
-call `mb` for facts. Claude Code is the supported runtime today; other
-runtimes are compatibility targets until adapter code and smoke evidence
-exist. See [compatibility.md](compatibility.md).
+Skills own judgment-heavy work: synthesis, writing, review, routing. They call
+`mb` for facts. Claude Code is the supported slash-skill runtime today. Codex
+CLI is supported for the proven owner loop through generated repo guidance and
+a generated owner-loop skill. Other runtimes are compatibility targets until
+adapter code and smoke evidence exist. See [compatibility.md](compatibility.md).
 
 Curated rails — GitHub, Cloudflare, Google/Workspace, official ads paths,
 Postiz, hledger, transcription helpers — earn their place by improving a loop

--- a/mb/mb/_data/educational/upgrading-mainbranch.md
+++ b/mb/mb/_data/educational/upgrading-mainbranch.md
@@ -95,5 +95,6 @@ backup location, and no conflicts.
 ## What Main Branch does not claim
 
 Updating the engine is not the same as proving a runtime behavior. Claude Code
-is the supported runtime today. Other runtimes remain roadmap targets until
-adapter code and smoke evidence exist.
+is the supported slash-skill runtime today, and Codex CLI is supported for the
+owner loop. Other runtimes remain roadmap targets until adapter code and smoke
+evidence exist.

--- a/mb/mb/_data/educational/why-mainbranch-not-saas.md
+++ b/mb/mb/_data/educational/why-mainbranch-not-saas.md
@@ -47,9 +47,10 @@ you to paste the same offer, audience, proof, and decisions every session.
 regular git. Issues and pull requests are durable work threads and proposals,
 not hidden rows in a vendor database.
 
-**You can switch tools later.** Claude Code is the supported runtime today, but
-the repo shape is not trapped inside Claude Code. Future adapters should read
-the same files and deterministic `mb` commands.
+**You can switch tools later.** Claude Code is the supported slash-skill
+runtime today, and Codex CLI is supported for the owner loop. The repo shape is
+not trapped inside either runtime. Future adapters should read the same files
+and deterministic `mb` commands.
 
 **You keep SaaS tools as rails, not the brain.** GitHub, Cloudflare,
 Google/Workspace, ads tools, Apify, Stripe, Cal.com, and other providers can be
@@ -90,6 +91,7 @@ portable, inspectable, and compounding.
 Main Branch is not a hosted dashboard, chat client, background daemon, vector
 database, scheduler, marketplace, or model host today.
 
-Claude Code is the supported runtime today. Codex, Cursor, OpenClaw, Hermes,
-Paperclip-adjacent orchestration, and local runtimes are compatibility targets
-until adapter code and smoke evidence prove support.
+Claude Code is the supported slash-skill runtime today. Codex CLI is supported
+for the owner loop. Cursor, OpenClaw, Hermes, Paperclip-adjacent orchestration,
+and local runtimes are compatibility targets until adapter code and smoke
+evidence prove support.

--- a/mb/mb/_data/templates/AGENTS.md.tmpl
+++ b/mb/mb/_data/templates/AGENTS.md.tmpl
@@ -84,14 +84,17 @@ current paths, frontmatter, JSON keys, validator rules, and command names.
 
 ## Codex Lifecycle Workflow Index
 
-This tracked `AGENTS.md` file is the current Codex lifecycle discovery surface.
-It is owned by `mb init`, `mb onboard`, `mb doctor repair`, and the operator.
-Keep it compact: route to lifecycle workflows and `mb` facts here, but do not
-duplicate the full Main Branch skill tree.
+This tracked `AGENTS.md` file is the repo-level Codex bootstrap. The generated
+project-local skill at `.agents/skills/main-branch-owner-loop/SKILL.md` is the
+Codex-native owner-loop discovery surface. Both are owned by `mb init`,
+`mb onboard`, `mb doctor repair`, and the operator. Keep them compact: route to
+lifecycle workflows and `mb` facts, but do not duplicate the full Main Branch
+skill tree.
 
-Do not create `.agents/skills`, Codex plugin manifests, generated runtime
-files, or symlinked Claude skills unless a future `mb` command or issue says
-that surface is supported for this repo.
+Use `.agents/skills/main-branch-owner-loop` for the proven owner loop only. Do
+not create Codex plugin manifests, copied Claude skill trees, or symlinked
+Claude skills unless a future `mb` command or issue says that surface is
+supported for this repo.
 
 Use this index to map natural Codex requests:
 

--- a/mb/mb/checkpoint.py
+++ b/mb/mb/checkpoint.py
@@ -431,7 +431,7 @@ def _surface(path: str) -> str:
         return "site"
     if path in {"package.json", "astro.config.mjs", "vite.config.ts", "vite.config.js"}:
         return "site"
-    if path.startswith((".github/", ".claude/", ".mainbranch/", ".mb/")):
+    if path.startswith((".github/", ".agents/", ".claude/", ".mainbranch/", ".mb/")):
         return "config"
     if path in {"AGENTS.md", "CLAUDE.md", ".gitignore", "README.md"}:
         return "config"

--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -20,6 +20,7 @@ from mb import __version__
 from mb import ads as ads_mod
 from mb import books as books_mod
 from mb import checkpoint as checkpoint_mod
+from mb import codex as codex_mod
 from mb import connect as connect_mod
 from mb import doctor as doctor_mod
 from mb import educational as educational_mod
@@ -131,6 +132,13 @@ suggest_app = typer.Typer(
     no_args_is_help=True,
 )
 app.add_typer(suggest_app, name="suggest")
+
+workflow_app = typer.Typer(
+    name="workflow",
+    help="List Main Branch workflow support across runtimes.",
+    no_args_is_help=True,
+)
+app.add_typer(workflow_app, name="workflow")
 
 CONNECT_METADATA_OPTION = typer.Option(
     [],
@@ -377,6 +385,46 @@ def _render_onboard_human(result: dict[str, Any]) -> None:
     if warnings:
         console.print(f"\nFor a full setup check, run `{result['doctor_command']}`.")
     console.print()
+
+
+def _render_workflow_inventory_human(result: dict[str, Any]) -> None:
+    from rich.console import Console
+
+    console = Console()
+    console.print("\n[bold]Main Branch workflow support[/bold]")
+    console.print(f"runtime: {result['runtime']}")
+    console.print(f"entrypoint: {result['entrypoint']}")
+    console.print()
+    for item in result["items"]:
+        commands = ", ".join(item.get("commands") or [])
+        suffix = f"  facts: {commands}" if commands else ""
+        console.print(
+            f"- {item['label']}  [{item['codex_status']}]\n  Codex: {item['codex_surface']}{suffix}"
+        )
+    console.print()
+
+
+@workflow_app.command("list")
+def workflow_list_cmd(
+    runtime: str = typer.Option("codex", "--runtime", help="Runtime inventory to show."),
+    json_out: bool = typer.Option(False, "--json", help="Machine-readable output."),
+) -> None:
+    """List supported and pending workflow surfaces for a runtime."""
+    normalized_runtime = runtime.strip().lower().replace("-", "_")
+    if normalized_runtime not in {"codex", "codex_cli"}:
+        typer.echo("mb workflow list: only --runtime codex is available today", err=True)
+        raise typer.Exit(2)
+    result = codex_mod.workflow_inventory(runtime="codex")
+    if json_out:
+        typer.echo(
+            _json_payload(
+                result,
+                command="mb workflow list",
+                schema_name="mainbranch.workflow.inventory.result",
+            )
+        )
+    else:
+        _render_workflow_inventory_human(result)
 
 
 @onboard_app.callback()

--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -412,7 +412,18 @@ def workflow_list_cmd(
     """List supported and pending workflow surfaces for a runtime."""
     normalized_runtime = runtime.strip().lower().replace("-", "_")
     if normalized_runtime not in {"codex", "codex_cli"}:
-        typer.echo("mb workflow list: only --runtime codex is available today", err=True)
+        message = "mb workflow list: only --runtime codex is available today"
+        if json_out:
+            typer.echo(
+                _json_error_payload(
+                    command="mb workflow list",
+                    schema_name="mainbranch.workflow.inventory.result",
+                    code="unsupported_runtime",
+                    message=message,
+                )
+            )
+        else:
+            typer.echo(message, err=True)
         raise typer.Exit(2)
     result = codex_mod.workflow_inventory(runtime="codex")
     if json_out:

--- a/mb/mb/codex.py
+++ b/mb/mb/codex.py
@@ -14,10 +14,25 @@ from typing import Any
 
 AGENTS_TEMPLATE = "AGENTS.md.tmpl"
 AGENTS_RELATIVE_PATH = "AGENTS.md"
+CODEX_SKILL_DIR_RELATIVE_PATH = ".agents/skills/main-branch-owner-loop"
+CODEX_SKILL_RELATIVE_PATH = f"{CODEX_SKILL_DIR_RELATIVE_PATH}/SKILL.md"
+CODEX_WORKFLOW_INVENTORY_RELATIVE_PATH = (
+    f"{CODEX_SKILL_DIR_RELATIVE_PATH}/references/workflow-inventory.md"
+)
 REQUIRED_FACT_COMMANDS = (
     "mb status --json --peek",
     "mb start --json",
     "mb doctor repair --plan",
+)
+OWNER_LOOP_COMMANDS = (
+    "mb --version",
+    "mb status --json --peek",
+    "mb start --json",
+    "mb doctor repair --plan --json",
+    "mb update --check --json",
+    "mb validate --json",
+    "mb checkpoint --plan --json",
+    "mb workflow list --runtime codex --json",
 )
 CODEX_THINK_SOURCE_WORKFLOW = "workflows/mb-think/workflow.md"
 CODEX_THINK_REQUIRED_MB_COMMANDS = (
@@ -78,7 +93,7 @@ REQUIRED_LIFECYCLE_GUIDANCE = (
     "Shared source required JSON fact paths",
     "Shared source gates",
     "Shared public/private boundaries",
-    "Do not create `.agents/skills`",
+    "Use `.agents/skills/main-branch-owner-loop`",
     "do not claim these workflows are ported to",
 )
 REQUIRED_LIFECYCLE_GUIDANCE_MARKERS = (
@@ -87,6 +102,139 @@ REQUIRED_LIFECYCLE_GUIDANCE_MARKERS = (
     *(f"- `{fact}`" for fact in CODEX_THINK_REQUIRED_JSON_FACTS),
     *(f"`{gate}`" for gate in CODEX_THINK_APPROVAL_GATES),
     *(f"`{boundary}`" for boundary in CODEX_THINK_PUBLIC_PRIVATE_BOUNDARIES),
+)
+CODEX_SKILL_REQUIRED_MARKERS = (
+    "Main Branch owner loop for Codex",
+    "mb workflow list --runtime codex --json",
+    "start/status/setup/update/doctor",
+    "think/codify",
+    "end/checkpoint/save",
+    "Ask before durable writes",
+)
+
+CODEX_WORKFLOW_INVENTORY: tuple[dict[str, Any], ...] = (
+    {
+        "id": "owner-loop-start-status",
+        "label": "Start, status, and what changed",
+        "claude_surface": "/mb-start, /mb-status",
+        "codex_status": "supported",
+        "codex_surface": "AGENTS.md and .agents/skills/main-branch-owner-loop",
+        "commands": ("mb status --json --peek", "mb start --json"),
+        "notes": (
+            "Codex starts from deterministic status/start facts, translates them "
+            "into business language, and routes one next owner-loop move."
+        ),
+    },
+    {
+        "id": "owner-loop-setup-repair-update",
+        "label": "Setup, update, doctor, and repair planning",
+        "claude_surface": "/mb-setup, /mb-update, /mb-start repair routing",
+        "codex_status": "supported",
+        "codex_surface": "AGENTS.md and .agents/skills/main-branch-owner-loop",
+        "commands": (
+            "mb --version",
+            "mb doctor repair --plan --json",
+            "mb update --check --json",
+        ),
+        "notes": (
+            "Codex may inspect plans and explain next steps. Applying updates, "
+            "repairs, migrations, or setup writes requires explicit approval."
+        ),
+    },
+    {
+        "id": "think-codify",
+        "label": "Think, research, decide, and codify",
+        "claude_surface": "/mb-think",
+        "codex_status": "supported",
+        "codex_surface": "AGENTS.md#codex-think-route and owner-loop skill",
+        "shared_source": CODEX_THINK_SOURCE_WORKFLOW,
+        "commands": CODEX_THINK_REQUIRED_MB_COMMANDS,
+        "notes": (
+            "Codex uses the shared mb-think contract for research depth, source "
+            "privacy, decision routing, codification, and approval gates."
+        ),
+    },
+    {
+        "id": "end-checkpoint-save",
+        "label": "End, checkpoint, and save business memory",
+        "claude_surface": "/mb-end, mb checkpoint",
+        "codex_status": "supported",
+        "codex_surface": "AGENTS.md and .agents/skills/main-branch-owner-loop",
+        "commands": ("mb checkpoint --plan --json", "mb validate --json"),
+        "notes": (
+            "Codex can plan a closeout and propose checkpoint subjects. Creating "
+            "a checkpoint or editing files requires explicit approval."
+        ),
+    },
+    {
+        "id": "workflow-discovery",
+        "label": "Workflow discovery and support inventory",
+        "claude_surface": "/mb-help and docs",
+        "codex_status": "supported",
+        "codex_surface": "mb workflow list and owner-loop skill inventory",
+        "commands": ("mb workflow list --runtime codex --json",),
+        "notes": "Codex users can inspect supported, pending, and unsupported workflow surfaces.",
+    },
+    {
+        "id": "bets",
+        "label": "Bet lifecycle",
+        "claude_surface": "/mb-bet",
+        "codex_status": "pending_shared_source_migration",
+        "codex_surface": "Read-only facts and business-file planning only",
+        "commands": ("mb status --json --peek", "mb validate --json"),
+        "notes": (
+            "Codex may inspect and discuss bets. A generated Codex shell should "
+            "wait for a shared bet workflow source."
+        ),
+    },
+    {
+        "id": "ads",
+        "label": "Ads and paid creative",
+        "claude_surface": "/mb-ads",
+        "codex_status": "pending_shared_source_migration",
+        "codex_surface": "Read-only planning only",
+        "commands": ("mb status --json --peek", "mb connect doctor --json"),
+        "notes": "No provider mutation, spend, upload, or publishing is supported in Codex.",
+    },
+    {
+        "id": "organic-content",
+        "label": "Organic content and newsletter planning",
+        "claude_surface": "/mb-organic and related playbooks",
+        "codex_status": "pending_shared_source_migration",
+        "codex_surface": "Read-only planning only",
+        "commands": ("mb status --json --peek",),
+        "notes": (
+            "Codex may route content strategy questions through think/codify, "
+            "but publishing and newsletter dogfood remain outside this parity slice."
+        ),
+    },
+    {
+        "id": "site",
+        "label": "Site and page production",
+        "claude_surface": "/mb-site",
+        "codex_status": "pending_shared_source_migration",
+        "codex_surface": "Read-only planning and site readiness facts only",
+        "commands": ("mb status --json --peek", "mb site check --json"),
+        "notes": "Codex must not claim site build, deploy, domain, or publishing parity.",
+    },
+    {
+        "id": "wiki",
+        "label": "Wiki and personal atomic notes",
+        "claude_surface": "/mb-wiki",
+        "codex_status": "intentionally_unsupported",
+        "codex_surface": "None",
+        "commands": (),
+        "notes": "Specialty workflow outside the v0.3.28 owner-loop parity target.",
+    },
+    {
+        "id": "skill-authoring",
+        "label": "Skill concept, draft, and review",
+        "claude_surface": "/mb-skill-concept, /mb-skill-brief-draft, /mb-skill-review",
+        "codex_status": "intentionally_unsupported",
+        "codex_surface": "None",
+        "commands": (),
+        "notes": "Engine-contributor workflow, not a business owner-loop runtime surface.",
+    },
 )
 
 
@@ -176,14 +324,17 @@ canonical paths, frontmatter, JSON keys, validator rules, and command names.
 
 ## Codex Lifecycle Workflow Index
 
-This tracked `AGENTS.md` file is the current Codex lifecycle discovery surface.
-It is owned by `mb init`, `mb onboard`, `mb doctor repair`, and the operator.
-Keep it compact: route to lifecycle workflows and `mb` facts here, but do not
-duplicate the full Main Branch skill tree.
+This tracked `AGENTS.md` file is the repo-level Codex bootstrap. The generated
+project-local skill at `.agents/skills/main-branch-owner-loop/SKILL.md` is the
+Codex-native owner-loop discovery surface. Both are owned by `mb init`,
+`mb onboard`, `mb doctor repair`, and the operator. Keep them compact: route to
+lifecycle workflows and `mb` facts, but do not duplicate the full Main Branch
+skill tree.
 
-Do not create `.agents/skills`, Codex plugin manifests, generated runtime
-files, or symlinked Claude skills unless a future `mb` command or issue says
-that surface is supported for this repo.
+Use `.agents/skills/main-branch-owner-loop` for the proven owner loop only. Do
+not create Codex plugin manifests, copied Claude skill trees, or symlinked
+Claude skills unless a future `mb` command or issue says that surface is
+supported for this repo.
 
 Use this index to map natural Codex requests:
 
@@ -486,8 +637,137 @@ def render_agents_md(repo: str | Path, *, name: str = "", gh_username: str = "")
     return _render(template, mapping)
 
 
+def _commands_for_inventory_item(item: dict[str, Any]) -> tuple[str, ...]:
+    commands = item.get("commands") or ()
+    if not isinstance(commands, tuple):
+        return tuple(str(command) for command in commands)
+    return tuple(str(command) for command in commands)
+
+
+def workflow_inventory(*, runtime: str = "codex") -> dict[str, Any]:
+    """Return the public-safe Main Branch workflow support inventory."""
+
+    items = []
+    for item in CODEX_WORKFLOW_INVENTORY:
+        copied = dict(item)
+        copied["commands"] = list(_commands_for_inventory_item(item))
+        items.append(copied)
+    statuses = sorted({str(item["codex_status"]) for item in CODEX_WORKFLOW_INVENTORY})
+    return {
+        "ok": True,
+        "runtime": runtime,
+        "support_level": "first_class_owner_loop",
+        "entrypoint": CODEX_SKILL_RELATIVE_PATH,
+        "repo_guidance": AGENTS_RELATIVE_PATH,
+        "inventory_path": CODEX_WORKFLOW_INVENTORY_RELATIVE_PATH,
+        "statuses": statuses,
+        "items": items,
+        "safe_to_share": True,
+    }
+
+
+def render_workflow_inventory_md() -> str:
+    """Render the project-local Codex workflow inventory reference."""
+
+    rows = []
+    for item in CODEX_WORKFLOW_INVENTORY:
+        commands = ", ".join(f"`{command}`" for command in _commands_for_inventory_item(item))
+        rows.append(
+            "| {label} | `{status}` | {claude} | {codex} | {commands} |".format(
+                label=item["label"],
+                status=item["codex_status"],
+                claude=item["claude_surface"],
+                codex=item["codex_surface"],
+                commands=commands or "None",
+            )
+        )
+    return (
+        "# Main Branch Codex Workflow Inventory\n\n"
+        "Generated by `mb`. Do not edit by hand in business repos. This file maps "
+        "Main Branch workflow surfaces to the Codex owner-loop support boundary.\n\n"
+        "Status meanings:\n\n"
+        "- `supported`: Codex can use this surface for the owner loop from "
+        "deterministic `mb` facts and generated guidance.\n"
+        "- `pending_shared_source_migration`: Codex may plan from read-only facts, "
+        "but a runtime shell should wait for a shared workflow source.\n"
+        "- `generated_shell_pending`: a shared source exists, but a generated Codex "
+        "shell still needs implementation and smoke evidence.\n"
+        "- `intentionally_unsupported`: outside the current Codex owner-loop target.\n\n"
+        "| Workflow | Codex status | Claude Code surface | Codex surface | Fact commands |\n"
+        "|---|---|---|---|---|\n" + "\n".join(rows) + "\n\n"
+        "Codex must ask before durable writes, checkpoints, repairs, updates, "
+        "migrations, provider mutation, publishing, spend, customer contact, or "
+        "public issue/proposal submission.\n"
+    )
+
+
+def render_codex_skill_md() -> str:
+    """Render the project-local Codex skill for the owner loop."""
+
+    command_lines = "\n".join(f"- `{command}`" for command in OWNER_LOOP_COMMANDS)
+    description = (
+        "Use when the operator asks Codex to run Main Branch daily owner-loop work "
+        "from a business repo: start/status/setup/update/doctor, think/codify, "
+        "end/checkpoint/save, validate, or workflow discovery. Starts from "
+        "deterministic mb facts and asks before durable writes, provider mutations, "
+        "publishing, spend, customer contact, or checkpoints."
+    )
+    return f"""---
+name: main-branch-owner-loop
+description: >-
+  {description}
+---
+
+# Main Branch owner loop for Codex
+
+Run Main Branch owner-loop work from a business repo. This is a Codex-native
+skill generated by `mb`; `AGENTS.md` remains the repo-level bootstrap.
+
+## Start Here
+
+Before advice, run read-only facts that fit the request:
+
+{command_lines}
+
+Use `mb status --json --peek` as the first daily read. Use `mb start --json`
+when runtime handoff or adapter readiness matters. Use
+`mb workflow list --runtime codex --json` when the operator asks what Codex can
+do.
+
+## Supported Owner Loop
+
+- start/status/setup/update/doctor: inspect facts and plans, then ask before
+  applying repairs, migrations, setup writes, or updates.
+- think/codify: follow the `mb-think` shared workflow route in `AGENTS.md`.
+- end/checkpoint/save: run `mb checkpoint --plan --json`, propose a
+  business-readable checkpoint, and ask before saving it.
+- validate: run `mb validate --json` and explain repo health in business
+  language before technical details.
+- workflow discovery: read `references/workflow-inventory.md` or run
+  `mb workflow list --runtime codex --json`.
+
+## Approval Gates
+
+Ask before durable writes, checkpoints, updates, repairs, migrations, provider
+mutation, publishing, spend, customer contact, destructive operations, raw
+private-source reads, or public issue/proposal submission.
+
+Do not claim Claude Code slash commands work in Codex. Do not claim ads, site,
+organic, provider-write, wiki, or skill-authoring parity unless the inventory
+marks that surface `supported`.
+"""
+
+
 def agents_path(repo: str | Path) -> Path:
     return Path(repo).expanduser().resolve() / AGENTS_RELATIVE_PATH
+
+
+def codex_skill_path(repo: str | Path) -> Path:
+    return Path(repo).expanduser().resolve() / CODEX_SKILL_RELATIVE_PATH
+
+
+def workflow_inventory_path(repo: str | Path) -> Path:
+    return Path(repo).expanduser().resolve() / CODEX_WORKFLOW_INVENTORY_RELATIVE_PATH
 
 
 def executable_status() -> dict[str, Any]:
@@ -496,7 +776,57 @@ def executable_status() -> dict[str, Any]:
         "found": bool(path),
         "path": path,
         "executable": "codex",
-        "repair": "" if path else "Install Codex CLI before using the experimental Codex adapter.",
+        "repair": "" if path else "Install Codex CLI before using the Codex owner-loop adapter.",
+    }
+
+
+def skill_status(repo: str | Path) -> dict[str, Any]:
+    target = Path(repo).expanduser().resolve()
+    skill = codex_skill_path(target)
+    inventory = workflow_inventory_path(target)
+    skill_exists = skill.is_file()
+    inventory_exists = inventory.is_file()
+    expected_skill = render_codex_skill_md()
+    expected_inventory = render_workflow_inventory_md()
+    try:
+        skill_text = skill.read_text(encoding="utf-8") if skill_exists else ""
+        inventory_text = inventory.read_text(encoding="utf-8") if inventory_exists else ""
+    except OSError as exc:
+        return {
+            "ok": False,
+            "exists": bool(skill_exists and inventory_exists),
+            "current": False,
+            "path": CODEX_SKILL_RELATIVE_PATH,
+            "inventory_path": CODEX_WORKFLOW_INVENTORY_RELATIVE_PATH,
+            "missing_markers": list(CODEX_SKILL_REQUIRED_MARKERS),
+            "read_error": str(exc),
+            "repair": "Run `mb doctor repair --plan`, review, then `mb doctor repair --apply`.",
+            "repair_command": "mb doctor repair --apply",
+            "safe_to_share": True,
+        }
+    missing_markers = [
+        marker for marker in CODEX_SKILL_REQUIRED_MARKERS if marker not in skill_text
+    ]
+    template_match = bool(
+        skill_exists
+        and inventory_exists
+        and skill_text == expected_skill
+        and inventory_text == expected_inventory
+    )
+    ok = bool(skill_exists and inventory_exists and not missing_markers and template_match)
+    return {
+        "ok": ok,
+        "exists": bool(skill_exists and inventory_exists),
+        "current": template_match,
+        "path": CODEX_SKILL_RELATIVE_PATH,
+        "inventory_path": CODEX_WORKFLOW_INVENTORY_RELATIVE_PATH,
+        "missing_markers": missing_markers,
+        "read_error": "",
+        "repair": ""
+        if ok
+        else "Run `mb doctor repair --plan`, review, then `mb doctor repair --apply`.",
+        "repair_command": "mb doctor repair --apply",
+        "safe_to_share": True,
     }
 
 
@@ -522,10 +852,11 @@ def instructions_status(repo: str | Path) -> dict[str, Any]:
     fact_grounding_ok = bool(
         exists and not missing_commands and approval_ok and slash_ok and lifecycle_discovery_ok
     )
+    skill = skill_status(target)
     template_match = bool(exists and text == expected)
-    current = fact_grounding_ok
+    current = bool(fact_grounding_ok and skill["ok"])
     return {
-        "ok": fact_grounding_ok,
+        "ok": current,
         "exists": exists,
         "current": current,
         "template_match": template_match,
@@ -535,10 +866,12 @@ def instructions_status(repo: str | Path) -> dict[str, Any]:
         "missing_fact_commands": missing_commands,
         "missing_lifecycle_guidance": missing_lifecycle_guidance,
         "lifecycle_discovery_ok": lifecycle_discovery_ok,
+        "skill": skill,
+        "workflow_inventory": workflow_inventory(),
         "approval_boundary_ok": approval_ok,
         "codex_native_ok": slash_ok,
         "repair": ""
-        if fact_grounding_ok
+        if current
         else "Run `mb doctor repair --plan`, review, then `mb doctor repair --apply`.",
         "repair_command": "mb doctor repair --apply",
         "read_error": read_error,
@@ -553,9 +886,11 @@ def readiness(repo: str | Path) -> dict[str, Any]:
     return {
         "ok": ok,
         "status": "ready" if ok else "needs_setup",
-        "support_level": "experimental_cli_first_adapter",
+        "support_level": "first_class_owner_loop",
         "executable": executable,
         "instructions": instructions,
+        "skill": instructions["skill"],
+        "workflow_inventory": workflow_inventory(),
         "fact_commands": list(REQUIRED_FACT_COMMANDS),
         "repair": "" if ok else instructions["repair"] or executable["repair"],
         "start_command": f"codex -C {shlex.quote(str(Path(repo).expanduser().resolve()))}",
@@ -581,11 +916,32 @@ def write_agents_md(
     rendered = render_agents_md(target, name=name, gh_username=gh_username)
     existing = path.read_text(encoding="utf-8") if path.exists() else ""
     changed = existing != rendered
+    changed_paths: list[str] = []
     if changed:
         path.write_text(rendered, encoding="utf-8")
+        changed_paths.append(AGENTS_RELATIVE_PATH)
+
+    skill_path = codex_skill_path(target)
+    skill_path.parent.mkdir(parents=True, exist_ok=True)
+    rendered_skill = render_codex_skill_md()
+    existing_skill = skill_path.read_text(encoding="utf-8") if skill_path.exists() else ""
+    if existing_skill != rendered_skill:
+        skill_path.write_text(rendered_skill, encoding="utf-8")
+        changed_paths.append(CODEX_SKILL_RELATIVE_PATH)
+
+    inventory_path = workflow_inventory_path(target)
+    inventory_path.parent.mkdir(parents=True, exist_ok=True)
+    rendered_inventory = render_workflow_inventory_md()
+    existing_inventory = (
+        inventory_path.read_text(encoding="utf-8") if inventory_path.exists() else ""
+    )
+    if existing_inventory != rendered_inventory:
+        inventory_path.write_text(rendered_inventory, encoding="utf-8")
+        changed_paths.append(CODEX_WORKFLOW_INVENTORY_RELATIVE_PATH)
     return {
         "ok": True,
         "path": AGENTS_RELATIVE_PATH,
-        "changed": changed,
+        "changed": bool(changed_paths),
+        "changed_paths": changed_paths,
         "status": instructions_status(target),
     }

--- a/mb/mb/codex.py
+++ b/mb/mb/codex.py
@@ -914,6 +914,20 @@ def readiness(repo: str | Path) -> dict[str, Any]:
     }
 
 
+def human_readiness_label(readiness_report: dict[str, Any]) -> str:
+    """Return a short user-facing Codex readiness label."""
+
+    if readiness_report.get("ok"):
+        return "ready"
+    executable = readiness_report.get("executable") or {}
+    if not executable.get("found"):
+        return "missing"
+    instructions = readiness_report.get("instructions") or {}
+    if not instructions.get("ok"):
+        return "needs setup"
+    return "not ready"
+
+
 def write_agents_md(
     repo: str | Path,
     *,

--- a/mb/mb/codex.py
+++ b/mb/mb/codex.py
@@ -111,6 +111,12 @@ CODEX_SKILL_REQUIRED_MARKERS = (
     "end/checkpoint/save",
     "Ask before durable writes",
 )
+CODEX_WORKFLOW_STATUS_VOCABULARY = (
+    "supported",
+    "pending_shared_source_migration",
+    "generated_shell_pending",
+    "intentionally_unsupported",
+)
 
 CODEX_WORKFLOW_INVENTORY: tuple[dict[str, Any], ...] = (
     {
@@ -652,7 +658,10 @@ def workflow_inventory(*, runtime: str = "codex") -> dict[str, Any]:
         copied = dict(item)
         copied["commands"] = list(_commands_for_inventory_item(item))
         items.append(copied)
-    statuses = sorted({str(item["codex_status"]) for item in CODEX_WORKFLOW_INVENTORY})
+    statuses = sorted(
+        {*CODEX_WORKFLOW_STATUS_VOCABULARY}
+        | {str(item["codex_status"]) for item in CODEX_WORKFLOW_INVENTORY}
+    )
     return {
         "ok": True,
         "runtime": runtime,

--- a/mb/mb/doctor.py
+++ b/mb/mb/doctor.py
@@ -1340,11 +1340,14 @@ def run(path: str) -> dict[str, Any]:
         {
             "name": "codex-agents-md",
             "ok": bool(codex_instructions["ok"]),
-            "detail": "AGENTS.md is current and points Codex to mb facts and lifecycle routes"
+            "detail": (
+                "AGENTS.md and the Codex owner-loop skill are current and point "
+                "Codex to mb facts, lifecycle routes, and workflow inventory"
+            )
             if codex_instructions["ok"]
             else (
-                "AGENTS.md is missing, stale, or missing required mb fact commands "
-                "or lifecycle discovery guidance. "
+                "Codex AGENTS.md or owner-loop skill files are missing, stale, "
+                "or missing required mb fact commands or lifecycle discovery guidance. "
                 "Run `mb doctor repair --plan`, review, then `mb doctor repair --apply`."
             ),
             "severity": "ok" if codex_instructions["ok"] else "warn",
@@ -2026,16 +2029,18 @@ def repair_plan(
             "name": "AGENTS.md",
             "state": "ok" if codex_instruction_status["ok"] else "warn",
             "summary": (
-                "Codex instructions are current and include mb fact grounding and lifecycle routes"
+                "Codex instructions and owner-loop skill are current and include "
+                "mb fact grounding, lifecycle routes, and workflow inventory"
                 if codex_instruction_status["ok"]
                 else (
-                    "Codex instructions are missing, stale, or missing mb fact grounding "
-                    "or lifecycle discovery guidance"
+                    "Codex instructions or owner-loop skill files are missing, stale, "
+                    "or missing mb fact grounding or lifecycle discovery guidance"
                 )
             ),
             "missing_fact_commands": codex_instruction_status["missing_fact_commands"],
             "missing_lifecycle_guidance": codex_instruction_status["missing_lifecycle_guidance"],
             "lifecycle_discovery_ok": codex_instruction_status["lifecycle_discovery_ok"],
+            "skill": codex_instruction_status["skill"],
             "approval_boundary_ok": codex_instruction_status["approval_boundary_ok"],
             "codex_native_ok": codex_instruction_status["codex_native_ok"],
         },
@@ -2050,10 +2055,15 @@ def repair_plan(
             command="mb doctor repair --apply",
             safe_to_apply=True,
             reason=(
-                "AGENTS.md is the tracked Codex entrypoint; repair writes the current "
-                "CLI-first lifecycle workflow index, fact grounding, and approval boundaries"
+                "AGENTS.md and .agents/skills are the tracked Codex entrypoints; "
+                "repair writes the current owner-loop workflow index, fact grounding, "
+                "and approval boundaries"
             ),
-            writes=["AGENTS.md"],
+            writes=[
+                "AGENTS.md",
+                codex_mod.CODEX_SKILL_RELATIVE_PATH,
+                codex_mod.CODEX_WORKFLOW_INVENTORY_RELATIVE_PATH,
+            ],
         )
         actions.append(action)
         codex_actions.append(action)
@@ -2062,7 +2072,10 @@ def repair_plan(
             "codex-wiring",
             "Codex CLI Adapter",
             _max_state([str(item["state"]) for item in codex_checks]),
-            "Experimental CLI-first adapter instructions and executable readiness",
+            (
+                "First-class owner-loop adapter instructions, native skill, "
+                "workflow inventory, and executable readiness"
+            ),
             checks=codex_checks,
             actions=codex_actions,
         )
@@ -2392,16 +2405,21 @@ def repair_apply(repo: str | Path = ".", *, include_migration: bool = False) -> 
         applied.append(
             _action(
                 id="codex-agents-md",
-                title="Refreshed Codex AGENTS.md instructions",
+                title="Refreshed Codex owner-loop instructions",
                 state="ok" if agents["ok"] else "error",
                 mode="write",
                 command="mb doctor repair --apply",
                 safe_to_apply=True,
                 reason=(
-                    "wrote the current CLI-first Codex lifecycle workflow index, "
-                    "fact grounding, and approval boundaries"
+                    "wrote the current Codex owner-loop skill, lifecycle workflow "
+                    "index, fact grounding, and approval boundaries"
                 ),
-                writes=["AGENTS.md"],
+                writes=list(agents.get("changed_paths", []))
+                or [
+                    "AGENTS.md",
+                    codex_mod.CODEX_SKILL_RELATIVE_PATH,
+                    codex_mod.CODEX_WORKFLOW_INVENTORY_RELATIVE_PATH,
+                ],
                 applied=bool(agents["changed"]),
                 result=agents,
             )

--- a/mb/mb/init.py
+++ b/mb/mb/init.py
@@ -166,8 +166,9 @@ def run(path: str, name: str) -> dict[str, Any]:
         name=business_name,
         gh_username=gh_user,
     )
-    if agents_result["changed"]:
-        created.append("AGENTS.md")
+    for created_path in agents_result.get("changed_paths", []):
+        if created_path not in created:
+            created.append(str(created_path))
 
     vocabulary_tmpl = _read_template("core_vocabulary.md.tmpl")
     if vocabulary_tmpl:

--- a/mb/mb/start.py
+++ b/mb/mb/start.py
@@ -240,11 +240,14 @@ def _build_checks(
                 "name": "codex_agents_md",
                 "ok": bool(codex_instructions.get("ok")),
                 "severity": "warn" if codex_found else "info",
-                "detail": "AGENTS.md is present and points Codex to mb facts and lifecycle routes"
+                "detail": (
+                    "AGENTS.md and Codex owner-loop skill point Codex to mb facts, "
+                    "lifecycle routes, and workflow inventory"
+                )
                 if codex_instructions.get("ok")
                 else (
-                    "AGENTS.md is missing, stale, or missing required mb fact commands "
-                    "or lifecycle discovery guidance"
+                    "Codex AGENTS.md or owner-loop skill files are missing, stale, "
+                    "or missing required mb fact commands or lifecycle discovery guidance"
                 ),
                 "repair": codex_instructions.get("repair") if codex_found else "",
             },

--- a/mb/mb/start.py
+++ b/mb/mb/start.py
@@ -405,9 +405,10 @@ def render_human(report: dict[str, Any]) -> None:
         + ("[green]found[/green]" if runtime["found"] else "[red]missing[/red]")
     )
     codex = runtime.get("codex_cli") or {}
+    codex_label = codex_mod.human_readiness_label(codex)
+    codex_style = "green" if codex_label == "ready" else "yellow"
     console.print(
-        "[bold]Codex[/bold]  "
-        + ("[green]ready[/green]" if codex.get("ok") else "[blue]experimental[/blue]")
+        "[bold]Codex[/bold]  " + f"[{codex_style}]{codex_label}[/{codex_style}]" + "  owner loop"
     )
     console.print(
         "[bold]Skills[/bold]  /mb-start "

--- a/mb/mb/status.py
+++ b/mb/mb/status.py
@@ -3822,8 +3822,14 @@ def _drift(report: dict[str, Any]) -> dict[str, Any]:
             {
                 "id": "codex_instructions_not_ready",
                 "severity": "warn",
-                "summary": "Codex AGENTS.md instructions are missing or stale.",
-                "evidence": [str(codex_instructions.get("path") or "AGENTS.md")],
+                "summary": "Codex owner-loop instructions are missing or stale.",
+                "evidence": [
+                    str(codex_instructions.get("path") or "AGENTS.md"),
+                    str(
+                        (codex_instructions.get("skill") or {}).get("path")
+                        or codex_mod.CODEX_SKILL_RELATIVE_PATH
+                    ),
+                ],
                 "repair": str(
                     codex_instructions.get("repair")
                     or "Run `mb doctor repair --plan`, then `mb doctor repair --apply`."

--- a/mb/mb/status.py
+++ b/mb/mb/status.py
@@ -4257,7 +4257,9 @@ def render_human(
     codex = runtime.get("codex_cli") or {}
     claude_mark = "[green]found[/green]" if claude["found"] else "[yellow]missing[/yellow]"
     skill_mark = "[green]wired[/green]" if skills["ok"] else "[yellow]missing[/yellow]"
-    codex_mark = "[green]ready[/green]" if codex.get("ok") else "[blue]experimental[/blue]"
+    codex_label = codex_mod.human_readiness_label(codex)
+    codex_style = "green" if codex_label == "ready" else "yellow"
+    codex_mark = f"[{codex_style}]{codex_label}[/{codex_style}] owner loop"
     console.print(
         f"[bold]Runtime[/bold] Claude Code: {claude_mark}  skills: {skill_mark}  "
         f"Codex: {codex_mark}"

--- a/mb/mb/workflows.py
+++ b/mb/mb/workflows.py
@@ -39,7 +39,7 @@ REQUIRED_SECTIONS = {
 }
 REQUIRED_RUNTIME_SUPPORT = {
     "claude_code": "supported_shell",
-    "codex_cli": "experimental_shell",
+    "codex_cli": "owner_loop_shell",
 }
 MINIMUM_MB_COMMANDS = {
     "mb status --json --peek",
@@ -133,6 +133,13 @@ class WorkflowSource:
     @property
     def public_private_boundaries(self) -> list[str]:
         return [str(item) for item in self.frontmatter["public_private_boundaries"]]
+
+    @property
+    def runtime_support(self) -> dict[str, str]:
+        raw = self.frontmatter["runtime_support"]
+        if not isinstance(raw, dict):
+            return {}
+        return {str(key): str(value) for key, value in raw.items()}
 
 
 class WorkflowValidationError(ValueError):
@@ -421,13 +428,13 @@ def _render_start_money_path_codex_shell(workflow: WorkflowSource) -> str:
     output = f"""# Generated Codex Workflow Guidance: {workflow.title}
 
 Source workflow: `{_display_path(workflow.path)}`
-Runtime support: `codex_cli: experimental_shell`
+Runtime support: `codex_cli: {workflow.runtime_support.get("codex_cli", "")}`
 Approval gates: {_inline_code_list(workflow.approval_gates)}
 Public/private boundaries: {_inline_code_list(workflow.public_private_boundaries)}
 
-Codex remains experimental and CLI-first. This guidance is a generated snapshot
-for validation; it does not mean `/mb-start` slash commands work inside Codex
-and it does not claim selected Codex workflow support.
+Codex is first-class for the proven owner loop only. This guidance is a
+generated owner-loop shell; it does not mean `/mb-start` slash commands work
+inside Codex and it does not claim all Main Branch workflow support.
 
 Start from deterministic `mb` facts before reading business markdown or giving
 path-to-money advice.
@@ -553,14 +560,14 @@ def _render_think_codex_shell(workflow: WorkflowSource) -> str:
     output = f"""# Generated Codex Workflow Guidance: {workflow.title}
 
 Source workflow: `{_display_path(workflow.path)}`
-Runtime support: `codex_cli: experimental_shell`
+Runtime support: `codex_cli: {workflow.runtime_support.get("codex_cli", "")}`
 Approval gates: {_inline_code_list(workflow.approval_gates)}
 Public/private boundaries: {_inline_code_list(workflow.public_private_boundaries)}
 
-Codex remains experimental and CLI-first. This guidance is generated from the
-engine workflow source for business-repo `AGENTS.md`; the business repo does
-not need to contain `{_display_path(workflow.path)}`. Treat this rendered route
-as the Codex shell for natural-language thinking tasks. It does not claim
+Codex is first-class for the proven owner loop only. This guidance is generated
+from the engine workflow source for business-repo `AGENTS.md`; the business repo
+does not need to contain `{_display_path(workflow.path)}`. Treat this rendered
+route as the Codex shell for natural-language thinking tasks. It does not claim
 Claude Code slash commands work inside Codex or that all Main Branch workflows
 are available in Codex.
 

--- a/mb/tests/fixtures/workflows/mb-start-money-path.codex.md
+++ b/mb/tests/fixtures/workflows/mb-start-money-path.codex.md
@@ -1,13 +1,13 @@
 # Generated Codex Workflow Guidance: Start To MoneyPath Think Handoff
 
 Source workflow: `workflows/mb-start-money-path/workflow.md`
-Runtime support: `codex_cli: experimental_shell`
+Runtime support: `codex_cli: owner_loop_shell`
 Approval gates: `updates_repairs_migrations`, `file_writes`, `checkpoint`, `provider_mutation`, `publishing_or_spend`, `customer_contact`, `private_data`, `destructive_operations`
 Public/private boundaries: `no_secrets`, `no_raw_provider_exports`, `no_customer_member_data`, `no_private_runtime_settings`, `no_private_maintainer_notes`
 
-Codex remains experimental and CLI-first. This guidance is a generated snapshot
-for validation; it does not mean `/mb-start` slash commands work inside Codex
-and it does not claim selected Codex workflow support.
+Codex is first-class for the proven owner loop only. This guidance is a
+generated owner-loop shell; it does not mean `/mb-start` slash commands work
+inside Codex and it does not claim all Main Branch workflow support.
 
 Start from deterministic `mb` facts before reading business markdown or giving
 path-to-money advice.

--- a/mb/tests/fixtures/workflows/mb-think.codex.md
+++ b/mb/tests/fixtures/workflows/mb-think.codex.md
@@ -1,14 +1,14 @@
 # Generated Codex Workflow Guidance: Think Research Decision Codify
 
 Source workflow: `workflows/mb-think/workflow.md`
-Runtime support: `codex_cli: experimental_shell`
+Runtime support: `codex_cli: owner_loop_shell`
 Approval gates: `updates_repairs_migrations`, `file_writes`, `checkpoint`, `provider_mutation`, `publishing_or_spend`, `customer_contact`, `private_data`, `destructive_operations`, `structured_collection`, `public_issue_or_proposal`
 Public/private boundaries: `no_secrets`, `no_raw_provider_exports`, `no_raw_transcripts`, `no_customer_member_data`, `no_private_runtime_settings`, `no_private_dms_or_gated_communities`, `no_raw_finance_legal_records`
 
-Codex remains experimental and CLI-first. This guidance is generated from the
-engine workflow source for business-repo `AGENTS.md`; the business repo does
-not need to contain `workflows/mb-think/workflow.md`. Treat this rendered route
-as the Codex shell for natural-language thinking tasks. It does not claim
+Codex is first-class for the proven owner loop only. This guidance is generated
+from the engine workflow source for business-repo `AGENTS.md`; the business repo
+does not need to contain `workflows/mb-think/workflow.md`. Treat this rendered
+route as the Codex shell for natural-language thinking tasks. It does not claim
 Claude Code slash commands work inside Codex or that all Main Branch workflows
 are available in Codex.
 

--- a/mb/tests/test_doctor.py
+++ b/mb/tests/test_doctor.py
@@ -321,7 +321,8 @@ def test_doctor_repair_plan_reports_missing_codex_agents_md(tmp_path: Path) -> N
     assert agents_check["state"] == "warn"
     actions = {action["id"]: action for action in payload["actions"]}
     assert actions["codex-agents-md"]["safe_to_apply"] is True
-    assert actions["codex-agents-md"]["writes"] == ["AGENTS.md"]
+    assert "AGENTS.md" in actions["codex-agents-md"]["writes"]
+    assert ".agents/skills/main-branch-owner-loop/SKILL.md" in actions["codex-agents-md"]["writes"]
 
 
 def test_doctor_repair_plan_reports_stale_codex_lifecycle_guidance(tmp_path: Path) -> None:
@@ -378,7 +379,8 @@ def test_doctor_repair_plan_reports_pre_engine_source_boundary_codex_guidance(
     )
     actions = {action["id"]: action for action in payload["actions"]}
     assert actions["codex-agents-md"]["safe_to_apply"] is True
-    assert actions["codex-agents-md"]["writes"] == ["AGENTS.md"]
+    assert "AGENTS.md" in actions["codex-agents-md"]["writes"]
+    assert ".agents/skills/main-branch-owner-loop/SKILL.md" in actions["codex-agents-md"]["writes"]
 
 
 def test_doctor_repair_plan_reports_custom_codex_agents_missing_source_item(
@@ -423,6 +425,11 @@ def test_doctor_repair_apply_refreshes_codex_agents_md(tmp_path: Path) -> None:
     assert "## Codex Status Workflow" in agents_text
     assert "## Codex Think Route" in agents_text
     assert "mb status --json --peek" in agents_text
+    skill_text = (repo / ".agents" / "skills" / "main-branch-owner-loop" / "SKILL.md").read_text(
+        encoding="utf-8"
+    )
+    assert "Main Branch owner loop for Codex" in skill_text
+    assert "mb workflow list --runtime codex --json" in skill_text
 
 
 def test_doctor_repair_preserves_custom_codex_agents_md_when_contract_is_current(

--- a/mb/tests/test_init.py
+++ b/mb/tests/test_init.py
@@ -103,8 +103,9 @@ def _assert_agents_md_codex_start_contract(text: str) -> None:
     assert "Do not pretend Claude" in text
     assert "slash commands exist in Codex." in text
     assert "## Codex Lifecycle Workflow Index" in text
-    assert "current Codex lifecycle discovery surface" in text
-    assert "Do not create `.agents/skills`" in text
+    assert "repo-level Codex bootstrap" in text
+    assert ".agents/skills/main-branch-owner-loop/SKILL.md" in text
+    assert "Use `.agents/skills/main-branch-owner-loop`" in text
     assert "Start the day / what next / get oriented" in text
     assert "Inspect status / what changed / what is stale" in text
     assert "Think / research / decide / codify" in text
@@ -189,6 +190,15 @@ def test_init_scaffolds_folders(tmp_path: Path) -> None:
     assert (target / "CLAUDE.md").exists()
     assert (target / "README.md").exists()
     assert (target / "AGENTS.md").exists()
+    assert (target / ".agents" / "skills" / "main-branch-owner-loop" / "SKILL.md").exists()
+    assert (
+        target
+        / ".agents"
+        / "skills"
+        / "main-branch-owner-loop"
+        / "references"
+        / "workflow-inventory.md"
+    ).exists()
     assert (target / ".github" / "CODEOWNERS").exists()
     assert (target / ".gitignore").exists()
     assert (target / ".mb" / "schema_version").read_text(encoding="utf-8") == "0.2\n"
@@ -221,6 +231,9 @@ def test_init_scaffolds_folders(tmp_path: Path) -> None:
     assert ".vip/local.yaml" in gitignore
     claude_md = (target / "CLAUDE.md").read_text()
     agents_md = (target / "AGENTS.md").read_text()
+    codex_skill = (
+        target / ".agents" / "skills" / "main-branch-owner-loop" / "SKILL.md"
+    ).read_text()
     readme_md = (target / "README.md").read_text()
     assert "Acme Brewing" in claude_md
     assert "Acme Brewing" in agents_md
@@ -245,6 +258,8 @@ def test_init_scaffolds_folders(tmp_path: Path) -> None:
     _assert_claude_md_cli_first_contract(claude_md)
     _assert_claude_md_primitive_routing_contract(claude_md)
     _assert_agents_md_codex_start_contract(agents_md)
+    assert "Main Branch owner loop for Codex" in codex_skill
+    assert "mb workflow list --runtime codex --json" in codex_skill
     assert codex_mod.instructions_status(target)["ok"] is True
 
 

--- a/mb/tests/test_start.py
+++ b/mb/tests/test_start.py
@@ -131,6 +131,24 @@ def test_start_json_omits_codex_command_when_codex_is_missing(
     assert "Install Codex CLI" not in report["next_actions"]
 
 
+def test_start_human_labels_missing_codex_without_experimental_copy(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(start_mod, "_which", _with_claude)
+    monkeypatch.setattr(codex_mod, "_which", _without_codex)
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+
+    result = runner.invoke(app, ["start", "--repo", str(repo)])
+
+    assert result.exit_code == 0
+    assert "Codex" in result.stdout
+    assert "missing" in result.stdout
+    assert "owner loop" in result.stdout
+    assert "experimental" not in result.stdout
+
+
 def test_start_json_names_doctor_repair_when_start_wiring_is_missing(
     tmp_path: Path, monkeypatch
 ) -> None:

--- a/mb/tests/test_status.py
+++ b/mb/tests/test_status.py
@@ -1964,6 +1964,22 @@ def test_status_human_output_mentions_core_sections(tmp_path: Path, monkeypatch)
     assert "next:" in result.stdout
 
 
+def test_status_human_labels_missing_codex_without_experimental_copy(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
+    monkeypatch.setattr(codex_mod, "_which", _without_codex)
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+
+    result = runner.invoke(app, ["status", str(repo), "--no-color", "--peek"])
+
+    assert result.exit_code == 0
+    assert "Codex: missing owner loop" in result.stdout
+    assert "experimental" not in result.stdout
+
+
 def test_status_since_last_check_uses_repo_marker(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
     repo = tmp_path / "acme"

--- a/mb/tests/test_workflows.py
+++ b/mb/tests/test_workflows.py
@@ -173,9 +173,12 @@ def test_codex_workflow_inventory_command_lists_supported_and_pending_surfaces()
     data = json.loads(result.stdout)
     assert data["support_level"] == "first_class_owner_loop"
     statuses = set(data["statuses"])
-    assert {"supported", "pending_shared_source_migration", "intentionally_unsupported"}.issubset(
-        statuses
-    )
+    assert {
+        "supported",
+        "pending_shared_source_migration",
+        "generated_shell_pending",
+        "intentionally_unsupported",
+    }.issubset(statuses)
     by_id = {item["id"]: item for item in data["items"]}
     assert by_id["think-codify"]["codex_status"] == "supported"
     assert by_id["ads"]["codex_status"] == "pending_shared_source_migration"

--- a/mb/tests/test_workflows.py
+++ b/mb/tests/test_workflows.py
@@ -185,6 +185,24 @@ def test_codex_workflow_inventory_command_lists_supported_and_pending_surfaces()
     assert by_id["wiki"]["codex_status"] == "intentionally_unsupported"
 
 
+def test_codex_workflow_inventory_json_unsupported_runtime_uses_error_envelope() -> None:
+    result = runner.invoke(app, ["workflow", "list", "--runtime", "claude", "--json"])
+
+    assert result.exit_code == 2
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False
+    assert payload["result_status"] == "error"
+    assert payload["mb_command"] == "mb workflow list"
+    assert payload["result_schema"]["name"] == "mainbranch.workflow.inventory.result"
+    assert payload["errors"] == [
+        {
+            "code": "unsupported_runtime",
+            "message": "mb workflow list: only --runtime codex is available today",
+        }
+    ]
+    assert result.stderr == ""
+
+
 def test_drift_detection_flags_omitted_required_command_or_fact() -> None:
     workflow = load_workflow(WORKFLOW)
     shell = render_codex_shell(workflow)

--- a/mb/tests/test_workflows.py
+++ b/mb/tests/test_workflows.py
@@ -2,9 +2,14 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
+import yaml
+from typer.testing import CliRunner
+
 from mb import codex as codex_mod
+from mb.cli import app
 from mb.workflows import (
     codex_shell_policy_errors,
     load_workflow,
@@ -15,6 +20,7 @@ from mb.workflows import (
     validate_workflow,
 )
 
+runner = CliRunner()
 REPO_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW = REPO_ROOT / "workflows" / "mb-start-money-path" / "workflow.md"
 THINK_WORKFLOW = REPO_ROOT / "workflows" / "mb-think" / "workflow.md"
@@ -134,6 +140,46 @@ def test_codex_contract_markers_match_think_workflow_source() -> None:
     assert (
         tuple(workflow.public_private_boundaries) == codex_mod.CODEX_THINK_PUBLIC_PRIVATE_BOUNDARIES
     )
+
+
+def test_codex_owner_loop_skill_and_inventory_render() -> None:
+    skill = codex_mod.render_codex_skill_md()
+    inventory = codex_mod.render_workflow_inventory_md()
+
+    assert "Main Branch owner loop for Codex" in skill
+    assert "mb workflow list --runtime codex --json" in skill
+    assert "start/status/setup/update/doctor" in skill
+    assert "think/codify" in skill
+    assert "end/checkpoint/save" in skill
+    assert "Ask before durable writes" in skill
+    assert "pending_shared_source_migration" in inventory
+    assert "intentionally_unsupported" in inventory
+    assert "Copied Claude" not in skill
+
+
+def test_codex_owner_loop_skill_frontmatter_is_valid_yaml() -> None:
+    skill = codex_mod.render_codex_skill_md()
+    _, frontmatter, _ = skill.split("---", 2)
+    data = yaml.safe_load(frontmatter)
+
+    assert data["name"] == "main-branch-owner-loop"
+    assert "start/status/setup/update/doctor" in data["description"]
+
+
+def test_codex_workflow_inventory_command_lists_supported_and_pending_surfaces() -> None:
+    result = runner.invoke(app, ["workflow", "list", "--runtime", "codex", "--json"])
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["support_level"] == "first_class_owner_loop"
+    statuses = set(data["statuses"])
+    assert {"supported", "pending_shared_source_migration", "intentionally_unsupported"}.issubset(
+        statuses
+    )
+    by_id = {item["id"]: item for item in data["items"]}
+    assert by_id["think-codify"]["codex_status"] == "supported"
+    assert by_id["ads"]["codex_status"] == "pending_shared_source_migration"
+    assert by_id["wiki"]["codex_status"] == "intentionally_unsupported"
 
 
 def test_drift_detection_flags_omitted_required_command_or_fact() -> None:

--- a/workflows/mb-start-money-path/workflow.md
+++ b/workflows/mb-start-money-path/workflow.md
@@ -5,7 +5,7 @@ description: Ground daily start path-to-money prompts in deterministic MoneyPath
 loops: [sense, decide, ship]
 runtime_support:
   claude_code: supported_shell
-  codex_cli: experimental_shell
+  codex_cli: owner_loop_shell
   future: planned
 runtime_surfaces:
   claude_code: .claude/skills/mb-start/SKILL.md
@@ -216,10 +216,11 @@ skill validation and runtime evidence.
 
 ### Codex CLI
 
-Codex remains experimental and CLI-first. Rendered Codex shell snapshots must
-start from generated `AGENTS.md` style grounding and deterministic `mb` facts.
+Codex is first-class for the proven owner loop only. Rendered Codex shell
+snapshots must start from generated `AGENTS.md` style grounding and
+deterministic `mb` facts.
 
-Do not say `/mb-start` works inside Codex. Do not claim selected Codex workflow
+Do not say `/mb-start` works inside Codex. Do not claim broader Codex workflow
 support until a fresh fixture repo and read-only `codex exec --json --ephemeral
 --sandbox read-only -C <repo>` smoke prove the generated shell is actually
 used.

--- a/workflows/mb-think/workflow.md
+++ b/workflows/mb-think/workflow.md
@@ -5,7 +5,7 @@ description: Research, decide, and codify durable Main Branch business truth fro
 loops: [sense, decide, ship]
 runtime_support:
   claude_code: supported_shell
-  codex_cli: experimental_shell
+  codex_cli: owner_loop_shell
   future: planned
 runtime_surfaces:
   claude_code: .claude/skills/mb-think/SKILL.md
@@ -293,11 +293,11 @@ replacement and includes skill validation plus runtime evidence.
 
 ### Codex CLI
 
-Codex remains experimental and CLI-first. Rendered Codex shell snapshots must
-start from generated `AGENTS.md` style grounding, deterministic `mb` facts, and
-natural-language workflow routing.
+Codex is first-class for the proven owner loop only. Rendered Codex shell
+snapshots must start from generated `AGENTS.md` style grounding, deterministic
+`mb` facts, and natural-language workflow routing.
 
 Do not say `/mb-think` works inside Codex. Do not say "Run `/mb-think`." Do
-not claim selected Codex workflow support until a fresh fixture repo and
-read-only `codex exec --json --ephemeral --sandbox read-only -C <repo>` smoke
-prove the guidance is actually used.
+not claim broader Codex workflow support until a fresh fixture repo and read-only
+`codex exec --json --ephemeral --sandbox read-only -C <repo>` smoke prove the
+guidance is actually used.


### PR DESCRIPTION
## Summary

Makes Codex CLI first-class for the proven Main Branch owner loop by generating a Codex-native owner-loop skill, adding a deterministic workflow inventory command, and wiring Codex readiness/repair into `mb init`, `mb doctor`, `mb start`, and `mb status`.
The promotion is intentionally narrow: no slash-command parity, no all-skills parity, and no ads/site/provider-write/publishing/spend/customer-contact parity is claimed.

## Linked issue

Closes #676

## Why

Codex previously had generated `AGENTS.md` bridge guidance, but no runtime-native discovery surface or inventory that could tell users which Main Branch workflows were supported, pending, or intentionally unsupported.
This made Codex useful for selected read-only prompts but not credible as a first-class owner-loop runtime.

## Commits by concern

- [ ] Each commit body bullet-lists the changes in that commit
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`

Commits:

- `a168072 [add] MAIN-421 codex owner-loop runtime surface`
- `24f269e [update] MAIN-421 codex owner-loop docs`
- `b9283a1 [fix] MAIN-421 expose codex workflow status vocabulary`

## Validation

Pre-push gate from repo root:

```bash
scripts/check.sh
```

- [x] Level 1 static: `scripts/check.sh` passes
- [x] Level 2 CLI contract: focused Typer/CliRunner tests, exit codes, `--json` behavior, TTY vs non-TTY (if CLI behavior touched)
- [x] Level 3 package/install smoke (if packaging touched)
- [x] Level 4 fixture repo (if init/onboard/status/start/update touched)
- [x] Level 5 runtime smoke / dogfood harness / simulation-tier (if runtime, first-run, skill discovery, or release validation touched)
- [x] SKILL.md <=500 lines (if any skill touched)
- [ ] Package-visible release gate evidence before tag/publish (if preparing a release)
- [ ] Supply-chain review (if `.github/workflows/`, `.github/dependabot.yml`, `mb/pyproject.toml` deps, or `id-token`/`permissions` blocks touched -- see [docs/supply-chain-policy.md](../docs/supply-chain-policy.md))

Evidence:

- Level 1 static: `scripts/check.sh` — runtime: repo Python 3.13.7 — exit: 0 — log: formatting/Ruff/mypy passed, 756 tests passed, 15 bundled skills validated.
- Level 2 CLI contract: `pytest tests/test_workflows.py tests/test_doctor.py tests/test_init.py tests/test_start.py -q` — runtime: repo Python 3.13.7 — exit: 0 — log: 98 passed.
- Level 2 inventory check: `mb workflow list --runtime codex --json` — runtime: repo Python 3.13.7 — exit: 0 — log: statuses include `generated_shell_pending`, `intentionally_unsupported`, `pending_shared_source_migration`, and `supported`.
- Level 3 package/install: `(cd mb && python3 -m build)`, install wheel into a temporary venv, then `mb --version`, `mb skill list`, and `mb workflow list --runtime codex --json` — runtime: temporary venv Python — exit: 0 — log: installed `mb 0.3.27`, inventory reported `first_class_owner_loop`.
- Level 4 fixture repo: fresh `mb onboard` repo, then `mb doctor --json`, `mb status --json --peek`, `mb start --json`, `mb validate --json`, and `mb workflow list --runtime codex --json` — runtime: temporary venv Python — exit: 0 — log: generated Codex skill and workflow inventory existed and parsed as YAML.
- Level 4 repair path: stale `AGENTS.md` plus missing `.agents/skills/main-branch-owner-loop`, then `mb doctor repair --apply --json` — runtime: repo Python 3.13.7 — exit: 0 — log: applied `codex-agents-md` and wrote `AGENTS.md`, `.agents/skills/main-branch-owner-loop/SKILL.md`, and `.agents/skills/main-branch-owner-loop/references/workflow-inventory.md`.
- Level 5 Codex runtime: `codex exec --json --ephemeral --sandbox read-only` with `approval_policy="never"` and `shell_environment_policy.inherit="all"` against a fresh `mb onboard` fixture — runtime: Codex CLI plus temporary venv `mb 0.3.27` — exit: 0 — log: Codex loaded `.agents/skills/main-branch-owner-loop/SKILL.md`, ran the explicit read-only owner-loop command set, identified the generated Codex surfaces, and reported no edits; raw transcript stayed local and is not included.
- SKILL.md line gate: generated `.agents/skills/main-branch-owner-loop/SKILL.md` — runtime: repo Python 3.13.7 — exit: 0 — log: 50 rendered lines.

Not required:

- Package-visible release gate: not preparing or publishing a release in this PR.
- Supply-chain review: no workflow, dependency, Dependabot, `id-token`, or permissions changes.

## Success metric

A fresh Main Branch business repo can use Codex CLI for the daily owner loop through generated `AGENTS.md` plus `.agents/skills/main-branch-owner-loop`, and `mb workflow list --runtime codex` gives a deterministic inventory of supported, pending, generated-shell-pending, and intentionally unsupported surfaces.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [ ] N/A — change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [x] No
- [ ] Yes — migration note below

## Public / private boundary

No raw Codex transcripts, private maintainer notes, credentials, provider payloads, customer/member data, or machine-specific smoke details were committed.
Runtime evidence is summarized in public-safe terms, and local smoke artifacts stayed in ignored scratch space.
