### PR TITLE
[update] Add scoped agent surface repair receipts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+### Changed
+
+- Made `mb doctor repair` agent-surface writes explicit: operators can plan or
+  apply Claude-only, Codex-only, or reviewed all-agent repairs, and JSON reports
+  now include detected surfaces, touched files, receipts, skipped surfaces, and
+  refresh notes. Refs MAIN-440, #722.
+- Clarified `mb update` surface refresh behavior and added an explicit
+  `--no-refresh-surfaces` escape hatch for package-only updates. Refs MAIN-440,
+  #722.
+
 ## [0.3.36] - 2026-05-24
 
 v0.3.36 corrects the Codex support surface after v0.3.35. Codex now follows the

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -98,6 +98,7 @@ Common shipped automation-safe commands include:
 | Runtime handoff metadata | `mb start --repo "$repo" --json` |
 | Repo health | `mb doctor "$repo" --json` |
 | Repair preview | `mb doctor repair --repo "$repo" --plan --json` |
+| Agent-surface repair preview | `mb doctor repair --repo "$repo" --plan --only claude`, `--only codex`, or `--all-agents` |
 | Frontmatter/schema validation | `mb validate "$repo" --json` |
 | Graph/index facts | `mb graph "$repo" --json` |
 | Provider readiness | `mb connect status --repo "$repo" --json` |
@@ -164,7 +165,7 @@ smoke evidence exist.
 | Runtime surface | Status | Invocation | Skill/workflow discovery | Routing and automation | Observability and packaging |
 |---|---|---|---|---|---|
 | Claude Code | Supported | `mb start --repo "$repo"` prints the `claude` handoff; `mb start --launch` may launch after readiness checks. | `mb skill link --repo "$repo"` writes project-local `.claude/skills/mb-*` bridge links and `.claude/settings.local.json`. | Slash commands such as `/mb-start` and `/mb-think` own conversation and judgment; they call deterministic `mb` commands for facts. | `mb doctor`, `mb status --json`, `mb start --json`, `mb skill repair`, and runtime dogfood evidence gate release claims. Skills ship inside the Python package today. |
-| Codex CLI | Supported | Can call deterministic `mb` commands as a subprocess when pointed at a business repo. `AGENTS.md` gives Codex the repo bootstrap, and global Main Branch skills give Codex `mb-*` workflow routes. | Fresh `mb onboard` repos include tracked `AGENTS.md`. `mb doctor repair --plan --only codex` / `--apply --only codex` refresh repo guidance and install or repair the global Codex skill bundle. | Codex `mb-*` skills run `mb status --json --peek`, `mb start --json`, `mb doctor repair --plan --json`, `mb checkpoint --plan --json`, `mb validate --json`, and `mb workflow list --runtime codex --json` as needed, translate facts into business language, and ask before writes. | `mb doctor`, `mb status --json`, `mb start --json`, and `mb workflow list` expose Codex readiness and workflow support. Codex support covers start/status/setup/update/doctor, think/codify, end/checkpoint/save, validate, and workflow discovery. Ads, organic, site, bet, and playbook routes are installed for discovery but remain read-only planning unless their support level says otherwise. |
+| Codex CLI | Supported | Can call deterministic `mb` commands as a subprocess when pointed at a business repo. `AGENTS.md` gives Codex the repo bootstrap, and global Main Branch skills give Codex `mb-*` workflow routes. | Fresh `mb onboard` repos include tracked `AGENTS.md`. `mb doctor repair --plan --only codex` / `--apply --only codex` refresh repo guidance and install or repair the global Codex skill bundle. Use `--all-agents` only after reviewing both Claude and Codex surface writes. | Codex `mb-*` skills run `mb status --json --peek`, `mb start --json`, `mb doctor repair --plan --json`, `mb checkpoint --plan --json`, `mb validate --json`, and `mb workflow list --runtime codex --json` as needed, translate facts into business language, and ask before writes. | `mb doctor`, `mb status --json`, `mb start --json`, and `mb workflow list` expose Codex readiness and workflow support. Codex support covers start/status/setup/update/doctor, think/codify, end/checkpoint/save, validate, and workflow discovery. Ads, organic, site, bet, and playbook routes are installed for discovery but remain read-only planning unless their support level says otherwise. |
 | Cursor | Roadmap | Can call deterministic `mb` commands from terminal/tasks when pointed at a business repo. | No supported Cursor rules/package adapter yet. | No supported Main Branch routing contract. | Needs adapter docs, install/update rules, conflict handling, and smoke evidence. |
 | OpenClaw | Roadmap | Target public runtime surface. It should call `mb` through stable CLI/JSON commands rather than clone-era paths. | No supported OpenClaw adapter yet. | Main Branch should coexist with OpenClaw as the business repo/GitHub memory layer, not replace it. | Needs explicit adapter shape, migration notes, generated-file rules, and smoke evidence. |
 | Hermes | Roadmap | Target runtime/memory surface. It may supervise or host workflows that call packaged `mb` commands. | No supported Hermes adapter yet. | Hermes-specific routing belongs in the Hermes adapter, while `mb` remains deterministic and non-conversational. | Docs may describe internal-package expectations generically, but not as the only blessed public path. Smoke evidence is required before support claims. |
