### PR TITLE
[add] Codex slash command surface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,10 +21,10 @@ markdown files in git.
 
 Claude Code and Codex CLI are the supported agent runtimes today. Claude Code
 uses project-local slash skills. Codex uses generated `AGENTS.md`, a global Main
-Branch Codex plugin, deterministic `mb` facts, generated Codex guidance, and
-workflow inventory. That is daily-loop Codex support, not all-skill parity or
-full production workflow parity. Business repos should not carry repo-local
-Codex plugin copies unless a future issue proves that fallback is required.
+Branch Codex plugin, `/mb-*` commands, deterministic `mb` facts, and workflow
+inventory. That is daily-loop Codex support, not all-skill parity or full
+production workflow parity. Business repos should not carry repo-local Codex
+plugin copies unless a future issue proves that fallback is required.
 Cursor, OpenClaw, Hermes, Paperclip-adjacent orchestration, and local runtimes
 remain compatibility targets until tested. Do not claim support before there is
 an adapter and smoke evidence for the exact surface.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+### Changed
+
+- Added a clean global Codex `/mb-*` command surface for Main Branch: repair now
+  generates command files under the global plugin, removes the old visible
+  `main-branch-owner-loop` skill/plugin source, and readiness only passes when
+  the command files are current and the plugin is installed/enabled. Refs
+  MAIN-437, #717.
+- Updated `mb update` so package/source updates refresh Claude Code skill links
+  and then run the Codex command-surface repair from the upgraded `mb`
+  executable; Codex users still restart Codex to reload `/mb-*` commands.
+
 ## [0.3.34] - 2026-05-23
 
 v0.3.34 packages the Codex live workflow surface after v0.3.33. Codex starts

--- a/README.md
+++ b/README.md
@@ -219,13 +219,13 @@ You'll need a Claude plan that includes Claude Code. Install Claude Code from [c
 
 ### Using Codex CLI
 
-Codex CLI is supported through generated Main Branch guidance and deterministic
-`mb` facts. Fresh business folders include a tracked `AGENTS.md` bootstrap. The
-Main Branch Codex plugin is installed globally once per user and gives Codex
-generated Main Branch guidance that reads the current business repo through
-deterministic `mb` facts. That lets Codex start the day, inspect status, route
-setup/update/doctor work, think through or codify a decision, plan an
-end/checkpoint/save closeout, validate the repo, and list workflow support.
+Codex CLI is supported through the global Main Branch plugin's `/mb-*` commands
+and deterministic `mb` facts. Fresh business folders include a tracked
+`AGENTS.md` bootstrap. The plugin is installed globally once per user and reads
+the current business repo through deterministic `mb` facts. That lets Codex
+start the day, inspect status, route setup/update/doctor work, think through or
+codify a decision, plan an end/checkpoint/save closeout, validate the repo, and
+list workflow support.
 
 Expect Codex to run `mb status --json --peek`, `mb start --json`,
 `mb doctor repair --plan --json`, `mb checkpoint --plan --json`,
@@ -244,8 +244,8 @@ mb doctor repair --apply --only codex
 codex
 ```
 
-Then ask Codex to start the business day from read-only `mb` facts and to ask
-before writing files.
+Restart Codex after repair, type `/mb`, then run `/mb-start`. Codex should start
+from read-only `mb` facts and ask before writing files.
 
 For a read-only smoke test:
 
@@ -332,7 +332,7 @@ The `mb` CLI is the deterministic control plane. The agent runs it for normal us
 | `mb graph`               | Build a folder graph from frontmatter links, wikilinks, and entity tags. Graphviz DOT, JSON, and PNG outputs. |
 | `mb suggest links`       | Suggest likely frontmatter, inline, tag, data, and context connections for a file without editing it. |
 | `mb checkpoint`          | Plan or save a business-readable git checkpoint during long agent runs. |
-| `mb workflow list`       | List Codex workflow support: supported owner-loop surfaces, pending shared-source migrations, and intentionally unsupported workflows. |
+| `mb workflow list`       | List Codex workflow support: supported Main Branch commands, pending shared-source migrations, and intentionally unsupported workflows. |
 | `mb skill list` / `path` / `validate` / `link` / `repair` | Manage and repair the bundled Claude Code skills. |
 | `mb update`              | Update Main Branch in place. |
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,8 +1,8 @@
 # Compatibility
 
 Main Branch is intentionally narrow today: `mb`, bundled Claude Code skills,
-and generated Codex guidance. This page is the public compatibility contract
-for those surfaces.
+and Codex `/mb-*` commands. This page is the public compatibility contract for
+those surfaces.
 
 ## Supported matrix
 
@@ -15,7 +15,7 @@ for those surfaces.
 | Install mode | `pipx install mainbranch` | Official public install path. |
 | Developer mode | Git clone | For contributors who want to edit the engine or skills. |
 | Agent runtime | Claude Code | Supported through project-local slash skills. |
-| Codex CLI | Supported | Fresh business repos include `AGENTS.md`; the Main Branch Codex plugin installs globally once per user and provides generated Codex guidance. `mb workflow list --runtime codex` exposes supported, pending, and unsupported workflow surfaces. |
+| Codex CLI | Supported | Fresh business repos include `AGENTS.md`; the Main Branch Codex plugin installs globally once per user and provides `/mb-*` commands. `mb workflow list --runtime codex` exposes supported, pending, and unsupported workflow surfaces. |
 | Cursor, OpenClaw, Hermes, Paperclip-adjacent orchestration, local LLMs | Roadmap | `mb` is runtime-agnostic by design, but these adapters are not supported yet. |
 
 **Windows tip — try WSL2.** If you're on Windows and want a working setup today, use [Windows Subsystem for Linux 2 (WSL2)](https://learn.microsoft.com/en-us/windows/wsl/install). Inside WSL2, follow the supported Linux flow. The pipx install path works there.
@@ -164,7 +164,7 @@ smoke evidence exist.
 | Runtime surface | Status | Invocation | Skill/workflow discovery | Routing and automation | Observability and packaging |
 |---|---|---|---|---|---|
 | Claude Code | Supported | `mb start --repo "$repo"` prints the `claude` handoff; `mb start --launch` may launch after readiness checks. | `mb skill link --repo "$repo"` writes project-local `.claude/skills/mb-*` bridge links and `.claude/settings.local.json`. | Slash commands such as `/mb-start` and `/mb-think` own conversation and judgment; they call deterministic `mb` commands for facts. | `mb doctor`, `mb status --json`, `mb start --json`, `mb skill repair`, and runtime dogfood evidence gate release claims. Skills ship inside the Python package today. |
-| Codex CLI | Supported | Can call deterministic `mb` commands as a subprocess when pointed at a business repo. `AGENTS.md` gives Codex the repo bootstrap, and the globally installed Main Branch Codex plugin gives Codex generated Main Branch guidance. | Fresh `mb onboard` repos include tracked `AGENTS.md`. `mb doctor repair --plan --only codex` / `--apply --only codex` can refresh repo guidance and install or repair the global plugin source and marketplace registration. | Codex should run `mb status --json --peek`, `mb start --json`, `mb doctor repair --plan --json`, `mb checkpoint --plan --json`, `mb validate --json`, and `mb workflow list --runtime codex --json` before owner-loop advice, translate facts into business language, and ask before writes. | `mb doctor`, `mb status --json`, `mb start --json`, and `mb workflow list` expose Codex readiness and workflow support. Codex support covers start/status/setup/update/doctor, think/codify, end/checkpoint/save, validate, and workflow discovery. This is not all-skill, ads/site/provider, publishing, spend, or customer-contact parity. |
+| Codex CLI | Supported | Can call deterministic `mb` commands as a subprocess when pointed at a business repo. `AGENTS.md` gives Codex the repo bootstrap, and the globally installed Main Branch Codex plugin gives Codex `/mb-*` commands. | Fresh `mb onboard` repos include tracked `AGENTS.md`. `mb doctor repair --plan --only codex` / `--apply --only codex` can refresh repo guidance and install or repair the global plugin command surface and marketplace registration. | Codex `/mb-*` commands should run `mb status --json --peek`, `mb start --json`, `mb doctor repair --plan --json`, `mb checkpoint --plan --json`, `mb validate --json`, and `mb workflow list --runtime codex --json`, translate facts into business language, and ask before writes. | `mb doctor`, `mb status --json`, `mb start --json`, and `mb workflow list` expose Codex readiness and workflow support. Codex support covers start/status/setup/update/doctor, think/codify, end/checkpoint/save, validate, and workflow discovery. This is not all-skill, ads/site/provider, publishing, spend, or customer-contact parity. |
 | Cursor | Roadmap | Can call deterministic `mb` commands from terminal/tasks when pointed at a business repo. | No supported Cursor rules/package adapter yet. | No supported Main Branch routing contract. | Needs adapter docs, install/update rules, conflict handling, and smoke evidence. |
 | OpenClaw | Roadmap | Target public runtime surface. It should call `mb` through stable CLI/JSON commands rather than clone-era paths. | No supported OpenClaw adapter yet. | Main Branch should coexist with OpenClaw as the business repo/GitHub memory layer, not replace it. | Needs explicit adapter shape, migration notes, generated-file rules, and smoke evidence. |
 | Hermes | Roadmap | Target runtime/memory surface. It may supervise or host workflows that call packaged `mb` commands. | No supported Hermes adapter yet. | Hermes-specific routing belongs in the Hermes adapter, while `mb` remains deterministic and non-conversational. | Docs may describe internal-package expectations generically, but not as the only blessed public path. Smoke evidence is required before support claims. |
@@ -177,17 +177,17 @@ The CLI/repo contract and the slash-skill workflow contract have different
 support levels:
 
 Shared workflow sources under `workflows/` are runtime-agnostic contracts.
-Runtime shells, Claude Code skills, generated `AGENTS.md`, generated Codex
-skills/plugins, and future adapter packages should stay thin over those sources. A
+Runtime shells, Claude Code skills, generated `AGENTS.md`, Codex command
+plugins, and future adapter packages should stay thin over those sources. A
 checked shared workflow source does not by itself make every runtime supported;
 support still requires an adapter and smoke evidence for that runtime.
 
 | Surface | Claude Code | Other runtimes and orchestrators |
 |---|---|---|
 | Deterministic CLI facts (`mb status --json`, `mb validate --json`, `mb graph --json`, `mb connect status --json`) | Supported when `mb` is installed and pointed at a business repo. | Callable as packaged CLI subprocesses, but this does not make the hosting runtime supported. |
-| Runtime handoff (`mb start --json`, `mb start --launch`) | Supported for Claude Code handoff and launch readiness. | Codex CLI handoff metadata is supported for owner-loop readiness: `mb start --json` reports Codex executable, `AGENTS.md`, generated guidance, and plugin readiness. `mb` does not launch Codex. |
-| Lifecycle slash skills (`/mb-start`, `/mb-status`, `/mb-setup`, `/mb-update`, `/mb-end`, `/mb-help`) | Supported through Claude Code project-local skill discovery. | Codex supports start/status/setup/update/doctor, end/checkpoint/save, validate, and workflow discovery through deterministic `mb` facts and generated guidance. |
-| Production slash skills (`/mb-think`, `/mb-ads`, `/mb-organic`, `/mb-site`, `/mb-wiki`, `/mb-bet`) | Supported through Claude Code skills, subject to each skill's provider and workflow limits. Conversion scripts route through the owning workflow instead of a standalone primitive or skill. | Codex supports think/codify through `workflows/mb-think/workflow.md` and generated guidance. Ads, organic/newsletter, site, and bet workflows are pending shared-source migration. Wiki and skill-authoring workflows are intentionally unsupported for the owner-loop target. |
+| Runtime handoff (`mb start --json`, `mb start --launch`) | Supported for Claude Code handoff and launch readiness. | Codex CLI handoff metadata is supported for Main Branch command readiness: `mb start --json` reports Codex executable, `AGENTS.md`, command files, and plugin readiness. `mb` does not launch Codex. |
+| Lifecycle slash skills (`/mb-start`, `/mb-status`, `/mb-setup`, `/mb-update`, `/mb-end`, `/mb-help`) | Supported through Claude Code project-local skill discovery. | Codex supports these as global plugin `/mb-*` commands grounded in deterministic `mb` facts. |
+| Production slash skills (`/mb-think`, `/mb-ads`, `/mb-organic`, `/mb-site`, `/mb-wiki`, `/mb-bet`) | Supported through Claude Code skills, subject to each skill's provider and workflow limits. Conversion scripts route through the owning workflow instead of a standalone primitive or skill. | Codex supports `/mb-think` through `workflows/mb-think/workflow.md` and the global plugin command surface. Ads, organic/newsletter, site, and bet workflows are pending shared-source migration. Wiki and skill-authoring workflows are intentionally unsupported for the current Codex target. |
 | Automation routines | May call CLI commands before handing judgment work to Claude Code. | May call shipped deterministic CLI commands against an explicit repo path. Conversation, retries, routing, and model invocation belong to the runtime adapter, not `mb`. |
 
 ## Adapter checklist
@@ -207,13 +207,13 @@ write runtime state, credentials, or raw account data into tracked files.
 
 For the Codex staging plan, see
 [Codex Adapter Plan](../decisions/2026-05-08-codex-adapter-plan.md). The current
-implementation is the owner-loop slice: generated `AGENTS.md`, a global Main
-Branch Codex plugin, deterministic readiness facts, doctor repair coverage,
+implementation is the daily Main Branch slice: generated `AGENTS.md`, a global
+Main Branch Codex plugin with `/mb-*` commands, deterministic readiness facts, doctor repair coverage,
 `mb workflow list`, and
 compact workflow discovery for start/status/setup/update/doctor, think/codify,
 end/checkpoint/save, validate, and workflow inventory. The think route is checked against
 `workflows/mb-think/workflow.md` as the first official shared workflow source
-pattern, and fresh read-only Codex smoke covers the owner-loop surface from a
+pattern, and fresh read-only Codex smoke covers the supported command surface from a
 business repo. It does not claim all-skill parity, copied Claude skill parity,
 provider/publishing workflow support, spend, or customer-contact support.
 The `/mb-*` command bridge decision lives in
@@ -258,10 +258,13 @@ mb update
 ```
 
 `mb update` detects whether Main Branch is a `pipx` install or source checkout,
