### PR TITLE
[update] Prepare v0.3.29 release

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mainbranch",
-  "version": "0.3.28",
+  "version": "0.3.29",
   "description": "Main Branch Claude Code skills for running a business from markdown files in git.",
   "author": {
     "name": "Noontide"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+## [0.3.29] - 2026-05-22
+
+v0.3.29 packages the owner-loop hardening batch after v0.3.28. It tightens
+release dogfood grounding, checkpoint subject semantics, public-safe team
+member context, and the repo-scoped Codex owner-loop plugin/command surface
+while keeping broader Codex slash-command parity, all-skill parity,
+provider-write, publishing, spend, and customer-contact workflows out of scope.
+
 ### Added
 
 - Added a public-safe `core/team/<slug>.md` team member primitive, onboarding

--- a/mb/mb/__init__.py
+++ b/mb/mb/__init__.py
@@ -7,6 +7,6 @@ file stays a thin dispatcher.
 
 from __future__ import annotations
 
-__version__ = "0.3.28"
+__version__ = "0.3.29"
 
 __all__ = ["__version__"]

--- a/mb/mb/codex.py
+++ b/mb/mb/codex.py
@@ -437,7 +437,7 @@ CODEX_WORKFLOW_INVENTORY: tuple[dict[str, Any], ...] = (
         "codex_status": "intentionally_unsupported",
         "codex_surface": "None",
         "commands": (),
-        "notes": "Specialty workflow outside the v0.3.28 owner-loop parity target.",
+        "notes": "Specialty workflow outside the owner-loop support target.",
     },
     {
         "id": "skill-authoring",

--- a/mb/pyproject.toml
+++ b/mb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mainbranch"
-version = "0.3.28"
+version = "0.3.29"
 description = "Main Branch engine umbrella - scaffolds, validates, and graphs business-as-files repos. Claude Code first, runtime-agnostic by design."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Prepares the v0.3.29 release by dating the changelog section, bumping package and plugin version surfaces to `0.3.29`, and keeping Codex owner-loop inventory copy version-neutral.

## Linked issue

Refs #681 / MAIN-422

## Why

v0.3.29 packages the merged owner-loop hardening batch after v0.3.28: safer release dogfood grounding, stricter checkpoint subject semantics, public-safe team member context, and the repo-scoped Codex owner-loop plugin/command surface. The release prep needs package-visible version surfaces and release notes aligned without claiming post-publish verification before GitHub Release and PyPI publication.

## Commits by concern

- [x] Each commit body bullet-lists the changes in that commit
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`

Commit:

- `5fdb57e [update] Prepare v0.3.29 release`

## Validation

Pre-push gate from repo root:

```bash
scripts/check.sh
```

- [x] Level 1 static: `scripts/check.sh` passes
- [x] Level 2 CLI contract: focused Typer/CliRunner tests, exit codes, `--json` behavior, TTY vs non-TTY (if CLI behavior touched)
- [x] Level 3 package/install smoke (if packaging touched)
- [x] Level 4 fixture repo (if init/onboard/status/start/update touched)
- [x] Level 5 runtime smoke / dogfood harness / simulation-tier (if runtime, first-run, skill discovery, or release validation touched)
- [x] SKILL.md <=500 lines (if any skill touched)
- [x] Package-visible release gate evidence before tag/publish (if preparing a release)
- [x] Supply-chain review (if `.github/workflows/`, `.github/dependabot.yml`, `mb/pyproject.toml` deps, or `id-token`/`permissions` blocks touched — see [docs/supply-chain-policy.md](../docs/supply-chain-policy.md))

Evidence:

- Level 0 release preflight: version surface scan + `python3 -m pytest tests/test_smoke_coverage.py::test_claude_plugin_manifest_points_at_prefixed_skills -q` — runtime: `python3` — exit: 0 — log: `.agent/release-evidence/0.3.29/release-file-preflight.out`.
- Level 1 static: `scripts/check.sh` — runtime: `python3` — exit: 0 — log: `.agent/release-evidence/0.3.29/check-after-codex-note.out`.
- Level 2 CLI contract: focused workflow, dogfood harness, release simulation, checkpoint, team validation/status/init tests — runtime: `python3` — exit: 0 — log: `.agent/release-evidence/0.3.29/focused-tests.out`.
- Level 3 package/install: `(cd mb && python3 -m build)` plus fresh venv install of `mb/dist/mainbranch-0.3.29-py3-none-any.whl`, `mb --version`, and `mb skill list` — runtime: `/tmp/mainbranch-smoke-0.3.29/bin/python3` — exit: 0 — logs: `.agent/release-evidence/0.3.29/build-final.out`, `.agent/release-evidence/0.3.29/install-final.out`.
- Level 4 fixture repo: installed-wheel `mb onboard --yes`, `mb doctor`, `mb status --json --peek`, `mb start --json`, `mb validate`, `mb workflow list --runtime codex --json` — runtime: `/tmp/mainbranch-smoke-0.3.29/bin/mb` — exit: 0 — log: `.agent/release-evidence/0.3.29/fixture-smoke-final.out`.
- Level 5 runtime smoke: Codex CLI read-only owner-loop smoke from the fresh installed-package business repo — runtime: `codex-cli 0.133.0` with wheel-installed `mb 0.3.29` on `PATH` — exit: 0 — log: `.agent/release-evidence/0.3.29/codex-smoke.out`.
- Level 5 release simulations: `scripts/claude-runtime-dogfood.py --install-mode wheel --wheel mb/dist/mainbranch-0.3.29-py3-none-any.whl --run-claude-print --simulation-tier prerelease_candidate --max-budget-usd 0.75` — runtime: `python3` / Claude Code `2.1.140` — exit: 0 — evidence: `.agent/release-evidence/0.3.29/prerelease-candidate/`.
- Level 5 release simulations: `scripts/claude-runtime-dogfood.py --install-mode wheel --wheel mb/dist/mainbranch-0.3.29-py3-none-any.whl --run-claude-print --simulation-tier release_acceptance --max-budget-usd 0.75` — runtime: `python3` / Claude Code `2.1.140` — exit: 0 — evidence: `.agent/release-evidence/0.3.29/release-acceptance/`.
- Release spot checks: checkpoint subject metadata/accept/reject, generated team member file/status handle resolution, Codex plugin visibility/support boundary, dogfood direct-facts guardrails, public/private diff scan, supply-chain preflight — exit: 0 — logs: `.agent/release-evidence/0.3.29/spot-checks.out`, `.agent/release-evidence/0.3.29/public-private.out`, `.agent/release-evidence/0.3.29/supply-chain.out`.

Post-publish PyPI verification, GitHub Release verification, and post-release alignment are not part of this pre-publish PR and remain required after the release is published.

## Success metric

A fresh installed Main Branch package exposes the v0.3.29 owner-loop improvements coherently: safer release dogfood facts, stricter checkpoint history semantics, public-safe team member context, and a visible Codex owner-loop plugin/command surface, with release notes that do not overclaim beyond tested support.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [ ] N/A — change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [x] No
- [ ] Yes — migration note below

## Public / private boundary

Committed diff is limited to public release/version surfaces and version-neutral Codex inventory wording. No private operator strategy, machine-specific paths, secrets, raw transcripts, credentials, customer/member data, or local runtime evidence was committed; release evidence remains in ignored `.agent/` scratch.
