### PR TITLE
[fix] Steer release dogfood away from shell parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+### Fixed
+
+- Tightened Claude print-mode release dogfood prompts so agents can use
+  harness-captured fixture facts instead of shell-wrapping `mb status --json`
+  through pipes, redirects, temp files, or Python parsers. Refs MAIN-419, #672.
+
 ## [0.3.28] - 2026-05-19
 
 v0.3.28 packages the Codex owner-loop runtime release after v0.3.27. It makes

--- a/docs/claude-code-runtime-dogfood.md
+++ b/docs/claude-code-runtime-dogfood.md
@@ -131,6 +131,14 @@ evidence. The harness labels permission-denied grounding as proxy evidence;
 when profile `mb` facts are available, it records that as deterministic
 fallback rather than an interactive TUI pass.
 
+For each print-mode simulation, the harness also prepends a compact
+public-safe fixture fact block derived from direct read-only `mb` commands.
+That block exists so Claude can use small status fields without shell-wrapping
+`mb status --json --peek`, redirecting output, writing temp files, reading local
+Claude tool-result paths, or running Python parsers. Direct `mb` command output
+and interactive Claude Code evidence remain stronger than the compact fallback
+block.
+
 Print-mode evidence is a proxy. It is useful for repeatable regression signal,
 budget/auth failures, transcript excerpts, and rubric scoring, but it is not
 the same as interactive Claude Code TUI evidence. Release-bearing runtime

--- a/docs/release-simulations.md
+++ b/docs/release-simulations.md
@@ -110,6 +110,13 @@ Evidence records the profile name, mutations applied, relevant read-only `mb`
 command facts, post-run git state, fresh-session ids, permission-denial summary
 by category, and grounding verdict.
 
+The prompt for each print-mode simulation includes a compact, public-safe
+fixture fact block from the same direct read-only `mb` commands. That block is
+for small status fields only. Claude should use it or run direct read-only `mb`
+commands rather than shell-wrapping `mb status --json --peek`, redirecting
+output, writing temp files, reading local Claude tool-result paths, or running
+Python parsers.
+
 ## Running The Suite
 
 For normal PR runtime smoke:

