### PR TITLE
Tune release simulation routing rubric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+### Changed
+
+- Tuned the release-simulation `loop_routing` rubric so release acceptance
+  recognizes clear business-language routing while generic no-routing answers
+  still fail. Refs MAIN-425, #691.
+
 ## [0.3.30] - 2026-05-22
 
 v0.3.30 packages the Codex runtime readiness follow-up after v0.3.29. It

--- a/mb/mb/_data/release_simulations/manifest.json
+++ b/mb/mb/_data/release_simulations/manifest.json
@@ -108,8 +108,17 @@
         "sense + decide",
         "ship -> reflect",
         "route to",
+        "route through",
+        "route into",
         "routes to",
+        "routes through",
+        "routes into",
         "expected route",
+        "routing recommendation",
+        "orchestration path",
+        "ordered next steps",
+        "suggested order",
+        "recommended next step",
         "next action"
       ]
     },

--- a/mb/tests/test_release_simulation.py
+++ b/mb/tests/test_release_simulation.py
@@ -284,6 +284,24 @@ def test_score_transcript_uses_tighter_discovery_and_loop_keywords() -> None:
     assert routed_score["checks"]["loop_routing"]["ok"] is True
 
 
+@pytest.mark.parametrize(
+    "routing_text",
+    [
+        "Routing recommendation: start with the bet, then choose the work.",
+        "This is the offer-launch orchestration path for the operator.",
+        "Suggested order: inspect status, choose the primitive, then ask before writes.",
+        "Recommended next step: route into the launch readiness primitive.",
+        "Route through /mb-think before saving a durable decision.",
+    ],
+)
+def test_score_transcript_accepts_business_language_loop_routing(
+    routing_text: str,
+) -> None:
+    score = release_simulation.score_transcript(routing_text)
+
+    assert score["checks"]["loop_routing"]["ok"] is True
+
+
 def test_score_transcript_checks_bookkeeping_safety_language() -> None:
     generic = "Finance looks fine. Put your books in the repo and continue."
     grounded = """


### PR DESCRIPTION
## Summary

- Tune the packaged release-simulation `loop_routing` heuristic to recognize clear business-language routing from the v0.3.30 acceptance smoke.
- Keep generic no-routing answers failing.
- Add focused regression coverage and changelog note.

## Scope

In scope:
- Packaged release simulation manifest keyword rubric.
- Focused release simulation tests.
- CHANGELOG `[Unreleased]` note.

Out of scope:
- Runtime prompt behavior changes.
- Release tagging or PyPI publishing.

## Validation

- Focused CLI: `cd mb && python3 -m pytest tests/test_release_simulation.py -q` -- 56 passed.
- Level 1 static: `scripts/check.sh` -- exit 0; log `.agent/main-425/check.out`; 788 passed and skill validation passed.

Closes #691