### PR TITLE
[update] Prepare v0.3.30 release

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mainbranch",
-  "version": "0.3.29",
+  "version": "0.3.30",
   "description": "Main Branch Claude Code skills for running a business from markdown files in git.",
   "author": {
     "name": "Noontide"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+## [0.3.30] - 2026-05-22
+
+v0.3.30 packages the Codex runtime readiness follow-up after v0.3.29. It
+keeps the supported Codex owner loop honest when a login shell would resolve a
+different `mb` binary, and it narrows Codex repair guidance to the scoped
+adapter path when only Codex wiring needs repair.
+
 ### Added
 
 - Added Codex runtime `mb` path/version diagnostics so status, start, and doctor

--- a/mb/mb/__init__.py
+++ b/mb/mb/__init__.py
@@ -7,6 +7,6 @@ file stays a thin dispatcher.
 
 from __future__ import annotations
 
-__version__ = "0.3.29"
+__version__ = "0.3.30"
 
 __all__ = ["__version__"]

--- a/mb/pyproject.toml
+++ b/mb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mainbranch"
-version = "0.3.29"
+version = "0.3.30"
 description = "Main Branch engine umbrella - scaffolds, validates, and graphs business-as-files repos. Claude Code first, runtime-agnostic by design."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Prepares `mainbranch` / `mb` v0.3.30 as the follow-up package release for the merged Codex runtime readiness fixes.

Moves the MAIN-424 release notes into a dated `0.3.30` changelog section and bumps the package, engine, and Claude plugin version sites from `0.3.29` to `0.3.30`.

## Linked issue

Refs #688 / MAIN-424
Refs #689

## Why

`oe-v0.3.29` was already tagged and published from the release-prep commit before the MAIN-424 follow-up fix merged. PyPI versions are immutable, so the merged Codex runtime readiness fix needs a new package version rather than trying to republish `0.3.29`.

## Commits by concern

- [ ] Each commit body bullet-lists the changes in that commit
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`

Commit:

- `12f2ce9 [update] Prepare v0.3.30 release`

Note: this branch has one release-prep commit, but it does not include a bullet-list commit body. I did not rewrite history during PR creation.

## Validation

Pre-push gate from repo root:

```bash
scripts/check.sh
```

- [x] Level 1 static: `scripts/check.sh` passes
- [ ] Level 2 CLI contract: focused Typer/CliRunner tests, exit codes, `--json` behavior, TTY vs non-TTY (if CLI behavior touched)
- [x] Level 3 package/install smoke (if packaging touched)
- [ ] Level 4 fixture repo (if init/onboard/status/start/update touched)
- [x] Level 5 runtime smoke / dogfood harness / simulation-tier (if runtime, first-run, skill discovery, or release validation touched)
- [x] SKILL.md ≤500 lines (if any skill touched)
- [x] Package-visible release gate evidence before tag/publish (if preparing a release)
- [x] Supply-chain review (if `.github/workflows/`, `.github/dependabot.yml`, `mb/pyproject.toml` deps, or `id-token`/`permissions` blocks touched — see [docs/supply-chain-policy.md](../docs/supply-chain-policy.md))

Evidence:

- Release-file preflight: `cd mb && python3 -m pytest tests/test_smoke_coverage.py::test_claude_plugin_manifest_points_at_prefixed_skills -q` — runtime: `python3` — exit: 0 — output: 1 passed.
- Level 1 static: `scripts/check.sh` — runtime: `python3` via repo script — exit: 0 — log: `.agent/release-evidence/0.3.30/check.out`.
- Level 2 CLI contract: not rerun for this release-prep branch; the merged implementation PR carried the focused CLI/runtime regression coverage, and this branch only changes release files.
- Level 3 package/install: `(cd mb && python3 -m build)` plus fresh venv install of `mb/dist/mainbranch-0.3.30-py3-none-any.whl`, `mb --version`, `mb skill list`, and `mb books check --fixture --json` — runtime: `python3` and `/tmp/mainbranch-wheel-0.3.30/bin/mb` — exit: 0 — log: `.agent/release-evidence/0.3.30/wheel-install.out`.
- Level 3 books fixture fallback: fresh venv install of `mainbranch-0.3.30` wheel with `PATH` excluding `hledger`, then `mb books check --fixture --json` — runtime: `/tmp/mainbranch-wheel-0.3.30-nohledger/bin/mb` — exit: 0 — log: `.agent/release-evidence/0.3.30/wheel-install.out`.
- Level 4 fixture repo: not rerun separately for this release-prep branch; deterministic fixture setup is covered inside the release acceptance dogfood harness.
- Level 5 release acceptance proxy: `python3 scripts/claude-runtime-dogfood.py --install-mode wheel --wheel mb/dist/mainbranch-0.3.30-py3-none-any.whl --evidence-dir .agent/release-evidence/0.3.30/dogfood-release-acceptance-wheel --run-claude-print --simulation-tier release_acceptance --max-budget-usd 0.75` — runtime: `python3` — exit: 0 — log: `.agent/release-evidence/0.3.30/dogfood-release-acceptance-wheel.log`; summary reports `ok: true`, 11/11 heuristic checks, and `partial_proxy_with_deterministic_fallback` because print-mode proxy had one read-only grounding denial and deterministic fixture facts filled the gap.
- Interactive Claude Code TUI: not rerun post-patch for this release-prep branch; release acceptance evidence above is print-mode proxy, not full interactive TUI proof.
- SKILL.md line gate: covered by `scripts/check.sh` — exit: 0 — log: `.agent/release-evidence/0.3.30/check.out`.
- Package-visible release gate: pre-simulation checkpoint captured at `.agent/release-evidence/0.3.30/pre-simulation-checkpoint.md`; release acceptance wheel evidence captured as listed above.
- Supply-chain review: release workflow permissions reviewed with `grep -RIn "id-token\|permissions:" .github/workflows/`; this branch changes no workflow, Dependabot, dependency, trusted-publisher, or permissions/id-token files. `mb/pyproject.toml` change is version-only, not dependency-surface change.

## Success metric

After this PR merges, `oe-v0.3.30` can be tagged from `main` and PyPI can publish a new immutable package version that includes the merged MAIN-424 Codex runtime readiness fixes.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [ ] N/A — change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [x] No
- [ ] Yes — migration note below

## Public / private boundary

Committed diff is limited to public release metadata and changelog notes. Local release evidence, raw runtime logs, private paths, and transcript details remain under ignored `.agent/` scratch and are not committed.
