### PR TITLE
[add] Team member context for business repos

### DIFF
--- a/.claude/skills/mb-bet/SKILL.md
+++ b/.claude/skills/mb-bet/SKILL.md
@@ -108,8 +108,9 @@ Keep `appetite` human-readable, and use `appetite_tier` for rough financial
 weight. The tier should match the operator's appetite thresholds in
 `core/finance/books.md` when that file exists.
 
-When an owner is known, use the team member slug that will map to
-`core/team/<slug>.md`; do not invent team files before that primitive exists.
+When an owner is known, use the existing team member slug from
+`core/team/<slug>.md`. Ask before creating a new team file, and keep owner
+enforcement future-scoped unless the bet schema validates it.
 
 For financially material bets, use `money_path.bet_id` equal to the filename
 stem and tag private hledger transactions with `bet:<id>`. Check exposure with:

--- a/.claude/skills/mb-help/references/system-model.md
+++ b/.claude/skills/mb-help/references/system-model.md
@@ -3,8 +3,8 @@
 Main Branch has three user-visible pieces:
 
 - **Your business folder** -- the place Claude reads and writes durable
-  business memory: offer, audience, voice, proof, research, decisions, bets,
-  pushes, logs, and outcomes.
+  business memory: offer, audience, voice, proof, team context, research,
+  decisions, bets, pushes, logs, and outcomes.
 - **The `mb` CLI** -- the deterministic control plane. It checks setup,
   status, validation, graph links, provider readiness, updates, repairs, and
   checkpoints.
@@ -21,7 +21,7 @@ checkout. They open the business folder, start Claude Code, and run
 
 ```text
 business folder
-├── core/                 # offer, audience, voice, proof, strategy
+├── core/                 # offer, audience, voice, proof, team, strategy
 ├── research/             # source notes and investigations
 ├── decisions/            # choices the business made
 ├── bets/                 # time-boxed operating hypotheses

--- a/.claude/skills/mb-setup/SKILL.md
+++ b/.claude/skills/mb-setup/SKILL.md
@@ -322,7 +322,7 @@ Use templates from `references/templates.md`.
 
 **Teach WHY each file matters as you create it.** Don't just scaffold — explain. This is the user's first encounter with the system. The act of writing these files IS the learning.
 
-See **[references/file-education.md](references/file-education.md)** for the educational blurbs to present before writing each core file (soul, offer, audience, voice, multi-offer additions), the priority order, and the visual style scaffolding questions.
+See **[references/file-education.md](references/file-education.md)** for the educational blurbs to present before writing each core file (team, soul, offer, audience, voice, multi-offer additions), the priority order, and the visual style scaffolding questions.
 
 ### 6. Apply Business Setup Pattern
 

--- a/.claude/skills/mb-setup/references/file-education.md
+++ b/.claude/skills/mb-setup/references/file-education.md
@@ -8,6 +8,9 @@ When sorting content into files during setup, teach WHY each file matters as you
 
 Present each blurb before writing the corresponding file.
 
+### core/team/<slug>.md
+> "core/team records public-safe business context for the people in this repo: name, preferred name, role, relationship, owned areas, and GitHub handle. It helps Main Branch translate repo activity into business language. Do not put payroll, private contact details, legal ownership percentages, credentials, or customer/member data here."
+
 ### soul.md
 > "soul.md is WHY you exist. Not the marketing answer — the real one. Three questions: What do you research when no one's watching? What intersections excite you? What decisions feel like discovery vs obligation? This file is your reconnection fuel — when you're grinding and feel nothing, re-read it."
 
@@ -39,22 +42,23 @@ For multi-offer setups, also explain:
 
 ## Priority Order (Single-Offer)
 
-1. `core/soul.md` — Why you exist (reconnection fuel)
-2. `core/offer.md` — What you sell (or brand thesis if multi-offer)
-3. `core/audience.md` — Who buys
-4. `core/voice.md` — How you sound
-5. `core/proof/testimonials.md` — Social proof
-6. `core/proof/angles/` — Messaging entry points
-7. `core/brand/visual-style.md` — Visual brand identity (colors, typography, mood, image prompt fragments)
-8. `core/content-strategy.md` — Known-for target, pillars, asset jobs, distribution links, and optional `core/marketing/` / `core/people/` layers
-9. `core/operations/funnel/skool-surfaces.md` — Live Skool about page + pricing card copy (community businesses with Skool)
+1. `core/team/<slug>.md` — Public-safe owner/team context
+2. `core/soul.md` — Why you exist (reconnection fuel)
+3. `core/offer.md` — What you sell (or brand thesis if multi-offer)
+4. `core/audience.md` — Who buys
+5. `core/voice.md` — How you sound
+6. `core/proof/testimonials.md` — Social proof
+7. `core/proof/angles/` — Messaging entry points
+8. `core/brand/visual-style.md` — Visual brand identity (colors, typography, mood, image prompt fragments)
+9. `core/content-strategy.md` — Known-for target, pillars, asset jobs, distribution links, and optional `core/marketing/` / `core/people/` layers
+10. `core/operations/funnel/skool-surfaces.md` — Live Skool about page + pricing card copy (community businesses with Skool)
 
 ### Multi-Offer Additional Files (if applicable)
 
-10. `core/offers/[name]/offer.md` — Offer-specific details for each offer
-11. `core/offers/[name]/audience.md` — Only if this offer targets a different segment
-12. `core/offers/[name]/proof/` — Only if proof applies to one specific offer
-13. `core/product-ladder.md` — How offers relate to each other
+11. `core/offers/[name]/offer.md` — Offer-specific details for each offer
+12. `core/offers/[name]/audience.md` — Only if this offer targets a different segment
+13. `core/offers/[name]/proof/` — Only if proof applies to one specific offer
+14. `core/product-ladder.md` — How offers relate to each other
 
 > **Note:** content-strategy.md and visual-style.md start as templates and get filled through `/mb-think` cycles. Not required at setup — scaffolded with placeholder sections.
 

--- a/.claude/skills/mb-start/SKILL.md
+++ b/.claude/skills/mb-start/SKILL.md
@@ -30,10 +30,10 @@ actual file paths in commands.
 **CLI facts first:** Once the business repo path is known, run
 `mb status --json --peek` before asking setup or routing questions. Treat JSON
 as source of truth for update severity, readiness, drift, onboarding,
-integrations, GitHub, bets, dirty git, since-last-check, `content_strategy`,
-`money_path`, and `ranked_actions`. Parse the full JSON once; do not slice
-status output with `head` or `sed` in the normal path.
-
+integrations, GitHub, team, bets, dirty git, since-last-check,
+`content_strategy`, `money_path`, and `ranked_actions`. Use GitHub activity
+`author_display` / `author_known` fields when naming people. Parse the full
+JSON once; do not slice status output with `head` or `sed` in the normal path.
 **Continuity facts:** Use `since_last_check.journal`, top-level `journal`,
 GitHub activity, and `checkpoint` from status to explain "where we left off."
 Do not run raw `git log` unless status says journal facts are unavailable. If

--- a/.claude/skills/mb-status/SKILL.md
+++ b/.claude/skills/mb-status/SKILL.md
@@ -23,7 +23,7 @@ mb status --json --peek
 ```
 
 3. Treat the JSON as the source of truth for setup, update, drift, GitHub,
-   onboarding, integrations, bets, journal activity, since-last-check,
+   onboarding, integrations, team, bets, journal activity, since-last-check,
    readiness, vocabulary, content_strategy, money_path, and ranked actions.
 4. Summarize the top `ranked_actions` first. For each one, include:
    - title
@@ -43,6 +43,8 @@ mb status --json --peek
    If `vocabulary.terms.push` defines display words, use them in
    operator-facing prose without changing current paths, frontmatter, JSON
    keys, validator rules, or command names.
+   Use `team` facts and GitHub activity `author_display` / `author_known` fields
+   when naming people; keep unknown contributors as handles.
    Do not re-run shell probes that duplicate status facts.
    For "what changed?" or "what happened since last time?", answer from
    `since_last_check.journal` first, then top-level `journal` for recent

--- a/.claude/skills/mb-think/SKILL.md
+++ b/.claude/skills/mb-think/SKILL.md
@@ -363,7 +363,7 @@ See [decide-phase.md](references/decide-phase.md) for format details.
 
 Apply changes described in `## What Changes` to reference files. Mark decision as codified.
 
