### PR TITLE
[fix] Remove Codex slash prompt from onboarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 - Removed unproven Codex command-file shims from the generated global plugin;
   Codex support now starts from the plugin guidance and deterministic `mb`
   facts. Refs MAIN-434, #709.
+- Updated fresh business-repo onboarding and README guidance so Codex users are
+  told to ask Codex for a read-only `mb`-fact start instead of running
+  unsupported `/mb-start` slash commands. Refs MAIN-435, #712.
 - Extended the Codex workflow inventory to account for every bundled Claude
   `mb-*` skill source, keeping full workflow parity as an explicit routing
   ledger instead of an implied owner-loop subset. Refs MAIN-433, #707.

--- a/mb/mb/_data/templates/README.md.tmpl
+++ b/mb/mb/_data/templates/README.md.tmpl
@@ -29,11 +29,8 @@ mb doctor repair --apply --only codex
 codex
 ```
 
-Then run:
-
-```text
-/mb-start
-```
+Then ask Codex to start this Main Branch business day from read-only `mb` facts
+and to ask before writing files.
 
 For a terminal-only check:
 

--- a/mb/mb/onboard.py
+++ b/mb/mb/onboard.py
@@ -638,7 +638,7 @@ def _next_steps(repo: Path) -> list[str]:
                 "mb doctor repair --plan --only codex",
                 "mb doctor repair --apply --only codex",
                 f"codex -C {repo}",
-                "/mb-start",
+                "Ask Codex to start this Main Branch business day from read-only mb facts.",
             ]
         )
     return steps

--- a/mb/tests/test_init.py
+++ b/mb/tests/test_init.py
@@ -241,6 +241,7 @@ def test_init_scaffolds_folders(tmp_path: Path) -> None:
     assert "/mb-start" in readme_md
     assert "Codex CLI" in readme_md
     assert "mb doctor repair --apply --only codex" in readme_md
+    assert "/mb-start" not in readme_md.split("Or, in Codex CLI:", 1)[1]
     assert "## Save, Checkpoint, Backup" in readme_md
     assert "A checkpoint is an approved saved point" in readme_md
     assert "GitHub backup/sync is strongly recommended" in readme_md

--- a/mb/tests/test_onboard.py
+++ b/mb/tests/test_onboard.py
@@ -112,7 +112,7 @@ def test_onboard_next_steps_offer_global_codex_repair_when_available(
         "mb doctor repair --plan --only codex",
         "mb doctor repair --apply --only codex",
         f"codex -C {repo.resolve()}",
-        "/mb-start",
+        "Ask Codex to start this Main Branch business day from read-only mb facts.",
     ]
 
 


### PR DESCRIPTION
## Summary

Fresh Codex onboarding now points users to generated guidance and read-only `mb` facts instead of `/mb-start`. The generated business README carries the same direct Codex start language.

## Linked issue

Closes #712

## Why

MAIN-434 removed unsupported Codex slash-command claims, but fresh `mb onboard` output and the generated business README still told Codex users to run `/mb-start`. This keeps the first Codex implementation direct: Claude Code has `/mb-start`; Codex starts through generated guidance, the global Main Branch plugin, and deterministic `mb` facts.

## Commits by concern

- [x] `[fix] Remove Codex slash prompt from onboarding`
- [x] Each commit body bullet-lists the changes in that commit
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`

## Validation

Pre-push gate from repo root:

```bash
scripts/check.sh
```

- [x] Level 1 static: `scripts/check.sh` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: ruff, mypy, pytest, and skill validation passed; pytest reported `797 passed`
- [x] Level 2 CLI contract: `cd mb && /Library/Frameworks/Python.framework/Versions/3.13/bin/python3 -m pytest tests/test_init.py::test_init_scaffolds_folders tests/test_onboard.py::test_onboard_next_steps_offer_global_codex_repair_when_available tests/test_onboard.py::test_onboard_cli_yes_json_smoke tests/test_runtime_command_references.py::test_runtime_docs_reference_only_bundled_main_branch_slash_commands -q` — runtime: Python 3.13 — exit: 0 — log: `4 passed`
- [x] Level 3 package/install smoke: `(cd mb && python3.13 -m build)`, clean venv wheel install, `mb --version`, `mb skill list` — runtime: `/tmp/mainbranch-main435-smoke/bin/mb` — exit: 0 — log: built `mainbranch-0.3.33` wheel/sdist, installed wheel, `mb 0.3.33`, skill list returned bundled skills
- [x] Level 4 fixture repo: installed-wheel `mb onboard`, Codex repair plan/apply, `mb doctor`, `mb status --json --peek`, `mb start --json`, `mb workflow list --runtime codex --json`, `mb validate` — runtime: `/tmp/mainbranch-main435-smoke/bin/mb` — exit: 0 for required commands — log: Codex repair applied `codex-plugin-install`; status/start reported Codex plugin install `ok=true`, support `supported_generated_guidance`, slash commands `false`; workflow inventory reported 11 items; validate ended `all metadata looks right.`
- [x] Level 5 runtime smoke: `codex exec --json --ephemeral --sandbox read-only -c 'approval_policy="never"' -C <fixture>` — runtime: Codex CLI 0.133.0 with global installed `mb` — exit: 0 — log: Codex used the Main Branch owner-loop skill, ran read-only `mb` checks, did not apply repairs, and returned a repair-first next action. Not counted as package-branch acceptance because the subprocess resolved the globally installed `mb`, so post-release dogfood must rerun after the published package is installed.
- [x] SKILL.md <=500 lines: no skill files changed
- [x] Package-visible release gate evidence before tag/publish: not required for this PR; release happens after merge
- [x] Supply-chain review: not required; no workflows, dependency, or permission surfaces changed

## Success metric

A fresh business repo no longer tells Codex users to run `/mb-start`; it points them to generated Codex guidance and read-only `mb` facts while Claude Code keeps `/mb-start`.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section

## Breaking changes

- [x] No
- [ ] Yes — migration note below

## Public / private boundary

No private paths, operator strategy, credentials, or local runtime internals were committed. Public issue wording was also cleaned up to avoid naming a local maintainer path.
