### PR TITLE
[update] Prepare 0.3.37 release

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mainbranch",
-  "version": "0.3.36",
+  "version": "0.3.37",
   "description": "Main Branch Claude Code skills for running a business from markdown files in git.",
   "author": {
     "name": "Noontide"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+## [0.3.37] - 2026-05-25
+
 ### Changed
 
 - Made `mb doctor repair` agent-surface writes explicit: operators can plan or

--- a/mb/mb/__init__.py
+++ b/mb/mb/__init__.py
@@ -7,6 +7,6 @@ file stays a thin dispatcher.
 
 from __future__ import annotations
 
-__version__ = "0.3.36"
+__version__ = "0.3.37"
 
 __all__ = ["__version__"]

--- a/mb/pyproject.toml
+++ b/mb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mainbranch"
-version = "0.3.36"
+version = "0.3.37"
 description = "Main Branch engine umbrella - scaffolds, validates, and graphs business-as-files repos. Claude Code first, runtime-agnostic by design."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Prepares the 0.3.37 patch release by moving the MAIN-440 repair/update entries into a dated changelog section and bumping the package, runtime, and Claude plugin version metadata.

## Linked issue

Refs #729

## Why

PR #728 shipped user-visible CLI behavior for scoped agent-surface repair plans, apply receipts, and update surface refresh. This release-prep branch packages that work as 0.3.37 without adding new product changes.

## Commits by concern

- [x] `[update] Prepare 0.3.37 release`
- [x] Each commit body bullet-lists the changes in that commit
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`

## Validation

Pre-push gate from repo root:

```bash
scripts/check.sh
```

- [x] Level 0 release-file preflight: version grep plus `cd mb && python3 -m pytest tests/test_smoke_coverage.py::test_claude_plugin_manifest_points_at_prefixed_skills -q` — runtime: python3 source checkout — exit: 0 — log: `.agent/release-evidence/0.3.37/preflight.out` (`1 passed in 0.24s`; version sites show 0.3.37).
- [x] Level 1 static: `scripts/check.sh` — runtime: python3 source checkout — exit: 0 — log: `.agent/release-evidence/0.3.37/check.out` (`806 passed in 403.42s`, skill validation summary clean).
- [x] Level 2 CLI contract: covered by PR #728 focused tests and the full gate on this branch; release-prep diff only changes version/changelog files.
- [x] Level 3 package/install smoke: `(cd mb && python3 -m build)` plus fresh venv install of `mb/dist/mainbranch-0.3.37-py3-none-any.whl`, `mb --version`, and `mb skill list` — runtime: temporary venv — exit: 0 — log: `.agent/release-evidence/0.3.37/package-smoke.out` (`mb 0.3.37`; bundled skills listed through `mb-wiki`).
- [x] Level 4 fixture repo: `PYTHONPATH=mb python3 -m mb books check --fixture --json` plus focused hledger/missing-hledger fixture tests — runtime: python3 source checkout — exit: 0 — logs: `.agent/release-evidence/0.3.37/books-fixture*.out` (`fixture-valid` with local hledger; missing-hledger regression tests passed).
- [x] Level 5 runtime smoke / dogfood harness / simulation-tier: `scripts/claude-runtime-dogfood.py --install-mode wheel --wheel mb/dist/mainbranch-0.3.37-py3-none-any.whl --run-claude-print --simulation-tier release_acceptance --max-budget-usd 0.75` — runtime: wheel venv + Claude Code 2.1.150 print-mode proxy — exit: 0 — log: `.agent/release-evidence/0.3.37/release-acceptance.log`; copied evidence in `.agent/release-evidence/0.3.37/dogfood-evidence/` reports 11/11 heuristic checks, deterministic fixture facts, clean repo boundary, and no read-only `mb` grounding denials. Print-mode remains proxy evidence, not interactive TUI proof.
- [x] SKILL.md <=500 lines: no skill files changed; full gate passed existing line-count validation.
- [x] Package-visible release gate evidence before tag/publish: release acceptance completed against the 0.3.37 wheel before tagging.
- [x] Supply-chain review: no workflow, dependency, or Dependabot files changed; `grep -RIn "id-token\|permissions:" .github/workflows/` unchanged; Dependabot open alerts count is 0.

## Success metric

`oe-v0.3.37` can be tagged from `main`, the GitHub Release body can be generated from the 0.3.37 changelog section, and the PyPI package will report `mb 0.3.37` with the MAIN-440 repair/update behavior included.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [ ] N/A — change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [x] No
- [ ] Yes — migration note below

## Public / private boundary

Only version metadata and public changelog text are committed. Local release evidence stays under ignored `.agent/` and is referenced without publishing private paths or raw transcripts.
