### PR TITLE
[update] Prepare v0.3.34 release

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mainbranch",
-  "version": "0.3.33",
+  "version": "0.3.34",
   "description": "Main Branch Claude Code skills for running a business from markdown files in git.",
   "author": {
     "name": "Noontide"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+## [0.3.34] - 2026-05-23
+
+v0.3.34 packages the Codex live workflow surface after v0.3.33. Codex starts
+from generated Main Branch guidance, the global Codex plugin, and deterministic
+`mb` facts; fresh onboarding now points users at that supported path directly.
+
 ### Changed
 
 - Clarified the supported Codex path as generated Main Branch guidance delivered
@@ -25,6 +31,12 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 - Extended the Codex workflow inventory to account for every bundled Claude
   `mb-*` skill source, keeping full workflow parity as an explicit routing
   ledger instead of an implied owner-loop subset. Refs MAIN-433, #707.
+
+### Fixed
+
+- Fixed Codex-only doctor repair so a missing global Main Branch Codex plugin is
+  still installed when repo guidance is current but the Codex runtime PATH has a
+  warning. Refs MAIN-436, #714.
 
 ## [0.3.33] - 2026-05-23
 

--- a/mb/mb/__init__.py
+++ b/mb/mb/__init__.py
@@ -7,6 +7,6 @@ file stays a thin dispatcher.
 
 from __future__ import annotations
 
-__version__ = "0.3.33"
+__version__ = "0.3.34"
 
 __all__ = ["__version__"]

--- a/mb/mb/doctor.py
+++ b/mb/mb/doctor.py
@@ -2091,7 +2091,7 @@ def repair_plan(
             "state": (
                 "ok"
                 if codex_plugin_install["ok"]
-                else ("warn" if codex_runtime_relevant and codex_runtime_status["ok"] else "info")
+                else ("warn" if codex_runtime_relevant else "info")
             ),
             "summary": codex_plugin_install["summary"],
             "marketplace_registered": codex_plugin_install["marketplace_registered"],
@@ -2124,7 +2124,7 @@ def repair_plan(
         )
         actions.append(action)
         codex_actions.append(action)
-    if codex_runtime_relevant and codex_runtime_status["ok"] and not codex_plugin_install["ok"]:
+    if codex_runtime_relevant and not codex_plugin_install["ok"]:
         action = _action(
             id="codex-plugin-install",
             title="Install the Main Branch Codex plugin",
@@ -2533,12 +2533,11 @@ def repair_apply(
         )
 
     codex_status = codex_mod.readiness(target)
-    codex_runtime_status = codex_status["runtime"]
     codex_runtime_relevant = bool(
         codex_status["executable"]["found"] and codex_status["instructions"]["ok"]
     )
     codex_plugin_install = codex_status["plugin_install"]
-    if codex_runtime_relevant and codex_runtime_status["ok"] and not codex_plugin_install["ok"]:
+    if codex_runtime_relevant and not codex_plugin_install["ok"]:
         installed = codex_mod.install_plugin(target)
         applied.append(
             _action(

--- a/mb/pyproject.toml
+++ b/mb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mainbranch"
-version = "0.3.33"
+version = "0.3.34"
 description = "Main Branch engine umbrella - scaffolds, validates, and graphs business-as-files repos. Claude Code first, runtime-agnostic by design."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/mb/tests/test_doctor.py
+++ b/mb/tests/test_doctor.py
@@ -52,6 +52,27 @@ def _codex_runtime_ok() -> dict[str, Any]:
     }
 
 
+def _codex_runtime_path_mismatch_same_version() -> dict[str, Any]:
+    return {
+        "checked": True,
+        "ok": False,
+        "state": "warn",
+        "shell": "/bin/zsh",
+        "command": "command -v mb && mb --version",
+        "path": "/tmp/smoke/bin/mb",
+        "version": "0.3.34",
+        "active_path": "/Users/example/.local/bin/mb",
+        "active_version": "0.3.34",
+        "path_mismatch": True,
+        "version_mismatch": False,
+        "mismatch": True,
+        "error": "",
+        "summary": "Login-shell runtime resolves a different mb than this process.",
+        "repair": "Put the current Main Branch install earlier on the login-shell PATH.",
+        "safe_to_share": True,
+    }
+
+
 def _codex_plugin_list_result(repo: Path, *, installed: bool = True) -> dict[str, Any]:
     marketplace = codex_mod.marketplace_path(repo)
     plugin = codex_mod.plugin_manifest_path(repo).parent
@@ -499,6 +520,44 @@ def test_doctor_repair_plan_installs_missing_codex_plugin(
     assert plugin_check["plugin_installed"] is False
 
 
+def test_doctor_repair_plan_installs_missing_codex_plugin_with_runtime_path_warning(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(codex_mod, "_which", _with_codex)
+    monkeypatch.setattr(
+        codex_mod,
+        "_login_shell_mb_diagnostics",
+        _codex_runtime_path_mismatch_same_version,
+    )
+    _prepare_codex_global_plugin(tmp_path, monkeypatch)
+    repo = tmp_path / "biz"
+    init_run(path=str(repo), name="Acme")
+    monkeypatch.setattr(
+        codex_mod,
+        "_codex_plugin_list",
+        lambda plugin_repo: _codex_plugin_list_result(Path(plugin_repo), installed=False),
+    )
+
+    result = runner.invoke(
+        app, ["doctor", "repair", "--repo", str(repo), "--plan", "--only", "codex", "--json"]
+    )
+
+    assert result.exit_code in {0, 1}
+    payload = json.loads(result.stdout)
+    actions = {action["id"]: action for action in payload["actions"]}
+    assert "codex-plugin-install" in actions
+    section = next(section for section in payload["sections"] if section["id"] == "codex-wiring")
+    runtime_check = next(
+        check for check in section["checks"] if check["name"] == "codex-runtime-mb"
+    )
+    plugin_check = next(
+        check for check in section["checks"] if check["name"] == "codex-plugin-install"
+    )
+    assert runtime_check["state"] == "warn"
+    assert plugin_check["state"] == "warn"
+
+
 def test_doctor_repair_apply_installs_missing_codex_plugin(
     tmp_path: Path,
     monkeypatch,
@@ -543,6 +602,55 @@ def test_doctor_repair_apply_installs_missing_codex_plugin(
     assert "codex-plugin-install" in applied
     assert applied["codex-plugin-install"]["state"] == "ok"
     assert codex_mod.CODEX_PLUGIN_INSTALL_COMMAND in applied["codex-plugin-install"]["command"]
+
+
+def test_doctor_repair_apply_installs_missing_codex_plugin_with_runtime_path_warning(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(codex_mod, "_which", _with_codex)
+    monkeypatch.setattr(
+        codex_mod,
+        "_login_shell_mb_diagnostics",
+        _codex_runtime_path_mismatch_same_version,
+    )
+    _prepare_codex_global_plugin(tmp_path, monkeypatch)
+    repo = tmp_path / "biz"
+    init_run(path=str(repo), name="Acme")
+    monkeypatch.setattr(
+        codex_mod,
+        "_codex_plugin_list",
+        lambda plugin_repo: _codex_plugin_list_result(Path(plugin_repo), installed=False),
+    )
+    monkeypatch.setattr(
+        codex_mod,
+        "install_plugin",
+        lambda plugin_repo: {
+            "ok": True,
+            "steps": [
+                {"ok": True, "command": codex_mod.codex_marketplace_add_command()},
+                {"ok": True, "command": codex_mod.CODEX_PLUGIN_INSTALL_COMMAND},
+            ],
+            "status": {
+                "ok": True,
+                "state": "ok",
+                "plugin_installed": True,
+                "plugin_enabled": True,
+                "slash_commands_ready": False,
+            },
+            "safe_to_share": True,
+        },
+    )
+
+    result = runner.invoke(
+        app, ["doctor", "repair", "--repo", str(repo), "--apply", "--only", "codex", "--json"]
+    )
+
+    assert result.exit_code in {0, 1}
+    payload = json.loads(result.stdout)
+    applied = {action["id"]: action for action in payload["applied_actions"]}
+    assert "codex-plugin-install" in applied
+    assert applied["codex-plugin-install"]["state"] == "ok"
 
 
 def test_doctor_repair_plan_reports_stale_codex_lifecycle_guidance(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Prepares `mainbranch` / `mb` v0.3.34 and fixes the Codex repair blocker found during installed-wheel release smoke. This release packages the Codex guidance bridge, direct first-run Codex onboarding, and global-plugin repair path.

## Linked issue

Closes #714.
Refs #709.
Refs #712.

## Why

The latest shipped PyPI package is v0.3.33, while `main` now contains the Codex guidance bridge and fresh onboarding cleanup. Release smoke also found that `mb doctor repair --apply --only codex` skipped global plugin installation when repo guidance was current but the Codex runtime PATH check warned; this PR keeps that repair available so the release does not ship a broken first-run Codex setup path.

## Commits by concern

- [x] Each commit body bullet-lists the changes in that commit
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`

Commits:

- `02fc418 [fix] Keep Codex plugin repair available with path warnings`
- `eed8a20 [update] Prepare v0.3.34 release`

## Validation

Pre-push gate from repo root:

```bash
scripts/check.sh
```

- [x] Level 0 release-file preflight: `cd mb && /Library/Frameworks/Python.framework/Versions/3.13/bin/python3 -m pytest tests/test_smoke_coverage.py::test_claude_plugin_manifest_points_at_prefixed_skills -q` — runtime: Python 3.13.7 — exit: 0 — log: `.agent/release-evidence/0.3.34/release-file-preflight.out` (`1 passed`).
- [x] Level 1 static: `PATH="/Library/Frameworks/Python.framework/Versions/3.13/bin:$PATH" scripts/check.sh` — runtime: Python 3.13.7 — exit: 0 — log: `.agent/release-evidence/0.3.34/check.out` (`799 passed`, coverage `83.69%`, skill validation passed).
- [x] Level 2 CLI contract: focused doctor regression tests for Codex plugin repair with runtime path warnings — runtime: Python 3.13.7 — exit: 0 — log: `.agent/release-evidence/0.3.34/focused-doctor.out` (`4 passed`).
- [x] Level 3 package/install smoke: `(cd mb && python3.13 -m build) + fresh venv install of mb/dist/mainbranch-0.3.34-py3-none-any.whl` — runtime: Python 3.13.7 / `/tmp/mainbranch-0.3.34-smoke/venv/bin/mb` — exit: 0 — logs: `.agent/release-evidence/0.3.34/build.out`, `.agent/release-evidence/0.3.34/package-smoke.out`; verified `mb 0.3.34` and bundled skill list.
- [x] Level 4 fixture repo: installed-wheel `mb onboard`, Codex repair plan/apply, `mb doctor`, `mb status --json --peek`, `mb start --json`, `mb workflow list --runtime codex --json`, `mb validate` — runtime: `/tmp/mainbranch-0.3.34-smoke/venv/bin/mb` — exit: 0 for required commands — logs: `.agent/release-evidence/0.3.34/package-smoke.out`, `codex-*.json`; verified `codex-plugin-install` applied, plugin install `ok=true`, workflow inventory `supported_generated_guidance/11`, and `slash_commands_ready=false`.
- [x] Books fixture release check: installed-wheel `mb books check --fixture --json` with hledger available — runtime: `/tmp/mainbranch-0.3.34-smoke/venv/bin/mb` — exit: 0 — log: `.agent/release-evidence/0.3.34/books-fixture-installed.out`; includes `fixture-valid`.
- [x] Books fixture release check: installed-wheel `env PATH="/usr/bin:/bin" mb books check --fixture --json` with hledger hidden — runtime: `/tmp/mainbranch-0.3.34-smoke/venv/bin/mb` — exit: 0 — log: `.agent/release-evidence/0.3.34/books-fixture-no-hledger.out`; includes `hledger-missing`.
- [x] Level 5 prerelease candidate proxy: `python3.13 scripts/claude-runtime-dogfood.py --install-mode wheel --wheel mb/dist/mainbranch-0.3.34-py3-none-any.whl --evidence-dir .agent/release-evidence/0.3.34/prerelease-candidate --run-claude-print --simulation-tier prerelease_candidate --max-budget-usd 0.75` — exit: 0 — log: `.agent/release-evidence/0.3.34/prerelease-candidate.log`; 13 fixture profiles, 11/11 heuristic checks, no harness failures, 0 read-only `mb` grounding denials.
- [x] Level 5 release acceptance proxy: `python3.13 scripts/claude-runtime-dogfood.py --install-mode wheel --wheel mb/dist/mainbranch-0.3.34-py3-none-any.whl --evidence-dir .agent/release-evidence/0.3.34/release-acceptance-wheel --run-claude-print --simulation-tier release_acceptance --max-budget-usd 0.75` — exit: 0 — log: `.agent/release-evidence/0.3.34/release-acceptance-wheel.log`; 12 fixture profiles, 11/11 heuristic checks, no harness failures, 0 read-only `mb` grounding denials.
- [x] Manual transcript review: `.agent/release-evidence/0.3.34/manual-transcript-review.md` — no hard release blocker found; print-mode remains proxy evidence, not interactive TUI proof.
- [x] Package-visible release gate evidence before tag/publish: completed against the 0.3.34 wheel; post-publish PyPI acceptance remains a post-release step.
- [x] Supply-chain review: `.agent/release-evidence/0.3.34/workflow-permissions-scan.out` matches existing permissions shape; Dependabot open alert count is `0`; PyPI latest is still `0.3.33`; open PR scan shows unrelated dashboard PR #603.

One release-file preflight attempt with bare `python3` failed because the package directory resolved Homebrew Python 3.14 without pytest. The release checks then used the explicit Python 3.13.7 runtime consistently.

## Success metric

A maintainer can merge this PR, publish `oe-v0.3.34`, approve the PyPI gate, and verify a fresh `mainbranch==0.3.34` install exposes direct Codex generated guidance and repairs the global Codex plugin path.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [ ] N/A — change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [x] No
- [ ] Yes — migration note below

## Public / private boundary

Committed files contain no private local paths, credentials, raw runtime transcripts, or operator strategy. Release evidence stays under `.agent/`; PR text uses sanitized temp-path descriptions only.

Post-merge release steps:

1. Create GitHub Release/tag `oe-v0.3.34` from `main`.
2. Wait for the PyPI publish workflow and maintainer environment approval.
3. Verify PyPI shows `mainbranch 0.3.34`.
4. Fresh-install from PyPI and verify `mb --version`, `mb skill list`, fixture smoke, and books fixture modes.
5. Run post-publish release acceptance from PyPI.
6. Run Codex dogfood from the maintainer-provided local business repo if local auth/state allows it.
7. Complete post-release alignment and close out release state.