--- a/mb/mb/dogfood_harness.py
+++ b/mb/mb/dogfood_harness.py
@@ -92,8 +92,12 @@ CLAUDE_PRINT_PROMPT_PREFIX = """Release simulation harness constraints:
   `mb start --json`, `mb doctor --json`, `mb doctor repair --plan --json`,
   `mb validate --cross-refs --json`, `mb checkpoint --plan --json`,
   `mb books check`, and `mb educational <topic>`.
+- A compact harness-captured fact block may appear below. Use it when you need
+  small status fields. Do not re-create that summary with shell parsing.
 - Do not use shell pipes, redirects, temp files, Python parsers, or Claude
   tool-result paths to transform command output.
+- Do not run commands such as `mb status --json --peek | python3 ...`,
+  `mb status --json --peek > file`, or `python3 -c ...` to parse `mb` output.
 - In the final answer, use normal business-owner language first and avoid
   parenthetical git/GitHub restatements. Say "nothing unsaved locally" instead
   of "git is clean" or "working tree clean" / "working tree: clean"; "current
@@ -1058,9 +1062,45 @@ def score_transcript(text: str) -> dict[str, Any]:
     return release_simulation.score_transcript(text)
 
 
-def claude_print_prompt(simulation: release_simulation.Simulation) -> str:
+def claude_print_fixture_facts(facts: dict[str, Any] | None) -> str:
+    """Return public-safe compact fixture facts for the Claude print prompt."""
+    if not facts or not facts.get("facts_available"):
+        return (
+            "Harness-captured deterministic fixture facts:\n"
+            "- Not available for this simulation; use direct read-only `mb` commands."
+        )
+
+    lines = [
+        "Harness-captured deterministic fixture facts:",
+        f"- `mb status --json --peek`: schema {facts.get('status_schema_version', 'unknown')}; "
+        f"skill wiring ok {facts.get('status_skill_wiring_ok', 'unknown')}; "
+        f"dirty {facts.get('status_git_dirty', 'unknown')}",
+        f"- `mb start --json`: follow-up {facts.get('start_follow_up', 'unknown')}; "
+        f"handoff ready {facts.get('start_handoff_ready', 'unknown')}",
+        f"- `mb doctor repair --plan --json`: read-only "
+        f"{facts.get('doctor_repair_read_only', 'unknown')}; actions "
+        f"{len(facts.get('doctor_repair_actions', []) or [])}",
+        f"- `mb checkpoint --plan --json`: dirty {facts.get('checkpoint_plan_dirty', 'unknown')}",
+    ]
+    if facts.get("migrate_campaign_moves") is not None:
+        lines.append(
+            "- `mb migrate campaigns --plan --json`: "
+            f"moves {facts.get('migrate_campaign_moves', 'unknown')}; "
+            f"ambiguous {facts.get('migrate_campaign_ambiguous', 'unknown')}"
+        )
+    lines.append(
+        "- Treat this block as fallback evidence only; direct `mb` command output "
+        "or interactive Claude Code evidence is still stronger."
+    )
+    return "\n".join(lines)
+
+
+def claude_print_prompt(
+    simulation: release_simulation.Simulation, mb_command_facts: dict[str, Any] | None = None
+) -> str:
     """Return a prompt with harness constraints before the simulation text."""
-    return f"{CLAUDE_PRINT_PROMPT_PREFIX}\nSimulation prompt:\n{simulation.prompt}"
+    fixture_facts = claude_print_fixture_facts(mb_command_facts)
+    return f"{CLAUDE_PRINT_PROMPT_PREFIX}\n{fixture_facts}\nSimulation prompt:\n{simulation.prompt}"
 
 
 def claude_print_env(state: HarnessState) -> dict[str, str]:
@@ -1115,7 +1155,10 @@ def run_claude_print(state: HarnessState, *, max_budget_usd: str, simulation_tie
             f"--allowedTools={','.join(CLAUDE_PRINT_READ_ONLY_TOOLS)}",
             f"--disallowedTools={','.join(CLAUDE_PRINT_WRITE_DENY_TOOLS)}",
         ]
-        command = [*base_command, claude_print_prompt(simulation)]
+        command = [
+            *base_command,
+            claude_print_prompt(simulation, profile_record["mb_command_facts"]),
+        ]
         result = run_command(
             state,
             f"claude-print-{simulation.label}",

--- a/mb/mb/dogfood_harness.py
+++ b/mb/mb/dogfood_harness.py
@@ -782,6 +782,7 @@ def _profile_fact_summary(parsed: dict[str, Any]) -> dict[str, Any]:
     start = parsed.get("start", {})
     checkpoint = parsed.get("checkpoint_plan", {})
     migrate_campaigns = parsed.get("migrate_campaigns_plan", {})
+    captured_migrate_campaigns = "migrate_campaigns_plan" in parsed
     checks = doctor.get("checks", []) if isinstance(doctor, dict) else []
     repair_actions = repair.get("actions", []) if isinstance(repair, dict) else []
     return {
@@ -812,10 +813,10 @@ def _profile_fact_summary(parsed: dict[str, Any]) -> dict[str, Any]:
         "start_handoff_ready": start.get("handoff_ready") if isinstance(start, dict) else None,
         "checkpoint_plan_dirty": checkpoint.get("dirty") if isinstance(checkpoint, dict) else None,
         "migrate_campaign_moves": len(migrate_campaigns.get("moves", []))
-        if isinstance(migrate_campaigns, dict)
+        if captured_migrate_campaigns and isinstance(migrate_campaigns, dict)
         else None,
         "migrate_campaign_ambiguous": len(migrate_campaigns.get("ambiguous", []))
-        if isinstance(migrate_campaigns, dict)
+        if captured_migrate_campaigns and isinstance(migrate_campaigns, dict)
         else None,
     }
 

--- a/mb/tests/test_dogfood_harness.py
+++ b/mb/tests/test_dogfood_harness.py
@@ -211,6 +211,10 @@ def test_run_claude_print_allows_readonly_mb_and_denies_write_tools(
     assert "--permission-mode" not in command
     assert command[-1].endswith(simulation.prompt)
     assert "Do not use shell pipes" in command[-1]
+    assert "Do not re-create that summary with shell parsing" in command[-1]
+    assert "mb status --json --peek | python3" in command[-1]
+    assert "Harness-captured deterministic fixture facts" in command[-1]
+    assert "`mb status --json --peek`: schema" in command[-1]
     assert "Do not call AskUserQuestion" in command[-1]
     assert "Bash(mb status)" in allowed
     assert "Bash(mb status *)" in allowed

--- a/mb/tests/test_dogfood_harness.py
+++ b/mb/tests/test_dogfood_harness.py
@@ -631,6 +631,32 @@ def test_permission_denial_summary_separates_grounding_from_other_denials() -> N
     assert summary["other"] == 1
 
 
+def test_profile_fact_summary_uses_none_for_uncaptured_migration_facts() -> None:
+    summary = harness._profile_fact_summary(
+        {
+            "status_peek": {"schema_version": "1.0"},
+            "start": {"handoff_ready": True},
+            "doctor_repair_plan": {"read_only": True, "actions": []},
+            "checkpoint_plan": {"dirty": False},
+        }
+    )
+
+    assert summary["migrate_campaign_moves"] is None
+    assert summary["migrate_campaign_ambiguous"] is None
+
+
+def test_profile_fact_summary_counts_captured_empty_migration_plan() -> None:
+    summary = harness._profile_fact_summary(
+        {
+            "status_peek": {"schema_version": "1.0"},
+            "migrate_campaigns_plan": {"moves": [], "ambiguous": []},
+        }
+    )
+
+    assert summary["migrate_campaign_moves"] == 0
+    assert summary["migrate_campaign_ambiguous"] == 0
+
+
 def test_run_command_captures_artifacts_and_parses_json(tmp_path: Path) -> None:
     state = harness.HarnessState(
         engine_repo=tmp_path / "engine",

--- a/mb/tests/test_release_simulation.py
+++ b/mb/tests/test_release_simulation.py
@@ -218,6 +218,31 @@ def test_claude_print_prompt_includes_owner_language_guardrails() -> None:
     assert "[updated] offer and founder-call research" in normalized_prompt
 
 
+def test_claude_print_prompt_omits_uncaptured_migration_facts() -> None:
+    from mb import dogfood_harness
+
+    simulation = release_simulation.simulations_for_tier("pr_smoke")[0]
+    prompt = dogfood_harness.claude_print_prompt(
+        simulation,
+        {
+            "facts_available": True,
+            "status_schema_version": "1.0",
+            "status_skill_wiring_ok": True,
+            "status_git_dirty": False,
+            "start_follow_up": "/mb-start",
+            "start_handoff_ready": True,
+            "doctor_repair_read_only": True,
+            "doctor_repair_actions": [],
+            "checkpoint_plan_dirty": False,
+            "migrate_campaign_moves": None,
+            "migrate_campaign_ambiguous": None,
+        },
+    )
+
+    assert "`mb migrate campaigns --plan --json`" not in prompt
+    assert "moves 0; ambiguous 0" not in prompt
+
+
 def test_score_transcript_flags_provider_overclaim() -> None:
     transcript = """
     I ran mb status for the Dogfood Studio business repo, routed this through