-**Codify targets include:** `core/*.md`, active offer/audience files, proof files, `core/content-strategy.md`, `core/marketing/...`, `core/people/...`, `core/operations/funnel/skool-surfaces.md`, `core/product-ladder.md`, and `bets/` only when updating the live wager or verdict. See [codify-phase.md](references/codify-phase.md) for layer-specific rules.
+**Codify targets include:** `core/*.md`, active offer/audience files, proof files, `core/content-strategy.md`, `core/marketing/...`, `core/people/...`, `core/team/<slug>.md`, `core/operations/funnel/skool-surfaces.md`, `core/product-ladder.md`, and `bets/` only when updating the live wager or verdict. See [codify-phase.md](references/codify-phase.md) for layer-specific rules.
 
 ---
 

--- a/.claude/skills/mb-think/references/codify-phase.md
+++ b/.claude/skills/mb-think/references/codify-phase.md
@@ -254,6 +254,7 @@ research source and the evergreen reference separate. Raw extracts stay in
 | Average-case outcomes, typical timelines, caveats, common failure context | `core/proof/typicality.md` |
 | Proof that applies only to one offer | `core/offers/<slug>/proof/` |
 | Hook pattern, content framework, platform cue, comment insight | `core/content-strategy.md` |
+| Team role, relationship, owned area, or GitHub handle changed | `core/team/<slug>.md` with public-safe context only |
 | Mechanism story, pricing/distribution vulnerability | `core/offer.md` or offer-specific `offer.md` |
 | Live hypothesis, deadline, target, evidence, or verdict | `bets/YYYY-MM-DD-slug.md` |
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+### Added
+
+- Added a public-safe `core/team/<slug>.md` team member primitive, onboarding
+  scaffold, validation for normalized and duplicate GitHub handles, and status
+  GitHub activity handle resolution so business repos can name known team
+  contributors. Refs MAIN-396, #633.
+
 ### Fixed
 
 - Tightened Claude print-mode release dogfood prompts so agents can use

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@
 
 **You don't need to know git. You don't need to know terminals. You just need a folder.**
 
-Main Branch is a folder on your computer that holds your business — offer, audience, voice, decisions, research, bets, launches, meeting notes, fulfillment context, lessons. The agent reads that folder before it answers, so the work it gives you sounds like your business instead of generic AI output. The system saves itself between sessions, so you stop re-explaining who you are every time you open Claude.
+Main Branch is a folder on your computer that holds your business — offer, audience, voice, team context, decisions, research, bets, launches, meeting notes, fulfillment context, lessons. The agent reads that folder before it answers, so the work it gives you sounds like your business instead of generic AI output. The system saves itself between sessions, so you stop re-explaining who you are every time you open Claude.
 
 Open source. Lives on your machine. Bring your own Claude Code plan. That's it.
 
@@ -142,7 +142,7 @@ You don't run any of these commands yourself. You ask the agent. It runs them.
 
 Main Branch v0.3 has three layers:
 
-- **Your folder is the source of truth.** Offer, audience, voice, decisions, research, bets, launches, logs, documents, links to other repos. Plain markdown files you can read on any computer.
+- **Your folder is the source of truth.** Offer, audience, voice, public-safe team roles, decisions, research, bets, launches, logs, documents, links to other repos. Plain markdown files you can read on any computer.
 - **The CLI is the fact and safety layer.** It scaffolds the folder, validates the shape, maps how the business pieces connect, briefs the agent on what's changed, walks through repairs, saves readable checkpoints, and checks that connected accounts are wired up safely. It also exposes shipped facts for MoneyPath readiness, proof quality, content strategy health, books readiness, connected-account health, status, start, graph, and checkpoint workflows. The agent runs it. You don't have to learn it.
 - **The skills are the chat UX and judgment layer.** The agent reads your folder and `mb` facts, asks you the right questions, drafts work, reviews it, and routes approved artifacts back into files.
 

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ Tested on macOS and Linux. Windows is experimental — use WSL2.
 
 **Can I edit the skills?** You can. You don't need to.
 
-**What makes this different from ChatGPT?** ChatGPT resets between sessions. Main Branch is a folder Claude can re-read every session — your offer, audience, voice, decisions, research, and bets — so the output stays consistent with your business.
+**What makes this different from ChatGPT?** ChatGPT resets between sessions. Main Branch is a folder Claude can re-read every session — your offer, audience, voice, team context, decisions, research, and bets — so the output stays consistent with your business.
 
 **I'm stuck.** Type `/mb-start` again.
 

--- a/docs/architecture/system-map.md
+++ b/docs/architecture/system-map.md
@@ -43,7 +43,7 @@ flowchart TB
   end
 
   subgraph brain["Business repo - durable business brain"]
-    core["core/<br/>offer, audience, voice, strategy, operations, finance policy"]
+    core["core/<br/>offer, audience, voice, team, strategy, operations, finance policy"]
     growthcraft["offer sharpening + AI SEO/recognition<br/>content strategy and conversion knowledge"]
     research["research/<br/>point-in-time findings"]
     decisions["decisions/<br/>accepted choices and rationale"]

--- a/docs/beginner-setup.md
+++ b/docs/beginner-setup.md
@@ -170,9 +170,10 @@ cd my-business
 
 `mb onboard` walks you through the setup, explains why Main Branch uses local
 files, git, and GitHub, scaffolds the business folder taxonomy (`core/`,
-`research/`, `decisions/`, `bets/`, `log/`, `pushes/`, `documents/` plus an
-optional `core/vocabulary.md` for operator-owned display words), and wires the
-bridge files Claude Code needs to find Main Branch's skills.
+`research/`, `decisions/`, `bets/`, `log/`, `pushes/`, `documents/` plus
+`core/team/<owner>.md` for public-safe owner context and optional
+`core/vocabulary.md` for operator-owned display words), and wires the bridge
+files Claude Code needs to find Main Branch's skills.
 
 You may also see a `.mb/` folder. That is normal. It stores Main Branch's local
 operational state for that business repo, such as onboarding progress, safe

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -56,6 +56,7 @@ my-business/
 │   │   ├── distribution-strategy.md
 │   │   ├── channels/
 │   │   └── accounts/
+│   ├── team/
 │   ├── people/
 │   ├── strategy/
 │   ├── operations/
@@ -221,6 +222,43 @@ Specific execution still belongs in `pushes/<YYYY-MM-DD-slug>/`, and results
 or lessons land in `log/`, a push review log, research, decisions, or core
 updates. Do not duplicate publishable site/blog/wiki content into the business
 repo's operating strategy.
+
+### Team Members
+
+Public-safe team context lives in `core/team/<slug>.md`. The filename stem is
+the stable team member slug that other primitives can reference later, for
+example a future bet `owner: maya` or `owner: core/team/maya.md`. Prefer a slug
+that matches the person's primary GitHub handle when that is stable.
+
+Team member frontmatter:
+
+```yaml
+type: team_member
+slug: maya
+name: Maya Chen
+preferred_name: Maya
+role: Growth Lead
+relationship: member
+github:
+  - mayachen
+areas:
+  - paid traffic
+  - launch reviews
+notes: Public-safe business context only.
+```
+
+Allowed `relationship` values are `owner`, `member`, `contractor`, `advisor`,
+and `external_collaborator`. Owners and members are part of the operating team.
+Contractors and advisors are useful business context but may not own decisions.
+External collaborators are outside the team; add them only when GitHub activity,
+pushes, offers, or decisions need a business-readable name.
+
+Do not store payroll, compensation, legal ownership percentages, home contact
+details, private customer/member data, secrets, or account credentials in team
+files. GitHub handles should be stored without `@`. `mb validate` checks team
+frontmatter shape, handle normalization, and duplicate handles. `mb status`
+exposes a `team` block so GitHub activity can say a person's business name when
+the handle is known and preserve unknown handles when it is not.
 
 ### `research/`
 

--- a/mb/mb/_data/fixtures/acme-brewing/core/team/maya.md
+++ b/mb/mb/_data/fixtures/acme-brewing/core/team/maya.md
@@ -1,0 +1,18 @@
+---
+type: team_member
+slug: maya
+name: Maya Chen
+preferred_name: Maya
+role: Growth Lead
+relationship: member
+github:
+  - mayachen
+areas:
+  - paid traffic
+  - launches
+notes: Fake fixture data for public tests.
+---
+
+# Maya Chen
+
+Maya helps Acme Brewing review launch pushes and paid traffic experiments.

--- a/mb/mb/_data/fixtures/acme-brewing/core/team/rafa.md
+++ b/mb/mb/_data/fixtures/acme-brewing/core/team/rafa.md
@@ -1,0 +1,18 @@
+---
+type: team_member
+slug: rafa
+name: Rafael Ortiz
+preferred_name: Rafa
+role: Packaging Advisor
+relationship: advisor
+github:
+  - rafa-ops
+areas:
+  - wholesale
+  - packaging
+notes: Fake fixture data for public tests.
+---
+
+# Rafael Ortiz
+
+Rafa advises Acme Brewing on packaging and wholesale launch readiness.

