### PR TITLE
Make Codex plugin install state part of readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 - Made `mb start --json` top-level next actions prefer Codex-facing handoff
   and smoke commands when Codex owner-loop readiness is present, while keeping
   Claude launch details in the Claude command section. Refs MAIN-428, #697.
+- Made Codex plugin install state part of Codex readiness so status, start,
+  doctor repair, and update follow-ups distinguish current adapter files from
+  installed/enabled `/mb-*` slash commands. Refs MAIN-430, #700.
 
 ## [0.3.31] - 2026-05-23
 

--- a/mb/mb/codex.py
+++ b/mb/mb/codex.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import json
 import shlex
 import shutil
+import subprocess
 from importlib import resources
 from pathlib import Path
 from typing import Any
@@ -25,7 +26,11 @@ CODEX_WORKFLOW_INVENTORY_RELATIVE_PATH = (
     f"{CODEX_SKILL_DIR_RELATIVE_PATH}/references/workflow-inventory.md"
 )
 CODEX_MARKETPLACE_RELATIVE_PATH = ".agents/plugins/marketplace.json"
+CODEX_MARKETPLACE_NAME = "main-branch-local"
 CODEX_PLUGIN_NAME = "main-branch-owner-loop"
+CODEX_PLUGIN_SELECTOR = f"{CODEX_PLUGIN_NAME}@{CODEX_MARKETPLACE_NAME}"
+CODEX_PLUGIN_INSTALL_COMMAND = f"codex plugin add {CODEX_PLUGIN_SELECTOR}"
+CODEX_MARKETPLACE_ADD_COMMAND = "codex plugin marketplace add ."
 CODEX_PLUGIN_DIR_RELATIVE_PATH = f".agents/plugins/{CODEX_PLUGIN_NAME}"
 CODEX_PLUGIN_MANIFEST_RELATIVE_PATH = f"{CODEX_PLUGIN_DIR_RELATIVE_PATH}/.codex-plugin/plugin.json"
 CODEX_PLUGIN_SKILL_RELATIVE_PATH = (
@@ -1099,7 +1104,7 @@ def render_codex_marketplace_json() -> str:
     """Render the repo-scoped Codex plugin marketplace metadata."""
 
     payload = {
-        "name": "main-branch-local",
+        "name": CODEX_MARKETPLACE_NAME,
         "interface": {"displayName": "Main Branch"},
         "plugins": [
             {
@@ -1219,6 +1224,214 @@ def executable_status() -> dict[str, Any]:
         "path": path,
         "executable": "codex",
         "repair": "" if path else "Install Codex CLI before using the Codex owner-loop adapter.",
+    }
+
+
+def _run_codex_plugin_command(repo: Path, args: list[str]) -> dict[str, Any]:
+    codex_path = _which("codex")
+    command = [codex_path or "codex", *args]
+    if not codex_path:
+        return {
+            "ok": False,
+            "returncode": 127,
+            "stdout": "",
+            "stderr": "codex not on PATH",
+            "command": " ".join(["codex", *args]),
+        }
+    try:
+        proc = subprocess.run(
+            command,
+            cwd=repo,
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        return {
+            "ok": False,
+            "returncode": 124,
+            "stdout": "",
+            "stderr": "codex plugin command timed out",
+            "command": " ".join(["codex", *args]),
+        }
+    except (FileNotFoundError, subprocess.SubprocessError) as exc:
+        return {
+            "ok": False,
+            "returncode": 1,
+            "stdout": "",
+            "stderr": str(exc),
+            "command": " ".join(["codex", *args]),
+        }
+    return {
+        "ok": proc.returncode == 0,
+        "returncode": proc.returncode,
+        "stdout": proc.stdout,
+        "stderr": proc.stderr,
+        "command": " ".join(["codex", *args]),
+    }
+
+
+def _codex_plugin_list(repo: Path) -> dict[str, Any]:
+    return _run_codex_plugin_command(
+        repo,
+        ["plugin", "list", "--marketplace", CODEX_MARKETPLACE_NAME],
+    )
+
+
+def _parse_plugin_install_status(output: str, expected_marketplace_path: Path) -> dict[str, Any]:
+    lines = output.splitlines()
+    actual_marketplace_path = ""
+    for index, line in enumerate(lines):
+        if line.strip() == f"Marketplace `{CODEX_MARKETPLACE_NAME}`":
+            if index + 1 < len(lines):
+                actual_marketplace_path = lines[index + 1].strip()
+            break
+
+    marketplace_registered = bool(
+        actual_marketplace_path
+        and Path(actual_marketplace_path).expanduser().resolve()
+        == expected_marketplace_path.expanduser().resolve()
+    )
+    marketplace_stale = bool(actual_marketplace_path and not marketplace_registered)
+    plugin_line = next((line.strip() for line in lines if CODEX_PLUGIN_SELECTOR in line), "")
+    plugin_available = bool(plugin_line and marketplace_registered)
+    status_text = plugin_line.split(CODEX_PLUGIN_SELECTOR, 1)[1].strip() if plugin_line else ""
+    plugin_installed = bool(
+        plugin_available and "installed" in status_text and "not installed" not in status_text
+    )
+    plugin_enabled = bool(plugin_installed and "enabled" in status_text)
+    return {
+        "marketplace_registered": marketplace_registered,
+        "marketplace_stale": marketplace_stale,
+        "marketplace_path": str(expected_marketplace_path),
+        "registered_marketplace_path": actual_marketplace_path,
+        "plugin_available": plugin_available,
+        "plugin_installed": plugin_installed,
+        "plugin_enabled": plugin_enabled,
+        "slash_commands_ready": bool(plugin_installed and plugin_enabled),
+        "plugin_line": plugin_line,
+    }
+
+
+def plugin_install_status(repo: str | Path, *, adapter_files_ok: bool = True) -> dict[str, Any]:
+    target = Path(repo).expanduser().resolve()
+    expected_marketplace_path = marketplace_path(target)
+    install_command = CODEX_PLUGIN_INSTALL_COMMAND
+    register_command = CODEX_MARKETPLACE_ADD_COMMAND
+    if not _which("codex"):
+        return {
+            "checked": False,
+            "ok": False,
+            "state": "codex_missing",
+            "summary": "Codex CLI is not installed, so plugin install state was not checked.",
+            "marketplace_name": CODEX_MARKETPLACE_NAME,
+            "plugin_selector": CODEX_PLUGIN_SELECTOR,
+            "marketplace_registered": False,
+            "marketplace_stale": False,
+            "plugin_available": False,
+            "plugin_installed": False,
+            "plugin_enabled": False,
+            "slash_commands_ready": False,
+            "install_command": install_command,
+            "register_command": register_command,
+            "repair": "Install Codex CLI before using the Codex owner-loop adapter.",
+            "safe_to_share": True,
+        }
+    if not adapter_files_ok:
+        return {
+            "checked": False,
+            "ok": False,
+            "state": "waiting_for_adapter_files",
+            "summary": (
+                "Codex plugin install check waits until generated adapter files "
+                "and marketplace metadata are current."
+            ),
+            "marketplace_name": CODEX_MARKETPLACE_NAME,
+            "plugin_selector": CODEX_PLUGIN_SELECTOR,
+            "marketplace_registered": False,
+            "marketplace_stale": False,
+            "plugin_available": False,
+            "plugin_installed": False,
+            "plugin_enabled": False,
+            "slash_commands_ready": False,
+            "install_command": install_command,
+            "register_command": register_command,
+            "repair": CODEX_REPAIR_TEXT,
+            "safe_to_share": True,
+        }
+
+    result = _codex_plugin_list(target)
+    parsed = _parse_plugin_install_status(
+        str(result.get("stdout") or ""), expected_marketplace_path
+    )
+    state = "ok"
+    summary = "Codex plugin is installed and enabled; slash commands should be available."
+    repair = ""
+    if not result["ok"]:
+        state = "plugin_state_unverified"
+        summary = "Codex plugin install state could not be checked."
+        repair = f"Run `{register_command}`, then `{install_command}`."
+    elif not parsed["marketplace_registered"]:
+        state = "marketplace_not_registered"
+        summary = (
+            "Generated Codex plugin files are ready, but this repo's Codex "
+            "marketplace is not registered."
+        )
+        if parsed["marketplace_stale"]:
+            summary = (
+                "A `main-branch-local` Codex marketplace is registered, but it "
+                "points at a different repo."
+            )
+        repair = f"Run `{register_command}`, then `{install_command}`."
+    elif not parsed["plugin_available"]:
+        state = "plugin_not_available"
+        summary = (
+            "This repo's Codex marketplace is registered, but the Main Branch plugin is missing."
+        )
+        repair = f"Run `{register_command}`, then `{install_command}`."
+    elif not parsed["plugin_installed"]:
+        state = "plugin_not_installed"
+        summary = (
+            "Generated Codex plugin files are ready, but the Main Branch plugin "
+            "is not installed in Codex yet."
+        )
+        repair = f"Run `{install_command}`."
+    elif not parsed["plugin_enabled"]:
+        state = "plugin_disabled"
+        summary = "The Main Branch Codex plugin is installed but not enabled."
+        repair = f"Enable `{CODEX_PLUGIN_SELECTOR}` in Codex plugins."
+
+    return {
+        "checked": True,
+        "ok": state == "ok",
+        "state": state,
+        "summary": summary,
+        "marketplace_name": CODEX_MARKETPLACE_NAME,
+        "plugin_selector": CODEX_PLUGIN_SELECTOR,
+        **parsed,
+        "install_command": install_command,
+        "register_command": register_command,
+        "repair": repair,
+        "command": result.get("command", ""),
+        "returncode": result.get("returncode"),
+        "error": str(result.get("stderr") or "").strip(),
+        "safe_to_share": True,
+    }
+
+
+def install_plugin(repo: str | Path) -> dict[str, Any]:
+    target = Path(repo).expanduser().resolve()
+    steps = [
+        _run_codex_plugin_command(target, ["plugin", "marketplace", "add", "."]),
+        _run_codex_plugin_command(target, ["plugin", "add", CODEX_PLUGIN_SELECTOR]),
+    ]
+    final = plugin_install_status(target)
+    return {
+        "ok": bool(final.get("ok")),
+        "steps": steps,
+        "status": final,
+        "safe_to_share": True,
     }
 
 
@@ -1410,13 +1623,17 @@ def readiness(repo: str | Path) -> dict[str, Any]:
     static_ok = bool(executable["found"] and instructions["ok"])
     runtime = _login_shell_mb_diagnostics()
     runtime_ok = bool(runtime.get("ok"))
-    ok = bool(static_ok and runtime_ok)
+    plugin_install = plugin_install_status(repo, adapter_files_ok=bool(instructions["ok"]))
+    plugin_ok = bool(plugin_install.get("ok"))
+    ok = bool(static_ok and runtime_ok and plugin_ok)
     if ok:
         status = "ready"
     elif not executable["found"] or not instructions["ok"]:
         status = "needs_setup"
     elif runtime.get("mismatch"):
         status = "runtime_mismatch"
+    elif runtime_ok and not plugin_ok:
+        status = str(plugin_install.get("state") or "plugin_not_installed")
     else:
         status = "runtime_unverified"
     return {
@@ -1425,6 +1642,8 @@ def readiness(repo: str | Path) -> dict[str, Any]:
         "support_level": "first_class_owner_loop",
         "static_ok": static_ok,
         "runtime_ok": runtime_ok,
+        "plugin_ok": plugin_ok,
+        "plugin_install": plugin_install,
         "runtime": runtime,
         "executable": executable,
         "instructions": instructions,
@@ -1437,6 +1656,8 @@ def readiness(repo: str | Path) -> dict[str, Any]:
         else (
             str(runtime.get("repair") or "")
             if static_ok and not runtime_ok
+            else str(plugin_install.get("repair") or "")
+            if static_ok and runtime_ok and not plugin_ok
             else instructions["repair"] or executable["repair"]
         ),
         "start_command": f"codex -C {shlex.quote(str(Path(repo).expanduser().resolve()))}",
@@ -1467,6 +1688,13 @@ def human_readiness_label(readiness_report: dict[str, Any]) -> str:
         return "runtime mismatch"
     if not runtime.get("ok"):
         return "runtime unverified"
+    plugin_install = readiness_report.get("plugin_install") or {}
+    if not plugin_install.get("ok"):
+        if plugin_install.get("state") == "plugin_not_installed":
+            return "plugin not installed"
+        if plugin_install.get("state") == "marketplace_not_registered":
+            return "marketplace missing"
+        return "plugin not ready"
     return "not ready"
 
 

--- a/mb/mb/doctor.py
+++ b/mb/mb/doctor.py
@@ -1326,6 +1326,7 @@ def run(path: str) -> dict[str, Any]:
     codex_readiness = codex_mod.readiness(repo)
     codex_executable = codex_readiness["executable"]
     codex_instructions = codex_readiness["instructions"]
+    codex_plugin_install = codex_readiness["plugin_install"]
     checks.append(
         {
             "name": "codex-cli",
@@ -1354,6 +1355,20 @@ def run(path: str) -> dict[str, Any]:
             "repair": codex_instructions["repair"],
             "safe_to_share": True,
             "status": codex_instructions,
+        }
+    )
+    checks.append(
+        {
+            "name": "codex-plugin-install",
+            "ok": bool(codex_plugin_install["ok"]),
+            "detail": codex_plugin_install["summary"],
+            "severity": "ok"
+            if codex_plugin_install["ok"]
+            else ("warn" if codex_executable["found"] and codex_instructions["ok"] else "info"),
+            "repair": codex_plugin_install["repair"],
+            "repair_command": codex_plugin_install["install_command"],
+            "safe_to_share": True,
+            "status": codex_plugin_install,
         }
     )
 
@@ -2021,6 +2036,7 @@ def repair_plan(
     codex_status = codex_mod.readiness(target)
     codex_instruction_status = codex_status["instructions"]
     codex_runtime_status = codex_status["runtime"]
+    codex_plugin_install = codex_status["plugin_install"]
     codex_runtime_relevant = bool(
         codex_status["executable"]["found"] and codex_instruction_status["ok"]
     )
@@ -2072,6 +2088,22 @@ def repair_plan(
             "runtime_version": codex_runtime_status.get("version", ""),
             "repair": codex_runtime_status.get("repair", "") if codex_runtime_relevant else "",
         },
+        {
+            "name": "codex-plugin-install",
+            "state": (
+                "ok"
+                if codex_plugin_install["ok"]
+                else ("warn" if codex_runtime_relevant and codex_runtime_status["ok"] else "info")
+            ),
+            "summary": codex_plugin_install["summary"],
+            "marketplace_registered": codex_plugin_install["marketplace_registered"],
+            "marketplace_stale": codex_plugin_install["marketplace_stale"],
+            "plugin_installed": codex_plugin_install["plugin_installed"],
+            "plugin_enabled": codex_plugin_install["plugin_enabled"],
+            "slash_commands_ready": codex_plugin_install["slash_commands_ready"],
+            "install_command": codex_plugin_install["install_command"],
+            "repair": codex_plugin_install["repair"],
+        },
     ]
     codex_actions: list[dict[str, Any]] = []
     if not codex_instruction_status["ok"]:
@@ -2096,6 +2128,26 @@ def repair_plan(
                 codex_mod.CODEX_PLUGIN_SKILL_RELATIVE_PATH,
                 *codex_mod.CODEX_PLUGIN_COMMAND_RELATIVE_PATHS,
             ],
+        )
+        actions.append(action)
+        codex_actions.append(action)
+    if codex_runtime_relevant and codex_runtime_status["ok"] and not codex_plugin_install["ok"]:
+        action = _action(
+            id="codex-plugin-install",
+            title="Install the Main Branch Codex plugin",
+            state="warn",
+            mode="write",
+            command=(
+                f"{codex_mod.CODEX_MARKETPLACE_ADD_COMMAND} && "
+                f"{codex_mod.CODEX_PLUGIN_INSTALL_COMMAND}"
+            ),
+            safe_to_apply=True,
+            reason=(
+                "Generated Codex plugin files are ready, but Codex must install "
+                "and enable the plugin before /mb-* slash commands are available"
+            ),
+            writes=["~/.codex/config.toml", "~/.codex/plugins/"],
+            result=codex_plugin_install,
         )
         actions.append(action)
         codex_actions.append(action)
@@ -2260,7 +2312,11 @@ def repair_plan(
         if only != "codex":
             raise ValueError(f"unknown repair scope: {only}")
         sections = [section for section in sections if section["id"] in {"codex-wiring", "git"}]
-        actions = [action for action in actions if str(action.get("id")) == "codex-agents-md"]
+        actions = [
+            action
+            for action in actions
+            if str(action.get("id")) in {"codex-agents-md", "codex-plugin-install"}
+        ]
 
     states = [str(section["state"]) for section in sections]
     summary = {
@@ -2482,6 +2538,35 @@ def repair_apply(
                 ],
                 applied=bool(agents["changed"]),
                 result=agents,
+            )
+        )
+
+    codex_status = codex_mod.readiness(target)
+    codex_runtime_status = codex_status["runtime"]
+    codex_runtime_relevant = bool(
+        codex_status["executable"]["found"] and codex_status["instructions"]["ok"]
+    )
+    codex_plugin_install = codex_status["plugin_install"]
+    if codex_runtime_relevant and codex_runtime_status["ok"] and not codex_plugin_install["ok"]:
+        installed = codex_mod.install_plugin(target)
+        applied.append(
+            _action(
+                id="codex-plugin-install",
+                title="Installed the Main Branch Codex plugin",
+                state="ok" if installed["ok"] else "error",
+                mode="write",
+                command=(
+                    f"{codex_mod.CODEX_MARKETPLACE_ADD_COMMAND} && "
+                    f"{codex_mod.CODEX_PLUGIN_INSTALL_COMMAND}"
+                ),
+                safe_to_apply=True,
+                reason=(
+                    "installed and enabled the generated Codex plugin so /mb-* "
+                    "slash commands are available"
+                ),
+                writes=["~/.codex/config.toml", "~/.codex/plugins/"],
+                applied=bool(installed.get("steps")),
+                result=installed,
             )
         )
 

--- a/mb/mb/start.py
+++ b/mb/mb/start.py
@@ -315,6 +315,14 @@ def _codex_next_actions(repo: Path, codex: dict[str, Any]) -> list[str]:
     if not codex.get("runtime_ok"):
         repair = str(runtime.get("repair") or codex.get("repair") or "")
         return [repair] if repair else []
+    if not codex.get("plugin_ok"):
+        plugin_install = codex.get("plugin_install") or {}
+        repair = str(plugin_install.get("repair") or codex.get("repair") or "")
+        actions = []
+        if repair:
+            actions.append(repair)
+        actions.append("Rerun `mb status --json --peek` before using Codex slash commands.")
+        return actions[:3]
     smoke_command = str(codex.get("smoke_command") or "")
     actions = [
         f"Run `{_codex_display_command(repo)}`.",

--- a/mb/mb/status.py
+++ b/mb/mb/status.py
@@ -3826,6 +3826,7 @@ def _drift(report: dict[str, Any]) -> dict[str, Any]:
     codex_executable = codex_cli.get("executable") or {}
     codex_instructions = codex_cli.get("instructions") or {}
     codex_runtime = codex_cli.get("runtime") or {}
+    codex_plugin = codex_cli.get("plugin_install") or {}
     if codex_executable.get("found") and not codex_instructions.get("ok"):
         items.append(
             {
@@ -3868,6 +3869,31 @@ def _drift(report: dict[str, Any]) -> dict[str, Any]:
                 "repair": str(
                     codex_runtime.get("repair")
                     or "Put the current Main Branch install earlier on the runtime PATH."
+                ),
+                "safe_to_share": True,
+            }
+        )
+    if (
+        codex_executable.get("found")
+        and codex_instructions.get("ok")
+        and codex_runtime.get("ok")
+        and not codex_plugin.get("ok")
+    ):
+        items.append(
+            {
+                "id": "codex_plugin_not_installed",
+                "severity": "warn",
+                "summary": str(
+                    codex_plugin.get("summary")
+                    or "Codex plugin files are ready, but slash commands are not installed."
+                ),
+                "evidence": [
+                    f"marketplace: {codex_plugin.get('marketplace_name') or ''}".strip(),
+                    f"plugin: {codex_plugin.get('plugin_selector') or ''}".strip(),
+                    f"state: {codex_plugin.get('state') or 'unknown'}",
+                ],
+                "repair": str(
+                    codex_plugin.get("repair") or f"Run `{codex_mod.CODEX_PLUGIN_INSTALL_COMMAND}`."
                 ),
                 "safe_to_share": True,
             }

--- a/mb/mb/update.py
+++ b/mb/mb/update.py
@@ -202,19 +202,38 @@ def _base_result(repo: Path, *, check: bool, mode: str, root: Path | None) -> di
 
 
 def _add_codex_follow_up(result: dict[str, Any], repo: Path) -> None:
-    codex = codex_mod.instructions_status(repo)
+    codex = codex_mod.readiness(repo)
+    instructions = codex.get("instructions", {})
+    plugin_install = codex.get("plugin_install", {})
     result["codex_adapter"] = {
         "ok": codex["ok"],
-        "exists": codex["exists"],
-        "current": codex["current"],
-        "repair_command": codex.get("repair_command", ""),
+        "status": codex.get("status", ""),
+        "static_ok": codex.get("static_ok", False),
+        "runtime_ok": codex.get("runtime_ok", False),
+        "plugin_ok": codex.get("plugin_ok", False),
+        "exists": instructions.get("exists", False),
+        "current": instructions.get("current", False),
+        "repair_command": codex.get("repair", "") or instructions.get("repair_command", ""),
+        "plugin_install": plugin_install,
     }
     if not codex["ok"]:
-        message = (
-            "Codex owner-loop files still need repo repair. Run "
-            "`mb doctor repair --plan --only codex`, review it, then approve "
-            "`mb doctor repair --apply --only codex`."
-        )
+        if not instructions.get("ok", False):
+            message = (
+                "Codex owner-loop files still need repo repair. Run "
+                "`mb doctor repair --plan --only codex`, review it, then approve "
+                "`mb doctor repair --apply --only codex`."
+            )
+        elif not codex.get("plugin_ok", False):
+            message = (
+                "Codex plugin files are current, but slash commands are not ready. "
+                "Run `mb doctor repair --plan --only codex`, review it, then approve "
+                "`mb doctor repair --apply --only codex`."
+            )
+        else:
+            message = (
+                "Codex runtime readiness still needs attention. Run "
+                "`mb status --json --peek` and repair the reported runtime issue."
+            )
         result["warnings"].append(message)
         result["next_actions"].extend(
             [

--- a/mb/tests/test_doctor.py
+++ b/mb/tests/test_doctor.py
@@ -6,6 +6,7 @@ import json
 from pathlib import Path
 from typing import Any
 
+import pytest
 from typer.testing import CliRunner
 
 from mb import codex as codex_mod
@@ -17,6 +18,56 @@ from mb.doctor import _detect_cloud_paths, _repo_layout_check, run
 from mb.init import run as init_run
 
 runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def codex_missing_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(codex_mod, "_which", lambda name: "" if name == "codex" else None)
+
+
+def _with_codex(name: str) -> str:
+    if name == "codex":
+        return "/usr/local/bin/codex"
+    return ""
+
+
+def _codex_runtime_ok() -> dict[str, Any]:
+    return {
+        "checked": True,
+        "ok": True,
+        "state": "ok",
+        "shell": "/bin/zsh",
+        "command": "command -v mb && mb --version",
+        "path": "/usr/local/bin/mb",
+        "version": "0.3.31",
+        "active_path": "/usr/local/bin/mb",
+        "active_version": "0.3.31",
+        "path_mismatch": False,
+        "version_mismatch": False,
+        "mismatch": False,
+        "error": "",
+        "summary": "Login-shell runtime resolves the active mb.",
+        "repair": "",
+        "safe_to_share": True,
+    }
+
+
+def _codex_plugin_list_result(repo: Path, *, installed: bool = True) -> dict[str, Any]:
+    marketplace = repo / codex_mod.CODEX_MARKETPLACE_RELATIVE_PATH
+    plugin = repo / codex_mod.CODEX_PLUGIN_DIR_RELATIVE_PATH
+    status = "installed, enabled" if installed else "not installed"
+    return {
+        "ok": True,
+        "returncode": 0,
+        "stdout": (
+            f"Marketplace `{codex_mod.CODEX_MARKETPLACE_NAME}`\n"
+            f"{marketplace}\n\n"
+            "PLUGIN                                    STATUS              VERSION  PATH\n"
+            f"{codex_mod.CODEX_PLUGIN_SELECTOR}  {status}  0.1.0  {plugin}\n"
+        ),
+        "stderr": "",
+        "command": f"codex plugin list --marketplace {codex_mod.CODEX_MARKETPLACE_NAME}",
+    }
 
 
 def _write_md(path: Path, text: str) -> None:
@@ -409,6 +460,83 @@ def test_doctor_repair_plan_marks_codex_runtime_info_when_codex_missing(
     assert runtime_check["state"] == "info"
     assert "waits until Codex CLI is installed" in runtime_check["summary"]
     assert runtime_check["repair"] == ""
+
+
+def test_doctor_repair_plan_installs_missing_codex_plugin(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(codex_mod, "_which", _with_codex)
+    monkeypatch.setattr(codex_mod, "_login_shell_mb_diagnostics", _codex_runtime_ok)
+    repo = tmp_path / "biz"
+    init_run(path=str(repo), name="Acme")
+    monkeypatch.setattr(
+        codex_mod,
+        "_codex_plugin_list",
+        lambda plugin_repo: _codex_plugin_list_result(Path(plugin_repo), installed=False),
+    )
+
+    result = runner.invoke(
+        app, ["doctor", "repair", "--repo", str(repo), "--plan", "--only", "codex", "--json"]
+    )
+
+    assert result.exit_code in {0, 1}
+    payload = json.loads(result.stdout)
+    actions = {action["id"]: action for action in payload["actions"]}
+    assert "codex-plugin-install" in actions
+    assert actions["codex-plugin-install"]["safe_to_apply"] is True
+    assert codex_mod.CODEX_PLUGIN_INSTALL_COMMAND in actions["codex-plugin-install"]["command"]
+    section = next(section for section in payload["sections"] if section["id"] == "codex-wiring")
+    plugin_check = next(
+        check for check in section["checks"] if check["name"] == "codex-plugin-install"
+    )
+    assert plugin_check["state"] == "warn"
+    assert plugin_check["plugin_installed"] is False
+
+
+def test_doctor_repair_apply_installs_missing_codex_plugin(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(codex_mod, "_which", _with_codex)
+    monkeypatch.setattr(codex_mod, "_login_shell_mb_diagnostics", _codex_runtime_ok)
+    repo = tmp_path / "biz"
+    init_run(path=str(repo), name="Acme")
+    monkeypatch.setattr(
+        codex_mod,
+        "_codex_plugin_list",
+        lambda plugin_repo: _codex_plugin_list_result(Path(plugin_repo), installed=False),
+    )
+    monkeypatch.setattr(
+        codex_mod,
+        "install_plugin",
+        lambda plugin_repo: {
+            "ok": True,
+            "steps": [
+                {"ok": True, "command": codex_mod.CODEX_MARKETPLACE_ADD_COMMAND},
+                {"ok": True, "command": codex_mod.CODEX_PLUGIN_INSTALL_COMMAND},
+            ],
+            "status": {
+                "ok": True,
+                "state": "ok",
+                "plugin_installed": True,
+                "plugin_enabled": True,
+                "slash_commands_ready": True,
+            },
+            "safe_to_share": True,
+        },
+    )
+
+    result = runner.invoke(
+        app, ["doctor", "repair", "--repo", str(repo), "--apply", "--only", "codex", "--json"]
+    )
+
+    assert result.exit_code in {0, 1}
+    payload = json.loads(result.stdout)
+    applied = {action["id"]: action for action in payload["applied_actions"]}
+    assert "codex-plugin-install" in applied
+    assert applied["codex-plugin-install"]["state"] == "ok"
+    assert codex_mod.CODEX_PLUGIN_INSTALL_COMMAND in applied["codex-plugin-install"]["command"]
 
 
 def test_doctor_repair_plan_reports_stale_codex_lifecycle_guidance(tmp_path: Path) -> None:

--- a/mb/tests/test_start.py
+++ b/mb/tests/test_start.py
@@ -59,11 +59,56 @@ def _without_codex(name: str) -> str:
     return shutil.which(name) or ""
 
 
+def _codex_plugin_list_result(repo: Path, *, installed: bool = True) -> dict[str, Any]:
+    marketplace = repo / codex_mod.CODEX_MARKETPLACE_RELATIVE_PATH
+    plugin = repo / codex_mod.CODEX_PLUGIN_DIR_RELATIVE_PATH
+    status = "installed, enabled" if installed else "not installed"
+    return {
+        "ok": True,
+        "returncode": 0,
+        "stdout": (
+            f"Marketplace `{codex_mod.CODEX_MARKETPLACE_NAME}`\n"
+            f"{marketplace}\n\n"
+            "PLUGIN                                    STATUS              VERSION  PATH\n"
+            f"{codex_mod.CODEX_PLUGIN_SELECTOR}  {status}  0.1.0  {plugin}\n"
+        ),
+        "stderr": "",
+        "command": f"codex plugin list --marketplace {codex_mod.CODEX_MARKETPLACE_NAME}",
+    }
+
+
+def _codex_runtime_ok() -> dict[str, Any]:
+    return {
+        "checked": True,
+        "ok": True,
+        "state": "ok",
+        "shell": "/bin/zsh",
+        "command": "command -v mb && mb --version",
+        "path": "/usr/local/bin/mb",
+        "version": "0.3.31",
+        "active_path": "/usr/local/bin/mb",
+        "active_version": "0.3.31",
+        "path_mismatch": False,
+        "version_mismatch": False,
+        "mismatch": False,
+        "error": "",
+        "summary": "Login-shell runtime resolves the active mb.",
+        "repair": "",
+        "safe_to_share": True,
+    }
+
+
 def test_start_json_prints_ready_handoff(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(start_mod, "_which", _with_claude)
     monkeypatch.setattr(codex_mod, "_which", _with_codex)
+    monkeypatch.setattr(codex_mod, "_login_shell_mb_diagnostics", _codex_runtime_ok)
     repo = tmp_path / "acme"
     init_run(path=str(repo), name="Acme")
+    monkeypatch.setattr(
+        codex_mod,
+        "_codex_plugin_list",
+        lambda plugin_repo: _codex_plugin_list_result(Path(plugin_repo)),
+    )
     (repo / "core" / "vocabulary.md").write_text(
         "---\n"
         "type: vocabulary\n"
@@ -141,6 +186,7 @@ def test_start_json_separates_codex_static_and_runtime_readiness(
 ) -> None:
     monkeypatch.setattr(start_mod, "_which", _with_claude)
     monkeypatch.setattr(codex_mod, "_which", _with_codex)
+    monkeypatch.setattr(codex_mod, "_login_shell_mb_diagnostics", _codex_runtime_ok)
     monkeypatch.setattr(
         codex_mod,
         "_login_shell_mb_diagnostics",
@@ -165,6 +211,11 @@ def test_start_json_separates_codex_static_and_runtime_readiness(
     )
     repo = tmp_path / "acme"
     init_run(path=str(repo), name="Acme")
+    monkeypatch.setattr(
+        codex_mod,
+        "_codex_plugin_list",
+        lambda plugin_repo: _codex_plugin_list_result(Path(plugin_repo)),
+    )
 
     result = runner.invoke(app, ["start", "--repo", str(repo), "--json"])
 
@@ -187,6 +238,35 @@ def test_start_json_separates_codex_static_and_runtime_readiness(
     assert "Run `claude" not in top_level_actions
     assert "login-shell PATH" in top_level_actions
     assert "mb status --json --peek" in top_level_actions
+
+
+def test_start_json_routes_to_codex_plugin_repair_when_plugin_is_missing(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(start_mod, "_which", _with_claude)
+    monkeypatch.setattr(codex_mod, "_which", _with_codex)
+    monkeypatch.setattr(codex_mod, "_login_shell_mb_diagnostics", _codex_runtime_ok)
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+    monkeypatch.setattr(
+        codex_mod,
+        "_codex_plugin_list",
+        lambda plugin_repo: _codex_plugin_list_result(Path(plugin_repo), installed=False),
+    )
+
+    result = runner.invoke(app, ["start", "--repo", str(repo), "--json"])
+
+    assert result.exit_code == 0
+    report = json.loads(result.stdout)
+    codex = report["runtime"]["codex_cli"]
+    assert codex["status"] == "plugin_not_installed"
+    assert codex["plugin_ok"] is False
+    assert codex["plugin_install"]["plugin_installed"] is False
+    next_actions = "\n".join(report["next_actions"])
+    assert codex_mod.CODEX_PLUGIN_INSTALL_COMMAND in next_actions
+    assert f"codex -C {shlex.quote(str(repo.resolve()))}" not in next_actions
+    assert "Run `claude" not in next_actions
 
 
 def test_start_human_labels_missing_codex_without_experimental_copy(

--- a/mb/tests/test_status.py
+++ b/mb/tests/test_status.py
@@ -42,6 +42,45 @@ def _without_codex(name: str) -> str:
     return shutil.which(name) or ""
 
 
+def _codex_plugin_list_result(repo: Path, *, installed: bool = True) -> dict[str, Any]:
+    marketplace = repo / codex_mod.CODEX_MARKETPLACE_RELATIVE_PATH
+    plugin = repo / codex_mod.CODEX_PLUGIN_DIR_RELATIVE_PATH
+    status = "installed, enabled" if installed else "not installed"
+    return {
+        "ok": True,
+        "returncode": 0,
+        "stdout": (
+            f"Marketplace `{codex_mod.CODEX_MARKETPLACE_NAME}`\n"
+            f"{marketplace}\n\n"
+            "PLUGIN                                    STATUS              VERSION  PATH\n"
+            f"{codex_mod.CODEX_PLUGIN_SELECTOR}  {status}  0.1.0  {plugin}\n"
+        ),
+        "stderr": "",
+        "command": f"codex plugin list --marketplace {codex_mod.CODEX_MARKETPLACE_NAME}",
+    }
+
+
+def _codex_runtime_ok() -> dict[str, Any]:
+    return {
+        "checked": True,
+        "ok": True,
+        "state": "ok",
+        "shell": "/bin/zsh",
+        "command": "command -v mb && mb --version",
+        "path": "/usr/local/bin/mb",
+        "version": "0.3.31",
+        "active_path": "/usr/local/bin/mb",
+        "active_version": "0.3.31",
+        "path_mismatch": False,
+        "version_mismatch": False,
+        "mismatch": False,
+        "error": "",
+        "summary": "Login-shell runtime resolves the active mb.",
+        "repair": "",
+        "safe_to_share": True,
+    }
+
+
 def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         ["git", *args],
@@ -322,6 +361,11 @@ def test_status_money_path_default_repo_stays_low(tmp_path: Path, monkeypatch) -
     monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
     repo = tmp_path / "acme"
     init_run(path=str(repo), name="Acme")
+    monkeypatch.setattr(
+        codex_mod,
+        "_codex_plugin_list",
+        lambda plugin_repo: _codex_plugin_list_result(Path(plugin_repo)),
+    )
 
     report = status_mod.run(path=str(repo), update_marker=False)
 
@@ -1402,6 +1446,64 @@ def test_status_warns_when_codex_runtime_uses_stale_mb(
     )
     assert "different mb" in finding["summary"]
     assert "login-shell PATH" in finding["repair"]
+
+
+def test_status_marks_codex_not_ready_when_plugin_is_not_installed(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
+    monkeypatch.setattr(codex_mod, "_which", _with_codex)
+    monkeypatch.setattr(codex_mod, "_login_shell_mb_diagnostics", _codex_runtime_ok)
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+    monkeypatch.setattr(
+        codex_mod,
+        "_codex_plugin_list",
+        lambda plugin_repo: _codex_plugin_list_result(Path(plugin_repo), installed=False),
+    )
+
+    report = status_mod.run(path=str(repo), update_marker=False)
+
+    codex = report["runtime"]["codex_cli"]
+    assert codex["ok"] is False
+    assert codex["status"] == "plugin_not_installed"
+    assert codex["static_ok"] is True
+    assert codex["runtime_ok"] is True
+    assert codex["plugin_ok"] is False
+    assert codex["plugin_install"]["marketplace_registered"] is True
+    assert codex["plugin_install"]["plugin_installed"] is False
+    finding = next(
+        item for item in report["drift"]["items"] if item["id"] == "codex_plugin_not_installed"
+    )
+    assert codex_mod.CODEX_PLUGIN_INSTALL_COMMAND in finding["repair"]
+
+
+def test_status_marks_codex_ready_when_plugin_is_installed(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
+    monkeypatch.setattr(codex_mod, "_which", _with_codex)
+    monkeypatch.setattr(codex_mod, "_login_shell_mb_diagnostics", _codex_runtime_ok)
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+    monkeypatch.setattr(
+        codex_mod,
+        "_codex_plugin_list",
+        lambda plugin_repo: _codex_plugin_list_result(Path(plugin_repo)),
+    )
+
+    report = status_mod.run(path=str(repo), update_marker=False)
+
+    codex = report["runtime"]["codex_cli"]
+    assert codex["ok"] is True
+    assert codex["status"] == "ready"
+    assert codex["plugin_ok"] is True
+    assert codex["plugin_install"]["plugin_installed"] is True
+    assert codex["plugin_install"]["plugin_enabled"] is True
+    assert codex["plugin_install"]["slash_commands_ready"] is True
+    assert not any(item["id"] == "codex_plugin_not_installed" for item in report["drift"]["items"])
 
 
 def test_status_json_exposes_push_and_legacy_campaign_facts(tmp_path: Path, monkeypatch) -> None:

--- a/mb/tests/test_update.py
+++ b/mb/tests/test_update.py
@@ -22,12 +22,28 @@ runner = CliRunner()
 def codex_adapter_ready(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         codex_mod,
-        "instructions_status",
+        "readiness",
         lambda repo: {
             "ok": True,
-            "exists": True,
-            "current": True,
-            "repair_command": "",
+            "status": "ready",
+            "static_ok": True,
+            "runtime_ok": True,
+            "plugin_ok": True,
+            "repair": "",
+            "instructions": {
+                "ok": True,
+                "exists": True,
+                "current": True,
+                "repair_command": "",
+            },
+            "plugin_install": {
+                "ok": True,
+                "state": "ok",
+                "plugin_installed": True,
+                "plugin_enabled": True,
+                "slash_commands_ready": True,
+                "repair": "",
+            },
         },
     )
 
@@ -162,12 +178,28 @@ def test_update_points_to_scoped_codex_repair_when_adapter_missing(
     monkeypatch.setattr(update_mod, "_run_command", fake_run)
     monkeypatch.setattr(
         codex_mod,
-        "instructions_status",
+        "readiness",
         lambda repo: {
             "ok": False,
-            "exists": False,
-            "current": False,
-            "repair_command": "mb doctor repair --apply --only codex",
+            "status": "needs_setup",
+            "static_ok": False,
+            "runtime_ok": True,
+            "plugin_ok": False,
+            "repair": "mb doctor repair --apply --only codex",
+            "instructions": {
+                "ok": False,
+                "exists": False,
+                "current": False,
+                "repair_command": "mb doctor repair --apply --only codex",
+            },
+            "plugin_install": {
+                "ok": False,
+                "state": "waiting_for_adapter_files",
+                "plugin_installed": False,
+                "plugin_enabled": False,
+                "slash_commands_ready": False,
+                "repair": "mb doctor repair --apply --only codex",
+            },
         },
     )
 
@@ -179,6 +211,67 @@ def test_update_points_to_scoped_codex_repair_when_adapter_missing(
     assert any(
         "Codex owner-loop files still need repo repair" in item for item in result["warnings"]
     )
+
+
+def test_update_points_to_scoped_codex_repair_when_plugin_is_missing(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    def fake_run(args: list[str], *, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+        if args == ["pipx", "upgrade", "mainbranch"]:
+            return _completed(args, stdout="upgraded package mainbranch")
+        if args == ["mb", "--version"]:
+            return _completed(args, stdout="mb 0.3.32\n")
+        if args[:3] == ["mb", "skill", "link"]:
+            return _completed(
+                args,
+                stdout=json.dumps(
+                    {"ok": True, "linked": [], "copied": [], "skipped": [], "errors": []}
+                ),
+            )
+        return _completed(args, returncode=1, stderr="unexpected")
+
+    monkeypatch.setattr(update_mod, "install_mode", lambda: "pipx")
+    monkeypatch.setattr(update_mod, "engine_root", lambda: tmp_path / "_engine")
+    monkeypatch.setattr(
+        update_mod.shutil,  # type: ignore[attr-defined]
+        "which",
+        lambda name: "/opt/homebrew/bin/pipx",
+    )
+    monkeypatch.setattr(update_mod, "_run_command", fake_run)
+    monkeypatch.setattr(
+        codex_mod,
+        "readiness",
+        lambda repo: {
+            "ok": False,
+            "status": "plugin_not_installed",
+            "static_ok": True,
+            "runtime_ok": True,
+            "plugin_ok": False,
+            "repair": f"Run `{codex_mod.CODEX_PLUGIN_INSTALL_COMMAND}`.",
+            "instructions": {
+                "ok": True,
+                "exists": True,
+                "current": True,
+                "repair_command": "",
+            },
+            "plugin_install": {
+                "ok": False,
+                "state": "plugin_not_installed",
+                "plugin_installed": False,
+                "plugin_enabled": False,
+                "slash_commands_ready": False,
+                "repair": f"Run `{codex_mod.CODEX_PLUGIN_INSTALL_COMMAND}`.",
+            },
+        },
+    )
+
+    result = update_mod.run(repo=tmp_path / "biz")
+
+    assert result["ok"] is True
+    assert result["codex_adapter"]["status"] == "plugin_not_installed"
+    assert result["codex_adapter"]["plugin_ok"] is False
+    assert "mb doctor repair --plan --only codex" in result["next_actions"]
+    assert any("slash commands are not ready" in item for item in result["warnings"])
 
 
 def test_update_check_clone_fetches_before_reading_origin(monkeypatch: Any, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Makes Codex slash-command install state part of Codex readiness instead of treating generated repo files alone as ready.

## In Scope

- Detect `main-branch-owner-loop@main-branch-local` from `codex plugin list --marketplace main-branch-local`.
- Verify the registered marketplace points at this repo's `.agents/plugins/marketplace.json`.
- Expose `plugin_install` facts under `runtime.codex_cli`.
- Require static files, runtime `mb`, and installed/enabled plugin for Codex `ready`.
- Surface `codex-plugin-install` in `mb doctor repair --plan --only codex`.
- Apply plugin install through `mb doctor repair --apply --only codex`.
- Route `mb start --json` and `mb update` follow-ups to Codex plugin repair when slash commands are not ready.

## Out Of Scope

- Full #125 workflow porting program.
- Non-owner-loop Codex skill parity.
- Local shell profile cleanup.

## Commits

- `[fix] Include Codex plugin install in readiness`

## Release / Issues

Release: target `0.3.32`.

Closes #700.
Refs MAIN-430.

## Success Metric

`mb status` no longer reports Codex ready when adapter files are current but `/mb-*` slash commands are not installed/enabled in Codex.

## Validation

Level 1 static:

- `scripts/check.sh` passed.

Focused regression coverage:

- `cd mb && pytest tests/test_start.py tests/test_status.py::test_status_warns_when_codex_runtime_uses_stale_mb tests/test_status.py::test_status_marks_codex_not_ready_when_plugin_is_not_installed tests/test_status.py::test_status_marks_codex_ready_when_plugin_is_installed tests/test_doctor.py::test_doctor_repair_only_codex_filters_unrelated_related_links tests/test_doctor.py::test_doctor_repair_plan_marks_codex_runtime_info_when_codex_missing tests/test_doctor.py::test_doctor_repair_plan_installs_missing_codex_plugin tests/test_doctor.py::test_doctor_repair_apply_installs_missing_codex_plugin tests/test_update.py::test_update_points_to_scoped_codex_repair_when_adapter_missing tests/test_update.py::test_update_points_to_scoped_codex_repair_when_plugin_is_missing -q` passed, 27 tests.
- `cd mb && pytest tests/test_start.py tests/test_status.py tests/test_doctor.py tests/test_update.py -q` passed, 189 tests.

Full gate evidence from `scripts/check.sh`:

- `ruff format --check .` passed.
- `ruff check .` passed.
- `mypy mb tests` passed.
- `pytest tests/ -v --cov=mb --cov-report=term-missing --cov-fail-under=79` passed: 794 passed, coverage 83.85%.
- `mb skill validate --all --json` passed.

## Runtime Smoke

Not run before PR because this branch changes deterministic CLI readiness and repair contracts. Release runtime smoke will run after merge as part of `0.3.32` release verification.

## Public / Private Boundary

No private paths, credentials, or local operator details committed. The new plugin facts report repo-relative/public-safe adapter state plus Codex command names.
