### PR TITLE
Align Codex release stance after 0.3.36

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@
   HERO VISUAL - ADD BEFORE PUBLISHING
   Best README conversion asset:
     1. Open a sample business folder.
-    2. Open the folder in Claude Code or Codex, then run `/mb-start`.
+    2. Open the folder in Claude Code and run `/mb-start`, or open it in Codex
+       and use the global `mb-start` skill.
     3. Show the agent reading Main Branch facts and naming the next business move.
     4. Flash to `mb checkpoint --plan` or `mb graph --open`.
   Save to docs/assets/hero.gif and uncomment the image below.
@@ -300,10 +301,10 @@ It is a good fit if:
 
 | Objection | Reality |
 | --- | --- |
-| "I'm not technical enough." | Install once. Then open the folder in Claude Code or Codex, run `/mb-start`, and answer plain-language questions. |
+| "I'm not technical enough." | Install once. Then open the folder in Claude Code and run `/mb-start`, or open it in Codex and use the global `mb-start` skill. Answer plain-language questions. |
 | "I'll set it up wrong." | Main Branch checks the folder, explains what is wrong, and shows the repair path. |
 | "I'll lose work." | Approved checkpoints and GitHub backup give you readable history and reviewable changes. |
-| "I need someone to walk me through it." | Open the folder in Claude Code or Codex and run `/mb-start`. The agent explains the next step. |
+| "I need someone to walk me through it." | Open the folder in Claude Code and run `/mb-start`, or open it in Codex and use the global `mb-start` skill. The agent explains the next step. |
 | "I won't maintain it." | Run `/mb-update` when asked. Repair checks tell you if anything needs fixing. |
 
 ---
@@ -313,7 +314,7 @@ It is a good fit if:
 | App | Current support |
 | --- | --- |
 | **Claude Code** | Open or select the business folder, run `/mb-start`, and use the bundled Main Branch skills. |
-| **Codex** | Open or select the business folder, run `/mb-start`, and use the Main Branch Codex plugin and skills. |
+| **Codex** | Open or select the business folder and use the global Main Branch `mb-*` skills. |
 
 Account writes, publishing, spend, customer contact, and account changes remain
 approval-gated everywhere.
@@ -341,9 +342,9 @@ See [docs/compatibility.md](docs/compatibility.md) for the current support list.
 
 ## FAQ
 
-**Do I need to know how to code?** No. Open the folder in Claude Code or Codex,
-run `/mb-start`, and answer questions. The beginner walkthrough shows each
-setup step.
+**Do I need to know how to code?** No. Open the folder in Claude Code and run
+`/mb-start`, or open it in Codex and use the global `mb-start` skill. Answer
+questions. The beginner walkthrough shows each setup step.
 
 **Do I need to know git?** No. Main Branch uses git as the hidden save/history
 layer and speaks in business language: checkpoints, saved history, tasks, and
@@ -362,7 +363,8 @@ boundary, or operating history.
 try, why, by when, and how you will know. An offer is a durable thing you sell.
 A winning bet can graduate into an offer through an accepted decision.
 
-**How do I update?** Type `/mb-update` in Claude Code or Codex.
+**How do I update?** Type `/mb-update` in Claude Code, or use the global
+`mb-update` skill in Codex.
 
 **Can Claude or Codex migrate an old setup for me?** Yes. Open the folder in
 Claude Code or Codex and follow the migration prompt in

--- a/docs/architecture/system-map.md
+++ b/docs/architecture/system-map.md
@@ -27,7 +27,7 @@ flowchart TB
 
   subgraph runtime["Agent runtime layer"]
     claude["Claude Code<br/>supported runtime"]
-    codex["Codex CLI<br/>first-class owner loop"]
+    codex["Codex CLI<br/>global mb-* skills"]
     future["Cursor / OpenClaw / Hermes / local runtimes<br/>roadmap until adapter + smoke evidence"]
     skills["Bundled mb-* skills<br/>judgment, routing, writing, review, explanation"]
   end
