### PR TITLE
[update] mb workflow source status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ### Changed
 
+- Changed `mb workflow list --json` to expose the canonical workflow
+  architecture and a source-of-truth status for each Codex route, distinguishing
+  shared workflow sources, temporary source-skill mirrors, pending migrations,
+  and intentionally unsupported surfaces. Refs MAIN-447, #738.
 - Changed generated Codex `AGENTS.md` freshness to use hidden schema/template
   metadata instead of a visible exact package version sentence, reducing
   business-repo diffs for patch releases that do not change the guidance

--- a/mb/mb/codex.py
+++ b/mb/mb/codex.py
@@ -283,6 +283,27 @@ CODEX_WORKFLOW_STATUS_VOCABULARY = (
     "generated_shell_pending",
     "intentionally_unsupported",
 )
+CODEX_SOURCE_STATUS_VOCABULARY = (
+    "shared_workflow_source",
+    "temporary_source_skill_mirror",
+    "pending_shared_source_migration",
+    "intentionally_unsupported",
+)
+CODEX_SOURCE_STATUS_DESCRIPTIONS = {
+    "shared_workflow_source": (
+        "portable workflow semantics live in workflows/<name>/workflow.md and "
+        "the checked Claude/Codex shells must preserve that contract"
+    ),
+    "temporary_source_skill_mirror": (
+        "Codex mirrors existing Claude skill or CLI guidance until a shared "
+        "workflow source owns both runtime shells"
+    ),
+    "pending_shared_source_migration": (
+        "Codex may use read-only facts or planning guidance, but runtime shells "
+        "must wait for a shared source migration"
+    ),
+    "intentionally_unsupported": "outside the current Codex daily-loop target",
+}
 
 CODEX_WORKFLOW_INVENTORY: tuple[dict[str, Any], ...] = (
     {
@@ -291,9 +312,16 @@ CODEX_WORKFLOW_INVENTORY: tuple[dict[str, Any], ...] = (
         "claude_surface": "/mb-start, /mb-status",
         "claude_skill_sources": ("mb-start", "mb-status"),
         "codex_status": "supported",
+        "source_status": "temporary_source_skill_mirror",
         "codex_surface": "main-branch skill routes: mb-start, mb-status",
         "codex_entrypoints": ("main-branch mb-start", "main-branch mb-status"),
         "commands": ("mb status --json --peek", "mb start --json"),
+        "contract_checks": (
+            "required_mb_commands",
+            "runtime_mismatch_gate",
+            "read_before_write_boundary",
+            "one_next_route_core_flow",
+        ),
         "notes": (
             "Codex starts from deterministic status/start facts, translates them "
             "into business language, and routes one next Main Branch move."
@@ -305,6 +333,7 @@ CODEX_WORKFLOW_INVENTORY: tuple[dict[str, Any], ...] = (
         "claude_surface": "/mb-setup, /mb-update, /mb-start repair routing",
         "claude_skill_sources": ("mb-setup", "mb-update"),
         "codex_status": "supported",
+        "source_status": "temporary_source_skill_mirror",
         "codex_surface": "main-branch skill routes: mb-setup, mb-update, mb-doctor",
         "codex_entrypoints": (
             "main-branch mb-setup",
@@ -315,6 +344,12 @@ CODEX_WORKFLOW_INVENTORY: tuple[dict[str, Any], ...] = (
             "mb --version",
             "mb doctor repair --plan --json",
             "mb update --check --json",
+        ),
+        "contract_checks": (
+            "required_mb_commands",
+            "approval_gates",
+            "read_before_write_boundary",
+            "repair_plan_core_flow",
         ),
         "notes": (
             "Codex may inspect plans and explain next steps. Applying updates, "
@@ -327,10 +362,21 @@ CODEX_WORKFLOW_INVENTORY: tuple[dict[str, Any], ...] = (
         "claude_surface": "/mb-think",
         "claude_skill_sources": ("mb-think",),
         "codex_status": "supported",
+        "source_status": "shared_workflow_source",
         "codex_surface": "main-branch skill route: mb-think plus AGENTS.md#codex-think-route",
         "codex_entrypoints": ("main-branch mb-think",),
         "shared_source": CODEX_THINK_SOURCE_WORKFLOW,
         "commands": CODEX_THINK_REQUIRED_MB_COMMANDS,
+        "contract_checks": (
+            "intent",
+            "required_mb_commands",
+            "required_json_facts",
+            "approval_gates",
+            "read_boundaries",
+            "write_boundaries",
+            "core_flow",
+            "public_private_boundaries",
+        ),
         "notes": (
             "Codex uses the shared mb-think contract for research depth, source "
             "privacy, decision routing, codification, and approval gates."
@@ -342,12 +388,21 @@ CODEX_WORKFLOW_INVENTORY: tuple[dict[str, Any], ...] = (
         "claude_surface": "/mb-end, mb checkpoint",
         "claude_skill_sources": ("mb-end",),
         "codex_status": "supported",
+        "source_status": "temporary_source_skill_mirror",
         "codex_surface": "main-branch skill route: mb-end",
         "codex_entrypoints": ("main-branch mb-end",),
         "commands": ("mb checkpoint --plan --json", "mb validate --json"),
+        "contract_checks": (
+            "required_mb_commands",
+            "approval_gates",
+            "read_before_write_boundary",
+            "closeout_plan_core_flow",
+        ),
+        "follow_up_issue": "MAIN-448",
         "notes": (
             "Codex can plan a closeout and propose checkpoint subjects. Creating "
-            "a checkpoint or editing files requires explicit approval."
+            "a checkpoint or editing files requires explicit approval. MAIN-448 "
+            "owns the shared closeout workflow source."
         ),
     },
     {
@@ -356,9 +411,11 @@ CODEX_WORKFLOW_INVENTORY: tuple[dict[str, Any], ...] = (
         "claude_surface": "/mb-help and docs",
         "claude_skill_sources": ("mb-help",),
         "codex_status": "supported",
+        "source_status": "temporary_source_skill_mirror",
         "codex_surface": "main-branch skill route: mb-help",
         "codex_entrypoints": ("main-branch mb-help",),
         "commands": ("mb workflow list --runtime codex --json",),
+        "contract_checks": ("inventory_json_schema", "support_boundary_copy"),
         "notes": "Codex users can inspect supported, pending, and unsupported workflow surfaces.",
     },
     {
@@ -367,6 +424,7 @@ CODEX_WORKFLOW_INVENTORY: tuple[dict[str, Any], ...] = (
         "claude_surface": "/mb-bet",
         "claude_skill_sources": ("mb-bet",),
         "codex_status": "pending_shared_source_migration",
+        "source_status": "pending_shared_source_migration",
         "codex_surface": "Read-only facts and business-file planning only",
         "commands": ("mb status --json --peek", "mb validate --json"),
         "notes": (
@@ -380,6 +438,7 @@ CODEX_WORKFLOW_INVENTORY: tuple[dict[str, Any], ...] = (
         "claude_surface": "/mb-ads",
         "claude_skill_sources": ("mb-ads",),
         "codex_status": "pending_shared_source_migration",
+        "source_status": "pending_shared_source_migration",
         "codex_surface": "Read-only planning only",
         "commands": ("mb status --json --peek", "mb connect doctor --json"),
         "notes": "No provider mutation, spend, upload, or publishing is supported in Codex.",
@@ -390,6 +449,7 @@ CODEX_WORKFLOW_INVENTORY: tuple[dict[str, Any], ...] = (
         "claude_surface": "/mb-organic and related playbooks",
         "claude_skill_sources": ("mb-organic",),
         "codex_status": "pending_shared_source_migration",
+        "source_status": "pending_shared_source_migration",
         "codex_surface": "Read-only planning only",
         "commands": ("mb status --json --peek",),
         "notes": (
@@ -403,6 +463,7 @@ CODEX_WORKFLOW_INVENTORY: tuple[dict[str, Any], ...] = (
         "claude_surface": "/mb-site",
         "claude_skill_sources": ("mb-site",),
         "codex_status": "pending_shared_source_migration",
+        "source_status": "pending_shared_source_migration",
         "codex_surface": "Read-only planning and site readiness facts only",
         "commands": ("mb status --json --peek", "mb site check --json"),
         "notes": "Codex must not claim site build, deploy, domain, or publishing parity.",
@@ -413,6 +474,7 @@ CODEX_WORKFLOW_INVENTORY: tuple[dict[str, Any], ...] = (
         "claude_surface": "/mb-wiki",
         "claude_skill_sources": ("mb-wiki",),
         "codex_status": "intentionally_unsupported",
+        "source_status": "intentionally_unsupported",
         "codex_surface": "None",
         "commands": (),
         "notes": "Specialty workflow outside the current Codex command target.",
@@ -424,6 +486,7 @@ CODEX_WORKFLOW_INVENTORY: tuple[dict[str, Any], ...] = (
         "claude_skill_sources": (),
         "claude_playbook_sources": ("google-ads-search-launch",),
         "codex_status": "pending_shared_source_migration",
+        "source_status": "pending_shared_source_migration",
         "codex_surface": "Read-only planning only",
         "codex_entrypoints": ("google-ads-search-launch",),
         "commands": ("mb status --json --peek", "mb connect doctor --json"),
@@ -438,6 +501,7 @@ CODEX_WORKFLOW_INVENTORY: tuple[dict[str, Any], ...] = (
         "claude_skill_sources": (),
         "claude_playbook_sources": ("ship-bet",),
         "codex_status": "pending_shared_source_migration",
+        "source_status": "pending_shared_source_migration",
         "codex_surface": "Read-only planning only",
         "codex_entrypoints": ("ship-bet",),
         "commands": ("mb status --json --peek", "mb checkpoint --plan --json"),
@@ -452,6 +516,7 @@ CODEX_WORKFLOW_INVENTORY: tuple[dict[str, Any], ...] = (
         "claude_skill_sources": (),
         "claude_playbook_sources": ("weekly-review",),
         "codex_status": "pending_shared_source_migration",
+        "source_status": "pending_shared_source_migration",
         "codex_surface": "Read-only planning only",
         "codex_entrypoints": ("weekly-review",),
         "commands": ("mb status --json --peek", "mb validate --json"),
@@ -470,6 +535,7 @@ CODEX_WORKFLOW_INVENTORY: tuple[dict[str, Any], ...] = (
             "mb-skill-review",
         ),
         "codex_status": "intentionally_unsupported",
+        "source_status": "intentionally_unsupported",
         "codex_surface": "None",
         "commands": (),
         "notes": "Engine-contributor workflow, not a business runtime surface.",
@@ -996,6 +1062,22 @@ def _claude_playbook_sources_for_inventory_item(item: dict[str, Any]) -> tuple[s
     return tuple(f".claude/playbooks/{name}/SKILL.md" for name in names)
 
 
+def _source_of_truth_for_inventory_item(item: dict[str, Any]) -> dict[str, Any]:
+    status = str(item["source_status"])
+    return {
+        "status": status,
+        "description": CODEX_SOURCE_STATUS_DESCRIPTIONS[status],
+        "shared_source": item.get("shared_source"),
+        "claude_sources": list(
+            _claude_skill_sources_for_inventory_item(item)
+            + _claude_playbook_sources_for_inventory_item(item)
+        ),
+        "codex_sources": [str(entrypoint) for entrypoint in item.get("codex_entrypoints", ())],
+        "contract_checks": [str(check) for check in item.get("contract_checks", ())],
+        "follow_up_issue": item.get("follow_up_issue"),
+    }
+
+
 def workflow_inventory(*, runtime: str = "codex") -> dict[str, Any]:
     """Return the public-safe Main Branch workflow support inventory."""
 
@@ -1008,10 +1090,15 @@ def workflow_inventory(*, runtime: str = "codex") -> dict[str, Any]:
         copied["codex_entrypoints"] = [
             str(entrypoint) for entrypoint in item.get("codex_entrypoints", ())
         ]
+        copied["source_of_truth"] = _source_of_truth_for_inventory_item(item)
         items.append(copied)
     statuses = sorted(
         {*CODEX_WORKFLOW_STATUS_VOCABULARY}
         | {str(item["codex_status"]) for item in CODEX_WORKFLOW_INVENTORY}
+    )
+    source_statuses = sorted(
+        {*CODEX_SOURCE_STATUS_VOCABULARY}
+        | {str(item["source_status"]) for item in CODEX_WORKFLOW_INVENTORY}
     )
     return {
         "ok": True,
@@ -1020,6 +1107,17 @@ def workflow_inventory(*, runtime: str = "codex") -> dict[str, Any]:
         "entrypoint": "main-branch mb-start",
         "repo_guidance": AGENTS_RELATIVE_PATH,
         "inventory_path": CODEX_WORKFLOW_INVENTORY_RELATIVE_PATH,
+        "architecture": {
+            "canonical_flow": (
+                "shared workflow source -> Claude Code shell -> Codex shell -> inventory/tests"
+            ),
+            "shared_source_root": "workflows/<workflow>/workflow.md",
+            "runtime_shells": {
+                "claude_code": ".claude/skills/<name>/SKILL.md",
+                "codex_cli": "global main-branch skills plus AGENTS.md guidance",
+            },
+            "status_field": "items[].source_of_truth.status",
+        },
         "claude_skill_sources": [
             f".claude/skills/{name}/SKILL.md" for name in CLAUDE_SKILL_SOURCE_NAMES
         ],
@@ -1035,6 +1133,8 @@ def workflow_inventory(*, runtime: str = "codex") -> dict[str, Any]:
             "install_hint": CODEX_REPAIR_COMMAND,
         },
         "statuses": statuses,
+        "source_statuses": source_statuses,
+        "source_status_descriptions": CODEX_SOURCE_STATUS_DESCRIPTIONS,
         "items": items,
         "safe_to_share": True,
     }
@@ -1055,12 +1155,14 @@ def render_workflow_inventory_md() -> str:
             )
         )
         row_template = (
-            "| {label} | `{status}` | {claude} | {sources} | {codex} | {entrypoints} | {commands} |"
+            "| {label} | `{status}` | `{source_status}` | {claude} | {sources} | "
+            "{codex} | {entrypoints} | {commands} |"
         )
         rows.append(
             row_template.format(
                 label=item["label"],
                 status=item["codex_status"],
+                source_status=item["source_status"],
                 claude=item["claude_surface"],
                 sources=claude_sources or "None",
                 codex=item["codex_surface"],
@@ -1080,6 +1182,17 @@ def render_workflow_inventory_md() -> str:
         "- `generated_shell_pending`: a shared source exists, but a generated Codex "
         "shell still needs implementation and smoke evidence.\n"
         "- `intentionally_unsupported`: outside the current Codex daily-loop target.\n\n"
+        "Source-of-truth meanings:\n\n"
+        "- `shared_workflow_source`: `workflows/<workflow>/workflow.md` owns "
+        "the portable workflow contract and tests check runtime shells against it.\n"
+        "- `temporary_source_skill_mirror`: Codex mirrors existing Claude skill "
+        "or CLI guidance until a shared source owns both runtime shells.\n"
+        "- `pending_shared_source_migration`: Codex may use read-only facts or "
+        "planning guidance, but runtime shells wait for a shared source migration.\n"
+        "- `intentionally_unsupported`: outside the current Codex daily-loop target.\n\n"
+        "Canonical architecture: shared workflow source -> Claude Code shell -> "
+        "Codex shell -> inventory/tests. Temporary mirrors are explicit so "
+        "reviewers can see which routes still need migration.\n\n"
         "The global Main Branch skill bundle is installed by "
         "`mb doctor repair --only codex`; business repos keep only lightweight "
         "`AGENTS.md` guidance. After repair, open a fresh Codex thread in the "
@@ -1087,9 +1200,9 @@ def render_workflow_inventory_md() -> str:
         "Each row names its bundled Claude skill "
         "source(s); every bundled Claude `mb-*` skill must be accounted for here "
         "until the shared workflow generator owns both runtime shells.\n\n"
-        "| Workflow | Codex status | Claude Code surface | Claude source | Codex surface | "
-        "Codex route | Fact commands |\n"
-        "|---|---|---|---|---|---|---|\n" + "\n".join(rows) + "\n\n"
+        "| Workflow | Codex status | Source of truth | Claude Code surface | Claude source | "
+        "Codex surface | Codex route | Fact commands |\n"
+        "|---|---|---|---|---|---|---|---|\n" + "\n".join(rows) + "\n\n"
         "Codex must ask before durable writes, checkpoints, repairs, updates, "
         "migrations, provider mutation, publishing, spend, customer contact, or "
         "public issue/proposal submission.\n"
@@ -1357,7 +1470,7 @@ close a session, get help, or use one of the inventoried Main Branch workflows.
 {route_guidance}
 
 Use the route names above as product-facing workflow names. Do not introduce
-`main-branch-owner-loop`, plugin, adapter, or command-surface vocabulary in
+legacy adapter names, installation internals, or command-surface vocabulary in
 operator-facing answers.
 
 ## Grounding
@@ -1390,8 +1503,8 @@ customer contact, destructive operations, or public issue/proposal submission.
 
 Codex supports the daily Main Branch routes listed here. Do not claim all Claude
 Code skills, provider mutation, ads/site production, publishing, spend, customer
-contact, or slash commands are available unless `mb workflow list --runtime
-codex --json` and current runtime evidence say so.
+contact, or Claude Code command surfaces are available unless `mb workflow list
+--runtime codex --json` and current runtime evidence say so.
 """
 
 

--- a/mb/tests/test_workflows.py
+++ b/mb/tests/test_workflows.py
@@ -174,6 +174,11 @@ def test_codex_command_surface_and_inventory_render() -> None:
     assert "codex plugin list --marketplace main-branch" not in inventory
     assert ".claude/skills/mb-start/SKILL.md" in inventory
     assert ".claude/skills/mb-skill-review/SKILL.md" in inventory
+    assert "Source-of-truth meanings" in inventory
+    assert (
+        "shared workflow source -> Claude Code shell -> Codex shell -> inventory/tests" in inventory
+    )
+    assert "temporary_source_skill_mirror" in inventory
     assert "plugin" not in inventory_json
     assert inventory_json["global_skill"]["install_hint"] == "mb doctor repair --apply --only codex"
     assert "mb-start" in inventory_json["global_skill"]["routes"]
@@ -252,20 +257,101 @@ def test_codex_workflow_inventory_command_lists_supported_and_pending_surfaces()
     }.issubset(statuses)
     by_id = {item["id"]: item for item in data["items"]}
     assert by_id["think-codify"]["codex_status"] == "supported"
+    assert by_id["think-codify"]["source_status"] == "shared_workflow_source"
+    assert by_id["think-codify"]["source_of_truth"]["status"] == "shared_workflow_source"
+    assert (
+        by_id["think-codify"]["source_of_truth"]["shared_source"]
+        == "workflows/mb-think/workflow.md"
+    )
+    assert {
+        "intent",
+        "required_mb_commands",
+        "required_json_facts",
+        "approval_gates",
+        "read_boundaries",
+        "write_boundaries",
+        "core_flow",
+        "public_private_boundaries",
+    }.issubset(set(by_id["think-codify"]["source_of_truth"]["contract_checks"]))
     assert by_id["think-codify"]["codex_entrypoints"] == ["main-branch mb-think"]
     assert by_id["daily-start-status"]["codex_entrypoints"] == [
         "main-branch mb-start",
         "main-branch mb-status",
     ]
+    assert by_id["daily-start-status"]["source_status"] == "temporary_source_skill_mirror"
+    assert by_id["daily-start-status"]["source_of_truth"]["shared_source"] is None
+    assert by_id["end-checkpoint-save"]["source_status"] == "temporary_source_skill_mirror"
+    assert by_id["end-checkpoint-save"]["source_of_truth"]["follow_up_issue"] == "MAIN-448"
     assert by_id["daily-start-status"]["claude_skill_sources"] == [
         ".claude/skills/mb-start/SKILL.md",
         ".claude/skills/mb-status/SKILL.md",
     ]
     assert by_id["ads"]["codex_status"] == "pending_shared_source_migration"
+    assert by_id["ads"]["source_status"] == "pending_shared_source_migration"
     assert by_id["wiki"]["codex_status"] == "intentionally_unsupported"
+    assert by_id["wiki"]["source_status"] == "intentionally_unsupported"
+    assert data["architecture"] == {
+        "canonical_flow": (
+            "shared workflow source -> Claude Code shell -> Codex shell -> inventory/tests"
+        ),
+        "shared_source_root": "workflows/<workflow>/workflow.md",
+        "runtime_shells": {
+            "claude_code": ".claude/skills/<name>/SKILL.md",
+            "codex_cli": "global main-branch skills plus AGENTS.md guidance",
+        },
+        "status_field": "items[].source_of_truth.status",
+    }
+    assert {
+        "shared_workflow_source",
+        "temporary_source_skill_mirror",
+        "pending_shared_source_migration",
+        "intentionally_unsupported",
+    }.issubset(set(data["source_statuses"]))
     assert "plugin" not in data
     assert data["global_skill"]["path"] == codex_mod.CODEX_GLOBAL_SKILL_RELATIVE_PATH
     assert "mb-start" in data["global_skill"]["routes"]
+
+
+def test_codex_workflow_inventory_source_status_contract_is_explicit() -> None:
+    inventory = codex_mod.workflow_inventory(runtime="codex")
+    items = inventory["items"]
+
+    for item in items:
+        source = item["source_of_truth"]
+        assert source["status"] == item["source_status"]
+        assert source["description"]
+        assert isinstance(source["claude_sources"], list)
+        assert isinstance(source["codex_sources"], list)
+        assert isinstance(source["contract_checks"], list)
+        if item["codex_status"] == "supported":
+            assert item["source_status"] in {
+                "shared_workflow_source",
+                "temporary_source_skill_mirror",
+            }
+            assert source["contract_checks"]
+        if item["source_status"] == "shared_workflow_source":
+            assert source["shared_source"] in {
+                path.relative_to(REPO_ROOT).as_posix() for path in WORKFLOW_PATHS
+            }
+            assert "required_mb_commands" in source["contract_checks"]
+            assert "approval_gates" in source["contract_checks"]
+            assert "write_boundaries" in source["contract_checks"]
+            assert "core_flow" in source["contract_checks"]
+        else:
+            assert not source["shared_source"]
+
+
+def test_codex_global_skills_hide_legacy_plugin_and_fake_slash_claims() -> None:
+    texts = [
+        codex_mod.render_codex_global_skill_md(name) for name in codex_mod.CODEX_GLOBAL_SKILL_NAMES
+    ]
+    combined = "\n".join(texts)
+
+    assert "main-branch-owner-loop" not in combined
+    assert "plugin readiness" not in combined.lower()
+    assert "slash commands are available" not in combined.lower()
+    assert "slash-command parity" not in combined.lower()
+    assert "Claude Code command surfaces are available" in combined
 
 
 def test_codex_workflow_inventory_accounts_for_every_bundled_claude_skill() -> None:


### PR DESCRIPTION
<!--
  Thanks for contributing to Main Branch.

  See CONTRIBUTING.md for branch + PR shape, concern-based commit
  organization, and pre-push gates. Keep PRs scoped — one logical
  change per PR, ideally 3–5 commits by concern.
-->

## Summary

`mb workflow list --json` now names the canonical workflow architecture and the source-of-truth status for every Codex route. The inventory distinguishes shared workflow sources, temporary source-skill mirrors, pending migrations, and intentionally unsupported surfaces.

## Linked issue

Closes #738

## Why

Main Branch had overlapping Claude and Codex skill surfaces without a clear machine-readable answer for which route was canonical, mirrored, pending, or unsupported. This makes shared workflow source migration visible to reviewers and gives tests a place to fail when a supported route loses required facts, gates, boundaries, or core flow.

## Commits by concern

- [ ] Each commit body bullet-lists the changes in that commit
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`

Commit list:

- `33af7a3 [update] MAIN-447 workflow source status`

## Validation

Pre-push gate from repo root:

```bash
scripts/check.sh
```

Level 1 static: `scripts/check.sh` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: format/Ruff/mypy/full pytest/skill validation passed.

Level 2 CLI contract: `cd mb && python3 -m pytest tests/test_workflows.py -q` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: `26 passed in 0.30s`.

Level 3 package/install smoke: not required; packaging, entrypoints, bundled data installation, and update paths were not changed.

Level 4 fixture repo: not required; init/onboard/status/start/update fixture behavior was not changed.

Level 5 runtime smoke / dogfood harness / simulation-tier: not required; this branch changes workflow inventory metadata and contract tests, not runtime invocation or discovery behavior.

- [x] Level 1 static: `scripts/check.sh` passes
- [x] Level 2 CLI contract: focused Typer/CliRunner tests, exit codes, `--json` behavior, TTY vs non-TTY (if CLI behavior touched)
- [ ] Level 3 package/install smoke (if packaging touched)
- [ ] Level 4 fixture repo (if init/onboard/status/start/update touched)
- [ ] Level 5 runtime smoke / dogfood harness / simulation-tier (if runtime, first-run, skill discovery, or release validation touched)
- [x] SKILL.md ≤500 lines (if any skill touched)
- [ ] Package-visible release gate evidence before tag/publish (if preparing a release)
- [ ] Supply-chain review (if `.github/workflows/`, `.github/dependabot.yml`, `mb/pyproject.toml` deps, or `id-token`/`permissions` blocks touched — see [docs/supply-chain-policy.md](../docs/supply-chain-policy.md))

## Success metric

A reviewer can inspect `mb workflow list --runtime codex --json` and see which routes are shared-source mirrors, temporary mirrors, pending migrations, or unsupported, with tests guarding the shared-source contract and Codex support boundaries.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [ ] N/A — change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [x] No
- [ ] Yes — migration note below

## Public / private boundary

No private operator strategy, customer/member data, secrets, machine-specific paths, or private runtime internals were committed. The only durable changes are public workflow inventory metadata, tests, and changelog text.