-runs the appropriate update path, and refreshes skill links. Use
+runs the appropriate update path, refreshes Claude Code skill links, and runs
+the Codex command-surface repair from the upgraded `mb` executable. Use
 `mb update --check` for a dry-run and `mb update --json` for automation.
 Inside Claude Code, `/mb-update` calls `mb update` for this mechanical step and keeps
-ownership of the human-readable "what's new" summary.
+ownership of the human-readable "what's new" summary. Codex users should
+restart Codex after an update so `/mb-*` commands reload from the refreshed
+global plugin.
 
 Early `0.1.x` installs do not have `mb update` yet. If `mb`, `mb doctor`,
 `mb status`, or `mb start` says "Update required", run this once first:
@@ -281,8 +284,8 @@ mb doctor
 ## Known Limits
 
 - Claude Code is supported through project-local slash skills.
-- Codex CLI is supported through generated guidance and deterministic `mb`
-  facts. Main Branch does not claim all-skill parity, copied Claude skill
+- Codex CLI is supported through global plugin `/mb-*` commands and
+  deterministic `mb` facts. Main Branch does not claim all-skill parity, copied Claude skill
   parity, provider writes, publishing, spend, or customer-contact workflows.
 - Windows is experimental.
 - Skills are bundled into the installed Python package, so public users update
@@ -297,4 +300,4 @@ mb doctor
   discovery.
 - Cursor, OpenClaw, Hermes, Paperclip-adjacent orchestration, and local
   runtimes remain roadmap surfaces until each has a documented adapter and
-  smoke evidence. Codex support is limited to the owner-loop surface above.
+  smoke evidence. Codex support is limited to the command surface above.

--- a/mb/mb/_data/templates/AGENTS.md.tmpl
+++ b/mb/mb/_data/templates/AGENTS.md.tmpl
@@ -7,8 +7,8 @@ Main Branch business repo instructions for Codex.
 Main Branch CLI facts are the source of truth for repo health, setup, runtime
 wiring, updates, graph/status signals, provider readiness, and repair paths.
 When the operator asks to start, begin, get oriented, triage the day, or decide
-what to do next, use this Codex-native start workflow or the generated Codex
-guidance. Do not pretend Claude Code skills work in Codex.
+what to do next, use `/mb-start`, `/mb-status`, or the read-only `mb` fact
+commands below. Do not pretend Claude Code skills work in Codex.
 
 Start in this repo. Before setup, routing, migration, update, or repair advice,
 run the runtime preflight and read-only checks that fit the situation:
@@ -30,7 +30,7 @@ After `mb status --json --peek` or `mb start --json`, stop if
 `runtime.codex_cli.status` is `runtime_mismatch` or any `drift.items[].id`
 equals `codex_runtime_mb_mismatch`. Treat that as a runtime `mb` mismatch: tell
 the operator to fix the runtime/login-shell PATH and rerun read-only checks
-before owner-loop advice, repair planning, or writes.
+before Main Branch advice, repair planning, or writes.
 
 Use `mb status --json --peek` as the default daily briefing before routing the
 operator. It names readiness, drift, onboarding progress, update state, GitHub
@@ -102,14 +102,14 @@ emails, or usernames alone.
 
 ## Codex Lifecycle Workflow Index
 
-This tracked `AGENTS.md` file is the repo-level Codex bootstrap. The generated
-Main Branch Codex plugin is installed globally once per user and supplies
-generated Codex guidance over deterministic `mb` facts. Business repos keep this
-lightweight `AGENTS.md` guidance instead of tracked repo-local plugin copies.
-`mb doctor repair --only codex` refreshes this file and installs or repairs the
-global plugin when Codex CLI is available.
+This tracked `AGENTS.md` file is the repo-level Codex bootstrap. The Main
+Branch Codex plugin is installed globally once per user and supplies `/mb-*`
+commands over deterministic `mb` facts. Business repos keep this lightweight
+`AGENTS.md` guidance instead of tracked repo-local plugin copies. `mb doctor
+repair --only codex` refreshes this file and installs or repairs the global
+plugin when Codex CLI is available.
 
-Use the global Main Branch Codex plugin for the proven owner loop only. Do not
+Use the global Main Branch Codex plugin for Main Branch daily commands only. Do not
 create repo-local Codex plugin manifests, copied Claude skill trees, or
 symlinked Claude skills unless a future `mb` command or issue says that surface
 is supported for this repo.