@@ -218,7 +218,7 @@ flowchart TB
 | GitHub is repo, checks, and history. | GitHub issues are durable tasks, PRs are proposals, Actions/checks gate changes, Releases mark package-visible publication. |
 | Cloudflare is site and deploy. | Cloudflare is the adopted site/DNS/Pages rail where evidence exists; GitHub Pages is not the default setup path. |
 | Real private data stays out of broad repos. | Secrets, raw ledgers, account exports, customer/member data, legal records, and machine-specific paths stay in secret stores, private vaults, provider systems, or local ignored state. |
-| Runtime support stays honest. | Claude Code is the first-class slash-skill runtime. Codex CLI is first-class for the proven owner-loop plugin surface only. Other runtimes are roadmap until adapter and smoke evidence exist. |
+| Runtime support stays honest. | Claude Code is the first-class slash-skill runtime. Codex CLI is supported for daily Main Branch routes through generated `AGENTS.md`, global `mb-*` skills, workflow inventory, and deterministic `mb` facts. Other runtimes are roadmap until adapter and smoke evidence exist. |
 
 ## Data And Privacy Boundaries
 
@@ -262,7 +262,7 @@ Sources: [Data-source registry](../data-source-registry.md),
 | Runtime | Status | Contract |
 | --- | --- | --- |
 | Claude Code | Supported. | Slash skills and `mb start` handoff are the reference runtime path. |
-| Codex CLI | First-class owner loop. | Fresh business repos include `AGENTS.md`; the global Main Branch Codex plugin supplies generated guidance; Codex should run deterministic `mb` fact commands, use workflow inventory, and ask before writes. |
+| Codex CLI | Supported daily routes. | Fresh business repos include `AGENTS.md`; `mb doctor repair --only codex` installs global Main Branch `mb-*` skills under the Codex skills root; Codex should run deterministic `mb` fact commands, use workflow inventory, and ask before writes. |
 | Cursor, OpenClaw, Hermes, Paperclip-adjacent orchestration, local runtimes | Roadmap. | No support claim until adapter code, docs, generated-file rules, and fresh-repo smoke evidence exist. |
 
 Source: [Compatibility](../compatibility.md).

--- a/docs/ethos.md
+++ b/docs/ethos.md
@@ -100,11 +100,11 @@ and power users, but they should not be the default user experience.
 ### 5. Runtime Honesty
 
 Claude Code is the first supported slash-skill runtime today. Codex CLI is
-first-class for the proven owner loop through generated repo guidance,
-the global Main Branch Codex plugin, deterministic `mb` facts, and smoke
-evidence. Cursor, OpenClaw, Hermes, Paperclip-adjacent orchestration, and local
-runtimes are compatibility targets only when adapter code and smoke evidence
-exist.
+supported for the daily Main Branch routes through generated repo guidance,
+global `mb-*` skills under the Codex skills root, deterministic `mb` facts, and
+smoke evidence. Cursor, OpenClaw, Hermes, Paperclip-adjacent orchestration, and
+local runtimes are compatibility targets only when adapter code and smoke
+evidence exist.
 
 Main Branch should meet operators where they already work, but it should not
 claim support before support is proven.

--- a/docs/post-release-alignment.md
+++ b/docs/post-release-alignment.md
@@ -255,9 +255,9 @@ truth lives in the linked doc or decision.
   schema, primitive) are fine in code comments and contributor docs, not in
   user-facing copy. See `docs/agent-writing-style.md`.
 - **Runtime claims**: Claude Code is first-class for slash skills. Codex CLI is
