### PR TITLE
[update] Prepare v0.3.33 release

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mainbranch",
-  "version": "0.3.32",
+  "version": "0.3.33",
   "description": "Main Branch Claude Code skills for running a business from markdown files in git.",
   "author": {
     "name": "Noontide"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+## [0.3.33] - 2026-05-23
+
+v0.3.33 packages the global-only Codex owner-loop plugin model after v0.3.32.
+It retires the brief repo-local Codex plugin default so users install one global
+Main Branch plugin while business repos keep lightweight `AGENTS.md` guidance.
+
 ### Changed
 
 - Pivoted Codex owner-loop slash commands to a global Main Branch plugin install

--- a/mb/mb/__init__.py
+++ b/mb/mb/__init__.py
@@ -7,6 +7,6 @@ file stays a thin dispatcher.
 
 from __future__ import annotations
 
-__version__ = "0.3.32"
+__version__ = "0.3.33"
 
 __all__ = ["__version__"]

--- a/mb/pyproject.toml
+++ b/mb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mainbranch"
-version = "0.3.32"
+version = "0.3.33"
 description = "Main Branch engine umbrella - scaffolds, validates, and graphs business-as-files repos. Claude Code first, runtime-agnostic by design."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Prepares `mainbranch` / `mb` v0.3.33. This release packages the merged global-only Codex owner-loop plugin model after v0.3.32 so users can install one global Main Branch Codex plugin while business repos keep lightweight `AGENTS.md` guidance.

## Linked issue

Closes #705.
Refs #703, #125.

## Why

The global Codex plugin install model is merged on `main`, but the latest shipped PyPI package is still v0.3.32. This release-only PR aligns version metadata and release notes so a maintainer can tag `oe-v0.3.33`, approve PyPI publish, and verify the global plugin model from an installed package.

## Commits by concern

- [x] Each commit body bullet-lists the changes in that commit
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`

Commits:

- `c2049e9 [update] Prepare v0.3.33 release`

## Validation

Pre-push gate from repo root:

```bash
scripts/check.sh
```

- [x] Level 1 static: `scripts/check.sh` passes
- [x] Level 2 CLI contract: focused Typer/CliRunner tests, exit codes, `--json` behavior, TTY vs non-TTY (if CLI behavior touched)
- [x] Level 3 package/install smoke (if packaging touched)
- [x] Level 4 fixture repo (if init/onboard/status/start/update touched)
- [x] Level 5 runtime smoke / dogfood harness / simulation-tier (if runtime, first-run, skill discovery, or release validation touched)
- [x] SKILL.md ≤500 lines (if any skill touched)
- [x] Package-visible release gate evidence before tag/publish (if preparing a release)
- [x] Supply-chain review (if `.github/workflows/`, `.github/dependabot.yml`, `mb/pyproject.toml` deps, or `id-token`/`permissions` blocks touched — see [docs/supply-chain-policy.md](../docs/supply-chain-policy.md))

Evidence:

- Level 0 release-file preflight: `cd mb && python3 -m pytest tests/test_smoke_coverage.py::test_claude_plugin_manifest_points_at_prefixed_skills -q` — runtime: `python3` — exit: `0` — log: `.agent/release-evidence/0.3.33/release-file-preflight.out` (`1 passed`).
- Level 1 static: `scripts/check.sh` — runtime: `python3` — exit: `0` — log: `.agent/release-evidence/0.3.33/check.out` (`794 passed`, coverage `83.69%`, skill validation passed).
- Level 3 package/install: `(cd mb && python3 -m build) + fresh venv install of mb/dist/mainbranch-0.3.33-py3-none-any.whl` — runtime: `python3` / temp venv Python 3.13 — exit: `0` — logs: `.agent/release-evidence/0.3.33/build.out`, `.agent/release-evidence/0.3.33/package-smoke.out`; verified `mb --version` prints `mb 0.3.33` and `mb skill list` is populated.
- Level 4 fixture repo: installed-wheel `mb onboard --yes --name "Release Smoke" --path <tmp>/business` with temp HOME and `MAINBRANCH_CODEX_PLUGIN_ROOT` — runtime: temp venv `mb` — exit: `0` — log: `.agent/release-evidence/0.3.33/package-smoke.out`; verified no repo-local `.agents/plugins` or `.agents/skills/main-branch-owner-loop` artifacts.
- Level 5 runtime / Codex readiness: installed-wheel scoped Codex repair and plugin check under temp HOME: `mb doctor repair --repo <tmp>/business --apply --only codex --json`, `codex plugin list --marketplace main-branch`, and `mb status <tmp>/business --json --peek` — runtime: temp venv `mb` + Codex CLI — exit: `0` — logs: `.agent/release-evidence/0.3.33/codex-doctor-apply.json`, `.agent/release-evidence/0.3.33/codex-plugin-list.out`, `.agent/release-evidence/0.3.33/codex-status.json`; verified Codex status `ready` with `slash_commands_ready: true`.
- Books fixture release check: installed-wheel `mb books check --fixture --json` with hledger available — runtime: temp venv `mb` — exit: `0` — log: `.agent/release-evidence/0.3.33/books-fixture-installed.out`; includes `fixture-valid`.
- Books fixture release check: installed-wheel `env PATH="/usr/bin:/bin" mb books check --fixture --json` with hledger hidden — runtime: temp venv `mb` — exit: `0` — log: `.agent/release-evidence/0.3.33/books-fixture-no-hledger.out`; includes `hledger-missing` info fallback.
- Level 5 prerelease candidate proxy: `python3 scripts/claude-runtime-dogfood.py --install-mode wheel --wheel mb/dist/mainbranch-0.3.33-py3-none-any.whl --evidence-dir .agent/release-evidence/0.3.33/prerelease-candidate --run-claude-print --simulation-tier prerelease_candidate --max-budget-usd 0.75` — runtime: `python3` — exit: `0` — log: `.agent/release-evidence/0.3.33/prerelease-candidate.log`; 13 fixture profiles, 11/11 heuristic checks, no harness failures.
- Level 5 release acceptance proxy: `python3 scripts/claude-runtime-dogfood.py --install-mode wheel --wheel mb/dist/mainbranch-0.3.33-py3-none-any.whl --evidence-dir .agent/release-evidence/0.3.33/release-acceptance-wheel --run-claude-print --simulation-tier release_acceptance --max-budget-usd 0.75` — runtime: `python3` — exit: `0` — log: `.agent/release-evidence/0.3.33/release-acceptance-wheel.log`; 12 turns, 11/11 heuristic checks, 0 read-only `mb` grounding denials, no harness failures.
- Manual transcript review: `.agent/release-evidence/0.3.33/manual-transcript-review.md` — no hard release blocker found; print-mode remains proxy evidence, not interactive TUI proof.
- Supply-chain review: workflow permission scan captured in `.agent/release-evidence/0.3.33/workflow-permissions-scan.out`; no workflow/dependency changes in this PR. PyPI pre-release check shows latest published version is still `0.3.32`, as expected before publish. Open PR scan found only unrelated dashboard PR #603.

One package-smoke attempt first reported Codex `runtime_mismatch` because the temp HOME login shell did not put the wheel venv first on PATH. That log is preserved as `.agent/release-evidence/0.3.33/package-smoke-attempt1-runtime-path-mismatch.out`; the rerun added the venv to the temp login profile and passed.

## Success metric

A maintainer can merge this PR, tag `oe-v0.3.33`, approve PyPI publish, and verify a fresh `mainbranch==0.3.33` install includes the global Codex plugin install model.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [ ] N/A — change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [ ] No
- [x] Yes — migration note below

Migration note: v0.3.33 packages the intentional retirement of the brief repo-local Codex plugin default. Users should run `mb doctor repair --apply --only codex` to install or repair the global `main-branch-owner-loop@main-branch` plugin and remove transitional repo-local Codex plugin artifacts.

## Public / private boundary

Release PR commits only release files. Local evidence remains under `.agent/` and is not committed. No private operator strategy, credentials, machine-specific paths, or runtime internals were added to public files.

Post-merge release steps:

1. Create GitHub Release/tag `oe-v0.3.33` from `main`.
2. Wait for the PyPI publish workflow and maintainer environment approval.
3. Verify PyPI shows `mainbranch 0.3.33`.
4. Fresh-install from PyPI and verify `mb --version`.
5. Run post-publish release acceptance from PyPI.
6. Run/record Codex plugin readiness smoke from an installed `0.3.33` runtime.
7. Complete post-release alignment and close out release state.