@@ -258,9 +259,11 @@ mb update
 ```
 
 `mb update` detects whether Main Branch is a `pipx` install or source checkout,
-runs the appropriate update path, refreshes Claude Code skill links, and runs
-the Codex global-skill repair from the upgraded `mb` executable. Use
-`mb update --check` for a dry-run and `mb update --json` for automation.
+runs the appropriate update path, and then runs the explicit surface-refresh
+path by default: Claude Code skill links/guidance plus Codex global skills and
+repo `AGENTS.md` from the upgraded `mb` executable. Use `mb update --check` for
+a dry-run, `mb update --json` for automation, and `--no-refresh-surfaces` only
+when deliberately updating the package without touching runtime surfaces.
 Inside Claude Code, `/mb-update` calls `mb update` for this mechanical step and keeps
 ownership of the human-readable "what's new" summary. Codex users should open a
 fresh Codex thread after an update so refreshed global skills are loaded.

--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -673,6 +673,7 @@ def _doctor_repair_from_args(args: list[str], *, json_out: bool) -> None:
     apply_changes = False
     include_migration = False
     only = ""
+    all_agents = False
     local_json = json_out
     idx = 0
     while idx < len(args):
@@ -680,7 +681,7 @@ def _doctor_repair_from_args(args: list[str], *, json_out: bool) -> None:
         if arg == "--help":
             typer.echo(
                 "Usage: mb doctor repair [--repo PATH] [--plan | --apply] "
-                "[--only codex] [--include-migration] [--json]"
+                "[--only claude|codex | --all-agents] [--include-migration] [--json]"
             )
             typer.echo("")
             typer.echo("Plan or apply guided business-repo reconciliation repairs.")
@@ -702,6 +703,8 @@ def _doctor_repair_from_args(args: list[str], *, json_out: bool) -> None:
             apply_changes = True
         elif arg == "--include-migration":
             include_migration = True
+        elif arg == "--all-agents":
+            all_agents = True
         elif arg == "--only":
             idx += 1
             if idx >= len(args):
@@ -726,19 +729,29 @@ def _doctor_repair_from_args(args: list[str], *, json_out: bool) -> None:
             err=True,
         )
         raise typer.Exit(2)
-    if only and only != "codex":
-        typer.echo("mb doctor repair: --only currently supports only `codex`", err=True)
+    if only and only not in {"claude", "codex"}:
+        typer.echo("mb doctor repair: --only supports `claude` or `codex`", err=True)
+        raise typer.Exit(2)
+    if only and all_agents:
+        typer.echo("mb doctor repair: --only cannot be combined with --all-agents", err=True)
         raise typer.Exit(2)
     if only and include_migration:
         typer.echo("mb doctor repair: --only cannot be combined with --include-migration", err=True)
         raise typer.Exit(2)
+    if all_agents and include_migration:
+        typer.echo(
+            "mb doctor repair: --all-agents cannot be combined with --include-migration",
+            err=True,
+        )
+        raise typer.Exit(2)
 
     if apply_changes:
-        if only:
+        if only or all_agents:
             report = doctor_mod.repair_apply(
                 repo=repo,
                 include_migration=include_migration,
                 only=only,
+                all_agents=all_agents,
             )
         else:
             report = doctor_mod.repair_apply(
@@ -747,8 +760,8 @@ def _doctor_repair_from_args(args: list[str], *, json_out: bool) -> None:
             )
     else:
         report = (
-            doctor_mod.repair_plan(repo=repo, only=only)
-            if only
+            doctor_mod.repair_plan(repo=repo, only=only, all_agents=all_agents)
+            if only or all_agents
             else doctor_mod.repair_plan(repo=repo)
         )
 
@@ -777,7 +790,7 @@ def _doctor_help() -> None:
     typer.echo("Repair:")
     typer.echo(
         "  mb doctor repair [--repo PATH] [--plan | --apply] "
-        "[--only codex] [--include-migration] [--json]"
+        "[--only claude|codex | --all-agents] [--include-migration] [--json]"
     )
     typer.echo("  Note: --include-migration is valid only with --apply after plan review.")
 
@@ -1761,10 +1774,15 @@ def educational_cmd(
 def update_cmd(
     repo: str = typer.Option(".", "--repo", help="Business repo whose skill links refresh."),
     check: bool = typer.Option(False, "--check", help="Dry-run only; do not upgrade or relink."),
+    refresh_surfaces: bool = typer.Option(
+        True,
+        "--refresh-surfaces/--no-refresh-surfaces",
+        help="Refresh Claude links/guidance, Codex global skills, and AGENTS.md after update.",
+    ),
     json_out: bool = typer.Option(False, "--json", help="Machine-readable output."),
 ) -> None:
     """Refresh Main Branch according to its install mode."""
-    result = update_mod.run(repo=repo, check=check)
+    result = update_mod.run(repo=repo, check=check, refresh_surfaces=refresh_surfaces)
     if json_out:
         typer.echo(json.dumps(result, indent=2))
     else:

--- a/mb/mb/doctor.py
+++ b/mb/mb/doctor.py
@@ -77,6 +77,11 @@ REFERENCE_COMPAT_LINKS = {
 }
 STATE_ORDER = {"ok": 0, "info": 1, "warn": 2, "error": 3}
 AUDIENCE_VALUES = frozenset({"mechanical", "operator_decision", "informational"})
+AGENT_REPAIR_SCOPES = frozenset({"claude", "codex"})
+CLAUDE_ACTION_IDS = frozenset({"skill-link", "skill-shadow-repair", "legacy-claude-link-repair"})
+CODEX_ACTION_IDS = frozenset({"codex-agents-md", "codex-global-skill"})
+AGENT_ACTION_IDS = CLAUDE_ACTION_IDS | CODEX_ACTION_IDS
+AGENT_SECTION_IDS = frozenset({"claude-wiring", "codex-wiring", "git"})
 
 
 def _derive_audience(mode: str, safe_to_apply: bool) -> str:
@@ -245,6 +250,188 @@ def _section(
         "summary": summary,
         "checks": checks or [],
         "actions": actions or [],
+    }
+
+
+def _unique(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        result.append(value)
+    return result
+
+
+def _action_ids_for_scope(only: str = "", *, all_agents: bool = False) -> set[str]:
+    if all_agents:
+        return set(AGENT_ACTION_IDS)
+    if only == "claude":
+        return set(CLAUDE_ACTION_IDS)
+    if only == "codex":
+        return set(CODEX_ACTION_IDS)
+    return set()
+
+
+def _agent_scope_label(only: str = "", *, all_agents: bool = False) -> str:
+    if all_agents:
+        return "all-agents"
+    return only or "default"
+
+
+def _agent_scope_filter(
+    sections: list[dict[str, Any]],
+    actions: list[dict[str, Any]],
+    *,
+    only: str = "",
+    all_agents: bool = False,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    action_ids = _action_ids_for_scope(only, all_agents=all_agents)
+    if not action_ids:
+        return sections, actions
+    section_ids = set(AGENT_SECTION_IDS)
+    if only == "claude":
+        section_ids = {"claude-wiring", "git"}
+    elif only == "codex":
+        section_ids = {"codex-wiring", "git"}
+    filtered_sections = [section for section in sections if str(section.get("id")) in section_ids]
+    filtered_actions = [action for action in actions if str(action.get("id")) in action_ids]
+    return filtered_sections, filtered_actions
+
+
+def _agent_surfaces(
+    sections: list[dict[str, Any]],
+    actions: list[dict[str, Any]],
+    *,
+    only: str = "",
+    all_agents: bool = False,
+) -> dict[str, Any]:
+    by_section = {str(section.get("id")): section for section in sections}
+    by_action = {str(action.get("id")): action for action in actions}
+
+    def surface(
+        *,
+        key: str,
+        section_id: str,
+        action_ids: frozenset[str],
+        label: str,
+        repair_command: str,
+    ) -> dict[str, Any]:
+        section = by_section.get(section_id, {})
+        surface_actions = [
+            by_action[action_id] for action_id in action_ids if action_id in by_action
+        ]
+        return {
+            "id": key,
+            "label": label,
+            "state": str(section.get("state") or "info"),
+            "detected": bool(section),
+            "repair_command": repair_command,
+            "checks": [
+                {
+                    "name": str(check.get("name") or ""),
+                    "state": str(check.get("state") or "info"),
+                    "summary": str(check.get("summary") or ""),
+                }
+                for check in section.get("checks", [])
+            ],
+            "planned_actions": [str(action.get("id")) for action in surface_actions],
+            "touched_files": _unique(
+                [str(path) for action in surface_actions for path in action.get("writes", [])]
+            ),
+        }
+
+    return {
+        "scope": _agent_scope_label(only, all_agents=all_agents),
+        "scope_choices": [
+            "mb doctor repair --plan --only claude",
+            "mb doctor repair --plan --only codex",
+            "mb doctor repair --plan --all-agents",
+        ],
+        "apply_choices": [
+            "mb doctor repair --apply --only claude",
+            "mb doctor repair --apply --only codex",
+            "mb doctor repair --apply --all-agents",
+        ],
+        "surfaces": [
+            surface(
+                key="claude",
+                section_id="claude-wiring",
+                action_ids=CLAUDE_ACTION_IDS,
+                label="Claude Code project-local skills",
+                repair_command="mb doctor repair --apply --only claude",
+            ),
+            surface(
+                key="codex",
+                section_id="codex-wiring",
+                action_ids=CODEX_ACTION_IDS,
+                label="Codex global mb-* skills and repo AGENTS.md",
+                repair_command="mb doctor repair --apply --only codex",
+            ),
+        ],
+    }
+
+
+def _repair_receipt(
+    applied_actions: list[dict[str, Any]],
+    *,
+    only: str = "",
+    all_agents: bool = False,
+) -> dict[str, Any]:
+    touched_files = _unique(
+        [str(path) for action in applied_actions for path in action.get("writes", [])]
+    )
+    installed_skills: list[str] = []
+    for action in applied_actions:
+        if str(action.get("id")) != "codex-global-skill":
+            continue
+        result = action.get("result", {})
+        if not isinstance(result, dict):
+            continue
+        status = result.get("status", {})
+        if isinstance(status, dict):
+            installed_skills.extend(str(name) for name in status.get("required_skills", []))
+        source = result.get("source", {})
+        if isinstance(source, dict) and not installed_skills:
+            installed_skills.extend(
+                str(path).removesuffix("/SKILL.md") for path in source.get("relative_paths", [])
+            )
+    scope = _agent_scope_label(only, all_agents=all_agents)
+    skipped_surfaces: list[str] = []
+    if scope == "default":
+        skipped_surfaces = [
+            "claude: run mb doctor repair --apply --only claude",
+            "codex: run mb doctor repair --apply --only codex",
+        ]
+    elif scope == "claude":
+        skipped_surfaces = ["codex"]
+    elif scope == "codex":
+        skipped_surfaces = ["claude"]
+
+    return {
+        "scope": scope,
+        "installed_skills": _unique(installed_skills),
+        "touched_files": touched_files,
+        "skipped_surfaces": skipped_surfaces,
+        "warnings": [
+            str(action.get("reason") or "")
+            for action in applied_actions
+            if str(action.get("state")) in {"warn", "error"}
+        ],
+        "restart_notes": [
+            "Open a fresh Codex thread after Codex global skills change.",
+            "Restart Claude Code if it was already open while project-local skill links changed.",
+        ],
+        "rollback": [
+            "Review touched files with git diff before committing.",
+            "Use git restore for repo-local generated files you do not want to keep.",
+            "Remove generated Codex skill folders from the Codex skills root if needed.",
+        ],
+        "uninstall": [
+            "Claude: remove project-local .claude/skills links and settings entries after review.",
+            "Codex: remove Main Branch folders under the Codex skills root after review.",
+        ],
     }
 
 
@@ -1571,8 +1758,13 @@ def repair_plan(
     mode: str = "plan",
     applied_actions: list[dict[str, Any]] | None = None,
     only: str = "",
+    all_agents: bool = False,
 ) -> dict[str, Any]:
     """Build the guided reconciliation plan without writing repo status markers."""
+    if only and only not in AGENT_REPAIR_SCOPES:
+        raise ValueError(f"unknown repair scope: {only}")
+    if only and all_agents:
+        raise ValueError("--only cannot be combined with --all-agents")
     target = Path(repo).expanduser().resolve()
     doctor_report = run(str(target))
     actions: list[dict[str, Any]] = []
@@ -1984,7 +2176,7 @@ def repair_plan(
                 title="Restore Main Branch start wiring for Claude Code",
                 state="error",
                 mode="write",
-                command="mb doctor repair --apply",
+                command="mb doctor repair --apply --only claude",
                 safe_to_apply=True,
                 reason=(
                     "restores project-local Main Branch start wiring so Claude Code "
@@ -2004,7 +2196,7 @@ def repair_plan(
                 title="Move stale personal Main Branch skill symlinks to backup",
                 state="warn",
                 mode="write",
-                command="mb skill repair --repo . --apply",
+                command="mb doctor repair --apply --only claude",
                 safe_to_apply=True,
                 reason="only stale or broken Main Branch personal symlinks are moved",
                 writes=[str(shadow_report.get("personal_skills_dir") or "~/.claude/skills")],
@@ -2017,7 +2209,7 @@ def repair_plan(
                 title="Move old clone-path lens/reference symlinks to backup",
                 state="warn",
                 mode="write",
-                command="mb doctor repair --apply",
+                command="mb doctor repair --apply --only claude",
                 safe_to_apply=True,
                 reason="only stale Main Branch clone-path symlinks are moved; user files stay put",
                 writes=[".claude/lenses/", ".claude/reference/", ".mb/backups/"],
@@ -2094,6 +2286,7 @@ def repair_plan(
             "skill_path": codex_global_skill["path"],
             "skills_root": codex_global_skill["skills_root"],
             "routes": codex_global_skill["routes"],
+            "required_skills": codex_global_skill.get("required_skills", []),
             "stale": codex_global_skill["stale"],
             "missing": codex_global_skill["missing"],
             "missing_markers": codex_global_skill["missing_markers"],
@@ -2124,12 +2317,15 @@ def repair_plan(
     if not codex_global_skill["ok"]:
         action = _action(
             id="codex-global-skill",
-            title="Install the global Main Branch Codex skill",
+            title="Install the global Main Branch Codex skill bundle",
             state="warn",
             mode="write",
             command="mb doctor repair --apply --only codex",
             safe_to_apply=True,
-            reason=("Codex uses one global Main Branch skill for the supported mb-* routes"),
+            reason=(
+                "Codex uses a global Main Branch skill bundle for supported and "
+                "discoverable mb-* routes"
+            ),
             writes=[
                 str(codex_mod.global_skill_source_root()),
             ],
@@ -2294,15 +2490,18 @@ def repair_plan(
         )
     )
 
-    if only:
-        if only != "codex":
-            raise ValueError(f"unknown repair scope: {only}")
-        sections = [section for section in sections if section["id"] in {"codex-wiring", "git"}]
-        actions = [
-            action
-            for action in actions
-            if str(action.get("id")) in {"codex-agents-md", "codex-global-skill"}
-        ]
+    agent_surfaces = _agent_surfaces(
+        sections,
+        actions,
+        only=only,
+        all_agents=all_agents,
+    )
+    sections, actions = _agent_scope_filter(
+        sections,
+        actions,
+        only=only,
+        all_agents=all_agents,
+    )
 
     states = [str(section["state"]) for section in sections]
     summary = {
@@ -2322,6 +2521,7 @@ def repair_plan(
         "ok": summary["error"] == 0,
         "mode": mode,
         "only": only,
+        "all_agents": all_agents,
         "read_only": mode == "plan",
         "repo": str(target),
         "generated_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
@@ -2329,6 +2529,12 @@ def repair_plan(
         "sections": sections,
         "actions": actions,
         "applied_actions": applied_actions or [],
+        "agent_surfaces": agent_surfaces,
+        "receipt": _repair_receipt(
+            applied_actions or [],
+            only=only,
+            all_agents=all_agents,
+        ),
         "post_apply": {
             "structural_verification": "mb doctor repair --plan --json",
             "validation_frontmatter_debt": "mb validate --cross-refs",
@@ -2367,17 +2573,23 @@ def repair_apply(
     *,
     include_migration: bool = False,
     only: str = "",
+    all_agents: bool = False,
 ) -> dict[str, Any]:
     """Apply safe doctor repairs and return a fresh reconciliation report."""
-    if only and only != "codex":
+    if only and only not in AGENT_REPAIR_SCOPES:
         raise ValueError(f"unknown repair scope: {only}")
+    if only and all_agents:
+        raise ValueError("--only cannot be combined with --all-agents")
     target = Path(repo).expanduser().resolve()
-    before = repair_plan(target, only=only)
+    before = repair_plan(target, only=only, all_agents=all_agents)
     applied: list[dict[str, Any]] = []
+    apply_non_agent = not only and not all_agents
+    apply_claude = only == "claude" or all_agents
+    apply_codex = only == "codex" or all_agents
 
     missing_gitignore = _missing_gitignore_entries(target)
     tracked_local_state = _tracked_local_state_paths(target)
-    if missing_gitignore and not only:
+    if missing_gitignore and apply_non_agent:
         changed = _append_unique_lines(target / ".gitignore", missing_gitignore)
         applied.append(
             _action(
@@ -2393,7 +2605,7 @@ def repair_apply(
                 result={"added": missing_gitignore},
             )
         )
-    if tracked_local_state and not only:
+    if tracked_local_state and apply_non_agent:
         results = [_untrack_local_state_path(target, rel) for rel in tracked_local_state]
         applied.append(
             _action(
@@ -2414,7 +2626,7 @@ def repair_apply(
         )
 
     checkpoint_hook = checkpoint_mod.hook_status(target)
-    if checkpoint_hook.get("state") in {"missing", "broken"} and not only:
+    if checkpoint_hook.get("state") in {"missing", "broken"} and apply_non_agent:
         installed = checkpoint_mod.install_commit_hook(target)
         applied.append(
             _action(
@@ -2431,8 +2643,8 @@ def repair_apply(
             )
         )
 
-    shadow = engine_mod.inspect_personal_skill_conflicts(target, apply=not bool(only))
-    if int(shadow.get("summary", {}).get("repaired", 0) or 0) and not only:
+    shadow = engine_mod.inspect_personal_skill_conflicts(target, apply=apply_claude)
+    if int(shadow.get("summary", {}).get("repaired", 0) or 0) and apply_claude:
         applied.append(
             _action(
                 id="skill-shadow-repair",
@@ -2448,7 +2660,7 @@ def repair_apply(
             )
         )
 
-    if not link_status(target).get("ok") and not only:
+    if not link_status(target).get("ok") and apply_claude:
         linked = engine_mod.link_skills(target)
         applied.append(
             _action(
@@ -2470,11 +2682,11 @@ def repair_apply(
 
     legacy_links = _legacy_claude_symlinks(target)
     repaired_links = (
-        {"moved": [], "errors": [], "ok": True}
-        if only
-        else _repair_legacy_claude_symlinks(target, legacy_links["findings"])
+        _repair_legacy_claude_symlinks(target, legacy_links["findings"])
+        if apply_claude
+        else {"moved": [], "errors": [], "ok": True}
     )
-    if (repaired_links["moved"] or repaired_links["errors"]) and not only:
+    if (repaired_links["moved"] or repaired_links["errors"]) and apply_claude:
         _append_unique_lines(target / ".gitignore", [".mb/backups/"])
         applied.append(
             _action(
@@ -2483,7 +2695,11 @@ def repair_apply(
                 state="ok" if repaired_links["ok"] else "error",
                 mode="write",
                 command=(
-                    "mb doctor repair --apply --only codex" if only else "mb doctor repair --apply"
+                    "mb doctor repair --apply --only claude"
+                    if only == "claude"
+                    else "mb doctor repair --apply --all-agents"
+                    if all_agents
+                    else "mb doctor repair --apply"
                 ),
                 safe_to_apply=True,
                 reason="moved stale symlink entries, not user-authored files",
@@ -2494,7 +2710,7 @@ def repair_apply(
         )
 
     codex_instruction_status = codex_mod.instructions_status(target)
-    if not codex_instruction_status["ok"]:
+    if not codex_instruction_status["ok"] and apply_codex:
         agents = codex_mod.write_agents_md(target)
         applied.append(
             _action(
@@ -2505,6 +2721,8 @@ def repair_apply(
                 command=(
                     "mb doctor repair --apply --only codex"
                     if only == "codex"
+                    else "mb doctor repair --apply --all-agents"
+                    if all_agents
                     else "mb doctor repair --apply"
                 ),
                 safe_to_apply=True,
@@ -2522,11 +2740,8 @@ def repair_apply(
         )
 
     codex_status = codex_mod.readiness(target)
-    codex_runtime_relevant = bool(
-        codex_status["executable"]["found"] and codex_status["instructions"]["ok"]
-    )
     codex_global_skill = codex_status["global_skill"]
-    if codex_runtime_relevant and not codex_global_skill["ok"]:
+    if not codex_global_skill["ok"] and apply_codex:
         installed = codex_mod.install_global_skill(target)
         applied.append(
             _action(
@@ -2534,7 +2749,11 @@ def repair_apply(
                 title="Installed the global Main Branch Codex skill bundle",
                 state="ok" if installed["ok"] else "error",
                 mode="write",
-                command="mb doctor repair --apply --only codex",
+                command=(
+                    "mb doctor repair --apply --only codex"
+                    if only == "codex"
+                    else "mb doctor repair --apply --all-agents"
+                ),
                 safe_to_apply=True,
                 reason=("installed global Codex skills for the supported Main Branch mb-* routes"),
                 writes=[
@@ -2546,7 +2765,7 @@ def repair_apply(
         )
 
     related_links_result: dict[str, Any] = {"changed": [], "errors": [], "ok": True}
-    if not only:
+    if apply_non_agent:
         related_links_result = related_links_mod.apply(target)
     if related_links_result["changed"] or related_links_result["errors"]:
         applied.append(
@@ -2567,7 +2786,7 @@ def repair_apply(
             )
         )
 
-    if include_migration and not only:
+    if include_migration and apply_non_agent:
         migrated = migrate_mod.apply(target)
         applied.append(
             _action(
@@ -2584,7 +2803,13 @@ def repair_apply(
             )
         )
 
-    after = repair_plan(target, mode="apply", applied_actions=applied, only=only)
+    after = repair_plan(
+        target,
+        mode="apply",
+        applied_actions=applied,
+        only=only,
+        all_agents=all_agents,
+    )
     after["before_summary"] = before["summary"]
     return after
 
@@ -2598,6 +2823,8 @@ def render_repair(report: dict[str, Any]) -> None:
     console.print(f"\n[bold]mb doctor repair[/bold]  {mode}")
     if report.get("only"):
         console.print(f"scope: {report['only']}")
+    elif report.get("all_agents"):
+        console.print("scope: all agent surfaces")
     console.print(f"repo: {report['repo']}\n")
     for section in report["sections"]:
         state = str(section["state"])
@@ -2623,6 +2850,23 @@ def render_repair(report: dict[str, Any]) -> None:
         console.print("\n[bold]Applied safe repairs[/bold]")
         for action in report["applied_actions"]:
             console.print(f"  - {action['title']}: {action['command']}")
+        receipt = report.get("receipt", {})
+        touched = receipt.get("touched_files", []) if isinstance(receipt, dict) else []
+        installed = receipt.get("installed_skills", []) if isinstance(receipt, dict) else []
+        if touched:
+            console.print("  touched: " + ", ".join(str(item) for item in touched[:8]))
+        if installed:
+            console.print("  installed Codex skills: " + ", ".join(str(item) for item in installed))
+    if report.get("agent_surfaces"):
+        console.print("\n[bold]Agent surfaces[/bold]")
+        for surface in report["agent_surfaces"].get("surfaces", []):
+            files = surface.get("touched_files", [])
+            console.print(
+                f"  - {surface['label']}: {surface['state']} "
+                f"({len(surface.get('planned_actions', []))} action(s))"
+            )
+            if files:
+                console.print("    would touch: " + ", ".join(str(item) for item in files[:8]))
     if report["actions"]:
         console.print("\n[bold]Repair plan[/bold]")
         for action in report["actions"]:

--- a/mb/mb/update.py
+++ b/mb/mb/update.py
@@ -218,11 +218,19 @@ def _repair_codex_surface(repo: Path) -> tuple[bool, list[str], list[str], dict[
     return True, [], warnings, payload
 
 
-def _base_result(repo: Path, *, check: bool, mode: str, root: Path | None) -> dict[str, Any]:
+def _base_result(
+    repo: Path,
+    *,
+    check: bool,
+    mode: str,
+    root: Path | None,
+    refresh_surfaces: bool,
+) -> dict[str, Any]:
     return {
         "ok": True,
         "mode": mode,
         "check": check,
+        "refresh_surfaces": refresh_surfaces,
         "repo": str(repo),
         "engine_root": str(root) if root is not None else None,
         "old_version": _engine_version(root),
@@ -237,6 +245,13 @@ def _base_result(repo: Path, *, check: bool, mode: str, root: Path | None) -> di
         "errors": [],
         "next_actions": [],
         "codex_adapter": {},
+        "surface_refresh": {
+            "enabled": refresh_surfaces,
+            "claude": {},
+            "codex": {},
+            "commands": [],
+            "skipped": [] if refresh_surfaces else ["claude", "codex"],
+        },
     }
 
 
@@ -303,12 +318,23 @@ def _add_codex_follow_up(result: dict[str, Any], repo: Path) -> None:
         result["next_actions"].append("Open a fresh Codex thread in the business repo.")
 
 
-def run(repo: str | Path = ".", *, check: bool = False) -> dict[str, Any]:
+def run(
+    repo: str | Path = ".",
+    *,
+    check: bool = False,
+    refresh_surfaces: bool = True,
+) -> dict[str, Any]:
     """Update the active Main Branch install and refresh business-repo skills."""
     target_repo = Path(repo).resolve()
     mode = install_mode()
     root = engine_root()
-    result = _base_result(target_repo, check=check, mode=mode, root=root)
+    result = _base_result(
+        target_repo,
+        check=check,
+        mode=mode,
+        root=root,
+        refresh_surfaces=refresh_surfaces,
+    )
 
     if mode not in {"pipx", "clone"}:
         result["ok"] = False
@@ -323,8 +349,6 @@ def run(repo: str | Path = ".", *, check: bool = False) -> dict[str, Any]:
             result["new_version"] = _latest_pypi_version() or result["old_version"]
             result["actions"] = [
                 "would run `pipx upgrade mainbranch`",
-                f"would run `mb skill link --repo {target_repo} --json`",
-                (f"would run `mb doctor repair --repo {target_repo} --apply --only codex --json`"),
             ]
         else:
             if root is None:
@@ -345,16 +369,29 @@ def run(repo: str | Path = ".", *, check: bool = False) -> dict[str, Any]:
             result["actions"].extend(
                 [
                     f"would run `git pull --ff-only origin main` in {root}",
-                    f"would run `mb skill link --repo {target_repo} --json`",
-                    (
-                        "would run `mb doctor repair --repo "
-                        f"{target_repo} --apply --only codex --json`"
-                    ),
                 ]
             )
