### PR TITLE
[add] Codex owner-loop plugin surface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,11 +21,12 @@ markdown files in git.
 
 Claude Code is the first-class slash-skill runtime today. Codex CLI is
 first-class for the proven owner loop through generated `AGENTS.md`,
-`.agents/skills/main-branch-owner-loop`, deterministic `mb` facts, and
-workflow inventory. That is not slash-command parity or full production
-workflow parity. Cursor, OpenClaw, Hermes, Paperclip-adjacent orchestration,
-and local runtimes remain compatibility targets until tested. Do not claim
-support before there is an adapter and smoke evidence for the exact surface.
+`.agents/skills/main-branch-owner-loop`, `.agents/plugins/main-branch-owner-loop`,
+deterministic `mb` facts, and workflow inventory. That is owner-loop plugin
+command support, not all-skill parity or full production workflow parity.
+Cursor, OpenClaw, Hermes, Paperclip-adjacent orchestration, and local runtimes
+remain compatibility targets until tested. Do not claim support before there is
+an adapter and smoke evidence for the exact surface.
 
 The public product frame lives in `docs/ethos.md`, the operator loop taxonomy
 lives in `docs/operator-loops.md`, and release direction lives in
@@ -37,7 +38,7 @@ The current product center is the daily owner loop:
 
 1. The operator opens the business repo and starts Claude Code or Codex CLI.
 2. `/mb-start`, the generated repo instructions, or the generated Codex
-   owner-loop skill ground the agent in
+   owner-loop skill/plugin surface ground the agent in
    deterministic `mb` facts before advice.
 3. The agent routes thought dumps and requests into business primitives:
    bets, goals, offers, research, decisions, pushes, playbooks, outcomes, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   scaffold, validation for normalized and duplicate GitHub handles, and status
   GitHub activity handle resolution so business repos can name known team
   contributors. Refs MAIN-396, #633.
+- Added a repo-scoped Codex plugin marketplace, owner-loop plugin manifest,
+  plugin-packaged owner-loop skill, and thin `/mb-*` command shims for the
+  supported Main Branch owner loop while keeping deterministic `mb` facts and
+  shared workflow sources as the source of truth. Refs MAIN-423, #682.
 
 ### Changed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,9 @@ Bundled Claude Code skills live in `.claude/skills/`. If you edit a skill:
 
 Claude Code is the first-class slash-skill runtime today. Codex CLI is
 first-class for the proven owner loop through generated `AGENTS.md`,
-`.agents/skills/main-branch-owner-loop`, deterministic `mb` facts, and workflow
-inventory. That is not slash-command parity or full production workflow parity.
-Other runtimes are roadmap targets until an adapter and smoke evidence exist,
-so do not overclaim compatibility in docs.
+`.agents/skills/main-branch-owner-loop`, the repo-scoped
+`.agents/plugins/main-branch-owner-loop` plugin command surface, deterministic
+`mb` facts, and workflow inventory. That is owner-loop plugin command support,
+not full Claude skill parity or full production workflow parity. Other runtimes
+are roadmap targets until an adapter and smoke evidence exist, so do not
+overclaim compatibility in docs.

--- a/README.md
+++ b/README.md
@@ -241,12 +241,14 @@ After installing Codex CLI, test a new repo with:
 ```bash
 mb onboard --yes --name "Codex Smoke Business" --path codex-smoke-business
 cd codex-smoke-business
+codex plugin marketplace add .
 codex
 ```
 
-Open `/plugins`, install **Main Branch Owner Loop** from the repo marketplace,
-then run `/mb-start`. If the plugin is not installed yet, ask Codex to start
-the business day from read-only `mb` facts and to ask before writing files.
+Open `/plugins`, install **Main Branch Owner Loop** from the registered repo
+marketplace, then run `/mb-start`. If the plugin is not installed yet, ask
+Codex to start the business day from read-only `mb` facts and to ask before
+writing files.
 
 For a read-only smoke test:
 

--- a/README.md
+++ b/README.md
@@ -221,18 +221,20 @@ You'll need a Claude plan that includes Claude Code. Install Claude Code from [c
 
 Codex CLI is first-class for the Main Branch owner loop, not for Claude Code
 slash-command parity. Fresh business folders include a tracked `AGENTS.md`
-bootstrap plus `.agents/skills/main-branch-owner-loop`, so Codex can start the
-day, inspect status, route setup/update/doctor work, think through or codify a
+bootstrap, `.agents/skills/main-branch-owner-loop`, and a repo-scoped Codex
+plugin at `.agents/plugins/main-branch-owner-loop`, so Codex can start the day,
+inspect status, route setup/update/doctor work, think through or codify a
 decision, plan an end/checkpoint/save closeout, validate the repo, and list
 workflow support.
 
 Expect Codex to run `mb status --json --peek`, `mb start --json`,
 `mb doctor repair --plan --json`, `mb checkpoint --plan --json`,
 `mb validate --json`, and `mb workflow list --runtime codex --json`, then
-translate those facts into a useful owner briefing. Do not expect Claude Code slash commands
-such as `/mb-start` to work inside Codex, and do not expect site, ads,
-publishing, provider mutation, spend, or customer-contact workflows to be
-ported there.
+translate those facts into a useful owner briefing. When the plugin is
+installed from `/plugins`, Codex exposes thin owner-loop commands such as
+`/mb-start`, `/mb-status`, `/mb-think`, `/mb-end`, and `/mb-help`. Do not expect
+all Claude Code skills, site, ads, publishing, provider mutation, spend, or
+customer-contact workflows to be ported there.
 
 After installing Codex CLI, test a new repo with:
 