--- a/mb/mb/_data/templates/README.md.tmpl
+++ b/mb/mb/_data/templates/README.md.tmpl
@@ -30,7 +30,8 @@ codex
 ```
 
 Then ask Codex to start this Main Branch business day from read-only `mb` facts
-and to ask before writing files.
+and to ask before writing files. After repair and a Codex restart, `/mb-start`
+is the normal entrypoint.
 
 For a terminal-only check:
 

--- a/mb/mb/codex.py
+++ b/mb/mb/codex.py
@@ -1,8 +1,8 @@
-"""Codex owner-loop adapter helpers.
+"""Codex command-surface helpers.
 
-Codex owner-loop support starts with repo instructions, the global plugin
-surface, and deterministic ``mb`` facts. This module intentionally does not
-invoke Codex or manage model conversation.
+Codex support starts with repo instructions, global plugin commands, and
+deterministic ``mb`` facts. This module intentionally does not invoke Codex or
+manage model conversation.
 """
 
 from __future__ import annotations
@@ -23,21 +23,23 @@ AGENTS_TEMPLATE = "AGENTS.md.tmpl"
 AGENTS_RELATIVE_PATH = "AGENTS.md"
 CODEX_SKILL_DIR_RELATIVE_PATH = ".agents/skills/main-branch-owner-loop"
 CODEX_SKILL_RELATIVE_PATH = f"{CODEX_SKILL_DIR_RELATIVE_PATH}/SKILL.md"
-CODEX_WORKFLOW_INVENTORY_RELATIVE_PATH = (
-    f"{CODEX_SKILL_DIR_RELATIVE_PATH}/references/workflow-inventory.md"
-)
+CODEX_WORKFLOW_INVENTORY_RELATIVE_PATH = AGENTS_RELATIVE_PATH
 CODEX_MARKETPLACE_RELATIVE_PATH = ".agents/plugins/marketplace.json"
 CODEX_MARKETPLACE_NAME = "main-branch"
-CODEX_PLUGIN_NAME = "main-branch-owner-loop"
+CODEX_LEGACY_PLUGIN_NAME = "main-branch-owner-loop"
+CODEX_PLUGIN_NAME = "main-branch"
 CODEX_PLUGIN_SELECTOR = f"{CODEX_PLUGIN_NAME}@{CODEX_MARKETPLACE_NAME}"
+CODEX_LEGACY_PLUGIN_SELECTOR = f"{CODEX_LEGACY_PLUGIN_NAME}@{CODEX_MARKETPLACE_NAME}"
 CODEX_PLUGIN_INSTALL_COMMAND = f"codex plugin add {CODEX_PLUGIN_SELECTOR}"
 CODEX_PLUGIN_DIR_RELATIVE_PATH = f".agents/plugins/{CODEX_PLUGIN_NAME}"
-CODEX_PLUGIN_LEGACY_COMMANDS_RELATIVE_PATH = f"{CODEX_PLUGIN_DIR_RELATIVE_PATH}/commands"
+CODEX_LEGACY_PLUGIN_DIR_RELATIVE_PATH = f".agents/plugins/{CODEX_LEGACY_PLUGIN_NAME}"
+CODEX_PLUGIN_COMMANDS_RELATIVE_PATH = f"{CODEX_PLUGIN_DIR_RELATIVE_PATH}/commands"
+CODEX_PLUGIN_LEGACY_COMMANDS_RELATIVE_PATH = f"{CODEX_LEGACY_PLUGIN_DIR_RELATIVE_PATH}/commands"
 CODEX_PLUGIN_MANIFEST_RELATIVE_PATH = f"{CODEX_PLUGIN_DIR_RELATIVE_PATH}/.codex-plugin/plugin.json"
 CODEX_PLUGIN_SKILL_RELATIVE_PATH = (
-    f"{CODEX_PLUGIN_DIR_RELATIVE_PATH}/skills/main-branch-owner-loop/SKILL.md"
+    f"{CODEX_LEGACY_PLUGIN_DIR_RELATIVE_PATH}/skills/main-branch-owner-loop/SKILL.md"
 )
-CODEX_SUPPORT_LEVEL = "supported_generated_guidance"
+CODEX_SUPPORT_LEVEL = "supported_main_branch_slash_commands"
 CODEX_REPAIR_COMMAND = "mb doctor repair --apply --only codex"
 CODEX_REPAIR_TEXT = (
     "Run `mb doctor repair --plan --only codex`, review, then "
@@ -55,16 +57,45 @@ REQUIRED_FACT_COMMANDS = (
     "mb start --json",
     "mb doctor repair --plan",
 )
-OWNER_LOOP_COMMANDS = (
-    "mb --version",
-    "mb status --json --peek",
-    "mb start --json",
-    "mb doctor repair --plan --json",
-    "mb update --check --json",
-    "mb validate --json",
-    "mb checkpoint --plan --json",
-    "mb workflow list --runtime codex --json",
+CODEX_SLASH_COMMAND_NAMES = (
+    "mb-start",
+    "mb-status",
+    "mb-setup",
+    "mb-update",
+    "mb-doctor",
+    "mb-think",
+    "mb-end",
+    "mb-help",
 )
+CODEX_SLASH_COMMAND_RELATIVE_PATHS = tuple(
+    f"{CODEX_PLUGIN_COMMANDS_RELATIVE_PATH}/{name}.md" for name in CODEX_SLASH_COMMAND_NAMES
+)
+CODEX_SLASH_COMMAND_FACTS: dict[str, tuple[str, ...]] = {
+    "mb-start": ("mb status --json --peek", "mb start --json"),
+    "mb-status": ("mb status --json --peek",),
+    "mb-setup": ("mb --version", "mb onboard --help", "mb status --json --peek"),
+    "mb-update": ("mb update --check --json", "mb status --json --peek"),
+    "mb-doctor": ("mb doctor repair --plan --json", "mb status --json --peek"),
+    "mb-think": (
+        "mb status --json --peek",
+        "mb start --json",
+        "mb doctor repair --plan",
+        "mb connect doctor --json",
+        "mb checkpoint --plan --json",
+    ),
+    "mb-end": ("mb checkpoint --plan --json", "mb validate --json"),
+    "mb-help": ("mb workflow list --runtime codex --json", "mb status --json --peek"),
+}
+CODEX_SLASH_COMMAND_DESCRIPTIONS = {
+    "mb-start": "Start Main Branch.",
+    "mb-status": "Show Main Branch status.",
+    "mb-setup": "Set up Main Branch.",
+    "mb-update": "Update Main Branch.",
+    "mb-doctor": "Repair Main Branch setup.",
+    "mb-think": "Think through a Main Branch decision.",
+    "mb-end": "End and checkpoint work.",
+    "mb-help": "Show Main Branch commands.",
+}
 CODEX_THINK_SOURCE_WORKFLOW = "workflows/mb-think/workflow.md"
 CODEX_THINK_REQUIRED_MB_COMMANDS = (
     "mb status --json --peek",
@@ -129,7 +160,7 @@ REQUIRED_LIFECYCLE_GUIDANCE = (
     "Shared public/private boundaries",
     "Use the global Main Branch Codex plugin",
     "do not claim these workflows are ported to",
-    "generated Codex guidance",
+    "supplies `/mb-*`",
     "/plugins",
 )
 REQUIRED_LIFECYCLE_GUIDANCE_MARKERS = (
@@ -139,21 +170,11 @@ REQUIRED_LIFECYCLE_GUIDANCE_MARKERS = (
     *(f"`{gate}`" for gate in CODEX_THINK_APPROVAL_GATES),
     *(f"`{boundary}`" for boundary in CODEX_THINK_PUBLIC_PRIVATE_BOUNDARIES),
 )
-CODEX_SKILL_REQUIRED_MARKERS = (
-    "Main Branch owner loop for Codex",
-    "mb workflow list --runtime codex --json",
-    "runtime/login-shell PATH",
-    "codex_runtime_mb_mismatch",
-    "start/status/setup/update/doctor",
-    "think/codify",
-    "end/checkpoint/save",
-    "Ask before durable writes",
-)
 CODEX_PLUGIN_REQUIRED_MARKERS = (
     "Main Branch",
-    "skills",
-    "main-branch-owner-loop",
-    "mb facts",
+    "commands",
+    "mb-*",
+    "business repos",
 )
 CLAUDE_SKILL_SOURCE_NAMES = (
     "mb-start",
@@ -181,27 +202,27 @@ CODEX_WORKFLOW_STATUS_VOCABULARY = (
 
 CODEX_WORKFLOW_INVENTORY: tuple[dict[str, Any], ...] = (
     {
-        "id": "owner-loop-start-status",
+        "id": "daily-start-status",
         "label": "Start, status, and what changed",
         "claude_surface": "/mb-start, /mb-status",
         "claude_skill_sources": ("mb-start", "mb-status"),
         "codex_status": "supported",
-        "codex_surface": ("Generated Codex guidance plus mb status/start facts"),
-        "codex_entrypoints": ("Codex Start Workflow", "Codex Status Workflow"),
+        "codex_surface": ("/mb-start and /mb-status"),
+        "codex_entrypoints": ("/mb-start", "/mb-status"),
         "commands": ("mb status --json --peek", "mb start --json"),
         "notes": (
             "Codex starts from deterministic status/start facts, translates them "
-            "into business language, and routes one next owner-loop move."
+            "into business language, and routes one next Main Branch move."
         ),
     },
     {
-        "id": "owner-loop-setup-repair-update",
+        "id": "daily-setup-repair-update",
         "label": "Setup, update, doctor, and repair planning",
         "claude_surface": "/mb-setup, /mb-update, /mb-start repair routing",
         "claude_skill_sources": ("mb-setup", "mb-update"),
         "codex_status": "supported",
-        "codex_surface": ("Generated Codex guidance plus mb setup/update/doctor fact commands"),
-        "codex_entrypoints": ("Setup/update/doctor guidance",),
+        "codex_surface": ("/mb-setup, /mb-update, and /mb-doctor"),
+        "codex_entrypoints": ("/mb-setup", "/mb-update", "/mb-doctor"),
         "commands": (
             "mb --version",
             "mb doctor repair --plan --json",
@@ -218,8 +239,8 @@ CODEX_WORKFLOW_INVENTORY: tuple[dict[str, Any], ...] = (
         "claude_surface": "/mb-think",
         "claude_skill_sources": ("mb-think",),
         "codex_status": "supported",
-        "codex_surface": ("Generated Codex guidance plus AGENTS.md#codex-think-route"),
-        "codex_entrypoints": ("Codex Think Route",),
+        "codex_surface": ("/mb-think plus AGENTS.md#codex-think-route"),
+        "codex_entrypoints": ("/mb-think",),
         "shared_source": CODEX_THINK_SOURCE_WORKFLOW,
         "commands": CODEX_THINK_REQUIRED_MB_COMMANDS,
         "notes": (
@@ -233,8 +254,8 @@ CODEX_WORKFLOW_INVENTORY: tuple[dict[str, Any], ...] = (
         "claude_surface": "/mb-end, mb checkpoint",
         "claude_skill_sources": ("mb-end",),
         "codex_status": "supported",
-        "codex_surface": ("Generated Codex guidance plus mb checkpoint/validate facts"),
-        "codex_entrypoints": ("End/checkpoint guidance",),
+        "codex_surface": ("/mb-end"),
+        "codex_entrypoints": ("/mb-end",),
         "commands": ("mb checkpoint --plan --json", "mb validate --json"),
         "notes": (
             "Codex can plan a closeout and propose checkpoint subjects. Creating "
@@ -247,8 +268,8 @@ CODEX_WORKFLOW_INVENTORY: tuple[dict[str, Any], ...] = (
         "claude_surface": "/mb-help and docs",
         "claude_skill_sources": ("mb-help",),
         "codex_status": "supported",
-        "codex_surface": ("Generated Codex guidance plus workflow inventory facts"),
-        "codex_entrypoints": ("Workflow inventory guidance",),
+        "codex_surface": ("/mb-help"),
+        "codex_entrypoints": ("/mb-help",),
         "commands": ("mb workflow list --runtime codex --json",),
         "notes": "Codex users can inspect supported, pending, and unsupported workflow surfaces.",
     },
@@ -306,7 +327,7 @@ CODEX_WORKFLOW_INVENTORY: tuple[dict[str, Any], ...] = (
         "codex_status": "intentionally_unsupported",
         "codex_surface": "None",
         "commands": (),
-        "notes": "Specialty workflow outside the owner-loop support target.",
+        "notes": "Specialty workflow outside the current Codex command target.",
     },
     {
         "id": "skill-authoring",
@@ -320,7 +341,7 @@ CODEX_WORKFLOW_INVENTORY: tuple[dict[str, Any], ...] = (
         "codex_status": "intentionally_unsupported",
         "codex_surface": "None",
         "commands": (),
-        "notes": "Engine-contributor workflow, not a business owner-loop runtime surface.",
+        "notes": "Engine-contributor workflow, not a business runtime surface.",
     },
 )
 
@@ -352,8 +373,8 @@ Main Branch business repo instructions for Codex.
 Main Branch CLI facts are the source of truth for repo health, setup, runtime
 wiring, updates, graph/status signals, provider readiness, and repair paths.
 When the operator asks to start, begin, get oriented, triage the day, or decide
-what to do next, use this Codex-native start workflow or the generated Codex
-guidance. Do not pretend Claude Code skills work in Codex.
+what to do next, use `/mb-start`, `/mb-status`, or the read-only `mb` fact
+commands below. Do not pretend Claude Code skills work in Codex.
 
 Start in this repo. Before setup, routing, migration, update, or repair advice,
 run the runtime preflight and read-only checks that fit the situation:
@@ -375,7 +396,7 @@ After `mb status --json --peek` or `mb start --json`, stop if
 `runtime.codex_cli.status` is `runtime_mismatch` or any `drift.items[].id`
 equals `codex_runtime_mb_mismatch`. Treat that as a runtime `mb` mismatch: tell
 the operator to fix the runtime/login-shell PATH and rerun read-only checks
-before owner-loop advice, repair planning, or writes.
+before Main Branch advice, repair planning, or writes.
 
 Use `mb status --json --peek` as the default daily briefing before routing the
 operator. It names readiness, drift, onboarding progress, update state, GitHub
@@ -440,14 +461,14 @@ canonical paths, frontmatter, JSON keys, validator rules, and command names.
 
 ## Codex Lifecycle Workflow Index
 
-This tracked `AGENTS.md` file is the repo-level Codex bootstrap. The generated
-Main Branch Codex plugin is installed globally once per user and supplies
-generated Codex guidance over deterministic `mb` facts. Business repos keep this
-lightweight `AGENTS.md` guidance instead of tracked repo-local plugin copies.
-`mb doctor repair --only codex` refreshes this file and installs or repairs the
-global plugin when Codex CLI is available.
+This tracked `AGENTS.md` file is the repo-level Codex bootstrap. The Main
+Branch Codex plugin is installed globally once per user and supplies `/mb-*`
+commands over deterministic `mb` facts. Business repos keep this lightweight
+`AGENTS.md` guidance instead of tracked repo-local plugin copies. `mb doctor
+repair --only codex` refreshes this file and installs or repairs the global
+plugin when Codex CLI is available.
 
-Use the global Main Branch Codex plugin for the proven owner loop only. Do not
+Use the global Main Branch Codex plugin for Main Branch daily commands only. Do not
 create repo-local Codex plugin manifests, copied Claude skill trees, or
 symlinked Claude skills unless a future `mb` command or issue says that surface
 is supported for this repo.
@@ -796,7 +817,7 @@ def workflow_inventory(*, runtime: str = "codex") -> dict[str, Any]:
         "ok": True,
         "runtime": runtime,
         "support_level": CODEX_SUPPORT_LEVEL,
-        "entrypoint": CODEX_SKILL_RELATIVE_PATH,
+        "entrypoint": "/mb-start",
         "repo_guidance": AGENTS_RELATIVE_PATH,
         "inventory_path": CODEX_WORKFLOW_INVENTORY_RELATIVE_PATH,
         "claude_skill_sources": [
@@ -808,8 +829,11 @@ def workflow_inventory(*, runtime: str = "codex") -> dict[str, Any]:
             "plugin_selector": CODEX_PLUGIN_SELECTOR,
             "marketplace_path": CODEX_MARKETPLACE_RELATIVE_PATH,
             "manifest_path": CODEX_PLUGIN_MANIFEST_RELATIVE_PATH,
-            "skill_path": CODEX_PLUGIN_SKILL_RELATIVE_PATH,
-            "slash_commands_ready": False,
+            "skill_path": "",
+            "commands_path": CODEX_PLUGIN_COMMANDS_RELATIVE_PATH,
+            "generated_command_files": list(CODEX_SLASH_COMMAND_RELATIVE_PATHS),
+            "slash_commands_generated": True,
+            "slash_commands_ready": True,
             "install_hint": (
                 f"Run `{codex_marketplace_add_command()}`, then `{CODEX_PLUGIN_INSTALL_COMMAND}`."
             ),
@@ -847,19 +871,21 @@ def render_workflow_inventory_md() -> str:
     return (
         "# Main Branch Codex Workflow Inventory\n\n"
         "Generated by `mb`. Do not edit by hand in business repos. This file maps "
-        "Main Branch workflow surfaces to the Codex daily-loop support boundary.\n\n"
+        "Main Branch workflow surfaces to the Codex command support boundary.\n\n"
         "Status meanings:\n\n"
-        "- `supported`: Codex can use this surface for the owner loop from "
-        "deterministic `mb` facts and generated guidance.\n"
+        "- `supported`: Codex can use this surface through `/mb-*` commands "
+        "grounded in deterministic `mb` facts.\n"
         "- `pending_shared_source_migration`: Codex may plan from read-only facts, "
         "but a runtime shell should wait for a shared workflow source.\n"
         "- `generated_shell_pending`: a shared source exists, but a generated Codex "
         "shell still needs implementation and smoke evidence.\n"
         "- `intentionally_unsupported`: outside the current Codex daily-loop target.\n\n"
-        "Codex plugin files are installed globally by `mb doctor repair --only codex`; "
-        "business repos keep only lightweight `AGENTS.md` guidance. Use `/plugins` "
-        "or `codex plugin list --marketplace main-branch` to inspect the global "
-        "Main Branch Codex plugin. Each row names its bundled Claude skill "
+        "Codex plugin files and `/mb-*` command files are installed globally by "
+        "`mb doctor repair --only codex`; business repos keep only lightweight "
+        "`AGENTS.md` guidance. Use `/plugins` or "
+        "`codex plugin list --marketplace main-branch` to inspect the global "
+        "Main Branch Codex plugin. After repair and a Codex restart, typing `/mb` "
+        "should show the Main Branch commands. Each row names its bundled Claude skill "
         "source(s); every bundled Claude `mb-*` skill must be accounted for here "
         "until the shared workflow generator owns both runtime shells.\n\n"
         "| Workflow | Codex status | Claude Code surface | Claude source | Codex surface | "
@@ -871,72 +897,6 @@ def render_workflow_inventory_md() -> str:
     )
 
 
-def render_codex_skill_md() -> str:
-    """Render the Codex guidance packaged as a skill."""
-
-    command_lines = "\n".join(f"- `{command}`" for command in OWNER_LOOP_COMMANDS)
-    description = (
-        "Use when the operator asks Codex to run the Main Branch daily owner loop "
-        "from a business repo: start/status/setup/update/doctor, think/codify, "
-        "end/checkpoint/save, validate, or workflow discovery. Starts from "
-        "deterministic mb facts and asks before durable writes, provider mutations, "
-        "publishing, spend, customer contact, or checkpoints."
-    )
-    return f"""---
-name: main-branch-owner-loop
-description: >-
-  {description}
----
-
-# Main Branch daily loop for Codex
-
-Run the Main Branch daily owner loop from a business repo. This is generated
-Codex guidance packaged in the global Main Branch plugin; `AGENTS.md` remains
-the repo-level bootstrap.
-
-## Start Here
-
-Before advice, run read-only facts that fit the request:
-
-{command_lines}
-
-Run `command -v mb` and `mb --version` as a standalone runtime preflight before
-substantive `mb` commands. This guidance was generated by Main Branch
-`{__version__}`. If the runtime reports an older or different version, stop and
-tell the operator to put the current Main Branch install earlier on the
-runtime/login-shell PATH before continuing.
-
-{CODEX_RUNTIME_MISMATCH_STOP_TEXT}
-
-Use `mb status --json --peek` as the first daily read. Use `mb start --json`
-when runtime handoff or adapter readiness matters. Use
-`mb workflow list --runtime codex --json` when the operator asks what Codex can
-do.
-
-## Supported Daily Loop
-
-- start/status/setup/update/doctor: inspect facts and plans, then ask before
-  applying repairs, migrations, setup writes, or updates.
-- think/codify: follow the `mb-think` shared workflow route in `AGENTS.md`.
-- end/checkpoint/save: run `mb checkpoint --plan --json`, propose a
-  business-readable checkpoint, and ask before saving it.
-- validate: run `mb validate --json` and explain repo health in business
-  language before technical details.
-- workflow discovery: read `references/workflow-inventory.md` or run
-  `mb workflow list --runtime codex --json`.
-
-## Approval Gates
-
-Ask before durable writes, checkpoints, updates, repairs, migrations, provider
-mutation, publishing, spend, customer contact, destructive operations, raw
-private-source reads, or public issue/proposal submission.
-
-Do not claim Claude Code slash-skill parity in Codex. Do not claim ads, site,
-organic, provider mutation, wiki, or skill-authoring parity unless the
-inventory marks that surface `supported`.
-"""
-
-
 def render_codex_plugin_manifest() -> str:
     """Render the global Codex plugin manifest."""
 
@@ -944,32 +904,31 @@ def render_codex_plugin_manifest() -> str:
         "name": CODEX_PLUGIN_NAME,
         "version": "0.1.0",
         "description": (
-            "Main Branch daily-loop guidance for Codex. Uses deterministic mb facts "
-            "and generated business-repo guidance."
+            "Main Branch /mb commands for Codex. Uses deterministic mb facts "
+            "and business-repo guidance."
         ),
         "author": {"name": "Noontide"},
         "homepage": "https://github.com/noontide-co/mainbranch",
         "repository": "https://github.com/noontide-co/mainbranch",
         "license": "MIT",
-        "keywords": ["main-branch", "mainbranch", "owner-loop", "business-memory"],
-        "skills": "./skills/",
+        "keywords": ["main-branch", "mainbranch", "business-memory"],
         "interface": {
             "displayName": "Main Branch",
-            "shortDescription": "Start, inspect, decide, and checkpoint from mb facts",
+            "shortDescription": "Main Branch /mb commands for business repos",
             "longDescription": (
-                "Adds Codex-native guidance for Main Branch business repos. The plugin "
-                "routes through generated guidance and direct mb facts; it does not add "
-                "provider mutation, publishing, spend, customer contact, ads/site "
-                "production, or all-skill parity."
+                "Adds Codex `/mb-*` commands for Main Branch business repos. Commands "
+                "route through deterministic mb facts and repo guidance; "
+                "they do not add provider mutation, publishing, spend, customer "
+                "contact, ads/site production, or all-skill parity."
             ),
             "developerName": "Noontide",
             "category": "Productivity",
             "capabilities": ["Interactive", "Read", "Write"],
             "websiteURL": "https://github.com/noontide-co/mainbranch",
             "defaultPrompt": [
-                "Start this Main Branch business day from mb facts",
-                "Show what Main Branch workflows Codex supports",
-                "Plan a Main Branch checkpoint before saving work",
+                "Use /mb-start to start this Main Branch business day",
+                "Use /mb-help to show supported Main Branch Codex commands",
+                "Use /mb-end to plan a checkpoint before saving work",
             ],
             "brandColor": "#0F766E",
             "screenshots": [],
@@ -1002,14 +961,102 @@ def render_codex_marketplace_json() -> str:
     return json.dumps(payload, indent=2) + "\n"
 
 
-def render_codex_plugin_skill_md() -> str:
-    """Render the plugin-packaged Codex guidance.
+def _slash_command_label(name: str) -> str:
+    return f"/{name}"
 
-    Keep this equal to the generated project-local skill so drift tests catch
-    accidental second-source behavior.
-    """
 
-    return render_codex_skill_md()
+def render_codex_slash_command_md(name: str) -> str:
+    """Render one thin Codex slash-command file for the global plugin."""
+
+    if name not in CODEX_SLASH_COMMAND_NAMES:
+        raise ValueError(f"unknown Codex slash command: {name}")
+    description = CODEX_SLASH_COMMAND_DESCRIPTIONS[name]
+    facts = CODEX_SLASH_COMMAND_FACTS[name]
+    fact_lines = "\n".join(f"- `{command}`" for command in facts)
+    command = _slash_command_label(name)
+    specific = {
+        "mb-start": (
+            "Summarize the business state, readiness, ranked actions, and one "
+            "clear next route. Use `mb start --json` when runtime handoff or "
+            "Codex readiness matters."
+        ),
+        "mb-status": (
+            "Answer from status facts: readiness, drift, recent work, "
+            "since-last-check, MoneyPath, content strategy, provider signals, "
+            "and ranked actions."
+        ),
+        "mb-setup": (
+            "Treat setup prompts as onboarding intent. Explain the target folder "
+            "and ask before running any command that writes files."
+        ),
+        "mb-update": (
+            "Report whether an update is required or recommended. Ask before "
+            "running update, repair, migration, or package-changing commands."
+        ),
+        "mb-doctor": (
+            "Explain the repair plan in business language first. Quote exact "
+            "safe commands and ask before applying any write action."
+        ),
+        "mb-think": (
+            "Use the Codex Think Route in `AGENTS.md`. Choose the smallest honest "
+            "research depth, read only needed business files, and ask before "
+            "codifying or checkpointing."
+        ),
+        "mb-end": (
+            "Plan the closeout from checkpoint and validation facts. Propose the "
+            "business-readable checkpoint subject and ask before saving it."
+        ),
+        "mb-help": (
+            "Show the supported, pending, and unsupported Codex workflow surfaces. "
+            "Do not claim parity for surfaces the inventory does not mark supported."
+        ),
+    }[name]
+    return f"""---
+description: {description}
+---
+
+# {command}
+
+Use Main Branch from the current repo. This command is a thin Codex route over
+deterministic `mb` facts and the repo `AGENTS.md` guidance. Do not duplicate
+workflow logic here.
+
+## Preflight
+
+Run first:
+
+- `command -v mb`
+- `mb --version`
+
+If `mb` is missing or reports an unexpected version, stop and tell the operator
+to fix the runtime/login-shell PATH before continuing.
+
+## Facts
+
+Run the read-only facts that fit this command:
+
+{fact_lines}
+
+Stop before business routing if `runtime.codex_cli.status` is
+`runtime_mismatch` or if any drift item is `codex_runtime_mb_mismatch`.
+
+## Route
+
+{specific}
+
+Ask before durable writes, checkpoints, updates, repairs, migrations, provider
+mutation, publishing, spend, customer contact, destructive operations, or public
+issue/proposal submission.
+"""
+
+
+def render_codex_slash_commands() -> dict[str, str]:
+    """Render all generated Codex slash-command files by relative path."""
+
+    return {
+        f"{CODEX_PLUGIN_COMMANDS_RELATIVE_PATH}/{name}.md": render_codex_slash_command_md(name)
+        for name in CODEX_SLASH_COMMAND_NAMES
+    }
 
 
 def agents_path(repo: str | Path) -> Path:
@@ -1036,13 +1083,21 @@ def plugin_skill_path(repo: str | Path) -> Path:
     return global_plugin_source_root() / CODEX_PLUGIN_SKILL_RELATIVE_PATH
 
 
+def plugin_commands_dir(repo: str | Path) -> Path:
+    return global_plugin_source_root() / CODEX_PLUGIN_COMMANDS_RELATIVE_PATH
+
+
+def plugin_command_path(repo: str | Path, name: str) -> Path:
+    return plugin_commands_dir(repo) / f"{name}.md"
+
+
 def executable_status() -> dict[str, Any]:
     path = _which("codex")
     return {
         "found": bool(path),
         "path": path,
         "executable": "codex",
-        "repair": "" if path else "Install Codex CLI before using the Codex owner-loop adapter.",
+        "repair": "" if path else "Install Codex CLI before using Main Branch Codex commands.",
     }
 
 
@@ -1120,7 +1175,6 @@ def _parse_plugin_install_status(output: str, expected_marketplace_path: Path) -
         plugin_available and "installed" in status_text and "not installed" not in status_text
     )
     plugin_enabled = bool(plugin_installed and "enabled" in status_text)
-    skill_ready = bool(plugin_installed and plugin_enabled)
     return {
         "marketplace_registered": marketplace_registered,
         "marketplace_stale": marketplace_stale,
@@ -1130,7 +1184,8 @@ def _parse_plugin_install_status(output: str, expected_marketplace_path: Path) -
         "plugin_available": plugin_available,
         "plugin_installed": plugin_installed,
         "plugin_enabled": plugin_enabled,
-        "skill_ready": skill_ready,
+        "skill_available": False,
+        "skill_ready": False,
         "slash_commands_ready": False,
         "plugin_line": plugin_line,
     }
@@ -1159,11 +1214,15 @@ def plugin_install_status(repo: str | Path, *, adapter_files_ok: bool = True) ->
             "global_plugin_installed": False,
             "plugin_installed": False,
             "plugin_enabled": False,
+            "command_files_current": bool(source_status.get("command_files_current", False)),
+            "command_surface_ok": False,
+            "slash_commands_likely_loaded": False,
+            "slash_commands_restart_required": False,
             "skill_ready": False,
             "slash_commands_ready": False,
             "install_command": install_command,
             "register_command": register_command,
-            "repair": "Install Codex CLI before using the Codex owner-loop adapter.",
+            "repair": "Install Codex CLI before using Main Branch Codex commands.",
             "safe_to_share": True,
         }
     if not adapter_files_ok:
@@ -1184,6 +1243,10 @@ def plugin_install_status(repo: str | Path, *, adapter_files_ok: bool = True) ->
             "global_plugin_installed": False,
             "plugin_installed": False,
             "plugin_enabled": False,
+            "command_files_current": bool(source_status.get("command_files_current", False)),
+            "command_surface_ok": False,
+            "slash_commands_likely_loaded": False,
+            "slash_commands_restart_required": False,
             "skill_ready": False,
             "slash_commands_ready": False,
             "install_command": install_command,
@@ -1211,6 +1274,10 @@ def plugin_install_status(repo: str | Path, *, adapter_files_ok: bool = True) ->
             "plugin_installed": False,
             "plugin_enabled": False,
             "slash_commands_ready": False,
+            "command_files_current": bool(source_status.get("command_files_current", False)),
+            "command_surface_ok": False,
+            "slash_commands_likely_loaded": False,
+            "slash_commands_restart_required": False,
             "skill_ready": False,
             "plugin_line": "",
             "install_command": install_command,
@@ -1223,8 +1290,9 @@ def plugin_install_status(repo: str | Path, *, adapter_files_ok: bool = True) ->
     parsed = _parse_plugin_install_status(
         str(result.get("stdout") or ""), expected_marketplace_path
     )
+    command_files_current = bool(source_status.get("command_files_current"))
     state = "ok"
-    summary = "Codex plugin is installed and enabled; generated Codex guidance is available."
+    summary = "Main Branch Codex commands are installed and ready after restarting Codex."
     repair = ""
     if not result["ok"]:
         state = "plugin_state_unverified"
@@ -1259,6 +1327,10 @@ def plugin_install_status(repo: str | Path, *, adapter_files_ok: bool = True) ->
         state = "plugin_disabled"
         summary = "The Main Branch Codex plugin is installed but not enabled."
         repair = f"Enable `{CODEX_PLUGIN_SELECTOR}` in Codex plugins."
+    elif not command_files_current:
+        state = "slash_commands_stale"
+        summary = "Main Branch Codex command files are missing or stale."
+        repair = CODEX_REPAIR_TEXT
 
     return {
         "checked": True,
@@ -1270,6 +1342,20 @@ def plugin_install_status(repo: str | Path, *, adapter_files_ok: bool = True) ->
         **parsed,
         "global_source_path": str(global_plugin_source_root()),
         "global_source_ok": source_ok,
+        "command_files": list(CODEX_SLASH_COMMAND_RELATIVE_PATHS),
+        "command_files_current": command_files_current,
+        "command_surface_ok": bool(
+            state == "ok" and parsed["plugin_installed"] and parsed["plugin_enabled"]
+        ),
+        "slash_commands_ready": bool(
+            state == "ok" and parsed["plugin_installed"] and parsed["plugin_enabled"]
+        ),
+        "slash_commands_likely_loaded": bool(
+            state == "ok" and parsed["plugin_installed"] and parsed["plugin_enabled"]
+        ),
+        "slash_commands_restart_required": bool(
+            command_files_current and parsed["plugin_installed"] and parsed["plugin_enabled"]
+        ),
         "install_command": install_command,
         "register_command": register_command,
         "repair": repair,
@@ -1284,6 +1370,7 @@ def install_plugin(repo: str | Path) -> dict[str, Any]:
     target = Path(repo).expanduser().resolve()
     source = write_global_plugin_source()
     steps = [
+        _run_codex_plugin_command(target, ["plugin", "remove", CODEX_LEGACY_PLUGIN_SELECTOR]),
         _run_codex_plugin_command(
             target,
             ["plugin", "marketplace", "add", str(global_plugin_source_root())],
@@ -1304,15 +1391,17 @@ def plugin_status(repo: str | Path) -> dict[str, Any]:
     target = Path(repo).expanduser().resolve()
     marketplace = marketplace_path(target)
     manifest = plugin_manifest_path(target)
-    skill = plugin_skill_path(target)
     expected_marketplace = render_codex_marketplace_json()
     expected_manifest = render_codex_plugin_manifest()
-    expected_skill = render_codex_plugin_skill_md()
+    expected_commands = render_codex_slash_commands()
 
     paths = {
         CODEX_MARKETPLACE_RELATIVE_PATH: marketplace,
         CODEX_PLUGIN_MANIFEST_RELATIVE_PATH: manifest,
-        CODEX_PLUGIN_SKILL_RELATIVE_PATH: skill,
+        **{
+            relative: global_plugin_source_root() / relative
+            for relative in CODEX_SLASH_COMMAND_RELATIVE_PATHS
+        },
     }
     missing = [relative for relative, path in paths.items() if not path.is_file()]
     stale: list[str] = []
@@ -1321,7 +1410,7 @@ def plugin_status(repo: str | Path) -> dict[str, Any]:
     expected_by_path = {
         CODEX_MARKETPLACE_RELATIVE_PATH: expected_marketplace,
         CODEX_PLUGIN_MANIFEST_RELATIVE_PATH: expected_manifest,
-        CODEX_PLUGIN_SKILL_RELATIVE_PATH: expected_skill,
+        **expected_commands,
     }
     missing_markers: list[str] = []
     for relative, path in paths.items():
@@ -1338,9 +1427,15 @@ def plugin_status(repo: str | Path) -> dict[str, Any]:
             missing_markers.extend(
                 marker for marker in CODEX_PLUGIN_REQUIRED_MARKERS if marker not in text
             )
-    legacy_commands = global_plugin_source_root() / CODEX_PLUGIN_LEGACY_COMMANDS_RELATIVE_PATH
-    if legacy_commands.exists():
-        stale.append(CODEX_PLUGIN_LEGACY_COMMANDS_RELATIVE_PATH)
+    legacy_plugin = global_plugin_source_root() / CODEX_LEGACY_PLUGIN_DIR_RELATIVE_PATH
+    if legacy_plugin.exists():
+        stale.append(CODEX_LEGACY_PLUGIN_DIR_RELATIVE_PATH)
+    visible_skill_dir = global_plugin_source_root() / CODEX_PLUGIN_DIR_RELATIVE_PATH / "skills"
+    if visible_skill_dir.exists():
+        stale.append(f"{CODEX_PLUGIN_DIR_RELATIVE_PATH}/skills")
+    command_files_current = not any(
+        relative in missing or relative in stale for relative in CODEX_SLASH_COMMAND_RELATIVE_PATHS
+    )
 
     ok = not missing and not stale and not read_errors and not missing_markers
     return {
@@ -1349,8 +1444,12 @@ def plugin_status(repo: str | Path) -> dict[str, Any]:
         "current": not stale and not missing_markers,
         "marketplace_path": CODEX_MARKETPLACE_RELATIVE_PATH,
         "manifest_path": CODEX_PLUGIN_MANIFEST_RELATIVE_PATH,
-        "skill_path": CODEX_PLUGIN_SKILL_RELATIVE_PATH,
-        "slash_commands_ready": False,
+        "skill_path": "",
+        "commands_path": CODEX_PLUGIN_COMMANDS_RELATIVE_PATH,
+        "command_files": list(CODEX_SLASH_COMMAND_RELATIVE_PATHS),
+        "command_files_current": command_files_current,
+        "command_surface_ok": command_files_current,
+        "slash_commands_ready": command_files_current,
         "missing": missing,
         "stale": stale,
         "missing_markers": missing_markers,
@@ -1367,14 +1466,13 @@ def write_global_plugin_source() -> dict[str, Any]:
     root = global_plugin_source_root()
     marketplace = marketplace_path(root)
     manifest = plugin_manifest_path(root)
-    skill = plugin_skill_path(root)
     expected_marketplace = render_codex_marketplace_json()
     expected_manifest = render_codex_plugin_manifest()
-    expected_skill = render_codex_plugin_skill_md()
+    expected_commands = render_codex_slash_commands()
     writes = {
         CODEX_MARKETPLACE_RELATIVE_PATH: (marketplace, expected_marketplace),
         CODEX_PLUGIN_MANIFEST_RELATIVE_PATH: (manifest, expected_manifest),
-        CODEX_PLUGIN_SKILL_RELATIVE_PATH: (skill, expected_skill),
+        **{relative: (root / relative, text) for relative, text in expected_commands.items()},
     }
     changed_paths: list[str] = []
     for _relative, (path, text) in writes.items():
@@ -1383,9 +1481,19 @@ def write_global_plugin_source() -> dict[str, Any]:
         if existing != text:
             path.write_text(text, encoding="utf-8")
             changed_paths.append(str(path))
-    old_commands = root / CODEX_PLUGIN_LEGACY_COMMANDS_RELATIVE_PATH
-    if _remove_generated_tree(old_commands):
-        changed_paths.append(str(old_commands))
+    old_skill = root / CODEX_PLUGIN_DIR_RELATIVE_PATH / "skills"
+    if _remove_generated_tree(old_skill):
+        changed_paths.append(str(old_skill))
+    old_plugin = root / CODEX_LEGACY_PLUGIN_DIR_RELATIVE_PATH
+    if _remove_generated_tree(old_plugin):
+        changed_paths.append(str(old_plugin))
+    commands_dir = root / CODEX_PLUGIN_COMMANDS_RELATIVE_PATH
+    expected_names = {f"{name}.md" for name in CODEX_SLASH_COMMAND_NAMES}
+    if commands_dir.is_dir():
+        for path in commands_dir.iterdir():
+            if path.is_file() and path.name not in expected_names:
+                path.unlink()
+                changed_paths.append(str(path))
     return {
         "ok": True,
         "path": str(root),
@@ -1413,6 +1521,7 @@ def remove_repo_local_codex_plugin_files(repo: str | Path) -> list[str]:
     removed: list[str] = []
     for relative in (
         CODEX_PLUGIN_DIR_RELATIVE_PATH,
+        CODEX_LEGACY_PLUGIN_DIR_RELATIVE_PATH,
         CODEX_MARKETPLACE_RELATIVE_PATH,
         CODEX_SKILL_DIR_RELATIVE_PATH,
     ):
@@ -1438,7 +1547,7 @@ def skill_status(repo: str | Path) -> dict[str, Any]:
         "ok": True,
         "exists": False,
         "current": True,
-        "path": CODEX_SKILL_RELATIVE_PATH,
+        "path": "",
         "inventory_path": CODEX_WORKFLOW_INVENTORY_RELATIVE_PATH,
         "missing_markers": [],
         "plugin": plugin,
@@ -1447,8 +1556,8 @@ def skill_status(repo: str | Path) -> dict[str, Any]:
         "repair_command": CODEX_REPAIR_COMMAND,
         "deprecated": True,
         "summary": (
-            "Repo-local Codex guidance files are no longer required; the Main Branch "
-            "Codex plugin is installed globally."
+            "Repo-local Codex plugin files are no longer required; Main Branch "
+            "Codex commands are installed globally."
         ),
         "safe_to_share": True,
     }
@@ -1483,6 +1592,7 @@ def instructions_status(repo: str | Path) -> dict[str, Any]:
             CODEX_SKILL_DIR_RELATIVE_PATH,
             CODEX_MARKETPLACE_RELATIVE_PATH,
             CODEX_PLUGIN_DIR_RELATIVE_PATH,
+            CODEX_LEGACY_PLUGIN_DIR_RELATIVE_PATH,
         )
         if (target / relative).exists()
     ]
@@ -1524,9 +1634,9 @@ def readiness(repo: str | Path) -> dict[str, Any]:
     plugin_install = plugin_install_status(repo, adapter_files_ok=bool(instructions["ok"]))
     plugin_ok = bool(plugin_install.get("ok"))
     slash_commands_ready = bool(plugin_install.get("slash_commands_ready"))
-    generated_guidance_ready = bool(plugin_ok and plugin_install.get("skill_ready"))
-    command_surface_ok = generated_guidance_ready
-    ok = bool(static_ok and runtime_ok and generated_guidance_ready)
+    command_surface_ok = bool(plugin_ok and plugin_install.get("command_surface_ok"))
+    generated_guidance_ready = command_surface_ok
+    ok = bool(static_ok and runtime_ok and command_surface_ok and slash_commands_ready)
     if ok:
         status = "ready"
     elif not executable["found"] or not instructions["ok"]:

--- a/mb/mb/codex.py
+++ b/mb/mb/codex.py
@@ -833,7 +833,7 @@ def workflow_inventory(*, runtime: str = "codex") -> dict[str, Any]:
             "commands_path": CODEX_PLUGIN_COMMANDS_RELATIVE_PATH,
             "generated_command_files": list(CODEX_SLASH_COMMAND_RELATIVE_PATHS),
             "slash_commands_generated": True,
-            "slash_commands_ready": True,
+            "slash_commands_ready": False,
             "install_hint": (
                 f"Run `{codex_marketplace_add_command()}`, then `{CODEX_PLUGIN_INSTALL_COMMAND}`."
             ),
@@ -1332,6 +1332,12 @@ def plugin_install_status(repo: str | Path, *, adapter_files_ok: bool = True) ->
         summary = "Main Branch Codex command files are missing or stale."
         repair = CODEX_REPAIR_TEXT
 
+    installed_enabled_current = bool(
+        state == "ok"
+        and command_files_current
+        and parsed["plugin_installed"]
+        and parsed["plugin_enabled"]
+    )
     return {
         "checked": True,
         "ok": state == "ok",
@@ -1344,18 +1350,11 @@ def plugin_install_status(repo: str | Path, *, adapter_files_ok: bool = True) ->
         "global_source_ok": source_ok,
         "command_files": list(CODEX_SLASH_COMMAND_RELATIVE_PATHS),
         "command_files_current": command_files_current,
-        "command_surface_ok": bool(
-            state == "ok" and parsed["plugin_installed"] and parsed["plugin_enabled"]
-        ),
-        "slash_commands_ready": bool(
-            state == "ok" and parsed["plugin_installed"] and parsed["plugin_enabled"]
-        ),
-        "slash_commands_likely_loaded": bool(
-            state == "ok" and parsed["plugin_installed"] and parsed["plugin_enabled"]
-        ),
-        "slash_commands_restart_required": bool(
-            command_files_current and parsed["plugin_installed"] and parsed["plugin_enabled"]
-        ),
+        "slash_commands_generated": command_files_current,
+        "command_surface_ok": installed_enabled_current,
+        "slash_commands_ready": installed_enabled_current,
+        "slash_commands_likely_loaded": False,
+        "slash_commands_restart_required": installed_enabled_current,
         "install_command": install_command,
         "register_command": register_command,
         "repair": repair,
@@ -1448,8 +1447,9 @@ def plugin_status(repo: str | Path) -> dict[str, Any]:
         "commands_path": CODEX_PLUGIN_COMMANDS_RELATIVE_PATH,
         "command_files": list(CODEX_SLASH_COMMAND_RELATIVE_PATHS),
         "command_files_current": command_files_current,
+        "slash_commands_generated": command_files_current,
         "command_surface_ok": command_files_current,
-        "slash_commands_ready": command_files_current,
+        "slash_commands_ready": False,
         "missing": missing,
         "stale": stale,
         "missing_markers": missing_markers,

--- a/mb/mb/doctor.py
+++ b/mb/mb/doctor.py
@@ -1342,7 +1342,7 @@ def run(path: str) -> dict[str, Any]:
             "name": "codex-agents-md",
             "ok": bool(codex_instructions["ok"]),
             "detail": (
-                "AGENTS.md and generated Codex guidance are current and point Codex "
+                "AGENTS.md and Main Branch Codex commands are current and point Codex "
                 "to mb facts, lifecycle routes, and workflow inventory"
             )
             if codex_instructions["ok"]
@@ -2099,7 +2099,16 @@ def repair_plan(
             "global_plugin_installed": codex_plugin_install.get("global_plugin_installed", False),
             "plugin_installed": codex_plugin_install["plugin_installed"],
             "plugin_enabled": codex_plugin_install["plugin_enabled"],
-            "skill_ready": codex_plugin_install.get("skill_ready", False),
+            "skill_available": codex_plugin_install.get("skill_available", False),
+            "command_files_current": codex_plugin_install.get("command_files_current", False),
+            "command_surface_ok": codex_plugin_install.get("command_surface_ok", False),
+            "slash_commands_ready": codex_plugin_install.get("slash_commands_ready", False),
+            "slash_commands_likely_loaded": codex_plugin_install.get(
+                "slash_commands_likely_loaded", False
+            ),
+            "slash_commands_restart_required": codex_plugin_install.get(
+                "slash_commands_restart_required", False
+            ),
             "install_command": codex_plugin_install["install_command"],
             "repair": codex_plugin_install["repair"],
         },
@@ -2137,7 +2146,7 @@ def repair_plan(
             safe_to_apply=True,
             reason=(
                 "Codex must install and enable the global Main Branch plugin before "
-                "generated Codex guidance is available"
+                "the /mb command surface is available"
             ),
             writes=[
                 str(codex_mod.global_plugin_source_root()),
@@ -2151,11 +2160,11 @@ def repair_plan(
     sections.append(
         _section(
             "codex-wiring",
-            "Codex CLI Adapter",
+            "Codex Commands",
             _max_state([str(item["state"]) for item in codex_checks]),
             (
-                "Supported Codex adapter instructions, generated plugin guidance, "
-                "workflow inventory, global plugin, and executable readiness"
+                "Main Branch Codex commands, repo guidance, workflow inventory, "
+                "global plugin, and executable readiness"
             ),
             checks=codex_checks,
             actions=codex_actions,
@@ -2551,8 +2560,8 @@ def repair_apply(
                 ),
                 safe_to_apply=True,
                 reason=(
-                    "installed and enabled the global Codex plugin so generated "
-                    "Codex guidance is available"
+                    "installed and enabled the global Codex plugin so /mb commands "
+                    "are available after restarting Codex"
                 ),
                 writes=[
                     str(codex_mod.global_plugin_source_root()),

--- a/mb/mb/start.py
+++ b/mb/mb/start.py
@@ -323,10 +323,17 @@ def _codex_next_actions(repo: Path, codex: dict[str, Any]) -> list[str]:
             actions.append(repair)
         actions.append("Rerun `mb status --json --peek` before using Codex.")
         return actions[:3]
+    if not codex.get("slash_commands_ready"):
+        repair = str(codex.get("repair") or "")
+        actions = []
+        if repair:
+            actions.append(repair)
+        actions.append("Restart Codex, then type `/mb` to verify Main Branch commands.")
+        return actions[:3]
     smoke_command = str(codex.get("smoke_command") or "")
     actions = [
         f"Run `{_codex_display_command(repo)}`.",
-        "Start from generated Codex guidance and read-only `mb` facts.",
+        "After Codex restarts, type `/mb-start` or `/mb-status`.",
     ]
     if smoke_command:
         actions.append(f"For a read-only Codex smoke, run `{smoke_command}`.")
@@ -380,8 +387,8 @@ def run(repo: str = ".", launch: bool = False) -> dict[str, Any]:
             "argv": ["codex", "-C", str(repo_path)],
             "display": _codex_display_command(repo_path),
             "startup_prompt": (
-                "Start this Main Branch business day from generated Codex guidance "
-                "and read-only mb facts. Ask before writes. Stop if mb status/start reports "
+                "Start this Main Branch business day from `/mb-start` and read-only "
+                "mb facts. Ask before writes. Stop if mb status/start reports "
                 "runtime.codex_cli.status == runtime_mismatch or drift id "
                 "codex_runtime_mb_mismatch."
             ),

--- a/mb/mb/start.py
+++ b/mb/mb/start.py
@@ -323,6 +323,7 @@ def _codex_next_actions(repo: Path, codex: dict[str, Any]) -> list[str]:
             actions.append(repair)
         actions.append("Rerun `mb status --json --peek` before using Codex.")
         return actions[:3]
+    plugin_install = codex.get("plugin_install") or {}
     if not codex.get("slash_commands_ready"):
         repair = str(codex.get("repair") or "")
         actions = []
@@ -330,6 +331,15 @@ def _codex_next_actions(repo: Path, codex: dict[str, Any]) -> list[str]:
             actions.append(repair)
         actions.append("Restart Codex, then type `/mb` to verify Main Branch commands.")
         return actions[:3]
+    if plugin_install.get("slash_commands_restart_required"):
+        actions = [
+            f"Run `{_codex_display_command(repo)}` or restart Codex if it is already open.",
+            "Type `/mb` to verify Main Branch commands.",
+        ]
+        smoke_command = str(codex.get("smoke_command") or "")
+        if smoke_command:
+            actions.append(f"For a read-only Codex smoke, run `{smoke_command}`.")
+        return actions
     smoke_command = str(codex.get("smoke_command") or "")
     actions = [
         f"Run `{_codex_display_command(repo)}`.",

--- a/mb/mb/status.py
+++ b/mb/mb/status.py
@@ -3835,10 +3835,6 @@ def _drift(report: dict[str, Any]) -> dict[str, Any]:
                 "summary": "Codex owner-loop instructions are missing or stale.",
                 "evidence": [
                     str(codex_instructions.get("path") or "AGENTS.md"),
-                    str(
-                        (codex_instructions.get("skill") or {}).get("path")
-                        or codex_mod.CODEX_SKILL_RELATIVE_PATH
-                    ),
                 ],
                 "repair": str(
                     codex_instructions.get("repair")
@@ -3891,6 +3887,7 @@ def _drift(report: dict[str, Any]) -> dict[str, Any]:
                     f"marketplace: {codex_plugin.get('marketplace_name') or ''}".strip(),
                     f"plugin: {codex_plugin.get('plugin_selector') or ''}".strip(),
                     f"state: {codex_plugin.get('state') or 'unknown'}",
+                    f"commands current: {codex_plugin.get('command_files_current')}",
                 ],
                 "repair": str(
                     codex_plugin.get("repair") or f"Run `{codex_mod.CODEX_PLUGIN_INSTALL_COMMAND}`."

--- a/mb/mb/update.py
+++ b/mb/mb/update.py
@@ -181,6 +181,43 @@ def _link_skills(repo: Path) -> tuple[int, list[str], list[str], dict[str, Any] 
     return _skill_count_from_link_result(payload), [], warnings, payload
 
 
+def _repair_codex_surface(repo: Path) -> tuple[bool, list[str], list[str], dict[str, Any] | None]:
+    result = _run_command(
+        [
+            "mb",
+            "doctor",
+            "repair",
+            "--repo",
+            str(repo),
+            "--apply",
+            "--only",
+            "codex",
+            "--json",
+        ]
+    )
+    if result.returncode != 0:
+        return False, [_command_error("mb doctor repair --only codex", result)], [], None
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return False, ["mb doctor repair --only codex returned invalid JSON"], [], None
+    if not isinstance(payload, dict):
+        return (
+            False,
+            ["mb doctor repair --only codex returned an unexpected JSON payload"],
+            [],
+            None,
+        )
+
+    raw_warnings = payload.get("warnings", [])
+    warnings = [str(item) for item in raw_warnings] if isinstance(raw_warnings, list) else []
+    raw_errors = payload.get("errors", [])
+    errors = [str(item) for item in raw_errors] if isinstance(raw_errors, list) else []
+    if payload.get("ok") is not True:
+        return False, errors or ["mb doctor repair --only codex failed"], warnings, payload
+    return True, [], warnings, payload
+
+
 def _base_result(repo: Path, *, check: bool, mode: str, root: Path | None) -> dict[str, Any]:
     return {
         "ok": True,
@@ -192,6 +229,8 @@ def _base_result(repo: Path, *, check: bool, mode: str, root: Path | None) -> di
         "new_version": None,
         "skills_relinked_count": 0,
         "planned_skills_relink_count": 0,
+        "codex_repaired": False,
+        "codex_repair_result": {},
         "release": {},
         "actions": [],
         "warnings": [],
@@ -218,7 +257,7 @@ def _add_codex_follow_up(result: dict[str, Any], repo: Path) -> None:
         "repair_command": codex.get("repair", "") or instructions.get("repair_command", ""),
         "plugin_install": plugin_install,
     }
-    if not codex["ok"]:
+    if not codex["ok"] or not codex.get("slash_commands_ready", False):
         next_actions: list[str]
         if not instructions.get("ok", False):
             message = (
@@ -232,10 +271,20 @@ def _add_codex_follow_up(result: dict[str, Any], repo: Path) -> None:
             ]
         elif not codex.get("plugin_ok", False):
             message = (
-                "The global Main Branch Codex plugin is not ready, so generated Codex "
-                "guidance may be unavailable. "
+                "The global Main Branch Codex plugin is not ready, so `/mb-*` "
+                "commands may be missing or stale. "
                 "Run `mb doctor repair --plan --only codex`, review it, then approve "
                 "`mb doctor repair --apply --only codex`."
+            )
+            next_actions = [
+                "mb doctor repair --plan --only codex",
+                "mb doctor repair --apply --only codex",
+            ]
+        elif not codex.get("slash_commands_ready", False):
+            message = (
+                "Main Branch Codex commands are missing or stale. Run "
+                "`mb doctor repair --plan --only codex`, review it, then approve "
+                "`mb doctor repair --apply --only codex`, then restart Codex."
             )
             next_actions = [
                 "mb doctor repair --plan --only codex",
@@ -272,6 +321,7 @@ def run(repo: str | Path = ".", *, check: bool = False) -> dict[str, Any]:
             result["actions"] = [
                 "would run `pipx upgrade mainbranch`",
                 f"would run `mb skill link --repo {target_repo} --json`",
+                (f"would run `mb doctor repair --repo {target_repo} --apply --only codex --json`"),
             ]
         else:
             if root is None:
@@ -293,6 +343,10 @@ def run(repo: str | Path = ".", *, check: bool = False) -> dict[str, Any]:
                 [
                     f"would run `git pull --ff-only origin main` in {root}",
                     f"would run `mb skill link --repo {target_repo} --json`",
+                    (
+                        "would run `mb doctor repair --repo "
+                        f"{target_repo} --apply --only codex --json`"
+                    ),
                 ]
             )
         planned_count = len(bundled_skills())