--- a/mb/tests/test_release_simulation.py
+++ b/mb/tests/test_release_simulation.py
@@ -187,9 +187,27 @@ def test_claude_print_prompt_includes_owner_language_guardrails() -> None:
     from mb import dogfood_harness
 
     simulation = release_simulation.simulations_for_tier("pr_smoke")[0]
-    prompt = dogfood_harness.claude_print_prompt(simulation)
+    prompt = dogfood_harness.claude_print_prompt(
+        simulation,
+        {
+            "facts_available": True,
+            "status_schema_version": "1.0",
+            "status_skill_wiring_ok": True,
+            "status_git_dirty": False,
+            "start_follow_up": "/mb-start",
+            "start_handoff_ready": True,
+            "doctor_repair_read_only": True,
+            "doctor_repair_actions": [],
+            "checkpoint_plan_dirty": False,
+        },
+    )
     normalized_prompt = " ".join(prompt.split())
 
+    assert "compact harness-captured fact block" in normalized_prompt
+    assert "Do not re-create that summary with shell parsing" in normalized_prompt
+    assert "mb status --json --peek | python3" in normalized_prompt
+    assert "`mb status --json --peek`: schema 1.0; skill wiring ok True; dirty False" in prompt
+    assert "`mb start --json`: follow-up /mb-start; handoff ready True" in prompt
     assert "nothing unsaved locally" in normalized_prompt
     assert "current business folder" in normalized_prompt
     assert "no connected GitHub backup or shared task source" in normalized_prompt