@@ -242,8 +244,9 @@ cd codex-smoke-business
 codex
 ```
 
-Ask Codex to start the business day from read-only `mb` facts and to ask before
-writing files.
+Open `/plugins`, install **Main Branch Owner Loop** from the repo marketplace,
+then run `/mb-start`. If the plugin is not installed yet, ask Codex to start
+the business day from read-only `mb` facts and to ask before writing files.
 
 For a read-only smoke test:
 

--- a/decisions/2026-05-08-codex-adapter-plan.md
+++ b/decisions/2026-05-08-codex-adapter-plan.md
@@ -20,6 +20,12 @@ tags: [runtime-adapters, codex, skills, cli, decision-needed]
 > `mb start` expose Codex readiness. This decision remains the staging plan;
 > current public support wording lives in
 > [docs/compatibility.md](../docs/compatibility.md).
+>
+> Status note, MAIN-423 / #682: the proven owner loop has since gained a
+> repo-scoped Codex plugin and installed `/mb-*` command surface through
+> `.agents/plugins/main-branch-owner-loop`. This updates the current support
+> boundary without changing this decision's historical staging rationale. See
+> [docs/compatibility.md](../docs/compatibility.md) for current claims.
 
 ## Decision
 

--- a/decisions/2026-05-08-codex-adapter-plan.md
+++ b/decisions/2026-05-08-codex-adapter-plan.md
@@ -15,10 +15,10 @@ tags: [runtime-adapters, codex, skills, cli, decision-needed]
 
 # Codex Adapter Plan
 
-> Status note: Stage 1 has shipped as the experimental CLI-first Codex adapter.
-> Fresh business repos include `AGENTS.md`, and `mb doctor`, `mb status`, and
-> `mb start` expose Codex readiness. This decision remains the staging plan;
-> current public support wording lives in
+> Status note: Stage 1 shipped as the first Codex adapter. Fresh business repos
+> include `AGENTS.md`, and `mb doctor`, `mb status`, and `mb start` expose Codex
+> readiness. This decision remains the staging plan; current public support
+> wording lives in
 > [docs/compatibility.md](../docs/compatibility.md).
 >
 > Status note, MAIN-423 / #682: the proven owner loop has since gained a
@@ -56,15 +56,14 @@ runtime-neutral `skills/` corpus that generates Claude and Codex adapters.
 Codex supports a compatible `SKILL.md` directory shape, but compatible format
 does not mean identical runtime behavior.
 
-## Current Facts
+## Facts At Decision Time
 
 Main Branch facts:
 
 - Claude Code is the only supported runtime today.
-- Codex CLI has an experimental CLI-first adapter for power users. Fresh
-  business repos include generated `AGENTS.md`; `mb doctor`, `mb status`, and
-  `mb start` expose Codex readiness; no slash-command or workflow parity is
-  claimed.
+- Codex CLI has a first adapter for power users. Fresh business repos include
+  generated `AGENTS.md`; `mb doctor`, `mb status`, and `mb start` expose Codex
+  readiness; no installed command or workflow parity was claimed at the time.
 - `mb start --json`, `mb status --json`, generated business `CLAUDE.md`, and
   generated business `AGENTS.md` are the current runtime handoff surfaces.
 - Claude Code discovery depends on project-local `.claude/skills/mb-*` bridge
@@ -109,12 +108,14 @@ Local Codex capability evidence:
 
 ## What "Codex Support" Means
 
-Use these terms in public docs and implementation PRs.
+This decision used these staged terms in public docs and implementation PRs at
+the time. Current support language lives in
+[docs/compatibility.md](../docs/compatibility.md).
 
 | Level | Meaning | Allowed public claim | Required evidence |
 |---|---|---|---|
 | CLI-callable compatibility | Codex can run packaged `mb` commands when launched in or pointed at a business repo. | "Codex can call deterministic `mb` JSON facts manually." | Existing package install plus local command evidence. This is not runtime support. |
-| Experimental CLI-first adapter | `mb` can generate or repair Codex-facing repo instructions and handoff metadata, and Codex can ground a fresh business repo in `mb status --json --peek`. No skill parity claim. | "Experimental Codex CLI-first adapter for power users." | Fresh `mb onboard` repo, generated `AGENTS.md`, read-only `codex exec --json --ephemeral --sandbox read-only -C "$repo"`, no tracked secret/runtime state, no business write without approval. |
+| Stage 1 instruction-file adapter | `mb` can generate or repair Codex-facing repo instructions and handoff metadata, and Codex can ground a fresh business repo in `mb status --json --peek`. No skill parity claim. | "Stage 1 Codex adapter for power users." | Fresh `mb onboard` repo, generated `AGENTS.md`, read-only `codex exec --json --ephemeral --sandbox read-only -C "$repo"`, no tracked secret/runtime state, no business write without approval. |
 | Experimental workflow adapter | Codex can discover selected Main Branch Agent Skills from one canonical source through `.agents/skills` or a Codex plugin package. | "Selected Main Branch workflows are experimental in Codex." | Stage 1 evidence plus selected skill invocation, repo-boundary checks, generated-file rules, and known gaps. |
 | Supported parity | Codex covers the daily `/mb-start`-equivalent loop and selected production workflows with release-simulation evidence comparable to Claude Code. | "Codex is a supported Main Branch runtime." | Full adapter contract, install/update/repair docs, fixture repo smoke, runtime transcript review, and release gate. |
 

--- a/decisions/2026-05-13-shared-workflow-corpus-and-native-runtime-renderers.md
+++ b/decisions/2026-05-13-shared-workflow-corpus-and-native-runtime-renderers.md
@@ -59,8 +59,8 @@ This decision does not:
 - implement the workflow corpus, renderer, or validator;
 - port `/mb-think`, `/mb-site`, or any full production workflow to Codex;
 - copy `.claude/skills` into `.agents/skills`;
-- claim native Codex skills, slash-command parity, Codex Mac app support,
-  Codex cloud support, or selected Codex workflow support;
+- claim native Codex skills, Claude-style installed command parity, Codex Mac
+  app support, Codex cloud support, or selected Codex workflow support;
 - make `mb` invoke Codex, Claude, or any model;
 - replace Claude Code as the supported runtime;
 - build dashboard, runtime UI, provider mutation, publishing, spend, or
@@ -80,8 +80,9 @@ strong enough to claim workflow parity.
 - The dogfood report
   [`docs/reports/2026-05-12-codex-stage1-dogfood.md`](../docs/reports/2026-05-12-codex-stage1-dogfood.md)
   records the current boundary: Codex used `mb` facts and did not silently
-  mutate repos, but it did not prove native Codex skills, slash-command parity,
-  Mac app support, cloud support, or selected production workflow ports.
+  mutate repos, but it did not prove native Codex skills, Claude-style
+  installed command parity, Mac app support, cloud support, or selected
+  production workflow ports.
 - [MAIN-349 / #539](https://github.com/noontide-co/mainbranch/issues/539)
   proved the Claude Code side of the same handoff shape: `/mb-start`
   path-to-money prompts should start from `money_path` facts, carry the
@@ -381,11 +382,12 @@ required before support language changes.
 
 ## Support Language
 
-Use these claims until future evidence changes them:
+At decision time, use these claims until future evidence changes them:
 
 - Claude Code: supported runtime for current slash-command skills.
-- Codex CLI: experimental CLI-first adapter grounded by generated `AGENTS.md`
-  and deterministic `mb` facts; no slash-command parity.
+- Codex CLI: Stage 1 instruction-file adapter grounded by generated `AGENTS.md`
+  and deterministic `mb` facts; no installed plugin command surface had shipped
+  yet.
 - Codex selected workflows: not shipped yet.
 - Future runtimes: compatibility targets only.
 

--- a/decisions/2026-05-13-shared-workflow-corpus-and-native-runtime-renderers.md
+++ b/decisions/2026-05-13-shared-workflow-corpus-and-native-runtime-renderers.md
@@ -22,6 +22,13 @@ shape was being chosen. Current product language is **shared workflow source**,
 with **runtime shells**, **runtime guidance**, and **runtime adapters** over
 that source.
 
+> Status note, MAIN-423 / #682: the proven Codex owner loop has since gained a
+> repo-scoped plugin and installed `/mb-*` command surface through
+> `.agents/plugins/main-branch-owner-loop`. That support is still an adapter
+> over shared workflow sources and deterministic `mb` facts, not full Claude
+> skill parity or broad production workflow parity. See
+> [docs/compatibility.md](../docs/compatibility.md) for current claims.
+
 ## Decision
 
 Main Branch should introduce a runtime-neutral workflow corpus under

--- a/decisions/2026-05-13-shared-workflow-source-and-runtime-shells.md
+++ b/decisions/2026-05-13-shared-workflow-source-and-runtime-shells.md
@@ -53,7 +53,7 @@ canonical workflow source for Main Branch workflows.
 
 The first Codex adapter slice proved that Codex can be grounded by generated
 `AGENTS.md` and deterministic `mb` facts, but it did not prove Claude-style
-slash-command parity or selected workflow support.
+installed command support or selected workflow support.
 
 The first shared source prototype proved that a portable workflow file can
 declare intent, required `mb` commands, JSON fact paths, routing rules,
@@ -93,11 +93,12 @@ Runtime shells own presentation and discovery:
 `mb` owns deterministic facts and validation. It may render, validate, and
 repair runtime files. It must not invoke a model or run the conversation.
 
-## Codex Boundary
+## Codex Boundary At Decision Time
 
 Codex is CLI/instruction-file-first in the current Main Branch support model.
 Fresh business repos include `AGENTS.md`; `mb status`, `mb start`, and
-`mb doctor repair` expose Codex readiness. That is not slash-command parity.
+`mb doctor repair` expose Codex readiness. At the time, that did not prove an
+installed plugin command surface.
 
 Codex guidance should say how to treat a natural request as a Main Branch
 workflow, starting from read-only `mb` facts. It should not tell users to run
@@ -111,7 +112,7 @@ The narrow support claim after a successful `/mb-think` read-only smoke is:
 Do not claim:
 
 - Codex supports all Main Branch skills.
-- Codex has `/mb-think` slash-command parity.
+- Codex has full Claude-style `/mb-think` skill parity.
 - Claude Code skills work in Codex.
 
 ## `.agents/skills` Boundary

--- a/decisions/2026-05-13-shared-workflow-source-and-runtime-shells.md
+++ b/decisions/2026-05-13-shared-workflow-source-and-runtime-shells.md
@@ -19,6 +19,13 @@ tags: [runtime-adapters, codex, claude-code, workflows, shared-workflow-source]
 
 # Shared Workflow Source And Runtime Shells
 
+> Status note, MAIN-423 / #682: the proven Codex owner loop has since gained a
+> repo-scoped plugin and installed `/mb-*` command surface through
+> `.agents/plugins/main-branch-owner-loop`. The generated `AGENTS.md` sections
+> remain fallback shells over shared workflow sources when the plugin is not
+> installed. See [docs/compatibility.md](../docs/compatibility.md) for current
+> support claims.
+
 ## Decision
 
 Main Branch workflow semantics belong in a shared workflow source under

--- a/docs/architecture/system-map.md
+++ b/docs/architecture/system-map.md
@@ -218,7 +218,7 @@ flowchart TB
 | GitHub is repo, checks, and history. | GitHub issues are durable tasks, PRs are proposals, Actions/checks gate changes, Releases mark package-visible publication. |
 | Cloudflare is site and deploy. | Cloudflare is the adopted site/DNS/Pages rail where evidence exists; GitHub Pages is not the default setup path. |
 | Real private data stays out of broad repos. | Secrets, raw ledgers, account exports, customer/member data, legal records, and machine-specific paths stay in secret stores, private vaults, provider systems, or local ignored state. |
-| Runtime support stays honest. | Claude Code is the first-class slash-skill runtime. Codex CLI is first-class for the proven owner loop only. Other runtimes are roadmap until adapter and smoke evidence exist. |
+| Runtime support stays honest. | Claude Code is the first-class slash-skill runtime. Codex CLI is first-class for the proven owner-loop plugin surface only. Other runtimes are roadmap until adapter and smoke evidence exist. |
 
 ## Data And Privacy Boundaries
 
@@ -262,7 +262,7 @@ Sources: [Data-source registry](../data-source-registry.md),
 | Runtime | Status | Contract |
 | --- | --- | --- |
 | Claude Code | Supported. | Slash skills and `mb start` handoff are the reference runtime path. |
-| Codex CLI | First-class owner loop. | Fresh business repos include `AGENTS.md` and `.agents/skills/main-branch-owner-loop`; Codex should run deterministic `mb` fact commands, use workflow inventory, and ask before writes. |
+| Codex CLI | First-class owner loop. | Fresh business repos include `AGENTS.md`, `.agents/skills/main-branch-owner-loop`, and `.agents/plugins/main-branch-owner-loop`; Codex should run deterministic `mb` fact commands, use workflow inventory, and ask before writes. |
 | Cursor, OpenClaw, Hermes, Paperclip-adjacent orchestration, local runtimes | Roadmap. | No support claim until adapter code, docs, generated-file rules, and fresh-repo smoke evidence exist. |
 
 Source: [Compatibility](../compatibility.md).

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -15,7 +15,7 @@ contract for those surfaces.
 | Install mode | `pipx install mainbranch` | Official public install path. |
 | Developer mode | Git clone | For contributors who want to edit the engine or skills. |
 | Agent runtime | Claude Code | First-class slash-skill runtime today. |
-| Codex CLI | First-class owner loop | Fresh business repos include `AGENTS.md` and `.agents/skills/main-branch-owner-loop`; `mb workflow list --runtime codex` exposes supported, pending, and unsupported workflow surfaces. This is not slash-command parity or provider/publishing parity. |
+| Codex CLI | First-class owner loop | Fresh business repos include `AGENTS.md`, `.agents/skills/main-branch-owner-loop`, and `.agents/plugins/main-branch-owner-loop`; `mb workflow list --runtime codex` exposes supported, pending, and unsupported workflow surfaces. This is owner-loop plugin command support, not all-skill or provider/publishing parity. |
 | Cursor, OpenClaw, Hermes, Paperclip-adjacent orchestration, local LLMs | Roadmap | `mb` is runtime-agnostic by design, but these adapters are not supported yet. |
 
 **Windows tip — try WSL2.** If you're on Windows and want a working setup today, use [Windows Subsystem for Linux 2 (WSL2)](https://learn.microsoft.com/en-us/windows/wsl/install). Inside WSL2, follow the supported Linux flow. The pipx install path works there.
@@ -164,7 +164,7 @@ smoke evidence exist.
 | Runtime surface | Status | Invocation | Skill/workflow discovery | Routing and automation | Observability and packaging |
 |---|---|---|---|---|---|
 | Claude Code | Supported | `mb start --repo "$repo"` prints the `claude` handoff; `mb start --launch` may launch after readiness checks. | `mb skill link --repo "$repo"` writes project-local `.claude/skills/mb-*` bridge links and `.claude/settings.local.json`. | Slash commands such as `/mb-start` and `/mb-think` own conversation and judgment; they call deterministic `mb` commands for facts. | `mb doctor`, `mb status --json`, `mb start --json`, `mb skill repair`, and runtime dogfood evidence gate release claims. Skills ship inside the Python package today. |
-| Codex CLI | First-class owner loop | Can call deterministic `mb` commands as a subprocess when pointed at a business repo. `AGENTS.md` gives Codex the repo bootstrap and `.agents/skills/main-branch-owner-loop` gives Codex a native owner-loop discovery surface. | Fresh `mb onboard` repos include tracked `AGENTS.md`, `.agents/skills/main-branch-owner-loop/SKILL.md`, and a generated workflow inventory. `mb doctor repair --plan` / `--apply` can report and refresh them. | Codex should run `mb status --json --peek`, `mb start --json`, `mb doctor repair --plan --json`, `mb checkpoint --plan --json`, `mb validate --json`, and `mb workflow list --runtime codex --json` before owner-loop advice, translate facts into business language, and ask before writes. | `mb doctor`, `mb status --json`, `mb start --json`, and `mb workflow list` expose Codex readiness and workflow support. Support is first-class only for the proven owner loop: start/status/setup/update/doctor, think/codify, end/checkpoint/save, validate, and workflow discovery. This is not slash-command, ads/site/provider, publishing, spend, or customer-contact parity. |
+| Codex CLI | First-class owner loop | Can call deterministic `mb` commands as a subprocess when pointed at a business repo. `AGENTS.md` gives Codex the repo bootstrap, `.agents/skills/main-branch-owner-loop` gives Codex a native owner-loop skill surface, and `.agents/plugins/main-branch-owner-loop` gives Codex owner-loop plugin commands. | Fresh `mb onboard` repos include tracked `AGENTS.md`, `.agents/skills/main-branch-owner-loop/SKILL.md`, `.agents/plugins/marketplace.json`, a plugin manifest, plugin-packaged skill, thin `/mb-*` command shims, and a generated workflow inventory. `mb doctor repair --plan` / `--apply` can report and refresh them. | Codex should run `mb status --json --peek`, `mb start --json`, `mb doctor repair --plan --json`, `mb checkpoint --plan --json`, `mb validate --json`, and `mb workflow list --runtime codex --json` before owner-loop advice, translate facts into business language, and ask before writes. The generated plugin exposes `/mb-start`, `/mb-status`, `/mb-setup`, `/mb-update`, `/mb-doctor`, `/mb-think`, `/mb-end`, `/mb-checkpoint`, `/mb-validate`, `/mb-workflows`, and `/mb-help` as thin shims over those facts. | `mb doctor`, `mb status --json`, `mb start --json`, and `mb workflow list` expose Codex readiness and workflow support. Support is first-class only for the proven owner loop: start/status/setup/update/doctor, think/codify, end/checkpoint/save, validate, and workflow discovery. This is not all-skill, ads/site/provider, publishing, spend, or customer-contact parity. |
 | Cursor | Roadmap | Can call deterministic `mb` commands from terminal/tasks when pointed at a business repo. | No supported Cursor rules/package adapter yet. | No supported Main Branch routing contract. | Needs adapter docs, install/update rules, conflict handling, and smoke evidence. |
 | OpenClaw | Roadmap | Target public runtime surface. It should call `mb` through stable CLI/JSON commands rather than clone-era paths. | No supported OpenClaw adapter yet. | Main Branch should coexist with OpenClaw as the business repo/GitHub memory layer, not replace it. | Needs explicit adapter shape, migration notes, generated-file rules, and smoke evidence. |
 | Hermes | Roadmap | Target runtime/memory surface. It may supervise or host workflows that call packaged `mb` commands. | No supported Hermes adapter yet. | Hermes-specific routing belongs in the Hermes adapter, while `mb` remains deterministic and non-conversational. | Docs may describe internal-package expectations generically, but not as the only blessed public path. Smoke evidence is required before support claims. |
@@ -178,16 +178,16 @@ support levels:
 
 Shared workflow sources under `workflows/` are runtime-agnostic contracts.
 Runtime shells, Claude Code skills, generated `AGENTS.md`, generated Codex
-skills, and future adapter packages should stay thin over those sources. A
+skills/plugins, and future adapter packages should stay thin over those sources. A
 checked shared workflow source does not by itself make every runtime supported;
 support still requires an adapter and smoke evidence for that runtime.
 
 | Surface | Claude Code | Other runtimes and orchestrators |
 |---|---|---|
 | Deterministic CLI facts (`mb status --json`, `mb validate --json`, `mb graph --json`, `mb connect status --json`) | Supported when `mb` is installed and pointed at a business repo. | Callable as packaged CLI subprocesses, but this does not make the hosting runtime supported. |
-| Runtime handoff (`mb start --json`, `mb start --launch`) | Supported for Claude Code handoff and launch readiness. | Codex CLI handoff metadata is supported for owner-loop readiness: `mb start --json` reports Codex executable, `AGENTS.md`, and owner-loop skill readiness. `mb` does not launch Codex. |
-| Lifecycle slash skills (`/mb-start`, `/mb-status`, `/mb-setup`, `/mb-update`, `/mb-end`, `/mb-help`) | Supported through Claude Code project-local skill discovery. | Codex does not use slash commands. The generated owner-loop skill covers start/status/setup/update/doctor, end/checkpoint/save, validate, and workflow discovery through deterministic `mb` facts and approval gates. |
-| Production slash skills (`/mb-think`, `/mb-ads`, `/mb-organic`, `/mb-site`, `/mb-wiki`, `/mb-bet`) | Supported through Claude Code skills, subject to each skill's provider and workflow limits. Conversion scripts route through the owning workflow instead of a standalone primitive or skill. | Codex supports think/codify through `workflows/mb-think/workflow.md` and generated guidance. Ads, organic/newsletter, site, and bet workflows are pending shared-source migration. Wiki and skill-authoring workflows are intentionally unsupported for the owner-loop target. |
+| Runtime handoff (`mb start --json`, `mb start --launch`) | Supported for Claude Code handoff and launch readiness. | Codex CLI handoff metadata is supported for owner-loop readiness: `mb start --json` reports Codex executable, `AGENTS.md`, owner-loop skill, and plugin readiness. `mb` does not launch Codex. |
+| Lifecycle slash skills (`/mb-start`, `/mb-status`, `/mb-setup`, `/mb-update`, `/mb-end`, `/mb-help`) | Supported through Claude Code project-local skill discovery. | Codex supports owner-loop plugin commands for start/status/setup/update/doctor, end/checkpoint/save, validate, and workflow discovery through deterministic `mb` facts and approval gates. This is not all Claude Code slash-skill parity. |
+| Production slash skills (`/mb-think`, `/mb-ads`, `/mb-organic`, `/mb-site`, `/mb-wiki`, `/mb-bet`) | Supported through Claude Code skills, subject to each skill's provider and workflow limits. Conversion scripts route through the owning workflow instead of a standalone primitive or skill. | Codex supports `/mb-think` for think/codify through `workflows/mb-think/workflow.md` and generated guidance. Ads, organic/newsletter, site, and bet workflows are pending shared-source migration. Wiki and skill-authoring workflows are intentionally unsupported for the owner-loop target. |
 | Automation routines | May call CLI commands before handing judgment work to Claude Code. | May call shipped deterministic CLI commands against an explicit repo path. Conversation, retries, routing, and model invocation belong to the runtime adapter, not `mb`. |
 
 ## Adapter checklist
@@ -208,15 +208,14 @@ write runtime state, credentials, or raw account data into tracked files.
 For the Codex staging plan, see
 [Codex Adapter Plan](../decisions/2026-05-08-codex-adapter-plan.md). The current
 implementation is the owner-loop slice: generated `AGENTS.md`, generated
-`.agents/skills/main-branch-owner-loop`, deterministic readiness facts, doctor
-repair coverage, `mb workflow list`, and compact workflow discovery for
-start/status/setup/update/doctor, think/codify, end/checkpoint/save, validate,
-and workflow inventory. The think route is checked against
+`.agents/skills/main-branch-owner-loop`, `.agents/plugins/main-branch-owner-loop`,
+deterministic readiness facts, doctor repair coverage, `mb workflow list`, and
+compact workflow discovery for start/status/setup/update/doctor, think/codify,
+end/checkpoint/save, validate, and workflow inventory. The think route is checked against
 `workflows/mb-think/workflow.md` as the first official shared workflow source
 pattern, and fresh read-only Codex smoke covers the owner-loop surface from a
-business repo. It does not claim slash-command parity, copied Claude skill
-parity, provider/publishing workflow support, spend, or customer-contact
-support.
+business repo. It does not claim all-skill parity, copied Claude skill parity,
+provider/publishing workflow support, spend, or customer-contact support.
 
 ## Recommended setup
 
@@ -281,7 +280,7 @@ mb doctor
 
 - Claude Code is the first-class slash-skill runtime today.
 - Codex CLI is first-class for the proven owner loop. Main Branch does not
-  claim Codex slash-command parity, copied Claude skill parity, provider writes,
+  claim all-skill parity, copied Claude skill parity, provider writes,
   publishing, spend, or customer-contact workflows.
 - Windows is experimental.
 - Skills are bundled into the installed Python package, so public users update

--- a/docs/ethos.md
+++ b/docs/ethos.md
@@ -169,7 +169,10 @@ autosave; it is durable business memory.
 ## What We Are Not Building Yet
 
 Main Branch is not a hosted SaaS dashboard, chat client, background daemon,
-model host, vector database, scheduler, or marketplace today.
+model host, vector database, scheduler, or hosted marketplace product today.
+Repo-local runtime marketplace metadata, such as the Codex plugin marketplace
+file generated into a business repo, is an adapter mechanism rather than a
+Main Branch marketplace business surface.
 
 Those may become useful surfaces later. They earn their way in by preserving
 the same source of truth: the business repo, GitHub, git history, deterministic

--- a/docs/ethos.md
+++ b/docs/ethos.md
@@ -101,10 +101,10 @@ and power users, but they should not be the default user experience.
 
 Claude Code is the first supported slash-skill runtime today. Codex CLI is
 first-class for the proven owner loop through generated repo guidance,
-generated owner-loop skill discovery, deterministic `mb` facts, and smoke
-evidence. Cursor, OpenClaw, Hermes, Paperclip-adjacent orchestration, and local
-runtimes are compatibility targets only when adapter code and smoke evidence
-exist.
+generated owner-loop skill/plugin discovery, deterministic `mb` facts, and
+smoke evidence. Cursor, OpenClaw, Hermes, Paperclip-adjacent orchestration, and
+local runtimes are compatibility targets only when adapter code and smoke
+evidence exist.
 
 Main Branch should meet operators where they already work, but it should not
 claim support before support is proven.

--- a/docs/post-release-alignment.md
+++ b/docs/post-release-alignment.md
@@ -255,9 +255,10 @@ truth lives in the linked doc or decision.
   schema, primitive) are fine in code comments and contributor docs, not in
   user-facing copy. See `docs/agent-writing-style.md`.
 - **Runtime claims**: Claude Code is first-class for slash skills. Codex CLI is
-  first-class for the proven owner loop through generated repo guidance and a
-  generated owner-loop skill. Other runtimes are compatibility targets until
-  smoke evidence exists. See `docs/compatibility.md`.
+  first-class for the proven owner loop through generated repo guidance, a
+  generated owner-loop skill, and a repo-scoped owner-loop plugin. Other
+  runtimes are compatibility targets until smoke evidence exists. See
+  `docs/compatibility.md`.
 
 If a PR or issue contradicts one of these, treat the contradiction as a
 stale-assumption finding and block until reconciled or a new decision file

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -149,7 +149,7 @@ Anti-scope for v0.3.x:
 
 - no dashboard as source of truth;
 - no broad multi-runtime support claims;
-- no marketplace;
+- no hosted/public/provider marketplace product;
 - no automatic model invocation from `mb`;
 - no provider setup that stores secrets in repo files.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -70,9 +70,9 @@ Main Branch already ships:
 
 Claude Code is the supported slash-skill runtime today. Codex CLI is
 first-class for the proven owner loop through generated `AGENTS.md`,
-`.agents/skills/main-branch-owner-loop`, deterministic `mb` facts, and workflow
-inventory. Other runtimes are compatibility targets until adapter code and
-smoke evidence exist.
+`.agents/skills/main-branch-owner-loop`, `.agents/plugins/main-branch-owner-loop`,
+deterministic `mb` facts, and workflow inventory. Other runtimes are
+compatibility targets until adapter code and smoke evidence exist.
 
 ## Current Direction: Chat-First, CLI-Backed Daily Loop
 

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -115,10 +115,11 @@ surfaces, required `mb` fact commands, JSON fact paths, approval gates,
 public/private boundaries, routing rules, handoff shape, and validation
 expectations. Claude Code remains the first-class slash-skill runtime shell
 through `.claude/skills/mb-think/SKILL.md`; Codex uses tracked `AGENTS.md` and
-generated `.agents/skills/main-branch-owner-loop` guidance for the proven owner
-loop, checked against shared workflow sources where migrated. Neither
-`.claude/skills` nor `.agents/skills` is the canonical source for cross-runtime
-workflow semantics.
+generated `.agents/skills/main-branch-owner-loop` plus
+`.agents/plugins/main-branch-owner-loop` guidance for the proven owner loop,
+checked against shared workflow sources where migrated. Neither
+`.claude/skills`, `.agents/skills`, nor `.agents/plugins` is the canonical
+source for cross-runtime workflow semantics.
 
 `mb` may validate, render snapshots for tests, and repair generated runtime
 guidance. It must not invoke Claude, Codex, or any model.
@@ -622,8 +623,9 @@ and checkpoint. The full surface lives in
 Skills own judgment-heavy work: synthesis, writing, review, routing. They call
 `mb` for facts. Claude Code is the supported slash-skill runtime today. Codex
 CLI is supported for the proven owner loop through generated repo guidance and
-a generated owner-loop skill. Other runtimes are compatibility targets until
-adapter code and smoke evidence exist. See [compatibility.md](compatibility.md).
+a generated owner-loop skill/plugin surface. Other runtimes are compatibility
+targets until adapter code and smoke evidence exist. See
+[compatibility.md](compatibility.md).
 
 Curated rails — GitHub, Cloudflare, Google/Workspace, official ads paths,
 Postiz, hledger, transcription helpers — earn their place by improving a loop

--- a/mb/mb/_data/templates/AGENTS.md.tmpl
+++ b/mb/mb/_data/templates/AGENTS.md.tmpl
@@ -186,8 +186,10 @@ the daily check-in and wants it recorded.
 ## Codex Think Route
 
 This is Codex-native guidance for the existing `mb-think` shared workflow
-source. It is not a slash command, and it does not mean all Main Branch skills
-work in Codex.
+source. When the generated Main Branch Owner Loop plugin is installed, this is
+the fallback route behind `/mb-think`; without the plugin, treat this section as
+the natural-language Codex route. It does not mean all Main Branch skills work
+in Codex.
 
 Engine source workflow: `workflows/mb-think/workflow.md`. This business repo
 does not need to contain that engine source file. Treat this generated

--- a/mb/mb/_data/templates/AGENTS.md.tmpl
+++ b/mb/mb/_data/templates/AGENTS.md.tmpl
@@ -7,8 +7,8 @@ Main Branch business repo instructions for Codex.
 Main Branch CLI facts are the source of truth for repo health, setup, runtime
 wiring, updates, graph/status signals, provider readiness, and repair paths.
 When the operator asks to start, begin, get oriented, triage the day, or decide
-what to do next, use this Codex-native start workflow. Do not pretend Claude
-Code slash commands exist in Codex.
+what to do next, use this Codex-native start workflow or the generated Codex
+plugin command surface. Do not pretend Claude Code skills work in Codex.
 
 Start in this repo. Before setup, routing, migration, update, or repair advice,
 run the read-only checks that fit the situation:
@@ -91,37 +91,43 @@ emails, or usernames alone.
 ## Codex Lifecycle Workflow Index
 
 This tracked `AGENTS.md` file is the repo-level Codex bootstrap. The generated
-project-local skill at `.agents/skills/main-branch-owner-loop/SKILL.md` is the
-Codex-native owner-loop discovery surface. Both are owned by `mb init`,
+project-local skill at `.agents/skills/main-branch-owner-loop/SKILL.md` plus
+the repo-scoped plugin at `.agents/plugins/main-branch-owner-loop/` are the
+Codex-native owner-loop discovery surfaces. They are owned by `mb init`,
 `mb onboard`, `mb doctor repair`, and the operator. Keep them compact: route to
 lifecycle workflows and `mb` facts, but do not duplicate the full Main Branch
 skill tree.
 
 Use `.agents/skills/main-branch-owner-loop` for the proven owner loop only. Do
-not create Codex plugin manifests, copied Claude skill trees, or symlinked
-Claude skills unless a future `mb` command or issue says that surface is
-supported for this repo.
+not create additional Codex plugin manifests, copied Claude skill trees, or
+symlinked Claude skills unless a future `mb` command or issue says that surface
+is supported for this repo.
 
 Use this index to map natural Codex requests:
 
-- **Start the day / what next / get oriented:** use the Codex Start Workflow
-  below. Run `mb status --json --peek` first, then `mb start --json` when
-  runtime handoff or adapter-readiness facts matter.
-- **Inspect status / what changed / what is stale:** use the Codex Status
-  Workflow below. Answer from `ranked_actions`, `since_last_check`, `journal`,
-  `money_path`, `content_strategy`, `integrations`, `readiness`, and
-  `drift.items`.
-- **Think / research / decide / codify:** use the Codex Think Route below.
-  Start from `mb` facts, choose a research depth, and ask before writing
-  durable business files.
+- **Start the day / what next / get oriented:** use `/mb-start` when the
+  generated Codex plugin is installed, or the Codex Start Workflow below. Run
+  `mb status --json --peek` first, then `mb start --json` when runtime handoff
+  or adapter-readiness facts matter.
+- **Inspect status / what changed / what is stale:** use `/mb-status` when the
+  generated Codex plugin is installed, or the Codex Status Workflow below.
+  Answer from `ranked_actions`, `since_last_check`, `journal`, `money_path`,
+  `content_strategy`, `integrations`, `readiness`, and `drift.items`.
+- **Think / research / decide / codify:** use `/mb-think` when the generated
+  Codex plugin is installed, or the Codex Think Route below. Start from `mb`
+  facts, choose a research depth, and ask before writing durable business files.
 - **Site, ads, organic production, provider mutation, publishing, spend,
   domains, or customer contact:** do not claim these workflows are ported to
   Codex. Use read-only `mb` facts for planning and ask before any action.
 
+The generated plugin also exposes `/mb-setup`, `/mb-update`, `/mb-doctor`,
+`/mb-end`, `/mb-checkpoint`, `/mb-validate`, `/mb-workflows`, and `/mb-help`
+as thin command shims over this owner-loop contract. Use `/plugins` to inspect
+or install the Main Branch Owner Loop plugin from this repo.
+
 ## Codex Start Workflow
 
-This is the Codex-native port of `/mb-start`. It is a workflow, not a slash
-command.
+This is the Codex-native port behind `/mb-start`.
 
 1. Run `mb status --json --peek` from the current working directory. Use the
    repo markers in that JSON to confirm this is the business repo. If the
@@ -154,7 +160,7 @@ before acting.
 
 ## Codex Status Workflow
 
-This is the Codex-native status route. It is a workflow, not a slash command.
+This is the Codex-native status route behind `/mb-status`.
 
 1. Run `mb status --json --peek`.
 2. Treat the JSON as the source of truth for setup, update, drift, GitHub,

--- a/mb/mb/_data/templates/README.md.tmpl
+++ b/mb/mb/_data/templates/README.md.tmpl
@@ -3,9 +3,9 @@
 This is the Main Branch business folder for {{BUSINESS_NAME}}.
 
 The durable business memory lives here: offer, audience, voice, proof,
-team context, decisions, bets, pushes, logs, research, and approved summaries. Claude Code
-reads this folder before advising, so work starts from the business context
-instead of a blank chat.
+team context, decisions, bets, pushes, logs, research, and approved summaries.
+Claude Code or Codex CLI read this folder before advising, so work starts from
+the business context instead of a blank chat.
 
 ## Start
 
@@ -16,6 +16,18 @@ claude
 ```
 
 Then run:
+
+```text
+/mb-start
+```
+
+Or, in Codex CLI:
+
+```bash
+codex
+```
+
+Open `/plugins`, install **Main Branch Owner Loop** from this repo, then run:
 
 ```text
 /mb-start

--- a/mb/mb/_data/templates/README.md.tmpl
+++ b/mb/mb/_data/templates/README.md.tmpl
@@ -24,10 +24,12 @@ Then run:
 Or, in Codex CLI:
 
 ```bash
+codex plugin marketplace add .
 codex
 ```
 
-Open `/plugins`, install **Main Branch Owner Loop** from this repo, then run:
+Open `/plugins`, install **Main Branch Owner Loop** from the registered repo
+marketplace, then run:
 
 ```text
 /mb-start

--- a/mb/mb/codex.py
+++ b/mb/mb/codex.py
@@ -1,7 +1,8 @@
-"""Experimental Codex CLI-first adapter helpers.
+"""Codex owner-loop adapter helpers.
 
-Codex support starts with repo instructions and deterministic ``mb`` facts.
-This module intentionally does not invoke Codex or manage model conversation.
+Codex owner-loop support starts with repo instructions, the repo-scoped plugin
+surface, and deterministic ``mb`` facts. This module intentionally does not
+invoke Codex or manage model conversation.
 """
 
 from __future__ import annotations
@@ -628,8 +629,10 @@ the daily check-in and wants it recorded.
 ## Codex Think Route
 
 This is Codex-native guidance for the existing `mb-think` shared workflow
-source. It is not a slash command, and it does not mean all Main Branch skills
-work in Codex.
+source. When the generated Main Branch Owner Loop plugin is installed, this is
+the fallback route behind `/mb-think`; without the plugin, treat this section as
+the natural-language Codex route. It does not mean all Main Branch skills work
+in Codex.
 
 Engine source workflow: `workflows/mb-think/workflow.md`. This business repo
 does not need to contain that engine source file. Treat this generated

--- a/mb/mb/codex.py
+++ b/mb/mb/codex.py
@@ -892,7 +892,8 @@ def workflow_inventory(*, runtime: str = "codex") -> dict[str, Any]:
             "command_paths": list(CODEX_PLUGIN_COMMAND_RELATIVE_PATHS),
             "commands": [f"/{name}" for name in CODEX_COMMAND_NAMES],
             "install_hint": (
-                "Open `/plugins`, choose the repo marketplace, then install Main Branch Owner Loop."
+                "Run `codex plugin marketplace add .`, open `/plugins`, choose the "
+                "repo marketplace, then install Main Branch Owner Loop."
             ),
         },
         "statuses": statuses,
@@ -931,7 +932,8 @@ def render_workflow_inventory_md() -> str:
         "shell still needs implementation and smoke evidence.\n"
         "- `intentionally_unsupported`: outside the current Codex owner-loop target.\n\n"
         "Codex plugin files live under `.agents/plugins/main-branch-owner-loop/` "
-        "and are listed by `.agents/plugins/marketplace.json` for `/plugins`.\n\n"
+        "and are listed by `.agents/plugins/marketplace.json`. Register the repo "
+        "first with `codex plugin marketplace add .`, then use `/plugins`.\n\n"
         "| Workflow | Codex status | Claude Code surface | Codex surface | "
         "Codex commands | Fact commands |\n"
         "|---|---|---|---|---|---|\n" + "\n".join(rows) + "\n\n"

--- a/mb/mb/codex.py
+++ b/mb/mb/codex.py
@@ -6,6 +6,7 @@ This module intentionally does not invoke Codex or manage model conversation.
 
 from __future__ import annotations
 
+import json
 import shlex
 import shutil
 from importlib import resources
@@ -18,6 +19,30 @@ CODEX_SKILL_DIR_RELATIVE_PATH = ".agents/skills/main-branch-owner-loop"
 CODEX_SKILL_RELATIVE_PATH = f"{CODEX_SKILL_DIR_RELATIVE_PATH}/SKILL.md"
 CODEX_WORKFLOW_INVENTORY_RELATIVE_PATH = (
     f"{CODEX_SKILL_DIR_RELATIVE_PATH}/references/workflow-inventory.md"
+)
+CODEX_MARKETPLACE_RELATIVE_PATH = ".agents/plugins/marketplace.json"
+CODEX_PLUGIN_NAME = "main-branch-owner-loop"
+CODEX_PLUGIN_DIR_RELATIVE_PATH = f".agents/plugins/{CODEX_PLUGIN_NAME}"
+CODEX_PLUGIN_MANIFEST_RELATIVE_PATH = f"{CODEX_PLUGIN_DIR_RELATIVE_PATH}/.codex-plugin/plugin.json"
+CODEX_PLUGIN_SKILL_RELATIVE_PATH = (
+    f"{CODEX_PLUGIN_DIR_RELATIVE_PATH}/skills/main-branch-owner-loop/SKILL.md"
+)
+CODEX_PLUGIN_COMMANDS_RELATIVE_PATH = f"{CODEX_PLUGIN_DIR_RELATIVE_PATH}/commands"
+CODEX_COMMAND_NAMES = (
+    "mb-start",
+    "mb-status",
+    "mb-setup",
+    "mb-update",
+    "mb-doctor",
+    "mb-think",
+    "mb-end",
+    "mb-checkpoint",
+    "mb-validate",
+    "mb-workflows",
+    "mb-help",
+)
+CODEX_PLUGIN_COMMAND_RELATIVE_PATHS = tuple(
+    f"{CODEX_PLUGIN_COMMANDS_RELATIVE_PATH}/{name}.md" for name in CODEX_COMMAND_NAMES
 )
 REQUIRED_FACT_COMMANDS = (
     "mb status --json --peek",
@@ -95,6 +120,8 @@ REQUIRED_LIFECYCLE_GUIDANCE = (
     "Shared public/private boundaries",
     "Use `.agents/skills/main-branch-owner-loop`",
     "do not claim these workflows are ported to",
+    "generated Codex plugin is installed",
+    "/plugins",
 )
 REQUIRED_LIFECYCLE_GUIDANCE_MARKERS = (
     *REQUIRED_LIFECYCLE_GUIDANCE,
@@ -111,11 +138,185 @@ CODEX_SKILL_REQUIRED_MARKERS = (
     "end/checkpoint/save",
     "Ask before durable writes",
 )
+CODEX_PLUGIN_REQUIRED_MARKERS = (
+    "Main Branch Owner Loop",
+    "skills",
+    "main-branch-owner-loop",
+    "mb facts",
+)
+CODEX_COMMAND_REQUIRED_MARKERS = (
+    "Main Branch owner-loop skill",
+    "mb status --json --peek",
+    "mb start --json",
+    "Ask before",
+    "provider mutation",
+    "publishing",
+    "customer contact",
+)
 CODEX_WORKFLOW_STATUS_VOCABULARY = (
     "supported",
     "pending_shared_source_migration",
     "generated_shell_pending",
     "intentionally_unsupported",
+)
+
+CODEX_COMMAND_DEFINITIONS: tuple[dict[str, Any], ...] = (
+    {
+        "name": "mb-start",
+        "title": "Main Branch Start",
+        "description": "Start the Main Branch owner loop from direct mb facts.",
+        "route": "Start/status/setup/update/doctor",
+        "commands": ("mb status --json --peek", "mb start --json", "mb doctor repair --plan"),
+        "task": (
+            "Orient the operator, name the top business route, and ask before any "
+            "repair, update, setup write, file write, checkpoint, provider mutation, "
+            "publishing, spend, customer contact, or public issue/proposal submission."
+        ),
+    },
+    {
+        "name": "mb-status",
+        "title": "Main Branch Status",
+        "description": "Summarize current business state and what changed.",
+        "route": "Start/status/setup/update/doctor",
+        "commands": ("mb status --json --peek", "mb start --json"),
+        "task": (
+            "Summarize ranked actions, since-last-check changes, readiness, drift, "
+            "MoneyPath, content strategy, integrations, bets, pushes, vocabulary, "
+            "and checkpoint state from the JSON facts."
+        ),
+    },
+    {
+        "name": "mb-setup",
+        "title": "Main Branch Setup",
+        "description": "Use onboarding facts to continue first-run setup.",
+        "route": "Start/status/setup/update/doctor",
+        "commands": ("mb --version", "mb status --json --peek", "mb start --json"),
+        "task": (
+            "Treat setup guides or pasted folder descriptions as setup intent. "
+            "Explain which folder becomes the business brain and ask before any "
+            "onboarding or GitHub setup write."
+        ),
+    },
+    {
+        "name": "mb-update",
+        "title": "Main Branch Update",
+        "description": "Plan a Main Branch update without applying it first.",
+        "route": "Start/status/setup/update/doctor",
+        "commands": (
+            "mb status --json --peek",
+            "mb start --json",
+            "mb update --check --json",
+        ),
+        "task": (
+            "Report installed/latest version facts, release-note context when present, "
+            "and the exact update command. Ask before running update or repair commands."
+        ),
+    },
+    {
+        "name": "mb-doctor",
+        "title": "Main Branch Doctor",
+        "description": "Inspect repairable repo drift before applying fixes.",
+        "route": "Start/status/setup/update/doctor",
+        "commands": (
+            "mb status --json --peek",
+            "mb start --json",
+            "mb doctor repair --plan --json",
+        ),
+        "task": (
+            "Explain repair plan actions in business language. Applying repairs, "
+            "migrations, or runtime wiring writes requires explicit approval."
+        ),
+    },
+    {
+        "name": "mb-think",
+        "title": "Main Branch Think",
+        "description": "Route research, decisions, and codification through mb-think.",
+        "route": "Think/codify",
+        "commands": CODEX_THINK_REQUIRED_MB_COMMANDS,
+        "task": (
+            "Use the shared mb-think route in AGENTS.md, choose the smallest honest "
+            "research depth, preserve source privacy, and ask before codifying files "
+            "or opening public issues/proposals."
+        ),
+    },
+    {
+        "name": "mb-end",
+        "title": "Main Branch End",
+        "description": "Close a session with a checkpoint/save plan.",
+        "route": "End/checkpoint/save",
+        "commands": (
+            "mb status --json --peek",
+            "mb start --json",
+            "mb checkpoint --plan --json",
+            "mb validate --json",
+        ),
+        "task": (
+            "Summarize what changed, propose next memory updates or checkpoint subjects, "
+            "and ask before writing files or saving a checkpoint."
+        ),
+    },
+    {
+        "name": "mb-checkpoint",
+        "title": "Main Branch Checkpoint",
+        "description": "Plan a business-readable saved checkpoint.",
+        "route": "End/checkpoint/save",
+        "commands": (
+            "mb status --json --peek",
+            "mb start --json",
+            "mb checkpoint --plan --json",
+            "mb validate --json",
+        ),
+        "task": (
+            "Use checkpoint facts to propose a concise business-readable subject. "
+            "Creating the checkpoint requires explicit operator approval."
+        ),
+    },
+    {
+        "name": "mb-validate",
+        "title": "Main Branch Validate",
+        "description": "Validate business repo health from JSON facts.",
+        "route": "Validate",
+        "commands": (
+            "mb status --json --peek",
+            "mb start --json",
+            "mb validate --json",
+        ),
+        "task": (
+            "Explain validation health in business language first, then cite technical "
+            "paths or repair commands. Ask before editing files."
+        ),
+    },
+    {
+        "name": "mb-workflows",
+        "title": "Main Branch Workflows",
+        "description": "Show supported, pending, and unsupported Codex surfaces.",
+        "route": "Workflow discovery",
+        "commands": (
+            "mb status --json --peek",
+            "mb start --json",
+            "mb workflow list --runtime codex --json",
+        ),
+        "task": (
+            "List supported owner-loop surfaces, pending shared-source migrations, "
+            "and intentionally unsupported workflows without overclaiming parity."
+        ),
+    },
+    {
+        "name": "mb-help",
+        "title": "Main Branch Help",
+        "description": "Answer Main Branch support questions from runtime inventory.",
+        "route": "Workflow discovery",
+        "commands": (
+            "mb status --json --peek",
+            "mb start --json",
+            "mb workflow list --runtime codex --json",
+        ),
+        "task": (
+            "Answer from the generated owner-loop skill, workflow inventory, and mb "
+            "facts. Name unsupported provider/publishing/spend/customer-contact "
+            "boundaries plainly."
+        ),
+    },
 )
 
 CODEX_WORKFLOW_INVENTORY: tuple[dict[str, Any], ...] = (
@@ -124,7 +325,8 @@ CODEX_WORKFLOW_INVENTORY: tuple[dict[str, Any], ...] = (
         "label": "Start, status, and what changed",
         "claude_surface": "/mb-start, /mb-status",
         "codex_status": "supported",
-        "codex_surface": "AGENTS.md and .agents/skills/main-branch-owner-loop",
+        "codex_surface": "Codex plugin commands /mb-start and /mb-status",
+        "codex_entrypoints": ("mb-start", "mb-status"),
         "commands": ("mb status --json --peek", "mb start --json"),
         "notes": (
             "Codex starts from deterministic status/start facts, translates them "
@@ -136,7 +338,8 @@ CODEX_WORKFLOW_INVENTORY: tuple[dict[str, Any], ...] = (
         "label": "Setup, update, doctor, and repair planning",
         "claude_surface": "/mb-setup, /mb-update, /mb-start repair routing",
         "codex_status": "supported",
-        "codex_surface": "AGENTS.md and .agents/skills/main-branch-owner-loop",
+        "codex_surface": "Codex plugin commands /mb-setup, /mb-update, and /mb-doctor",
+        "codex_entrypoints": ("mb-setup", "mb-update", "mb-doctor"),
         "commands": (
             "mb --version",
             "mb doctor repair --plan --json",
@@ -152,7 +355,8 @@ CODEX_WORKFLOW_INVENTORY: tuple[dict[str, Any], ...] = (
         "label": "Think, research, decide, and codify",
         "claude_surface": "/mb-think",
         "codex_status": "supported",
-        "codex_surface": "AGENTS.md#codex-think-route and owner-loop skill",
+        "codex_surface": "Codex plugin command /mb-think and AGENTS.md#codex-think-route",
+        "codex_entrypoints": ("mb-think",),
         "shared_source": CODEX_THINK_SOURCE_WORKFLOW,
         "commands": CODEX_THINK_REQUIRED_MB_COMMANDS,
         "notes": (
@@ -165,7 +369,8 @@ CODEX_WORKFLOW_INVENTORY: tuple[dict[str, Any], ...] = (
         "label": "End, checkpoint, and save business memory",
         "claude_surface": "/mb-end, mb checkpoint",
         "codex_status": "supported",
-        "codex_surface": "AGENTS.md and .agents/skills/main-branch-owner-loop",
+        "codex_surface": "Codex plugin commands /mb-end and /mb-checkpoint",
+        "codex_entrypoints": ("mb-end", "mb-checkpoint"),
         "commands": ("mb checkpoint --plan --json", "mb validate --json"),
         "notes": (
             "Codex can plan a closeout and propose checkpoint subjects. Creating "
@@ -177,7 +382,8 @@ CODEX_WORKFLOW_INVENTORY: tuple[dict[str, Any], ...] = (
         "label": "Workflow discovery and support inventory",
         "claude_surface": "/mb-help and docs",
         "codex_status": "supported",
-        "codex_surface": "mb workflow list and owner-loop skill inventory",
+        "codex_surface": "Codex plugin commands /mb-workflows and /mb-help",
+        "codex_entrypoints": ("mb-workflows", "mb-help"),
         "commands": ("mb workflow list --runtime codex --json",),
         "notes": "Codex users can inspect supported, pending, and unsupported workflow surfaces.",
     },
@@ -254,8 +460,8 @@ Main Branch business repo instructions for Codex.
 Main Branch CLI facts are the source of truth for repo health, setup, runtime
 wiring, updates, graph/status signals, provider readiness, and repair paths.
 When the operator asks to start, begin, get oriented, triage the day, or decide
-what to do next, use this Codex-native start workflow. Do not pretend Claude
-Code slash commands exist in Codex.
+what to do next, use this Codex-native start workflow or the generated Codex
+plugin command surface. Do not pretend Claude Code skills work in Codex.
 
 Start in this repo. Before setup, routing, migration, update, or repair advice,
 run the read-only checks that fit the situation:
@@ -331,37 +537,43 @@ canonical paths, frontmatter, JSON keys, validator rules, and command names.
 ## Codex Lifecycle Workflow Index
 
 This tracked `AGENTS.md` file is the repo-level Codex bootstrap. The generated
-project-local skill at `.agents/skills/main-branch-owner-loop/SKILL.md` is the
-Codex-native owner-loop discovery surface. Both are owned by `mb init`,
+project-local skill at `.agents/skills/main-branch-owner-loop/SKILL.md` plus
+the repo-scoped plugin at `.agents/plugins/main-branch-owner-loop/` are the
+Codex-native owner-loop discovery surfaces. They are owned by `mb init`,
 `mb onboard`, `mb doctor repair`, and the operator. Keep them compact: route to
 lifecycle workflows and `mb` facts, but do not duplicate the full Main Branch
 skill tree.
 
 Use `.agents/skills/main-branch-owner-loop` for the proven owner loop only. Do
-not create Codex plugin manifests, copied Claude skill trees, or symlinked
-Claude skills unless a future `mb` command or issue says that surface is
-supported for this repo.
+not create additional Codex plugin manifests, copied Claude skill trees, or
+symlinked Claude skills unless a future `mb` command or issue says that surface
+is supported for this repo.
 
 Use this index to map natural Codex requests:
 
-- **Start the day / what next / get oriented:** use the Codex Start Workflow
-  below. Run `mb status --json --peek` first, then `mb start --json` when
-  runtime handoff or adapter-readiness facts matter.
-- **Inspect status / what changed / what is stale:** use the Codex Status
-  Workflow below. Answer from `ranked_actions`, `since_last_check`, `journal`,
-  `money_path`, `content_strategy`, `integrations`, `readiness`, and
-  `drift.items`.
-- **Think / research / decide / codify:** use the Codex Think Route below.
-  Start from `mb` facts, choose a research depth, and ask before writing
-  durable business files.
+- **Start the day / what next / get oriented:** use `/mb-start` when the
+  generated Codex plugin is installed, or the Codex Start Workflow below. Run
+  `mb status --json --peek` first, then `mb start --json` when runtime handoff
+  or adapter-readiness facts matter.
+- **Inspect status / what changed / what is stale:** use `/mb-status` when the
+  generated Codex plugin is installed, or the Codex Status Workflow below.
+  Answer from `ranked_actions`, `since_last_check`, `journal`, `money_path`,
+  `content_strategy`, `integrations`, `readiness`, and `drift.items`.
+- **Think / research / decide / codify:** use `/mb-think` when the generated
+  Codex plugin is installed, or the Codex Think Route below. Start from `mb`
+  facts, choose a research depth, and ask before writing durable business files.
 - **Site, ads, organic production, provider mutation, publishing, spend,
   domains, or customer contact:** do not claim these workflows are ported to
   Codex. Use read-only `mb` facts for planning and ask before any action.
 
+The generated plugin also exposes `/mb-setup`, `/mb-update`, `/mb-doctor`,
+`/mb-end`, `/mb-checkpoint`, `/mb-validate`, `/mb-workflows`, and `/mb-help`
+as thin command shims over this owner-loop contract. Use `/plugins` to inspect
+or install the Main Branch Owner Loop plugin from this repo.
+
 ## Codex Start Workflow
 
-This is the Codex-native port of `/mb-start`. It is a workflow, not a slash
-command.
+This is the Codex-native port behind `/mb-start`.
 
 1. Run `mb status --json --peek` from the current working directory. Use the
    repo markers in that JSON to confirm this is the business repo. If the
@@ -390,7 +602,7 @@ before acting.
 
 ## Codex Status Workflow
 
-This is the Codex-native status route. It is a workflow, not a slash command.
+This is the Codex-native status route behind `/mb-status`.
 
 1. Run `mb status --json --peek`.
 2. Treat the JSON as the source of truth for setup, update, drift, GitHub,
@@ -657,6 +869,9 @@ def workflow_inventory(*, runtime: str = "codex") -> dict[str, Any]:
     for item in CODEX_WORKFLOW_INVENTORY:
         copied = dict(item)
         copied["commands"] = list(_commands_for_inventory_item(item))
+        copied["codex_entrypoints"] = [
+            f"/{entrypoint}" for entrypoint in item.get("codex_entrypoints", ())
+        ]
         items.append(copied)
     statuses = sorted(
         {*CODEX_WORKFLOW_STATUS_VOCABULARY}
@@ -669,6 +884,17 @@ def workflow_inventory(*, runtime: str = "codex") -> dict[str, Any]:
         "entrypoint": CODEX_SKILL_RELATIVE_PATH,
         "repo_guidance": AGENTS_RELATIVE_PATH,
         "inventory_path": CODEX_WORKFLOW_INVENTORY_RELATIVE_PATH,
+        "plugin": {
+            "name": CODEX_PLUGIN_NAME,
+            "marketplace_path": CODEX_MARKETPLACE_RELATIVE_PATH,
+            "manifest_path": CODEX_PLUGIN_MANIFEST_RELATIVE_PATH,
+            "skill_path": CODEX_PLUGIN_SKILL_RELATIVE_PATH,
+            "command_paths": list(CODEX_PLUGIN_COMMAND_RELATIVE_PATHS),
+            "commands": [f"/{name}" for name in CODEX_COMMAND_NAMES],
+            "install_hint": (
+                "Open `/plugins`, choose the repo marketplace, then install Main Branch Owner Loop."
+            ),
+        },
         "statuses": statuses,
         "items": items,
         "safe_to_share": True,
@@ -681,12 +907,14 @@ def render_workflow_inventory_md() -> str:
     rows = []
     for item in CODEX_WORKFLOW_INVENTORY:
         commands = ", ".join(f"`{command}`" for command in _commands_for_inventory_item(item))
+        entrypoints = ", ".join(f"`/{entry}`" for entry in item.get("codex_entrypoints", ()))
         rows.append(
-            "| {label} | `{status}` | {claude} | {codex} | {commands} |".format(
+            "| {label} | `{status}` | {claude} | {codex} | {entrypoints} | {commands} |".format(
                 label=item["label"],
                 status=item["codex_status"],
                 claude=item["claude_surface"],
                 codex=item["codex_surface"],
+                entrypoints=entrypoints or "None",
                 commands=commands or "None",
             )
         )
@@ -702,8 +930,11 @@ def render_workflow_inventory_md() -> str:
         "- `generated_shell_pending`: a shared source exists, but a generated Codex "
         "shell still needs implementation and smoke evidence.\n"
         "- `intentionally_unsupported`: outside the current Codex owner-loop target.\n\n"
-        "| Workflow | Codex status | Claude Code surface | Codex surface | Fact commands |\n"
-        "|---|---|---|---|---|\n" + "\n".join(rows) + "\n\n"
+        "Codex plugin files live under `.agents/plugins/main-branch-owner-loop/` "
+        "and are listed by `.agents/plugins/marketplace.json` for `/plugins`.\n\n"
+        "| Workflow | Codex status | Claude Code surface | Codex surface | "
+        "Codex commands | Fact commands |\n"
+        "|---|---|---|---|---|---|\n" + "\n".join(rows) + "\n\n"
         "Codex must ask before durable writes, checkpoints, repairs, updates, "
         "migrations, provider mutation, publishing, spend, customer contact, or "
         "public issue/proposal submission.\n"
@@ -761,10 +992,134 @@ Ask before durable writes, checkpoints, updates, repairs, migrations, provider
 mutation, publishing, spend, customer contact, destructive operations, raw
 private-source reads, or public issue/proposal submission.
 
-Do not claim Claude Code slash commands work in Codex. Do not claim ads, site,
-organic, provider-write, wiki, or skill-authoring parity unless the inventory
-marks that surface `supported`.
+Do not claim Claude Code slash-skill parity in Codex. Do not claim ads, site,
+organic, provider mutation, wiki, or skill-authoring parity unless the
+inventory marks that surface `supported`.
 """