@@ -352,6 +406,18 @@ def run(repo: str | Path = ".", *, check: bool = False) -> dict[str, Any]:
     if link_errors:
         result["ok"] = False
         result["errors"].extend(link_errors)
+    else:
+        codex_ok, codex_errors, codex_warnings, codex_payload = _repair_codex_surface(target_repo)
+        result["actions"].append(
+            f"ran `mb doctor repair --repo {target_repo} --apply --only codex --json`"
+        )
+        result["codex_repaired"] = codex_ok
+        if codex_payload is not None:
+            result["codex_repair_result"] = codex_payload
+        result["warnings"].extend(codex_warnings)
+        if codex_errors:
+            result["ok"] = False
+            result["errors"].extend(codex_errors)
     _add_codex_follow_up(result, target_repo)
     return result
 
@@ -386,6 +452,8 @@ def render_human(result: dict[str, Any]) -> None:
     elif result.get("ok"):
         print(f"updated Main Branch ({old} -> {new})")
         print(f"refreshed {count} skill link(s)")
+        if result.get("codex_repaired"):
+            print("refreshed Codex command surface")
         for action in result.get("next_actions", []):
             print(f"next: {action}")
 

--- a/mb/mb/update.py
+++ b/mb/mb/update.py
@@ -252,6 +252,10 @@ def _add_codex_follow_up(result: dict[str, Any], repo: Path) -> None:
         "plugin_ok": codex.get("plugin_ok", False),
         "command_surface_ok": codex.get("command_surface_ok", False),
         "slash_commands_ready": codex.get("slash_commands_ready", False),
