### PR TITLE
[update] README conversion and beginner setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 <h1 align="center">Main Branch</h1>
 
-<p align="center"><strong>Durable operating memory for AI-assisted businesses.</strong></p>
+<p align="center"><strong>Give your AI the business brain it was missing.</strong></p>
 
-<p align="center"><code>AI should remember your business before it answers.</code></p>
+<p align="center"><em>One folder for your offers, proof, research, decisions, launches, ads, pages, bets, and lessons, readable by Claude Code, Codex, and you.</em></p>
 
 <p align="center">
   <a href="https://github.com/noontide-co/mainbranch/stargazers"><img alt="GitHub stars" src="https://img.shields.io/github/stars/noontide-co/mainbranch?style=social"></a>
@@ -18,162 +18,54 @@
 </p>
 
 <p align="center">
-  <strong>Overview:</strong>
-  <a href="#what-is-main-branch">What it is</a> &middot;
-  <a href="#the-operating-loop">Operating loop</a> &middot;
-  <a href="#what-you-can-do-today">Features</a>
-</p>
-
-<p align="center">
-  <strong>Get started:</strong>
   <a href="#quickstart"><strong>Quickstart</strong></a> &middot;
-  <a href="docs/beginner-setup.md"><strong>Beginner setup</strong></a> &middot;
-  <a href="docs/compatibility.md"><strong>Compatibility</strong></a>
-</p>
-
-<p align="center">
-  <strong>Resources:</strong>
-  <a href="docs/ethos.md"><strong>Ethos</strong></a> &middot;
-  <a href="docs/roadmap.md"><strong>Roadmap</strong></a> &middot;
-  <a href="https://skool.com/main"><strong>Community</strong></a>
+  <a href="#what-changes">What changes</a> &middot;
+  <a href="#what-it-actually-does">What it does</a> &middot;
+  <a href="#named-workflows">Workflows</a> &middot;
+  <a href="#works-with">Works with</a> &middot;
+  <a href="docs/beginner-setup.md">Beginner setup</a>
 </p>
 
 ---
 
-## What is Main Branch?
+<!--
+  HERO VISUAL - ADD BEFORE PUBLISHING
+  Best README conversion asset:
+    1. Open a sample business folder.
+    2. Open the folder in Claude Code or Codex, then run `/mb-start`.
+    3. Show the agent reading Main Branch facts and naming the next business move.
+    4. Flash to `mb checkpoint --plan` or `mb graph --open`.
+  Save to docs/assets/hero.gif and uncomment the image below.
+-->
+<!-- <p align="center"><img src="docs/assets/hero.gif" alt="Main Branch in action" width="780" /></p> -->
 
-**You don't need to know git. You don't need to know terminals. You just need a folder.**
+## Why this exists
 
-Main Branch is a folder on your computer that holds your business — offer, audience, voice, team context, decisions, research, bets, launches, meeting notes, fulfillment context, lessons. The agent reads that folder before it answers, so the work it gives you sounds like your business instead of generic AI output. The system saves itself between sessions, so you stop re-explaining who you are every time you open Claude.
+Your business context is probably scattered: a Notion page for the offer, Looms
+for voice, Google Docs for research, a few chats with good ideas, a launch plan
+somewhere, and decisions no one can find when the next AI session starts.
 
-Open source. Lives on your machine. Bring your own Claude Code plan. That's it.
+Main Branch turns one folder on your computer into business memory your agent
+reads before it answers, then saves approved decisions, launches, bets, pages,
+ads, research, and lessons back into files you own.
 
-|        | Step             | What happens                                                                 |
-| ------ | ---------------- | ---------------------------------------------------------------------------- |
-| **01** | Open the folder  | One business, one folder. Your offer, voice, audience, and history live here.|
-| **02** | Talk to the agent| It reads the folder before it speaks. No re-pasting. No re-explaining.       |
-| **03** | The work ships   | Drafts, ad copy, landing pages, decisions. You approve. It saves itself.     |
+It is built for revenue-producing work: sharpening offers, building proof,
+planning launches, writing ads, creating organic content, checking pages,
+tracking bets, and turning what you learn into the next decision.
 
----
+Open the folder. Run `/mb-start`. Tell the agent what you want help with. Main
+Branch checks what changed, what matters, and what to do next.
 
-<div align="center">
-  <em>Works with</em> <strong>Claude Code</strong> and <strong>Codex CLI</strong>. Cursor, OpenClaw, Hermes, and local runtimes remain compatibility targets — see <a href="docs/compatibility.md">compatibility</a>.
-</div>
+| Step | What you do | What happens |
+| --- | --- | --- |
+| **01** | Open the business folder | Your offer, audience, voice, proof, research, bets, pushes, logs, and documents live there. |
+| **02** | Run `/mb-start` | The agent checks current Main Branch facts before giving advice: status, MoneyPath, recent work, connected tools, drift, checkpoints, and next actions. |
+| **03** | Pick the next move | The agent routes the work into an offer, bet, decision, push, playbook, research note, outcome, or checkpoint. |
+| **04** | Approve the work | Writing files, publishing, spending, account changes, and customer contact stay your call. |
+| **05** | Keep the lesson | Approved work becomes durable memory for the next session. |
 
----
-
-## Main Branch is right for you if
-
-- You're a solo founder, small agency owner, course creator, productized-services operator, indie SaaS founder, or small ecom team
-- Your offer lives in Notion, your voice lives in Loom transcripts, your research lives in three Google Docs you can't find
-- Every chat session with your AI starts from zero and the output sounds generic
-- You're paying for SaaS dashboards that get more expensive without getting smarter
-- You want the work to live somewhere you own — not on someone else's server
-- You want a system that gets better the longer you use it, instead of starting fresh every Monday
-
----
-
-## What stops you isn't what you think
-
-| What stops you                                          | What's actually true                                                              |
-| ------------------------------------------------------- | --------------------------------------------------------------------------------- |
-| "I'm not technical enough. I don't know git, terminals, or any of that." | If you can move a file into a folder, the system handles the rest.       |
-| "I'll set it up wrong and not know."                    | The system tells you the next command. It can't get lost.                         |
-| "I'd mess it up and lose everything."                   | Every change can be saved and reviewed. Mistakes don't stick.                     |
-| "I need a clear plan before I start."                   | Start with the folder. The system explains itself in plain English as you go.     |
-| "I need someone to sit down and walk me through it."    | Type `/mb-start` in Claude. The agent explains. You go at your own pace.          |
-| "I won't keep up with the maintenance."                 | When something falls out of date, the system tells you the exact next step.       |
-
----
-
-## What changes vs. just AI
-
-| Just AI                                                 | Main Branch + Claude                                                              |
-| ------------------------------------------------------- | --------------------------------------------------------------------------------- |
-| Every chat starts from zero. You re-paste your context. | The agent reads your folder before it answers.                                    |
-| Output sounds like every other AI.                      | Output sounds like you — because the agent reads your voice files first.          |
-| Important decisions live in chat that disappears.       | Decisions live as plain notes you can read on a Tuesday.                          |
-| You build the system yourself: prompts, files, glue.    | The rails are built. Your business folder plugs in.                               |
-| Another rented subscription. Gets more expensive.       | Claude Code + a folder you own forever. Your stuff still works without us.        |
-
----
-
-## The operating loop
-
-Main Branch is chat-first for the operator and CLI-backed under the hood.
-
-1. **Your folder remembers.** Your core files, research, decisions, bets, pushes,
-   logs, documents, and checkpoints hold the business truth.
-2. **`mb` checks facts.** The CLI reads the repo and returns deterministic
-   status, graph, provider, MoneyPath, proof-quality, content-strategy,
-   books-readiness, and checkpoint facts.
-3. **The agent explains.** Claude Code skills turn those facts into plain
-   business guidance, route the work, and ask for the missing decision.
-4. **You approve action.** Writing files, publishing, spending money, mutating
-   provider accounts, and contacting customers stay intentional operator
-   choices.
-5. **The lesson becomes memory.** Accepted work and useful lessons land back in
-   the repo as durable business context for the next session.
-
-Normal users ask the agent. The agent runs `mb` internally. Power users can
-still run the same commands directly when they want to inspect, script, debug,
-or build on the system.
-
----
-
-## What you can do today
-
-- Research a topic and turn it into a decision the system remembers
-- Open, run, close, and narrate business bets so the lessons stick around
-- Plan and run launches, drops, challenges, and promos as repeatable playbooks
-- Generate ad copy, video scripts, organic content (Reels, TikTok, carousels), and page copy in your voice
-- Draft and ship landing pages on Cloudflare from your core files and research
-- Capture meeting transcripts, source material, and fulfillment notes into durable docs
-- Save readable progress points during long agent runs so the next session starts where this one stopped
-- Clean up stale folders, broken links, and old settings before they break a session
-- Turn errors and confusing steps into clean public GitHub issues without leaking your business data
-- Close sessions intentionally with a crystallize moment that updates your durable memory
-
-You don't run any of these commands yourself. You ask the agent. It runs them.
-
----
-
-## What's underneath
-
-Main Branch v0.3 has three layers:
-
-- **Your folder is the source of truth.** Offer, audience, voice, public-safe team roles, decisions, research, bets, launches, logs, documents, links to other repos. Plain markdown files you can read on any computer.
-- **The CLI is the fact and safety layer.** It scaffolds the folder, validates the shape, maps how the business pieces connect, briefs the agent on what's changed, walks through repairs, saves readable checkpoints, and checks that connected accounts are wired up safely. It also exposes shipped facts for MoneyPath readiness, proof quality, content strategy health, books readiness, connected-account health, status, start, graph, and checkpoint workflows. The agent runs it. You don't have to learn it.
-- **The skills are the chat UX and judgment layer.** The agent reads your folder and `mb` facts, asks you the right questions, drafts work, reviews it, and routes approved artifacts back into files.
-
-Agent recommends. You decide what gets shipped, spent, published, or saved.
-
-The longer-arc operating-memory model — where multiple business repos, GitHub teams, structured data, and runtime adapters compose into a full team operating system — is direction, not the v0.3 shape. See [`decisions/2026-05-15-repo-owned-operating-memory.md`](decisions/2026-05-15-repo-owned-operating-memory.md).
-
----
-
-## What Main Branch is not
-
-|                                  |                                                                                                |
-| -------------------------------- | ---------------------------------------------------------------------------------------------- |
-| **Not a chat app.**              | The supported chat surfaces are Claude Code and Codex CLI. Main Branch gives agents durable context to read from. |
-| **Not a SaaS dashboard.**        | Your business doesn't live on our servers. It lives in your folder.                            |
-| **Not a connect-every-tool hub.**| We pick boring, inspectable rails: GitHub, Cloudflare, official ads paths. Curated, not sprawl.|
-| **Not a model host.**            | We don't run models. We hand the agent the right context so the model you already use is sharper.|
-| **Not magic.**                   | The work is still real. The foundation is just the right one to build on.                      |
-
----
-
-## Direction, not promises
-
-The current package is the chat-first daily operating loop: open the folder,
-start Claude Code, let the agent read `mb` facts, choose the next business
-move, ship approved work, and save a readable checkpoint. Next direction
-tightens the same loop, expands curated provider rails, deepens offer and
-market research guidance, and prepares an optional local dashboard that reads
-from repo and CLI facts instead of replacing them.
-
-Mobile thought capture, team views, finance/fulfillment roll-ups, broader Ops/bookkeeping, an optional dashboard, and any future hosted/model-invocation surface are eventual targets in [docs/roadmap.md](docs/roadmap.md), not current behavior.
+If you want AI business memory that stays yours, star this repo so more
+business owners find it.
 
 ---
 