-  first-class for the proven owner loop through generated repo guidance and the
-  global Main Branch Codex plugin. Other
-  runtimes are compatibility targets until smoke evidence exists. See
+  supported for daily Main Branch routes through generated repo guidance and
+  global `mb-*` skills under the Codex skills root. Other runtimes are
+  compatibility targets until smoke evidence exists. See
   `docs/compatibility.md`.
 
 If a PR or issue contradicts one of these, treat the contradiction as a

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -68,11 +68,11 @@ Main Branch already ships:
   team daily log, bookkeeping, and multi-repo work;
 - initial paid-traffic site readiness checks through `mb site check`.
 
-Claude Code is the supported slash-skill runtime today. Codex CLI is
-first-class for the proven owner loop through generated `AGENTS.md`, the
-global Main Branch Codex plugin, deterministic `mb` facts, and workflow
-inventory. Other runtimes are
-compatibility targets until adapter code and smoke evidence exist.
+Claude Code is the supported slash-skill runtime today. Codex CLI is supported
+for daily Main Branch routes through generated `AGENTS.md`, global `mb-*` skills
+under the Codex skills root, deterministic `mb` facts, and workflow inventory.
+Other runtimes are compatibility targets until adapter code and smoke evidence
+exist.
 
 ## Current Direction: Chat-First, CLI-Backed Daily Loop
 

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -115,9 +115,9 @@ surfaces, required `mb` fact commands, JSON fact paths, approval gates,
 public/private boundaries, routing rules, handoff shape, and validation
 expectations. Claude Code remains the first-class slash-skill runtime shell
 through `.claude/skills/mb-think/SKILL.md`; Codex uses tracked `AGENTS.md` plus
-the global Main Branch Codex plugin for the proven owner loop, checked against
-shared workflow sources where migrated. Neither `.claude/skills`, generated
-repo guidance, nor runtime plugin files are the canonical source for
+global Main Branch `mb-*` skills under the Codex skills root for daily routes,
+checked against shared workflow sources where migrated. Neither `.claude/skills`,
+generated repo guidance, nor runtime skill files are the canonical source for
 cross-runtime workflow semantics.
 
 `mb` may validate, render snapshots for tests, and repair generated runtime
@@ -621,10 +621,10 @@ and checkpoint. The full surface lives in
 
 Skills own judgment-heavy work: synthesis, writing, review, routing. They call
 `mb` for facts. Claude Code is the supported slash-skill runtime today. Codex
-CLI is supported for the proven owner loop through generated repo guidance, the
-global Main Branch Codex plugin, and deterministic `mb` facts. Other runtimes
-are compatibility targets until adapter code and smoke evidence exist. See
-[compatibility.md](compatibility.md).
+CLI is supported for daily Main Branch routes through generated repo guidance,
+global `mb-*` skills under the Codex skills root, and deterministic `mb` facts.
+Other runtimes are compatibility targets until adapter code and smoke evidence
+exist. See [compatibility.md](compatibility.md).
 
 Curated rails — GitHub, Cloudflare, Google/Workspace, official ads paths,
 Postiz, hledger, transcription helpers — earn their place by improving a loop

--- a/mb/tests/test_doctor.py
+++ b/mb/tests/test_doctor.py
@@ -408,7 +408,10 @@ def test_doctor_repair_plan_reports_missing_codex_agents_md(tmp_path: Path) -> N
     assert "AGENTS.md" in actions["codex-agents-md"]["writes"]
 
 
-def test_doctor_repair_only_codex_filters_unrelated_related_links(tmp_path: Path) -> None:
+def test_doctor_repair_only_codex_filters_unrelated_related_links(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _prepare_codex_global_skill_roots(tmp_path, monkeypatch)
     repo = tmp_path / "biz"
     init_run(path=str(repo), name="Acme")
     (repo / "AGENTS.md").write_text("# stale\n\nNo facts here.\n", encoding="utf-8")


### PR DESCRIPTION
## Summary
- updates current product/docs language from the retired Codex plugin stance to global Main Branch mb-* skills under the Codex skills root
- keeps the historical 0.3.34 report untouched as release evidence
- isolates a Codex repair regression test from the operator real global Codex skills install

## Validation
- scripts/check.sh