### PR TITLE
Fix Codex global skill support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,11 +20,11 @@ markdown files in git.
 - A user is not met with git speak but instead business speak.
 
 Claude Code and Codex CLI are the supported agent runtimes today. Claude Code
-uses project-local slash skills. Codex uses generated `AGENTS.md`, a global Main
-Branch Codex plugin, `/mb-*` commands, deterministic `mb` facts, and workflow
-inventory. That is daily-loop Codex support, not all-skill parity or full
-production workflow parity. Business repos should not carry repo-local Codex
-plugin copies unless a future issue proves that fallback is required.
+uses project-local slash skills. Codex uses generated `AGENTS.md`, global Main
+Branch skills, deterministic `mb` facts, and workflow inventory. That is
+daily-loop Codex support, not full production workflow parity. Business repos
+should not carry repo-local Codex plugin or skill copies unless a future issue
+proves that fallback is required.
 Cursor, OpenClaw, Hermes, Paperclip-adjacent orchestration, and local runtimes
 remain compatibility targets until tested. Do not claim support before there is
 an adapter and smoke evidence for the exact surface.
@@ -38,9 +38,8 @@ lives in `docs/operator-loops.md`, and release direction lives in
 The current product center is the daily owner loop:
 
 1. The operator opens the business repo and starts Claude Code or Codex CLI.
-2. `/mb-start`, the generated repo instructions, or the global Main Branch
-   Codex plugin guidance ground the agent in deterministic `mb` facts before
-   advice.
+2. `/mb-start`, the generated repo instructions, or global Main Branch Codex
+   skills ground the agent in deterministic `mb` facts before advice.
 3. The agent routes thought dumps and requests into business primitives:
    bets, goals, offers, research, decisions, pushes, playbooks, outcomes, and
    checkpoints.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+### Fixed
+
+- Corrected Codex support to install a global Main Branch skill bundle under
+  the Codex skills root, with one generated skill/playbook folder per supported
+  or inventoried workflow. Codex readiness now requires current global skills,
+  current repo `AGENTS.md`, and the current runtime `mb`; plugin command state
+  is no longer part of readiness. Refs MAIN-439, #721.
+
 ## [0.3.35] - 2026-05-24
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -219,13 +219,13 @@ You'll need a Claude plan that includes Claude Code. Install Claude Code from [c
 
 ### Using Codex CLI
 
-Codex CLI is supported through the global Main Branch plugin's `/mb-*` commands
-and deterministic `mb` facts. Fresh business folders include a tracked
-`AGENTS.md` bootstrap. The plugin is installed globally once per user and reads
-the current business repo through deterministic `mb` facts. That lets Codex
-start the day, inspect status, route setup/update/doctor work, think through or
-codify a decision, plan an end/checkpoint/save closeout, validate the repo, and
-list workflow support.
+Codex CLI is supported through global Main Branch `mb-*` skills installed under
+the Codex global skills root and deterministic `mb` facts. Fresh business
+folders include a tracked `AGENTS.md` bootstrap. The skills install globally
+once per user and read the current business repo through deterministic `mb`
+facts. That lets Codex start the day, inspect status, route setup/update/doctor
+work, think through or codify a decision, plan an end/checkpoint/save closeout,
+validate the repo, and list workflow support.
 
 Expect Codex to run `mb status --json --peek`, `mb start --json`,
 `mb doctor repair --plan --json`, `mb checkpoint --plan --json`,
@@ -244,8 +244,8 @@ mb doctor repair --apply --only codex
 codex
 ```
 
-Restart Codex after repair, type `/mb`, then run `/mb-start`. Codex should start
-from read-only `mb` facts and ask before writing files.
+Open a fresh Codex thread after repair and use the `mb-start` skill. Codex
+should start from read-only `mb` facts and ask before writing files.
 
 For a read-only smoke test:
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,8 +1,8 @@
 # Compatibility
 
 Main Branch is intentionally narrow today: `mb`, bundled Claude Code skills,
-and Codex `/mb-*` commands. This page is the public compatibility contract for
-those surfaces.
+and global Codex `mb-*` skills. This page is the public compatibility contract
+for those surfaces.
 
 ## Supported matrix
 
@@ -15,7 +15,7 @@ those surfaces.
 | Install mode | `pipx install mainbranch` | Official public install path. |
 | Developer mode | Git clone | For contributors who want to edit the engine or skills. |
 | Agent runtime | Claude Code | Supported through project-local slash skills. |
-| Codex CLI | Supported | Fresh business repos include `AGENTS.md`; the Main Branch Codex plugin installs globally once per user and provides `/mb-*` commands. `mb workflow list --runtime codex` exposes supported, pending, and unsupported workflow surfaces. |
+| Codex CLI | Supported | Fresh business repos include `AGENTS.md`; global Main Branch `mb-*` skills install once per user under `~/.codex/skills` and route through deterministic `mb` facts. `mb workflow list --runtime codex` exposes supported, pending, and unsupported workflow surfaces. |
 | Cursor, OpenClaw, Hermes, Paperclip-adjacent orchestration, local LLMs | Roadmap | `mb` is runtime-agnostic by design, but these adapters are not supported yet. |
 
 **Windows tip — try WSL2.** If you're on Windows and want a working setup today, use [Windows Subsystem for Linux 2 (WSL2)](https://learn.microsoft.com/en-us/windows/wsl/install). Inside WSL2, follow the supported Linux flow. The pipx install path works there.
@@ -164,7 +164,7 @@ smoke evidence exist.
 | Runtime surface | Status | Invocation | Skill/workflow discovery | Routing and automation | Observability and packaging |
 |---|---|---|---|---|---|
 | Claude Code | Supported | `mb start --repo "$repo"` prints the `claude` handoff; `mb start --launch` may launch after readiness checks. | `mb skill link --repo "$repo"` writes project-local `.claude/skills/mb-*` bridge links and `.claude/settings.local.json`. | Slash commands such as `/mb-start` and `/mb-think` own conversation and judgment; they call deterministic `mb` commands for facts. | `mb doctor`, `mb status --json`, `mb start --json`, `mb skill repair`, and runtime dogfood evidence gate release claims. Skills ship inside the Python package today. |
-| Codex CLI | Supported | Can call deterministic `mb` commands as a subprocess when pointed at a business repo. `AGENTS.md` gives Codex the repo bootstrap, and the globally installed Main Branch Codex plugin gives Codex `/mb-*` commands. | Fresh `mb onboard` repos include tracked `AGENTS.md`. `mb doctor repair --plan --only codex` / `--apply --only codex` can refresh repo guidance and install or repair the global plugin command surface and marketplace registration. | Codex `/mb-*` commands should run `mb status --json --peek`, `mb start --json`, `mb doctor repair --plan --json`, `mb checkpoint --plan --json`, `mb validate --json`, and `mb workflow list --runtime codex --json`, translate facts into business language, and ask before writes. | `mb doctor`, `mb status --json`, `mb start --json`, and `mb workflow list` expose Codex readiness and workflow support. Codex support covers start/status/setup/update/doctor, think/codify, end/checkpoint/save, validate, and workflow discovery. This is not all-skill, ads/site/provider, publishing, spend, or customer-contact parity. |
+| Codex CLI | Supported | Can call deterministic `mb` commands as a subprocess when pointed at a business repo. `AGENTS.md` gives Codex the repo bootstrap, and global Main Branch skills give Codex `mb-*` workflow routes. | Fresh `mb onboard` repos include tracked `AGENTS.md`. `mb doctor repair --plan --only codex` / `--apply --only codex` refresh repo guidance and install or repair the global Codex skill bundle. | Codex `mb-*` skills run `mb status --json --peek`, `mb start --json`, `mb doctor repair --plan --json`, `mb checkpoint --plan --json`, `mb validate --json`, and `mb workflow list --runtime codex --json` as needed, translate facts into business language, and ask before writes. | `mb doctor`, `mb status --json`, `mb start --json`, and `mb workflow list` expose Codex readiness and workflow support. Codex support covers start/status/setup/update/doctor, think/codify, end/checkpoint/save, validate, and workflow discovery. Ads, organic, site, bet, and playbook routes are installed for discovery but remain read-only planning unless their support level says otherwise. |
 | Cursor | Roadmap | Can call deterministic `mb` commands from terminal/tasks when pointed at a business repo. | No supported Cursor rules/package adapter yet. | No supported Main Branch routing contract. | Needs adapter docs, install/update rules, conflict handling, and smoke evidence. |
 | OpenClaw | Roadmap | Target public runtime surface. It should call `mb` through stable CLI/JSON commands rather than clone-era paths. | No supported OpenClaw adapter yet. | Main Branch should coexist with OpenClaw as the business repo/GitHub memory layer, not replace it. | Needs explicit adapter shape, migration notes, generated-file rules, and smoke evidence. |
 | Hermes | Roadmap | Target runtime/memory surface. It may supervise or host workflows that call packaged `mb` commands. | No supported Hermes adapter yet. | Hermes-specific routing belongs in the Hermes adapter, while `mb` remains deterministic and non-conversational. | Docs may describe internal-package expectations generically, but not as the only blessed public path. Smoke evidence is required before support claims. |
@@ -185,9 +185,9 @@ support still requires an adapter and smoke evidence for that runtime.
 | Surface | Claude Code | Other runtimes and orchestrators |
 |---|---|---|
 | Deterministic CLI facts (`mb status --json`, `mb validate --json`, `mb graph --json`, `mb connect status --json`) | Supported when `mb` is installed and pointed at a business repo. | Callable as packaged CLI subprocesses, but this does not make the hosting runtime supported. |
-| Runtime handoff (`mb start --json`, `mb start --launch`) | Supported for Claude Code handoff and launch readiness. | Codex CLI handoff metadata is supported for Main Branch command readiness: `mb start --json` reports Codex executable, `AGENTS.md`, command files, and plugin readiness. `mb` does not launch Codex. |
-| Lifecycle slash skills (`/mb-start`, `/mb-status`, `/mb-setup`, `/mb-update`, `/mb-end`, `/mb-help`) | Supported through Claude Code project-local skill discovery. | Codex supports these as global plugin `/mb-*` commands grounded in deterministic `mb` facts. |
-| Production slash skills (`/mb-think`, `/mb-ads`, `/mb-organic`, `/mb-site`, `/mb-wiki`, `/mb-bet`) | Supported through Claude Code skills, subject to each skill's provider and workflow limits. Conversion scripts route through the owning workflow instead of a standalone primitive or skill. | Codex supports `/mb-think` through `workflows/mb-think/workflow.md` and the global plugin command surface. Ads, organic/newsletter, site, and bet workflows are pending shared-source migration. Wiki and skill-authoring workflows are intentionally unsupported for the current Codex target. |
+| Runtime handoff (`mb start --json`, `mb start --launch`) | Supported for Claude Code handoff and launch readiness. | Codex CLI handoff metadata is supported for global skill readiness: `mb start --json` reports Codex executable, `AGENTS.md`, global skills, and runtime `mb` readiness. `mb` does not launch Codex. |
+| Lifecycle slash skills (`/mb-start`, `/mb-status`, `/mb-setup`, `/mb-update`, `/mb-end`, `/mb-help`) | Supported through Claude Code project-local skill discovery. | Codex supports matching global skills (`mb-start`, `mb-status`, `mb-setup`, `mb-update`, `mb-doctor`, `mb-end`, `mb-help`) grounded in deterministic `mb` facts. |
+| Production slash skills (`/mb-think`, `/mb-ads`, `/mb-organic`, `/mb-site`, `/mb-wiki`, `/mb-bet`) | Supported through Claude Code skills, subject to each skill's provider and workflow limits. Conversion scripts route through the owning workflow instead of a standalone primitive or skill. | Codex supports `mb-think` through `workflows/mb-think/workflow.md` and global skills. Ads, organic/newsletter, site, bet, and shipped playbook names are installed for inventory and read-only planning. Wiki and skill-authoring workflows are intentionally unsupported for the current Codex target. |
 | Automation routines | May call CLI commands before handing judgment work to Claude Code. | May call shipped deterministic CLI commands against an explicit repo path. Conversation, retries, routing, and model invocation belong to the runtime adapter, not `mb`. |
 
 ## Adapter checklist
@@ -207,17 +207,17 @@ write runtime state, credentials, or raw account data into tracked files.
 
 For the Codex staging plan, see
 [Codex Adapter Plan](../decisions/2026-05-08-codex-adapter-plan.md). The current
-implementation is the daily Main Branch slice: generated `AGENTS.md`, a global
-Main Branch Codex plugin with `/mb-*` commands, deterministic readiness facts, doctor repair coverage,
+implementation is the daily Main Branch slice: generated `AGENTS.md`, global
+Main Branch Codex skills, deterministic readiness facts, doctor repair coverage,
 `mb workflow list`, and
 compact workflow discovery for start/status/setup/update/doctor, think/codify,
 end/checkpoint/save, validate, and workflow inventory. The think route is checked against
 `workflows/mb-think/workflow.md` as the first official shared workflow source
-pattern, and fresh read-only Codex smoke covers the supported command surface from a
+pattern, and fresh read-only Codex smoke covers the supported skill surface from a
 business repo. It does not claim all-skill parity, copied Claude skill parity,
 provider/publishing workflow support, spend, or customer-contact support.
-The `/mb-*` command bridge decision lives in
-[Codex Slash-Command Bridge](../decisions/2026-05-23-codex-slash-command-bridge.md).
+Codex plugin slash commands are not the readiness path until runtime smoke proves
+they load in Codex Desktop.
 
 ## Recommended setup
 
@@ -259,12 +259,11 @@ mb update
 
 `mb update` detects whether Main Branch is a `pipx` install or source checkout,
 runs the appropriate update path, refreshes Claude Code skill links, and runs
-the Codex command-surface repair from the upgraded `mb` executable. Use
+the Codex global-skill repair from the upgraded `mb` executable. Use
 `mb update --check` for a dry-run and `mb update --json` for automation.
 Inside Claude Code, `/mb-update` calls `mb update` for this mechanical step and keeps
-ownership of the human-readable "what's new" summary. Codex users should
-restart Codex after an update so `/mb-*` commands reload from the refreshed
-global plugin.
+ownership of the human-readable "what's new" summary. Codex users should open a
+fresh Codex thread after an update so refreshed global skills are loaded.
 
 Early `0.1.x` installs do not have `mb update` yet. If `mb`, `mb doctor`,
 `mb status`, or `mb start` says "Update required", run this once first:
@@ -284,7 +283,7 @@ mb doctor
 ## Known Limits
 
 - Claude Code is supported through project-local slash skills.
-- Codex CLI is supported through global plugin `/mb-*` commands and
+- Codex CLI is supported through global Main Branch `mb-*` skills and
   deterministic `mb` facts. Main Branch does not claim all-skill parity, copied Claude skill
   parity, provider writes, publishing, spend, or customer-contact workflows.
 - Windows is experimental.
@@ -300,4 +299,4 @@ mb doctor
   discovery.
 - Cursor, OpenClaw, Hermes, Paperclip-adjacent orchestration, and local
   runtimes remain roadmap surfaces until each has a documented adapter and
-  smoke evidence. Codex support is limited to the command surface above.
+  smoke evidence. Codex support is limited to the skill surface above.

--- a/mb/mb/_data/templates/AGENTS.md.tmpl
+++ b/mb/mb/_data/templates/AGENTS.md.tmpl
@@ -7,8 +7,9 @@ Main Branch business repo instructions for Codex.
 Main Branch CLI facts are the source of truth for repo health, setup, runtime
 wiring, updates, graph/status signals, provider readiness, and repair paths.
 When the operator asks to start, begin, get oriented, triage the day, or decide
-what to do next, use `/mb-start`, `/mb-status`, or the read-only `mb` fact
-commands below. Do not pretend Claude Code skills work in Codex.
+what to do next, use the global Main Branch skill route (`mb-start`,
+`mb-status`, or the closest `mb-*` route) or the read-only `mb` fact commands
+below. Do not pretend Claude Code slash skills work in Codex.
 
 Start in this repo. Before setup, routing, migration, update, or repair advice,
 run the runtime preflight and read-only checks that fit the situation:
@@ -103,16 +104,18 @@ emails, or usernames alone.
 ## Codex Lifecycle Workflow Index
 
 This tracked `AGENTS.md` file is the repo-level Codex bootstrap. The Main
-Branch Codex plugin is installed globally once per user and supplies `/mb-*`
-commands over deterministic `mb` facts. Business repos keep this lightweight
-`AGENTS.md` guidance instead of tracked repo-local plugin copies. `mb doctor
-repair --only codex` refreshes this file and installs or repairs the global
-plugin when Codex CLI is available.
+Branch Codex skill bundle is installed globally once per user and routes `mb-*`
+workflow names over deterministic `mb` facts. Business repos keep this
+lightweight `AGENTS.md` guidance instead of tracked repo-local plugin or skill
+copies. `mb doctor repair --only codex` refreshes this file and installs or
+repairs the global skills.
 
-Use the global Main Branch Codex plugin for Main Branch daily commands only. Do not
+Use the global Main Branch skills for Main Branch daily routes only. Do not
 create repo-local Codex plugin manifests, copied Claude skill trees, or
 symlinked Claude skills unless a future `mb` command or issue says that surface
 is supported for this repo.
+The global `main-branch` skill is an index; named global skills such as
+`mb-start`, `mb-status`, and `mb-think` carry the workflow routes.
 
 Use this index to map natural Codex requests:
 
@@ -130,7 +133,7 @@ Use this index to map natural Codex requests:
   domains, or customer contact:** do not claim these workflows are ported to
   Codex. Use read-only `mb` facts for planning and ask before any action.
 
-Use `/plugins` to inspect or install the global Main Branch plugin.
+Use `mb doctor repair --plan --only codex` to inspect global skill wiring.
 
 ## Codex Start Workflow
 

--- a/mb/mb/_data/templates/README.md.tmpl
+++ b/mb/mb/_data/templates/README.md.tmpl
@@ -30,8 +30,8 @@ codex
 ```
 
 Then ask Codex to start this Main Branch business day from read-only `mb` facts