--- a/mb/mb/_data/templates/AGENTS.md.tmpl
+++ b/mb/mb/_data/templates/AGENTS.md.tmpl
@@ -82,6 +82,12 @@ Use the `vocabulary` block from `mb status --json --peek` when present. If
 challenges, or promos, use that word in operator-facing prose while preserving
 current paths, frontmatter, JSON keys, validator rules, and command names.
 
+Use the `team` block from `mb status --json --peek` when present. Map known
+GitHub handles to the business names in `core/team/<slug>.md`; keep unknown
+handles as handles and suggest adding a public-safe team file when the person is
+part of the business context. Do not invent identities from commit authors,
+emails, or usernames alone.
+
 ## Codex Lifecycle Workflow Index
 
 This tracked `AGENTS.md` file is the repo-level Codex bootstrap. The generated

--- a/mb/mb/_data/templates/AGENTS.md.tmpl
+++ b/mb/mb/_data/templates/AGENTS.md.tmpl
@@ -294,8 +294,10 @@ customers.
 ## Business Folders
 
 - `core/` - the business brain: offer, audience, voice, soul, proof, brand,
-  strategy, operations, finance.
+  team, strategy, operations, finance.
 - `core/offers/` - per-offer specifics when this is a multi-offer repo.
+- `core/team/` - public-safe team member names, roles, GitHub handles, and
+  ownership context.
 - `core/proof/` - testimonials, typicality, and reusable proof. Use
   structured permission and offer-link fields when proof should be detectable
   by `mb status`. If specific proof is not approved for public marketing, use

--- a/mb/mb/_data/templates/CLAUDE.md.tmpl
+++ b/mb/mb/_data/templates/CLAUDE.md.tmpl
@@ -107,6 +107,7 @@ detail:" line after the owner meaning.
 - `core/proof/` — testimonials, typicality, and reusable proof
 - `core/brand/` — visual identity, voice guardrails, and brand systems
 - `core/marketing/` — optional content distribution, channel, and account strategy
+- `core/team/` — public-safe team member files for names, roles, GitHub handles, and ownership context
 - `core/people/` — optional founder/person voice source material, beliefs, stories, and proof
 - `core/strategy/` — strategic context that should remain evergreen
 - `core/operations/` — operating context such as fulfillment, classroom, funnel, or membership notes
@@ -200,6 +201,15 @@ are good, bad, high-converting, or likely to convert. If
 collect permission before using that proof in public ads, pages, or claims.
 A live idea can be both a bet and an offer candidate: open the bet first, then
 create or update the offer only when the operator wants durable sellable truth.
+
+Team context lives in `core/team/<slug>.md`. Use it for public-safe business
+identity: name, preferred name, role, relationship, owned areas, and GitHub
+handles without `@`. Do not put payroll, legal ownership percentages, home
+contact details, private customer/member data, or credentials there. Keep
+external collaborators in the same folder with
+`relationship: external_collaborator` only when they are useful business
+context. Unknown GitHub handles should stay as handles until the operator
+chooses to add a team file.
 
 Do not rename, delete, merge, split, or move offer folders until an accepted
 decision, approved migration plan, or explicit operator instruction exists.

--- a/mb/mb/_data/templates/README.md.tmpl
+++ b/mb/mb/_data/templates/README.md.tmpl
@@ -3,7 +3,7 @@
 This is the Main Branch business folder for {{BUSINESS_NAME}}.
 
 The durable business memory lives here: offer, audience, voice, proof,
-decisions, bets, pushes, logs, research, and approved summaries. Claude Code
+team context, decisions, bets, pushes, logs, research, and approved summaries. Claude Code
 reads this folder before advising, so work starts from the business context
 instead of a blank chat.
 
@@ -42,7 +42,9 @@ mb start --json
 
 Commit business-readable files. Do not commit API keys, OAuth tokens,
 service-account JSON, customer exports, raw finance/legal records, or local
-runtime settings.
+runtime settings. `core/team/` is for public-safe business identity and GitHub
+handles, not payroll, legal ownership percentages, home contact details, or
+private personal data.
 
 Local setup files such as `.claude/settings.local.json`, `.mb/onboarding.json`,
 `.mb/connect.yaml`, and `.mb/private/` stay on this machine and are ignored by

--- a/mb/mb/_data/templates/core_team_member.md.tmpl
+++ b/mb/mb/_data/templates/core_team_member.md.tmpl
@@ -1,0 +1,20 @@
+---
+type: team_member
+slug: {{OWNER_SLUG}}
+name: {{OWNER_NAME}}
+preferred_name: {{OWNER_NAME}}
+role: Owner / Operator
+relationship: owner
+github:
+  - {{GH_USERNAME}}
+areas:
+  - business direction
+  - offer
+  - operations
+notes: Public-safe business context only. Do not add private personal data here.
+---
+
+# {{OWNER_NAME}}
+
+This file tells Main Branch who owns the business context so GitHub activity and
+saved history can use business names instead of only handles.