-        planned_count = len(bundled_skills())
-        result["skills_relinked_count"] = planned_count
-        result["planned_skills_relink_count"] = planned_count
+        if refresh_surfaces:
+            surface_commands = [
+                f"mb skill link --repo {target_repo} --json",
+                f"mb doctor repair --repo {target_repo} --apply --only codex --json",
+            ]
+            result["surface_refresh"]["commands"] = surface_commands
+            result["actions"].extend(f"would run `{command}`" for command in surface_commands)
+            planned_count = len(bundled_skills())
+            result["skills_relinked_count"] = planned_count
+            result["planned_skills_relink_count"] = planned_count
+            result["surface_refresh"]["claude"] = {
+                "planned": True,
+                "skill_count": planned_count,
+                "command": surface_commands[0],
+            }
+            result["surface_refresh"]["codex"] = {
+                "planned": True,
+                "command": surface_commands[1],
+            }
+        else:
+            result["actions"].append("would skip agent surface refresh")
         new_version = str(result.get("new_version") or "")
         old_version = str(result.get("old_version") or "")
         if new_version and version_key(new_version) > version_key(old_version):
@@ -402,25 +439,43 @@ def run(repo: str | Path = ".", *, check: bool = False) -> dict[str, Any]:
             return result
         result["new_version"] = _engine_version(root)
 