+        "slash_commands_likely_loaded": plugin_install.get("slash_commands_likely_loaded", False),
+        "slash_commands_restart_required": plugin_install.get(
+            "slash_commands_restart_required", False
+        ),
         "exists": instructions.get("exists", False),
         "current": instructions.get("current", False),
         "repair_command": codex.get("repair", "") or instructions.get("repair_command", ""),
@@ -298,6 +302,12 @@ def _add_codex_follow_up(result: dict[str, Any], repo: Path) -> None:
             next_actions = ["mb status --json --peek"]
         result["warnings"].append(message)
         result["next_actions"].extend(next_actions)
+    elif plugin_install.get("slash_commands_restart_required"):
+        result["warnings"].append(
+            "Main Branch Codex commands are installed. Restart Codex, then type `/mb` "
+            "to verify the slash command surface loaded."
+        )
+        result["next_actions"].append("Restart Codex, then type `/mb`.")
 
 
 def run(repo: str | Path = ".", *, check: bool = False) -> dict[str, Any]:

--- a/mb/tests/test_init.py
+++ b/mb/tests/test_init.py
@@ -111,7 +111,7 @@ def _assert_agents_md_codex_start_contract(text: str) -> None:
     assert "`runtime.codex_cli.status` is `runtime_mismatch`" in text
     assert "`codex_runtime_mb_mismatch`" in text
     assert "Start the day / what next / get oriented" in text
