### PR TITLE
Prepare v0.3.36 release

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mainbranch",
-  "version": "0.3.35",
+  "version": "0.3.36",
   "description": "Main Branch Claude Code skills for running a business from markdown files in git.",
   "author": {
     "name": "Noontide"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+## [0.3.36] - 2026-05-24
+
+v0.3.36 corrects the Codex support surface after v0.3.35. Codex now follows the
+plain global skill bundle model under the Codex skills root instead of treating
+plugin slash commands as readiness.
+
 ### Fixed
 
 - Corrected Codex support to install a global Main Branch skill bundle under

--- a/mb/mb/__init__.py
+++ b/mb/mb/__init__.py
@@ -7,6 +7,6 @@ file stays a thin dispatcher.
 
 from __future__ import annotations
 
-__version__ = "0.3.35"
+__version__ = "0.3.36"
 
 __all__ = ["__version__"]

--- a/mb/pyproject.toml
+++ b/mb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mainbranch"
-version = "0.3.35"
+version = "0.3.36"
 description = "Main Branch engine umbrella - scaffolds, validates, and graphs business-as-files repos. Claude Code first, runtime-agnostic by design."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Prepares the `0.3.36` corrective release for Codex global skills.

## Release

- Version: `0.3.36`
- Tag: `oe-v0.3.36`
- Release focus: Codex global skill bundle under the Codex skills root, not plugin slash commands.

## Changes

- Bumps `mb/pyproject.toml`, `mb/mb/__init__.py`, and `.claude-plugin/plugin.json` to `0.3.36`.
- Moves the Codex global-skill corrective changelog entry into `0.3.36`.

## Validation

- `scripts/check.sh` passed.
- Focused version manifest test passed: `pytest tests/test_smoke_coverage.py::test_claude_plugin_manifest_points_at_prefixed_skills -q`.
- Package/install smoke:
  - clean-built `mainbranch-0.3.36-py3-none-any.whl`
  - installed into `/tmp/mainbranch-036-smoke`
  - verified `mb --version` prints `mb 0.3.36`
  - ran `mb skill list`
  - onboarded `/tmp/mainbranch-036-biz`
  - ran isolated Codex repair with `MAINBRANCH_CODEX_SKILLS_ROOT=/tmp/mainbranch-036-codex-skills`
  - verified 20 generated Codex `SKILL.md` files, including `mb-start` and `weekly-review`, and no `main-branch-owner-loop`

## Runtime Note

The isolated package smoke’s `mb status --json --peek` showed `global_skill_ok: true` and `slash_commands_ready: false`, but the Codex runtime status remained `runtime_mismatch` because this Mac’s login shell resolves the pre-release installed `mb 0.3.35` outside the smoke venv. The post-release installed-package smoke will verify the real user install after PyPI publish.

Closes #724
Refs #721
Refs #722