+
+
+def render_codex_plugin_manifest() -> str:
+    """Render the repo-scoped Codex plugin manifest."""
+
+    payload = {
+        "name": CODEX_PLUGIN_NAME,
+        "version": "0.1.0",
+        "description": (
+            "Main Branch owner-loop commands for Codex. Uses deterministic mb facts "
+            "and generated business-repo guidance."
+        ),
+        "author": {"name": "Noontide"},
+        "homepage": "https://github.com/noontide-co/mainbranch",
+        "repository": "https://github.com/noontide-co/mainbranch",
+        "license": "MIT",
+        "keywords": ["main-branch", "mainbranch", "owner-loop", "business-memory"],
+        "skills": "./skills/",
+        "interface": {
+            "displayName": "Main Branch Owner Loop",
+            "shortDescription": "Start, inspect, decide, and checkpoint from mb facts",
+            "longDescription": (
+                "Adds Codex-native owner-loop commands for Main Branch business repos. "
+                "The plugin routes through generated owner-loop guidance and direct "
+                "mb facts; it does not add provider mutation, publishing, spend, "
+                "customer contact, ads/site production, or all-skill parity."
+            ),
+            "developerName": "Noontide",
+            "category": "Productivity",
+            "capabilities": ["Interactive", "Read", "Write"],
+            "websiteURL": "https://github.com/noontide-co/mainbranch",
+            "defaultPrompt": [
+                "Start this Main Branch business day from mb facts",
+                "Show what Main Branch workflows Codex supports",
+                "Plan a Main Branch checkpoint before saving work",
+            ],
+            "brandColor": "#0F766E",
+            "screenshots": [],
+        },
+    }
+    return json.dumps(payload, indent=2) + "\n"
+
+
+def render_codex_marketplace_json() -> str:
+    """Render the repo-scoped Codex plugin marketplace metadata."""
+
+    payload = {
+        "name": "main-branch-local",
+        "interface": {"displayName": "Main Branch"},
+        "plugins": [
+            {
+                "name": CODEX_PLUGIN_NAME,
+                "source": {
+                    "source": "local",
+                    "path": f"./{CODEX_PLUGIN_DIR_RELATIVE_PATH}",
+                },
+                "policy": {
+                    "installation": "AVAILABLE",
+                    "authentication": "ON_INSTALL",
+                },
+                "category": "Productivity",
+            }
+        ],
+    }
+    return json.dumps(payload, indent=2) + "\n"
+
+
+def _command_definition(name: str) -> dict[str, Any]:
+    for command in CODEX_COMMAND_DEFINITIONS:
+        if command["name"] == name:
+            return command
+    raise KeyError(name)
+
+
+def render_codex_command_md(name: str) -> str:
+    """Render one thin Codex slash-command shim."""
+
+    command = _command_definition(name)
+    facts = "\n".join(f"- `{item}`" for item in command["commands"])
+    return f"""---
+description: {command["description"]}
+---
+
+# /{command["name"]}
+
+Use the Main Branch owner-loop skill and the business repo `AGENTS.md` guidance.
+This command is a thin Codex shim, not a separate workflow source.
+
+## Route
+
+{command["route"]}
+
+## Required Facts
+
+Run the direct `mb` facts that fit this request:
+
+{facts}
+
+Do not shell-wrap `mb` JSON through `jq`, temp files, redirects, or Python parsers.
+
+## Task
+
+{command["task"]}
+
+## Boundaries
+
+Ask before durable writes, checkpoints, updates, repairs, migrations, provider
+mutation, publishing, spend, customer contact, destructive operations,
+raw private-source reads, or public issue/proposal submission.
+
+Do not claim Claude Code skill parity, all-skill parity, ads/site production,
+provider mutation support, publishing support, spend support, or customer-contact
+support in Codex.
+"""
+
+
+def render_codex_plugin_skill_md() -> str:
+    """Render the plugin-packaged owner-loop skill.
+
+    Keep this equal to the generated project-local skill so drift tests catch
+    accidental second-source behavior.
+    """
+
+    return render_codex_skill_md()
 
 
 def agents_path(repo: str | Path) -> Path:
