### PR TITLE
Prepare v0.3.31 release

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mainbranch",
-  "version": "0.3.30",
+  "version": "0.3.31",
   "description": "Main Branch Claude Code skills for running a business from markdown files in git.",
   "author": {
     "name": "Noontide"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+## [0.3.31] - 2026-05-23
+
+v0.3.31 packages the post-v0.3.30 Codex readiness follow-ups. It tightens
+generated Codex guidance around runtime `mb` mismatches and tunes release
+simulation scoring so future release acceptance runs flag real routing misses
+instead of acceptable business-language routing.
+
 ### Changed
 
 - Tightened generated Codex owner-loop guidance so runtime `mb` mismatches

--- a/mb/mb/__init__.py
+++ b/mb/mb/__init__.py
@@ -7,6 +7,6 @@ file stays a thin dispatcher.
 
 from __future__ import annotations
 
-__version__ = "0.3.30"
+__version__ = "0.3.31"
 
 __all__ = ["__version__"]

--- a/mb/pyproject.toml
+++ b/mb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mainbranch"
-version = "0.3.30"
+version = "0.3.31"
 description = "Main Branch engine umbrella - scaffolds, validates, and graphs business-as-files repos. Claude Code first, runtime-agnostic by design."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

- Move current `[Unreleased]` notes into `0.3.31` dated 2026-05-23.
- Bump `mb/pyproject.toml`, `mb/mb/__init__.py`, and `.claude-plugin/plugin.json` to `0.3.31`.
- Package MAIN-425 / #691 and MAIN-426 / #692 as the next patch release.

## Scope

In scope:
- Release-only version files: `CHANGELOG.md`, `mb/pyproject.toml`, `mb/mb/__init__.py`, `.claude-plugin/plugin.json`.

Out of scope:
- Product/code changes.
- Creating the GitHub Release/tag before maintainer approval.
- Approving the PyPI deployment.

## Validation

- Release preflight: `cd mb && python3 -m pytest tests/test_smoke_coverage.py::test_claude_plugin_manifest_points_at_prefixed_skills -q` -- exit 0; 1 passed.
- Level 1 static: `scripts/check.sh` -- exit 0; log `.agent/release-evidence/0.3.31/check.out`; 788 passed and skill validation passed.
- Level 3 package/install: `python3 -m build --outdir .agent/release-evidence/0.3.31/dist` + fresh venv install of `mainbranch-0.3.31-py3-none-any.whl` + `mb --version` + `mb skill list` -- exit 0; logs `build.out`, `install.out`.
- Books fixture, hledger-equipped mode: `/tmp/mainbranch-0.3.31-smoke/bin/mb books check --fixture --json` -- exit 0; `result_status: ok`; fixture-valid passed with hledger; log `books-fixture.out`.
- Books fixture, no-hledger mode: `PATH=/tmp/mainbranch-0.3.31-smoke/bin:/usr/bin:/bin mb books check --fixture --json` -- exit 0; `result_status: ok`; hledger-missing informational fallback; log `books-fixture-no-hledger.out`.
- Level 5 proxy, prerelease candidate: `scripts/claude-runtime-dogfood.py --install-mode wheel --wheel .agent/release-evidence/0.3.31/dist/mainbranch-0.3.31-py3-none-any.whl --run-claude-print --simulation-tier prerelease_candidate --max-budget-usd 0.75` -- exit 0; `summary.json ok: true`; no failures/warnings; rubric 11/11; evidence `.agent/release-evidence/0.3.31/dogfood-prerelease/`.
- Level 5 proxy, release acceptance: `scripts/claude-runtime-dogfood.py --install-mode wheel --wheel .agent/release-evidence/0.3.31/dist/mainbranch-0.3.31-py3-none-any.whl --run-claude-print --simulation-tier release_acceptance --max-budget-usd 0.75` -- exit 0; `summary.json ok: true`; no failures/warnings; rubric 11/11; evidence `.agent/release-evidence/0.3.31/dogfood-release-acceptance/`.

Print-mode proxy note: both dogfood tiers reported partial proxy grounding with deterministic fallback because Claude attempted at least one non-allowlisted read-only shell shape. No harness failures or warnings were recorded. Interactive Claude Code TUI smoke remains distinct from print-mode proxy evidence.

## Supply-chain checks

- CHANGELOG `[Unreleased]` moved into `0.3.31`.
- Dependency review: only release version line changed in `mb/pyproject.toml`; no dependency changes.
- Workflow permissions scan: `.github/workflows/publish-pypi.yml` still has exactly one `id-token: write` occurrence, in the publish job.
- Dependabot alerts: `0` open alerts via GitHub API.
- `pypi` GitHub Environment: required reviewer rule present for `dmthepm`.

## Release approval boundary

After this PR merges, `main` is prepared for `oe-v0.3.31`. Do not create the GitHub Release/tag or approve the PyPI deployment until Devon approves that release step.

Closes #695