--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -248,10 +248,16 @@ def main_callback(
 def init_cmd(
     path: str = typer.Argument(".", help="Where to scaffold (default: current dir)."),
     name: str = typer.Option("", "--name", help="Business name (skips prompt if given)."),
+    owner_name: str = typer.Option("", "--owner-name", help="Business name for the owner file."),
+    owner_github: str = typer.Option(
+        "",
+        "--owner-github",
+        help="GitHub handle for the owner file, without @.",
+    ),
     json_out: bool = typer.Option(False, "--json", help="Machine-readable output."),
 ) -> None:
     """Set up a fresh business repo (business folders, CLAUDE.md, git init)."""
-    result = init_mod.run(path=path, name=name)
+    result = init_mod.run(path=path, name=name, owner_name=owner_name, owner_github=owner_github)
     if json_out:
         typer.echo(json.dumps(result, indent=2))
     else:
@@ -443,6 +449,12 @@ def onboard_cmd(
     ctx: typer.Context,
     path_opt: str = typer.Option("", "--path", help="Repo path to create or connect."),
     name: str = typer.Option("", "--name", help="Business name."),
+    owner_name: str = typer.Option("", "--owner-name", help="Business name for the owner file."),
+    owner_github: str = typer.Option(
+        "",
+        "--owner-github",
+        help="GitHub handle for the owner file, without @.",
+    ),
     mode: str = typer.Option(
         "auto",
         "--mode",
@@ -505,6 +517,8 @@ def onboard_cmd(
     selected_mode = mode
     target = _onboard_target_path("", path_opt, name)
     business_name = name
+    selected_owner_name = owner_name
+    selected_owner_github = owner_github
 
     if not yes:
         typer.echo("Main Branch setup")
@@ -524,11 +538,19 @@ def onboard_cmd(
         if target == "." and business_name:
             default_path = onboard_mod._slug(business_name)
         target = typer.prompt("Repo path", default=default_path)
+        if selected_mode != "connect":
+            selected_owner_name = typer.prompt("Owner name", default=owner_name or "Business Owner")
+            selected_owner_github = typer.prompt(
+                "Owner GitHub handle (without @)",
+                default=owner_github or "",
+            )
 
     try:
         result = onboard_mod.run(
             path=target,
             name=business_name,
+            owner_name=selected_owner_name,
+            owner_github=selected_owner_github,
             mode=selected_mode,
             level=selected_level,
             team_size=team_size,

--- a/mb/mb/github_activity.py
+++ b/mb/mb/github_activity.py
@@ -11,6 +11,8 @@ from datetime import date, timedelta
 from pathlib import Path
 from typing import Any
 
+from mb import team as team_mod
+
 CommandResult = dict[str, Any]
 CommandRunner = Callable[[list[str], Path | None, float], CommandResult]
 JsonRunner = Callable[[list[str], Path], tuple[bool, Any, str]]
@@ -71,6 +73,7 @@ def collect(
     *,
     remote: str = "",
     today: date | None = None,
+    team_facts: dict[str, Any] | None = None,
     which_func: Which = which,
     command_runner: CommandRunner = run_command,
     json_runner: JsonRunner = gh_json,
@@ -180,6 +183,7 @@ def collect(
                     repo_name,
                     business_status="needs_review",
                     reason="Your review is requested",
+                    team_facts=team_facts,
                 )
                 for item in review_requests
             ],
@@ -198,6 +202,7 @@ def collect(
                     repo_name,
                     business_status="mentioned",
                     reason="You were mentioned",
+                    team_facts=team_facts,
                 )
                 for item in mentioned_prs
             ],
@@ -209,10 +214,11 @@ def collect(
             repo_name,
             business_status="open_proposal",
             reason="Your open proposal may need follow-up",
+            team_facts=team_facts,
         )
         for item in open_prs
     ]
-    shipped_this_week = recent_merged_prs(merged, repo_name=repo_name)
+    shipped_this_week = recent_merged_prs(merged, repo_name=repo_name, team_facts=team_facts)
     recently_closed_tasks = [
         _task_item(item, repo_name, business_status="closed", reason="Recently closed")
         for item in closed
@@ -254,12 +260,22 @@ def collect(
     return report
 
 
-def recent_merged_prs(prs: list[dict[str, Any]], repo_name: str = "") -> list[dict[str, Any]]:
+def recent_merged_prs(
+    prs: list[dict[str, Any]],
+    repo_name: str = "",
+    *,
+    team_facts: dict[str, Any] | None = None,
+) -> list[dict[str, Any]]:
     sorted_prs = sorted(prs, key=lambda pr: str(pr.get("mergedAt", "") or ""), reverse=True)
-    return [summarize_pr(pr, repo_name=repo_name) for pr in sorted_prs[:5]]
+    return [summarize_pr(pr, repo_name=repo_name, team_facts=team_facts) for pr in sorted_prs[:5]]
 
 
-def summarize_pr(pr: dict[str, Any], repo_name: str = "") -> dict[str, Any]:
+def summarize_pr(
+    pr: dict[str, Any],
+    repo_name: str = "",
+    *,
+    team_facts: dict[str, Any] | None = None,
+) -> dict[str, Any]:
     title = str(pr.get("title", "") or "")
     body = str(pr.get("body", "") or "")
     summary = ""
@@ -276,6 +292,7 @@ def summarize_pr(pr: dict[str, Any], repo_name: str = "") -> dict[str, Any]:
         repo_name=repo_name,
         business_status="shipped",
         reason="Merged this week",
+        team_facts=team_facts,
     )
     item["what_shipped"] = summary[:220]
     item["mergedAt"] = item["merged_at"]
@@ -389,7 +406,10 @@ def _proposal_item(
     *,
     business_status: str,
     reason: str,
+    team_facts: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
+    author = _author_login(pr.get("author"))
+    author_identity = team_mod.resolve_github_handle(author, team_facts)
     return {
         "type": "proposal",
         "github_type": "pull_request",
@@ -402,7 +422,11 @@ def _proposal_item(
         "state": str(pr.get("state", "") or ""),
         "updated_at": str(pr.get("updatedAt", "") or ""),
         "merged_at": str(pr.get("mergedAt", "") or ""),
-        "author": _author_login(pr.get("author")),
+        "author": author,
+        "author_handle": author_identity["handle"],
+        "author_display": author_identity["label"],
+        "author_known": author_identity["known"],
+        "author_team_slug": author_identity["slug"],
         "is_draft": bool(pr.get("isDraft", False)),
         "review_decision": str(pr.get("reviewDecision", "") or ""),
     }

--- a/mb/mb/init.py
+++ b/mb/mb/init.py
@@ -85,23 +85,15 @@ def _gh_username() -> str:
     return ""
 
 
-def _git_user_name() -> str:
-    """Best-effort git author name probe. Returns empty string on miss."""
+def _owner_display_name(owner_name: str) -> str:
+    """Return an explicit owner name without reading local machine identity."""
+    explicit_name = owner_name.strip()
+    if explicit_name:
+        return explicit_name
     env_name = os.environ.get("MB_OWNER_NAME", "").strip()
     if env_name:
         return env_name
-    try:
-        out = subprocess.run(
-            ["git", "config", "--global", "user.name"],
-            capture_output=True,
-            text=True,
-            timeout=5,
-        )
-        if out.returncode == 0:
-            return out.stdout.strip()
-    except (FileNotFoundError, subprocess.SubprocessError):
-        pass
-    return ""
+    return "Business Owner"
 
 
 def _read_template(name: str) -> str:
@@ -166,8 +158,12 @@ def run(
     if not business_name:
         return {"status": "error", "path": str(target), "error": "empty business name"}
 
-    gh_user = team_mod.normalize_github_handle(owner_github) or _gh_username() or "your-gh-username"
-    owner_display_name = owner_name.strip() or _git_user_name() or "Business Owner"
+    gh_user = (
+        team_mod.normalize_github_handle(owner_github)
+        or team_mod.normalize_github_handle(_gh_username())
+        or "your-gh-username"
+    )
+    owner_display_name = _owner_display_name(owner_name)
     owner_slug = _owner_slug(owner_display_name, gh_user)
 
     created: list[str] = []

--- a/mb/mb/init.py
+++ b/mb/mb/init.py
@@ -8,6 +8,7 @@ an existing repo returns ``status=already-initialized`` (idempotent).
 from __future__ import annotations
 
 import os
+import re
 import shutil
 import subprocess
 from importlib import resources
@@ -16,6 +17,7 @@ from typing import Any
 
 from mb import checkpoint as checkpoint_mod
 from mb import codex as codex_mod
+from mb import team as team_mod
 from mb.engine import link_skills
 from mb.migrate import LATEST_SCHEMA_VERSION, SCHEMA_MARKER
 
@@ -28,6 +30,7 @@ DATA_FOLDERS = [
     "core/marketing",
     "core/marketing/channels",
     "core/marketing/accounts",
+    "core/team",
     "core/people",
     "core/strategy",
     "core/operations",
@@ -82,6 +85,25 @@ def _gh_username() -> str:
     return ""
 
 
+def _git_user_name() -> str:
+    """Best-effort git author name probe. Returns empty string on miss."""
+    env_name = os.environ.get("MB_OWNER_NAME", "").strip()
+    if env_name:
+        return env_name
+    try:
+        out = subprocess.run(
+            ["git", "config", "--global", "user.name"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if out.returncode == 0:
+            return out.stdout.strip()
+    except (FileNotFoundError, subprocess.SubprocessError):
+        pass
+    return ""
+
+
 def _read_template(name: str) -> str:
     """Read a bundled template by relative path under ``_data/templates/``."""
     try:
@@ -102,7 +124,21 @@ def _render(text: str, mapping: dict[str, str]) -> str:
     return out
 
 
-def run(path: str, name: str) -> dict[str, Any]:
+def _owner_slug(owner_name: str, github_handle: str) -> str:
+    handle = team_mod.normalize_github_handle(github_handle)
+    if handle:
+        return handle
+    slug = re.sub(r"[^a-z0-9]+", "-", owner_name.lower()).strip("-")
+    return slug or "owner"
+
+
+def run(
+    path: str,
+    name: str,
+    *,
+    owner_name: str = "",
+    owner_github: str = "",
+) -> dict[str, Any]:
     """Scaffold ``path`` as a Main Branch business repo.
 
     Returns a dict with ``status`` ∈ {ok, already-initialized, error},
@@ -130,7 +166,9 @@ def run(path: str, name: str) -> dict[str, Any]:
     if not business_name:
         return {"status": "error", "path": str(target), "error": "empty business name"}
 
-    gh_user = _gh_username() or "your-gh-username"
+    gh_user = team_mod.normalize_github_handle(owner_github) or _gh_username() or "your-gh-username"
+    owner_display_name = owner_name.strip() or _git_user_name() or "Business Owner"
+    owner_slug = _owner_slug(owner_display_name, gh_user)
 
     created: list[str] = []
     for sub in DATA_FOLDERS:
@@ -150,6 +188,8 @@ def run(path: str, name: str) -> dict[str, Any]:
     mapping = {
         "BUSINESS_NAME": business_name,
         "GH_USERNAME": gh_user,
+        "OWNER_NAME": owner_display_name,
+        "OWNER_SLUG": owner_slug,
     }
 
     claude_tmpl = _read_template("CLAUDE.md.tmpl") or _DEFAULT_CLAUDE
@@ -177,6 +217,14 @@ def run(path: str, name: str) -> dict[str, Any]:
         if not vocabulary_path.exists():
             vocabulary_path.write_text(_render(vocabulary_tmpl, mapping), encoding="utf-8")
             created.append("core/vocabulary.md")
+
+    team_tmpl = _read_template("core_team_member.md.tmpl")
+    if team_tmpl:
+        owner_path = target / "core" / "team" / f"{owner_slug}.md"
+        owner_path.parent.mkdir(parents=True, exist_ok=True)
+        if not owner_path.exists():
+            owner_path.write_text(_render(team_tmpl, mapping), encoding="utf-8")
+            created.append(f"core/team/{owner_slug}.md")
 
     codeowners_tmpl = _read_template("CODEOWNERS.tmpl") or f"* @{gh_user}\n"
     github_dir = target / ".github"
@@ -335,6 +383,8 @@ detail:" line after the owner meaning.
 - `core/proof/` — testimonials, typicality, and reusable proof
 - `core/brand/` — visual identity, voice guardrails, and brand systems
 - `core/marketing/` — optional content distribution, channel, and account strategy
+- `core/team/` — public-safe team member files for names, roles, GitHub
+  handles, and ownership context
 - `core/people/` — optional founder/person voice source material, beliefs, stories, and proof
 - `core/strategy/` — strategic context that should remain evergreen
 - `core/operations/` — operating context such as fulfillment, classroom, funnel, or membership notes
@@ -427,6 +477,15 @@ are good, bad, high-converting, or likely to convert. If
 collect permission before using that proof in public ads, pages, or claims.
 A live idea can be both a bet and an offer candidate: open the bet first, then
 create or update the offer only when the operator wants durable sellable truth.
+
+Team context lives in `core/team/<slug>.md`. Use it for public-safe business
+identity: name, preferred name, role, relationship, owned areas, and GitHub
+handles without `@`. Do not put payroll, legal ownership percentages, home
+contact details, private customer/member data, or credentials there. Keep
+external collaborators in the same folder with
+`relationship: external_collaborator` only when they are useful business
+context. Unknown GitHub handles should stay as handles until the operator
+chooses to add a team file.
 
 Do not rename, delete, merge, split, or move offer folders until an accepted
 decision, approved migration plan, or explicit operator instruction exists.

--- a/mb/mb/onboard.py
+++ b/mb/mb/onboard.py
@@ -681,6 +681,11 @@ def _profile_missing(profile: dict[str, Any]) -> list[str]:
 
 def _team_step(profile: dict[str, Any], repo: Path) -> dict[str, Any]:
     team_size = str(profile.get("team_size") or "unknown")
+    team_files = [
+        path
+        for path in (repo / "core" / "team").glob("*.md")
+        if path.is_file() and path.name != "README.md"
+    ]
     if team_size == "unknown":
         return {
             "id": "team_layer",
@@ -692,19 +697,22 @@ def _team_step(profile: dict[str, Any], repo: Path) -> dict[str, Any]:
             "required": False,
         }
     if team_size == "solo":
+        missing = [] if team_files else ["core/team/<owner>.md"]
         return {
             "id": "team_layer",
             "title": "Solo operating loop",
-            "status": "complete",
+            "status": "complete" if not missing else "pending",
             "owner": "agent",
-            "missing_inputs": [],
+            "missing_inputs": missing,
             "next_action": (
-                "Use GitHub issues as your personal task list when work starts to sprawl."
+                "Keep the owner file in core/team/ so GitHub activity can use a business name."
             ),
             "required": False,
         }
 
     missing = []
+    if len(team_files) < 2:
+        missing.append("core/team/<member>.md for each teammate")
     if not (repo / ".github" / "CODEOWNERS").exists():
         missing.append(".github/CODEOWNERS")
     if not _has_any_file([repo / "decisions", repo / "documents" / "team-workflow.md"]):
@@ -840,6 +848,8 @@ def run(
     *,
     path: str,
     name: str = "",
+    owner_name: str = "",
+    owner_github: str = "",
     mode: str = "auto",
     level: str = "auto",
     team_size: str = "unknown",
@@ -880,7 +890,12 @@ def run(
     else:
         business_name = name.strip() or target.name.replace("-", " ").title()
         result_business_name = business_name
-        init_result = init_mod.run(path=str(target), name=business_name)
+        init_result = init_mod.run(
+            path=str(target),
+            name=business_name,
+            owner_name=owner_name,
+            owner_github=owner_github,
+        )
         created.extend(str(item) for item in init_result.get("created", []))
         if init_result["status"] == "error":
             errors.append(str(init_result.get("error") or "mb init failed"))

--- a/mb/mb/status.py
+++ b/mb/mb/status.py
@@ -4016,7 +4016,7 @@ def run(
     git = _git_info(repo_path)
     update = package_update_status(repo_path)
     team_facts = team.facts(repo_path)
-    github = _github(repo_path, git)
+    github = _github(repo_path, git, team_facts=team_facts)
     brain = _brain(repo_path)
     topology_payload = topology_mod.collect(
         str(repo_path),

--- a/mb/mb/status.py
+++ b/mb/mb/status.py
@@ -12,7 +12,7 @@ from typing import Any
 
 import yaml
 
-from mb import __version__, github_activity, relationships, vocabulary
+from mb import __version__, github_activity, relationships, team, vocabulary
 from mb import books as books_mod
 from mb import codex as codex_mod
 from mb import connect as connect_mod
@@ -3219,7 +3219,12 @@ def _gh_json(args: list[str], repo: Path) -> tuple[bool, Any, str]:
         return False, None, "gh returned invalid JSON"
 
 
-def _github(repo: Path, git: dict[str, Any]) -> dict[str, Any]:
+def _github(
+    repo: Path,
+    git: dict[str, Any],
+    *,
+    team_facts: dict[str, Any] | None = None,
+) -> dict[str, Any]:
     context = connect_mod.github_context(repo, which_func=_which, command_runner=_run_command)
     if not context["ok"]:
         sections: dict[str, list[dict[str, Any]]] = {
@@ -3251,9 +3256,12 @@ def _github(repo: Path, git: dict[str, Any]) -> dict[str, Any]:
             "recent_merged_prs": [],
             "context": context,
         }
+    if team_facts is None:
+        team_facts = team.facts(repo)
     report = github_activity.collect(
         repo,
         remote=str(git.get("remote", "")),
+        team_facts=team_facts,
         which_func=_which,
         command_runner=_run_command,
         json_runner=_gh_json,
@@ -4007,6 +4015,7 @@ def run(
     repo_shape = _looks_like_mainbranch_repo(repo_path)
     git = _git_info(repo_path)
     update = package_update_status(repo_path)
+    team_facts = team.facts(repo_path)
     github = _github(repo_path, git)
     brain = _brain(repo_path)
     topology_payload = topology_mod.collect(
@@ -4038,6 +4047,7 @@ def run(
         "deprecated_campaign_keys": True,
         "push_compatibility": push_report["compatibility"],
         "vocabulary": vocabulary.facts(repo_path),
+        "team": team_facts,
         "books": books_mod.readiness(repo_path),
         "onboarding": onboard_mod.onboarding_status(repo_path),
         "integrations": connect_mod.status_all(repo_path, github=github.get("context")),

--- a/mb/mb/team.py
+++ b/mb/mb/team.py
@@ -1,0 +1,186 @@
+"""Public-safe team member facts for business repos."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+TEAM_SCHEMA_VERSION = "1.0"
+TEAM_DIR = Path("core") / "team"
+RELATIONSHIPS = {"owner", "member", "contractor", "advisor", "external_collaborator"}
+SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+GITHUB_HANDLE_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$")
+
+
+def normalize_github_handle(value: Any) -> str:
+    """Return a canonical GitHub handle, without leading @, or empty on invalid input."""
+    if not isinstance(value, str):
+        return ""
+    raw = value.strip()
+    if not raw:
+        return ""
+    if raw.startswith("https://github.com/"):
+        raw = raw.removeprefix("https://github.com/").split("/", maxsplit=1)[0]
+    if raw.startswith("http://github.com/"):
+        raw = raw.removeprefix("http://github.com/").split("/", maxsplit=1)[0]
+    normalized = raw.removeprefix("@").strip().lower()
+    return normalized if GITHUB_HANDLE_RE.fullmatch(normalized) else ""
+
+
+def display_name(member: dict[str, Any]) -> str:
+    preferred = str(member.get("preferred_name") or "").strip()
+    if preferred:
+        return preferred
+    name = str(member.get("name") or "").strip()
+    if name:
+        return name
+    return str(member.get("slug") or "").strip()
+
+
+def _read_frontmatter(path: Path) -> tuple[dict[str, Any], str]:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return {}, f"unreadable: {exc}"
+    if not text.startswith("---"):
+        return {}, "no frontmatter"
+    try:
+        end = text.index("\n---", 3)
+    except ValueError:
+        return {}, "unterminated frontmatter"
+    raw = text[3:end].lstrip("\n")
+    try:
+        parsed = yaml.safe_load(raw) or {}
+    except yaml.YAMLError as exc:
+        return {}, f"yaml error: {exc}"
+    if not isinstance(parsed, dict):
+        return {}, "frontmatter not a mapping"
+    return parsed, ""
+
+
+def _github_values(value: Any) -> list[str]:
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, list):
+        return [item for item in value if isinstance(item, str)]
+    return []
+
+
+def _member_from_file(repo: Path, path: Path) -> dict[str, Any]:
+    frontmatter, error = _read_frontmatter(path)
+    rel = path.relative_to(repo).as_posix()
+    slug = path.stem
+    handles = [
+        normalize_github_handle(value) for value in _github_values(frontmatter.get("github"))
+    ]
+    handles = [handle for handle in handles if handle]
+    member = {
+        "slug": slug,
+        "path": rel,
+        "name": str(frontmatter.get("name") or "").strip(),
+        "preferred_name": str(frontmatter.get("preferred_name") or "").strip(),
+        "display_name": "",
+        "role": str(frontmatter.get("role") or "").strip(),
+        "relationship": str(frontmatter.get("relationship") or "").strip(),
+        "github": handles,
+        "areas": [item for item in frontmatter.get("areas", []) if isinstance(item, str)]
+        if isinstance(frontmatter.get("areas"), list)
+        else [],
+        "external": frontmatter.get("relationship") == "external_collaborator",
+        "ok": not error,
+        "error": error,
+    }
+    member["display_name"] = display_name(member)
+    return member
+
+
+def facts(repo: str | Path = ".") -> dict[str, Any]:
+    target = Path(repo).resolve()
+    team_root = target / TEAM_DIR
+    members: list[dict[str, Any]] = []
+    if team_root.exists():
+        for path in sorted(team_root.glob("*.md")):
+            if path.name == "README.md":
+                continue
+            members.append(_member_from_file(target, path))
+
+    known_handles: dict[str, dict[str, str]] = {}
+    duplicate_handles: dict[str, list[str]] = {}
+    for member in members:
+        for handle in member.get("github", []):
+            if handle in known_handles:
+                duplicate_handles.setdefault(handle, [known_handles[handle]["path"]]).append(
+                    str(member["path"])
+                )
+                continue
+            known_handles[handle] = {
+                "slug": str(member["slug"]),
+                "path": str(member["path"]),
+                "display_name": str(member["display_name"]),
+                "relationship": str(member["relationship"]),
+            }
+
+    owner_count = sum(1 for member in members if member.get("relationship") == "owner")
+    return {
+        "schema_version": TEAM_SCHEMA_VERSION,
+        "ok": all(bool(member.get("ok")) for member in members) and not duplicate_handles,
+        "path": TEAM_DIR.as_posix(),
+        "members": members,
+        "github": {
+            "known_handles": known_handles,
+            "duplicate_handles": duplicate_handles,
+            "unknown_contributor_guidance": (
+                "Keep unknown GitHub handles as handles and add core/team/<slug>.md "
+                "when the contributor is part of the business context."
+            ),
+        },
+        "summary": {
+            "members": len(members),
+            "owners": owner_count,
+            "external_collaborators": sum(
+                1 for member in members if member.get("relationship") == "external_collaborator"
+            ),
+            "github_handles": len(known_handles),
+        },
+        "safe_to_share": True,
+    }
+
+
+def resolve_github_handle(handle: str, team_facts: dict[str, Any] | None) -> dict[str, Any]:
+    normalized = normalize_github_handle(handle)
+    if not normalized:
+        return {
+            "handle": handle,
+            "known": False,
+            "display_name": "",
+            "slug": "",
+            "path": "",
+            "label": f"unknown contributor ({handle})" if handle else "unknown contributor",
+        }
+    known = (
+        ((team_facts or {}).get("github") or {}).get("known_handles") or {}
+        if isinstance(team_facts, dict)
+        else {}
+    )
+    member = known.get(normalized)
+    if isinstance(member, dict):
+        display = str(member.get("display_name") or normalized)
+        return {
+            "handle": normalized,
+            "known": True,
+            "display_name": display,
+            "slug": str(member.get("slug") or ""),
+            "path": str(member.get("path") or ""),
+            "label": display,
+        }
+    return {
+        "handle": normalized,
+        "known": False,
+        "display_name": "",
+        "slug": "",
+        "path": "",
+        "label": f"unknown contributor (@{normalized})",
+    }

--- a/mb/mb/validate.py
+++ b/mb/mb/validate.py
@@ -15,7 +15,7 @@ from typing import Any
 
 import yaml
 
-from mb import content_strategy, github_activity, migration_lint, related_links, relationships
+from mb import content_strategy, github_activity, migration_lint, related_links, relationships, team
 from mb import pushes as pushes_mod
 
 DECISION_STATUS = {"proposed", "accepted", "rejected", "superseded", "running"}
@@ -68,6 +68,7 @@ DATA_SOURCE_CADENCE = {
 }
 DATA_SOURCE_PROVIDER_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
 DATA_SOURCE_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+TEAM_MEMBER_TYPE = "team_member"
 
 TOPOLOGY_SCHEMA = {"mb.repo_topology.v0"}
 TOPOLOGY_STATUS = {"proposed", "active", "paused", "superseded", "archived"}
@@ -165,6 +166,8 @@ VALIDATION_CATEGORY_REPAIR: dict[str, str] = {
     "other_warning": (
         "Review the warning and decide whether the relationship or file shape is intentional."
     ),
+    "duplicate_github_handle": "Use each GitHub handle in only one core/team/<slug>.md file.",
+    "unnormalized_github_handle": "Store GitHub handles without @, URLs, or uppercase letters.",
 }
 
 # Audience routing per category. See decision
@@ -197,6 +200,8 @@ VALIDATION_CATEGORY_OPERATOR_SUMMARY: dict[str, str] = {
     ),
     "other_error": "Read the validation message and decide how to fix the file.",
     "other_warning": "Decide whether the relationship or shape is intentional, or change it.",
+    "duplicate_github_handle": "One GitHub handle points to more than one team member.",
+    "unnormalized_github_handle": "Normalize the GitHub handle before agents rely on it.",
 }
 
 DECISION_STATUS_ORDER = {
@@ -333,6 +338,12 @@ SCHEMAS: dict[str, dict[str, Any]] = {
         "enums": {"type": {DATA_SOURCE_TYPE}, "privacy": DATA_SOURCE_PRIVACY},
         "primitive": "data-source",
     },
+    "team-members": {
+        "glob": "core/team/*.md",
+        "required": ["type", "slug", "name", "relationship"],
+        "enums": {"type": {TEAM_MEMBER_TYPE}, "relationship": team.RELATIONSHIPS},
+        "primitive": "team-member",
+    },
 }
 
 
@@ -384,6 +395,8 @@ def _check_one(path: Path, schema: dict[str, Any]) -> dict[str, Any]:
         _check_repo_topology_frontmatter(path, fm, errors, warnings)
     elif primitive == "data-source":
         _check_data_source_frontmatter(path, fm, errors, warnings)
+    elif primitive == "team-member":
+        _check_team_member_frontmatter(path, fm, errors, warnings)
     _check_provider_refs_shape(fm, errors)
     return {"path": str(path), "ok": not errors, "errors": errors, "warnings": warnings}
 
@@ -797,6 +810,70 @@ def _check_data_source_frontmatter(
     if secret_paths:
         errors.append(
             "data-source frontmatter must not contain secrets: " + ", ".join(secret_paths)
+        )
+
+
+def _check_team_member_frontmatter(
+    path: Path,
+    fm: dict[str, Any],
+    errors: list[str],
+    warnings: list[str],
+) -> None:
+    if fm.get("type") != TEAM_MEMBER_TYPE:
+        errors.append(f"type must be {TEAM_MEMBER_TYPE!r}")
+    if not team.SLUG_RE.fullmatch(path.stem):
+        errors.append("team member filename must be a lowercase slug")
+    slug = fm.get("slug")
+    if isinstance(slug, str) and slug.strip() and slug.strip() != path.stem:
+        errors.append("slug must match the core/team/<slug>.md filename")
+    _require_non_empty_string(fm, "name", errors)
+
+    github = fm.get("github")
+    raw_handles: list[str] = []
+    if github is None:
+        raw_handles = []
+    elif isinstance(github, str):
+        raw_handles = [github]
+    elif isinstance(github, list) and all(isinstance(item, str) for item in github):
+        raw_handles = [str(item) for item in github]
+    else:
+        errors.append("github must be a string or list of strings")
+
+    seen_handles: set[str] = set()
+    for raw_handle in raw_handles:
+        normalized = team.normalize_github_handle(raw_handle)
+        if not normalized:
+            errors.append(f"github handle {raw_handle!r} is not valid")
+            continue
+        if raw_handle.strip() != normalized:
+            errors.append(f"github handle {raw_handle!r} must be normalized as {normalized!r}")
+        if normalized in seen_handles:
+            errors.append(f"duplicate github handle {normalized!r} in this team member")
+        seen_handles.add(normalized)
+
+    areas = fm.get("areas")
+    if areas is not None and (
+        not isinstance(areas, list)
+        or not all(isinstance(item, str) and item.strip() for item in areas)
+    ):
+        errors.append("areas must be a list of non-empty strings")
+
+    secret_paths = sorted(set(_iter_secret_paths(fm)))
+    if secret_paths:
+        errors.append(
+            "team member frontmatter must not contain secrets: " + ", ".join(secret_paths)
+        )
+
+    sensitive_keys = sorted(
+        key
+        for key in fm
+        if isinstance(key, str)
+        and re.search(r"(home|birthday|birthdate|ssn|compensation|payroll)", key, re.IGNORECASE)
+    )
+    if sensitive_keys:
+        warnings.append(
+            "team member frontmatter should avoid sensitive personal fields: "
+            + ", ".join(sensitive_keys)
         )
 
 
@@ -1234,8 +1311,52 @@ def _add_migration_lint_warnings(
         files_by_path[rel].setdefault("warnings", []).append(message)
 
 
+def _add_team_handle_duplicate_errors(repo: Path, files_by_path: dict[str, dict[str, Any]]) -> None:
+    handles: dict[str, list[str]] = {}
+    for path in sorted((repo / team.TEAM_DIR).glob("*.md")):
+        if path.name == "README.md":
+            continue
+        fm, err = _read_frontmatter(path)
+        if err is not None or fm is None:
+            continue
+        github = fm.get("github")
+        raw_handles = (
+            [github] if isinstance(github, str) else github if isinstance(github, list) else []
+        )
+        if not isinstance(raw_handles, list):
+            continue
+        rel = path.relative_to(repo).as_posix()
+        for raw_handle in raw_handles:
+            normalized = team.normalize_github_handle(raw_handle)
+            if normalized:
+                handles.setdefault(normalized, []).append(rel)
+
+    for handle, paths in handles.items():
+        unique_paths = sorted(set(paths))
+        if len(unique_paths) < 2:
+            continue
+        message = f"duplicate github handle {handle!r} appears in {', '.join(unique_paths)}"
+        for rel in unique_paths:
+            files_by_path.setdefault(
+                rel,
+                {
+                    "path": rel,
+                    "ok": True,
+                    "errors": [],
+                    "warnings": [],
+                    "schema": "team-members",
+                },
+            )
+            files_by_path[rel].setdefault("errors", []).append(message)
+            files_by_path[rel]["ok"] = False
+
+
 def _validation_category(message: str, *, severity: str, schema: str) -> str:
     lowered = message.lower()
+    if schema == "team-members" and "duplicate github handle" in lowered:
+        return "duplicate_github_handle"
+    if schema == "team-members" and "must be normalized as" in lowered:
+        return "unnormalized_github_handle"
     if message == "missing key: slug":
         return "missing_slug"
     if message.startswith("missing key:"):
@@ -1696,6 +1817,7 @@ def _is_folder_doc(path: Path, schema_name: str) -> bool:
         "log",
         "documents",
         "push-playbooks",
+        "team-members",
     } and (path.name == "README.md")
 
 
@@ -1719,6 +1841,7 @@ def run(
             r["path"] = str(f.relative_to(repo))
             files_by_path[r["path"]] = r
     files_by_path.update(content_strategy.validation_results(repo))
+    _add_team_handle_duplicate_errors(repo, files_by_path)
 
     if migration_drift_report is None:
         migration_drift_report = migration_lint.run(repo)

--- a/mb/tests/fixtures/status/schema-v1-basic.json
+++ b/mb/tests/fixtures/status/schema-v1-basic.json
@@ -36,6 +36,7 @@
     "schema",
     "schema_version",
     "since_last_check",
+    "team",
     "topology",
     "update",
     "validation",
@@ -143,6 +144,15 @@
       "terms",
       "type",
       "warnings"
+    ],
+    "team": [
+      "github",
+      "members",
+      "ok",
+      "path",
+      "safe_to_share",
+      "schema_version",
+      "summary"
     ],
     "onboarding": [
       "boundaries",

--- a/mb/tests/test_init.py
+++ b/mb/tests/test_init.py
@@ -174,6 +174,10 @@ def test_init_scaffolds_folders(tmp_path: Path) -> None:
     assert (target / "core" / "marketing").is_dir()
     assert (target / "core" / "marketing" / "channels").is_dir()
     assert (target / "core" / "marketing" / "accounts").is_dir()
+    assert (target / "core" / "team").is_dir()
+    team_files = list((target / "core" / "team").glob("*.md"))
+    assert len(team_files) == 1
+    assert "type: team_member" in team_files[0].read_text(encoding="utf-8")
     assert (target / "core" / "people").is_dir()
     assert (target / "core" / "strategy").is_dir()
     assert (target / "core" / "operations").is_dir()

--- a/mb/tests/test_init.py
+++ b/mb/tests/test_init.py
@@ -6,6 +6,7 @@ import json
 from pathlib import Path
 
 from mb import codex as codex_mod
+from mb import init as init_mod
 from mb.init import _DEFAULT_CLAUDE, DATA_FOLDERS, _read_template, run
 
 
@@ -265,6 +266,38 @@ def test_init_scaffolds_folders(tmp_path: Path) -> None:
     assert "Main Branch owner loop for Codex" in codex_skill
     assert "mb workflow list --runtime codex --json" in codex_skill
     assert codex_mod.instructions_status(target)["ok"] is True
+
+
+def test_init_defaults_owner_name_without_local_git_identity(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("MB_OWNER_NAME", "")
+    monkeypatch.setattr(init_mod, "_gh_username", lambda: "MixedCaseUser")
+    target = tmp_path / "acme"
+
+    result = run(path=str(target), name="Acme Brewing")
+
+    assert result["status"] == "ok"
+    owner_file = target / "core" / "team" / "mixedcaseuser.md"
+    assert owner_file.exists()
+    text = owner_file.read_text(encoding="utf-8")
+    assert "name: Business Owner" in text
+    assert "preferred_name: Business Owner" in text
+    assert "  - mixedcaseuser" in text
+
+
+def test_init_uses_explicit_owner_name_env_override(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("MB_OWNER_NAME", "Env Owner")
+    monkeypatch.setattr(init_mod, "_gh_username", lambda: "")
+    target = tmp_path / "acme"
+
+    result = run(path=str(target), name="Acme Brewing")
+
+    assert result["status"] == "ok"
+    owner_file = target / "core" / "team" / "your-gh-username.md"
+    assert owner_file.exists()
+    assert "name: Env Owner" in owner_file.read_text(encoding="utf-8")
 
 
 def test_init_idempotent(tmp_path: Path) -> None:

--- a/mb/tests/test_onboard.py
+++ b/mb/tests/test_onboard.py
@@ -368,7 +368,7 @@ def test_onboard_cli_interactive_path_renders_clear_labels(tmp_path: Path, monke
     result = runner.invoke(
         app,
         ["onboard"],
-        input=f"beginner\nnew\nInteractive Business\n{repo}\n",
+        input=f"beginner\nnew\nInteractive Business\n{repo}\nTaylor Owner\ntaylor-owner\n",
     )
 
     assert result.exit_code == 0

--- a/mb/tests/test_status.py
+++ b/mb/tests/test_status.py
@@ -292,6 +292,7 @@ def test_status_schema_v1_matches_golden_fixture(tmp_path: Path, monkeypatch) ->
                 "brain",
                 "books",
                 "vocabulary",
+                "team",
                 "onboarding",
                 "integrations",
                 "measurement",
@@ -2839,6 +2840,64 @@ def test_status_github_activity_business_sections(tmp_path: Path, monkeypatch) -
     assert sections["shipped_this_week"][0]["what_shipped"] == "Launched 7"
     assert sections["recently_closed_tasks"][0]["business_status"] == "closed"
     assert sections["blocked_or_stale_tasks"][0]["labels"] == ["blocked"]
+
+
+def test_status_github_activity_resolves_team_handles(tmp_path: Path, monkeypatch) -> None:
+    (tmp_path / "core" / "team").mkdir(parents=True)
+    (tmp_path / "core" / "team" / "maya.md").write_text(
+        (
+            "---\n"
+            "type: team_member\n"
+            "slug: maya\n"
+            "name: Maya Chen\n"
+            "preferred_name: Maya\n"
+            "relationship: member\n"
+            "github:\n"
+            "  - mayachen\n"
+            "---\n\n"
+            "# Maya\n"
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        connect_mod,
+        "github_context",
+        lambda repo, **kwargs: {
+            "ok": True,
+            "state": "ready",
+            "summary": "GitHub ready",
+            "repair": "",
+            "repair_command": "",
+            "safe_to_share": True,
+        },
+    )
+    monkeypatch.setattr(status_mod, "_which", lambda name: "/usr/bin/gh" if name == "gh" else "")
+    monkeypatch.setattr(
+        status_mod,
+        "_run_command",
+        lambda args, cwd=None, timeout=3.0: {"ok": True, "stdout": "", "stderr": ""},
+    )
+
+    def fake_gh_json(args: list[str], repo: Path) -> tuple[bool, Any, str]:
+        if args[1:3] == ["pr", "list"] and "review-requested:@me" in args:
+            return True, [{"number": 6, "title": "Review me", "author": {"login": "mayachen"}}], ""
+        if args[1:3] == ["pr", "list"] and "--state" in args and "merged" in args:
+            return True, [{"number": 7, "title": "Merged", "author": {"login": "unknown-dev"}}], ""
+        return True, [], ""
+
+    monkeypatch.setattr(status_mod, "_gh_json", fake_gh_json)
+
+    report = status_mod.run(path=str(tmp_path), update_marker=False)
+    attention = report["github"]["sections"]["attention_requests"][0]
+    shipped = report["github"]["sections"]["shipped_this_week"][0]
+
+    assert report["team"]["summary"]["members"] == 1
+    assert attention["author"] == "mayachen"
+    assert attention["author_display"] == "Maya"
+    assert attention["author_known"] is True
+    assert attention["author_team_slug"] == "maya"
+    assert shipped["author_display"] == "unknown contributor (@unknown-dev)"
+    assert shipped["author_known"] is False
 
 
 def test_status_github_context_stops_before_low_level_remote_errors(

--- a/mb/tests/test_status.py
+++ b/mb/tests/test_status.py
@@ -2440,7 +2440,7 @@ def test_status_ranker_mentions_due_bets(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(
         status_mod,
         "_github",
-        lambda repo, git: {
+        lambda repo, git, **kwargs: {
             "available": True,
             "authenticated": True,
             "degraded": False,

--- a/mb/tests/test_validate.py
+++ b/mb/tests/test_validate.py
@@ -81,6 +81,96 @@ def test_validate_accepts_simple_content_strategy_entry_point(tmp_path: Path) ->
     assert strategy["errors"] == []
 
 
+def test_validate_accepts_team_members_and_normalized_github_handles(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "core" / "team" / "maya.md",
+        (
+            "---\n"
+            "type: team_member\n"
+            "slug: maya\n"
+            "name: Maya Chen\n"
+            "preferred_name: Maya\n"
+            "role: Growth Lead\n"
+            "relationship: member\n"
+            "github:\n"
+            "  - mayachen\n"
+            "areas:\n"
+            "  - paid traffic\n"
+            "  - launch reviews\n"
+            "---\n\n"
+            "# Maya\n"
+        ),
+    )
+    _write(
+        tmp_path / "core" / "team" / "rafa.md",
+        (
+            "---\n"
+            "type: team_member\n"
+            "slug: rafa\n"
+            "name: Rafael Ortiz\n"
+            "role: Advisor\n"
+            "relationship: advisor\n"
+            "github: rafa-ops\n"
+            "---\n\n"
+            "# Rafael\n"
+        ),
+    )
+
+    report = run(path=str(tmp_path))
+
+    assert report["ok"] is True
+    team_files = [file for file in report["files"] if file["schema"] == "team-members"]
+    assert len(team_files) == 2
+    assert all(file["errors"] == [] for file in team_files)
+
+
+def test_validate_rejects_duplicate_and_unnormalized_team_github_handles(
+    tmp_path: Path,
+) -> None:
+    _write(
+        tmp_path / "core" / "team" / "maya.md",
+        (
+            "---\n"
+            "type: team_member\n"
+            "slug: maya\n"
+            "name: Maya Chen\n"
+            "relationship: member\n"
+            "github:\n"
+            "  - '@MayaChen'\n"
+            "---\n\n"
+            "# Maya\n"
+        ),
+    )
+    _write(
+        tmp_path / "core" / "team" / "ops.md",
+        (
+            "---\n"
+            "type: team_member\n"
+            "slug: ops\n"
+            "name: Ops Contractor\n"
+            "relationship: contractor\n"
+            "github:\n"
+            "  - mayachen\n"
+            "---\n\n"
+            "# Ops\n"
+        ),
+    )
+
+    report = run(path=str(tmp_path))
+
+    assert report["ok"] is False
+    by_path = {file["path"]: file for file in report["files"]}
+    assert any(
+        "must be normalized as 'mayachen'" in error
+        for error in by_path["core/team/maya.md"]["errors"]
+    )
+    assert any(
+        "duplicate github handle 'mayachen'" in error
+        for error in by_path["core/team/maya.md"]["errors"]
+    )
+    assert report["by_category"]["duplicate_github_handle"]["errors"] == 2
+
+
 def test_validate_reports_layered_content_strategy_connection_failures(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

Adds `core/team/<slug>.md` as the public-safe team member primitive for business repos, including owner scaffolding, validation, status facts, GitHub PR author name resolution, fixtures, and docs.

## Linked issue

Closes #633

## Why

Business repos need a durable way to translate GitHub handles and repo activity into business names, roles, and ownership context without becoming HR/contact software.

## Commits by concern

- [x] `a166257 [add] MAIN-396 team member primitive`
- [x] `67d9bdb [add] MAIN-396 team member coverage`
- [x] `dbc18bb [update] MAIN-396 document team member context`
- [x] `b7d6054 [fix] MAIN-396 address team scaffold review`
- [x] `92a98e8 [update] MAIN-396 mention team codify target`
- [x] Each commit body bullet-lists the changes in that commit
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`

## Validation

Level 1 static: `scripts/check.sh` — runtime: local Python environment — exit: 0 — log: excerpt `ruff`, `mypy`, full pytest, and `mb skill validate --all --json` passed.

Level 2 CLI contract: `cd mb && pytest tests/test_validate.py tests/test_init.py tests/test_onboard.py tests/test_status.py -q` — runtime: local Python environment — exit: 0 — log: excerpt `200 passed in 171.12s`.

Level 3 package/install smoke: `(cd mb && python3 -m build) && python3 -m venv /tmp/mainbranch-smoke && /tmp/mainbranch-smoke/bin/pip install mb/dist/*.whl && /tmp/mainbranch-smoke/bin/mb --version && /tmp/mainbranch-smoke/bin/mb skill list` — runtime: `/tmp/mainbranch-smoke` — exit: 0 — log: excerpt built and installed `mainbranch-0.3.28`; `mb 0.3.28`; skill list succeeded.

Level 4 fixture repo: `/tmp/mainbranch-smoke/bin/mb onboard --yes --name "Test Business" --path "$tmpdir/test-business" --owner-name "Test Owner" --owner-github test-owner && mb doctor && mb status && mb start --json && mb validate` — runtime: `/tmp/mainbranch-smoke` — exit: 0 — log: excerpt `core/team/test-owner.md` created and `team-members ok`.

Level 4 review smoke: `cd mb && python3 -m mb onboard --yes --name "Review Fix Business" --path "$tmpdir/review-fix-business" --json && python3 -m mb validate --repo "$tmpdir/review-fix-business"` — runtime: local Python environment — exit: 0 — log: excerpt generated `name: Business Owner`, normalized `github: dmthepm`, and `team-members ok`.

Skill guidance touch: `cd mb && python3 -m mb skill validate --all --json` — runtime: local Python environment — exit: 0 — log: excerpt `skills: 15`, `passed: 15`, `failed: 0`; `mb-think` line count `499`.

Level 5 runtime smoke was not required because this branch changes generated guidance/status facts but does not add a new runtime entrypoint; fixture smoke verified current Claude/Codex wiring.

- [x] Level 1 static: `scripts/check.sh` passes
- [x] Level 2 CLI contract: focused Typer/CliRunner tests, exit codes, `--json` behavior, TTY vs non-TTY (if CLI behavior touched)
- [x] Level 3 package/install smoke (if packaging touched)
- [x] Level 4 fixture repo (if init/onboard/status/start/update touched)
- [x] Level 5 runtime smoke / dogfood harness / simulation-tier (if runtime, first-run, skill discovery, or release validation touched)
- [x] SKILL.md <=500 lines (`mb-start` is 500 lines; touched skills passed `mb skill validate --all --json`)
- [x] Package-visible release gate evidence before tag/publish (N/A, not preparing a release)
- [x] Supply-chain review (N/A, no workflow, dependency, id-token, or permissions changes)

## Success metric

Fresh business repos get validated public-safe team member context, and CLI/status activity can resolve known GitHub handles to business names while preserving unknown handles safely.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [ ] N/A — change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [x] No
- [ ] Yes — migration note below

## Public / private boundary

No private operator strategy, machine-specific paths, secrets, or customer/member data were committed; fixtures use fake names, and docs/validation steer sensitive personal data out of `core/team/`.
