### PR TITLE
[update] Prepare v0.3.35 release

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mainbranch",
-  "version": "0.3.34",
+  "version": "0.3.35",
   "description": "Main Branch Claude Code skills for running a business from markdown files in git.",
   "author": {
     "name": "Noontide"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+## [0.3.35] - 2026-05-24
+
 ### Changed
 
 - Added a clean global Codex `/mb-*` command surface for Main Branch: repair now

--- a/mb/mb/__init__.py
+++ b/mb/mb/__init__.py
@@ -7,6 +7,6 @@ file stays a thin dispatcher.
 
 from __future__ import annotations
 
-__version__ = "0.3.34"
+__version__ = "0.3.35"
 
 __all__ = ["__version__"]

--- a/mb/pyproject.toml
+++ b/mb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mainbranch"
-version = "0.3.34"
+version = "0.3.35"
 description = "Main Branch engine umbrella - scaffolds, validates, and graphs business-as-files repos. Claude Code first, runtime-agnostic by design."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Prepare v0.3.35 so the merged Codex slash command surface ships as a package-visible release.

## Scope

In scope:
- Move the `[Unreleased]` Codex `/mb-*` command-surface notes into `0.3.35`.
- Bump `mb/pyproject.toml`, `mb/mb/__init__.py`, and `.claude-plugin/plugin.json` to `0.3.35`.

Out of scope:
- Additional Codex command behavior changes after #718.
- New runtime parity claims beyond the command surface already merged.

## Commits

- `[update] Prepare v0.3.35 release`

## Release / Issues

Closes #719.
Refs #717.

## Success Metric

A user can install `mainbranch 0.3.35`, run Codex repair, and get the global Main Branch Codex plugin with `/mb-*` command files generated and ready after restarting Codex.

## Validation

- Level 0 release preflight: `cd mb && python3 -m pytest tests/test_smoke_coverage.py::test_claude_plugin_manifest_points_at_prefixed_skills -q` — exit 0 — log `.agent/release-evidence/0.3.35/release-preflight.out` (1 passed).
- Level 1 static: `scripts/check.sh` — exit 0 — log `.agent/release-evidence/0.3.35/check.out` (format ok, mypy ok, 798 tests passed, 15 skills passed).
- Level 3 package/install: `(cd mb && python3 -m build)` — exit 0 — log `.agent/release-evidence/0.3.35/build.out` (built `mainbranch-0.3.35` sdist + wheel).
- Level 3 wheel smoke: fresh venv install from `mb/dist/mainbranch-0.3.35-py3-none-any.whl`, `mb --version`, `mb skill list`, fresh onboard, `mb doctor repair --apply --only codex`, `mb status --json --peek` — exit 0 — log `.agent/release-evidence/0.3.35/package-smoke.out` (`status_codex ready`, `command_surface_ok True`, all eight `/mb-*` command files present, restart required surfaced).
- Level 3 books fixture: `mb books check --fixture --json` with hledger available — exit 0 — log `.agent/release-evidence/0.3.35/books-fixture.out` (`fixture-valid`).
- Level 3 books fixture fallback: package wheel `mb books check --fixture --json` with PATH excluding hledger — exit 0 — log `.agent/release-evidence/0.3.35/books-fixture-no-hledger.out` (`hledger-missing`, result_status ok).
- Level 5 runtime proxy: `scripts/claude-runtime-dogfood.py --install-mode wheel --wheel mb/dist/mainbranch-0.3.35-py3-none-any.whl --run-claude-print --simulation-tier release_acceptance --max-budget-usd 0.75` — exit 0 — evidence `.agent/release-evidence/0.3.35/pretag-dogfood/` (11/11 heuristic checks; direct read-only mb grounding denials 0; manual transcript review found no release-blocking hard failures). Print-mode proxy does not prove restarted Codex UI `/mb` discovery.

## Supply Chain

- No runtime dependency additions; package metadata version only.
- `grep -RIn "id-token\|permissions:" .github/workflows/` reviewed; no workflow changes in this PR.
- `gh api repos/noontide-co/mainbranch/dependabot/alerts` reported 0 open Dependabot alerts.
- PyPI environment approval remains the required publish gate after GitHub Release publication.

## Public / Private Boundary

Public diff contains only release metadata and changelog. Raw release evidence stays under `.agent/` and is not committed.