@@ -181,203 +73,397 @@ Mobile thought capture, team views, finance/fulfillment roll-ups, broader Ops/bo
 
 Start with the folder that should become your business brain:
 
+Tell the agent what you are setting up. It should create or connect the business
+folder, not save your note as another document.
+
 ```bash
 pipx install mainbranch
 mb onboard --name "My Business" --path my-business
-cd my-business
-claude
-/mb-start
 ```
 
-That's it. `mb onboard` creates the folder, wires Claude Code, and shows the next step. `/mb-start` reads the folder and tells you what to do.
+`mb onboard` creates the folder, prepares Claude Code and Codex, and shows the next step.
+`/mb-start` reads the folder and Main Branch facts, then tells you what to do.
 
-If you open Claude Code or Codex CLI in an empty folder first, paste the
-folder-first bootstrap from [beginner setup](docs/beginner-setup.md#folder-first-bootstrap).
-It tells the agent this is setup intent, not a document to save, and routes it
-to deterministic `mb onboard` checks before anything writes.
+### Daily use
 
-GitHub backup/sync is strongly recommended for almost everyone. It does not
-need to cost anything, and it gives the business brain cloud backup, readable
-saved history, shared tasks/proposals, and a repo that AI tools with GitHub
-connectors can read. Before choosing the GitHub-backed setup path, install
-GitHub CLI and confirm it is signed in to the account you expect:
+1. Open or select the business folder in Claude Code or Codex.
+2. Run `/mb-start`.
+3. Tell the agent what you want help with: an offer, page, ad, launch, research
+   question, decision, or cleanup.
+
+You do not need to make terminal commands your daily workflow.
+
+Use either Claude Code or Codex. Both start from the same business folder.
+Step-by-step walkthrough: [docs/beginner-setup.md](docs/beginner-setup.md).
+
+### Backup and sync
+
+GitHub backup/sync is strongly recommended. It gives the business brain cloud
+backup, readable saved history, shared tasks/proposals, and a repo that AI tools
+with GitHub connectors can read. Before using the GitHub-backed path, confirm
+GitHub is signed in on your computer:
 
 ```bash
 gh auth status
 gh api user --jq .login
 ```
 
-After the first session, the daily flow is:
+To create the folder, save the first scaffold, create a private GitHub repo,
+and push it in one pass:
 
 ```bash
-cd /path/to/my-business
-claude
-/mb-start
+mb onboard --yes --name "My Business" --path my-business --github owner/my-business --github-visibility private --push
 ```
 
-You'll need a Claude plan that includes Claude Code. Install Claude Code from [claude.ai](https://claude.ai). Step-by-step beginner walkthrough: [docs/beginner-setup.md](docs/beginner-setup.md).
+Tested on macOS and Linux. Windows is experimental; use WSL2 for the closest
+supported path.
 
-### Using Codex CLI
+---
 
-Codex CLI is supported through global Main Branch `mb-*` skills installed under
-the Codex global skills root and deterministic `mb` facts. Fresh business
-folders include a tracked `AGENTS.md` bootstrap. The skills install globally
-once per user and read the current business repo through deterministic `mb`
-facts. That lets Codex start the day, inspect status, route setup/update/doctor
-work, think through or codify a decision, plan an end/checkpoint/save closeout,
-validate the repo, and list workflow support.
+## What changes
 
-Expect Codex to run `mb status --json --peek`, `mb start --json`,
-`mb doctor repair --plan --json`, `mb checkpoint --plan --json`,
-`mb validate --json`, and `mb workflow list --runtime codex --json`, then
-translate those facts into a useful owner briefing. Do not expect all Claude
-Code skills, site, ads, publishing, provider mutation, spend, or
-customer-contact workflows to be ported there.
+| Just AI | Main Branch + Agent |
+| --- | --- |
+| Context lives in chats, projects, docs, and memory you manage manually. | Business truth lives in a folder the agent reads every session. |
+| Output can drift away from your offer, voice, proof, or latest decision. | The agent reads current files and Main Branch facts before acting. |
+| Decisions disappear into conversation history. | Decisions become plain files future sessions can cite. |
+| Long workflows are hard to pause and resume. | Checkpoints preserve approved progress in readable history. |
+| Tool setup breaks silently. | Main Branch checks health and shows repair paths. |
+| Connected accounts can leak secrets or blur authority. | Secrets stay outside tracked files, and account changes stay approval-gated. |
 
-After installing Codex CLI, test a new repo with:
+---
 
-```bash
-mb onboard --yes --name "Codex Smoke Business" --path codex-smoke-business
-cd codex-smoke-business
-mb doctor repair --plan --only codex
-mb doctor repair --apply --only codex
-codex
-```
+## What it actually does
 
-Open a fresh Codex thread after repair and use the `mb-start` skill. Codex
-should start from read-only `mb` facts and ask before writing files.
+The short version: Main Branch makes AI business work durable, inspectable, and
+grounded in the business you are actually running.
 
-For a read-only smoke test:
+### 1. Starts every session from business facts
 
-```bash
-codex exec --json --ephemeral --sandbox read-only -c 'approval_policy="never"' -C . \
-  'Start this Main Branch business day. Run only read-only mb checks and do not edit files.'
-git status --short
-```
+`/mb-start` is the daily entry point. It checks:
 
-The smoke passes when Codex uses the `mb` fact commands and `git status --short`
-stays clean. See [docs/compatibility.md](docs/compatibility.md) for the current
-support boundary.
+- what changed since last time;
+- what is unsaved or needs a checkpoint;
+- whether offer, proof, CTA, page, channel, push, playbook, and outcome
+  feedback are connected;
+- whether content strategy, bookkeeping setup, connected tools, updates, or
+  folder health need attention;
+- the ranked next actions with the signals behind them.
 
-Tested on macOS and Linux. Windows is experimental — use WSL2.
+You ask the agent. Main Branch runs the checks underneath the conversation.
+
+### 2. Saves long AI sessions as readable history
+
+Pause a four-hour research, offer, ad, or site session. Come back Monday. Scan
+your history in plain English.
+
+When you ask to save progress, Main Branch previews the changed files, proposes
+a readable checkpoint, blocks obvious secrets and scratch files, and waits for
+approval. `/mb-end` uses the same save path to close a session.
+
+This is not noisy autosave and not blanket automatic pushing. It is approved
+business memory at meaningful boundaries.
+
+### 3. Runs real business workflows
+
+Main Branch skills run multi-step workflows, not prompt snippets:
+
+- **`/mb-think`** researches, sharpens offers, turns source material into
+  decisions, analyzes sales videos, and cleans up stale claims.
+- **`/mb-ads`** creates paid creative: hooks, static ads, image prompts, video
+  scripts, long-form paid creative, launch plans, optional read-only account
+  checks, and 6-lens P1/P2/P3 compliance review.
+- **`/mb-organic`** creates Reels, TikToks, carousels, static posts, and
+  sales-video repurposing drafts from your voice and content strategy.
+- **`/mb-site`** supports landers, minisites, websites, Cloudflare Pages,
+  concept variations, pitch scripts, VSL-style work, and paid-traffic
+  measurement checks.
+- **`/mb-bet`** opens, updates, closes, lists, and narrates business bets with
+  appetite, metrics, deadlines, evidence, kill/double-down thinking, and
+  graduation paths.
+- **`/mb-end`** closes a session with summary, crystallization, and approved
+  checkpoint options.
+
+Playbooks and push records turn repeatable work into durable business memory.
+They record plans, approval gates, connected-account boundaries, manual steps, and
+outcomes without giving the agent hidden authority to publish, spend, DM, or
+mutate accounts.
+
+### 4. Builds a graph of your business
+
+Main Branch can map how decisions, research, bets, launches, pages, files, and
+connected tools relate. Use the graph to see what the agent is reading from
+instead of trusting a black box.
+
+### 5. Keeps the business folder healthy
+
+Main Branch checks structure, links, setup, updates, connected tools, saved
+history, and business relationships so the agent does not have to guess.
+
+It can show what changed, what needs repair, what is ready to ship, what still
+needs approval, and where the next useful action is.
+
+### 6. Connects real tools safely
+
+Main Branch is not a connect-every-SaaS hub. It connects to real tools only
+where that makes daily business work clearer and safer.
+
+The choices are deliberate. GitHub is for saved history and proposals.
+Cloudflare is the launch rail for domains, DNS, websites, ad landing pages, and
+small always-on tools. Bookkeeping uses plain files so owners have an exit path
+from QuickBooks-style software. Social and ad tools stay narrow until posting,
+spend, or account changes can be handled safely.
+
+| Tool | What Main Branch does |
+| --- | --- |
+| **GitHub** | Backup, saved history, tasks/proposals, folder detection, and privacy-scrubbed public issue drafting. First-run setup can create and push a GitHub repo when you choose that path. |
+| **Cloudflare** | The default web launch path: domain and DNS work, websites, ad landing pages, Cloudflare Pages, and future Workers for small always-on business tasks. Tokens stay out of saved files, and deploys or account changes require approval. |
+| **Google / Workspace** | Planned optional connection for source material and metadata; durable summaries belong back in the folder. |
+| **Google Ads / GTM** | Checks whether a site is ready to measure paid traffic. Publishing tags, creating conversions, uploading data, changing budgets, or launching campaigns requires separate approval. |
+| **Meta Ads** | Read-only account summaries after setup. No campaign editing, budget changes, or launch claim. |
+| **Bookkeeping** | Plain-file bookkeeping for owners who want to stop depending on QuickBooks-style software. Uses hledger under the hood, keeps raw ledgers private, tracks bet exposure, and can show sample monthly reports. |
+| **Apify** | Optional read-only research path. No official X integration, no posting, no DMs, no guaranteed scrape coverage. |
+| **Postiz** | Future path for scheduling and automatically posting approved content to social channels. Today, treat social posting as a draft-and-approve workflow, not an automatic publishing promise. |
+
+Secrets stay out of saved business files. Publishing, spend, customer contact,
+account changes, GTM publication, Google Ads changes, Meta campaign changes, and
+DM automation stay approval-gated or out of scope until there is tested support.
+
+---
+
+## The operating loop
+
+Main Branch is built around four loops every business owner runs whether they
+name them or not.
+
+**Sense -> Decide -> Ship -> Reflect.**
+
+| Loop | The question | What it looks like |
+| --- | --- | --- |
+| **Sense** | What's true right now? | `/mb-start` and `/mb-status` read folder health, recent work, MoneyPath, content strategy, connected-account status, and tasks/proposals. |
+| **Decide** | What do we do next? | `/mb-think`, bets, decisions, and ranked actions help choose the next business move. |
+| **Ship** | What goes out the door? | `/mb-ads`, `/mb-organic`, `/mb-site`, `/mb-bet`, pushes, playbooks, issue drafts, updates, and checkpoints move work forward. |
+| **Reflect** | What sticks? | `/mb-end`, bet close/narrate, outcomes, retros, decisions, and checkpoint history turn lessons into future context. |
+
+Each loop reads your folder before it speaks. Each loop writes back only when
+you approve.
+
+---
+
+## Named workflows
+
+Things you can ask for this week:
+
+- **Start the business day from facts.** Main Branch reads status, MoneyPath,
+  recent work, drift, connected tools, and ranked actions before advice.
+- **Turn research into a decision.** Ask it to turn source material,
+  transcripts, market context, and business files into research, decisions,
+  offer updates, proof context, or stale-source cleanup.
+- **Create paid creative with review gates.** Ask it to draft hooks, static ads,
+  image prompts, video scripts, long-form paid creative, and launch plans, then
+  run 6-lens P1/P2/P3 compliance review before approval.
+- **Create organic content in your voice.** Ask for Reels, TikToks, carousels,
+  static posts, and sales-video repurposing from your content strategy and
+  source material.
+- **Plan and check a landing page.** Ask for a lander, minisite, site pass,
+  pitch script, or paid-traffic measurement check.
+- **Open a bet with a real exit path.** Record the hypothesis, appetite, metric,
+  target, deadline, evidence, and linked work.
+- **Save a long session as readable history.** Close the session, review what
+  happened, preview the checkpoint, and save only after approval.
+- **Draft a public GitHub issue safely.** Turn confusing friction into a scrubbed
+  issue draft you review before anything posts.
+- **See your business as a graph.** Map how decisions, research, bets, pushes,
+  and connected tools relate.
+- **Repair a folder that drifted.** Ask for a repair plan before changing files.
+
+---
+
+## Who it is for
+
+Main Branch is for solo founders, small agencies, course creators,
+productized-service owners, indie SaaS founders, small ecom teams, and
+small teams that want AI help without surrendering their operating memory to
+another SaaS.
+
+It is a good fit if:
+
+- your offer, voice, research, proof, and launch context are scattered;
+- you want AI help with offers, pages, ads, content, launches, and decisions;
+- you want history you can inspect instead of chat output you have to trust;
+- you want private business truth to stay in files you own;
+- you want the system to get sharper the longer you use it.
+
+---
+
+## Common objections
+
+| Objection | Reality |
+| --- | --- |
+| "I'm not technical enough." | Install once. Then open the folder in Claude Code or Codex, run `/mb-start`, and answer plain-language questions. |
+| "I'll set it up wrong." | Main Branch checks the folder, explains what is wrong, and shows the repair path. |
+| "I'll lose work." | Approved checkpoints and GitHub backup give you readable history and reviewable changes. |
+| "I need someone to walk me through it." | Open the folder in Claude Code or Codex and run `/mb-start`. The agent explains the next step. |
+| "I won't maintain it." | Run `/mb-update` when asked. Repair checks tell you if anything needs fixing. |
+
+---
+
+## Works with
+
+| App | Current support |
+| --- | --- |
+| **Claude Code** | Open or select the business folder, run `/mb-start`, and use the bundled Main Branch skills. |
+| **Codex** | Open or select the business folder, run `/mb-start`, and use the Main Branch Codex plugin and skills. |
+
+Account writes, publishing, spend, customer contact, and account changes remain
+approval-gated everywhere.
+
+Cursor, OpenClaw, Hermes, Paperclip-adjacent orchestration, Windows native, and
+local-only agent setups are not documented as supported until the exact path is
+tested.
+
+See [docs/compatibility.md](docs/compatibility.md) for the current support list.
+
+---
+
+## What Main Branch is not
+
+| | |
+| --- | --- |
+| **Not a chat app.** | Use it inside Claude Code or Codex. Main Branch gives them durable context to read from. |
+| **Not a SaaS dashboard.** | Your business does not live on our servers. It lives in your folder. |
+| **Not a connect-every-tool hub.** | We pick boring, inspectable connections: GitHub, Cloudflare, Meta Ads, bookkeeping, and a few optional tool paths. Curated, not sprawl. |
+| **Not an ad manager or publisher.** | Paid creative and site checks are supported; spend, publishing, account changes, and customer contact require explicit approval and tested support. |
+| **Not a model host.** | `mb` does not run models. It gives the agent the right context so the model you already use is sharper. |
+| **Not magic.** | The work is still real. Main Branch makes the memory and workflow durable. |
 
 ---
 
 ## FAQ
 
-**Do I need to know how to code?** No. You invoke skills with slash prompts and answer questions.
+**Do I need to know how to code?** No. Open the folder in Claude Code or Codex,
+run `/mb-start`, and answer questions. The beginner walkthrough shows each
+setup step.
 
-**What if I have multiple products under one brand?** Use one folder with `core/offers/` when products share brand, team, voice, and access. Move an offer into its own folder if it grows its own team, accounts, site, finance boundary, or operating history.
+**Do I need to know git?** No. Main Branch uses git as the hidden save/history
+layer and speaks in business language: checkpoints, saved history, tasks, and
+proposals.
 
-**What's a bet vs. an offer?** A bet is a time-boxed hypothesis: what you'll try, why, by when, how you'll know. An offer is a durable thing you sell. A good bet can graduate into an offer.
+**Does it push to GitHub automatically?** No. Checkpoints save accepted work
+into local git history. GitHub backup/sync is recommended, and first-run
+onboarding can create and push a GitHub repo when you choose that path.
 
-**What if I have multiple separate businesses?** One folder per brand, legal entity, ad-account boundary, or team-access boundary.
+**What if I have multiple products under one brand?** Use one folder with
+`core/offers/` when products share brand, team, voice, and access. Move an
+offer into its own folder if it grows its own team, accounts, site, finance
+boundary, or operating history.
 
-**How do I update?** Type `/mb-update` in Claude. Power users can run `mb update` from the folder.
+**What's a bet vs. an offer?** A bet is a time-boxed hypothesis: what you will
+try, why, by when, and how you will know. An offer is a durable thing you sell.
+A winning bet can graduate into an offer through an accepted decision.
 
-**Can Claude migrate an old setup for me?** Yes. Start Claude Code anywhere and paste the prompt in [docs/migrating.md](docs/migrating.md#recommended-let-claude-walk-you-through-it).
+**How do I update?** Type `/mb-update` in Claude Code or Codex.
 
-**Can I edit the skills?** You can. You don't need to.
+**Can Claude or Codex migrate an old setup for me?** Yes. Open the folder in
+Claude Code or Codex and follow the migration prompt in
+[docs/migrating.md](docs/migrating.md#recommended-let-claude-walk-you-through-it).
 
-**What makes this different from ChatGPT?** ChatGPT resets between sessions. Main Branch is a folder Claude can re-read every session — your offer, audience, voice, team context, decisions, research, and bets — so the output stays consistent with your business.
+**Can I edit the skills?** You can. You usually do not need to.
+
+**What makes this different from ChatGPT or project memory?** Main Branch is
+not only memory text. It is a structured folder, health checks, validation,
+graphing, repair paths, connected-tool checks, checkpoints, and agent workflows
+that write approved business artifacts back into files you own.
 
 **I'm stuck.** Type `/mb-start` again.
 
 ---
 
-## Help
-
-**In the Skool community:** post in the Main Branch group. Tag @Devon for technical questions.
-
-**Not in the Skool community?** Open an issue at [github.com/noontide-co/mainbranch/issues](https://github.com/noontide-co/mainbranch/issues).
-
-For platform support and security reporting, see [SUPPORT.md](SUPPORT.md), [SECURITY.md](SECURITY.md), and [docs/compatibility.md](docs/compatibility.md).
-
-**Common issues:**
-
-- "404" or "Repository not found" — verify the URL. The repo is public; no access request needed.
-- "Claude doesn't see my files" — make sure you started Claude in your business folder and ran `/mb-start`.
-- "Skills aren't working" — ask Claude to repair the wiring, or run `/mb-setup`.
-- "Output sounds generic" — add more detail to your core files, especially `core/voice.md`.
-- "I edited Main Branch but can't push" — that's expected. Main Branch itself is read-only for most users. Your business files go in your business folder.
-
-Hit a real problem? Ask the agent to draft a clean public issue for you. It scrubs private context before submitting.
-
----
-
 ## Open source and optional community
 
-- **Open-source (MIT)**: the `mb` CLI, bundled skills, schema, framework, docs, and any future local dashboard. Usable without joining the community.
-- **Community ([Skool](https://skool.com/main))**: Watch us build companies live with Main Branch. Live narration, calls, support, and curated examples — not required to use the CLI or skills.
-
-Main Branch is usable on its own. The community is the live narration on top.
+The command-line tool, bundled skills, schema, framework, docs, and any future
+local dashboard are MIT-licensed and usable without joining anything. The
+[Skool community](https://skool.com/main) is the live narration on top: watch
+us build companies with Main Branch in real time.
 
 ---
 
 ## For contributors and power users
 
-The `mb` CLI is the deterministic control plane. The agent runs it for normal users. If you want to inspect, script, or build on it, here's the surface.
+The agent runs `mb` for normal users. If you want to inspect, script, debug, or
+build on it, here is the command list.
 
-| Command                  | What it does |
-|---|---|
-| `mb onboard`             | Human setup flow: create or connect a business folder, wire Claude Code skills, show next steps. |
-| `mb init`                | Quiet scriptable primitive underneath `mb onboard`. |
-| `mb status`              | Local-first daily briefing: ranked next actions, MoneyPath readiness, since-last-check changes, drift, repo health, runtime wiring, recent activity, GitHub tasks/proposals. `--json` and `--peek` for callers. |
-| `mb doctor`              | Check environment, repo shape, frontmatter, settings. `mb doctor repair --plan` / `--apply` walks through guided reconciliation, including migration drift. |
-| `mb connect`             | Register provider credentials, test provider health, inspect repair-safe integration status without committing secrets. |
-| `mb books`               | Check privacy-bounded bookkeeping setup, inspect hledger readiness, and plan safe repairs without reading private ledgers. |
-| `mb site check`          | Local paid-traffic measurement readiness for a site folder: GTM install, dataLayer events, consent posture, Google Ads metadata, operator-review gates. |
-| `mb issue draft` / `open`| Draft a privacy-scrubbed GitHub issue locally, review it, then submit through `gh`. |
-| `mb validate`            | Frontmatter shape check across `core/`, `research/`, `decisions/`, `bets/`, `log/`, `pushes/`, `documents/`. Pass/fail per file. |
-| `mb graph`               | Build a folder graph from frontmatter links, wikilinks, and entity tags. Graphviz DOT, JSON, and PNG outputs. |
-| `mb suggest links`       | Suggest likely frontmatter, inline, tag, data, and context connections for a file without editing it. |
-| `mb checkpoint`          | Plan or save a business-readable git checkpoint during long agent runs. |
-| `mb workflow list`       | List Codex workflow support: supported Main Branch commands, pending shared-source migrations, and intentionally unsupported workflows. |
-| `mb skill list` / `path` / `validate` / `link` / `repair` | Manage and repair the bundled Claude Code skills. |
-| `mb update`              | Update Main Branch in place. |
+<details>
+<summary>CLI commands</summary>
 
-Full list: `mb --help`. JSON output contract: [docs/json-output-contract.md](docs/json-output-contract.md). Provider readiness: [docs/dependency-choices.md](docs/dependency-choices.md).
+| Command | What it does |
+| --- | --- |
+| `mb onboard` | Human setup flow: create or connect a business folder, prepare Claude/Codex setup, show next steps. |
+| `mb init` | Quiet scriptable primitive underneath `mb onboard`. |
+| `mb status` | Local-first daily briefing with ranked next actions, MoneyPath readiness, recent activity, GitHub tasks/proposals, updates, and drift. |
+| `mb doctor` | Check environment, repo shape, frontmatter, settings, app setup, provider state, and repair paths. |
+| `mb connect` | Register connected-account metadata/credentials, test health where supported, inspect repair-safe integration status without committing secrets. |
+| `mb books` | Plain-file bookkeeping setup checks, bookkeeping engine health, safe repair plans, bet exposure, and fake-data sample monthly reporting. |
+| `mb site check` | Local paid-traffic measurement readiness: GTM install, dataLayer events, consent posture, Google Ads metadata, approval gates. |
+| `mb ads meta summary` | Read-only Meta Ads account context through the official Meta CLI path after setup. |
+| `mb issue draft` / `open` | Draft a privacy-scrubbed GitHub issue locally, review it, then submit through `gh`. |
+| `mb validate` | Frontmatter and cross-reference checks across business repo files. |
+| `mb graph` | Build a folder graph from links, tags, connected-tool refs, and repo topology. DOT, JSON, and PNG outputs. |
+| `mb suggest links` | Suggest likely connections for a file without editing it. |
+| `mb checkpoint` | Plan or save a readable git checkpoint during long agent runs. |
+| `mb workflow list` | List workflow support, pending migrations, and intentionally unsupported workflows. |
+| `mb skill list` / `path` / `validate` / `link` / `repair` | Inspect, validate, link, and repair bundled skills and generated app guidance. |
+| `mb update` | Update Main Branch in place. |
 
-**Skills:**
+</details>
 
-| Skill | Loop |
-|---|---|
-| `/mb-start` | Daily entry point — figure out what you need and route there |
-| `/mb-status` | Daily briefing facts and ranked next actions |
-| `/mb-setup` | First-time setup |
-| `/mb-think` | Research, decide, codify |
-| `/mb-bet` | Open, update, close, narrate business bets |
-| `/mb-end` | Close the session — summary, crystallize, checkpoint guidance |
-| `/mb-help` | Get answers, troubleshoot, learn the system |
-| `/mb-update` | Update Main Branch (delegates to `mb update`) |
-| `/mb-ads` `/mb-organic` `/mb-site` | Channel skills (Paid / Organic / Pages). |
-| `/mb-wiki` | Specialty: personal/atomic-notes wiki, not part of the core daily loop |
+<details>
+<summary>Bundled skills</summary>
 
-**Reading order:**
+| Skill | What it does |
+| --- | --- |
+| `/mb-start` | Daily entry point: figure out what you need and route there. |
+| `/mb-status` | Daily briefing facts and ranked next actions. |
+| `/mb-setup` | First-time setup with business-type routing. |
+| `/mb-think` | Research, decide, codify, keyword-gate, sharpen offers, and source cleanup. |
+| `/mb-bet` | Open, update, close, list, and narrate business bets. |
+| `/mb-end` | Close the session: summary, crystallization, checkpoint options. |
+| `/mb-ads` | Paid creative: hooks, ads, image prompts, video scripts, launch plans, compliance review. |
+| `/mb-organic` | Organic content: Reels, TikToks, carousels, static posts, and sales-video repurpose. |
+| `/mb-site` | Lander, minisite, website, Cloudflare Pages, pitch scripts, and measurement checks. |
+| `/mb-wiki` | Specialty personal atomic-notes wiki on Cloudflare Pages. |
+| `/mb-update` | Update Main Branch. |
+| `/mb-help` | Q&A, troubleshooting, and system help. |
 
-- [AGENTS.md](AGENTS.md) — shared operating contract for Codex, Claude Code, and other agents
-- [CLAUDE.md](CLAUDE.md) — Claude Code-specific guidance
-- [CONTRIBUTING.md](CONTRIBUTING.md) — branch / commit / validation discipline
-- [docs/ethos.md](docs/ethos.md) — product principles
-- [docs/operator-loops.md](docs/operator-loops.md) — Sense → Decide → Ship → Reflect taxonomy
-- [docs/business-connections.md](docs/business-connections.md) — how to connect notes, reports, data, and GitHub history without noisy links
-- [docs/roadmap.md](docs/roadmap.md) — release direction
-- [docs/compatibility.md](docs/compatibility.md) — runtime support matrix
-- [docs/release-simulations.md](docs/release-simulations.md) — release evidence ladder
+</details>
+
+Full list: `mb --help`. JSON output contract:
+[docs/json-output-contract.md](docs/json-output-contract.md). Connected-tool
+choices: [docs/dependency-choices.md](docs/dependency-choices.md).
+
+### Reading order
+
+- [AGENTS.md](AGENTS.md) - shared operating contract for Codex, Claude Code, and other agents
+- [CLAUDE.md](CLAUDE.md) - Claude Code-specific guidance
+- [CONTRIBUTING.md](CONTRIBUTING.md) - branch, commit, and validation discipline
+- [docs/ethos.md](docs/ethos.md) - product principles
+- [docs/operator-loops.md](docs/operator-loops.md) - Sense -> Decide -> Ship -> Reflect taxonomy
+- [docs/roadmap.md](docs/roadmap.md) - release direction
+- [docs/compatibility.md](docs/compatibility.md) - runtime support matrix
 
 ---
 
 ## Community
 
-- [Skool community](https://skool.com/main) — watch us build with Main Branch
-- [GitHub Issues](https://github.com/noontide-co/mainbranch/issues) — bugs and feature requests
-- [GitHub Discussions](https://github.com/noontide-co/mainbranch/discussions) — ideas
+- [Skool community](https://skool.com/main) - watch us build with Main Branch
+- [GitHub Issues](https://github.com/noontide-co/mainbranch/issues) - bugs and feature requests
+- [GitHub Discussions](https://github.com/noontide-co/mainbranch/discussions) - ideas
 
 ---
 
 ## License
 
-[MIT](LICENSE) © 2026 Noontide
+[MIT](LICENSE) (c) 2026 Noontide
 
 <p align="center">
   <sub>Open source. Built for people who want to own their business memory, not rent it.</sub>

--- a/docs/beginner-setup.md
+++ b/docs/beginner-setup.md
@@ -1,52 +1,42 @@
 # Beginner Setup Guide
 
-Setup guide for people new to Claude Code, Git, or terminal. Plan on under 30 minutes.
+Setup guide for people new to Claude Code, Codex, Git, or the terminal. Plan
+on under 30 minutes.
 
 ---
 
-## Read This First
+## Read this first
 
-If this feels over your head, that's okay. Most of this is one-time setup. After that, you're mostly chatting with Claude in your business repo and getting outputs back.
+Main Branch turns one folder on your computer into the business brain your AI
+reads before it helps. That folder holds your offer, proof, research, decisions,
+launches, pages, ads, bets, notes, and lessons in files you own.
 
-You need a terminal because Main Branch creates real files on your machine. That's the magic — your business context lives in files Claude reads every session, instead of resetting to zero. Don't let the unfamiliarity stop you. One step at a time.
+Most of this page is one-time setup. After that, your normal flow is simple:
 
-If you want the "why" while you set up, Main Branch has short educational
-topics you can print from the terminal:
+1. Open or select the business folder in Claude Code or Codex.
+2. Run `/mb-start`.
+3. Tell the agent what you want help with.
 
-```bash
-mb educational daily-owner-loop
-mb educational why-mainbranch-not-saas
-mb educational github-vs-gdocs
-mb educational cli-vs-dashboard
-mb educational markdown-vs-notion
-mb educational git-history-vs-cloud-sync
-```
-
-Start with `daily-owner-loop`. The other topics explain the tool philosophy
-behind that loop: local files, markdown, git history, GitHub work threads, `mb`
-readiness checks, and Claude Code skills.
+You will use a few terminal commands during setup because Main Branch creates
+real files on your machine. You do not need to make terminal commands your daily
+workflow.
 
 ---
 
-## What You Need
+## What you need
 
-- **A folder on your computer** — this becomes the business brain.
-- **Main Branch (`mb`)** — creates and checks that folder.
-- **Claude Code** — the first supported chat runtime for Main Branch skills.
-- **A Claude plan that includes Claude Code** — pricing and limits can change;
-  use Anthropic's current Claude Code plan details as the source of truth.
-- **GitHub CLI (`gh`)** — strongly recommended for almost everyone, and
-  required when you want GitHub backup, sync, collaboration, or
-  `mb onboard --github <owner/repo> --push`.
+- **A folder on your computer** - this becomes your business brain.
+- **Main Branch (`mb`)** - creates the folder, checks it, updates it, and
+  repairs it when something drifts.
+- **Claude Code or Codex** - the app where you talk to the agent.
+- **GitHub CLI (`gh`)** - strongly recommended for backup, sync, shared tasks,
+  proposals, and AI tools that can read GitHub repos.
 
-GitHub does not need to cost anything, and it is the highest-leverage
-connection after your local folder. It gives you cloud backup, readable saved
-history, shared tasks and proposals, and a repo that other AI tools with GitHub
-connectors can read as your business brain. Main Branch can start locally
-before GitHub is ready, but most users should connect it during first setup.
+GitHub does not need to cost anything. Main Branch can start locally before
+GitHub is ready, but most users should connect GitHub during first setup so the
+business brain has cloud backup and readable saved history.
 
-Before using GitHub-backed setup, install GitHub CLI and confirm it is signed in
-to the account you expect:
+Before using GitHub-backed setup, confirm GitHub is signed in on your computer:
 
 ```bash
 gh auth status
@@ -56,400 +46,323 @@ gh api user --jq .login
 If that account is wrong, stop before creating the GitHub-backed setup and run
 `gh auth login` or `gh auth switch`.
 
-## Folder-First Bootstrap
+---
 
-If you are starting from an empty folder with Claude Code, Codex CLI, or another
-agent-like runtime, open that runtime in the folder where the business brain
-should live and paste this prompt:
+## Setup with an agent
+
+If you are starting from an empty folder, open or select that folder in Claude
+Code or Codex and paste this:
 
 ```text
-I want to set up Main Branch for this business in the current folder.
+I want to set up Main Branch for this business in this folder.
 
 Treat this as setup intent, not as a document to save.
 
 First, check whether `mb` is available. If it is not installed, stop and tell me
-the exact install step. If it is installed, inspect the available setup/onboard
-command before running it.
+the exact install step. If it is installed, inspect the setup command before
+running it.
 
-Use this folder as the business repo location unless I say otherwise. Before any
-write, explain the folder or repo that will be created or modified and ask for
-approval.
+Use this folder as the business folder unless I say otherwise. Before any write,
+explain what will be created or changed and ask for approval.
 
 If I ask for GitHub backup or sync, first check whether GitHub CLI is installed,
-authenticated, and signed in to the account I expect. GitHub is strongly
-recommended because it gives Main Branch a free cloud backup, shared history,
-task/proposal layer, and connector-friendly copy of the business brain. Main
-Branch can start locally without GitHub, but GitHub is needed for sync,
-collaboration, and `mb onboard --github <owner/repo> --push`.
+authenticated, and signed in to the account I expect.
 
-After setup, run the read-only health/status checks, summarize what was created
-in business language, and tell me the next safest action.
+After setup, run read-only health checks, summarize what was created in plain
+business language, and tell me the next safest action.
 ```
 
-Do not save that prompt as a markdown document. It is the instruction that tells
-the agent to start setup.
+Do not save that prompt as a markdown document. It tells the agent to start
+setup.
 
 ---
 
-## Step 1: Install the Tools
+## Step 1: Install the tools
 
 ### Mac
 
 ```bash
-# 1. Install Claude Code
-curl -fsSL https://claude.ai/install.sh | bash
-
-# 2. Install pipx (Python package installer for CLIs)
+# 1. Install pipx, the Python app installer Main Branch uses
 brew install pipx
 pipx ensurepath
 
-# 3. Install Main Branch
+# 2. Install Main Branch
 pipx install mainbranch
 
-# 4. Strongly recommended, for GitHub backup/sync/collaboration
+# 3. Strongly recommended for backup/sync/collaboration
 brew install gh
 gh auth login
 ```
 
+Install Claude Code, Codex, or both from their official instructions. Main
+Branch works from the same business folder in either app.
+
 ### Linux
 
-Same flow as macOS — use `apt install pipx` (Debian/Ubuntu) or `dnf install
-pipx` (Fedora) instead of `brew install pipx`. Then `pipx ensurepath && pipx
-install mainbranch`. For GitHub backup/sync/collaboration, install GitHub CLI
-from [cli.github.com](https://cli.github.com/) and run
-`gh auth login`.
+Use `apt install pipx` on Debian/Ubuntu or `dnf install pipx` on Fedora, then:
+
+```bash
+pipx ensurepath
+pipx install mainbranch
+```
+
+For GitHub backup/sync/collaboration, install GitHub CLI from
+[cli.github.com](https://cli.github.com/) and run `gh auth login`.
 
 ### Windows
 
-> **Windows is experimental.** It may work but isn't tested in CI; expect rough edges. See [compatibility](compatibility.md). Power users should use WSL2 for the closest supported path.
+> **Windows is experimental.** It may work, but it is not tested in CI. For the
+> closest supported path, use WSL2. See [compatibility](compatibility.md).
 
 ```powershell
-# 1. Install Claude Code
-irm https://claude.ai/install.ps1 | iex
-
-# 2. Install Git for Windows
-# Download from: https://git-scm.com/download/win
-
-# 3. Install pipx
+# 1. Install pipx
 python -m pip install --user pipx
 python -m pipx ensurepath
 
-# 4. Install Main Branch
+# 2. Install Main Branch
 pipx install mainbranch
 
-# 5. Strongly recommended, for GitHub backup/sync/collaboration
-# Download GitHub CLI from: https://cli.github.com/
+# 3. Strongly recommended for backup/sync/collaboration
+# Download GitHub CLI from https://cli.github.com/
 gh auth login
 ```
 
 After install, verify:
 
 ```bash
-mb --version    # should print something like "mb X.Y.Z"
-claude doctor   # should report Claude Code is healthy
+mb --version
 ```
 
 ---
 
-## Step 2: Create Your Business Repo
+## Step 2: Create your business folder
 
-Pick a name and a folder. Local-only setup:
+Local setup:
 
 ```bash
-cd ~/Documents/GitHub          # or wherever you keep code
 mb onboard --name "My Business" --path my-business
-cd my-business
 ```
 
 GitHub-backed setup, after `gh auth status` shows the expected account:
 
 ```bash
 mb onboard --name "My Business" --path my-business --github your-gh-username/my-business --github-visibility private --push
-cd my-business
 ```
 
-`mb onboard` walks you through the setup, explains why Main Branch uses local
-files, git, and GitHub, scaffolds the business folder taxonomy (`core/`,
-`research/`, `decisions/`, `bets/`, `log/`, `pushes/`, `documents/` plus
-`core/team/<owner>.md` for public-safe owner context and optional
-`core/vocabulary.md` for operator-owned display words), and wires the bridge
-files Claude Code needs to find Main Branch's skills.
+`mb onboard` creates or connects the folder, prepares Claude Code and Codex,
+and shows the next step.
 
-You may also see a `.mb/` folder. That is normal. It stores Main Branch's local
-operational state for that business repo, such as onboarding progress, safe
-provider metadata, backups, and issue drafts. You do not need a `.mb-vip/`
-folder; that name comes from the old clone-based setup.
+The folder will include places for core business context, research, decisions,
+bets, logs, launches, documents, playbooks, and saved lessons. You may also see
+a `.mb/` folder. That is normal. It stores local Main Branch state for this
+business, such as onboarding progress, safe connected-account metadata, backups,
+and issue drafts.
 
-### What Gets Saved
+You do not need a `.mb-vip/` folder. That name comes from the old setup.
+
+### What gets saved
 
 - Saving a file writes it on your computer.
 - A checkpoint is an approved saved point in the business history.
-- GitHub backup/sync means the approved history is also available from GitHub,
-  where AI tools with GitHub connectors can read the business brain.
-- Main Branch updates change the engine and skills; they do not rewrite your
+- GitHub backup/sync means approved history is also available from GitHub, where
+  AI tools with GitHub connectors can read the business brain.
+- Main Branch updates change the engine and skills. They do not rewrite your
   business files without an approved repair, migration, or edit.
 
-Use one business repo when brand, team, voice, access, and operating history are
-shared. Create a separate business repo for a separate entity or independent
-operating history. Use linked child repos for sites, products, finance/legal,
-client work, or private ops when access or lifecycle differs. The full model
-lives in [system architecture](system-architecture.md#repo-topology).
+Use one business folder when brand, team, voice, access, and operating history
+are shared. Use separate folders for separate entities or independent operating
+histories. Use linked child repos for sites, products, finance/legal, client
+work, or private ops when access or lifecycle differs. The full model lives in
+[system architecture](system-architecture.md#repo-topology).
 
 ---
 
-## Step 3: First Session
+## Step 3: Start the first session
 
-```bash
-claude
-```
+Open or select the business folder in Claude Code or Codex.
 
-Then in Claude Code:
+Then run:
 
-```
+```text
 /mb-start
 ```
 
-`/mb-start` walks you through the rest. It reads the same status facts as `mb status`, checks for updates or repair needs, and routes you to setup, thinking, shipping, or closing work.
+`/mb-start` checks what changed, what matters, and what to do next. It can route
+you into setup, thinking, ads, organic content, site work, bookkeeping checks,
+repairs, updates, or closing a session.
 
-Plain `/mb-start` is the reliable beginner path. Extra text after `/mb-start`
-is treated as normal instruction, not as a project-command argument API.
-Natural-language requests can route into the skill, but setup docs teach the
-explicit slash command because it is easier to recognize and repair. See the
-[Claude Code invocation contract](claude-code-invocation-contract.md) for the
-runtime details.
+Daily use is:
 
-That's it. From this point on:
+1. Open or select the business folder in Claude Code or Codex.
+2. Run `/mb-start`.
+3. Tell the agent what you want help with: an offer, page, ad, launch, research
+   question, decision, bookkeeping check, or cleanup.
 
-```bash
-cd ~/Documents/GitHub/my-business
-claude
-/mb-start
-```
-
-Three lines. That's the daily flow.
-
-`/mb-start` runs the same status facts internally, so you do not need to run
-`mb status` before opening Claude Code. Use `mb status` only when you want a
-terminal-only briefing.
+You do not need to run `mb status` first. `/mb-start` reads those facts for you.
 
 ---
 
-## Provider Readiness
+## Connected tools
 
-Providers are outside accounts Main Branch can use when a business workflow
-needs them. You do not need to connect everything during first setup.
+You do not need to connect every account during first setup. Main Branch chooses
+tools carefully so each one has a clear job and a safe boundary.
 
-Use the plan command from your business repo:
+| Tool | Why it is included |
+| --- | --- |
+| **GitHub** | Backup, saved history, shared tasks/proposals, and a copy of the business brain AI tools can read. |
+| **Cloudflare** | Domains, DNS, websites, ad landing pages, Cloudflare Pages, and future Workers for small always-on business tasks. |
+| **Google / Workspace** | Planned optional connection for source material and metadata; durable summaries belong back in the folder. |
+| **Google Ads / GTM** | Checks whether a site is ready to measure paid traffic. Publishing tags, creating conversions, changing budgets, or launching campaigns requires separate approval. |
+| **Meta Ads** | Read-only account summaries after setup. No campaign editing, budget changes, or launch claim. |
+| **Bookkeeping** | Plain-file bookkeeping for owners who want to stop depending on QuickBooks-style software. Uses hledger under the hood and keeps raw ledgers private. |
+| **Apify** | Optional read-only research path for web research where scraping is appropriate. |
+| **Postiz** | Future path for scheduling and automatically posting approved content to social channels. Today, treat social posting as draft-and-approve, not automatic publishing. |
+
+Secrets stay outside saved business files. Publishing, spend, customer contact,
+account changes, Google Ads changes, Meta campaign changes, and DM automation
+stay approval-gated or out of scope until there is tested support.
+
+Power users can inspect setup choices from the business folder:
 
 ```bash
 mb connect plan
-```
-
-It shows numbered choices:
-
-1. **GitHub** — tasks, proposals, reviews, and shipped history.
-2. **Cloudflare** — sites, DNS, Pages, and future Workers.
-3. **Google / Workspace** — existing Docs, Drive, Sheets, and Slides.
-4. **Meta Ads** — ad accounts, campaigns, and pixels.
-5. **Apify** — research sidecar for scraping, YouTube, Instagram, and web mining.
-
-If a provider is missing, Main Branch prints the next command. Examples:
-
-```bash
-gh auth login
-printf '%s' "$CLOUDFLARE_API_TOKEN" | mb connect cloudflare --token-stdin --metadata token_type=account --metadata account_id=...
-mb connect doctor --json
-```
-
-Secrets stay outside your repo. Main Branch stores only safe metadata in
-`.mb/connect.yaml`, such as provider name, account label, account-token type,
-and last check time. The file is gitignored by default.
-
-If you use disposable checkouts or agent workspaces, store provider setup in
-user scope and hydrate each workspace:
-
-```bash
-printf '%s' "$CLOUDFLARE_API_TOKEN" | mb connect cloudflare --scope user --token-stdin --metadata token_type=account --metadata account_id=...
-mb connect hydrate --repo .
-```
-
-User scope is keyed by the business repo identity, so another business repo can
-use a different Cloudflare account or zone without sharing that connection.
-
-For the longer plain-English explanation, run:
-
-```bash
-mb educational provider-readiness
-```
-
-Provider-specific education is available when a job needs that rail:
-
-```bash
-mb educational cloudflare-pages
-mb educational cal-com
-mb educational stripe
-mb educational hledger
-mb educational forgejo
-```
-
-For runtime/editor boundaries, use:
-
-```bash
-mb educational cursor
 ```
 
 ---
 
 ## Updating Main Branch
 
-When new versions drop, use Claude Code:
+When Main Branch says an update matters, run this in Claude Code or Codex:
 
 ```text
 /mb-update
 ```
 
 `/mb-update` figures out which install you have and runs the right update path.
-`/mb-start` also checks for important updates at the beginning of a session and
-will tell you when updating matters. The CHANGELOG entry for the new version
-surfaces as a banner the next time you run `/mb-start`.
+`/mb-start` also checks for important updates at the beginning of a session.
 
-Power users can run the same product update path from a business repo:
+Power users can run the same update path from a business folder:
 
 ```bash
 mb update --repo .
 ```
 
 If you installed an early `0.1.x` version, `/mb-update` or `mb update` may say
-the install is too old to update itself. Ask Claude to help with the bootstrap.
-The fallback command is:
+the install is too old to update itself. The fallback command is:
 
 ```bash
 pipx upgrade mainbranch
 ```
 
-### Already Using The Old Setup?
+---
+
+## Already using the old setup?
 
 Read [migrating.md](migrating.md) before repairing old clone-era installs,
 `reference/core/` layouts, or stale skill links. You usually do not need to
-move files immediately; update Main Branch first, then let Claude run the
-confirmation-gated migration prompt from that doc.
+move files immediately. Update Main Branch first, then let the agent walk you
+through the confirmation-gated migration prompt from that doc.
 
-Start Claude Code anywhere and paste:
+Open Claude Code or Codex and paste:
 
 ```text
 I want to migrate my existing Main Branch setup to the current pipx + /mb-start
-workflow. Please run read-only checks first, find my likely business repos,
-show me the exact commands you recommend, and ask before running anything that
+workflow. Please run read-only checks first, find my likely business folders,
+show me the exact changes you recommend, and ask before running anything that
 writes files. If an old `reference/` layout is present, run `mb migrate --check`
-first and do not run `mb migrate --apply` until I approve the dry-run. Use
+first and do not run `mb migrate --apply` until I approve the dry run. Use
 docs/migrating.md as the source of truth.
 ```
 
-Claude may ask you to restart in a business folder after it repairs skill
-discovery. That is normal. Claude Code loads slash commands when a session
-starts, so repaired `/mb-start` links usually appear after restart.
+The agent may ask you to restart in the business folder after it repairs setup.
+That is normal.
 
 ---
 
-## Available Skills
+## What you can ask for
 
-| Skill | What it does |
-|---|---|
-| `/mb-start` | Main entry point — figures out what you need and routes you. |
-| `/mb-status` | Claude Code briefing over `mb status --json --peek`, including ranked next actions. |
-| `/mb-think` | Research, decide, codify — turns thinking into durable business files. |
-| `/mb-bet` | Open, update, close, list, and narrate business bets. |
-| `/mb-ads` | Generate ad copy and review for compliance. |
-| `/mb-organic` | Generate organic content (Reels, TikTok, carousels). |
-| `/mb-site` | Generate and deploy landing pages. |
-| `/mb-wiki` | Personal wiki with atomic notes. |
-| `/mb-end` | Close session intentionally — summary, crystallize, checkpoint. |
-| `/mb-help` | Get answers, troubleshoot. |
-| `/mb-update` | Update Main Branch (figures out pipx vs clone). |
+You can ask naturally, or use the slash commands when you know them.
+
+| Ask for | What Main Branch does |
+| --- | --- |
+| `/mb-start` | Starts from current business facts and routes you to the next safe move. |
+| `/mb-status` | Gives a briefing over current facts and ranked next actions. |
+| `/mb-think` | Turns research, transcripts, market context, or messy ideas into decisions and business files. |
+| `/mb-bet` | Opens, updates, closes, lists, and narrates business bets. |
+| `/mb-ads` | Drafts paid creative and reviews it for compliance before approval. |
+| `/mb-organic` | Drafts Reels, TikToks, carousels, static posts, and sales-video repurposing. |
+| `/mb-site` | Helps plan, write, check, and launch landing pages, minisites, websites, and Cloudflare Pages work. |
+| `/mb-wiki` | Builds a personal wiki with atomic notes. |
+| `/mb-end` | Closes a session with summary, crystallization, and checkpoint options. |
+| `/mb-help` | Answers questions and helps troubleshoot. |
+| `/mb-update` | Updates Main Branch. |
 
 ---
 
-## The mb CLI
+## Terminal commands for support
+
+The agent normally runs `mb` for you. These are useful when you want to inspect
+or repair something yourself.
 
 | Command | What it does |
-|---|---|
-| `mb onboard` | Guided setup for humans. Creates or connects a business repo and shows the next `/mb-start` step. |
-| `mb init` | Scaffold a fresh business repo. |
-| `mb status` | Show a terminal-only repo/runtime/GitHub briefing. `/mb-start` reads these facts internally. |
-| `mb start` | Check runtime handoff readiness and print or launch Claude Code with `--launch`. |
-| `mb connect plan` | Show numbered provider setup choices with readiness and exact next commands. |
-| `mb issue draft` | Draft a privacy-safe GitHub issue from a bug, confusing step, or feature gap. |
-| `mb checkpoint` | Plan or save a business-readable git checkpoint during long work. |
-| `mb similar-bets` | Find similar past bets and outcomes before starting a new one. |
-| `mb update` | Update Main Branch based on pipx vs clone install mode. |
-| `mb doctor` | Check that everything is set up correctly. Walks you through fixes. |
-| `mb skill link --repo .` | Repair Claude Code skill discovery if `/mb-start` doesn't show up. |
-| `mb skill repair --repo .` | Check for old personal Claude Code skills that can shadow Main Branch. |
-| `mb validate` | Check your business files have correct frontmatter. |
-| `mb graph` | Visualize or export the graph of files, links, wikilinks, and business entity tags. |
-| `mb skill list` | Show which skills your installed Main Branch ships. |
+| --- | --- |
+| `mb onboard` | Creates or connects a business folder and shows the next `/mb-start` step. |
+| `mb status` | Shows a terminal-only briefing. `/mb-start` reads these facts internally. |
+| `mb start` | Checks handoff readiness for Claude Code and Codex. |
+| `mb connect plan` | Shows connected-tool setup choices. |
+| `mb issue draft` | Drafts a privacy-safe GitHub issue from a bug, confusing step, or feature gap. |
+| `mb checkpoint` | Plans or saves a readable checkpoint during long work. |
+| `mb similar-bets` | Finds similar past bets and outcomes before starting a new one. |
+| `mb update` | Updates Main Branch. |
+| `mb doctor` | Checks setup and walks through fixes. |
+| `mb validate` | Checks your business files. |
+| `mb graph` | Shows how business files, decisions, bets, launches, and connected tools relate. |
+| `mb skill list` | Shows which skills your installed Main Branch ships. |
 
-For the full list: `mb --help`.
+For the full list, run `mb --help`.
 
 ---
 
-## Common Issues
+## Common issues
 
-**`/mb-start` not recognized in Claude Code:**
-
-```bash
-mb skill link --repo .
-```
-
-Then restart Claude. This re-wires skill discovery in your business repo and
-clears known stale Main Branch personal-skill shadows.
-
-The project-local `.claude/skills/mb-start` bridge link is required for
-reliable slash-command discovery; `.claude/settings.local.json` alone is not
-enough.
-
-If `/mb-start` is still missing after relinking and restarting, run:
+**`/mb-start` does not appear:** ask the agent to repair Main Branch setup in
+this folder. Power users can run:
 
 ```bash
-mb skill repair --repo .
+mb doctor repair --plan
 ```
 
-That inspect-only command reports unresolved personal-skill conflicts so you can
-decide whether to move them with `mb skill repair --repo . --apply`.
+Apply only after reviewing the plan.
 
-**I only see `.mb/`, not `.mb-vip/`:** good. `.mb/` is the current folder.
-`.mb-vip/` was old setup language and is not required.
+**I only see `.mb/`, not `.mb-vip/`:** good. `.mb/` is current. `.mb-vip/` was
+old setup language and is not required.
 
-**`mb` not found after install:** run `pipx ensurepath`, close your terminal completely, reopen it.
+**`mb` not found after install:** run `pipx ensurepath`, close your terminal
+completely, reopen it, then try `mb --version`.
 
-**Output sounds generic:** add more detail to your core files, especially `core/voice.md`. The richer those files, the more specific your outputs.
+**Output sounds generic:** add more detail to your core files, especially the
+files about your offer, audience, voice, proof, and current bets.
 
-**You hit a 404:** the repo is public; no access request needed. Double-check the URL spelling.
+**You hit a 404:** the repo is public; no access request is needed. Double-check
+the URL spelling.
 
 ---
 
 ## Help
 
-- **In Claude Code:** type `/mb-help` or describe the issue in plain English.
-- **In Skool:** post in the Main Branch group with a screenshot of the exact error. Tag Devon for setup issues.
-- **For contributors:** open an issue at [https://github.com/noontide-co/mainbranch/issues](https://github.com/noontide-co/mainbranch/issues).
+- **In Claude Code or Codex:** run `/mb-help` or describe the issue in plain
+  English.
+- **In the community:** post with a screenshot of the exact error.
+- **For contributors:** open an issue at
+  [https://github.com/noontide-co/mainbranch/issues](https://github.com/noontide-co/mainbranch/issues).
 - **Platform support:** see [compatibility](compatibility.md).
 
 ---
 
-## You've Got This
+## After setup
 
-After the install, you're mostly talking to Claude in your business repo. The
-important part is that the work does not disappear into chat: status, decisions,
-bets, pushes, logs, checkpoints, and outputs persist locally and in git. The
-terminal becomes background.
+You do not need to memorize the commands.
 
-You don't need to memorize anything. The daily flow is three lines:
-
-```bash
-cd ~/Documents/GitHub/my-business
-claude
-/mb-start
-```
-
-Keep going.
+Open or select your business folder in Claude Code or Codex, run `/mb-start`,
+and tell the agent what you want help with. Main Branch keeps the useful work in
+files you own so the next session does not start from scratch.

--- a/mb/tests/test_first_run_setup_contract.py
+++ b/mb/tests/test_first_run_setup_contract.py
@@ -20,21 +20,21 @@ def _setup_section(text: str) -> str:
     return text[start : start + 1400]
 
 
-def test_beginner_setup_uses_folder_first_bootstrap_prompt() -> None:
+def test_beginner_setup_uses_owner_friendly_setup_prompt() -> None:
     text = _read("docs/beginner-setup.md")
     normalized = _normalize(text)
 
     required = [
-        "## Folder-First Bootstrap",
-        "I want to set up Main Branch for this business in the current folder.",
+        "## Setup with an agent",
+        "Open or select the business folder in Claude Code or Codex.",
+        "I want to set up Main Branch for this business in this folder.",
         "Treat this as setup intent, not as a document to save.",
         "check whether `mb` is available",
-        "Use this folder as the business repo location unless I say otherwise.",
+        "Use this folder as the business folder unless I say otherwise.",
         "GitHub CLI is installed, authenticated, and signed in to the account I expect",
-        "GitHub is strongly recommended",
-        "connector-friendly copy of the business brain",
-        "Main Branch can start locally without GitHub",
-        "mb onboard --github <owner/repo> --push",
+        "GitHub does not need to cost anything",
+        "the business brain has cloud backup and readable saved history",
+        "AI tools with GitHub connectors can read the business brain",
         "Do not save that prompt as a markdown document.",
         "A checkpoint is an approved saved point in the business history.",
         "Main Branch updates change the engine and skills",
@@ -84,8 +84,8 @@ def test_readme_points_empty_folder_users_to_bootstrap() -> None:
     normalized = _normalize(text)
 
     assert "Start with the folder that should become your business brain" in normalized
-    assert "folder-first bootstrap" in normalized
-    assert "setup intent, not a document to save" in normalized
+    assert "Tell the agent what you are setting up" in normalized
+    assert "not save your note as another document" in normalized
     assert "GitHub backup/sync is strongly recommended" in normalized
     assert "AI tools with GitHub connectors can read" in normalized
     assert "gh auth status" in normalized


### PR DESCRIPTION
## Summary

Reframes the README and beginner setup guide around a business-owner first path: install once, open/select the business folder in Claude Code or Codex, run `/mb-start`, and tell the agent what to help with. It also tightens connected-tool claims so Cloudflare, bookkeeping, ads, social, and GitHub are described by owner outcomes and approval boundaries.

## Linked issue

N/A — direct README and beginner setup audit request; no tracked GitHub issue.

## Why

The old docs were too terminal-first and insider-heavy for business owners evaluating Main Branch from GitHub. This pass makes the first impression more conversion-focused while keeping runtime, publishing, spend, and connected-account claims honest.

## Commits by concern

- [ ] Each commit body bullet-lists the changes in that commit
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`

Commits:
- `7aa26cb [update] Reframe README for conversion`
- `b05edfa [update] Simplify README and beginner setup`

## Validation

Pre-push gate from repo root:

```bash
scripts/check.sh
```

Level 0 docs/regression: `cd mb && pytest tests/test_first_run_setup_contract.py tests/test_conversion_video_routing.py::test_operator_help_avoids_retired_data_repo_and_public_conductor_framing -q` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: `0` — log: `5 passed in 0.19s`.
Level 1 static: `scripts/check.sh` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: `0` — log: `92 files already formatted; All checks passed!; Success: no issues found in 91 source files; 798 passed in 390.96s`.
Level 2 CLI contract: not required — no CLI behavior changed.
Level 3 package/install smoke: not required — packaging and entrypoints were not touched.
Level 4 fixture repo: not required — init/onboard/status/start/update behavior was not changed.
Level 5 runtime smoke: not required — runtime discovery and skill behavior were not changed.
SKILL.md line gate: not required — no skill files changed.
Package-visible release gate evidence: not required — this is not a release branch.
Supply-chain review: not required — no workflow, dependency, or permission files changed.

- [x] Level 1 static: `scripts/check.sh` passes
- [ ] Level 2 CLI contract: focused Typer/CliRunner tests, exit codes, `--json` behavior, TTY vs non-TTY (if CLI behavior touched)
- [ ] Level 3 package/install smoke (if packaging touched)
- [ ] Level 4 fixture repo (if init/onboard/status/start/update touched)
- [ ] Level 5 runtime smoke / dogfood harness / simulation-tier (if runtime, first-run, skill discovery, or release validation touched)
- [ ] SKILL.md <=500 lines (if any skill touched)
- [ ] Package-visible release gate evidence before tag/publish (if preparing a release)
- [ ] Supply-chain review (if `.github/workflows/`, `.github/dependabot.yml`, `mb/pyproject.toml` deps, or `id-token`/`permissions` blocks touched — see [docs/supply-chain-policy.md](../docs/supply-chain-policy.md))

## Success metric

A business owner can understand the Main Branch promise and first daily flow from the README or beginner setup page without learning `cd`, git plumbing, runtime internals, or provider jargon first.

## CHANGELOG

- [ ] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [x] N/A — docs-only positioning/onboarding copy; no CLI, skill, packaging, compatibility, or workflow behavior changed.

## Breaking changes

- [x] No
- [ ] Yes — migration note below

## Public / private boundary

No private operator strategy, machine-specific paths, secrets, or private runtime internals were committed. The README and beginner setup guide describe public product behavior and keep unproven publishing, spend, social posting, and account-mutation claims approval-gated or future-scoped.