-    assert "generated Codex guidance over deterministic `mb` facts" in text
+    assert "supplies `/mb-*`" in text
     assert "Inspect status / what changed / what is stale" in text
     assert "Think / research / decide / codify" in text
     assert "do not claim these workflows are ported to" in text
@@ -241,7 +241,7 @@ def test_init_scaffolds_folders(tmp_path: Path) -> None:
     assert "/mb-start" in readme_md
     assert "Codex CLI" in readme_md
     assert "mb doctor repair --apply --only codex" in readme_md
-    assert "/mb-start" not in readme_md.split("Or, in Codex CLI:", 1)[1]
+    assert "/mb-start" in readme_md.split("Or, in Codex CLI:", 1)[1]
     assert "## Save, Checkpoint, Backup" in readme_md
     assert "A checkpoint is an approved saved point" in readme_md
     assert "GitHub backup/sync is strongly recommended" in readme_md

--- a/mb/tests/test_start.py
+++ b/mb/tests/test_start.py
@@ -141,7 +141,7 @@ def test_start_json_keeps_codex_slash_visibility_honest(tmp_path: Path, monkeypa
     assert report["runtime"]["codex_cli"]["status"] == "ready"
     assert report["runtime"]["codex_cli"]["plugin_ok"] is True
     assert report["runtime"]["codex_cli"]["generated_guidance_ready"] is True
-    assert report["runtime"]["codex_cli"]["slash_commands_ready"] is False
+    assert report["runtime"]["codex_cli"]["slash_commands_ready"] is True
     assert report["runtime"]["codex_cli"]["instructions"]["ok"] is True
     assert report["experimental_runtimes"]["codex_cli"]["command"]["argv"] == [
         "codex",
@@ -149,14 +149,14 @@ def test_start_json_keeps_codex_slash_visibility_honest(tmp_path: Path, monkeypa
         str(repo.resolve()),
     ]
     next_actions = "\n".join(report["next_actions"])
-    assert "generated Codex guidance" in next_actions
+    assert "/mb-start" in next_actions
     assert f"codex -C {shlex.quote(str(repo.resolve()))}" in next_actions
     assert "Run `claude" not in next_actions
     assert report["command"]["argv"] == ["claude"]
     assert report["command"]["display"].endswith(" && claude")
     assert report["command"]["follow_up"] == "/mb-start"
     codex_prompt = report["experimental_runtimes"]["codex_cli"]["command"]["startup_prompt"]
-    assert "generated Codex guidance" in codex_prompt
+    assert "/mb-start" in codex_prompt
     assert "with /mb-start" not in codex_prompt
     assert report["launch"]["requested"] is False
     assert report["checkpoint"]["pending"]["status"] == "ready"

--- a/mb/tests/test_start.py
+++ b/mb/tests/test_start.py
@@ -149,8 +149,12 @@ def test_start_json_keeps_codex_slash_visibility_honest(tmp_path: Path, monkeypa
         str(repo.resolve()),
     ]
     next_actions = "\n".join(report["next_actions"])
-    assert "/mb-start" in next_actions
     assert f"codex -C {shlex.quote(str(repo.resolve()))}" in next_actions
+    codex_next_actions = "\n".join(
+        report["experimental_runtimes"]["codex_cli"]["command"]["next_actions"]
+    )
+    assert "/mb" in codex_next_actions
+    assert "restart Codex" in codex_next_actions
     assert "Run `claude" not in next_actions
     assert report["command"]["argv"] == ["claude"]
     assert report["command"]["display"].endswith(" && claude")

--- a/mb/tests/test_status.py
+++ b/mb/tests/test_status.py
@@ -1486,7 +1486,7 @@ def test_status_marks_codex_not_ready_when_plugin_is_not_installed(
     assert codex_mod.CODEX_PLUGIN_INSTALL_COMMAND in finding["repair"]
 
 
-def test_status_does_not_overclaim_codex_slash_commands_when_plugin_is_installed(
+def test_status_marks_codex_ready_when_command_surface_is_installed(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
@@ -1510,15 +1510,13 @@ def test_status_does_not_overclaim_codex_slash_commands_when_plugin_is_installed
     assert codex["plugin_ok"] is True
     assert codex["generated_guidance_ready"] is True
     assert codex["command_surface_ok"] is True
-    assert codex["slash_commands_ready"] is False
+    assert codex["slash_commands_ready"] is True
     assert codex["plugin_install"]["plugin_installed"] is True
     assert codex["plugin_install"]["plugin_enabled"] is True
-    assert codex["plugin_install"]["skill_ready"] is True
-    assert codex["plugin_install"]["slash_commands_ready"] is False
+    assert codex["plugin_install"]["skill_ready"] is False
+    assert codex["plugin_install"]["command_files_current"] is True
+    assert codex["plugin_install"]["slash_commands_ready"] is True
     assert not any(item["id"] == "codex_plugin_not_installed" for item in report["drift"]["items"])
-    assert not any(
-        item["id"] == "codex_slash_commands_unsupported" for item in report["drift"]["items"]
-    )
 
 
 def test_status_json_exposes_push_and_legacy_campaign_facts(tmp_path: Path, monkeypatch) -> None:

--- a/mb/tests/test_status.py
+++ b/mb/tests/test_status.py
@@ -1516,6 +1516,8 @@ def test_status_marks_codex_ready_when_command_surface_is_installed(
     assert codex["plugin_install"]["skill_ready"] is False
     assert codex["plugin_install"]["command_files_current"] is True
     assert codex["plugin_install"]["slash_commands_ready"] is True
+    assert codex["plugin_install"]["slash_commands_likely_loaded"] is False
+    assert codex["plugin_install"]["slash_commands_restart_required"] is True
     assert not any(item["id"] == "codex_plugin_not_installed" for item in report["drift"]["items"])
 
 

--- a/mb/tests/test_update.py
+++ b/mb/tests/test_update.py
@@ -46,6 +46,8 @@ def codex_adapter_ready(monkeypatch: pytest.MonkeyPatch) -> None:
                 "command_files_current": True,
                 "command_surface_ok": True,
                 "slash_commands_ready": True,
+                "slash_commands_likely_loaded": False,
+                "slash_commands_restart_required": False,
                 "repair": "",
             },
         },
@@ -384,6 +386,78 @@ def test_update_reports_manual_codex_slash_visibility_verification(
     assert any("commands are missing or stale" in item for item in result["warnings"])
     assert not any("Codex command API" in item for item in result["next_actions"])
     assert not any("Codex command API" in item for item in result["warnings"])
+
+
+def test_update_surfaces_codex_restart_when_commands_were_refreshed(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    def fake_run(args: list[str], *, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+        if args == ["pipx", "upgrade", "mainbranch"]:
+            return _completed(args, stdout="upgraded package mainbranch")
+        if args == ["mb", "--version"]:
+            return _completed(args, stdout="mb 0.3.34\n")
+        if args[:3] == ["mb", "skill", "link"]:
+            return _completed(
+                args,
+                stdout=json.dumps(
+                    {"ok": True, "linked": [], "copied": [], "skipped": [], "errors": []}
+                ),
+            )
+        if args[:3] == ["mb", "doctor", "repair"]:
+            return _codex_repair_completed(args)
+        return _completed(args, returncode=1, stderr="unexpected")
+
+    monkeypatch.setattr(update_mod, "install_mode", lambda: "pipx")
+    monkeypatch.setattr(update_mod, "engine_root", lambda: tmp_path / "_engine")
+    monkeypatch.setattr(
+        update_mod.shutil,  # type: ignore[attr-defined]
+        "which",
+        lambda name: "/opt/homebrew/bin/pipx",
+    )
+    monkeypatch.setattr(update_mod, "_run_command", fake_run)
+    monkeypatch.setattr(
+        codex_mod,
+        "readiness",
+        lambda repo: {
+            "ok": True,
+            "status": "ready",
+            "static_ok": True,
+            "runtime_ok": True,
+            "plugin_ok": True,
+            "generated_guidance_ready": True,
+            "command_surface_ok": True,
+            "slash_commands_ready": True,
+            "repair": "",
+            "instructions": {
+                "ok": True,
+                "exists": True,
+                "current": True,
+                "repair_command": "",
+            },
+            "plugin_install": {
+                "ok": True,
+                "state": "ok",
+                "plugin_installed": True,
+                "plugin_enabled": True,
+                "skill_ready": False,
+                "command_files_current": True,
+                "command_surface_ok": True,
+                "slash_commands_ready": True,
+                "slash_commands_likely_loaded": False,
+                "slash_commands_restart_required": True,
+                "repair": "",
+            },
+        },
+    )
+
+    result = update_mod.run(repo=tmp_path / "biz")
+
+    assert result["ok"] is True
+    assert result["codex_adapter"]["slash_commands_ready"] is True
+    assert result["codex_adapter"]["slash_commands_likely_loaded"] is False
+    assert result["codex_adapter"]["slash_commands_restart_required"] is True
+    assert "Restart Codex, then type `/mb`." in result["next_actions"]
+    assert any("slash command surface loaded" in item for item in result["warnings"])
 
 
 def test_update_check_clone_fetches_before_reading_origin(monkeypatch: Any, tmp_path: Path) -> None:

--- a/mb/tests/test_update.py
+++ b/mb/tests/test_update.py
@@ -29,6 +29,8 @@ def codex_adapter_ready(monkeypatch: pytest.MonkeyPatch) -> None:
             "static_ok": True,
             "runtime_ok": True,
             "plugin_ok": True,
+            "command_surface_ok": True,
+            "slash_commands_ready": True,
             "repair": "",
             "instructions": {
                 "ok": True,
@@ -41,6 +43,8 @@ def codex_adapter_ready(monkeypatch: pytest.MonkeyPatch) -> None:
                 "state": "ok",
                 "plugin_installed": True,
                 "plugin_enabled": True,
+                "command_files_current": True,
+                "command_surface_ok": True,
                 "slash_commands_ready": True,
                 "repair": "",
             },
@@ -60,6 +64,21 @@ def _completed(
         returncode=returncode,
         stdout=stdout,
         stderr=stderr,
+    )
+
+
+def _codex_repair_completed(args: list[str]) -> subprocess.CompletedProcess[str]:
+    return _completed(
+        args,
+        stdout=json.dumps(
+            {
+                "ok": True,
+                "warnings": [],
+                "errors": [],
+                "actions": [],
+                "applied_actions": [],
+            }
+        ),
     )
 
 
@@ -124,6 +143,8 @@ def test_update_pipx_runs_upgrade_then_relinks(monkeypatch: Any, tmp_path: Path)
                     }
                 ),
             )
+        if args[:3] == ["mb", "doctor", "repair"]:
+            return _codex_repair_completed(args)
         return _completed(args, returncode=1, stderr="unexpected")
 
     monkeypatch.setattr(update_mod, "install_mode", lambda: "pipx")
@@ -148,7 +169,19 @@ def test_update_pipx_runs_upgrade_then_relinks(monkeypatch: Any, tmp_path: Path)
         ["pipx", "upgrade", "mainbranch"],
         ["mb", "--version"],
         ["mb", "skill", "link", "--repo", str(repo.resolve()), "--json"],
+        [
+            "mb",
+            "doctor",
+            "repair",
+            "--repo",
+            str(repo.resolve()),
+            "--apply",
+            "--only",
+            "codex",
+            "--json",
+        ],
     ]
+    assert result["codex_repaired"] is True
 
 
 def test_update_points_to_scoped_codex_repair_when_adapter_missing(
@@ -166,6 +199,8 @@ def test_update_points_to_scoped_codex_repair_when_adapter_missing(
                     {"ok": True, "linked": [], "copied": [], "skipped": [], "errors": []}
                 ),
             )
+        if args[:3] == ["mb", "doctor", "repair"]:
+            return _codex_repair_completed(args)
         return _completed(args, returncode=1, stderr="unexpected")
 
     monkeypatch.setattr(update_mod, "install_mode", lambda: "pipx")
@@ -228,6 +263,8 @@ def test_update_points_to_scoped_codex_repair_when_plugin_is_missing(
                     {"ok": True, "linked": [], "copied": [], "skipped": [], "errors": []}
                 ),
             )
+        if args[:3] == ["mb", "doctor", "repair"]:
+            return _codex_repair_completed(args)
         return _completed(args, returncode=1, stderr="unexpected")
 
     monkeypatch.setattr(update_mod, "install_mode", lambda: "pipx")
@@ -291,6 +328,8 @@ def test_update_reports_manual_codex_slash_visibility_verification(
                     {"ok": True, "linked": [], "copied": [], "skipped": [], "errors": []}
                 ),
             )
+        if args[:3] == ["mb", "doctor", "repair"]:
+            return _codex_repair_completed(args)
         return _completed(args, returncode=1, stderr="unexpected")
 
     monkeypatch.setattr(update_mod, "install_mode", lambda: "pipx")
@@ -313,7 +352,7 @@ def test_update_reports_manual_codex_slash_visibility_verification(
             "generated_guidance_ready": True,
             "command_surface_ok": True,
             "slash_commands_ready": False,
-            "repair": "",
+            "repair": codex_mod.CODEX_REPAIR_TEXT,
             "instructions": {
                 "ok": True,
                 "exists": True,
@@ -325,9 +364,11 @@ def test_update_reports_manual_codex_slash_visibility_verification(
                 "state": "ok",
                 "plugin_installed": True,
                 "plugin_enabled": True,
-                "skill_ready": True,
+                "skill_ready": False,
+                "command_files_current": False,
+                "command_surface_ok": False,
                 "slash_commands_ready": False,
-                "repair": "",
+                "repair": codex_mod.CODEX_REPAIR_TEXT,
             },
         },
     )
@@ -338,8 +379,9 @@ def test_update_reports_manual_codex_slash_visibility_verification(
     assert result["codex_adapter"]["plugin_ok"] is True
     assert result["codex_adapter"]["ok"] is True
     assert result["codex_adapter"]["slash_commands_ready"] is False
-    assert "mb doctor repair --plan --only codex" not in result["next_actions"]
-    assert "mb doctor repair --apply --only codex" not in result["next_actions"]
+    assert "mb doctor repair --plan --only codex" in result["next_actions"]
+    assert "mb doctor repair --apply --only codex" in result["next_actions"]
+    assert any("commands are missing or stale" in item for item in result["warnings"])
     assert not any("Codex command API" in item for item in result["next_actions"])
     assert not any("Codex command API" in item for item in result["warnings"])
 
@@ -416,6 +458,8 @@ def test_update_clone_pulls_engine_root_then_relinks(monkeypatch: Any, tmp_path:
                     }
                 ),
             )