### PR DESCRIPTION
<!--
  Thanks for contributing to Main Branch.

  See CONTRIBUTING.md for branch + PR shape, concern-based commit
  organization, and pre-push gates. Keep PRs scoped — one logical
  change per PR, ideally 3–5 commits by concern.
-->

## Summary

Tightens Claude print-mode release dogfood prompts so agents can use compact harness-captured fixture facts instead of shell-wrapping `mb status --json --peek`.

## Linked issue

Closes #672

## Why

Recent release dogfood evidence repeatedly showed Claude trying `mb status --json --peek | python3 ...`; this keeps the no-pipe/no-write privacy boundary while giving the model the small status fields it was trying to extract.

## Commits by concern

- `d56d4ff [fix] MAIN-419 steer release dogfood away from shell parsing`
- `7db97ff [fix] MAIN-419 omit uncaptured migration facts`
- [ ] Each commit body bullet-lists the changes in that commit
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`

## Validation

Pre-push gate from repo root:

```bash
scripts/check.sh
```

Level 1 static: `scripts/check.sh` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: excerpt `Ruff format/check passed; mypy passed; pytest 762 passed; coverage 84%; skill validation and docs checks passed`.

Level 2 harness contract: `pytest tests/test_release_simulation.py tests/test_dogfood_harness.py -q` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: excerpt `70 passed`.

- [x] Level 1 static: `scripts/check.sh` passes
- [x] Level 2 CLI contract: focused Typer/CliRunner tests, exit codes, `--json` behavior, TTY vs non-TTY (if CLI behavior touched)
- [ ] Level 3 package/install smoke (if packaging touched)
- [ ] Level 4 fixture repo (if init/onboard/status/start/update touched)
- [ ] Level 5 runtime smoke / dogfood harness / simulation-tier (if runtime, first-run, skill discovery, or release validation touched)
- [ ] SKILL.md <=500 lines (if any skill touched)
- [ ] Package-visible release gate evidence before tag/publish (if preparing a release)
- [ ] Supply-chain review (if `.github/workflows/`, `.github/dependabot.yml`, `mb/pyproject.toml` deps, or `id-token`/`permissions` blocks touched — see [docs/supply-chain-policy.md](../docs/supply-chain-policy.md))

Levels 3 and 4 were not required because this does not change packaging, install, fixture creation, init, onboard, status, start, or update behavior. Level 5 interactive/runtime smoke was not run because the change is print-mode prompt assembly and is covered by focused harness tests; the docs still preserve that interactive Claude Code evidence is stronger for release-bearing runtime claims.

## Success metric

The next release dogfood run naturally uses direct read-only `mb` commands or the compact fixture fact block instead of pipes, redirects, temp files, local tool-result paths, Python parsers, or uncaptured migration facts.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [ ] N/A — change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [x] No
- [ ] Yes — migration note below

## Public / private boundary

Only public-safe harness prompt text, docs, tests, and changelog language changed; no private transcript details, local paths, secrets, account data, or operator strategy were committed.
