### PR TITLE
[update] Prepare 0.3.38 release

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mainbranch",
-  "version": "0.3.37",
+  "version": "0.3.38",
   "description": "Main Branch Claude Code skills for running a business from markdown files in git.",
   "author": {
     "name": "Noontide"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+## [0.3.38] - 2026-05-25
+
 ### Fixed
 
 - Fixed Codex guidance freshness checks so `mb doctor repair --plan --only

--- a/mb/mb/__init__.py
+++ b/mb/mb/__init__.py
@@ -7,6 +7,6 @@ file stays a thin dispatcher.
 
 from __future__ import annotations
 
-__version__ = "0.3.37"
+__version__ = "0.3.38"
 
 __all__ = ["__version__"]

--- a/mb/pyproject.toml
+++ b/mb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mainbranch"
-version = "0.3.37"
+version = "0.3.38"
 description = "Main Branch engine umbrella - scaffolds, validates, and graphs business-as-files repos. Claude Code first, runtime-agnostic by design."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

- prepare the focused 0.3.38 patch release
- move the stale Codex generated-guidance marker fix into the 0.3.38 changelog section
- bump package and plugin metadata to 0.3.38

## Scope

In scope:
- release metadata for the #731 hotfix
- package version, plugin manifest version, and changelog release section

Out of scope:
- new Codex surface behavior beyond the already-merged stale marker fix
- plugin slash-command readiness claims

## Commits

- `[update] Prepare 0.3.38 release`

## Release / Issues

- Release: oe-v0.3.38
- Closes #733
- Includes the fix from #731

## Success Metric

A fresh install of `mainbranch==0.3.38` reports `mb 0.3.38`, and stale generated Codex `AGENTS.md` markers are repairable through the 0.3.38 package.

## Validation

Level 1 static:
- `scripts/check.sh` -> passed, 807 tests

Level 2 focused CLI:
- `python3 -m pytest tests/test_smoke_coverage.py::test_claude_plugin_manifest_points_at_prefixed_skills tests/test_doctor.py::test_doctor_repair_plan_reports_stale_codex_generated_version -q` -> passed

Level 3 package/install:
- `(cd mb && python3 -m build)` -> passed
- fresh venv wheel install -> passed
- `/tmp/mainbranch-smoke-038/bin/mb --version` -> `mb 0.3.38`
- `/tmp/mainbranch-smoke-038/bin/mb skill list` -> passed

Level 5 runtime:
- Not rerun for this metadata-only release branch. The runtime-relevant fix was validated in #732 and will be dogfooded again after PyPI publish.

## Public / Private Boundary

No private paths, credentials, or local dogfood transcripts are committed. Codex remains documented as global skills, not plugin slash commands.