@@ -779,6 +1134,22 @@ def workflow_inventory_path(repo: str | Path) -> Path:
     return Path(repo).expanduser().resolve() / CODEX_WORKFLOW_INVENTORY_RELATIVE_PATH
 
 
+def marketplace_path(repo: str | Path) -> Path:
+    return Path(repo).expanduser().resolve() / CODEX_MARKETPLACE_RELATIVE_PATH
+
+
+def plugin_manifest_path(repo: str | Path) -> Path:
+    return Path(repo).expanduser().resolve() / CODEX_PLUGIN_MANIFEST_RELATIVE_PATH
+
+
+def plugin_skill_path(repo: str | Path) -> Path:
+    return Path(repo).expanduser().resolve() / CODEX_PLUGIN_SKILL_RELATIVE_PATH
+
+
+def plugin_command_path(repo: str | Path, name: str) -> Path:
+    return Path(repo).expanduser().resolve() / CODEX_PLUGIN_COMMANDS_RELATIVE_PATH / f"{name}.md"
+
+
 def executable_status() -> dict[str, Any]:
     path = _which("codex")
     return {
@@ -789,10 +1160,87 @@ def executable_status() -> dict[str, Any]:
     }
 
 
+def plugin_status(repo: str | Path) -> dict[str, Any]:
+    target = Path(repo).expanduser().resolve()
+    marketplace = marketplace_path(target)
+    manifest = plugin_manifest_path(target)
+    skill = plugin_skill_path(target)
+    expected_marketplace = render_codex_marketplace_json()
+    expected_manifest = render_codex_plugin_manifest()
+    expected_skill = render_codex_plugin_skill_md()
+    expected_commands = {name: render_codex_command_md(name) for name in CODEX_COMMAND_NAMES}
+
+    paths = {
+        CODEX_MARKETPLACE_RELATIVE_PATH: marketplace,
+        CODEX_PLUGIN_MANIFEST_RELATIVE_PATH: manifest,
+        CODEX_PLUGIN_SKILL_RELATIVE_PATH: skill,
+        **{
+            f"{CODEX_PLUGIN_COMMANDS_RELATIVE_PATH}/{name}.md": plugin_command_path(target, name)
+            for name in CODEX_COMMAND_NAMES
+        },
+    }
+    missing = [relative for relative, path in paths.items() if not path.is_file()]
+    stale: list[str] = []
+    read_errors: list[str] = []
+
+    expected_by_path = {
+        CODEX_MARKETPLACE_RELATIVE_PATH: expected_marketplace,
+        CODEX_PLUGIN_MANIFEST_RELATIVE_PATH: expected_manifest,
+        CODEX_PLUGIN_SKILL_RELATIVE_PATH: expected_skill,
+        **{
+            f"{CODEX_PLUGIN_COMMANDS_RELATIVE_PATH}/{name}.md": expected
+            for name, expected in expected_commands.items()
+        },
+    }
+    missing_markers: list[str] = []
+    for relative, path in paths.items():
+        if not path.is_file():
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            read_errors.append(f"{relative}: {exc}")
+            continue
+        if text != expected_by_path[relative]:
+            stale.append(relative)
+        if relative == CODEX_PLUGIN_MANIFEST_RELATIVE_PATH:
+            missing_markers.extend(
+                marker for marker in CODEX_PLUGIN_REQUIRED_MARKERS if marker not in text
+            )
+        elif relative.startswith(f"{CODEX_PLUGIN_COMMANDS_RELATIVE_PATH}/"):
+            missing_markers.extend(
+                f"{relative}: {marker}"
+                for marker in CODEX_COMMAND_REQUIRED_MARKERS
+                if marker not in text
+            )
+
+    ok = not missing and not stale and not read_errors and not missing_markers
+    return {
+        "ok": ok,
+        "exists": not missing,
+        "current": not stale and not missing_markers,
+        "marketplace_path": CODEX_MARKETPLACE_RELATIVE_PATH,
+        "manifest_path": CODEX_PLUGIN_MANIFEST_RELATIVE_PATH,
+        "skill_path": CODEX_PLUGIN_SKILL_RELATIVE_PATH,
+        "command_paths": list(CODEX_PLUGIN_COMMAND_RELATIVE_PATHS),
+        "commands": [f"/{name}" for name in CODEX_COMMAND_NAMES],
+        "missing": missing,
+        "stale": stale,
+        "missing_markers": missing_markers,
+        "read_errors": read_errors,
+        "repair": ""
+        if ok
+        else "Run `mb doctor repair --plan`, review, then `mb doctor repair --apply`.",
+        "repair_command": "mb doctor repair --apply",
+        "safe_to_share": True,
+    }
+
+
 def skill_status(repo: str | Path) -> dict[str, Any]:
     target = Path(repo).expanduser().resolve()
     skill = codex_skill_path(target)
     inventory = workflow_inventory_path(target)
