### PR TITLE
[update] mb checkpoint bracket enforcement

### DIFF
--- a/.claude/skills/mb-site/SKILL.md
+++ b/.claude/skills/mb-site/SKILL.md
@@ -103,7 +103,7 @@ Four behaviors `/mb-site` uses on every run:
 1. **One flow: brief to site.** Do not route the operator to a separate brief skill and then ask them to come back. `/mb-site` walks research, brief draft, review, lock, concept variations, publish, and iteration as one flow.
 2. **Foreground subagents.** Research, concept, and review subagents run in the foreground. Background subagents can appear to write files that do not persist.
 3. **Parallel by default.** Multiple research questions, concepts, or review passes should run in parallel.
-4. **Publish-first, then iterate.** Commit the rawest durable brief and rawest working concept before iterating. Git history is the memory across context clears.
+4. **Publish-first, then iterate.** Checkpoint the rawest durable business-repo brief and commit the rawest working site-repo concept before iterating. Git history is the memory across context clears.
 
 When research subagents record findings, they follow the `/mb-think` research pattern: dated `research/YYYY-MM-DD-slug-claude-code.md` files with frontmatter and `linked_decisions: []`.
 When the operator needs a broad researched brief before the site brief, run or
@@ -111,6 +111,14 @@ reuse `/mb-think --brief-format=grok-8`. Its eight categories feed the site
 flow directly: offering, ICP, journey, competitive landscape, brand story,
 technical requirements, assets, and metrics/constraints. Keep the `grok-8`
 brief in `research/`; the locked site brief still belongs in `decisions/`.
+
+Business-repo saves use `mb checkpoint`, not raw git commits. For accepted
+research files, locked briefs, and reverse site records, run
+`mb checkpoint --plan --json`, validate a subject such as
+`[drafted] minisite research -- <slug>`, `[decided] minisite brief -- <slug>`,
+or `[connected] site repo -- <slug>`, then save with
+`mb checkpoint --message "<subject>" --yes` after operator approval. Site repo
+code commits still use that site's normal git flow.
 
 ## Invocation Mode
 

--- a/.claude/skills/mb-site/references/minisite-brief.md
+++ b/.claude/skills/mb-site/references/minisite-brief.md
@@ -104,13 +104,13 @@ Synthesize findings and surface them to the operator. They address or proceed.
 
 ## Brief Lock
 
-Once review is addressed, or skipped with operator awareness, commit the brief to the business repo:
+Once review is addressed, or skipped with operator awareness, checkpoint the brief in the business repo:
 
 ```bash
 cd <business_repo>
-git add decisions/YYYY-MM-DD-minisite-brief-<slug>.md
-git commit -m "[lock] minisite brief - <slug>"
-git push
+mb checkpoint --plan --json
+mb checkpoint --validate "[decided] minisite brief -- <slug>" --json
+mb checkpoint --message "[decided] minisite brief -- <slug>" --yes
 ```
 
 The brief is now durable. Move to [`minisite-setup.md`](minisite-setup.md).

--- a/.claude/skills/mb-site/references/minisite-research.md
+++ b/.claude/skills/mb-site/references/minisite-research.md
@@ -45,6 +45,19 @@ shape. It covers business/offering, ICP, customer journey, competitive
 landscape, brand story, technical requirements, content/assets, and
 metrics/constraints before the brief is drafted.
 
+After the operator accepts research files written directly by `/mb-site`, save
+the business-repo research through the checkpoint path:
+
+```bash
+cd <business_repo>
+mb checkpoint --plan --json
+mb checkpoint --validate "[drafted] minisite research -- <slug>" --json
+mb checkpoint --message "[drafted] minisite research -- <slug>" --yes
+```
+
+If research was routed through `/mb-think`, use `/mb-think`'s own checkpoint
+loop instead of duplicating the save.
+
 ## Exit Criteria
 
 Research is ready to feed the brief when:

--- a/.claude/skills/mb-site/references/minisite-setup.md
+++ b/.claude/skills/mb-site/references/minisite-setup.md
@@ -155,6 +155,16 @@ record or offer note: site repo path or URL, domain, Cloudflare project,
 environment, measurement state, launch status, and the next manual approval
 step.
 