-    linked_count, link_errors, link_warnings, _link_payload = _link_skills(target_repo)
-    result["actions"].append(f"ran `mb skill link --repo {target_repo} --json`")
-    result["skills_relinked_count"] = linked_count
-    result["warnings"].extend(link_warnings)
-    if link_errors:
-        result["ok"] = False
-        result["errors"].extend(link_errors)
-    else:
-        codex_ok, codex_errors, codex_warnings, codex_payload = _repair_codex_surface(target_repo)
-        result["actions"].append(
-            f"ran `mb doctor repair --repo {target_repo} --apply --only codex --json`"
-        )
-        result["codex_repaired"] = codex_ok
-        if codex_payload is not None:
-            result["codex_repair_result"] = codex_payload
-        result["warnings"].extend(codex_warnings)
-        if codex_errors:
+    if refresh_surfaces:
+        linked_count, link_errors, link_warnings, link_payload = _link_skills(target_repo)
+        claude_command = f"mb skill link --repo {target_repo} --json"
+        result["actions"].append(f"ran `{claude_command}`")
+        result["surface_refresh"]["commands"].append(claude_command)
+        result["surface_refresh"]["claude"] = {
+            "ok": not link_errors,
+            "skill_count": linked_count,
+            "command": claude_command,
+            "result": link_payload or {},
+        }
+        result["skills_relinked_count"] = linked_count
+        result["warnings"].extend(link_warnings)
+        if link_errors:
             result["ok"] = False