+    plugin = plugin_status(target)
     skill_exists = skill.is_file()
     inventory_exists = inventory.is_file()
     expected_skill = render_codex_skill_md()
@@ -808,6 +1256,7 @@ def skill_status(repo: str | Path) -> dict[str, Any]:
             "path": CODEX_SKILL_RELATIVE_PATH,
             "inventory_path": CODEX_WORKFLOW_INVENTORY_RELATIVE_PATH,
             "missing_markers": list(CODEX_SKILL_REQUIRED_MARKERS),
+            "plugin": plugin,
             "read_error": str(exc),
             "repair": "Run `mb doctor repair --plan`, review, then `mb doctor repair --apply`.",
             "repair_command": "mb doctor repair --apply",
@@ -822,14 +1271,21 @@ def skill_status(repo: str | Path) -> dict[str, Any]:
         and skill_text == expected_skill
         and inventory_text == expected_inventory
     )
-    ok = bool(skill_exists and inventory_exists and not missing_markers and template_match)
+    ok = bool(
+        skill_exists
+        and inventory_exists
+        and not missing_markers
+        and template_match
+        and plugin["ok"]
+    )
     return {
         "ok": ok,
-        "exists": bool(skill_exists and inventory_exists),
-        "current": template_match,
+        "exists": bool(skill_exists and inventory_exists and plugin["exists"]),
+        "current": bool(template_match and plugin["current"]),
         "path": CODEX_SKILL_RELATIVE_PATH,
         "inventory_path": CODEX_WORKFLOW_INVENTORY_RELATIVE_PATH,
         "missing_markers": missing_markers,
+        "plugin": plugin,
         "read_error": "",
         "repair": ""
         if ok
@@ -853,7 +1309,7 @@ def instructions_status(repo: str | Path) -> dict[str, Any]:
         read_error = ""
     missing_commands = [command for command in REQUIRED_FACT_COMMANDS if command not in text]
     approval_ok = "explicit operator approval" in text
-    slash_ok = "Do not pretend Claude" in text and "slash commands exist in Codex." in text
+    slash_ok = "Do not pretend Claude Code skills work in Codex." in text
     missing_lifecycle_guidance = [
         marker for marker in REQUIRED_LIFECYCLE_GUIDANCE_MARKERS if marker not in text
     ]
@@ -899,6 +1355,7 @@ def readiness(repo: str | Path) -> dict[str, Any]:
         "executable": executable,
         "instructions": instructions,
         "skill": instructions["skill"],
+        "plugin": instructions["skill"]["plugin"],
         "workflow_inventory": workflow_inventory(),
         "fact_commands": list(REQUIRED_FACT_COMMANDS),
         "repair": "" if ok else instructions["repair"] or executable["repair"],
@@ -961,6 +1418,41 @@ def write_agents_md(
     if existing_inventory != rendered_inventory:
         inventory_path.write_text(rendered_inventory, encoding="utf-8")
         changed_paths.append(CODEX_WORKFLOW_INVENTORY_RELATIVE_PATH)
+
+    marketplace = marketplace_path(target)
+    marketplace.parent.mkdir(parents=True, exist_ok=True)
+    rendered_marketplace = render_codex_marketplace_json()
+    existing_marketplace = marketplace.read_text(encoding="utf-8") if marketplace.exists() else ""
+    if existing_marketplace != rendered_marketplace:
+        marketplace.write_text(rendered_marketplace, encoding="utf-8")
+        changed_paths.append(CODEX_MARKETPLACE_RELATIVE_PATH)
+
+    manifest = plugin_manifest_path(target)
+    manifest.parent.mkdir(parents=True, exist_ok=True)
+    rendered_manifest = render_codex_plugin_manifest()
+    existing_manifest = manifest.read_text(encoding="utf-8") if manifest.exists() else ""
+    if existing_manifest != rendered_manifest:
+        manifest.write_text(rendered_manifest, encoding="utf-8")
+        changed_paths.append(CODEX_PLUGIN_MANIFEST_RELATIVE_PATH)
+
+    plugin_skill = plugin_skill_path(target)
+    plugin_skill.parent.mkdir(parents=True, exist_ok=True)
+    rendered_plugin_skill = render_codex_plugin_skill_md()
+    existing_plugin_skill = (
+        plugin_skill.read_text(encoding="utf-8") if plugin_skill.exists() else ""
+    )
+    if existing_plugin_skill != rendered_plugin_skill:
+        plugin_skill.write_text(rendered_plugin_skill, encoding="utf-8")
+        changed_paths.append(CODEX_PLUGIN_SKILL_RELATIVE_PATH)
+
+    for command_name in CODEX_COMMAND_NAMES:
+        command_path = plugin_command_path(target, command_name)
+        command_path.parent.mkdir(parents=True, exist_ok=True)
+        rendered_command = render_codex_command_md(command_name)
+        existing_command = command_path.read_text(encoding="utf-8") if command_path.exists() else ""
+        if existing_command != rendered_command:
+            command_path.write_text(rendered_command, encoding="utf-8")
+            changed_paths.append(f"{CODEX_PLUGIN_COMMANDS_RELATIVE_PATH}/{command_name}.md")
     return {
         "ok": True,
         "path": AGENTS_RELATIVE_PATH,

--- a/mb/mb/doctor.py
+++ b/mb/mb/doctor.py
@@ -2029,12 +2029,14 @@ def repair_plan(
             "name": "AGENTS.md",
             "state": "ok" if codex_instruction_status["ok"] else "warn",
             "summary": (
-                "Codex instructions and owner-loop skill are current and include "
-                "mb fact grounding, lifecycle routes, and workflow inventory"
+                "Codex instructions, owner-loop skill, plugin commands, and marketplace "
+                "are current and include mb fact grounding, lifecycle routes, "
+                "and workflow inventory"
                 if codex_instruction_status["ok"]
                 else (
-                    "Codex instructions or owner-loop skill files are missing, stale, "
-                    "or missing mb fact grounding or lifecycle discovery guidance"
+                    "Codex instructions, owner-loop skill, plugin, marketplace, or command "
+                    "files are missing, stale, or missing mb fact grounding or lifecycle "
+                    "discovery guidance"
                 )
             ),
             "missing_fact_commands": codex_instruction_status["missing_fact_commands"],
@@ -2055,14 +2057,18 @@ def repair_plan(
             command="mb doctor repair --apply",
             safe_to_apply=True,
             reason=(
-                "AGENTS.md and .agents/skills are the tracked Codex entrypoints; "
-                "repair writes the current owner-loop workflow index, fact grounding, "
-                "and approval boundaries"
+                "AGENTS.md, .agents/skills, and .agents/plugins are the tracked Codex "
+                "entrypoints; repair writes the current owner-loop plugin, command "
+                "shims, workflow index, fact grounding, and approval boundaries"
             ),
             writes=[
                 "AGENTS.md",
                 codex_mod.CODEX_SKILL_RELATIVE_PATH,
                 codex_mod.CODEX_WORKFLOW_INVENTORY_RELATIVE_PATH,
+                codex_mod.CODEX_MARKETPLACE_RELATIVE_PATH,
+                codex_mod.CODEX_PLUGIN_MANIFEST_RELATIVE_PATH,
+                codex_mod.CODEX_PLUGIN_SKILL_RELATIVE_PATH,
+                *codex_mod.CODEX_PLUGIN_COMMAND_RELATIVE_PATHS,
             ],
         )
         actions.append(action)
@@ -2073,8 +2079,8 @@ def repair_plan(
             "Codex CLI Adapter",
             _max_state([str(item["state"]) for item in codex_checks]),
             (
-                "First-class owner-loop adapter instructions, native skill, "
-                "workflow inventory, and executable readiness"
+                "First-class owner-loop adapter instructions, native skill, plugin "
+                "commands, workflow inventory, marketplace, and executable readiness"
             ),
             checks=codex_checks,
             actions=codex_actions,
@@ -2419,6 +2425,10 @@ def repair_apply(repo: str | Path = ".", *, include_migration: bool = False) -> 
                     "AGENTS.md",
                     codex_mod.CODEX_SKILL_RELATIVE_PATH,
                     codex_mod.CODEX_WORKFLOW_INVENTORY_RELATIVE_PATH,
+                    codex_mod.CODEX_MARKETPLACE_RELATIVE_PATH,
+                    codex_mod.CODEX_PLUGIN_MANIFEST_RELATIVE_PATH,
+                    codex_mod.CODEX_PLUGIN_SKILL_RELATIVE_PATH,
+                    *codex_mod.CODEX_PLUGIN_COMMAND_RELATIVE_PATHS,
                 ],
                 applied=bool(agents["changed"]),
                 result=agents,

--- a/mb/mb/onboard.py
+++ b/mb/mb/onboard.py
@@ -332,6 +332,14 @@ def _setup_complete(repo: Path, *, github_requested: bool = False) -> dict[str, 
         "github_requested": github_requested,
         "claude_code_handoff_ready": bool(wiring.get("ok")),
         "codex_instructions_present": (repo / "AGENTS.md").is_file(),
+        "codex_plugin_present": (
+            repo
+            / ".agents"
+            / "plugins"
+            / "main-branch-owner-loop"
+            / ".codex-plugin"
+            / "plugin.json"
+        ).is_file(),
         "owner_outcome": (
             "This business folder is created, saved, synced to GitHub, and ready to open "
             "in Claude Code."
@@ -625,11 +633,20 @@ def _normalize_mode(mode: str, existing: bool) -> str:
 
 
 def _next_steps(repo: Path) -> list[str]:
-    return [
+    steps = [
         f"cd {repo}",
         "claude",
         "/mb-start",
     ]
+    if _which("codex"):
+        steps.extend(
+            [
+                f"codex -C {repo}",
+                "/plugins -> install Main Branch Owner Loop",
+                "/mb-start",
+            ]
+        )
+    return steps
 
 
 def _has_any_file(paths: list[Path]) -> bool:

--- a/mb/mb/onboard.py
+++ b/mb/mb/onboard.py
@@ -641,6 +641,7 @@ def _next_steps(repo: Path) -> list[str]:
     if _which("codex"):
         steps.extend(
             [
+                f"codex plugin marketplace add {repo}",
                 f"codex -C {repo}",
                 "/plugins -> install Main Branch Owner Loop",
                 "/mb-start",

--- a/mb/mb/start.py
+++ b/mb/mb/start.py
@@ -241,13 +241,14 @@ def _build_checks(
                 "ok": bool(codex_instructions.get("ok")),
                 "severity": "warn" if codex_found else "info",
                 "detail": (
-                    "AGENTS.md and Codex owner-loop skill point Codex to mb facts, "
-                    "lifecycle routes, and workflow inventory"
+                    "AGENTS.md, Codex owner-loop skill, plugin commands, and marketplace "
+                    "point Codex to mb facts, lifecycle routes, and workflow inventory"
                 )
                 if codex_instructions.get("ok")
                 else (
-                    "Codex AGENTS.md or owner-loop skill files are missing, stale, "
-                    "or missing required mb fact commands or lifecycle discovery guidance"
+                    "Codex AGENTS.md, owner-loop skill, plugin, marketplace, or command "
+                    "files are missing, stale, or missing required mb fact commands or "
+                    "lifecycle discovery guidance"
                 ),
                 "repair": codex_instructions.get("repair") if codex_found else "",
             },
@@ -324,8 +325,9 @@ def run(repo: str = ".", launch: bool = False) -> dict[str, Any]:
             "argv": ["codex", "-C", str(repo_path)],
             "display": _codex_display_command(repo_path),
             "startup_prompt": (
-                "Start this Main Branch business day. Run only read-only mb checks "
-                "before advice and ask before writes."
+                "Start this Main Branch business day with /mb-start if the Main Branch "
+                "plugin is installed; otherwise run only read-only mb checks before "
+                "advice and ask before writes."
             ),
         }
 

--- a/mb/tests/test_doctor.py
+++ b/mb/tests/test_doctor.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from typer.testing import CliRunner
 
+from mb import codex as codex_mod
 from mb import doctor as doctor_mod
 from mb import engine as engine_mod
 from mb import migration_lint
@@ -430,6 +431,44 @@ def test_doctor_repair_apply_refreshes_codex_agents_md(tmp_path: Path) -> None:
     )
     assert "Main Branch owner loop for Codex" in skill_text
     assert "mb workflow list --runtime codex --json" in skill_text
+    plugin_skill_text = (repo / codex_mod.CODEX_PLUGIN_SKILL_RELATIVE_PATH).read_text(
+        encoding="utf-8"
+    )
+    command_text = (
+        repo / ".agents" / "plugins" / "main-branch-owner-loop" / "commands" / "mb-start.md"
+    ).read_text(encoding="utf-8")
+    marketplace_text = (repo / codex_mod.CODEX_MARKETPLACE_RELATIVE_PATH).read_text(
+        encoding="utf-8"
+    )
+    assert plugin_skill_text == skill_text
+    assert "Main Branch Owner Loop" in (
+        repo / codex_mod.CODEX_PLUGIN_MANIFEST_RELATIVE_PATH
+    ).read_text(encoding="utf-8")
+    assert "thin Codex shim" in command_text
+    assert "mb start --json" in command_text
+    assert "main-branch-owner-loop" in marketplace_text
+
+
+def test_doctor_repair_refreshes_stale_codex_plugin_command(tmp_path: Path) -> None:
+    repo = tmp_path / "biz"
+    init_run(path=str(repo), name="Acme")
+    command = repo / ".agents" / "plugins" / "main-branch-owner-loop" / "commands" / "mb-start.md"
+    command.write_text("# stale\n", encoding="utf-8")
+
+    plan_result = runner.invoke(app, ["doctor", "repair", "--repo", str(repo), "--plan", "--json"])
+    assert plan_result.exit_code in {0, 1}
+    plan = json.loads(plan_result.stdout)
+    actions = {action["id"]: action for action in plan["actions"]}
+    assert "codex-agents-md" in actions
+    assert str(command.relative_to(repo)) in actions["codex-agents-md"]["writes"]
+
+    apply_result = runner.invoke(
+        app, ["doctor", "repair", "--repo", str(repo), "--apply", "--json"]
+    )
+    assert apply_result.exit_code in {0, 1}
+    command_text = command.read_text(encoding="utf-8")
+    assert "thin Codex shim" in command_text
+    assert "provider mutation" in command_text
 
 
 def test_doctor_repair_preserves_custom_codex_agents_md_when_contract_is_current(

--- a/mb/tests/test_init.py
+++ b/mb/tests/test_init.py
@@ -102,19 +102,22 @@ def _assert_agents_md_codex_start_contract(text: str) -> None:
     normalized = _normalize(text)
     assert "## Codex Operating Contract" in text
     assert "Do not pretend Claude" in text
-    assert "slash commands exist in Codex." in text
+    assert "Code skills work in Codex." in text
     assert "## Codex Lifecycle Workflow Index" in text
     assert "repo-level Codex bootstrap" in text
     assert ".agents/skills/main-branch-owner-loop/SKILL.md" in text
+    assert ".agents/plugins/main-branch-owner-loop/" in text
     assert "Use `.agents/skills/main-branch-owner-loop`" in text
     assert "Start the day / what next / get oriented" in text
+    assert "generated Codex plugin is installed" in text
     assert "Inspect status / what changed / what is stale" in text
     assert "Think / research / decide / codify" in text
     assert "do not claim these workflows are ported to" in text
+    assert "/plugins" in text
     assert "## Codex Start Workflow" in text
-    assert "This is the Codex-native port of `/mb-start`" in text
+    assert "This is the Codex-native port behind `/mb-start`" in text
     assert "## Codex Status Workflow" in text
-    assert "This is the Codex-native status route" in text
+    assert "This is the Codex-native status route behind `/mb-status`" in text
     assert "since_last_check" in text
     assert "## Codex Think Route" in text
     assert "existing `mb-think` shared workflow" in text
@@ -204,6 +207,22 @@ def test_init_scaffolds_folders(tmp_path: Path) -> None:
         / "references"
         / "workflow-inventory.md"
     ).exists()
+    assert (
+        target / ".agents" / "plugins" / "main-branch-owner-loop" / ".codex-plugin" / "plugin.json"
+    ).exists()
+    assert (
+        target
+        / ".agents"
+        / "plugins"
+        / "main-branch-owner-loop"
+        / "skills"
+        / "main-branch-owner-loop"
+        / "SKILL.md"
+    ).exists()
+    assert (
+        target / ".agents" / "plugins" / "main-branch-owner-loop" / "commands" / "mb-start.md"
+    ).exists()
+    assert (target / ".agents" / "plugins" / "marketplace.json").exists()
     assert (target / ".github" / "CODEOWNERS").exists()
     assert (target / ".gitignore").exists()
     assert (target / ".mb" / "schema_version").read_text(encoding="utf-8") == "0.2\n"
@@ -244,6 +263,9 @@ def test_init_scaffolds_folders(tmp_path: Path) -> None:
     assert "Acme Brewing" in agents_md
     assert "Acme Brewing" in readme_md
     assert "/mb-start" in readme_md
+    assert "Codex CLI" in readme_md
+    assert "/plugins" in readme_md
+    assert "Main Branch Owner Loop" in readme_md
     assert "## Save, Checkpoint, Backup" in readme_md
     assert "A checkpoint is an approved saved point" in readme_md
     assert "GitHub backup/sync is strongly recommended" in readme_md

--- a/mb/tests/test_init.py
+++ b/mb/tests/test_init.py
@@ -264,6 +264,7 @@ def test_init_scaffolds_folders(tmp_path: Path) -> None:
     assert "Acme Brewing" in readme_md
     assert "/mb-start" in readme_md
     assert "Codex CLI" in readme_md
+    assert "codex plugin marketplace add ." in readme_md
     assert "/plugins" in readme_md
     assert "Main Branch Owner Loop" in readme_md
     assert "## Save, Checkpoint, Backup" in readme_md

--- a/mb/tests/test_onboard.py
+++ b/mb/tests/test_onboard.py
@@ -27,6 +27,12 @@ def _tool_path(name: str) -> str:
     return ""
 
 
+def _tool_path_with_codex(name: str) -> str:
+    if name == "codex":
+        return "/usr/local/bin/codex"
+    return _tool_path(name)
+
+
 def _normalize(text: str) -> str:
     return " ".join(text.split())
 
@@ -84,6 +90,30 @@ def test_onboard_yes_creates_repo_and_reports_next_steps(tmp_path: Path, monkeyp
     assert any(
         "gh auth login" in warning or "GitHub CLI" in warning for warning in result["warnings"]
     )
+
+
+def test_onboard_next_steps_register_codex_marketplace_when_available(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(onboard_mod, "_which", _tool_path_with_codex)
+    repo = tmp_path / "acme"
+
+    result = onboard_mod.run(
+        path=str(repo),
+        name="Acme Brewing",
+        mode="new",
+        level="beginner",
+    )
+
+    assert result["next_steps"] == [
+        f"cd {repo.resolve()}",
+        "claude",
+        "/mb-start",
+        f"codex plugin marketplace add {repo.resolve()}",
+        f"codex -C {repo.resolve()}",
+        "/plugins -> install Main Branch Owner Loop",
+        "/mb-start",
+    ]
 
 
 def test_onboard_rerun_is_idempotent(tmp_path: Path, monkeypatch) -> None:

--- a/mb/tests/test_runtime_command_references.py
+++ b/mb/tests/test_runtime_command_references.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
+from mb import codex as codex_mod
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 MAIN_BRANCH_COMMAND_RE = re.compile(
@@ -59,16 +61,22 @@ def _line_context(lines: list[str], index: int) -> str:
 
 def test_runtime_docs_reference_only_bundled_main_branch_slash_commands() -> None:
     bundled = _bundled_slash_commands()
+    codex_plugin_commands = set(codex_mod.CODEX_COMMAND_NAMES)
     failures: list[str] = []
 
     for path in _scan_paths():
         rel = path.relative_to(REPO_ROOT)
-        for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        lines = path.read_text(encoding="utf-8").splitlines()
+        for index, line in enumerate(lines):
             for match in MAIN_BRANCH_COMMAND_RE.finditer(line):
                 command_name = match.group("name")
                 if command_name in bundled:
                     continue
-                failures.append(f"{rel}:{line_number}: /{command_name} is not a bundled skill")
+                if command_name in codex_plugin_commands:
+                    context = _line_context(lines, index)
+                    if "codex" in context and "plugin" in context:
+                        continue
+                failures.append(f"{rel}:{index + 1}: /{command_name} is not a bundled skill")
 
     assert failures == []
 

--- a/mb/tests/test_workflows.py
+++ b/mb/tests/test_workflows.py
@@ -145,6 +145,8 @@ def test_codex_contract_markers_match_think_workflow_source() -> None:
 def test_codex_owner_loop_skill_and_inventory_render() -> None:
     skill = codex_mod.render_codex_skill_md()
     inventory = codex_mod.render_workflow_inventory_md()
+    manifest = codex_mod.render_codex_plugin_manifest()
+    marketplace = codex_mod.render_codex_marketplace_json()
 
     assert "Main Branch owner loop for Codex" in skill
     assert "mb workflow list --runtime codex --json" in skill
@@ -152,9 +154,39 @@ def test_codex_owner_loop_skill_and_inventory_render() -> None:
     assert "think/codify" in skill
     assert "end/checkpoint/save" in skill
     assert "Ask before durable writes" in skill
+    assert "Main Branch Owner Loop" in manifest
+    assert '"skills": "./skills/"' in manifest
+    assert '"path": "./.agents/plugins/main-branch-owner-loop"' in marketplace
+    assert "Codex plugin files live under `.agents/plugins/main-branch-owner-loop/`" in inventory
+    assert "`/mb-start`" in inventory
     assert "pending_shared_source_migration" in inventory
     assert "intentionally_unsupported" in inventory
     assert "Copied Claude" not in skill
+
+
+def test_codex_plugin_skill_matches_generated_owner_loop_skill() -> None:
+    assert codex_mod.render_codex_plugin_skill_md() == codex_mod.render_codex_skill_md()
+
+
+def test_codex_plugin_commands_are_thin_owner_loop_shims() -> None:
+    for command in codex_mod.CODEX_COMMAND_NAMES:
+        text = codex_mod.render_codex_command_md(command)
+        assert f"# /{command}" in text
+        assert "Main Branch owner-loop skill" in text
+        assert "thin Codex shim" in text
+        assert "mb status --json --peek" in text or command in {
+            "mb-doctor",
+            "mb-checkpoint",
+            "mb-validate",
+            "mb-workflows",
+            "mb-help",
+        }
+        assert "Ask before durable writes" in text
+        assert "provider mutation" in text
+        assert "publishing" in text
+        assert "customer contact" in text
+        assert "Do not claim Claude Code skill parity" in text
+        assert "Do not shell-wrap `mb` JSON" in text
 
 
 def test_codex_owner_loop_skill_frontmatter_is_valid_yaml() -> None:
@@ -181,8 +213,15 @@ def test_codex_workflow_inventory_command_lists_supported_and_pending_surfaces()
     }.issubset(statuses)
     by_id = {item["id"]: item for item in data["items"]}
     assert by_id["think-codify"]["codex_status"] == "supported"
+    assert by_id["think-codify"]["codex_entrypoints"] == ["/mb-think"]
+    assert by_id["owner-loop-start-status"]["codex_entrypoints"] == [
+        "/mb-start",
+        "/mb-status",
+    ]
     assert by_id["ads"]["codex_status"] == "pending_shared_source_migration"
     assert by_id["wiki"]["codex_status"] == "intentionally_unsupported"
+    assert data["plugin"]["manifest_path"] == codex_mod.CODEX_PLUGIN_MANIFEST_RELATIVE_PATH
+    assert "/mb-start" in data["plugin"]["commands"]
 
 
 def test_codex_workflow_inventory_json_unsupported_runtime_uses_error_envelope() -> None:

--- a/mb/tests/test_workflows.py
+++ b/mb/tests/test_workflows.py
@@ -147,6 +147,7 @@ def test_codex_owner_loop_skill_and_inventory_render() -> None:
     inventory = codex_mod.render_workflow_inventory_md()
     manifest = codex_mod.render_codex_plugin_manifest()
     marketplace = codex_mod.render_codex_marketplace_json()
+    inventory_json = codex_mod.workflow_inventory(runtime="codex")
 
     assert "Main Branch owner loop for Codex" in skill
     assert "mb workflow list --runtime codex --json" in skill
@@ -158,6 +159,12 @@ def test_codex_owner_loop_skill_and_inventory_render() -> None:
     assert '"skills": "./skills/"' in manifest
     assert '"path": "./.agents/plugins/main-branch-owner-loop"' in marketplace
     assert "Codex plugin files live under `.agents/plugins/main-branch-owner-loop/`" in inventory
+    assert "codex plugin marketplace add ." in inventory
+    assert (
+        inventory_json["plugin"]["install_hint"]
+        == "Run `codex plugin marketplace add .`, open `/plugins`, choose the repo "
+        "marketplace, then install Main Branch Owner Loop."
+    )
     assert "`/mb-start`" in inventory
     assert "pending_shared_source_migration" in inventory
     assert "intentionally_unsupported" in inventory

--- a/workflows/mb-start-money-path/workflow.md
+++ b/workflows/mb-start-money-path/workflow.md
@@ -220,7 +220,9 @@ Codex is first-class for the proven owner loop only. Rendered Codex shell
 snapshots must start from generated `AGENTS.md` style grounding and
 deterministic `mb` facts.
 
-Do not say `/mb-start` works inside Codex. Do not claim broader Codex workflow
-support until a fresh fixture repo and read-only `codex exec --json --ephemeral
---sandbox read-only -C <repo>` smoke prove the generated shell is actually
-used.
+When the generated Main Branch Owner Loop plugin is installed, `/mb-start` is
+the Codex owner-loop command for this route. Without the plugin, use the
+generated Codex shell fallback in `AGENTS.md` and natural-language routing from
+read-only `mb` facts. Do not claim broader Codex workflow support until a fresh
+fixture repo and read-only `codex exec --json --ephemeral --sandbox read-only
+-C <repo>` smoke prove the generated shell or plugin route is actually used.

--- a/workflows/mb-think/workflow.md
+++ b/workflows/mb-think/workflow.md
@@ -297,7 +297,9 @@ Codex is first-class for the proven owner loop only. Rendered Codex shell
 snapshots must start from generated `AGENTS.md` style grounding, deterministic
 `mb` facts, and natural-language workflow routing.
 
-Do not say `/mb-think` works inside Codex. Do not say "Run `/mb-think`." Do
-not claim broader Codex workflow support until a fresh fixture repo and read-only
-`codex exec --json --ephemeral --sandbox read-only -C <repo>` smoke prove the
-guidance is actually used.
+When the generated Main Branch Owner Loop plugin is installed, `/mb-think` is
+the Codex owner-loop command for this route. Without the plugin, use the
+generated Codex shell fallback in `AGENTS.md` and natural-language routing from
+read-only `mb` facts. Do not claim broader Codex workflow support until a fresh
+fixture repo and read-only `codex exec --json --ephemeral --sandbox read-only
+-C <repo>` smoke prove the generated guidance or plugin route is actually used.


### PR DESCRIPTION
## Summary

Adds a repo-scoped Codex plugin surface for the Main Branch owner loop, including local marketplace metadata, plugin manifest, plugin-packaged owner-loop skill, and thin `/mb-*` command shims. Updates generated guidance, repair/status/workflow inventory, docs, decisions, and tests so Codex users can register the repo marketplace, discover the supported owner-loop path, and avoid creating a second source of truth.

## Linked issue

Closes #682

## Why

Codex was first-class for generated owner-loop guidance, but the daily-driver affordance still depended on users finding files and commands manually. This makes the supported Main Branch owner loop visible through Codex plugin and command surfaces while keeping shared workflow sources and deterministic `mb` facts authoritative.

## Commits by concern

- `4aa7d5e [add] MAIN-423 Codex owner-loop plugin surface`
- `0702423 [fix] MAIN-423 register Codex marketplace before install`
- `167240b [fix] MAIN-423 align Codex plugin support language`
- `513b6a6 [fix] MAIN-423 clarify historical Codex decisions`
- [ ] Each commit body bullet-lists the changes in that commit
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`

## Validation

Pre-push gate from repo root:

```bash
scripts/check.sh
```

- [x] Level 1 static: `scripts/check.sh` passes
- [x] Level 2 CLI contract: focused Typer/CliRunner tests, exit codes, `--json` behavior, TTY vs non-TTY (if CLI behavior touched)
- [x] Level 3 package/install smoke (if packaging touched)
- [x] Level 4 fixture repo (if init/onboard/status/start/update touched)
- [x] Level 5 runtime smoke / dogfood harness / simulation-tier (if runtime, first-run, skill discovery, or release validation touched)
- [x] SKILL.md ≤500 lines (if any skill touched)
- [ ] Package-visible release gate evidence before tag/publish (if preparing a release)
- [ ] Supply-chain review (if `.github/workflows/`, `.github/dependabot.yml`, `mb/pyproject.toml` deps, or `id-token`/`permissions` blocks touched — see [docs/supply-chain-policy.md](../docs/supply-chain-policy.md))

Level 1 static: `scripts/check.sh` — runtime: repo Python environment — exit: 0 — log: formatting, ruff, mypy, 776 tests, and `mb skill validate` passed after review fixes.
Level 2 CLI contract: `cd mb && pytest tests/test_workflows.py tests/test_init.py tests/test_doctor.py tests/test_onboard.py tests/test_start.py -q` — runtime: repo Python environment — exit: 0 — log: `125 passed in 160.10s`; targeted marketplace-registration assertions passed with `3 passed in 2.07s`; targeted workflow/template checks passed with `26 passed in 0.91s`.
Level 3 package/install: `(cd mb && python3 -m build) && /tmp/mainbranch-smoke/bin/pip install mb/dist/*.whl && /tmp/mainbranch-smoke/bin/mb --version && /tmp/mainbranch-smoke/bin/mb skill list` — runtime: `/tmp/mainbranch-smoke` venv — exit: 0 — log: built `mainbranch-0.3.28` wheel, installed it, and verified `mb 0.3.28` plus skill listing.
Level 4 fixture repo: `/tmp/mainbranch-smoke/bin/mb onboard --yes --name "Codex Plugin Smoke Business" --path /tmp/mainbranch-codex-smoke/business` plus doctor/status/start/validate/workflow commands — runtime: `/tmp/mainbranch-smoke` venv — exit: 0 — log: plugin manifest, marketplace, `/mb-start` command, workflow plugin metadata, and start/status plugin readiness all verified.
Level 5 runtime smoke: `codex plugin marketplace add`, `codex plugin add`, and authenticated `codex exec --json --ephemeral --sandbox read-only ...` from the fresh business repo — runtime: `codex-cli 0.133.0` plus `/tmp/mainbranch-smoke/bin/mb` — exit: 0 — log: plugin installed/enabled; Codex read the generated owner-loop skill and ran direct read-only `mb` facts without editing files.
Not required: package-visible release gate before tag/publish because this PR is not tagging or publishing a release; supply-chain review because no workflow, Dependabot, dependency, `id-token`, or permissions files changed.

## Success metric

A fresh `mb onboard` business repo tells users to run `codex plugin marketplace add .`, exposes Main Branch in Codex through `/plugins`, installs the local owner-loop plugin, and routes supported `/mb-*` owner-loop commands through direct deterministic `mb` facts.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [ ] N/A — change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [x] No
- [ ] Yes — migration note below

## Public / private boundary

No private operator strategy, machine-specific paths, credentials, raw customer/member data, or runtime internals were committed. Smoke evidence stayed in `.context` or `/tmp`, and generated plugin files remain repo-local adapters over public-safe workflow guidance and deterministic `mb` facts.
