### PR TITLE
Prefer Codex start next actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+### Changed
+
+- Made `mb start --json` top-level next actions prefer Codex-facing handoff
+  and smoke commands when Codex owner-loop readiness is present, while keeping
+  Claude launch details in the Claude command section. Refs MAIN-428, #697.
+
 ## [0.3.31] - 2026-05-23
 
 v0.3.31 packages the post-v0.3.30 Codex readiness follow-ups. It tightens

--- a/mb/mb/start.py
+++ b/mb/mb/start.py
@@ -282,8 +282,13 @@ def _next_actions(
     repo: Path,
     checks: list[dict[str, Any]],
     handoff_ready: bool,
+    codex: dict[str, Any] | None = None,
 ) -> list[str]:
     actions = [str(check["repair"]) for check in checks if not check["ok"] and check["repair"]]
+    codex_actions = _codex_next_actions(repo, codex or {})
+    if codex_actions:
+        actions.extend(codex_actions)
+        return actions[:6]
     if handoff_ready:
         actions.extend(
             [f"Run `{_display_command(repo)}`.", "Then type `/mb-start` in Claude Code."]
@@ -310,10 +315,14 @@ def _codex_next_actions(repo: Path, codex: dict[str, Any]) -> list[str]:
     if not codex.get("runtime_ok"):
         repair = str(runtime.get("repair") or codex.get("repair") or "")
         return [repair] if repair else []
-    return [
+    smoke_command = str(codex.get("smoke_command") or "")
+    actions = [
         f"Run `{_codex_display_command(repo)}`.",
         "Use `/mb-start` if the Main Branch Owner Loop plugin is installed.",
     ]
+    if smoke_command:
+        actions.append(f"For a read-only Codex smoke, run `{smoke_command}`.")
+    return actions
 
 
 def run(repo: str = ".", launch: bool = False) -> dict[str, Any]:
@@ -408,7 +417,7 @@ def run(repo: str = ".", launch: bool = False) -> dict[str, Any]:
             "follow_up": "/mb-start",
         },
         "launch": launch_report,
-        "next_actions": _next_actions(repo_path, checks, handoff_ready),
+        "next_actions": _next_actions(repo_path, checks, handoff_ready, codex),
     }
 
 

--- a/mb/tests/test_start.py
+++ b/mb/tests/test_start.py
@@ -93,6 +93,10 @@ def test_start_json_prints_ready_handoff(tmp_path: Path, monkeypatch) -> None:
         "-C",
         str(repo.resolve()),
     ]
+    next_actions = "\n".join(report["next_actions"])
+    assert f"codex -C {shlex.quote(str(repo.resolve()))}" in next_actions
+    assert "codex exec --json --ephemeral --sandbox read-only" in next_actions
+    assert "Run `claude" not in next_actions
     assert report["command"]["argv"] == ["claude"]
     assert report["command"]["display"].endswith(" && claude")
     assert report["command"]["follow_up"] == "/mb-start"
@@ -179,6 +183,10 @@ def test_start_json_separates_codex_static_and_runtime_readiness(
     assert any(
         "mb status --json --peek" in action for action in codex_handoff["command"]["next_actions"]
     )
+    top_level_actions = "\n".join(report["next_actions"])
+    assert "Run `claude" not in top_level_actions
+    assert "login-shell PATH" in top_level_actions
+    assert "mb status --json --peek" in top_level_actions
 
 
 def test_start_human_labels_missing_codex_without_experimental_copy(


### PR DESCRIPTION
## Summary

Make `mb start --json` top-level `next_actions` prefer Codex-facing handoff when Codex owner-loop readiness is present.

## In Scope

- Reuse the existing Codex action selection for top-level JSON `next_actions` when Codex is available.
- Include the generated read-only Codex smoke command in the ready Codex path.
- Keep Claude launch details in the existing Claude `command` section.
- Preserve runtime mismatch stop/repair guidance.

## Out Of Scope

- Local `.zprofile` cleanup.
- Broad generated repair output cleanup.
- Any unrelated generated business-repo files.

## Commits

- `a84266b [update] Prefer Codex start next actions`

## Release / Issues

Closes #697
Refs MAIN-428

## Success Metric

`mb start --json` with Codex ready or runtime-mismatched reports Codex-facing top-level next actions instead of primarily routing through `claude`.

## Validation

- Level 1 static: `scripts/check.sh` passed.
- Level 2 CLI contract: `cd mb && pytest tests/test_start.py -q` passed, 17 tests.
- Manual fixture: fresh business repo with Codex repair applied showed top-level `next_actions` containing `codex -C <repo>` and the `codex exec --json --ephemeral --sandbox read-only ...` smoke command.

## Public / Private Boundary

No private data, local paths, secrets, or machine-specific runtime notes were added to tracked files. Local shell PATH cleanup was handled separately outside this PR.