+        if args[:3] == ["mb", "doctor", "repair"]:
+            return _codex_repair_completed(args)
         return _completed(args, returncode=1, stderr="unexpected")
 
     monkeypatch.setattr(update_mod, "install_mode", lambda: "clone")
@@ -432,6 +476,17 @@ def test_update_clone_pulls_engine_root_then_relinks(monkeypatch: Any, tmp_path:
         "could not refresh existing non-link skill path(s): .claude/skills/mb-start"
     ]
     assert calls[0] == (["git", "pull", "--ff-only", "origin", "main"], root)
+    assert calls[-1][0] == [
+        "mb",
+        "doctor",
+        "repair",
+        "--repo",
+        str((tmp_path / "biz").resolve()),
+        "--apply",
+        "--only",
+        "codex",
+        "--json",
+    ]
 
 
 def test_update_json_cli_envelope(monkeypatch: Any, tmp_path: Path) -> None:

--- a/mb/tests/test_workflows.py
+++ b/mb/tests/test_workflows.py
@@ -231,6 +231,7 @@ def test_codex_plugin_status_marks_missing_or_stale_commands_not_ready(
     assert status["current"] is False
     assert codex_mod.CODEX_SLASH_COMMAND_RELATIVE_PATHS[0] in status["stale"]
     assert status["command_files_current"] is False
+    assert status["slash_commands_generated"] is False
     assert status["slash_commands_ready"] is False
     assert status["repair"] == codex_mod.CODEX_REPAIR_TEXT
 
@@ -263,7 +264,8 @@ def test_codex_workflow_inventory_command_lists_supported_and_pending_surfaces()
     assert by_id["wiki"]["codex_status"] == "intentionally_unsupported"
     assert data["plugin"]["manifest_path"] == codex_mod.CODEX_PLUGIN_MANIFEST_RELATIVE_PATH
     assert data["plugin"]["commands_path"] == codex_mod.CODEX_PLUGIN_COMMANDS_RELATIVE_PATH
-    assert data["plugin"]["slash_commands_ready"] is True
+    assert data["plugin"]["slash_commands_generated"] is True
+    assert data["plugin"]["slash_commands_ready"] is False
     assert set(data["plugin"]["generated_command_files"]) == set(
         codex_mod.CODEX_SLASH_COMMAND_RELATIVE_PATHS
     )

--- a/mb/tests/test_workflows.py
+++ b/mb/tests/test_workflows.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import yaml
 from typer.testing import CliRunner
 
 from mb import codex as codex_mod
@@ -142,86 +141,98 @@ def test_codex_contract_markers_match_think_workflow_source() -> None:
     )
 
 