-            result["errors"].extend(codex_errors)
+            result["errors"].extend(link_errors)
+        else:
+            codex_ok, codex_errors, codex_warnings, codex_payload = _repair_codex_surface(
+                target_repo
+            )
+            codex_command = f"mb doctor repair --repo {target_repo} --apply --only codex --json"
+            result["actions"].append(f"ran `{codex_command}`")
+            result["surface_refresh"]["commands"].append(codex_command)
+            result["surface_refresh"]["codex"] = {
+                "ok": codex_ok,
+                "command": codex_command,
+                "result": codex_payload or {},
+            }
+            result["codex_repaired"] = codex_ok
+            if codex_payload is not None:
+                result["codex_repair_result"] = codex_payload
+            result["warnings"].extend(codex_warnings)
+            if codex_errors:
+                result["ok"] = False
+                result["errors"].extend(codex_errors)
+    else:
+        result["actions"].append("skipped agent surface refresh")
     _add_codex_follow_up(result, target_repo)
     return result
 
@@ -431,6 +486,7 @@ def render_human(result: dict[str, Any]) -> None:
     new = result.get("new_version") or "unknown"
     mode = result.get("mode") or "unknown"
     count = result.get("skills_relinked_count", 0)
+    refresh_surfaces = result.get("refresh_surfaces", True)
 
     if result.get("check"):
         print(f"install mode: {mode}")
