### PR TITLE
[update] Prepare v0.3.28 release

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mainbranch",
-  "version": "0.3.27",
+  "version": "0.3.28",
   "description": "Main Branch Claude Code skills for running a business from markdown files in git.",
   "author": {
     "name": "Noontide"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+## [0.3.28] - 2026-05-19
+
+v0.3.28 packages the Codex owner-loop runtime release after v0.3.27. It makes
+Codex first-class for the proven Main Branch owner loop by adding a generated
+Codex skill surface, workflow inventory, repair/status readiness, and release
+evidence while keeping slash-command, all-skills, provider-write, publishing,
+spend, and customer-contact parity out of scope.
+
 ### Added
 
 - Added a generated Codex owner-loop skill at

--- a/mb/mb/__init__.py
+++ b/mb/mb/__init__.py
@@ -7,6 +7,6 @@ file stays a thin dispatcher.
 
 from __future__ import annotations
 
-__version__ = "0.3.27"
+__version__ = "0.3.28"
 
 __all__ = ["__version__"]

--- a/mb/pyproject.toml
+++ b/mb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mainbranch"
-version = "0.3.27"
+version = "0.3.28"
 description = "Main Branch engine umbrella - scaffolds, validates, and graphs business-as-files repos. Claude Code first, runtime-agnostic by design."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Prepares Main Branch v0.3.28 for publish.

v0.3.28 packages the Codex owner-loop runtime release after v0.3.27. It makes Codex first-class for the proven Main Branch owner loop by adding a generated Codex skill surface, workflow inventory, repair/status readiness, connector-readiness guidance, and release evidence while keeping slash-command, all-skills, provider-write, publishing, spend, and customer-contact parity out of scope.

## Linked issue

Closes #673

## Included work

- #676 / PR #678: Codex owner-loop runtime surface.
- #671 / PR #674: Codex `mb-think` shared workflow route foundation.
- #657 / PR #675: source-ingestion privacy rails.
- #654 / PR #679: connector readiness guidance.
- #677: README logo/header update.

## Release changes

- Moves current `[Unreleased]` entries into `0.3.28` dated `2026-05-19`.
- Bumps `mb/pyproject.toml` to `0.3.28`.
- Bumps `mb/mb/__init__.py` to `0.3.28`.
- Bumps `.claude-plugin/plugin.json` to `0.3.28`.

## Validation

- Level 1 static: `scripts/check.sh` -> exit 0; formatting/Ruff/mypy passed, 756 tests passed, 15 bundled skills validated.
- Level 3 package/build: `(cd mb && python3 -m build)` -> built `mainbranch-0.3.28.tar.gz` and `mainbranch-0.3.28-py3-none-any.whl`.
- Level 3 package/install: fresh venv installed the wheel; `mb --version` returned `mb 0.3.28`; `mb skill list` passed; `mb workflow list --runtime codex --json` returned `support_level: first_class_owner_loop`.
- Level 4 fixture repo: wheel-installed `mb onboard --yes`, `mb doctor --json`, `mb status --json --peek`, `mb start --json`, `mb validate --json`, and `mb workflow list --runtime codex --json` passed; generated `.agents/skills/main-branch-owner-loop/SKILL.md` and workflow inventory existed.
- Level 4 repair path: stale `AGENTS.md` plus missing `.agents/skills/main-branch-owner-loop`; `mb doctor repair --apply --json` restored `AGENTS.md`, `SKILL.md`, and `references/workflow-inventory.md`.
- Level 5 Codex runtime smoke: `codex exec --json --ephemeral --sandbox read-only` with wheel-installed `mb 0.3.28` loaded `.agents/skills/main-branch-owner-loop/SKILL.md`, ran direct read-only owner-loop commands, reported supported/pending/unsupported surfaces, and made no edits.
- Release acceptance proxy: `scripts/claude-runtime-dogfood.py --install-mode wheel --wheel mb/dist/mainbranch-0.3.28-py3-none-any.whl --run-claude-print --simulation-tier release_acceptance --max-budget-usd 0.75` -> exit 0, 11/11 heuristic checks, no follow-up issues recorded. One read-only grounding denial used deterministic fallback evidence; print-mode remains proxy evidence, not interactive TUI proof.

## Public / private boundary

Release notes and committed files are public-safe. Raw smoke transcripts, local temp paths, provider payloads, credentials, private maintainer notes, customer/member data, and raw session exports are not committed.