+After writing or updating that business-repo record, checkpoint it before
+continuing:
+
+```bash
+cd <business_repo>
+mb checkpoint --plan --json
+mb checkpoint --validate "[connected] site repo -- <slug>" --json
+mb checkpoint --message "[connected] site repo -- <slug>" --yes
+```
+
 Treat `~/.mainbranch/sites.json` as legacy fallback only when no repo-local link exists. If needed, write or extend:
 
 ```json

--- a/.claude/skills/mb-site/references/site-repo-workflow.md
+++ b/.claude/skills/mb-site/references/site-repo-workflow.md
@@ -107,3 +107,13 @@ include:
 
 Keep secrets, tokens, raw provider exports, customer rows, and private browser
 traces out of both repos.
+
+After writing or updating the reverse site record, save that business-repo
+state through the checkpoint path:
+
+```bash
+cd <business_repo>
+mb checkpoint --plan --json
+mb checkpoint --validate "[connected] site repo -- <slug>" --json
+mb checkpoint --message "[connected] site repo -- <slug>" --yes
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+### Changed
+
+- Tightened `mb checkpoint` around finite bracketed checkpoint subjects such as
+  `[updated] offer.md -- clarified guarantee`, keeping saved business history
+  scannable while improving validation, hook guidance, journal facts, and
+  `/mb-site` business-repo save guidance. Refs MAIN-403, #648.
+
 ### Fixed
 
 - Tightened Claude print-mode release dogfood prompts so agents can use

--- a/docs/json-output-contract.md
+++ b/docs/json-output-contract.md
@@ -64,6 +64,25 @@ playbook, page readiness, and outcome feedback. These facts describe whether
 the path is legible, supported, connected, and instrumented; they do not infer
 conversion quality, market strength, or strategic correctness.
 
+`mb checkpoint --validate <message> --json` includes a `contract` object for
+the checkpoint subject format. In v1 this contract is a bracketed finite
+business verb, a required object, and an optional result segment:
+
+```json
+{
+  "contract": {
+    "format": "[verb] object [-- result]",
+    "format_id": "bracket_verb",
+    "accepted_prefixes": ["[added]", "[updated]"],
+    "legacy_prefixes": ["[checkpoint]"]
+  }
+}
+```
+
+`accepted_prefixes` contains the full packaged verb registry in command output;
+the shortened example above is illustrative. `legacy_prefixes` are readable in
+history but are not accepted for new checkpoint subjects.
+
 ### MoneyPath Proof Quality
 
 `money_path.objects.proof` has two layers:

--- a/mb/mb/checkpoint.py
+++ b/mb/mb/checkpoint.py
@@ -1141,6 +1141,7 @@ def validate_message(message: str) -> dict[str, Any]:
         "ok": validation["ok"],
         "status": "valid" if validation["ok"] else "invalid",
         "validation": validation,