@@ -452,11 +508,16 @@ def render_human(result: dict[str, Any]) -> None:
             print(f"next: {action}")
         if count:
             print(f"would refresh {count} skill link(s)")
+        if not refresh_surfaces:
+            print("would skip agent surface refresh")
     elif result.get("ok"):
         print(f"updated Main Branch ({old} -> {new})")
-        print(f"refreshed {count} skill link(s)")
-        if result.get("codex_repaired"):
-            print("refreshed Codex global skills")
+        if refresh_surfaces:
+            print(f"refreshed {count} skill link(s)")
+            if result.get("codex_repaired"):
+                print("refreshed Codex global skills")
+        else:
+            print("skipped agent surface refresh")
         for action in result.get("next_actions", []):
             print(f"next: {action}")
 

--- a/mb/tests/test_doctor.py
+++ b/mb/tests/test_doctor.py
@@ -378,10 +378,10 @@ def test_doctor_repair_apply_restores_missing_claude_worktree_start_wiring(
         "mb doctor repair --plan",
         "mb doctor repair --apply",
     ]
-    assert actions["skill-link"]["command"] == "mb doctor repair --apply"
+    assert actions["skill-link"]["command"] == "mb doctor repair --apply --only claude"
     assert "/mb-start" in actions["skill-link"]["reason"]
 
-    applied = doctor_mod.repair_apply(repo=worktree)
+    applied = doctor_mod.repair_apply(repo=worktree, only="claude")
     applied_actions = {action["id"]: action for action in applied["applied_actions"]}
 
     assert "skill-link" in applied_actions