-def test_codex_owner_loop_skill_and_inventory_render() -> None:
-    skill = codex_mod.render_codex_skill_md()
+def test_codex_command_surface_and_inventory_render() -> None:
+    commands = codex_mod.render_codex_slash_commands()
     inventory = codex_mod.render_workflow_inventory_md()
     manifest = codex_mod.render_codex_plugin_manifest()
     marketplace = codex_mod.render_codex_marketplace_json()
     inventory_json = codex_mod.workflow_inventory(runtime="codex")
 
-    assert "Main Branch daily loop for Codex" in skill
-    assert "mb workflow list --runtime codex --json" in skill
-    assert "runtime.codex_cli.status" in skill
-    assert "codex_runtime_mb_mismatch" in skill
-    assert "start/status/setup/update/doctor" in skill
-    assert "think/codify" in skill
-    assert "end/checkpoint/save" in skill
-    assert "Ask before durable writes" in skill
+    assert set(commands) == set(codex_mod.CODEX_SLASH_COMMAND_RELATIVE_PATHS)
+    assert (
+        "description: Start Main Branch."
+        in commands[f"{codex_mod.CODEX_PLUGIN_COMMANDS_RELATIVE_PATH}/mb-start.md"]
+    )
+    assert (
+        "mb status --json --peek"
+        in commands[f"{codex_mod.CODEX_PLUGIN_COMMANDS_RELATIVE_PATH}/mb-start.md"]
+    )
+    assert (
+        "codex_runtime_mb_mismatch"
+        in commands[f"{codex_mod.CODEX_PLUGIN_COMMANDS_RELATIVE_PATH}/mb-start.md"]
+    )
+    assert (
+        "Ask before durable writes"
+        in commands[f"{codex_mod.CODEX_PLUGIN_COMMANDS_RELATIVE_PATH}/mb-start.md"]
+    )
+    assert "main-branch-owner-loop" not in "\n".join(commands.values())
     assert "Main Branch" in manifest
-    assert '"skills": "./skills/"' in manifest
-    assert '"path": "./.agents/plugins/main-branch-owner-loop"' in marketplace
-    assert "Codex plugin files are installed globally" in inventory
+    assert '"skills": "./skills/"' not in manifest
+    assert "main-branch-owner-loop" not in manifest
+    assert '"path": "./.agents/plugins/main-branch"' in marketplace
+    assert "Codex plugin files and `/mb-*` command files are installed globally" in inventory
     assert "codex plugin list --marketplace main-branch" in inventory
     assert ".claude/skills/mb-start/SKILL.md" in inventory
     assert ".claude/skills/mb-skill-review/SKILL.md" in inventory
     assert "codex plugin marketplace add" in inventory_json["plugin"]["install_hint"]
     assert codex_mod.CODEX_PLUGIN_INSTALL_COMMAND in inventory_json["plugin"]["install_hint"]
-    assert "`Codex Start Workflow`" in inventory
+    assert "`/mb-start`" in inventory
     assert "pending_shared_source_migration" in inventory
     assert "intentionally_unsupported" in inventory
-    assert "Copied Claude" not in skill
+    assert "Copied Claude" not in "\n".join(commands.values())
 
 
-def test_codex_plugin_skill_matches_generated_owner_loop_skill() -> None:
-    assert codex_mod.render_codex_plugin_skill_md() == codex_mod.render_codex_skill_md()
-
-
-def test_codex_global_plugin_source_removes_unproven_command_shims(
+def test_codex_global_plugin_source_generates_slash_commands_and_removes_visible_skill(
     tmp_path: Path, monkeypatch
 ) -> None:
     monkeypatch.setenv("MAINBRANCH_CODEX_PLUGIN_ROOT", str(tmp_path / "codex-global"))
-    old_command = (
+    old_skill = (
         codex_mod.global_plugin_source_root()
-        / codex_mod.CODEX_PLUGIN_DIR_RELATIVE_PATH
-        / "commands"
-        / "mb-start.md"
+        / codex_mod.CODEX_LEGACY_PLUGIN_DIR_RELATIVE_PATH
+        / "skills"
+        / "main-branch-owner-loop"
+        / "SKILL.md"
     )
-    old_command.parent.mkdir(parents=True, exist_ok=True)
-    old_command.write_text("# stale\n", encoding="utf-8")
+    old_skill.parent.mkdir(parents=True, exist_ok=True)
+    old_skill.write_text("# stale\n", encoding="utf-8")
 
     result = codex_mod.write_global_plugin_source()
 
     assert result["ok"] is True
-    assert not old_command.exists()
-    assert codex_mod.CODEX_PLUGIN_SKILL_RELATIVE_PATH in result["relative_paths"]
+    assert not old_skill.exists()
+    assert codex_mod.CODEX_PLUGIN_MANIFEST_RELATIVE_PATH in result["relative_paths"]
+    assert codex_mod.CODEX_PLUGIN_SKILL_RELATIVE_PATH not in result["relative_paths"]
+    for relative in codex_mod.CODEX_SLASH_COMMAND_RELATIVE_PATHS:
+        path = codex_mod.global_plugin_source_root() / relative
+        assert path.is_file()
+        text = path.read_text(encoding="utf-8")
+        assert "deterministic `mb` facts" in text
+        assert "Ask before durable writes" in text
+    assert "description: Start Main Branch." in (
+        codex_mod.global_plugin_source_root()
+        / codex_mod.CODEX_PLUGIN_COMMANDS_RELATIVE_PATH
+        / "mb-start.md"
+    ).read_text(encoding="utf-8")
 
 
-def test_codex_plugin_status_marks_legacy_command_shims_stale(tmp_path: Path, monkeypatch) -> None:
+def test_codex_plugin_status_marks_missing_or_stale_commands_not_ready(
+    tmp_path: Path, monkeypatch
+) -> None:
     monkeypatch.setenv("MAINBRANCH_CODEX_PLUGIN_ROOT", str(tmp_path / "codex-global"))
     codex_mod.write_global_plugin_source()
-    old_command = (
-        codex_mod.global_plugin_source_root()
-        / codex_mod.CODEX_PLUGIN_LEGACY_COMMANDS_RELATIVE_PATH
-        / "mb-start.md"
+    command = (
+        codex_mod.global_plugin_source_root() / codex_mod.CODEX_SLASH_COMMAND_RELATIVE_PATHS[0]
     )
-    old_command.parent.mkdir(parents=True, exist_ok=True)
-    old_command.write_text("# stale\n", encoding="utf-8")
+    command.write_text("# stale\n", encoding="utf-8")
 
     status = codex_mod.plugin_status(tmp_path / "business")
 
     assert status["ok"] is False
     assert status["current"] is False
-    assert codex_mod.CODEX_PLUGIN_LEGACY_COMMANDS_RELATIVE_PATH in status["stale"]
+    assert codex_mod.CODEX_SLASH_COMMAND_RELATIVE_PATHS[0] in status["stale"]
+    assert status["command_files_current"] is False
+    assert status["slash_commands_ready"] is False
     assert status["repair"] == codex_mod.CODEX_REPAIR_TEXT
-
-
-def test_codex_owner_loop_skill_frontmatter_is_valid_yaml() -> None:
-    skill = codex_mod.render_codex_skill_md()
-    _, frontmatter, _ = skill.split("---", 2)
-    data = yaml.safe_load(frontmatter)
-
-    assert data["name"] == "main-branch-owner-loop"
-    assert "start/status/setup/update/doctor" in data["description"]
 
 
 def test_codex_workflow_inventory_command_lists_supported_and_pending_surfaces() -> None:
@@ -229,7 +240,7 @@ def test_codex_workflow_inventory_command_lists_supported_and_pending_surfaces()
 
     assert result.exit_code == 0
     data = json.loads(result.stdout)
-    assert data["support_level"] == "supported_generated_guidance"
+    assert data["support_level"] == "supported_main_branch_slash_commands"
     statuses = set(data["statuses"])
     assert {
         "supported",
@@ -239,20 +250,23 @@ def test_codex_workflow_inventory_command_lists_supported_and_pending_surfaces()
     }.issubset(statuses)
     by_id = {item["id"]: item for item in data["items"]}
     assert by_id["think-codify"]["codex_status"] == "supported"
-    assert by_id["think-codify"]["codex_entrypoints"] == ["Codex Think Route"]
-    assert by_id["owner-loop-start-status"]["codex_entrypoints"] == [
-        "Codex Start Workflow",
-        "Codex Status Workflow",
+    assert by_id["think-codify"]["codex_entrypoints"] == ["/mb-think"]
+    assert by_id["daily-start-status"]["codex_entrypoints"] == [
+        "/mb-start",
+        "/mb-status",
     ]
-    assert by_id["owner-loop-start-status"]["claude_skill_sources"] == [
+    assert by_id["daily-start-status"]["claude_skill_sources"] == [
         ".claude/skills/mb-start/SKILL.md",
         ".claude/skills/mb-status/SKILL.md",
     ]
     assert by_id["ads"]["codex_status"] == "pending_shared_source_migration"
     assert by_id["wiki"]["codex_status"] == "intentionally_unsupported"
     assert data["plugin"]["manifest_path"] == codex_mod.CODEX_PLUGIN_MANIFEST_RELATIVE_PATH
-    assert data["plugin"]["slash_commands_ready"] is False
-    assert "generated_command_files" not in data["plugin"]
+    assert data["plugin"]["commands_path"] == codex_mod.CODEX_PLUGIN_COMMANDS_RELATIVE_PATH
+    assert data["plugin"]["slash_commands_ready"] is True
+    assert set(data["plugin"]["generated_command_files"]) == set(
+        codex_mod.CODEX_SLASH_COMMAND_RELATIVE_PATHS
+    )
 
 
 def test_codex_workflow_inventory_accounts_for_every_bundled_claude_skill() -> None:


### PR DESCRIPTION
## Summary

Adds the real Codex `/mb-*` command surface through the global Main Branch plugin and removes the visible `main-branch-owner-loop` skill surface. Readiness now depends on current command files plus installed/enabled plugin state, and `mb update` refreshes both Claude Code skill links and Codex command files from the upgraded `mb` executable.

## Linked issue

Closes #717

## Why

MAIN-437 is a product-promise fix: Codex users should type `/mb` after install/repair/restart and see Main Branch commands, not an implementation-named skill or stale generated guidance.

## Commits by concern

- [x] `d01fbd6 [add] Codex slash command surface`
- [x] Commit body bullet-lists the changes in that commit
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`

## Validation

Pre-push gate from repo root:

```bash
scripts/check.sh
```

- [x] Level 1 static: `scripts/check.sh` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: `0` — log: `797 passed`; `mb skill validate --all --json` reported 15 passed, 0 failed.
- [x] Level 2 CLI contract: `cd mb && pytest tests/test_update.py tests/test_workflows.py tests/test_start.py::test_start_json_keeps_codex_slash_visibility_honest tests/test_status.py::test_status_marks_codex_ready_when_command_surface_is_installed -q` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: `0` — log: `45 passed`.
- [x] Level 3 package/install smoke: `(cd mb && python3 -m build)` plus venv install, fresh `mb onboard`, `mb doctor repair --apply --only codex --json`, and `mb status --json --peek` — runtime: `/tmp/mainbranch-main437-smoke-final/bin/mb` — exit: `0` — log: `status_codex ready`, `plugin_installed True`, `plugin_enabled True`, `command_surface_ok True`, `slash_ready True`, eight command files generated, legacy plugin absent.
- [x] Level 4 fixture repo: same package smoke onboarded a fresh `Codex Slash Smoke` business repo and verified `mb-start.md` description plus global command files from the installed wheel — runtime: `/tmp/mainbranch-main437-smoke-final/bin/mb` — exit: `0` — log: `commands mb-doctor.md,mb-end.md,mb-help.md,mb-setup.md,mb-start.md,mb-status.md,mb-think.md,mb-update.md`.
- [x] Level 5 runtime smoke / dogfood: branch-code repair in a private dogfood business repo — runtime: source checkout via `python3 -m mb` — exit: `0` — log: `codex-plugin-install ok Main Branch Codex commands are installed and ready after restarting Codex`; nested `codex exec --json --ephemeral --sandbox read-only` ran `command -v mb`, `mb --version`, `mb status --json --peek`, `mb start --json`, and `git status --short` without edits, but used installed `mb 0.3.34`, so UI `/mb` discovery remains manual after restart.
- [x] SKILL.md ≤500 lines: no bundled Claude `SKILL.md` files changed; `scripts/check.sh` still validates bundled skill line counts.
- [ ] Package-visible release gate evidence before tag/publish: not applicable at PR time; required before release.
- [ ] Supply-chain review: not applicable; no workflow, dependency, or permissions files changed.

## Success metric

After `mb doctor repair --apply --only codex` and a Codex restart, the global plugin contains `commands/mb-start.md`, `mb-status.md`, `mb-setup.md`, `mb-update.md`, `mb-doctor.md`, `mb-think.md`, `mb-end.md`, and `mb-help.md`; `mb status --json --peek` reports `slash_commands_ready: true`; typing `/mb` should show Main Branch commands rather than `main-branch-owner-loop`.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [ ] N/A — change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [x] No
- [ ] Yes — migration note below

## Public / private boundary

Committed changes are public-safe product code, tests, docs, and templates. Local dogfood touched a private business repo and left that repo dirty, but no private repo content was committed here.