-and to ask before writing files. After repair and a Codex restart, `/mb-start`
-is the normal entrypoint.
+and to ask before writing files. After repair and a fresh Codex thread, the
+global `mb-start` skill is the normal entrypoint.
 
 For a terminal-only check:
 

--- a/mb/mb/codex.py
+++ b/mb/mb/codex.py
@@ -1,6 +1,6 @@
-"""Codex command-surface helpers.
+"""Codex global-skill helpers.
 
-Codex support starts with repo instructions, global plugin commands, and
+Codex support starts with repo instructions, global Main Branch skills, and
 deterministic ``mb`` facts. This module intentionally does not invoke Codex or
 manage model conversation.
 """
@@ -24,6 +24,9 @@ AGENTS_RELATIVE_PATH = "AGENTS.md"
 CODEX_SKILL_DIR_RELATIVE_PATH = ".agents/skills/main-branch-owner-loop"
 CODEX_SKILL_RELATIVE_PATH = f"{CODEX_SKILL_DIR_RELATIVE_PATH}/SKILL.md"
 CODEX_WORKFLOW_INVENTORY_RELATIVE_PATH = AGENTS_RELATIVE_PATH
+CODEX_GLOBAL_SKILL_NAME = "main-branch"
+CODEX_LEGACY_GLOBAL_SKILL_NAME = "main-branch-owner-loop"
+CODEX_GLOBAL_SKILL_RELATIVE_PATH = f"{CODEX_GLOBAL_SKILL_NAME}/SKILL.md"
 CODEX_MARKETPLACE_RELATIVE_PATH = ".agents/plugins/marketplace.json"
 CODEX_MARKETPLACE_NAME = "main-branch"
 CODEX_LEGACY_PLUGIN_NAME = "main-branch-owner-loop"
@@ -39,7 +42,7 @@ CODEX_PLUGIN_MANIFEST_RELATIVE_PATH = f"{CODEX_PLUGIN_DIR_RELATIVE_PATH}/.codex-
 CODEX_PLUGIN_SKILL_RELATIVE_PATH = (
     f"{CODEX_LEGACY_PLUGIN_DIR_RELATIVE_PATH}/skills/main-branch-owner-loop/SKILL.md"
 )
-CODEX_SUPPORT_LEVEL = "supported_main_branch_slash_commands"
+CODEX_SUPPORT_LEVEL = "supported_global_main_branch_skill"
 CODEX_REPAIR_COMMAND = "mb doctor repair --apply --only codex"
 CODEX_REPAIR_TEXT = (
     "Run `mb doctor repair --plan --only codex`, review, then "
@@ -50,7 +53,7 @@ CODEX_RUNTIME_MISMATCH_STOP_TEXT = (
     "`runtime.codex_cli.status` is `runtime_mismatch` or any `drift.items[].id` "
     "equals `codex_runtime_mb_mismatch`. Treat that as a runtime `mb` mismatch: "
     "tell the operator to fix the runtime/login-shell PATH and rerun read-only "
-    "checks before owner-loop advice, repair planning, or writes."
+    "checks before Main Branch advice, repair planning, or writes."
 )
 REQUIRED_FACT_COMMANDS = (
     "mb status --json --peek",
@@ -66,6 +69,48 @@ CODEX_SLASH_COMMAND_NAMES = (
     "mb-think",
     "mb-end",
     "mb-help",
+)
+CLAUDE_SKILL_SOURCE_NAMES = (
+    "mb-start",
+    "mb-status",
+    "mb-setup",
+    "mb-update",
+    "mb-think",
+    "mb-end",
+    "mb-help",
+    "mb-bet",
+    "mb-ads",
+    "mb-organic",
+    "mb-site",
+    "mb-wiki",
+    "mb-skill-concept",
+    "mb-skill-brief-draft",
+    "mb-skill-review",
+)
+CLAUDE_PLAYBOOK_SOURCE_NAMES = (
+    "google-ads-search-launch",
+    "ship-bet",
+    "weekly-review",
+)
+CODEX_GLOBAL_SKILL_NAMES = (
+    CODEX_GLOBAL_SKILL_NAME,
+    "mb-doctor",
+    "mb-start",
+    "mb-status",
+    "mb-setup",
+    "mb-update",
+    "mb-think",
+    "mb-end",
+    "mb-help",
+    "mb-bet",
+    "mb-ads",
+    "mb-organic",
+    "mb-site",
+    "mb-wiki",
+    "mb-skill-concept",
+    "mb-skill-brief-draft",
+    "mb-skill-review",
+    *CLAUDE_PLAYBOOK_SOURCE_NAMES,
 )
 CODEX_SLASH_COMMAND_RELATIVE_PATHS = tuple(
     f"{CODEX_PLUGIN_COMMANDS_RELATIVE_PATH}/{name}.md" for name in CODEX_SLASH_COMMAND_NAMES
@@ -95,6 +140,58 @@ CODEX_SLASH_COMMAND_DESCRIPTIONS = {
     "mb-think": "Think through a Main Branch decision.",
     "mb-end": "End and checkpoint work.",
     "mb-help": "Show Main Branch commands.",
+}
+CODEX_GLOBAL_SKILL_DESCRIPTIONS = {
+    **CODEX_SLASH_COMMAND_DESCRIPTIONS,
+    "main-branch": "Route Main Branch work to the right mb-* skill.",
+    "mb-bet": "Plan and review Main Branch bets.",
+    "mb-ads": "Plan ads and paid creative from Main Branch facts.",
+    "mb-organic": "Plan organic content from Main Branch facts.",
+    "mb-site": "Plan pages and site readiness from Main Branch facts.",
+    "mb-wiki": "Explain wiki support status for Main Branch.",
+    "mb-skill-concept": "Plan a Main Branch skill concept.",
+    "mb-skill-brief-draft": "Draft a Main Branch skill brief.",
+    "mb-skill-review": "Review a Main Branch skill proposal.",
+    "google-ads-search-launch": "Plan a Google Ads search launch playbook.",
+    "ship-bet": "Plan a ship-bet playbook run.",
+    "weekly-review": "Plan a weekly review.",
+}
+CODEX_GLOBAL_SKILL_FACTS: dict[str, tuple[str, ...]] = {
+    **CODEX_SLASH_COMMAND_FACTS,
+    "main-branch": REQUIRED_FACT_COMMANDS,
+    "mb-bet": ("mb status --json --peek", "mb validate --json"),
+    "mb-ads": ("mb status --json --peek", "mb connect doctor --json"),
+    "mb-organic": ("mb status --json --peek",),
+    "mb-site": ("mb status --json --peek", "mb site check --json"),
+    "mb-wiki": ("mb workflow list --runtime codex --json",),
+    "mb-skill-concept": ("mb workflow list --runtime codex --json",),
+    "mb-skill-brief-draft": ("mb workflow list --runtime codex --json",),
+    "mb-skill-review": ("mb workflow list --runtime codex --json",),
+    "google-ads-search-launch": ("mb status --json --peek", "mb connect doctor --json"),
+    "ship-bet": ("mb status --json --peek", "mb checkpoint --plan --json"),
+    "weekly-review": ("mb status --json --peek", "mb validate --json"),
+}
+CODEX_GLOBAL_SKILL_SUPPORT: dict[str, str] = {
+    "main-branch": "supported",
+    "mb-start": "supported",
+    "mb-status": "supported",
+    "mb-setup": "supported",
+    "mb-update": "supported",
+    "mb-doctor": "supported",
+    "mb-think": "supported",
+    "mb-end": "supported",
+    "mb-help": "supported",
+    "mb-bet": "read_only_planning",
+    "mb-ads": "read_only_planning",
+    "mb-organic": "read_only_planning",
+    "mb-site": "read_only_planning",
+    "google-ads-search-launch": "read_only_planning",
+    "ship-bet": "read_only_planning",
+    "weekly-review": "read_only_planning",
+    "mb-wiki": "intentionally_unsupported",
+    "mb-skill-concept": "intentionally_unsupported",
+    "mb-skill-brief-draft": "intentionally_unsupported",
+    "mb-skill-review": "intentionally_unsupported",
 }
 CODEX_THINK_SOURCE_WORKFLOW = "workflows/mb-think/workflow.md"
 CODEX_THINK_REQUIRED_MB_COMMANDS = (
@@ -158,10 +255,10 @@ REQUIRED_LIFECYCLE_GUIDANCE = (
     "Shared source required JSON fact paths",
     "Shared source gates",
     "Shared public/private boundaries",
-    "Use the global Main Branch Codex plugin",
+    "Use the global Main Branch skill",
     "do not claim these workflows are ported to",
-    "supplies `/mb-*`",
-    "/plugins",
+    "global skill",
+    "main-branch",
 )
 REQUIRED_LIFECYCLE_GUIDANCE_MARKERS = (
     *REQUIRED_LIFECYCLE_GUIDANCE,
@@ -175,23 +272,6 @@ CODEX_PLUGIN_REQUIRED_MARKERS = (
     "commands",
     "mb-*",
     "business repos",
-)
-CLAUDE_SKILL_SOURCE_NAMES = (
-    "mb-start",
-    "mb-status",
-    "mb-setup",
-    "mb-update",
-    "mb-think",
-    "mb-end",
-    "mb-help",
-    "mb-bet",
-    "mb-ads",
-    "mb-organic",
-    "mb-site",
-    "mb-wiki",
-    "mb-skill-concept",
-    "mb-skill-brief-draft",
-    "mb-skill-review",
 )
 CODEX_WORKFLOW_STATUS_VOCABULARY = (
     "supported",
@@ -207,8 +287,8 @@ CODEX_WORKFLOW_INVENTORY: tuple[dict[str, Any], ...] = (
         "claude_surface": "/mb-start, /mb-status",
         "claude_skill_sources": ("mb-start", "mb-status"),
         "codex_status": "supported",
-        "codex_surface": ("/mb-start and /mb-status"),
-        "codex_entrypoints": ("/mb-start", "/mb-status"),
+        "codex_surface": "main-branch skill routes: mb-start, mb-status",
+        "codex_entrypoints": ("main-branch mb-start", "main-branch mb-status"),
         "commands": ("mb status --json --peek", "mb start --json"),
         "notes": (
             "Codex starts from deterministic status/start facts, translates them "
@@ -221,8 +301,12 @@ CODEX_WORKFLOW_INVENTORY: tuple[dict[str, Any], ...] = (
         "claude_surface": "/mb-setup, /mb-update, /mb-start repair routing",
         "claude_skill_sources": ("mb-setup", "mb-update"),
         "codex_status": "supported",
-        "codex_surface": ("/mb-setup, /mb-update, and /mb-doctor"),
-        "codex_entrypoints": ("/mb-setup", "/mb-update", "/mb-doctor"),
+        "codex_surface": "main-branch skill routes: mb-setup, mb-update, mb-doctor",
+        "codex_entrypoints": (
+            "main-branch mb-setup",
+            "main-branch mb-update",
+            "main-branch mb-doctor",
+        ),
         "commands": (
             "mb --version",
             "mb doctor repair --plan --json",
@@ -239,8 +323,8 @@ CODEX_WORKFLOW_INVENTORY: tuple[dict[str, Any], ...] = (
         "claude_surface": "/mb-think",
         "claude_skill_sources": ("mb-think",),
         "codex_status": "supported",
-        "codex_surface": ("/mb-think plus AGENTS.md#codex-think-route"),
-        "codex_entrypoints": ("/mb-think",),
+        "codex_surface": "main-branch skill route: mb-think plus AGENTS.md#codex-think-route",
+        "codex_entrypoints": ("main-branch mb-think",),
         "shared_source": CODEX_THINK_SOURCE_WORKFLOW,
         "commands": CODEX_THINK_REQUIRED_MB_COMMANDS,
         "notes": (
@@ -254,8 +338,8 @@ CODEX_WORKFLOW_INVENTORY: tuple[dict[str, Any], ...] = (
         "claude_surface": "/mb-end, mb checkpoint",
         "claude_skill_sources": ("mb-end",),
         "codex_status": "supported",
-        "codex_surface": ("/mb-end"),
-        "codex_entrypoints": ("/mb-end",),
+        "codex_surface": "main-branch skill route: mb-end",
+        "codex_entrypoints": ("main-branch mb-end",),
         "commands": ("mb checkpoint --plan --json", "mb validate --json"),
         "notes": (
             "Codex can plan a closeout and propose checkpoint subjects. Creating "
@@ -268,8 +352,8 @@ CODEX_WORKFLOW_INVENTORY: tuple[dict[str, Any], ...] = (
         "claude_surface": "/mb-help and docs",
         "claude_skill_sources": ("mb-help",),
         "codex_status": "supported",
-        "codex_surface": ("/mb-help"),
-        "codex_entrypoints": ("/mb-help",),
+        "codex_surface": "main-branch skill route: mb-help",
+        "codex_entrypoints": ("main-branch mb-help",),
         "commands": ("mb workflow list --runtime codex --json",),
         "notes": "Codex users can inspect supported, pending, and unsupported workflow surfaces.",
     },
@@ -330,6 +414,49 @@ CODEX_WORKFLOW_INVENTORY: tuple[dict[str, Any], ...] = (
         "notes": "Specialty workflow outside the current Codex command target.",
     },
     {
+        "id": "google-ads-search-launch-playbook",
+        "label": "Google Ads search launch playbook",
+        "claude_surface": "google-ads-search-launch playbook",
+        "claude_skill_sources": (),
+        "claude_playbook_sources": ("google-ads-search-launch",),
+        "codex_status": "pending_shared_source_migration",
+        "codex_surface": "Read-only planning only",
+        "codex_entrypoints": ("google-ads-search-launch",),
+        "commands": ("mb status --json --peek", "mb connect doctor --json"),
+        "notes": (
+            "No Google Ads account mutation, spend, upload, or publishing is supported in Codex."
+        ),
+    },
+    {
+        "id": "ship-bet-playbook",
+        "label": "Ship bet playbook",
+        "claude_surface": "ship-bet playbook",
+        "claude_skill_sources": (),
+        "claude_playbook_sources": ("ship-bet",),
+        "codex_status": "pending_shared_source_migration",
+        "codex_surface": "Read-only planning only",
+        "codex_entrypoints": ("ship-bet",),
+        "commands": ("mb status --json --peek", "mb checkpoint --plan --json"),
+        "notes": (
+            "Codex can plan from facts but must ask before changing bet, push, or checkpoint files."
+        ),
+    },
+    {
+        "id": "weekly-review-playbook",
+        "label": "Weekly review playbook",
+        "claude_surface": "weekly-review playbook",
+        "claude_skill_sources": (),
+        "claude_playbook_sources": ("weekly-review",),
+        "codex_status": "pending_shared_source_migration",
+        "codex_surface": "Read-only planning only",
+        "codex_entrypoints": ("weekly-review",),
+        "commands": ("mb status --json --peek", "mb validate --json"),
+        "notes": (
+            "Codex can summarize review inputs but should not update durable "
+            "files without approval."
+        ),
+    },
+    {
         "id": "skill-authoring",
         "label": "Skill concept, draft, and review",
         "claude_surface": "/mb-skill-concept, /mb-skill-brief-draft, /mb-skill-review",
@@ -359,6 +486,23 @@ def global_plugin_source_root() -> Path:
     return (base / "mainbranch" / "codex").expanduser().resolve()
 
 
+def global_skill_source_root() -> Path:
+    """Return the user-local directory where Codex global skills are installed."""
+
+    override = os.environ.get("MAINBRANCH_CODEX_SKILLS_ROOT", "").strip()
+    if override:
+        return Path(override).expanduser().resolve()
+    return (Path.home() / ".codex" / "skills").expanduser().resolve()
+
+
+def global_skill_path() -> Path:
+    return global_skill_source_root() / CODEX_GLOBAL_SKILL_RELATIVE_PATH
+
+
+def global_skill_file_path(name: str) -> Path:
+    return global_skill_source_root() / name / "SKILL.md"
+
+
 def codex_marketplace_add_command() -> str:
     return f"codex plugin marketplace add {shlex.quote(str(global_plugin_source_root()))}"
 
@@ -373,8 +517,9 @@ Main Branch business repo instructions for Codex.
 Main Branch CLI facts are the source of truth for repo health, setup, runtime
 wiring, updates, graph/status signals, provider readiness, and repair paths.
 When the operator asks to start, begin, get oriented, triage the day, or decide
-what to do next, use `/mb-start`, `/mb-status`, or the read-only `mb` fact
-commands below. Do not pretend Claude Code skills work in Codex.
+what to do next, use the global Main Branch skill route (`mb-start`,
+`mb-status`, or the closest `mb-*` route) or the read-only `mb` fact commands
+below. Do not pretend Claude Code slash skills work in Codex.
 
 Start in this repo. Before setup, routing, migration, update, or repair advice,
 run the runtime preflight and read-only checks that fit the situation:
@@ -462,16 +607,18 @@ canonical paths, frontmatter, JSON keys, validator rules, and command names.
 ## Codex Lifecycle Workflow Index
 
 This tracked `AGENTS.md` file is the repo-level Codex bootstrap. The Main
-Branch Codex plugin is installed globally once per user and supplies `/mb-*`
-commands over deterministic `mb` facts. Business repos keep this lightweight
-`AGENTS.md` guidance instead of tracked repo-local plugin copies. `mb doctor
-repair --only codex` refreshes this file and installs or repairs the global
-plugin when Codex CLI is available.
+Branch Codex skill bundle is installed globally once per user and routes `mb-*`
+workflow names over deterministic `mb` facts. Business repos keep this
+lightweight `AGENTS.md` guidance instead of tracked repo-local plugin or skill
+copies. `mb doctor repair --only codex` refreshes this file and installs or
+repairs the global skills.
 
-Use the global Main Branch Codex plugin for Main Branch daily commands only. Do not
+Use the global Main Branch skills for Main Branch daily routes only. Do not
 create repo-local Codex plugin manifests, copied Claude skill trees, or
 symlinked Claude skills unless a future `mb` command or issue says that surface
 is supported for this repo.
+The global `main-branch` skill is an index; named global skills such as
+`mb-start`, `mb-status`, and `mb-think` carry the workflow routes.
 
 Use this index to map natural Codex requests:
 
@@ -489,7 +636,7 @@ Use this index to map natural Codex requests:
   domains, or customer contact:** do not claim these workflows are ported to
   Codex. Use read-only `mb` facts for planning and ask before any action.
 
-Use `/plugins` to inspect or install the global Main Branch plugin.
+Use `mb doctor repair --plan --only codex` to inspect global skill wiring.
 
 ## Codex Start Workflow
 
@@ -797,6 +944,12 @@ def _claude_skill_sources_for_inventory_item(item: dict[str, Any]) -> tuple[str,
     return tuple(f".claude/skills/{name}/SKILL.md" for name in names)
 
 
+def _claude_playbook_sources_for_inventory_item(item: dict[str, Any]) -> tuple[str, ...]:
+    sources = item.get("claude_playbook_sources") or ()
+    names = sources if isinstance(sources, tuple) else tuple(str(source) for source in sources)
+    return tuple(f".claude/playbooks/{name}/SKILL.md" for name in names)
+
+
 def workflow_inventory(*, runtime: str = "codex") -> dict[str, Any]:
     """Return the public-safe Main Branch workflow support inventory."""
 
@@ -805,6 +958,7 @@ def workflow_inventory(*, runtime: str = "codex") -> dict[str, Any]:
         copied = dict(item)
         copied["commands"] = list(_commands_for_inventory_item(item))
         copied["claude_skill_sources"] = list(_claude_skill_sources_for_inventory_item(item))
+        copied["claude_playbook_sources"] = list(_claude_playbook_sources_for_inventory_item(item))
         copied["codex_entrypoints"] = [
             str(entrypoint) for entrypoint in item.get("codex_entrypoints", ())
         ]
@@ -817,26 +971,22 @@ def workflow_inventory(*, runtime: str = "codex") -> dict[str, Any]:
         "ok": True,
         "runtime": runtime,
         "support_level": CODEX_SUPPORT_LEVEL,
-        "entrypoint": "/mb-start",
+        "entrypoint": "main-branch mb-start",
         "repo_guidance": AGENTS_RELATIVE_PATH,
         "inventory_path": CODEX_WORKFLOW_INVENTORY_RELATIVE_PATH,
         "claude_skill_sources": [
             f".claude/skills/{name}/SKILL.md" for name in CLAUDE_SKILL_SOURCE_NAMES
         ],
-        "plugin": {
-            "name": CODEX_PLUGIN_NAME,
-            "marketplace_name": CODEX_MARKETPLACE_NAME,
-            "plugin_selector": CODEX_PLUGIN_SELECTOR,
-            "marketplace_path": CODEX_MARKETPLACE_RELATIVE_PATH,
-            "manifest_path": CODEX_PLUGIN_MANIFEST_RELATIVE_PATH,
-            "skill_path": "",
-            "commands_path": CODEX_PLUGIN_COMMANDS_RELATIVE_PATH,
-            "generated_command_files": list(CODEX_SLASH_COMMAND_RELATIVE_PATHS),
-            "slash_commands_generated": True,
-            "slash_commands_ready": False,
-            "install_hint": (
-                f"Run `{codex_marketplace_add_command()}`, then `{CODEX_PLUGIN_INSTALL_COMMAND}`."
-            ),
+        "claude_playbook_sources": [
+            f".claude/playbooks/{name}/SKILL.md" for name in CLAUDE_PLAYBOOK_SOURCE_NAMES
+        ],
+        "global_skill": {
+            "name": CODEX_GLOBAL_SKILL_NAME,
+            "display_name": "Main Branch",
+            "path": CODEX_GLOBAL_SKILL_RELATIVE_PATH,
+            "routes": list(CODEX_GLOBAL_SKILL_NAMES),
+            "support": CODEX_GLOBAL_SKILL_SUPPORT,
+            "install_hint": CODEX_REPAIR_COMMAND,
         },
         "statuses": statuses,
         "items": items,
@@ -852,7 +1002,11 @@ def render_workflow_inventory_md() -> str:
         commands = ", ".join(f"`{command}`" for command in _commands_for_inventory_item(item))
         entrypoints = ", ".join(f"`{entry}`" for entry in item.get("codex_entrypoints", ()))
         claude_sources = ", ".join(
-            f"`{source}`" for source in _claude_skill_sources_for_inventory_item(item)
+            f"`{source}`"
+            for source in (
+                _claude_skill_sources_for_inventory_item(item)
+                + _claude_playbook_sources_for_inventory_item(item)
+            )
         )
         row_template = (
             "| {label} | `{status}` | {claude} | {sources} | {codex} | {entrypoints} | {commands} |"
@@ -871,21 +1025,20 @@ def render_workflow_inventory_md() -> str:
     return (
         "# Main Branch Codex Workflow Inventory\n\n"
         "Generated by `mb`. Do not edit by hand in business repos. This file maps "
-        "Main Branch workflow surfaces to the Codex command support boundary.\n\n"
+        "Main Branch workflow surfaces to the Codex global-skill support boundary.\n\n"
         "Status meanings:\n\n"
-        "- `supported`: Codex can use this surface through `/mb-*` commands "
+        "- `supported`: Codex can use this surface through global Main Branch skills "
         "grounded in deterministic `mb` facts.\n"
         "- `pending_shared_source_migration`: Codex may plan from read-only facts, "
         "but a runtime shell should wait for a shared workflow source.\n"
         "- `generated_shell_pending`: a shared source exists, but a generated Codex "
         "shell still needs implementation and smoke evidence.\n"
         "- `intentionally_unsupported`: outside the current Codex daily-loop target.\n\n"
-        "Codex plugin files and `/mb-*` command files are installed globally by "
+        "The global Main Branch skill bundle is installed by "
         "`mb doctor repair --only codex`; business repos keep only lightweight "
-        "`AGENTS.md` guidance. Use `/plugins` or "
-        "`codex plugin list --marketplace main-branch` to inspect the global "
-        "Main Branch Codex plugin. After repair and a Codex restart, typing `/mb` "
-        "should show the Main Branch commands. Each row names its bundled Claude skill "
+        "`AGENTS.md` guidance. After repair, open a fresh Codex thread in the "
+        "business repo and ask Main Branch to run one of the `mb-*` routes. "
+        "Each row names its bundled Claude skill "
         "source(s); every bundled Claude `mb-*` skill must be accounted for here "
         "until the shared workflow generator owns both runtime shells.\n\n"
         "| Workflow | Codex status | Claude Code surface | Claude source | Codex surface | "
@@ -1059,6 +1212,143 @@ def render_codex_slash_commands() -> dict[str, str]:
     }
 
 
+def render_codex_global_skill_md(name: str = CODEX_GLOBAL_SKILL_NAME) -> str:
+    """Render one global Main Branch Codex skill."""
+
+    route_lines = "\n".join(
+        f"- `{skill}`: {CODEX_GLOBAL_SKILL_DESCRIPTIONS[skill]} "
+        f"({CODEX_GLOBAL_SKILL_SUPPORT[skill]})"
+        for skill in CODEX_GLOBAL_SKILL_NAMES
+        if skill != CODEX_GLOBAL_SKILL_NAME
+    )
+    if name not in CODEX_GLOBAL_SKILL_NAMES:
+        raise ValueError(f"unknown Codex global skill: {name}")
+    description = CODEX_GLOBAL_SKILL_DESCRIPTIONS[name]
+    support_level = CODEX_GLOBAL_SKILL_SUPPORT[name]
+    facts = CODEX_GLOBAL_SKILL_FACTS[name]
+    if name == CODEX_GLOBAL_SKILL_NAME:
+        argument_hint = (
+            "[mb-start|mb-status|mb-setup|mb-update|mb-doctor|mb-think|mb-end|mb-help|other-route]"
+        )
+        title = "Main Branch"
+        route_guidance = (
+            "Choose the closest route below, then follow that route's facts and approval boundary."
+        )
+    else:
+        argument_hint = "[target]"
+        title = name
+        supported_guidance = {
+            "mb-start": (
+                "Summarize the business state, readiness, ranked actions, and one "
+                "clear next route. Use `mb start --json` when runtime handoff or "
+                "Codex readiness matters."
+            ),
+            "mb-status": (
+                "Answer from status facts: readiness, drift, recent work, "
+                "since-last-check, MoneyPath, content strategy, provider signals, "
+                "and ranked actions."
+            ),
+            "mb-setup": (
+                "Treat setup prompts as onboarding intent. Explain the target folder "
+                "and ask before running any command that writes files."
+            ),
+            "mb-update": (
+                "Report whether an update is required or recommended. Ask before "
+                "running update, repair, migration, or package-changing commands."
+            ),
+            "mb-doctor": (
+                "Explain the repair plan in business language first. Quote exact "
+                "safe commands and ask before applying any write action."
+            ),
+            "mb-think": (
+                "Use the Codex Think Route in `AGENTS.md`. Choose the smallest honest "
+                "research depth, read only needed business files, and ask before "
+                "codifying or checkpointing."
+            ),
+            "mb-end": (
+                "Plan the closeout from checkpoint and validation facts. Propose the "
+                "business-readable checkpoint subject and ask before saving it."
+            ),
+            "mb-help": (
+                "Show the supported, pending, and unsupported Codex workflow surfaces. "
+                "Do not claim parity for surfaces the inventory does not mark supported."
+            ),
+        }
+        if name in supported_guidance:
+            route_guidance = supported_guidance[name]
+        elif support_level == "read_only_planning":
+            route_guidance = (
+                "Use this as a read-only planning route in Codex. Ground the answer "
+                "in the facts below, name what Claude Code can do more fully when "
+                "relevant, and ask before writing files or touching providers."
+            )
+        else:
+            route_guidance = (
+                "This workflow is inventoried for completeness but is not a supported "
+                "Codex execution route yet. Explain the support boundary and route "
+                "the operator to Claude Code or another supported Main Branch path."
+            )
+    fact_lines = "\n".join(f"- `{command}`" for command in facts)
+    return f"""---
+name: {name}
+description: "{description}"
+argument-hint: "{argument_hint}"
+user-invocable: true
+---
+
+# {title}
+
+Support level: `{support_level}`.
+
+Use this skill when the operator is in a Main Branch business repo and asks to
+start the day, inspect status, set up, update, repair, think through a decision,
+close a session, get help, or use one of the inventoried Main Branch workflows.
+
+## Routes
+
+{route_lines}
+
+{route_guidance}
+
+Use the route names above as product-facing workflow names. Do not introduce
+`main-branch-owner-loop`, plugin, adapter, or command-surface vocabulary in
+operator-facing answers.
+
+## Grounding
+
+Start in the current repo. Run the read-only facts that fit the route before
+advice:
+
+{fact_lines}
+
+Run `command -v mb` and `mb --version` first when setup, update, repair, or
+runtime readiness is uncertain. If `mb` is missing or reports an unexpected
+version, stop and tell the operator to fix the runtime/login-shell PATH before
+continuing.
+
+Use `mb status --json --peek` as the default daily briefing source. It names
+readiness, drift, onboarding progress, update state, GitHub activity, provider
+signals, recent work, MoneyPath, ranked actions, bets, pushes, and checkpoint
+state. Use `mb start --json` when runtime handoff or repo-boundary facts matter.
+
+Stop before business routing if `runtime.codex_cli.status` is `runtime_mismatch`
+or if any drift item is `codex_runtime_mb_mismatch`.
+
+## Approval
+
+Read-only fact commands can run without asking. Ask before durable writes,
+checkpoints, updates, repairs, migrations, provider mutation, publishing, spend,
+customer contact, destructive operations, or public issue/proposal submission.
+
+## Boundaries
+
+Codex supports the daily Main Branch routes listed here. Do not claim all Claude
+Code skills, provider mutation, ads/site production, publishing, spend, customer
+contact, or slash commands are available unless `mb workflow list --runtime
+codex --json` and current runtime evidence say so.
+"""
+
+
 def agents_path(repo: str | Path) -> Path:
     return Path(repo).expanduser().resolve() / AGENTS_RELATIVE_PATH
 
@@ -1097,7 +1387,7 @@ def executable_status() -> dict[str, Any]:
         "found": bool(path),
         "path": path,
         "executable": "codex",
-        "repair": "" if path else "Install Codex CLI before using Main Branch Codex commands.",
+        "repair": "" if path else "Install Codex CLI before using Main Branch in Codex.",
     }
 
 
@@ -1386,6 +1676,137 @@ def install_plugin(repo: str | Path) -> dict[str, Any]:
     }
 
 
+def global_skill_status(repo: str | Path) -> dict[str, Any]:
+    """Return status for the global Main Branch Codex skill bundle."""
+
+    expected_by_name = {
+        name: render_codex_global_skill_md(name) for name in CODEX_GLOBAL_SKILL_NAMES
+    }
+    path_by_name = {name: global_skill_file_path(name) for name in CODEX_GLOBAL_SKILL_NAMES}
+    missing = [f"{name}/SKILL.md" for name, path in path_by_name.items() if not path.is_file()]
+    read_error = ""
+    stale: list[str] = []
+    missing_markers: list[str] = []
+    skill_reports: dict[str, dict[str, Any]] = {}
+    for skill_name, path in path_by_name.items():
+        exists = path.is_file()
+        text = ""
+        skill_read_error = ""
+        try:
+            text = path.read_text(encoding="utf-8") if exists else ""
+        except OSError as exc:
+            skill_read_error = str(exc)
+            read_error = skill_read_error
+        markers = (
+            f"name: {skill_name}",
+            "user-invocable: true",
+            "mb status --json --peek",
+        )
+        route_missing = [marker for marker in markers if marker not in text]
+        if route_missing:
+            missing_markers.extend(f"{skill_name}: {marker}" for marker in route_missing)
+        if exists and not skill_read_error and text != expected_by_name[skill_name]:
+            stale.append(f"{skill_name}/SKILL.md")
+        skill_reports[skill_name] = {
+            "ok": bool(
+                exists
+                and not route_missing
+                and not skill_read_error
+                and text == expected_by_name[skill_name]
+            ),
+            "exists": exists,
+            "current": bool(exists and text == expected_by_name[skill_name]),
+            "path": f"{skill_name}/SKILL.md",
+            "absolute_path": str(path),
+            "missing_markers": route_missing,
+            "read_error": skill_read_error,
+        }
+    legacy_skill = global_skill_source_root() / CODEX_LEGACY_GLOBAL_SKILL_NAME
+    if legacy_skill.exists():
+        stale.append(CODEX_LEGACY_GLOBAL_SKILL_NAME)
+    legacy_plugin = global_plugin_source_root()
+    if legacy_plugin.exists():
+        stale.append(str(legacy_plugin))
+    ok = bool(not missing and not stale and not read_error and not missing_markers)
+    return {
+        "checked": True,
+        "ok": ok,
+        "state": "ok" if ok else "global_skill_missing_or_stale",
+        "summary": (
+            "The global Main Branch Codex skill bundle is installed and current."
+            if ok
+            else (
+                "The global Main Branch Codex skill bundle is missing, stale, "
+                "or has old plugin artifacts."
+            )
+        ),
+        "name": CODEX_GLOBAL_SKILL_NAME,
+        "display_name": "Main Branch",
+        "path": CODEX_GLOBAL_SKILL_RELATIVE_PATH,
+        "absolute_path": str(global_skill_path()),
+        "skills_root": str(global_skill_source_root()),
+        "exists": not missing,
+        "current": bool(not stale and not missing_markers),
+        "skills": skill_reports,
+        "required_skills": list(CODEX_GLOBAL_SKILL_NAMES),
+        "stale": stale,
+        "missing": missing,
+        "missing_markers": missing_markers,
+        "read_error": read_error,
+        "routes": list(CODEX_SLASH_COMMAND_NAMES),
+        "repair": "" if ok else CODEX_REPAIR_TEXT,
+        "repair_command": CODEX_REPAIR_COMMAND,
+        "safe_to_share": True,
+    }
+
+
+def write_global_skill_source() -> dict[str, Any]:
+    """Write the global Main Branch Codex skill bundle and remove old surfaces."""
+
+    changed_paths: list[str] = []
+    for name in CODEX_GLOBAL_SKILL_NAMES:
+        path = global_skill_file_path(name)
+        expected = render_codex_global_skill_md(name)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        existing = path.read_text(encoding="utf-8") if path.exists() else ""
+        if existing != expected:
+            path.write_text(expected, encoding="utf-8")
+            changed_paths.append(str(path))
+
+    legacy_skill = global_skill_source_root() / CODEX_LEGACY_GLOBAL_SKILL_NAME
+    if _remove_generated_tree(legacy_skill):
+        changed_paths.append(str(legacy_skill))
+
+    plugin_root = global_plugin_source_root()
+    if _remove_generated_tree(plugin_root):
+        changed_paths.append(str(plugin_root))
+
+    return {
+        "ok": True,
+        "path": str(global_skill_source_root()),
+        "skills_root": str(global_skill_source_root()),
+        "changed": bool(changed_paths),
+        "changed_paths": changed_paths,
+        "relative_paths": [f"{name}/SKILL.md" for name in CODEX_GLOBAL_SKILL_NAMES],
+        "status": global_skill_status(Path.cwd()),
+        "safe_to_share": True,
+    }
+
+
+def install_global_skill(repo: str | Path) -> dict[str, Any]:
+    """Install or refresh the primary global Codex skill."""
+
+    source = write_global_skill_source()
+    final = global_skill_status(repo)
+    return {
+        "ok": bool(final.get("ok")),
+        "source": source,
+        "steps": [],
+        "status": final,
+        "safe_to_share": True,
+    }
+
+
 def plugin_status(repo: str | Path) -> dict[str, Any]:
     target = Path(repo).expanduser().resolve()
     marketplace = marketplace_path(target)
@@ -1524,6 +1945,7 @@ def remove_repo_local_codex_plugin_files(repo: str | Path) -> list[str]:
         CODEX_LEGACY_PLUGIN_DIR_RELATIVE_PATH,
         CODEX_MARKETPLACE_RELATIVE_PATH,
         CODEX_SKILL_DIR_RELATIVE_PATH,
+        ".agents/skills/main-branch",
     ):
         path = target / relative
         if _remove_generated_tree(path):
@@ -1542,23 +1964,22 @@ def remove_repo_local_codex_plugin_files(repo: str | Path) -> list[str]:
 
 
 def skill_status(repo: str | Path) -> dict[str, Any]:
-    plugin = plugin_status(repo)
+    skill = global_skill_status(repo)
     return {
-        "ok": True,
-        "exists": False,
-        "current": True,
-        "path": "",
+        "ok": bool(skill["ok"]),
+        "exists": bool(skill["exists"]),
+        "current": bool(skill["current"]),
+        "path": skill["path"],
+        "absolute_path": skill["absolute_path"],
         "inventory_path": CODEX_WORKFLOW_INVENTORY_RELATIVE_PATH,
-        "missing_markers": [],
-        "plugin": plugin,
-        "read_error": "",
-        "repair": "",
+        "missing_markers": skill["missing_markers"],
+        "global_skill": skill,
+        "plugin": plugin_status(repo),
+        "read_error": skill["read_error"],
+        "repair": skill["repair"],
         "repair_command": CODEX_REPAIR_COMMAND,
-        "deprecated": True,
-        "summary": (
-            "Repo-local Codex plugin files are no longer required; Main Branch "
-            "Codex commands are installed globally."
-        ),
+        "deprecated": False,
+        "summary": ("The global Main Branch Codex skill is the supported Codex surface."),
         "safe_to_share": True,
     }
 
@@ -1577,7 +1998,7 @@ def instructions_status(repo: str | Path) -> dict[str, Any]:
         read_error = ""
     missing_commands = [command for command in REQUIRED_FACT_COMMANDS if command not in text]
     approval_ok = "explicit operator approval" in text
-    slash_ok = "Do not pretend Claude Code skills work in Codex." in text
+    slash_ok = "Do not pretend Claude Code slash skills work in Codex." in text
     missing_lifecycle_guidance = [
         marker for marker in REQUIRED_LIFECYCLE_GUIDANCE_MARKERS if marker not in text
     ]
@@ -1590,6 +2011,7 @@ def instructions_status(repo: str | Path) -> dict[str, Any]:
         relative
         for relative in (
             CODEX_SKILL_DIR_RELATIVE_PATH,
+            ".agents/skills/main-branch",
             CODEX_MARKETPLACE_RELATIVE_PATH,
             CODEX_PLUGIN_DIR_RELATIVE_PATH,
             CODEX_LEGACY_PLUGIN_DIR_RELATIVE_PATH,
@@ -1631,20 +2053,36 @@ def readiness(repo: str | Path) -> dict[str, Any]:
     static_ok = bool(executable["found"] and instructions["ok"])
     runtime = _login_shell_mb_diagnostics()
     runtime_ok = bool(runtime.get("ok"))
-    plugin_install = plugin_install_status(repo, adapter_files_ok=bool(instructions["ok"]))
-    plugin_ok = bool(plugin_install.get("ok"))
-    slash_commands_ready = bool(plugin_install.get("slash_commands_ready"))
-    command_surface_ok = bool(plugin_ok and plugin_install.get("command_surface_ok"))
-    generated_guidance_ready = command_surface_ok
-    ok = bool(static_ok and runtime_ok and command_surface_ok and slash_commands_ready)
+    global_skill = global_skill_status(repo)
+    global_skill_ok = bool(global_skill.get("ok"))
+    plugin_install = {
+        "checked": False,
+        "ok": False,
+        "state": "legacy_plugin_not_checked",
+        "summary": "Codex plugin commands are legacy/experimental and not part of readiness.",
+        "plugin_installed": False,
+        "plugin_enabled": False,
+        "command_files_current": False,
+        "command_surface_ok": False,
+        "slash_commands_ready": False,
+        "slash_commands_likely_loaded": False,
+        "slash_commands_restart_required": False,
+        "repair": "",
+        "safe_to_share": True,
+    }
+    plugin_ok = False
+    slash_commands_ready = False
+    command_surface_ok = global_skill_ok
+    generated_guidance_ready = bool(instructions["ok"] and global_skill_ok)
+    ok = bool(static_ok and runtime_ok and global_skill_ok)
     if ok:
         status = "ready"
     elif not executable["found"] or not instructions["ok"]:
         status = "needs_setup"
     elif runtime.get("mismatch"):
         status = "runtime_mismatch"
-    elif runtime_ok and not plugin_ok:
-        status = str(plugin_install.get("state") or "plugin_not_installed")
+    elif runtime_ok and not global_skill_ok:
+        status = str(global_skill.get("state") or "global_skill_missing_or_stale")
     else:
         status = "runtime_unverified"
     return {
@@ -1654,9 +2092,11 @@ def readiness(repo: str | Path) -> dict[str, Any]:
         "static_ok": static_ok,
         "runtime_ok": runtime_ok,
         "plugin_ok": plugin_ok,
+        "global_skill_ok": global_skill_ok,
         "generated_guidance_ready": generated_guidance_ready,
         "command_surface_ok": command_surface_ok,
         "slash_commands_ready": slash_commands_ready,
+        "global_skill": global_skill,
         "plugin_install": plugin_install,
         "runtime": runtime,
         "executable": executable,
@@ -1670,8 +2110,8 @@ def readiness(repo: str | Path) -> dict[str, Any]:
         else (
             str(runtime.get("repair") or "")
             if static_ok and not runtime_ok
-            else str(plugin_install.get("repair") or "")
-            if static_ok and runtime_ok and not plugin_ok
+            else str(global_skill.get("repair") or "")
+            if static_ok and runtime_ok and not global_skill_ok
             else instructions["repair"] or executable["repair"]
         ),
         "start_command": f"codex -C {shlex.quote(str(Path(repo).expanduser().resolve()))}",
@@ -1702,13 +2142,12 @@ def human_readiness_label(readiness_report: dict[str, Any]) -> str:
         return "runtime mismatch"
     if not runtime.get("ok"):
         return "runtime unverified"
+    global_skill = readiness_report.get("global_skill") or {}
+    if not global_skill.get("ok"):
+        return "skill not ready"
     plugin_install = readiness_report.get("plugin_install") or {}
     if not plugin_install.get("ok"):
-        if plugin_install.get("state") == "plugin_not_installed":
-            return "plugin not installed"
-        if plugin_install.get("state") == "marketplace_not_registered":
-            return "marketplace missing"
-        return "plugin not ready"
+        return "plugin optional"
     return "not ready"
 
 

--- a/mb/mb/doctor.py
+++ b/mb/mb/doctor.py
@@ -1326,7 +1326,7 @@ def run(path: str) -> dict[str, Any]:
     codex_readiness = codex_mod.readiness(repo)
     codex_executable = codex_readiness["executable"]
     codex_instructions = codex_readiness["instructions"]
-    codex_plugin_install = codex_readiness["plugin_install"]
+    codex_global_skill = codex_readiness["global_skill"]
     checks.append(
         {
             "name": "codex-cli",
@@ -1342,7 +1342,7 @@ def run(path: str) -> dict[str, Any]:
             "name": "codex-agents-md",
             "ok": bool(codex_instructions["ok"]),
             "detail": (
-                "AGENTS.md and Main Branch Codex commands are current and point Codex "
+                "AGENTS.md and Main Branch Codex skills are current and point Codex "
                 "to mb facts, lifecycle routes, and workflow inventory"
             )
             if codex_instructions["ok"]
@@ -1359,16 +1359,16 @@ def run(path: str) -> dict[str, Any]:
     )
     checks.append(
         {
-            "name": "codex-plugin-install",
-            "ok": bool(codex_plugin_install["ok"]),
-            "detail": codex_plugin_install["summary"],
+            "name": "codex-global-skill",
+            "ok": bool(codex_global_skill["ok"]),
+            "detail": codex_global_skill["summary"],
             "severity": "ok"
-            if codex_plugin_install["ok"]
+            if codex_global_skill["ok"]
             else ("warn" if codex_executable["found"] and codex_instructions["ok"] else "info"),
-            "repair": codex_plugin_install["repair"],
-            "repair_command": codex_plugin_install["install_command"],
+            "repair": codex_global_skill["repair"],
+            "repair_command": codex_global_skill["repair_command"],
             "safe_to_share": True,
-            "status": codex_plugin_install,
+            "status": codex_global_skill,
         }
     )
 
@@ -2036,7 +2036,7 @@ def repair_plan(
     codex_status = codex_mod.readiness(target)
     codex_instruction_status = codex_status["instructions"]
     codex_runtime_status = codex_status["runtime"]
-    codex_plugin_install = codex_status["plugin_install"]
+    codex_global_skill = codex_status["global_skill"]
     codex_runtime_relevant = bool(
         codex_status["executable"]["found"] and codex_instruction_status["ok"]
     )
@@ -2087,30 +2087,18 @@ def repair_plan(
             "repair": codex_runtime_status.get("repair", "") if codex_runtime_relevant else "",
         },
         {
-            "name": "codex-plugin-install",
-            "state": (
-                "ok"
-                if codex_plugin_install["ok"]
-                else ("warn" if codex_runtime_relevant else "info")
-            ),
-            "summary": codex_plugin_install["summary"],
-            "marketplace_registered": codex_plugin_install["marketplace_registered"],
-            "marketplace_stale": codex_plugin_install["marketplace_stale"],
-            "global_plugin_installed": codex_plugin_install.get("global_plugin_installed", False),
-            "plugin_installed": codex_plugin_install["plugin_installed"],
-            "plugin_enabled": codex_plugin_install["plugin_enabled"],
-            "skill_available": codex_plugin_install.get("skill_available", False),
-            "command_files_current": codex_plugin_install.get("command_files_current", False),
-            "command_surface_ok": codex_plugin_install.get("command_surface_ok", False),
-            "slash_commands_ready": codex_plugin_install.get("slash_commands_ready", False),
-            "slash_commands_likely_loaded": codex_plugin_install.get(
-                "slash_commands_likely_loaded", False
-            ),
-            "slash_commands_restart_required": codex_plugin_install.get(
-                "slash_commands_restart_required", False
-            ),
-            "install_command": codex_plugin_install["install_command"],
-            "repair": codex_plugin_install["repair"],
+            "name": "codex-global-skill",
+            "state": ("ok" if codex_global_skill["ok"] else "warn"),
+            "summary": codex_global_skill["summary"],
+            "skill_name": codex_global_skill["name"],
+            "skill_path": codex_global_skill["path"],
+            "skills_root": codex_global_skill["skills_root"],
+            "routes": codex_global_skill["routes"],
+            "stale": codex_global_skill["stale"],
+            "missing": codex_global_skill["missing"],
+            "missing_markers": codex_global_skill["missing_markers"],
+            "slash_commands_ready": codex_status.get("slash_commands_ready", False),
+            "repair": codex_global_skill["repair"],
         },
     ]
     codex_actions: list[dict[str, Any]] = []
@@ -2133,38 +2121,30 @@ def repair_plan(
         )
         actions.append(action)
         codex_actions.append(action)
-    if codex_runtime_relevant and not codex_plugin_install["ok"]:
+    if not codex_global_skill["ok"]:
         action = _action(
-            id="codex-plugin-install",
-            title="Install the Main Branch Codex plugin",
+            id="codex-global-skill",
+            title="Install the global Main Branch Codex skill",
             state="warn",
             mode="write",
-            command=(
-                f"{codex_mod.codex_marketplace_add_command()} && "
-                f"{codex_mod.CODEX_PLUGIN_INSTALL_COMMAND}"
-            ),
+            command="mb doctor repair --apply --only codex",
             safe_to_apply=True,
-            reason=(
-                "Codex must install and enable the global Main Branch plugin before "
-                "the /mb command surface is available"
-            ),
+            reason=("Codex uses one global Main Branch skill for the supported mb-* routes"),
             writes=[
-                str(codex_mod.global_plugin_source_root()),
-                "~/.codex/config.toml",
-                "~/.codex/plugins/",
+                str(codex_mod.global_skill_source_root()),
             ],
-            result=codex_plugin_install,
+            result=codex_global_skill,
         )
         actions.append(action)
         codex_actions.append(action)
     sections.append(
         _section(
             "codex-wiring",
-            "Codex Commands",
+            "Codex Global Skill",
             _max_state([str(item["state"]) for item in codex_checks]),
             (
-                "Main Branch Codex commands, repo guidance, workflow inventory, "
-                "global plugin, and executable readiness"
+                "Main Branch global Codex skill, repo guidance, workflow inventory, "
+                "and executable readiness"
             ),
             checks=codex_checks,
             actions=codex_actions,
@@ -2321,7 +2301,7 @@ def repair_plan(
         actions = [
             action
             for action in actions
-            if str(action.get("id")) in {"codex-agents-md", "codex-plugin-install"}
+            if str(action.get("id")) in {"codex-agents-md", "codex-global-skill"}
         ]
 
     states = [str(section["state"]) for section in sections]
@@ -2519,7 +2499,7 @@ def repair_apply(
         applied.append(
             _action(
                 id="codex-agents-md",
-                title="Refreshed Codex owner-loop instructions",
+                title="Refreshed Codex repo instructions",
                 state="ok" if agents["ok"] else "error",
                 mode="write",
                 command=(
@@ -2545,30 +2525,22 @@ def repair_apply(
     codex_runtime_relevant = bool(
         codex_status["executable"]["found"] and codex_status["instructions"]["ok"]
     )
-    codex_plugin_install = codex_status["plugin_install"]
-    if codex_runtime_relevant and not codex_plugin_install["ok"]:
-        installed = codex_mod.install_plugin(target)
+    codex_global_skill = codex_status["global_skill"]
+    if codex_runtime_relevant and not codex_global_skill["ok"]:
+        installed = codex_mod.install_global_skill(target)
         applied.append(
             _action(
-                id="codex-plugin-install",
-                title="Installed the Main Branch Codex plugin",
+                id="codex-global-skill",
+                title="Installed the global Main Branch Codex skill bundle",
                 state="ok" if installed["ok"] else "error",
                 mode="write",
-                command=(
-                    f"{codex_mod.codex_marketplace_add_command()} && "
-                    f"{codex_mod.CODEX_PLUGIN_INSTALL_COMMAND}"
-                ),
+                command="mb doctor repair --apply --only codex",
                 safe_to_apply=True,
-                reason=(
-                    "installed and enabled the global Codex plugin so /mb commands "
-                    "are available after restarting Codex"
-                ),
+                reason=("installed global Codex skills for the supported Main Branch mb-* routes"),
                 writes=[
-                    str(codex_mod.global_plugin_source_root()),
-                    "~/.codex/config.toml",
-                    "~/.codex/plugins/",
+                    str(codex_mod.global_skill_source_root()),
                 ],
-                applied=bool(installed.get("steps")),
+                applied=bool(installed.get("source", {}).get("changed")),
                 result=installed,
             )
         )

--- a/mb/mb/start.py
+++ b/mb/mb/start.py
@@ -226,6 +226,7 @@ def _build_checks(
         )
     codex_executable = codex.get("executable") or {}
     codex_instructions = codex.get("instructions") or {}
+    codex_global_skill = codex.get("global_skill") or {}
     codex_runtime = codex.get("runtime") or {}
     codex_found = bool(codex_executable.get("found"))
     checks.extend(
@@ -242,16 +243,24 @@ def _build_checks(
                 "ok": bool(codex_instructions.get("ok")),
                 "severity": "warn" if codex_found else "info",
                 "detail": (
-                    "AGENTS.md, the global Codex plugin, and generated guidance point "
+                    "AGENTS.md and global Codex skills point "
                     "Codex to mb facts, lifecycle routes, and workflow inventory"
                 )
                 if codex_instructions.get("ok")
                 else (
-                    "Codex AGENTS.md, plugin, marketplace, or generated guidance is "
+                    "Codex AGENTS.md or global skill guidance is "
                     "missing, stale, or missing required mb fact commands or lifecycle "
                     "discovery guidance"
                 ),
                 "repair": codex_instructions.get("repair") if codex_found else "",
+            },
+            {
+                "name": "codex_global_skills",
+                "ok": bool(codex_global_skill.get("ok")),
+                "severity": "warn" if codex_found else "info",
+                "detail": codex_global_skill.get("summary")
+                or "Global Main Branch Codex skills are not installed.",
+                "repair": codex_global_skill.get("repair") if codex_found else "",
             },
             {
                 "name": "codex_runtime_mb",
@@ -310,40 +319,25 @@ def _codex_next_actions(repo: Path, codex: dict[str, Any]) -> list[str]:
         actions = []
         if repair:
             actions.append(repair)
-        actions.append("Rerun `mb status --json --peek` before continuing Codex owner-loop work.")
+        actions.append(
+            "Rerun `mb status --json --peek` before continuing Main Branch work in Codex."
+        )
         return actions[:3]
     if not codex.get("runtime_ok"):
         repair = str(runtime.get("repair") or codex.get("repair") or "")
         return [repair] if repair else []
-    if not codex.get("plugin_ok"):
-        plugin_install = codex.get("plugin_install") or {}
-        repair = str(plugin_install.get("repair") or codex.get("repair") or "")
+    if not codex.get("global_skill_ok"):
+        global_skill = codex.get("global_skill") or {}
+        repair = str(global_skill.get("repair") or codex.get("repair") or "")
         actions = []
         if repair:
             actions.append(repair)
         actions.append("Rerun `mb status --json --peek` before using Codex.")
         return actions[:3]
-    plugin_install = codex.get("plugin_install") or {}
-    if not codex.get("slash_commands_ready"):
-        repair = str(codex.get("repair") or "")
-        actions = []
-        if repair:
-            actions.append(repair)
-        actions.append("Restart Codex, then type `/mb` to verify Main Branch commands.")
-        return actions[:3]
-    if plugin_install.get("slash_commands_restart_required"):
-        actions = [
-            f"Run `{_codex_display_command(repo)}` or restart Codex if it is already open.",
-            "Type `/mb` to verify Main Branch commands.",
-        ]
-        smoke_command = str(codex.get("smoke_command") or "")
-        if smoke_command:
-            actions.append(f"For a read-only Codex smoke, run `{smoke_command}`.")
-        return actions
     smoke_command = str(codex.get("smoke_command") or "")
     actions = [
         f"Run `{_codex_display_command(repo)}`.",
-        "After Codex restarts, type `/mb-start` or `/mb-status`.",
+        "Open a fresh Codex thread and use the global `mb-start` or `mb-status` skill.",
     ]
     if smoke_command:
         actions.append(f"For a read-only Codex smoke, run `{smoke_command}`.")
@@ -397,8 +391,8 @@ def run(repo: str = ".", launch: bool = False) -> dict[str, Any]:
             "argv": ["codex", "-C", str(repo_path)],
             "display": _codex_display_command(repo_path),
             "startup_prompt": (
-                "Start this Main Branch business day from `/mb-start` and read-only "
-                "mb facts. Ask before writes. Stop if mb status/start reports "
+                "Start this Main Branch business day from the global `mb-start` "
+                "skill and read-only mb facts. Ask before writes. Stop if mb status/start reports "
                 "runtime.codex_cli.status == runtime_mismatch or drift id "
                 "codex_runtime_mb_mismatch."
             ),
@@ -484,7 +478,7 @@ def render_human(report: dict[str, Any]) -> None:
     codex_label = codex_mod.human_readiness_label(codex)
     codex_style = "green" if codex_label == "ready" else "yellow"
     console.print(
-        "[bold]Codex[/bold]  " + f"[{codex_style}]{codex_label}[/{codex_style}]" + "  owner loop"
+        "[bold]Codex[/bold]  " + f"[{codex_style}]{codex_label}[/{codex_style}]" + "  global skills"
     )
     console.print(
         "[bold]Skills[/bold]  /mb-start "

--- a/mb/mb/status.py
+++ b/mb/mb/status.py
@@ -3826,13 +3826,13 @@ def _drift(report: dict[str, Any]) -> dict[str, Any]:
     codex_executable = codex_cli.get("executable") or {}
     codex_instructions = codex_cli.get("instructions") or {}
     codex_runtime = codex_cli.get("runtime") or {}
-    codex_plugin = codex_cli.get("plugin_install") or {}
+    codex_global_skill = codex_cli.get("global_skill") or {}
     if codex_executable.get("found") and not codex_instructions.get("ok"):
         items.append(
             {
                 "id": "codex_instructions_not_ready",
                 "severity": "warn",
-                "summary": "Codex owner-loop instructions are missing or stale.",
+                "summary": "Codex repo instructions are missing or stale.",
                 "evidence": [
                     str(codex_instructions.get("path") or "AGENTS.md"),
                 ],
@@ -3873,25 +3873,22 @@ def _drift(report: dict[str, Any]) -> dict[str, Any]:
         codex_executable.get("found")
         and codex_instructions.get("ok")
         and codex_runtime.get("ok")
-        and not codex_plugin.get("ok")
+        and not codex_global_skill.get("ok")
     ):
         items.append(
             {
-                "id": "codex_plugin_not_installed",
+                "id": "codex_global_skills_not_ready",
                 "severity": "warn",
                 "summary": str(
-                    codex_plugin.get("summary")
-                    or "Codex plugin files are ready, but the plugin is not installed."
+                    codex_global_skill.get("summary")
+                    or "Global Main Branch Codex skills are missing or stale."
                 ),
                 "evidence": [
-                    f"marketplace: {codex_plugin.get('marketplace_name') or ''}".strip(),
-                    f"plugin: {codex_plugin.get('plugin_selector') or ''}".strip(),
-                    f"state: {codex_plugin.get('state') or 'unknown'}",
-                    f"commands current: {codex_plugin.get('command_files_current')}",
+                    f"skills root: {codex_global_skill.get('skills_root') or ''}".strip(),
+                    f"state: {codex_global_skill.get('state') or 'unknown'}",
+                    f"missing: {', '.join(codex_global_skill.get('missing') or [])}",
                 ],
-                "repair": str(
-                    codex_plugin.get("repair") or f"Run `{codex_mod.CODEX_PLUGIN_INSTALL_COMMAND}`."
-                ),
+                "repair": str(codex_global_skill.get("repair") or codex_mod.CODEX_REPAIR_TEXT),
                 "safe_to_share": True,
             }
         )
@@ -4319,7 +4316,7 @@ def render_human(
     skill_mark = "[green]wired[/green]" if skills["ok"] else "[yellow]missing[/yellow]"
     codex_label = codex_mod.human_readiness_label(codex)
     codex_style = "green" if codex_label == "ready" else "yellow"
-    codex_mark = f"[{codex_style}]{codex_label}[/{codex_style}] owner loop"
+    codex_mark = f"[{codex_style}]{codex_label}[/{codex_style}] global skills"
     console.print(
         f"[bold]Runtime[/bold] Claude Code: {claude_mark}  skills: {skill_mark}  "
         f"Codex: {codex_mark}"

--- a/mb/mb/update.py
+++ b/mb/mb/update.py
@@ -243,15 +243,18 @@ def _base_result(repo: Path, *, check: bool, mode: str, root: Path | None) -> di
 def _add_codex_follow_up(result: dict[str, Any], repo: Path) -> None:
     codex = codex_mod.readiness(repo)
     instructions = codex.get("instructions", {})
+    global_skill = codex.get("global_skill", {})
     plugin_install = codex.get("plugin_install", {})
     result["codex_adapter"] = {
         "ok": codex["ok"],
         "status": codex.get("status", ""),
         "static_ok": codex.get("static_ok", False),
         "runtime_ok": codex.get("runtime_ok", False),
+        "global_skill_ok": codex.get("global_skill_ok", False),
         "plugin_ok": codex.get("plugin_ok", False),
         "command_surface_ok": codex.get("command_surface_ok", False),
         "slash_commands_ready": codex.get("slash_commands_ready", False),
+        "global_skill": global_skill,
         "slash_commands_likely_loaded": plugin_install.get("slash_commands_likely_loaded", False),
         "slash_commands_restart_required": plugin_install.get(
             "slash_commands_restart_required", False
@@ -261,7 +264,7 @@ def _add_codex_follow_up(result: dict[str, Any], repo: Path) -> None:
         "repair_command": codex.get("repair", "") or instructions.get("repair_command", ""),
         "plugin_install": plugin_install,
     }
-    if not codex["ok"] or not codex.get("slash_commands_ready", False):
+    if not codex["ok"]:
         next_actions: list[str]
         if not instructions.get("ok", False):
             message = (
@@ -273,22 +276,12 @@ def _add_codex_follow_up(result: dict[str, Any], repo: Path) -> None:
                 "mb doctor repair --plan --only codex",
                 "mb doctor repair --apply --only codex",
             ]
-        elif not codex.get("plugin_ok", False):
+        elif not codex.get("global_skill_ok", False):
             message = (
-                "The global Main Branch Codex plugin is not ready, so `/mb-*` "
-                "commands may be missing or stale. "
+                "The global Main Branch Codex skills are not ready, so `mb-*` "
+                "routes may be missing or stale. "
                 "Run `mb doctor repair --plan --only codex`, review it, then approve "
                 "`mb doctor repair --apply --only codex`."
-            )
-            next_actions = [
-                "mb doctor repair --plan --only codex",
-                "mb doctor repair --apply --only codex",
-            ]
-        elif not codex.get("slash_commands_ready", False):
-            message = (
-                "Main Branch Codex commands are missing or stale. Run "
-                "`mb doctor repair --plan --only codex`, review it, then approve "
-                "`mb doctor repair --apply --only codex`, then restart Codex."
             )
             next_actions = [
                 "mb doctor repair --plan --only codex",
@@ -304,10 +297,10 @@ def _add_codex_follow_up(result: dict[str, Any], repo: Path) -> None:
         result["next_actions"].extend(next_actions)
     elif plugin_install.get("slash_commands_restart_required"):
         result["warnings"].append(
-            "Main Branch Codex commands are installed. Restart Codex, then type `/mb` "
-            "to verify the slash command surface loaded."
+            "Codex may need a fresh thread before it sees the refreshed global "
+            "Main Branch skill bundle."
         )
-        result["next_actions"].append("Restart Codex, then type `/mb`.")
+        result["next_actions"].append("Open a fresh Codex thread in the business repo.")
 
 
 def run(repo: str | Path = ".", *, check: bool = False) -> dict[str, Any]:
@@ -463,7 +456,7 @@ def render_human(result: dict[str, Any]) -> None:
         print(f"updated Main Branch ({old} -> {new})")
         print(f"refreshed {count} skill link(s)")
         if result.get("codex_repaired"):
-            print("refreshed Codex command surface")
+            print("refreshed Codex global skills")
         for action in result.get("next_actions", []):
             print(f"next: {action}")
 

--- a/mb/tests/test_doctor.py
+++ b/mb/tests/test_doctor.py
@@ -96,6 +96,11 @@ def _prepare_codex_global_plugin(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     codex_mod.write_global_plugin_source()
 
 
+def _prepare_codex_global_skill_roots(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MAINBRANCH_CODEX_PLUGIN_ROOT", str(tmp_path / "codex-global"))
+    monkeypatch.setenv("MAINBRANCH_CODEX_SKILLS_ROOT", str(tmp_path / "codex-skills"))
+
+
 def _write_md(path: Path, text: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(text, encoding="utf-8")
@@ -429,7 +434,10 @@ def test_doctor_repair_only_codex_filters_unrelated_related_links(tmp_path: Path
     plan = json.loads(plan_result.stdout)
     assert plan["only"] == "codex"
     assert [section["id"] for section in plan["sections"]] == ["codex-wiring", "git"]
-    assert [action["id"] for action in plan["actions"]] == ["codex-agents-md"]
+    assert [action["id"] for action in plan["actions"]] == [
+        "codex-agents-md",
+        "codex-global-skill",
+    ]
 
     apply_result = runner.invoke(
         app,
@@ -487,20 +495,15 @@ def test_doctor_repair_plan_marks_codex_runtime_info_when_codex_missing(
     assert runtime_check["repair"] == ""
 
 
-def test_doctor_repair_plan_installs_missing_codex_plugin(
+def test_doctor_repair_plan_installs_missing_codex_global_skills(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
     monkeypatch.setattr(codex_mod, "_which", _with_codex)
     monkeypatch.setattr(codex_mod, "_login_shell_mb_diagnostics", _codex_runtime_ok)
-    _prepare_codex_global_plugin(tmp_path, monkeypatch)
+    _prepare_codex_global_skill_roots(tmp_path, monkeypatch)
     repo = tmp_path / "biz"
     init_run(path=str(repo), name="Acme")
-    monkeypatch.setattr(
-        codex_mod,
-        "_codex_plugin_list",
-        lambda plugin_repo: _codex_plugin_list_result(Path(plugin_repo), installed=False),
-    )
 
     result = runner.invoke(
         app, ["doctor", "repair", "--repo", str(repo), "--plan", "--only", "codex", "--json"]
@@ -509,18 +512,18 @@ def test_doctor_repair_plan_installs_missing_codex_plugin(
     assert result.exit_code in {0, 1}
     payload = json.loads(result.stdout)
     actions = {action["id"]: action for action in payload["actions"]}
-    assert "codex-plugin-install" in actions
-    assert actions["codex-plugin-install"]["safe_to_apply"] is True
-    assert codex_mod.CODEX_PLUGIN_INSTALL_COMMAND in actions["codex-plugin-install"]["command"]
+    assert "codex-global-skill" in actions
+    assert actions["codex-global-skill"]["safe_to_apply"] is True
+    assert actions["codex-global-skill"]["command"] == "mb doctor repair --apply --only codex"
     section = next(section for section in payload["sections"] if section["id"] == "codex-wiring")
-    plugin_check = next(
-        check for check in section["checks"] if check["name"] == "codex-plugin-install"
+    skill_check = next(
+        check for check in section["checks"] if check["name"] == "codex-global-skill"
     )
-    assert plugin_check["state"] == "warn"
-    assert plugin_check["plugin_installed"] is False
+    assert skill_check["state"] == "warn"
+    assert "mb-start/SKILL.md" in skill_check["missing"]
 
 
-def test_doctor_repair_plan_installs_missing_codex_plugin_with_runtime_path_warning(
+def test_doctor_repair_plan_installs_missing_codex_global_skills_with_runtime_path_warning(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
@@ -530,14 +533,9 @@ def test_doctor_repair_plan_installs_missing_codex_plugin_with_runtime_path_warn
         "_login_shell_mb_diagnostics",
         _codex_runtime_path_mismatch_same_version,
     )
-    _prepare_codex_global_plugin(tmp_path, monkeypatch)
+    _prepare_codex_global_skill_roots(tmp_path, monkeypatch)
     repo = tmp_path / "biz"
     init_run(path=str(repo), name="Acme")
-    monkeypatch.setattr(
-        codex_mod,
-        "_codex_plugin_list",
-        lambda plugin_repo: _codex_plugin_list_result(Path(plugin_repo), installed=False),
-    )
 
     result = runner.invoke(
         app, ["doctor", "repair", "--repo", str(repo), "--plan", "--only", "codex", "--json"]
@@ -546,51 +544,27 @@ def test_doctor_repair_plan_installs_missing_codex_plugin_with_runtime_path_warn
     assert result.exit_code in {0, 1}
     payload = json.loads(result.stdout)
     actions = {action["id"]: action for action in payload["actions"]}
-    assert "codex-plugin-install" in actions
+    assert "codex-global-skill" in actions
     section = next(section for section in payload["sections"] if section["id"] == "codex-wiring")
     runtime_check = next(
         check for check in section["checks"] if check["name"] == "codex-runtime-mb"
     )
-    plugin_check = next(
-        check for check in section["checks"] if check["name"] == "codex-plugin-install"
+    skill_check = next(
+        check for check in section["checks"] if check["name"] == "codex-global-skill"
     )
     assert runtime_check["state"] == "warn"
-    assert plugin_check["state"] == "warn"
+    assert skill_check["state"] == "warn"
 
 
-def test_doctor_repair_apply_installs_missing_codex_plugin(
+def test_doctor_repair_apply_installs_missing_codex_global_skills(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
     monkeypatch.setattr(codex_mod, "_which", _with_codex)
     monkeypatch.setattr(codex_mod, "_login_shell_mb_diagnostics", _codex_runtime_ok)
-    _prepare_codex_global_plugin(tmp_path, monkeypatch)
+    _prepare_codex_global_skill_roots(tmp_path, monkeypatch)
     repo = tmp_path / "biz"
     init_run(path=str(repo), name="Acme")
-    monkeypatch.setattr(
-        codex_mod,
-        "_codex_plugin_list",
-        lambda plugin_repo: _codex_plugin_list_result(Path(plugin_repo), installed=False),
-    )
-    monkeypatch.setattr(
-        codex_mod,
-        "install_plugin",
-        lambda plugin_repo: {
-            "ok": True,
-            "steps": [
-                {"ok": True, "command": codex_mod.codex_marketplace_add_command()},
-                {"ok": True, "command": codex_mod.CODEX_PLUGIN_INSTALL_COMMAND},
-            ],
-            "status": {
-                "ok": True,
-                "state": "ok",
-                "plugin_installed": True,
-                "plugin_enabled": True,
-                "slash_commands_ready": True,
-            },
-            "safe_to_share": True,
-        },
-    )
 
     result = runner.invoke(
         app, ["doctor", "repair", "--repo", str(repo), "--apply", "--only", "codex", "--json"]
@@ -599,12 +573,15 @@ def test_doctor_repair_apply_installs_missing_codex_plugin(
     assert result.exit_code in {0, 1}
     payload = json.loads(result.stdout)
     applied = {action["id"]: action for action in payload["applied_actions"]}
-    assert "codex-plugin-install" in applied
-    assert applied["codex-plugin-install"]["state"] == "ok"
-    assert codex_mod.CODEX_PLUGIN_INSTALL_COMMAND in applied["codex-plugin-install"]["command"]
+    assert "codex-global-skill" in applied
+    assert applied["codex-global-skill"]["state"] == "ok"
+    assert applied["codex-global-skill"]["command"] == "mb doctor repair --apply --only codex"
+    status = applied["codex-global-skill"]["result"]["status"]
+    assert status["skills"]["mb-start"]["ok"] is True
+    assert status["skills"]["mb-ads"]["ok"] is True
 
 
-def test_doctor_repair_apply_installs_missing_codex_plugin_with_runtime_path_warning(
+def test_doctor_repair_apply_installs_missing_codex_global_skills_with_runtime_path_warning(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
@@ -614,33 +591,9 @@ def test_doctor_repair_apply_installs_missing_codex_plugin_with_runtime_path_war
         "_login_shell_mb_diagnostics",
         _codex_runtime_path_mismatch_same_version,
     )
-    _prepare_codex_global_plugin(tmp_path, monkeypatch)
+    _prepare_codex_global_skill_roots(tmp_path, monkeypatch)
     repo = tmp_path / "biz"
     init_run(path=str(repo), name="Acme")
-    monkeypatch.setattr(
-        codex_mod,
-        "_codex_plugin_list",
-        lambda plugin_repo: _codex_plugin_list_result(Path(plugin_repo), installed=False),
-    )
-    monkeypatch.setattr(
-        codex_mod,
-        "install_plugin",
-        lambda plugin_repo: {
-            "ok": True,
-            "steps": [
-                {"ok": True, "command": codex_mod.codex_marketplace_add_command()},
-                {"ok": True, "command": codex_mod.CODEX_PLUGIN_INSTALL_COMMAND},
-            ],
-            "status": {
-                "ok": True,
-                "state": "ok",
-                "plugin_installed": True,
-                "plugin_enabled": True,
-                "slash_commands_ready": False,
-            },
-            "safe_to_share": True,
-        },
-    )
 
     result = runner.invoke(
         app, ["doctor", "repair", "--repo", str(repo), "--apply", "--only", "codex", "--json"]
@@ -649,8 +602,8 @@ def test_doctor_repair_apply_installs_missing_codex_plugin_with_runtime_path_war
     assert result.exit_code in {0, 1}
     payload = json.loads(result.stdout)
     applied = {action["id"]: action for action in payload["applied_actions"]}
-    assert "codex-plugin-install" in applied
-    assert applied["codex-plugin-install"]["state"] == "ok"
+    assert "codex-global-skill" in applied
+    assert applied["codex-global-skill"]["state"] == "ok"
 
 
 def test_doctor_repair_plan_reports_stale_codex_lifecycle_guidance(tmp_path: Path) -> None:

--- a/mb/tests/test_init.py
+++ b/mb/tests/test_init.py
@@ -102,20 +102,20 @@ def _assert_agents_md_codex_start_contract(text: str) -> None:
     normalized = _normalize(text)
     assert "## Codex Operating Contract" in text
     assert "Do not pretend Claude" in text
-    assert "Code skills work in Codex." in text
+    assert "global Main Branch skill route" in text
     assert "## Codex Lifecycle Workflow Index" in text
     assert "repo-level Codex bootstrap" in text
-    assert "installed globally once per user" in text
-    assert "repo-local plugin copies" in text
-    assert "Use the global Main Branch Codex plugin" in text
+    assert "skill bundle is installed globally once per user" in text
+    assert "repo-local plugin or skill" in text
+    assert "copies" in text
+    assert "Use the global Main Branch skills" in text
     assert "`runtime.codex_cli.status` is `runtime_mismatch`" in text
     assert "`codex_runtime_mb_mismatch`" in text
     assert "Start the day / what next / get oriented" in text
-    assert "supplies `/mb-*`" in text
+    assert "routes `mb-*`" in text
     assert "Inspect status / what changed / what is stale" in text
     assert "Think / research / decide / codify" in text
     assert "do not claim these workflows are ported to" in text
-    assert "/plugins" in text
     assert "## Codex Start Workflow" in text
     assert "This is the Codex-native start workflow" in text
     assert "## Codex Status Workflow" in text
@@ -241,7 +241,9 @@ def test_init_scaffolds_folders(tmp_path: Path) -> None:
     assert "/mb-start" in readme_md
     assert "Codex CLI" in readme_md
     assert "mb doctor repair --apply --only codex" in readme_md
-    assert "/mb-start" in readme_md.split("Or, in Codex CLI:", 1)[1]
+    codex_readme = readme_md.split("Or, in Codex CLI:", 1)[1]
+    assert "global `mb-start` skill" in codex_readme
+    assert "/mb-start" not in codex_readme
     assert "## Save, Checkpoint, Backup" in readme_md
     assert "A checkpoint is an approved saved point" in readme_md
     assert "GitHub backup/sync is strongly recommended" in readme_md

--- a/mb/tests/test_start.py
+++ b/mb/tests/test_start.py
@@ -59,27 +59,10 @@ def _without_codex(name: str) -> str:
     return shutil.which(name) or ""
 
 
-def _codex_plugin_list_result(repo: Path, *, installed: bool = True) -> dict[str, Any]:
-    marketplace = codex_mod.marketplace_path(repo)
-    plugin = codex_mod.plugin_manifest_path(repo).parent
-    status = "installed, enabled" if installed else "not installed"
-    return {
-        "ok": True,
-        "returncode": 0,
-        "stdout": (
-            f"Marketplace `{codex_mod.CODEX_MARKETPLACE_NAME}`\n"
-            f"{marketplace}\n\n"
-            "PLUGIN                                    STATUS              VERSION  PATH\n"
-            f"{codex_mod.CODEX_PLUGIN_SELECTOR}  {status}  0.1.0  {plugin}\n"
-        ),
-        "stderr": "",
-        "command": f"codex plugin list --marketplace {codex_mod.CODEX_MARKETPLACE_NAME}",
-    }
-
-
-def _prepare_codex_global_plugin(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("MAINBRANCH_CODEX_PLUGIN_ROOT", str(tmp_path / "codex-global"))
-    codex_mod.write_global_plugin_source()
+def _prepare_codex_global_skills(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MAINBRANCH_CODEX_SKILLS_ROOT", str(tmp_path / "codex-skills"))
+    monkeypatch.setenv("MAINBRANCH_CODEX_PLUGIN_ROOT", str(tmp_path / "codex-plugin"))
+    codex_mod.write_global_skill_source()
 
 
 def _codex_runtime_ok() -> dict[str, Any]:
@@ -103,18 +86,13 @@ def _codex_runtime_ok() -> dict[str, Any]:
     }
 
 
-def test_start_json_keeps_codex_slash_visibility_honest(tmp_path: Path, monkeypatch) -> None:
+def test_start_json_reports_codex_global_skill_handoff(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(start_mod, "_which", _with_claude)
     monkeypatch.setattr(codex_mod, "_which", _with_codex)
     monkeypatch.setattr(codex_mod, "_login_shell_mb_diagnostics", _codex_runtime_ok)
-    _prepare_codex_global_plugin(tmp_path, monkeypatch)
+    _prepare_codex_global_skills(tmp_path, monkeypatch)
     repo = tmp_path / "acme"
     init_run(path=str(repo), name="Acme")
-    monkeypatch.setattr(
-        codex_mod,
-        "_codex_plugin_list",
-        lambda plugin_repo: _codex_plugin_list_result(Path(plugin_repo)),
-    )
     (repo / "core" / "vocabulary.md").write_text(
         "---\n"
         "type: vocabulary\n"
@@ -139,9 +117,11 @@ def test_start_json_keeps_codex_slash_visibility_honest(tmp_path: Path, monkeypa
     assert report["runtime"]["skill_wiring"]["ok"] is True
     assert report["runtime"]["codex_cli"]["ok"] is True
     assert report["runtime"]["codex_cli"]["status"] == "ready"
-    assert report["runtime"]["codex_cli"]["plugin_ok"] is True
+    assert report["runtime"]["codex_cli"]["plugin_ok"] is False
+    assert report["runtime"]["codex_cli"]["global_skill_ok"] is True
     assert report["runtime"]["codex_cli"]["generated_guidance_ready"] is True
-    assert report["runtime"]["codex_cli"]["slash_commands_ready"] is True
+    assert report["runtime"]["codex_cli"]["slash_commands_ready"] is False
+    assert report["runtime"]["codex_cli"]["global_skill"]["skills"]["mb-start"]["ok"] is True
     assert report["runtime"]["codex_cli"]["instructions"]["ok"] is True
     assert report["experimental_runtimes"]["codex_cli"]["command"]["argv"] == [
         "codex",
@@ -153,15 +133,15 @@ def test_start_json_keeps_codex_slash_visibility_honest(tmp_path: Path, monkeypa
     codex_next_actions = "\n".join(
         report["experimental_runtimes"]["codex_cli"]["command"]["next_actions"]
     )
-    assert "/mb" in codex_next_actions
-    assert "restart Codex" in codex_next_actions
+    assert "global `mb-start`" in codex_next_actions
+    assert "restart Codex" not in codex_next_actions
     assert "Run `claude" not in next_actions
     assert report["command"]["argv"] == ["claude"]
     assert report["command"]["display"].endswith(" && claude")
     assert report["command"]["follow_up"] == "/mb-start"
     codex_prompt = report["experimental_runtimes"]["codex_cli"]["command"]["startup_prompt"]
-    assert "/mb-start" in codex_prompt
-    assert "with /mb-start" not in codex_prompt
+    assert "`mb-start`" in codex_prompt
+    assert "/mb-start" not in codex_prompt
     assert report["launch"]["requested"] is False
     assert report["checkpoint"]["pending"]["status"] == "ready"
     assert report["books"]["schema_version"] == "1.0"
@@ -204,7 +184,7 @@ def test_start_json_separates_codex_static_and_runtime_readiness(
     monkeypatch.setattr(start_mod, "_which", _with_claude)
     monkeypatch.setattr(codex_mod, "_which", _with_codex)
     monkeypatch.setattr(codex_mod, "_login_shell_mb_diagnostics", _codex_runtime_ok)
-    _prepare_codex_global_plugin(tmp_path, monkeypatch)
+    _prepare_codex_global_skills(tmp_path, monkeypatch)
     monkeypatch.setattr(
         codex_mod,
         "_login_shell_mb_diagnostics",
@@ -229,12 +209,6 @@ def test_start_json_separates_codex_static_and_runtime_readiness(
     )
     repo = tmp_path / "acme"
     init_run(path=str(repo), name="Acme")
-    monkeypatch.setattr(
-        codex_mod,
-        "_codex_plugin_list",
-        lambda plugin_repo: _codex_plugin_list_result(Path(plugin_repo)),
-    )
-
     result = runner.invoke(app, ["start", "--repo", str(repo), "--json"])
 
     assert result.exit_code == 0
@@ -258,32 +232,29 @@ def test_start_json_separates_codex_static_and_runtime_readiness(
     assert "mb status --json --peek" in top_level_actions
 
 
-def test_start_json_routes_to_codex_plugin_repair_when_plugin_is_missing(
+def test_start_json_routes_to_codex_global_skill_repair_when_skills_are_missing(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
     monkeypatch.setattr(start_mod, "_which", _with_claude)
     monkeypatch.setattr(codex_mod, "_which", _with_codex)
     monkeypatch.setattr(codex_mod, "_login_shell_mb_diagnostics", _codex_runtime_ok)
-    _prepare_codex_global_plugin(tmp_path, monkeypatch)
+    monkeypatch.setenv("MAINBRANCH_CODEX_SKILLS_ROOT", str(tmp_path / "codex-skills"))
+    monkeypatch.setenv("MAINBRANCH_CODEX_PLUGIN_ROOT", str(tmp_path / "codex-plugin"))
     repo = tmp_path / "acme"
     init_run(path=str(repo), name="Acme")
-    monkeypatch.setattr(
-        codex_mod,
-        "_codex_plugin_list",
-        lambda plugin_repo: _codex_plugin_list_result(Path(plugin_repo), installed=False),
-    )
 
     result = runner.invoke(app, ["start", "--repo", str(repo), "--json"])
 
     assert result.exit_code == 0
     report = json.loads(result.stdout)
     codex = report["runtime"]["codex_cli"]
-    assert codex["status"] == "plugin_not_installed"
+    assert codex["status"] == "global_skill_missing_or_stale"
+    assert codex["global_skill_ok"] is False
     assert codex["plugin_ok"] is False
-    assert codex["plugin_install"]["plugin_installed"] is False
+    assert "mb-start/SKILL.md" in codex["global_skill"]["missing"]
     next_actions = "\n".join(report["next_actions"])
-    assert codex_mod.CODEX_PLUGIN_INSTALL_COMMAND in next_actions
+    assert "mb doctor repair --plan --only codex" in next_actions
     assert f"codex -C {shlex.quote(str(repo.resolve()))}" not in next_actions
     assert "Run `claude" not in next_actions
 
@@ -302,7 +273,7 @@ def test_start_human_labels_missing_codex_without_experimental_copy(
     assert result.exit_code == 0
     assert "Codex" in result.stdout
     assert "missing" in result.stdout
-    assert "owner loop" in result.stdout
+    assert "global skills" in result.stdout
     assert "experimental" not in result.stdout
 
 

--- a/mb/tests/test_status.py
+++ b/mb/tests/test_status.py
@@ -65,6 +65,12 @@ def _prepare_codex_global_plugin(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     codex_mod.write_global_plugin_source()
 
 
+def _prepare_codex_global_skills(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MAINBRANCH_CODEX_PLUGIN_ROOT", str(tmp_path / "codex-global"))
+    monkeypatch.setenv("MAINBRANCH_CODEX_SKILLS_ROOT", str(tmp_path / "codex-skills"))
+    codex_mod.write_global_skill_source()
+
+
 def _codex_runtime_ok() -> dict[str, Any]:
     return {
         "checked": True,
@@ -1454,71 +1460,56 @@ def test_status_warns_when_codex_runtime_uses_stale_mb(
     assert "login-shell PATH" in finding["repair"]
 
 
-def test_status_marks_codex_not_ready_when_plugin_is_not_installed(
+def test_status_marks_codex_not_ready_when_global_skills_are_missing(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
     monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
     monkeypatch.setattr(codex_mod, "_which", _with_codex)
     monkeypatch.setattr(codex_mod, "_login_shell_mb_diagnostics", _codex_runtime_ok)
-    _prepare_codex_global_plugin(tmp_path, monkeypatch)
+    monkeypatch.setenv("MAINBRANCH_CODEX_PLUGIN_ROOT", str(tmp_path / "codex-global"))
+    monkeypatch.setenv("MAINBRANCH_CODEX_SKILLS_ROOT", str(tmp_path / "codex-skills"))
     repo = tmp_path / "acme"
     init_run(path=str(repo), name="Acme")
-    monkeypatch.setattr(
-        codex_mod,
-        "_codex_plugin_list",
-        lambda plugin_repo: _codex_plugin_list_result(Path(plugin_repo), installed=False),
-    )
 
     report = status_mod.run(path=str(repo), update_marker=False)
 
     codex = report["runtime"]["codex_cli"]
     assert codex["ok"] is False
-    assert codex["status"] == "plugin_not_installed"
+    assert codex["status"] == "global_skill_missing_or_stale"
     assert codex["static_ok"] is True
     assert codex["runtime_ok"] is True
-    assert codex["plugin_ok"] is False
-    assert codex["plugin_install"]["marketplace_registered"] is True
-    assert codex["plugin_install"]["plugin_installed"] is False
+    assert codex["global_skill_ok"] is False
+    assert "mb-start/SKILL.md" in codex["global_skill"]["missing"]
     finding = next(
-        item for item in report["drift"]["items"] if item["id"] == "codex_plugin_not_installed"
+        item for item in report["drift"]["items"] if item["id"] == "codex_global_skills_not_ready"
     )
-    assert codex_mod.CODEX_PLUGIN_INSTALL_COMMAND in finding["repair"]
+    assert "mb doctor repair --apply --only codex" in finding["repair"]
 
 
-def test_status_marks_codex_ready_when_command_surface_is_installed(
+def test_status_marks_codex_ready_when_global_skills_are_installed(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
     monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
     monkeypatch.setattr(codex_mod, "_which", _with_codex)
     monkeypatch.setattr(codex_mod, "_login_shell_mb_diagnostics", _codex_runtime_ok)
-    _prepare_codex_global_plugin(tmp_path, monkeypatch)
+    _prepare_codex_global_skills(tmp_path, monkeypatch)
     repo = tmp_path / "acme"
     init_run(path=str(repo), name="Acme")
-    monkeypatch.setattr(
-        codex_mod,
-        "_codex_plugin_list",
-        lambda plugin_repo: _codex_plugin_list_result(Path(plugin_repo)),
-    )
 
     report = status_mod.run(path=str(repo), update_marker=False)
 
     codex = report["runtime"]["codex_cli"]
     assert codex["ok"] is True
     assert codex["status"] == "ready"
-    assert codex["plugin_ok"] is True
+    assert codex["global_skill_ok"] is True
     assert codex["generated_guidance_ready"] is True
     assert codex["command_surface_ok"] is True
-    assert codex["slash_commands_ready"] is True
-    assert codex["plugin_install"]["plugin_installed"] is True
-    assert codex["plugin_install"]["plugin_enabled"] is True
-    assert codex["plugin_install"]["skill_ready"] is False
-    assert codex["plugin_install"]["command_files_current"] is True
-    assert codex["plugin_install"]["slash_commands_ready"] is True
-    assert codex["plugin_install"]["slash_commands_likely_loaded"] is False
-    assert codex["plugin_install"]["slash_commands_restart_required"] is True
-    assert not any(item["id"] == "codex_plugin_not_installed" for item in report["drift"]["items"])
+    assert codex["slash_commands_ready"] is False
+    assert set(codex["global_skill"]["required_skills"]) == set(codex_mod.CODEX_GLOBAL_SKILL_NAMES)
+    assert codex["global_skill"]["skills"]["mb-start"]["ok"] is True
+    assert codex["global_skill"]["skills"]["mb-ads"]["ok"] is True
 
 
 def test_status_json_exposes_push_and_legacy_campaign_facts(tmp_path: Path, monkeypatch) -> None:
@@ -2138,7 +2129,7 @@ def test_status_human_labels_missing_codex_without_experimental_copy(
     result = runner.invoke(app, ["status", str(repo), "--no-color", "--peek"])
 
     assert result.exit_code == 0
-    assert "Codex: missing owner loop" in result.stdout
+    assert "Codex: missing global skills" in result.stdout
     assert "experimental" not in result.stdout
 
 

--- a/mb/tests/test_update.py
+++ b/mb/tests/test_update.py
@@ -250,7 +250,7 @@ def test_update_points_to_scoped_codex_repair_when_adapter_missing(
     )
 
 
-def test_update_points_to_scoped_codex_repair_when_plugin_is_missing(
+def test_update_points_to_scoped_codex_repair_when_global_skills_are_missing(
     monkeypatch: Any, tmp_path: Path
 ) -> None:
     def fake_run(args: list[str], *, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
@@ -282,16 +282,22 @@ def test_update_points_to_scoped_codex_repair_when_plugin_is_missing(
         "readiness",
         lambda repo: {
             "ok": False,
-            "status": "plugin_not_installed",
+            "status": "global_skill_missing_or_stale",
             "static_ok": True,
             "runtime_ok": True,
+            "global_skill_ok": False,
             "plugin_ok": False,
-            "repair": f"Run `{codex_mod.CODEX_PLUGIN_INSTALL_COMMAND}`.",
+            "repair": "mb doctor repair --apply --only codex",
             "instructions": {
                 "ok": True,
                 "exists": True,
                 "current": True,
                 "repair_command": "",
+            },
+            "global_skill": {
+                "ok": False,
+                "state": "global_skill_missing_or_stale",
+                "repair": "mb doctor repair --apply --only codex",
             },
             "plugin_install": {
                 "ok": False,
@@ -307,15 +313,15 @@ def test_update_points_to_scoped_codex_repair_when_plugin_is_missing(
     result = update_mod.run(repo=tmp_path / "biz")
 
     assert result["ok"] is True
-    assert result["codex_adapter"]["status"] == "plugin_not_installed"
-    assert result["codex_adapter"]["plugin_ok"] is False
+    assert result["codex_adapter"]["status"] == "global_skill_missing_or_stale"
+    assert result["codex_adapter"]["global_skill_ok"] is False
     assert "mb doctor repair --plan --only codex" in result["next_actions"]
     assert any(
-        "global Main Branch Codex plugin is not ready" in item for item in result["warnings"]
+        "global Main Branch Codex skills are not ready" in item for item in result["warnings"]
     )
 
 
-def test_update_reports_manual_codex_slash_visibility_verification(
+def test_update_does_not_gate_ready_codex_on_slash_commands(
     monkeypatch: Any, tmp_path: Path
 ) -> None:
     def fake_run(args: list[str], *, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
@@ -350,6 +356,7 @@ def test_update_reports_manual_codex_slash_visibility_verification(
             "status": "ready",
             "static_ok": True,
             "runtime_ok": True,
+            "global_skill_ok": True,
             "plugin_ok": True,
             "generated_guidance_ready": True,
             "command_surface_ok": True,
@@ -360,6 +367,11 @@ def test_update_reports_manual_codex_slash_visibility_verification(
                 "exists": True,
                 "current": True,
                 "repair_command": "",
+            },
+            "global_skill": {
+                "ok": True,
+                "state": "ok",
+                "repair": "",
             },
             "plugin_install": {
                 "ok": True,
@@ -381,14 +393,13 @@ def test_update_reports_manual_codex_slash_visibility_verification(
     assert result["codex_adapter"]["plugin_ok"] is True
     assert result["codex_adapter"]["ok"] is True
     assert result["codex_adapter"]["slash_commands_ready"] is False
-    assert "mb doctor repair --plan --only codex" in result["next_actions"]
-    assert "mb doctor repair --apply --only codex" in result["next_actions"]
-    assert any("commands are missing or stale" in item for item in result["warnings"])
+    assert "mb doctor repair --plan --only codex" not in result["next_actions"]
+    assert not any("missing or stale" in item for item in result["warnings"])
     assert not any("Codex command API" in item for item in result["next_actions"])
     assert not any("Codex command API" in item for item in result["warnings"])
 
 
-def test_update_surfaces_codex_restart_when_commands_were_refreshed(
+def test_update_surfaces_fresh_codex_thread_when_plugin_commands_were_refreshed(
     monkeypatch: Any, tmp_path: Path
 ) -> None:
     def fake_run(args: list[str], *, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
@@ -456,8 +467,8 @@ def test_update_surfaces_codex_restart_when_commands_were_refreshed(
     assert result["codex_adapter"]["slash_commands_ready"] is True
     assert result["codex_adapter"]["slash_commands_likely_loaded"] is False
     assert result["codex_adapter"]["slash_commands_restart_required"] is True
-    assert "Restart Codex, then type `/mb`." in result["next_actions"]
-    assert any("slash command surface loaded" in item for item in result["warnings"])
+    assert "Open a fresh Codex thread in the business repo." in result["next_actions"]
+    assert any("global Main Branch skill bundle" in item for item in result["warnings"])
 
 
 def test_update_check_clone_fetches_before_reading_origin(monkeypatch: Any, tmp_path: Path) -> None:

--- a/mb/tests/test_workflows.py
+++ b/mb/tests/test_workflows.py
@@ -170,13 +170,14 @@ def test_codex_command_surface_and_inventory_render() -> None:
     assert '"skills": "./skills/"' not in manifest
     assert "main-branch-owner-loop" not in manifest
     assert '"path": "./.agents/plugins/main-branch"' in marketplace
-    assert "Codex plugin files and `/mb-*` command files are installed globally" in inventory
-    assert "codex plugin list --marketplace main-branch" in inventory
+    assert "global Main Branch skill bundle is installed" in inventory
+    assert "codex plugin list --marketplace main-branch" not in inventory
     assert ".claude/skills/mb-start/SKILL.md" in inventory
     assert ".claude/skills/mb-skill-review/SKILL.md" in inventory
-    assert "codex plugin marketplace add" in inventory_json["plugin"]["install_hint"]
-    assert codex_mod.CODEX_PLUGIN_INSTALL_COMMAND in inventory_json["plugin"]["install_hint"]
-    assert "`/mb-start`" in inventory
+    assert "plugin" not in inventory_json
+    assert inventory_json["global_skill"]["install_hint"] == "mb doctor repair --apply --only codex"
+    assert "mb-start" in inventory_json["global_skill"]["routes"]
+    assert "`main-branch mb-start`" in inventory
     assert "pending_shared_source_migration" in inventory
     assert "intentionally_unsupported" in inventory
     assert "Copied Claude" not in "\n".join(commands.values())
@@ -241,7 +242,7 @@ def test_codex_workflow_inventory_command_lists_supported_and_pending_surfaces()
 
     assert result.exit_code == 0
     data = json.loads(result.stdout)
-    assert data["support_level"] == "supported_main_branch_slash_commands"
+    assert data["support_level"] == "supported_global_main_branch_skill"
     statuses = set(data["statuses"])
     assert {
         "supported",
@@ -251,10 +252,10 @@ def test_codex_workflow_inventory_command_lists_supported_and_pending_surfaces()
     }.issubset(statuses)
     by_id = {item["id"]: item for item in data["items"]}
     assert by_id["think-codify"]["codex_status"] == "supported"
-    assert by_id["think-codify"]["codex_entrypoints"] == ["/mb-think"]
+    assert by_id["think-codify"]["codex_entrypoints"] == ["main-branch mb-think"]
     assert by_id["daily-start-status"]["codex_entrypoints"] == [
-        "/mb-start",
-        "/mb-status",
+        "main-branch mb-start",
+        "main-branch mb-status",
     ]
     assert by_id["daily-start-status"]["claude_skill_sources"] == [
         ".claude/skills/mb-start/SKILL.md",
@@ -262,13 +263,9 @@ def test_codex_workflow_inventory_command_lists_supported_and_pending_surfaces()
     ]
     assert by_id["ads"]["codex_status"] == "pending_shared_source_migration"
     assert by_id["wiki"]["codex_status"] == "intentionally_unsupported"
-    assert data["plugin"]["manifest_path"] == codex_mod.CODEX_PLUGIN_MANIFEST_RELATIVE_PATH
-    assert data["plugin"]["commands_path"] == codex_mod.CODEX_PLUGIN_COMMANDS_RELATIVE_PATH
-    assert data["plugin"]["slash_commands_generated"] is True
-    assert data["plugin"]["slash_commands_ready"] is False
-    assert set(data["plugin"]["generated_command_files"]) == set(
-        codex_mod.CODEX_SLASH_COMMAND_RELATIVE_PATHS
-    )
+    assert "plugin" not in data
+    assert data["global_skill"]["path"] == codex_mod.CODEX_GLOBAL_SKILL_RELATIVE_PATH
+    assert "mb-start" in data["global_skill"]["routes"]
 
 
 def test_codex_workflow_inventory_accounts_for_every_bundled_claude_skill() -> None:


### PR DESCRIPTION
## Summary

Corrects Codex support to the proven global skill model:

- installs the full Main Branch Codex skill/playbook bundle under the Codex skills root, one folder per route
- makes `mb doctor repair --apply --only codex` write/update that bundle without requiring the Codex CLI binary
- makes `mb status`, `mb start`, `mb update`, and `mb workflow list --runtime codex --json` treat global skills as the supported Codex surface
- removes plugin/slash-command readiness from the public workflow inventory and current readiness gates

## In Scope

- Codex global skills: `main-branch`, `mb-start`, `mb-status`, `mb-setup`, `mb-update`, `mb-doctor`, `mb-think`, `mb-end`, `mb-help`, business workflow skills, and playbooks.
- Repo `AGENTS.md` and onboarding README guidance for Codex.
- Legacy owner-loop/plugin artifact cleanup where repair already owns it.

## Out Of Scope

- Proving literal Codex Desktop `/mb-*` slash commands.
- All-agent dry-run UX and receipt polish. Filed #722.
- Full provider mutation parity in Codex.

## Success Metric

A fresh package install can run `mb doctor repair --apply --only codex` and produce a complete Codex global skill bundle, then `mb status --json --peek` reports `runtime.codex_cli.status: ready` with `global_skill_ok: true` and no visible `main-branch-owner-loop` skill.

## Validation

- Level 1/static: `scripts/check.sh` passed.
- Level 2/focused CLI: `pytest tests/test_start.py tests/test_status.py tests/test_doctor.py tests/test_update.py -q` passed (`193 passed`).
- Level 3/package/install smoke:
  - built wheel with `python3 -m build`
  - installed into `/tmp/mainbranch-439-smoke`
  - ran isolated `mb onboard`
  - ran `MAINBRANCH_CODEX_SKILLS_ROOT=/tmp/mainbranch-439-codex-skills MAINBRANCH_CODEX_PLUGIN_ROOT=/tmp/mainbranch-439-codex-plugin mb doctor repair --apply --only codex --json`
  - verified 20 generated `SKILL.md` files, including `mb-start` and `weekly-review`
  - verified `mb status --json --peek`: `codex_status ready`, `global_skill_ok true`, `slash_commands_ready false`

## Public/Private Boundary

No private paths are committed. Temp smoke paths and logs stayed in `.agent` or `/tmp`.

Closes #721
Refs #722
