### PR TITLE
Prepare v0.3.32 release

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mainbranch",
-  "version": "0.3.31",
+  "version": "0.3.32",
   "description": "Main Branch Claude Code skills for running a business from markdown files in git.",
   "author": {
     "name": "Noontide"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+## [0.3.32] - 2026-05-23
+
+v0.3.32 packages the Codex readiness truth cleanup after v0.3.31. It keeps the
+proven Codex owner-loop handoff native and treats installed/enabled Codex plugin
+slash commands as part of readiness, so `mb` no longer reports ready while
+`/mb-*` commands are absent.
+
 ### Changed
 
 - Made `mb start --json` top-level next actions prefer Codex-facing handoff

--- a/mb/mb/__init__.py
+++ b/mb/mb/__init__.py
@@ -7,6 +7,6 @@ file stays a thin dispatcher.
 
 from __future__ import annotations
 
-__version__ = "0.3.31"
+__version__ = "0.3.32"
 
 __all__ = ["__version__"]

--- a/mb/pyproject.toml
+++ b/mb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mainbranch"
-version = "0.3.31"
+version = "0.3.32"
 description = "Main Branch engine umbrella - scaffolds, validates, and graphs business-as-files repos. Claude Code first, runtime-agnostic by design."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Prepares `mainbranch` / `mb` v0.3.32.

This patch release packages the Codex readiness truth cleanup after v0.3.31:

- `mb start --json` now gives Codex-native next actions when Codex readiness is the relevant handoff.
- Codex readiness now includes installed/enabled plugin state, so generated adapter files alone do not count as full `/mb-*` slash-command readiness.
- `mb doctor repair --only codex` can surface and apply the Codex plugin install step.
- `mb update` follow-up guidance now notices Codex slash-command install gaps.

## In Scope

- `CHANGELOG.md` v0.3.32 section dated 2026-05-23.
- `mb/pyproject.toml` package version `0.3.32`.
- `mb/mb/__init__.py` runtime version `0.3.32`.
- `.claude-plugin/plugin.json` plugin version `0.3.32`.

## Out Of Scope

- New product changes beyond packaging already-merged PRs.
- Full Codex workflow porting program (#125).
- Post-publish PyPI acceptance, which happens after tag/release publish.

## Commits

- `[update] Prepare v0.3.32 release`

## Release / Issues

Closes #699.
Refs #697, #700, MAIN-429, MAIN-428, MAIN-430.

## Success Metric

A user can install `mainbranch==0.3.32` from PyPI and get the merged Codex start-action and plugin-readiness fixes with matching version metadata and release notes.

## Validation

Pre-simulation checkpoint:

- `.agent/release-evidence/0.3.32/pre-simulation-checkpoint.md`

Level 0 release-file preflight:

- `cd mb && python3 -m pytest tests/test_smoke_coverage.py::test_claude_plugin_manifest_points_at_prefixed_skills -q` — runtime: `python3` — exit: `0` — log: `.agent/release-evidence/0.3.32/release-file-preflight.out` (1 passed).

Level 1 static / full local gate:

- `scripts/check.sh` — runtime: `python3` — exit: `0` — log: `.agent/release-evidence/0.3.32/check.out`.
- Results: ruff format, ruff check, mypy, full pytest, coverage, and skill validation passed.
- Pytest summary: 794 passed, coverage 83.85%.

Level 3 package/install smoke:

- `(cd mb && python3 -m build) + fresh venv install of dist/mainbranch-0.3.32-py3-none-any.whl` — runtime: `python3` / `/tmp/mainbranch-0.3.32-smoke/bin/python3.13` — exit: `0` — log: `.agent/release-evidence/0.3.32/package-smoke.out`.
- Verified `mb --version` prints `mb 0.3.32`.
- Verified `mb skill list` is populated.

Books fixture release check:

- `/tmp/mainbranch-0.3.32-smoke/bin/mb books check --fixture --json` with hledger available — exit: `0` — log: `.agent/release-evidence/0.3.32/books-fixture-installed.out`; includes `fixture-valid`.
- `env PATH="/usr/bin:/bin" /tmp/mainbranch-0.3.32-smoke/bin/mb books check --fixture --json` with hledger hidden — exit: `0` — log: `.agent/release-evidence/0.3.32/books-fixture-no-hledger.out`; includes `hledger-missing` info fallback.

Level 5 release simulation / runtime proxy:

- `python3 scripts/claude-runtime-dogfood.py --install-mode wheel --wheel mb/dist/mainbranch-0.3.32-py3-none-any.whl --evidence-dir .agent/release-evidence/0.3.32/prerelease-candidate --run-claude-print --simulation-tier prerelease_candidate --max-budget-usd 0.75` — exit: `0` — log: `.agent/release-evidence/0.3.32/prerelease-candidate.log`.
  - Evidence template: `.agent/release-evidence/0.3.32/prerelease-candidate/evidence-template.md`.
  - 13 fixture profiles, 11/11 heuristic checks, no harness failures.
- `python3 scripts/claude-runtime-dogfood.py --install-mode wheel --wheel mb/dist/mainbranch-0.3.32-py3-none-any.whl --evidence-dir .agent/release-evidence/0.3.32/release-acceptance-wheel --run-claude-print --simulation-tier release_acceptance --max-budget-usd 0.75` — exit: `0` — log: `.agent/release-evidence/0.3.32/release-acceptance-wheel.log`.
  - Evidence template: `.agent/release-evidence/0.3.32/release-acceptance-wheel/evidence-template.md`.
  - 12 turns, 11/11 heuristic checks, no read-only `mb` grounding denial, no harness failures.

Manual transcript review:

- Reviewed `.agent/release-evidence/0.3.32/release-acceptance-wheel/claude/transcript-excerpts.md`.
- No hard release blocker found.
- Proxy caveat remains: print-mode evidence is not interactive TUI proof.
- The wheel fixture still surfaced a pre-publish local login-shell mismatch against installed `mb 0.3.31`; this is expected before publishing `0.3.32` and should be rechecked after PyPI install.

## Public / Private Boundary

Release PR commits only release files. Local evidence remains under `.agent/` and is not committed.

## Post-Merge Release Steps

After merge:

1. Create GitHub Release/tag `oe-v0.3.32` from `main`.
2. Wait for the PyPI publish workflow and maintainer environment approval.
3. Verify PyPI shows `mainbranch 0.3.32`.
4. Fresh-install from PyPI and verify `mb --version`.
5. Run post-publish release acceptance from PyPI.
6. Run/record Codex plugin readiness smoke from an installed `0.3.32` runtime.
7. Complete post-release alignment and close out release state.