@@ -450,9 +450,121 @@ def test_doctor_repair_only_codex_filters_unrelated_related_links(
     assert apply_result.exit_code in {0, 1}
     payload = json.loads(apply_result.stdout)
     applied = {action["id"]: action for action in payload["applied_actions"]}
-    assert set(applied) == {"codex-agents-md"}
+    assert set(applied) == {"codex-agents-md", "codex-global-skill"}
     assert applied["codex-agents-md"]["command"] == "mb doctor repair --apply --only codex"
     assert "## Related links" not in decision.read_text(encoding="utf-8")
+
+
+def test_doctor_repair_plan_lists_agent_surfaces_and_scope_choices(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _prepare_codex_global_skill_roots(tmp_path, monkeypatch)
+    repo = tmp_path / "biz"
+    init_run(path=str(repo), name="Acme")
+    (repo / "AGENTS.md").write_text("# stale\n\nNo facts here.\n", encoding="utf-8")
+
+    result = runner.invoke(app, ["doctor", "repair", "--repo", str(repo), "--plan", "--json"])
+
+    assert result.exit_code in {0, 1}
+    payload = json.loads(result.stdout)
+    surfaces = {surface["id"]: surface for surface in payload["agent_surfaces"]["surfaces"]}
+    assert payload["agent_surfaces"]["scope_choices"] == [
+        "mb doctor repair --plan --only claude",
+        "mb doctor repair --plan --only codex",
+        "mb doctor repair --plan --all-agents",
+    ]
+    assert surfaces["claude"]["label"] == "Claude Code project-local skills"
+    assert surfaces["codex"]["label"] == "Codex global mb-* skills and repo AGENTS.md"
+    assert "codex-agents-md" in surfaces["codex"]["planned_actions"]
+    assert "codex-global-skill" in surfaces["codex"]["planned_actions"]
+    assert "AGENTS.md" in surfaces["codex"]["touched_files"]
+    assert str(tmp_path / "codex-skills") in surfaces["codex"]["touched_files"]
+
+
+def test_doctor_repair_only_claude_filters_codex_actions(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _prepare_codex_global_skill_roots(tmp_path, monkeypatch)
+    repo = tmp_path / "biz"
+    init_run(path=str(repo), name="Acme")
+    (repo / "AGENTS.md").write_text("# stale\n\nNo facts here.\n", encoding="utf-8")
+
+    result = runner.invoke(
+        app, ["doctor", "repair", "--repo", str(repo), "--plan", "--only", "claude", "--json"]
+    )
+
+    assert result.exit_code in {0, 1}
+    payload = json.loads(result.stdout)
+    assert payload["only"] == "claude"
+    assert [section["id"] for section in payload["sections"]] == ["claude-wiring", "git"]
+    assert all(not action["id"].startswith("codex-") for action in payload["actions"])
+
+
+def test_doctor_repair_rejects_mixed_agent_scope(tmp_path: Path) -> None:
+    result = runner.invoke(
+        app,
+        [
+            "doctor",
+            "repair",
+            "--repo",
+            str(tmp_path),
+            "--plan",
+            "--only",
+            "codex",
+            "--all-agents",
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert "--only cannot be combined with --all-agents" in result.stderr
+
+
+def test_doctor_repair_apply_all_agents_installs_codex_without_codex_cli(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _prepare_codex_global_skill_roots(tmp_path, monkeypatch)
+    monkeypatch.setattr(codex_mod, "_which", lambda name: "" if name == "codex" else None)
+    repo = tmp_path / "biz"
+    init_run(path=str(repo), name="Acme")
+    (repo / "AGENTS.md").write_text("# stale\n\nNo facts here.\n", encoding="utf-8")
+
+    result = runner.invoke(
+        app, ["doctor", "repair", "--repo", str(repo), "--apply", "--all-agents", "--json"]
+    )
+
+    assert result.exit_code in {0, 1}
+    payload = json.loads(result.stdout)
+    applied = {action["id"]: action for action in payload["applied_actions"]}
+    assert "codex-agents-md" in applied
+    assert "codex-global-skill" in applied
+    receipt = payload["receipt"]
+    assert "mb-start" in receipt["installed_skills"]
+    assert "weekly-review" in receipt["installed_skills"]
+    assert "main-branch-owner-loop" not in receipt["installed_skills"]
+    assert str(tmp_path / "codex-skills") in receipt["touched_files"]
+    assert (tmp_path / "codex-skills" / "mb-start" / "SKILL.md").is_file()
+
+
+def test_doctor_repair_apply_default_does_not_silently_write_agent_surfaces(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _prepare_codex_global_skill_roots(tmp_path, monkeypatch)
+    repo = tmp_path / "biz"
+    init_run(path=str(repo), name="Acme")
+    (repo / "AGENTS.md").write_text("# stale\n\nNo facts here.\n", encoding="utf-8")
+
+    result = runner.invoke(app, ["doctor", "repair", "--repo", str(repo), "--apply", "--json"])
+
+    assert result.exit_code in {0, 1}
+    payload = json.loads(result.stdout)
+    applied_ids = {action["id"] for action in payload["applied_actions"]}
+    assert "codex-agents-md" not in applied_ids
+    assert "codex-global-skill" not in applied_ids
+    assert not (tmp_path / "codex-skills" / "mb-start" / "SKILL.md").exists()
+    assert payload["receipt"]["skipped_surfaces"] == [
+        "claude: run mb doctor repair --apply --only claude",
+        "codex: run mb doctor repair --apply --only codex",
+    ]
 
 
 def test_doctor_repair_plan_marks_codex_runtime_info_when_codex_missing(
@@ -696,7 +808,9 @@ def test_doctor_repair_apply_refreshes_codex_agents_md(tmp_path: Path) -> None:
     init_run(path=str(repo), name="Acme")
     (repo / "AGENTS.md").write_text("# stale\n\nNo facts here.\n", encoding="utf-8")
 
-    result = runner.invoke(app, ["doctor", "repair", "--repo", str(repo), "--apply", "--json"])
+    result = runner.invoke(
+        app, ["doctor", "repair", "--repo", str(repo), "--apply", "--only", "codex", "--json"]
+    )
 
     assert result.exit_code in {0, 1}
     payload = json.loads(result.stdout)
@@ -726,7 +840,7 @@ def test_doctor_repair_removes_stale_repo_local_codex_plugin(tmp_path: Path) -> 
     assert "codex-agents-md" in actions
 
     apply_result = runner.invoke(
-        app, ["doctor", "repair", "--repo", str(repo), "--apply", "--json"]
+        app, ["doctor", "repair", "--repo", str(repo), "--apply", "--only", "codex", "--json"]
     )
     assert apply_result.exit_code in {0, 1}
     assert not command.exists()
@@ -1405,7 +1519,9 @@ def test_doctor_repair_apply_moves_old_clone_symlink_to_backup(tmp_path: Path) -
     stale_link.parent.mkdir(parents=True, exist_ok=True)
     stale_link.symlink_to(old_lens, target_is_directory=True)
 
-    result = runner.invoke(app, ["doctor", "repair", "--repo", str(repo), "--apply", "--json"])
+    result = runner.invoke(
+        app, ["doctor", "repair", "--repo", str(repo), "--apply", "--only", "claude", "--json"]
+    )
 
     assert result.exit_code in {0, 1}
     payload = json.loads(result.stdout)

--- a/mb/tests/test_update.py
+++ b/mb/tests/test_update.py
@@ -123,6 +123,81 @@ def test_update_check_pipx_does_not_run_commands(monkeypatch: Any, tmp_path: Pat
     assert calls == []
 
 
+def test_update_check_exposes_surface_refresh_plan(monkeypatch: Any, tmp_path: Path) -> None:
+    monkeypatch.setattr(update_mod, "install_mode", lambda: "pipx")
+    monkeypatch.setattr(update_mod, "engine_root", lambda: tmp_path / "_engine")
+    monkeypatch.setattr(update_mod, "_latest_pypi_version", lambda: "9.9.9")
+    monkeypatch.setattr(update_mod, "bundled_skills", lambda: ["mb-start", "mb-status"])
+
+    result = update_mod.run(repo=tmp_path / "biz", check=True)
+
+    assert result["refresh_surfaces"] is True
+    assert result["surface_refresh"]["enabled"] is True
+    assert result["surface_refresh"]["claude"]["skill_count"] == 2
+    assert result["surface_refresh"]["claude"]["command"].startswith("mb skill link")
+    assert "--only codex" in result["surface_refresh"]["codex"]["command"]
+    assert any("would run `mb skill link" in action for action in result["actions"])
+    assert any("would run `mb doctor repair" in action for action in result["actions"])
+
+
+def test_update_can_skip_surface_refresh_explicitly(monkeypatch: Any, tmp_path: Path) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(args: list[str], *, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+        calls.append(args)
+        if args == ["pipx", "upgrade", "mainbranch"]:
+            return _completed(args, stdout="upgraded package mainbranch")
+        if args == ["mb", "--version"]:
+            return _completed(args, stdout="mb 0.2.0\n")
+        return _completed(args, returncode=1, stderr="unexpected")
+
+    monkeypatch.setattr(update_mod, "install_mode", lambda: "pipx")
+    monkeypatch.setattr(update_mod, "engine_root", lambda: tmp_path / "_engine")
+    monkeypatch.setattr(
+        update_mod.shutil,  # type: ignore[attr-defined]
+        "which",
+        lambda name: "/opt/homebrew/bin/pipx",
+    )
+    monkeypatch.setattr(update_mod, "_run_command", fake_run)
+
+    result = update_mod.run(repo=tmp_path / "biz", refresh_surfaces=False)
+
+    assert result["ok"] is True
+    assert result["refresh_surfaces"] is False
+    assert result["surface_refresh"]["skipped"] == ["claude", "codex"]
+    assert "skipped agent surface refresh" in result["actions"]
+    assert calls == [["pipx", "upgrade", "mainbranch"], ["mb", "--version"]]
+
+
+def test_update_cli_accepts_no_refresh_surfaces(monkeypatch: Any, tmp_path: Path) -> None:
+    monkeypatch.setattr(update_mod, "install_mode", lambda: "pipx")
+    monkeypatch.setattr(update_mod, "engine_root", lambda: tmp_path / "_engine")
+    monkeypatch.setattr(
+        update_mod.shutil,  # type: ignore[attr-defined]
+        "which",
+        lambda name: "/opt/homebrew/bin/pipx",
+    )
+    monkeypatch.setattr(
+        update_mod,
+        "_run_command",
+        lambda args, cwd=None: (
+            _completed(args, stdout="mb 0.2.0\n")
+            if args == ["mb", "--version"]
+            else _completed(args, stdout="upgraded package mainbranch")
+        ),
+    )
+
+    result = runner.invoke(
+        app,
+        ["update", "--repo", str(tmp_path / "biz"), "--no-refresh-surfaces", "--json"],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["refresh_surfaces"] is False
+    assert payload["surface_refresh"]["skipped"] == ["claude", "codex"]
+
+
 def test_update_pipx_runs_upgrade_then_relinks(monkeypatch: Any, tmp_path: Path) -> None:
     calls: list[list[str]] = []
 


### PR DESCRIPTION
## Summary

Adds explicit Claude-only, Codex-only, and reviewed all-agent repair paths for agent runtime surfaces. `mb doctor repair` now reports detected surfaces, touched files, skipped surfaces, restart notes, and installed Codex skills, while `mb update` makes its surface refresh step visible and skippable.

## Linked issue

Closes #722

## Why

The Codex correction moved the supported surface to global skills, but repair/update still needed Caveman-style plan/apply clarity: show what will be touched, avoid silent multi-runtime writes, and give operators a useful receipt after applying changes.

## Commits by concern

- [x] `[update] Add scoped agent surface repair receipts`
- [x] Each commit body bullet-lists the changes in that commit
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`

## Validation

Pre-push gate from repo root:

```bash
scripts/check.sh
```

- [x] Level 1 static: `scripts/check.sh` — runtime: python3 source checkout — exit: 0 — log: full repo gate completed with tests through `tests/test_workflows.py` at 100%.
- [x] Level 2 CLI contract: `pytest mb/tests/test_doctor.py mb/tests/test_update.py -q` — runtime: python3 source checkout — exit: 0 — log: `93 passed in 146.70s`.
- [x] Level 3 package/install smoke: `(cd mb && python3 -m build) && python3 -m venv "$tmpdir/mainbranch-smoke" && "$tmpdir/mainbranch-smoke/bin/pip" install mb/dist/*.whl && "$tmpdir/mainbranch-smoke/bin/mb" --version && "$tmpdir/mainbranch-smoke/bin/mb" skill list` — runtime: temporary venv — exit: 0 — log: built `mainbranch-0.3.36-py3-none-any.whl`, installed it, `mb 0.3.36`, and listed bundled skills through `mb-wiki`.
- [x] Level 4 fixture repo: isolated temp business repo repair plan/apply JSON inspection — runtime: python3 source checkout — exit: 0 — log: `--apply --all-agents` installed the full Codex bundle including `main-branch`, `mb-start`, `mb-status`, `mb-setup`, `mb-update`, `mb-doctor`, `mb-think`, `mb-end`, `mb-help`, `mb-bet`, `mb-ads`, `mb-organic`, `mb-site`, `mb-wiki`, skill-brief/review/concept routes, and the three playbooks.
- [x] Level 5 runtime smoke / dogfood harness / simulation-tier: not required; this branch changes repair/update orchestration and receipts, not generated skill prose or runtime discovery. It intentionally does not claim literal Codex slash commands.
- [x] SKILL.md <=500 lines: no skill files changed.
- [x] Package-visible release gate evidence before tag/publish: not required for PR creation; this is queued for the next patch release.
- [x] Supply-chain review: not required; no workflow, dependency, or permission files changed.

## Success metric

Operators can preview and apply Claude-only, Codex-only, or reviewed all-agent surface repairs without silent cross-runtime writes, and the JSON/human receipts show touched files, installed Codex skills, skipped surfaces, warnings, restart/fresh-thread notes, and rollback/uninstall guidance.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [ ] N/A — change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [x] No
- [ ] Yes — migration note below

## Public / private boundary

No private operator strategy, local machine paths, credentials, or account data were committed. Public docs keep Codex framed as global Main Branch skills plus `mb` facts, not plugin readiness or literal slash commands.