+        "contract": checkpoint_verbs.contract(),
         "verbs": {
             verb: {
                 "prefix": entry.prefix,

--- a/mb/mb/checkpoint_verbs.py
+++ b/mb/mb/checkpoint_verbs.py
@@ -12,6 +12,8 @@ import yaml
 
 VALID_LOOPS = {"sense", "decide", "ship", "reflect"}
 MAX_SUBJECT_LENGTH = 90
+CHECKPOINT_SUBJECT_FORMAT = "[verb] object [-- result]"
+LEGACY_PREFIXES = ("[checkpoint]",)
 
 PREFIX_RE = re.compile(r"^\[(?P<verb>[a-z]+)\]\s+(?P<object>.+?)\s*$")
 RESULT_SPLIT_RE = re.compile(r"\s+--\s+", re.ASCII)
@@ -85,6 +87,16 @@ def accepted_prefix_pattern() -> str:
     return rf"^\[({verbs}|checkpoint)\]"
 
 
+def contract() -> dict[str, Any]:
+    """Return the public checkpoint subject contract for JSON consumers."""
+    return {
+        "format": CHECKPOINT_SUBJECT_FORMAT,
+        "format_id": "bracket_verb",
+        "accepted_prefixes": [entry.prefix for entry in registry().values()],
+        "legacy_prefixes": list(LEGACY_PREFIXES),
+    }
+
+
 def parse_subject(subject: str) -> dict[str, Any]:
     """Parse a checkpoint subject without judging whether it is acceptable."""
     first_line = subject.strip().splitlines()[0] if subject.strip() else ""
@@ -92,6 +104,7 @@ def parse_subject(subject: str) -> dict[str, Any]:
     if not match:
         return {
             "recognized": False,
+            "format": None,
             "subject": first_line,
             "verb": None,
             "prefix": None,
@@ -110,6 +123,7 @@ def parse_subject(subject: str) -> dict[str, Any]:
     result = parts[1].strip() if len(parts) > 1 else ""
     return {
         "recognized": entry is not None,
+        "format": "bracket_verb",
         "subject": first_line,
         "verb": verb if entry else None,
         "prefix": f"[{verb}]",

--- a/mb/mb/journal.py
+++ b/mb/mb/journal.py
@@ -298,8 +298,9 @@ def event_from_commit(commit: dict[str, Any], files: list[str]) -> dict[str, Any
         if parsed.get("recognized")
         else "unrecognized"
     )
-    loop = _best_loop(parsed, files, refs)
-    channel = _best_channel(parsed, files, refs)
+    loop = None if recognized_as == "unrecognized" else _best_loop(parsed, files, refs)
+    channel = None if recognized_as == "unrecognized" else _best_channel(parsed, files, refs)
+    target_kind = "work" if recognized_as == "unrecognized" else _target_kind(parsed, files, refs)
     return {
         "id": str(commit.get("sha") or ""),
         "sha": str(commit.get("sha") or ""),
@@ -316,7 +317,7 @@ def event_from_commit(commit: dict[str, Any], files: list[str]) -> dict[str, Any
         "loops": parsed.get("loops") or ([] if loop is None else [loop]),
         "channel": channel,
         "channel_hint": parsed.get("channel_hint"),
-        "target_kind": _target_kind(parsed, files, refs),
+        "target_kind": target_kind,
         "refs": refs,
         "files": files[:12],
         "file_count": len(files),

--- a/mb/tests/test_checkpoint.py
+++ b/mb/tests/test_checkpoint.py
@@ -239,8 +239,12 @@ def test_checkpoint_validate_accepts_business_verb_json() -> None:
     payload = json.loads(result.stdout)
     assert payload["status"] == "valid"
     assert payload["validation"]["parsed"]["verb"] == "opened"
+    assert payload["validation"]["parsed"]["format"] == "bracket_verb"
     assert payload["validation"]["parsed"]["loop"] == "decide"
     assert payload["validation"]["acceptable_for_beginner"] is True
+    assert payload["contract"]["format"] == "[verb] object [-- result]"
+    assert "[opened]" in payload["contract"]["accepted_prefixes"]
+    assert payload["contract"]["legacy_prefixes"] == ["[checkpoint]"]
 
 
 def test_checkpoint_validate_rejects_vague_subject() -> None:
@@ -270,6 +274,31 @@ def test_checkpoint_validate_rejects_private_path_and_secret_like_subject() -> N
     codes = {error["code"] for error in payload["validation"]["errors"]}
     assert "private_local_path" in codes
     assert "secret_like_subject" in codes
+
+
+def test_checkpoint_validate_rejects_conventional_commit_type() -> None:
+    result = runner.invoke(app, ["checkpoint", "--validate", "docs: setup guide", "--json"])
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    codes = {error["code"] for error in payload["validation"]["errors"]}
+    assert "missing_prefix" in codes
+    assert payload["validation"]["parsed"]["recognized"] is False
+    assert payload["validation"]["parsed"]["format"] is None
+    assert payload["validation"]["parsed"]["verb"] is None
+
+
+def test_checkpoint_validate_rejects_unknown_bracket_prefix() -> None:
+    result = runner.invoke(app, ["checkpoint", "--validate", "[docs] setup guide", "--json"])
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    codes = {error["code"] for error in payload["validation"]["errors"]}
+    assert "unknown_prefix" in codes
+    assert payload["validation"]["parsed"]["recognized"] is False
+    assert payload["validation"]["parsed"]["format"] == "bracket_verb"
+    assert payload["validation"]["parsed"]["prefix"] == "[docs]"
+    assert payload["validation"]["parsed"]["verb"] is None
 
 
 def test_checkpoint_validate_reads_stdin() -> None:
@@ -348,6 +377,20 @@ def test_checkpoint_hook_rejects_vague_raw_git_commit(tmp_path: Path, monkeypatc
 
     assert result.returncode != 0
     assert "not business-readable" in result.stderr
+    assert _git(repo, "status", "--porcelain").stdout
+
+
+def test_checkpoint_hook_rejects_unknown_bracket_raw_git_commit(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    repo = _business_repo(tmp_path, monkeypatch)
+    (repo / "core" / "offer.md").write_text("# Offer\nUpdated\n", encoding="utf-8")
+    _git(repo, "add", "core/offer.md")
+
+    result = _git(repo, "commit", "-m", "[docs] setup guide")
+
+    assert result.returncode != 0
+    assert "[docs]` is not an accepted business checkpoint verb" in result.stderr
     assert _git(repo, "status", "--porcelain").stdout
 
 

--- a/mb/tests/test_journal.py
+++ b/mb/tests/test_journal.py
@@ -81,6 +81,27 @@ def test_parse_refs_stops_at_lowercase_body_header() -> None:
     assert refs[0]["path"] == "pushes/workshop/push.md"
 
 
+def test_event_from_commit_does_not_recognize_conventional_commit_type() -> None:
+    event = journal_mod.event_from_commit(
+        {
+            "sha": "abc123",
+            "commit": "abc123",
+            "date": "2026-05-22",
+            "authored_at": "2026-05-22",
+            "subject": "docs: setup guide",
+            "body": "",
+        },
+        ["core/offer.md"],
+    )
+
+    assert event["recognized_as"] == "unrecognized"
+    assert event["verb"] is None
+    assert event["loop"] is None
+    assert event["loops"] == []
+    assert event["channel"] is None
+    assert event["target_kind"] == "work"
+
+
 def test_collect_groups_business_commits_and_preserves_legacy_checkpoints(tmp_path: Path) -> None:
     repo = _business_repo(tmp_path)
     _commit(

--- a/mb/tests/test_onboard.py
+++ b/mb/tests/test_onboard.py
@@ -460,6 +460,7 @@ def test_onboard_github_create_push_commits_and_sets_tracking(tmp_path: Path, mo
     assert result["ok"] is True
     assert result["github"]["ok"] is True
     assert result["github"]["committed"] is True
+    assert ["git", "commit", "-m", "[opened] Main Branch scaffold for Acme"] in commands
     add_command = next(cmd for cmd in commands if cmd[:3] == ["git", "add", "--"])
     assert "." not in add_command
     assert "CLAUDE.md" in add_command

--- a/mb/tests/test_site.py
+++ b/mb/tests/test_site.py
@@ -76,6 +76,31 @@ def test_mb_site_skill_hard_gates_cloudflare_dependent_work() -> None:
     assert "Main Branch cannot buy domains through `domain.py` yet" in setup
 
 
+def test_mb_site_business_repo_saves_use_checkpoint_contract() -> None:
+    skill = (REPO_ROOT / ".claude" / "skills" / "mb-site" / "SKILL.md").read_text(encoding="utf-8")
+    brief = (
+        REPO_ROOT / ".claude" / "skills" / "mb-site" / "references" / "minisite-brief.md"
+    ).read_text(encoding="utf-8")
+    research = (
+        REPO_ROOT / ".claude" / "skills" / "mb-site" / "references" / "minisite-research.md"
+    ).read_text(encoding="utf-8")
+    setup = (
+        REPO_ROOT / ".claude" / "skills" / "mb-site" / "references" / "minisite-setup.md"
+    ).read_text(encoding="utf-8")
+    workflow = (
+        REPO_ROOT / ".claude" / "skills" / "mb-site" / "references" / "site-repo-workflow.md"
+    ).read_text(encoding="utf-8")
+
+    assert "Business-repo saves use `mb checkpoint`, not raw git commits." in skill
+    assert "site repo\ncode commits still use that site's normal git flow" in skill.lower()
+    assert 'git commit -m "[lock]' not in brief
+    assert "git add decisions/" not in brief
+    assert 'mb checkpoint --validate "[decided] minisite brief -- <slug>" --json' in brief
+    assert 'mb checkpoint --validate "[drafted] minisite research -- <slug>" --json' in research
+    assert 'mb checkpoint --validate "[connected] site repo -- <slug>" --json' in setup
+    assert 'mb checkpoint --validate "[connected] site repo -- <slug>" --json' in workflow
+
+
 def test_site_check_reports_ready_for_operator_review(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setenv("MB_CONNECT_SECRET_BACKEND", "local-file")
     monkeypatch.setenv("MAINBRANCH_HOME", str(tmp_path / "home"))


### PR DESCRIPTION
## Summary

`mb checkpoint` now publishes and validates the existing finite bracketed checkpoint contract instead of migrating business history to `type: description`. Bracketed subjects such as `[updated] offer.md -- clarified guarantee` remain canonical because they are easier to scan in a business journal and already match generated checkpoint history.

The branch tightens the CLI guardrails around that contract:

- `mb checkpoint --validate --json` exposes the subject contract, accepted prefixes, and legacy prefix metadata.
- The JSON contract now states the result segment is optional: `[verb] object [-- result]`.
- `parse_subject()` reports the bracket format without treating unknown prefixes as recognized business activity.
- `docs: setup guide` and `[docs] setup guide` are covered by regression tests and do not become business journal facts.
- Unrecognized subjects no longer inherit loop, channel, or target-kind facts from touched files.
- GitHub-backed onboarding is covered by a test asserting the first scaffold commit remains an accepted bracketed checkpoint subject.
- `docs/json-output-contract.md` documents the new `contract` object for JSON consumers.
- `/mb-site` now routes business-repo saves for minisite research, locked briefs, and reverse site records through `mb checkpoint`, while keeping child site-repo commits on the normal site git flow.

## Linked Issue

Refs #648

This is a scoped improvement to the existing `mb checkpoint` hook/CLI path, not the full GitHub/org-level enforcement design from the issue.

## Why

Brackets are the better default for Main Branch business repos right now. They visually separate saved business activity from conventional engineering commit types, keep the existing checkpoint history readable, and avoid breaking JSON consumers that already expect `recognized_as: business_verb`.

## Commit List

- `9eebf02 [update] MAIN-403 bracket checkpoint enforcement`

## Validation

Level 1 static and full local gate:

```bash
scripts/check.sh
```

Result: passed. The run covered formatting, ruff, mypy, 767 tests with coverage, and `mb skill validate` with 15/15 bundled skills passing.

Focused checks:

```bash
cd mb && pytest tests/test_checkpoint.py tests/test_journal.py tests/test_onboard.py -q
cd mb && pytest tests/test_site.py tests/test_skill_validate.py -q
```

Result: checkpoint/journal/onboard focused suite `63 passed`; site/skill focused suite `44 passed`.

Level 3 package/install smoke: not run; this branch does not change packaging, entry points, dependencies, bundled data, or install/update paths.

Level 5 runtime smoke: not run; this branch does not change runtime discovery or LLM-facing skill guidance.

## Success Metric

`mb checkpoint` keeps bracketed finite checkpoint messages as the canonical local save contract, rejects conventional/unknown commit subjects from business classification, gives JSON consumers explicit contract metadata without changing the stable journal `business_verb` classification, and keeps `/mb-site` business-repo saves on the checkpoint path.

## Changelog

Updated `CHANGELOG.md` under `[Unreleased]`.

## Public / Private Boundary

No private operator strategy, local machine paths, credentials, customer data, or runtime internals were committed.
