### PR TITLE
[add] mb-end shared closeout workflow

### DIFF
--- a/.claude/skills/mb-end/SKILL.md
+++ b/.claude/skills/mb-end/SKILL.md
@@ -21,6 +21,50 @@ dirty-work, readiness, and checkpoint facts as the primary source. Raw git is
 fallback/detail only when `mb` facts are unavailable or a crystallize step needs
 site-code history the CLI does not expose.
 
+**Shared contract markers:** Keep these aligned with the shared source.
+
+Required commands:
+
+- `mb status --json --peek`
+- `mb start --json`
+- `mb doctor repair --plan`
+- `mb checkpoint --plan --json`
+- `mb validate --json`
+
+Required fact paths:
+
+- `money_path`
+- `money_path.objects.proof.quality`
+- `content_strategy`
+- `ranked_actions`
+- `update`
+- `readiness`
+- `drift.items`
+- `runtime.codex_cli`
+- `runtime.claude_code`
+- `journal`
+- `since_last_check`
+- `checkpoint.pending`
+- `checkpoint.pending.changed_files`
+- `checkpoint.pending.blockers`
+- `checkpoint.pending.proposed_subject`
+- `summary.changed_files`
+- `safety.blocks`
+- `proposal.message`
+- `validation`
+
+Approval gates: `updates_repairs_migrations`, `file_writes`, `checkpoint`,
+`provider_mutation`, `publishing_or_spend`, `customer_contact`, `private_data`,
+`destructive_operations`, and `public_issue_or_proposal`.
+
+Public/private boundaries: `no_secrets`, `no_raw_provider_exports`,
+`no_raw_transcripts`, `no_customer_member_data`,
+`no_private_runtime_settings`, and `no_raw_finance_legal_records`.
+
+Core closeout flow: status scan, checkpoint plan, session summary, final
+thought capture, crystallize, approval-gated save, owner-facing save states,
+and warm close.
+
 ---
 
 ## Philosophy

--- a/.claude/skills/mb-end/SKILL.md
+++ b/.claude/skills/mb-end/SKILL.md
@@ -10,6 +10,10 @@ Close your session intentionally. The bookend to `/mb-start`.
 
 **You only run this when you choose to.** It is never auto-invoked.
 
+**Shared source:** The portable workflow contract lives in
+`workflows/mb-end/workflow.md`. This Claude skill is the Claude Code shell over
+that source.
+
 **CLI facts first:** After finding the business repo, run
 `mb status --json --peek` and `mb checkpoint --plan --json` before summarizing
 the session or offering to save. Use status `journal`, `since_last_check`,
@@ -54,7 +58,11 @@ This is not an audit. It is a thoughtful friend helping you close the session.
 6. Checkpoint & close
 ```
 
-Step 4 is optional. **Step 5 is NOT optional** -- if meaningful activity happened (decisions, research, core changes), you MUST spawn the crystallize agent. Do not try to do the crystallize analysis inline. Do not skip it. The subagent gets a fresh context window and spends real tokens reading the day's files. That depth is the whole point.
+Step 4 is optional. Step 5 is required when meaningful activity happened
+(decisions, research, core changes) unless the user explicitly asks for a quick
+close or the runtime cannot support it. In Claude Code, use the Task subagent
+for deep crystallize. In runtimes without that surface, the shared workflow
+still requires crystallize-lite instead of silently skipping the ritual.
 
 A quick `/mb-end` (user says "just commit and close") can be steps 1-3 and 6. But if there is meaningful activity and the user did not explicitly skip, always run Step 5.
 
@@ -286,6 +294,20 @@ If an insight was substantial enough to update reference directly (soul.md, offe
 
 Run `mb checkpoint --plan --json` from the business repo. Summarize the changed
 surfaces/files, proposed message, and any blockers.
+
+Lead with owner-facing save state before technical detail:
+
+- `drafted` -- work exists but is not yet saved as durable business memory.
+- `saved locally` -- work is saved in local business history.
+- `ready to send up` -- work is saved locally and ready for shared backup or
+  review.
+- `sent for review` -- work has been sent to the shared proposal/review lane.
+- `landed in main` -- work is accepted in the main business area.
+- `blocked by unrelated cleanup` -- session work is ready, but separate cleanup
+  or drift blocks a clean save or handoff.
+
+Use these states when the user asks "is that it?" Put branch, pull request,
+merge, and working-tree detail second unless the user asks for plumbing.
 
 **If there are unsaved changes:**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ### Changed
 
+- Changed `mb-end` to use a canonical shared closeout workflow source, with
+  checked Claude and Codex shell snapshots covering status scan, checkpoint
+  planning, final thought capture, crystallize, owner-facing save states, and
+  approval-gated saves. Refs MAIN-448, #739.
 - Changed `mb workflow list --json` to expose the canonical workflow
   architecture and a source-of-truth status for each Codex route, distinguishing
   shared workflow sources, temporary source-skill mirrors, pending migrations,

--- a/mb/mb/_data/templates/AGENTS.md.tmpl
+++ b/mb/mb/_data/templates/AGENTS.md.tmpl
@@ -294,6 +294,63 @@ checkpointing business files. Ask before publishing, opening a public issue,
 submitting a proposal, spending money, mutating provider state, or contacting
 customers.
 
+## Codex End Route
+
+This is Codex-native guidance for the existing `mb-end` shared workflow source.
+Treat this section as the natural-language Codex route. It does not mean all
+Main Branch skills work in Codex.
+
+Engine source workflow: `workflows/mb-end/workflow.md`. This business repo does
+not need to contain that engine source file. Treat this generated `AGENTS.md`
+section as the Codex shell for that source unless you are explicitly working
+inside the Main Branch engine repo.
+
+Shared source required `mb` commands:
+
+- `mb status --json --peek`
+- `mb start --json`
+- `mb doctor repair --plan`
+- `mb checkpoint --plan --json`
+- `mb validate --json`
+
+Shared source required JSON fact paths:
+
+- `money_path`
+- `money_path.objects.proof.quality`
+- `content_strategy`
+- `ranked_actions`
+- `update`
+- `readiness`
+- `drift.items`
+- `runtime.codex`
+- `runtime.claude_code`
+- `journal`
+- `since_last_check`
+- `checkpoint`
+- `checkpoint.changed_files`
+- `checkpoint.blockers`
+- `checkpoint.proposed_subject`
+- `validation`
+
+Shared source gates: `updates_repairs_migrations`, `file_writes`,
+`checkpoint`, `provider_mutation`, `publishing_or_spend`, `customer_contact`,
+`private_data`, `destructive_operations`, `public_issue_or_proposal`.
+
+Shared public/private boundaries: `no_secrets`, `no_raw_provider_exports`,
+`no_raw_transcripts`, `no_customer_member_data`,
+`no_private_runtime_settings`, `no_raw_finance_legal_records`.
+
+Use it when the operator is done, pausing, saving progress, checkpointing, or
+asking whether the work is saved. Run a status scan first, build the checkpoint
+plan, summarize the session, ask once for a final thought, run crystallize-lite
+in-thread or use available subagent tooling, name the owner-facing save state,
+and ask before saving.
+
+Owner-facing save states are `drafted`, `saved locally`, `ready to send up`,
+`sent for review`, `landed in main`, and `blocked by unrelated cleanup`.
+Technical branch, proposal, merge, and working-tree details come second unless
+the operator asks for plumbing.
+
 ## Routing Rules
 
 - If `ranked_actions` has entries, lead with the first action, its reason, and

--- a/mb/mb/_data/templates/AGENTS.md.tmpl
+++ b/mb/mb/_data/templates/AGENTS.md.tmpl
@@ -322,14 +322,17 @@ Shared source required JSON fact paths:
 - `update`
 - `readiness`
 - `drift.items`
-- `runtime.codex`
+- `runtime.codex_cli`
 - `runtime.claude_code`
 - `journal`
 - `since_last_check`
-- `checkpoint`
-- `checkpoint.changed_files`
-- `checkpoint.blockers`
-- `checkpoint.proposed_subject`
+- `checkpoint.pending`
+- `checkpoint.pending.changed_files`
+- `checkpoint.pending.blockers`
+- `checkpoint.pending.proposed_subject`
+- `summary.changed_files`
+- `safety.blocks`
+- `proposal.message`
 - `validation`
 
 Shared source gates: `updates_repairs_migrations`, `file_writes`,

--- a/mb/mb/codex.py
+++ b/mb/mb/codex.py
@@ -268,14 +268,17 @@ CODEX_END_REQUIRED_JSON_FACTS = (
     "update",
     "readiness",
     "drift.items",
-    "runtime.codex",
+    "runtime.codex_cli",
     "runtime.claude_code",
     "journal",
     "since_last_check",
-    "checkpoint",
-    "checkpoint.changed_files",
-    "checkpoint.blockers",
-    "checkpoint.proposed_subject",
+    "checkpoint.pending",
+    "checkpoint.pending.changed_files",
+    "checkpoint.pending.blockers",
+    "checkpoint.pending.proposed_subject",
+    "summary.changed_files",
+    "safety.blocks",
+    "proposal.message",
     "validation",
 )
 CODEX_END_APPROVAL_GATES = (
@@ -963,14 +966,17 @@ Shared source required JSON fact paths:
 - `update`
 - `readiness`
 - `drift.items`
-- `runtime.codex`
+- `runtime.codex_cli`
 - `runtime.claude_code`
 - `journal`
 - `since_last_check`
-- `checkpoint`
-- `checkpoint.changed_files`
-- `checkpoint.blockers`
-- `checkpoint.proposed_subject`
+- `checkpoint.pending`
+- `checkpoint.pending.changed_files`
+- `checkpoint.pending.blockers`
+- `checkpoint.pending.proposed_subject`
+- `summary.changed_files`
+- `safety.blocks`
+- `proposal.message`
 - `validation`
 
 Shared source gates: `updates_repairs_migrations`, `file_writes`,

--- a/mb/mb/codex.py
+++ b/mb/mb/codex.py
@@ -132,7 +132,13 @@ CODEX_SLASH_COMMAND_FACTS: dict[str, tuple[str, ...]] = {
         "mb connect doctor --json",
         "mb checkpoint --plan --json",
     ),
-    "mb-end": ("mb checkpoint --plan --json", "mb validate --json"),
+    "mb-end": (
+        "mb status --json --peek",
+        "mb start --json",
+        "mb doctor repair --plan",
+        "mb checkpoint --plan --json",
+        "mb validate --json",
+    ),
     "mb-help": ("mb workflow list --runtime codex --json", "mb status --json --peek"),
 }
 CODEX_SLASH_COMMAND_DESCRIPTIONS = {
@@ -246,11 +252,58 @@ CODEX_THINK_PUBLIC_PRIVATE_BOUNDARIES = (
     "no_private_dms_or_gated_communities",
     "no_raw_finance_legal_records",
 )
+CODEX_END_SOURCE_WORKFLOW = "workflows/mb-end/workflow.md"
+CODEX_END_REQUIRED_MB_COMMANDS = (
+    "mb status --json --peek",
+    "mb start --json",
+    "mb doctor repair --plan",
+    "mb checkpoint --plan --json",
+    "mb validate --json",
+)
+CODEX_END_REQUIRED_JSON_FACTS = (
+    "money_path",
+    "money_path.objects.proof.quality",
+    "content_strategy",
+    "ranked_actions",
+    "update",
+    "readiness",
+    "drift.items",
+    "runtime.codex",
+    "runtime.claude_code",
+    "journal",
+    "since_last_check",
+    "checkpoint",
+    "checkpoint.changed_files",
+    "checkpoint.blockers",
+    "checkpoint.proposed_subject",
+    "validation",
+)
+CODEX_END_APPROVAL_GATES = (
+    "updates_repairs_migrations",
+    "file_writes",
+    "checkpoint",
+    "provider_mutation",
+    "publishing_or_spend",
+    "customer_contact",
+    "private_data",
+    "destructive_operations",
+    "public_issue_or_proposal",
+)
+CODEX_END_PUBLIC_PRIVATE_BOUNDARIES = (
+    "no_secrets",
+    "no_raw_provider_exports",
+    "no_raw_transcripts",
+    "no_customer_member_data",
+    "no_private_runtime_settings",
+    "no_raw_finance_legal_records",
+)
 REQUIRED_LIFECYCLE_GUIDANCE = (
     "## Codex Lifecycle Workflow Index",
     "## Codex Status Workflow",
     "## Codex Think Route",
+    "## Codex End Route",
     f"Engine source workflow: `{CODEX_THINK_SOURCE_WORKFLOW}`",
+    f"Engine source workflow: `{CODEX_END_SOURCE_WORKFLOW}`",
     "does not need to contain that engine source file",
     "Shared source required `mb` commands",
     "runtime/login-shell PATH",
@@ -264,12 +317,26 @@ REQUIRED_LIFECYCLE_GUIDANCE = (
     "global skill",
     "main-branch",
 )
-REQUIRED_LIFECYCLE_GUIDANCE_MARKERS = (
-    *REQUIRED_LIFECYCLE_GUIDANCE,
-    *(f"- `{command}`" for command in CODEX_THINK_REQUIRED_MB_COMMANDS),
-    *(f"- `{fact}`" for fact in CODEX_THINK_REQUIRED_JSON_FACTS),
-    *(f"`{gate}`" for gate in CODEX_THINK_APPROVAL_GATES),
-    *(f"`{boundary}`" for boundary in CODEX_THINK_PUBLIC_PRIVATE_BOUNDARIES),
+REQUIRED_LIFECYCLE_GUIDANCE_MARKERS = (*REQUIRED_LIFECYCLE_GUIDANCE,)
+REQUIRED_LIFECYCLE_SECTION_MARKERS = (
+    (
+        "## Codex Think Route",
+        (
+            *(f"- `{command}`" for command in CODEX_THINK_REQUIRED_MB_COMMANDS),
+            *(f"- `{fact}`" for fact in CODEX_THINK_REQUIRED_JSON_FACTS),
+            *(f"`{gate}`" for gate in CODEX_THINK_APPROVAL_GATES),
+            *(f"`{boundary}`" for boundary in CODEX_THINK_PUBLIC_PRIVATE_BOUNDARIES),
+        ),
+    ),
+    (
+        "## Codex End Route",
+        (
+            *(f"- `{command}`" for command in CODEX_END_REQUIRED_MB_COMMANDS),
+            *(f"- `{fact}`" for fact in CODEX_END_REQUIRED_JSON_FACTS),
+            *(f"`{gate}`" for gate in CODEX_END_APPROVAL_GATES),
+            *(f"`{boundary}`" for boundary in CODEX_END_PUBLIC_PRIVATE_BOUNDARIES),
+        ),
+    ),
 )
 CODEX_PLUGIN_REQUIRED_MARKERS = (
     "Main Branch",
@@ -388,21 +455,26 @@ CODEX_WORKFLOW_INVENTORY: tuple[dict[str, Any], ...] = (
         "claude_surface": "/mb-end, mb checkpoint",
         "claude_skill_sources": ("mb-end",),
         "codex_status": "supported",
-        "source_status": "temporary_source_skill_mirror",
+        "source_status": "shared_workflow_source",
         "codex_surface": "main-branch skill route: mb-end",
         "codex_entrypoints": ("main-branch mb-end",),
-        "commands": ("mb checkpoint --plan --json", "mb validate --json"),
+        "shared_source": CODEX_END_SOURCE_WORKFLOW,
+        "commands": CODEX_END_REQUIRED_MB_COMMANDS,
         "contract_checks": (
+            "intent",
             "required_mb_commands",
+            "required_json_facts",
             "approval_gates",
-            "read_before_write_boundary",
-            "closeout_plan_core_flow",
+            "read_boundaries",
+            "write_boundaries",
+            "core_flow",
+            "public_private_boundaries",
+            "save_state_language",
         ),
-        "follow_up_issue": "MAIN-448",
         "notes": (
-            "Codex can plan a closeout and propose checkpoint subjects. Creating "
-            "a checkpoint or editing files requires explicit approval. MAIN-448 "
-            "owns the shared closeout workflow source."
+            "Codex uses the shared mb-end contract for status scan, checkpoint "
+            "plan, final thought capture, crystallize-lite/deep when available, "
+            "owner-facing save states, approval-gated save, and warm close."
         ),
     },
     {
@@ -863,6 +935,63 @@ checkpointing business files. Ask before publishing, opening a public issue,
 submitting a proposal, spending money, mutating provider state, or contacting
 customers.
 
+## Codex End Route
+
+This is Codex-native guidance for the existing `mb-end` shared workflow source.
+Treat this section as the natural-language Codex route. It does not mean all
+Main Branch skills work in Codex.
+
+Engine source workflow: `workflows/mb-end/workflow.md`. This business repo does
+not need to contain that engine source file. Treat this generated `AGENTS.md`
+section as the Codex shell for that source unless you are explicitly working
+inside the Main Branch engine repo.
+
+Shared source required `mb` commands:
+
+- `mb status --json --peek`
+- `mb start --json`
+- `mb doctor repair --plan`
+- `mb checkpoint --plan --json`
+- `mb validate --json`
+
+Shared source required JSON fact paths:
+
+- `money_path`
+- `money_path.objects.proof.quality`
+- `content_strategy`
+- `ranked_actions`
+- `update`
+- `readiness`
+- `drift.items`
+- `runtime.codex`
+- `runtime.claude_code`
+- `journal`
+- `since_last_check`
+- `checkpoint`
+- `checkpoint.changed_files`
+- `checkpoint.blockers`
+- `checkpoint.proposed_subject`
+- `validation`
+
+Shared source gates: `updates_repairs_migrations`, `file_writes`,
+`checkpoint`, `provider_mutation`, `publishing_or_spend`, `customer_contact`,
+`private_data`, `destructive_operations`, `public_issue_or_proposal`.
+
+Shared public/private boundaries: `no_secrets`, `no_raw_provider_exports`,
+`no_raw_transcripts`, `no_customer_member_data`,
+`no_private_runtime_settings`, `no_raw_finance_legal_records`.
+
+Use it when the operator is done, pausing, saving progress, checkpointing, or
+asking whether the work is saved. Run a status scan first, build the checkpoint
+plan, summarize the session, ask once for a final thought, run crystallize-lite
+in-thread or use available subagent tooling, name the owner-facing save state,
+and ask before saving.
+
+Owner-facing save states are `drafted`, `saved locally`, `ready to send up`,
+`sent for review`, `landed in main`, and `blocked by unrelated cleanup`.
+Technical branch, proposal, merge, and working-tree details come second unless
+the operator asks for plumbing.
+
 ## Routing Rules
 
 - If `ranked_actions` has entries, lead with the first action, its reason, and
@@ -1041,6 +1170,16 @@ def parse_guidance_metadata(text: str) -> dict[str, str]:
         key, value = item.split("=", 1)
         pairs[key.strip()] = value.strip().strip('"')
     return pairs
+
+
+def _markdown_section(text: str, heading: str) -> str:
+    start = text.find(heading)
+    if start == -1:
+        return ""
+    next_heading = text.find("\n## ", start + len(heading))
+    if next_heading == -1:
+        return text[start:]
+    return text[start:next_heading]
 
 
 def _commands_for_inventory_item(item: dict[str, Any]) -> tuple[str, ...]:
@@ -1315,8 +1454,10 @@ def render_codex_slash_command_md(name: str) -> str:
             "codifying or checkpointing."
         ),
         "mb-end": (
-            "Plan the closeout from checkpoint and validation facts. Propose the "
-            "business-readable checkpoint subject and ask before saving it."
+            "Use the shared closeout workflow. Run the status scan and checkpoint "
+            "plan, summarize the session, capture a final thought, do "
+            "crystallize-lite or an available subagent pass, name the owner-facing "
+            "save state, and ask before saving."
         ),
         "mb-help": (
             "Show the supported, pending, and unsupported Codex workflow surfaces. "
@@ -1425,8 +1566,10 @@ def render_codex_global_skill_md(name: str = CODEX_GLOBAL_SKILL_NAME) -> str:
                 "codifying or checkpointing."
             ),
             "mb-end": (
-                "Plan the closeout from checkpoint and validation facts. Propose the "
-                "business-readable checkpoint subject and ask before saving it."
+                "Use the shared closeout workflow. Run the status scan and checkpoint "
+                "plan, summarize the session, capture a final thought, do "
+                "crystallize-lite or an available subagent pass, name the owner-facing "
+                "save state, and ask before saving."
             ),
             "mb-help": (
                 "Show the supported, pending, and unsupported Codex workflow surfaces. "
@@ -2161,6 +2304,10 @@ def instructions_status(repo: str | Path) -> dict[str, Any]:
     missing_lifecycle_guidance = [
         marker for marker in REQUIRED_LIFECYCLE_GUIDANCE_MARKERS if marker not in text
     ]
+    for heading, markers in REQUIRED_LIFECYCLE_SECTION_MARKERS:
+        section = _markdown_section(text, heading)
+        missing_lifecycle_guidance.extend(marker for marker in markers if marker not in section)
+    missing_lifecycle_guidance = list(dict.fromkeys(missing_lifecycle_guidance))
     lifecycle_discovery_ok = bool(exists and not missing_lifecycle_guidance)
     guidance_metadata = parse_guidance_metadata(text) if exists else {}
     expected_template_hash = guidance_template_hash()

--- a/mb/mb/workflows.py
+++ b/mb/mb/workflows.py
@@ -81,12 +81,28 @@ REQUIRED_SHELL_PHRASES_BY_WORKFLOW: dict[str, dict[str, str]] = {
         "checkpoint approval": "checkpoint",
         "Codex slash-command boundary": "Do not tell Codex users to run Claude slash commands.",
     },
+    "mb-end": {
+        "status scan": "status scan",
+        "checkpoint plan": "checkpoint plan",
+        "session summary": "session summary",
+        "final thought capture": "final thought",
+        "crystallize": "crystallize",
+        "approval-gated save": "approval-gated save",
+        "save states": "drafted",
+        "warm close": "warm close",
+    },
 }
 CODEX_FORBIDDEN_PHRASES_BY_WORKFLOW: dict[str, tuple[str, ...]] = {
     "mb-think": (
         "Run `/mb-think`",
         "Claude Code skills work in Codex",
         "slash-command parity",
+    ),
+    "mb-end": (
+        "Run `/mb-end`",
+        "Claude Code skills work in Codex",
+        "slash-command parity",
+        "skip crystallize",
     ),
 }
 PUBLIC_PRIVATE_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
@@ -351,6 +367,8 @@ def render_claude_shell(workflow: WorkflowSource) -> str:
 
     if workflow.name == "mb-think":
         return _render_think_claude_shell(workflow)
+    if workflow.name == "mb-end":
+        return _render_end_claude_shell(workflow)
     return _render_start_money_path_claude_shell(workflow)
 
 
@@ -419,6 +437,8 @@ def render_codex_shell(workflow: WorkflowSource) -> str:
 
     if workflow.name == "mb-think":
         return _render_think_codex_shell(workflow)
+    if workflow.name == "mb-end":
+        return _render_end_codex_shell(workflow)
     return _render_start_money_path_codex_shell(workflow)
 
 
@@ -625,5 +645,136 @@ Approval needed before writes: yes.
 ```
 Do not tell Codex users to run Claude slash commands. Runtime smoke is required
 before docs say this selected workflow is supported or available in Codex.
+"""
+    return output
+
+
+def _render_end_claude_shell(workflow: WorkflowSource) -> str:
+    """Render a Claude Code shell snapshot for the closeout workflow."""
+
+    output = f"""# Generated Claude Shell: {workflow.title}
+
+Source workflow: `{_display_path(workflow.path)}`
+Runtime support: `claude_code: supported_shell`
+Approval gates: {_inline_code_list(workflow.approval_gates)}
+Public/private boundaries: {_inline_code_list(workflow.public_private_boundaries)}
+
+Use from `/mb-end` when the operator is done, pausing, closing a work block, or
+asking whether the work is saved. Preserve slash-command-native language for
+Claude Code only.
+
+This snapshot does not replace shipped `.claude/skills/mb-end/SKILL.md`.
+
+## Required mb Commands
+
+{_bullet_list(workflow.required_mb_commands)}
+
+## Required JSON Fact Paths
+
+{_bullet_list(workflow.json_facts)}
+
+## Routing
+
+1. Run a status scan first. Use deterministic status, checkpoint, validation,
+   readiness, drift, recent-work, and runtime facts before reading raw git
+   details.
+2. Build the checkpoint plan from `mb checkpoint --plan --json`; use
+   `mb validate --json` for blockers and cite `mb doctor repair --plan` when
+   repairs are needed.
+3. Give a short session summary in business language: decisions, research,
+   offers, pushes, outcomes, changed core truth, and unsaved work.
+4. Ask once for final thought capture before closeout. Offer to save a brief
+   research note only after operator approval.
+5. Run crystallize when meaningful activity happened. Claude may use a Task
+   subagent for deep crystallize; light sessions may use crystallize-lite.
+6. Present save state before plumbing: drafted, saved locally, ready to send
+   up, sent for review, landed in main, or blocked by unrelated cleanup.
+7. Make checkpointing an approval-gated save. Validate the subject, ask before
+   saving, and use `mb checkpoint`, not raw git commands.
+8. End with a warm close: one sentence naming the most important saved or
+   drafted business outcome, without tomorrow planning.
+
+## Handoff Shape
+
+```text
+Closeout state: <one owner-facing save state>.
+Status scan: <status/checkpoint/validate facts read>.
+Session summary: <3-6 bullets or one compact paragraph>.
+Final thought: <none, captured, or approved research note target>.
+Crystallize: <deep, lite, skipped with reason>.
+Checkpoint plan: <subject, changed surfaces, blockers, approval needed>.
+Warm close: <one sentence>.
+```
+
+Use business language first. Git, branch, pull request, merge, and working-tree
+details are secondary unless the operator asks for plumbing.
+"""
+    return output
+
+
+def _render_end_codex_shell(workflow: WorkflowSource) -> str:
+    """Render Codex CLI guidance for the closeout workflow."""
+
+    output = f"""# Generated Codex Workflow Guidance: {workflow.title}
+
+Source workflow: `{_display_path(workflow.path)}`
+Runtime support: `codex_cli: {workflow.runtime_support.get("codex_cli", "")}`
+Approval gates: {_inline_code_list(workflow.approval_gates)}
+Public/private boundaries: {_inline_code_list(workflow.public_private_boundaries)}
+
+Codex is first-class for the proven owner loop only. This guidance is generated
+from the engine workflow source for business-repo `AGENTS.md`; the business repo
+does not need to contain `{_display_path(workflow.path)}`. Treat this rendered
+route as the Codex shell for natural-language closeout tasks. It does not claim
+Claude Code slash commands work inside Codex or that all Main Branch workflows
+are available in Codex.
+
+## Required mb Commands
+
+{_bullet_list(workflow.required_mb_commands)}
+
+## Required JSON Fact Paths
+
+{_bullet_list(workflow.json_facts)}
+
+## Codex Route
+
+1. Run a status scan first. Use deterministic status, checkpoint, validation,
+   readiness, drift, recent-work, and runtime facts before reading raw git
+   details.
+2. Build the checkpoint plan from `mb checkpoint --plan --json`; use
+   `mb validate --json` for blockers and cite `mb doctor repair --plan` when
+   repairs are needed.
+3. Give a short session summary in business language: decisions, research,
+   offers, pushes, outcomes, changed core truth, and unsaved work.
+4. Ask once for final thought capture before closeout. Offer to save a brief
+   research note only after operator approval.
+5. Run crystallize-lite in-thread when meaningful activity happened, or use
+   available subagent tooling when the current Codex session supports it. If
+   neither is available, name the limitation and still ask one specific
+   crystallize question from the day's facts.
+6. Present save state before plumbing: drafted, saved locally, ready to send
+   up, sent for review, landed in main, or blocked by unrelated cleanup.
+7. Make checkpointing an approval-gated save. Validate the subject, ask before
+   saving, and use `mb checkpoint`, not raw git commands.
+8. End with a warm close: one sentence naming the most important saved or
+   drafted business outcome, without tomorrow planning.
+
+## Handoff Shape
+
+```text
+Closeout state: <one owner-facing save state>.
+Status scan: <status/checkpoint/validate facts read>.
+Session summary: <3-6 bullets or one compact paragraph>.
+Final thought: <none, captured, or approved research note target>.
+Crystallize: <lite, subagent, or limitation named>.
+Checkpoint plan: <subject, changed surfaces, blockers, approval needed>.
+Warm close: <one sentence>.
+```
+
+Use business language first. Git, branch, pull request, merge, and working-tree
+details are secondary unless the operator asks for plumbing. Do not tell Codex
+users to run Claude slash commands. Runtime smoke is required before docs say
+this selected workflow is supported or available in Codex.
 """
     return output

--- a/mb/tests/fixtures/workflows/mb-end.claude.md
+++ b/mb/tests/fixtures/workflows/mb-end.claude.md
@@ -28,14 +28,17 @@ This snapshot does not replace shipped `.claude/skills/mb-end/SKILL.md`.
 - `update`
 - `readiness`
 - `drift.items`
-- `runtime.codex`
+- `runtime.codex_cli`
 - `runtime.claude_code`
 - `journal`
 - `since_last_check`
-- `checkpoint`
-- `checkpoint.changed_files`
-- `checkpoint.blockers`
-- `checkpoint.proposed_subject`
+- `checkpoint.pending`
+- `checkpoint.pending.changed_files`
+- `checkpoint.pending.blockers`
+- `checkpoint.pending.proposed_subject`
+- `summary.changed_files`
+- `safety.blocks`
+- `proposal.message`
 - `validation`
 
 ## Routing

--- a/mb/tests/fixtures/workflows/mb-end.claude.md
+++ b/mb/tests/fixtures/workflows/mb-end.claude.md
@@ -1,0 +1,75 @@
+# Generated Claude Shell: End Checkpoint Save
+
+Source workflow: `workflows/mb-end/workflow.md`
+Runtime support: `claude_code: supported_shell`
+Approval gates: `updates_repairs_migrations`, `file_writes`, `checkpoint`, `provider_mutation`, `publishing_or_spend`, `customer_contact`, `private_data`, `destructive_operations`, `public_issue_or_proposal`
+Public/private boundaries: `no_secrets`, `no_raw_provider_exports`, `no_raw_transcripts`, `no_customer_member_data`, `no_private_runtime_settings`, `no_raw_finance_legal_records`
+
+Use from `/mb-end` when the operator is done, pausing, closing a work block, or
+asking whether the work is saved. Preserve slash-command-native language for
+Claude Code only.
+
+This snapshot does not replace shipped `.claude/skills/mb-end/SKILL.md`.
+
+## Required mb Commands
+
+- `mb status --json --peek`
+- `mb start --json`
+- `mb doctor repair --plan`
+- `mb checkpoint --plan --json`
+- `mb validate --json`
+
+## Required JSON Fact Paths
+
+- `money_path`
+- `money_path.objects.proof.quality`
+- `content_strategy`
+- `ranked_actions`
+- `update`
+- `readiness`
+- `drift.items`
+- `runtime.codex`
+- `runtime.claude_code`
+- `journal`
+- `since_last_check`
+- `checkpoint`
+- `checkpoint.changed_files`
+- `checkpoint.blockers`
+- `checkpoint.proposed_subject`
+- `validation`
+
+## Routing
+
+1. Run a status scan first. Use deterministic status, checkpoint, validation,
+   readiness, drift, recent-work, and runtime facts before reading raw git
+   details.
+2. Build the checkpoint plan from `mb checkpoint --plan --json`; use
+   `mb validate --json` for blockers and cite `mb doctor repair --plan` when
+   repairs are needed.
+3. Give a short session summary in business language: decisions, research,
+   offers, pushes, outcomes, changed core truth, and unsaved work.
+4. Ask once for final thought capture before closeout. Offer to save a brief
+   research note only after operator approval.
+5. Run crystallize when meaningful activity happened. Claude may use a Task
+   subagent for deep crystallize; light sessions may use crystallize-lite.
+6. Present save state before plumbing: drafted, saved locally, ready to send
+   up, sent for review, landed in main, or blocked by unrelated cleanup.
+7. Make checkpointing an approval-gated save. Validate the subject, ask before
+   saving, and use `mb checkpoint`, not raw git commands.
+8. End with a warm close: one sentence naming the most important saved or
+   drafted business outcome, without tomorrow planning.
+
+## Handoff Shape
+
+```text
+Closeout state: <one owner-facing save state>.
+Status scan: <status/checkpoint/validate facts read>.
+Session summary: <3-6 bullets or one compact paragraph>.
+Final thought: <none, captured, or approved research note target>.
+Crystallize: <deep, lite, skipped with reason>.
+Checkpoint plan: <subject, changed surfaces, blockers, approval needed>.
+Warm close: <one sentence>.
+```
+
+Use business language first. Git, branch, pull request, merge, and working-tree
+details are secondary unless the operator asks for plumbing.

--- a/mb/tests/fixtures/workflows/mb-end.codex.md
+++ b/mb/tests/fixtures/workflows/mb-end.codex.md
@@ -29,14 +29,17 @@ are available in Codex.
 - `update`
 - `readiness`
 - `drift.items`
-- `runtime.codex`
+- `runtime.codex_cli`
 - `runtime.claude_code`
 - `journal`
 - `since_last_check`
-- `checkpoint`
-- `checkpoint.changed_files`
-- `checkpoint.blockers`
-- `checkpoint.proposed_subject`
+- `checkpoint.pending`
+- `checkpoint.pending.changed_files`
+- `checkpoint.pending.blockers`
+- `checkpoint.pending.proposed_subject`
+- `summary.changed_files`
+- `safety.blocks`
+- `proposal.message`
 - `validation`
 
 ## Codex Route

--- a/mb/tests/fixtures/workflows/mb-end.codex.md
+++ b/mb/tests/fixtures/workflows/mb-end.codex.md
@@ -1,0 +1,80 @@
+# Generated Codex Workflow Guidance: End Checkpoint Save
+
+Source workflow: `workflows/mb-end/workflow.md`
+Runtime support: `codex_cli: owner_loop_shell`
+Approval gates: `updates_repairs_migrations`, `file_writes`, `checkpoint`, `provider_mutation`, `publishing_or_spend`, `customer_contact`, `private_data`, `destructive_operations`, `public_issue_or_proposal`
+Public/private boundaries: `no_secrets`, `no_raw_provider_exports`, `no_raw_transcripts`, `no_customer_member_data`, `no_private_runtime_settings`, `no_raw_finance_legal_records`
+
+Codex is first-class for the proven owner loop only. This guidance is generated
+from the engine workflow source for business-repo `AGENTS.md`; the business repo
+does not need to contain `workflows/mb-end/workflow.md`. Treat this rendered
+route as the Codex shell for natural-language closeout tasks. It does not claim
+Claude Code slash commands work inside Codex or that all Main Branch workflows
+are available in Codex.
+
+## Required mb Commands
+
+- `mb status --json --peek`
+- `mb start --json`
+- `mb doctor repair --plan`
+- `mb checkpoint --plan --json`
+- `mb validate --json`
+
+## Required JSON Fact Paths
+
+- `money_path`
+- `money_path.objects.proof.quality`
+- `content_strategy`
+- `ranked_actions`
+- `update`
+- `readiness`
+- `drift.items`
+- `runtime.codex`
+- `runtime.claude_code`
+- `journal`
+- `since_last_check`
+- `checkpoint`
+- `checkpoint.changed_files`
+- `checkpoint.blockers`
+- `checkpoint.proposed_subject`
+- `validation`
+
+## Codex Route
+
+1. Run a status scan first. Use deterministic status, checkpoint, validation,
+   readiness, drift, recent-work, and runtime facts before reading raw git
+   details.
+2. Build the checkpoint plan from `mb checkpoint --plan --json`; use
+   `mb validate --json` for blockers and cite `mb doctor repair --plan` when
+   repairs are needed.
+3. Give a short session summary in business language: decisions, research,
+   offers, pushes, outcomes, changed core truth, and unsaved work.
+4. Ask once for final thought capture before closeout. Offer to save a brief
+   research note only after operator approval.
+5. Run crystallize-lite in-thread when meaningful activity happened, or use
+   available subagent tooling when the current Codex session supports it. If
+   neither is available, name the limitation and still ask one specific
+   crystallize question from the day's facts.
+6. Present save state before plumbing: drafted, saved locally, ready to send
+   up, sent for review, landed in main, or blocked by unrelated cleanup.
+7. Make checkpointing an approval-gated save. Validate the subject, ask before
+   saving, and use `mb checkpoint`, not raw git commands.
+8. End with a warm close: one sentence naming the most important saved or
+   drafted business outcome, without tomorrow planning.
+
+## Handoff Shape
+
+```text
+Closeout state: <one owner-facing save state>.
+Status scan: <status/checkpoint/validate facts read>.
+Session summary: <3-6 bullets or one compact paragraph>.
+Final thought: <none, captured, or approved research note target>.
+Crystallize: <lite, subagent, or limitation named>.
+Checkpoint plan: <subject, changed surfaces, blockers, approval needed>.
+Warm close: <one sentence>.
+```
+
+Use business language first. Git, branch, pull request, merge, and working-tree
+details are secondary unless the operator asks for plumbing. Do not tell Codex
+users to run Claude slash commands. Runtime smoke is required before docs say
+this selected workflow is supported or available in Codex.

--- a/mb/tests/test_workflows.py
+++ b/mb/tests/test_workflows.py
@@ -24,6 +24,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW = REPO_ROOT / "workflows" / "mb-start-money-path" / "workflow.md"
 THINK_WORKFLOW = REPO_ROOT / "workflows" / "mb-think" / "workflow.md"
 END_WORKFLOW = REPO_ROOT / "workflows" / "mb-end" / "workflow.md"
+SHIPPED_END_SKILL = REPO_ROOT / ".claude" / "skills" / "mb-end" / "SKILL.md"
 FIXTURES = REPO_ROOT / "mb" / "tests" / "fixtures" / "workflows"
 AGENTS_TEMPLATE = REPO_ROOT / "mb" / "mb" / "_data" / "templates" / "AGENTS.md.tmpl"
 WORKFLOW_PATHS = [
@@ -111,6 +112,14 @@ def test_generated_end_claude_and_codex_snapshots_match_fixtures() -> None:
     assert render_codex_shell(workflow) == (FIXTURES / "mb-end.codex.md").read_text(
         encoding="utf-8"
     )
+
+
+def test_shipped_claude_end_skill_preserves_shared_workflow_contract() -> None:
+    workflow = load_workflow(END_WORKFLOW)
+    skill_text = SHIPPED_END_SKILL.read_text(encoding="utf-8")
+
+    assert shell_drift_errors(workflow, skill_text) == []
+    assert "workflows/mb-end/workflow.md" in skill_text
 
 
 def test_supported_shells_preserve_required_commands_and_json_facts() -> None:

--- a/mb/tests/test_workflows.py
+++ b/mb/tests/test_workflows.py
@@ -23,11 +23,13 @@ runner = CliRunner()
 REPO_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW = REPO_ROOT / "workflows" / "mb-start-money-path" / "workflow.md"
 THINK_WORKFLOW = REPO_ROOT / "workflows" / "mb-think" / "workflow.md"
+END_WORKFLOW = REPO_ROOT / "workflows" / "mb-end" / "workflow.md"
 FIXTURES = REPO_ROOT / "mb" / "tests" / "fixtures" / "workflows"
 AGENTS_TEMPLATE = REPO_ROOT / "mb" / "mb" / "_data" / "templates" / "AGENTS.md.tmpl"
 WORKFLOW_PATHS = [
     WORKFLOW,
     THINK_WORKFLOW,
+    END_WORKFLOW,
 ]
 
 
@@ -100,6 +102,17 @@ def test_generated_think_claude_and_codex_snapshots_match_fixtures() -> None:
     )
 
 
+def test_generated_end_claude_and_codex_snapshots_match_fixtures() -> None:
+    workflow = load_workflow(END_WORKFLOW)
+
+    assert render_claude_shell(workflow) == (FIXTURES / "mb-end.claude.md").read_text(
+        encoding="utf-8"
+    )
+    assert render_codex_shell(workflow) == (FIXTURES / "mb-end.codex.md").read_text(
+        encoding="utf-8"
+    )
+
+
 def test_supported_shells_preserve_required_commands_and_json_facts() -> None:
     for path in WORKFLOW_PATHS:
         workflow = load_workflow(path)
@@ -138,6 +151,18 @@ def test_codex_contract_markers_match_think_workflow_source() -> None:
     assert tuple(workflow.approval_gates) == codex_mod.CODEX_THINK_APPROVAL_GATES
     assert (
         tuple(workflow.public_private_boundaries) == codex_mod.CODEX_THINK_PUBLIC_PRIVATE_BOUNDARIES
+    )
+
+
+def test_codex_contract_markers_match_end_workflow_source() -> None:
+    workflow = load_workflow(END_WORKFLOW)
+
+    assert codex_mod.CODEX_END_SOURCE_WORKFLOW == "workflows/mb-end/workflow.md"
+    assert tuple(workflow.required_mb_commands) == codex_mod.CODEX_END_REQUIRED_MB_COMMANDS
+    assert tuple(workflow.json_facts) == codex_mod.CODEX_END_REQUIRED_JSON_FACTS
+    assert tuple(workflow.approval_gates) == codex_mod.CODEX_END_APPROVAL_GATES
+    assert (
+        tuple(workflow.public_private_boundaries) == codex_mod.CODEX_END_PUBLIC_PRIVATE_BOUNDARIES
     )
 
 
@@ -280,8 +305,14 @@ def test_codex_workflow_inventory_command_lists_supported_and_pending_surfaces()
     ]
     assert by_id["daily-start-status"]["source_status"] == "temporary_source_skill_mirror"
     assert by_id["daily-start-status"]["source_of_truth"]["shared_source"] is None
-    assert by_id["end-checkpoint-save"]["source_status"] == "temporary_source_skill_mirror"
-    assert by_id["end-checkpoint-save"]["source_of_truth"]["follow_up_issue"] == "MAIN-448"
+    assert by_id["end-checkpoint-save"]["source_status"] == "shared_workflow_source"
+    assert (
+        by_id["end-checkpoint-save"]["source_of_truth"]["shared_source"]
+        == "workflows/mb-end/workflow.md"
+    )
+    assert (
+        "save_state_language" in by_id["end-checkpoint-save"]["source_of_truth"]["contract_checks"]
+    )
     assert by_id["daily-start-status"]["claude_skill_sources"] == [
         ".claude/skills/mb-start/SKILL.md",
         ".claude/skills/mb-status/SKILL.md",
@@ -460,6 +491,37 @@ def test_think_codex_policy_flags_forbidden_support_language() -> None:
     assert (
         "Codex shell contains forbidden support phrase: Claude Code skills work in Codex" in errors
     )
+
+
+def test_end_runtime_shells_surface_closeout_save_state_contract() -> None:
+    workflow = load_workflow(END_WORKFLOW)
+
+    for shell in (render_claude_shell(workflow), render_codex_shell(workflow)):
+        normalized = " ".join(shell.split())
+        assert "status scan" in normalized
+        assert "checkpoint plan" in normalized
+        assert "session summary" in normalized
+        assert "final thought" in normalized
+        assert "crystallize" in normalized
+        assert "approval-gated save" in normalized
+        assert "drafted" in normalized
+        assert "saved locally" in normalized
+        assert "ready to send up" in normalized
+        assert "sent for review" in normalized
+        assert "landed in main" in normalized
+        assert "blocked by unrelated cleanup" in normalized
+        assert "warm close" in normalized
+
+
+def test_end_codex_shell_does_not_claim_slash_command_or_skill_parity() -> None:
+    workflow = load_workflow(END_WORKFLOW)
+    shell = render_codex_shell(workflow)
+
+    assert codex_shell_policy_errors(workflow, shell) == []
+    assert "Run `/mb-end`" not in shell
+    assert "Claude Code skills work in Codex" not in shell
+    assert "not need to contain `workflows/mb-end/workflow.md`" in shell
+    assert "as the Codex shell for natural-language closeout tasks" in shell
 
 
 def test_think_runtime_shells_stay_thin_and_currently_named() -> None:

--- a/workflows/mb-end/workflow.md
+++ b/workflows/mb-end/workflow.md
@@ -1,0 +1,270 @@
+---
+name: mb-end
+title: End Checkpoint Save
+description: Close a Main Branch session with deterministic status facts, crystallize analysis, owner-facing save states, and an approval-gated checkpoint.
+loops: [reflect, ship]
+runtime_support:
+  claude_code: supported_shell
+  codex_cli: owner_loop_shell
+  future: planned
+runtime_surfaces:
+  claude_code: .claude/skills/mb-end/SKILL.md
+  codex_cli: global main-branch mb-end skill
+required_mb_commands:
+  - mb status --json --peek
+  - mb start --json
+  - mb doctor repair --plan
+  - mb checkpoint --plan --json
+  - mb validate --json
+json_facts:
+  - money_path
+  - money_path.objects.proof.quality
+  - content_strategy
+  - ranked_actions
+  - update
+  - readiness
+  - drift.items
+  - runtime.codex
+  - runtime.claude_code
+  - journal
+  - since_last_check
+  - checkpoint
+  - checkpoint.changed_files
+  - checkpoint.blockers
+  - checkpoint.proposed_subject
+  - validation
+approval_gates:
+  - updates_repairs_migrations
+  - file_writes
+  - checkpoint
+  - provider_mutation
+  - publishing_or_spend
+  - customer_contact
+  - private_data
+  - destructive_operations
+  - public_issue_or_proposal
+public_private_boundaries:
+  - no_secrets
+  - no_raw_provider_exports
+  - no_raw_transcripts
+  - no_customer_member_data
+  - no_private_runtime_settings
+  - no_raw_finance_legal_records
+writes_business_files: true
+provider_mutation: false
+publishing_or_spend: false
+---
+
+# End Checkpoint Save
+
+This workflow source is the portable contract for closing a Main Branch session:
+scan what changed, summarize the business work, surface the final thought,
+crystallize the lesson when meaningful activity happened, and save only after
+approval.
+
+## Intent And Triggers
+
+Use this workflow when the operator says they are done, pausing, wrapping up,
+ending the day, saving progress, checkpointing, asking "is that it?", or asking
+whether the work is saved.
+
+This is the bookend to start/status. It is not a daily standup, task planner,
+or autosave. It closes the current session and keeps business memory durable.
+
+Do not use this workflow for provider mutation, publishing, spend, customer
+contact, broad research, ad/site production, or automatic model execution from
+`mb`.
+
+## Required Mb Commands
+
+Run or preserve these deterministic facts before interpreting changed files:
+
+- `mb status --json --peek`
+- `mb start --json`
+- `mb doctor repair --plan`
+- `mb checkpoint --plan --json`
+- `mb validate --json`
+
+`mb status --json --peek` is the normal status scan. Use its journal,
+since-last-check, readiness, drift, update, runtime, MoneyPath, content
+strategy, ranked-action, and checkpoint state before raw git inspection.
+`mb start --json` is optional when runtime handoff or repo-boundary facts
+matter. `mb doctor repair --plan` supplies repair blockers. `mb checkpoint
+--plan --json` supplies the checkpoint plan and changed surfaces; it is not
+permission to save. `mb validate --json` supplies validation blockers before
+the checkpoint is offered.
+
+## Required JSON Fact Paths
+
+The runtime shell must preserve these paths from the workflow source:
+
+- `money_path`
+- `money_path.objects.proof.quality`
+- `content_strategy`
+- `ranked_actions`
+- `update`
+- `readiness`
+- `drift.items`
+- `runtime.codex`
+- `runtime.claude_code`
+- `journal`
+- `since_last_check`
+- `checkpoint`
+- `checkpoint.changed_files`
+- `checkpoint.blockers`
+- `checkpoint.proposed_subject`
+- `validation`
+
+Treat these as facts, not strategy. The runtime may explain what changed,
+recommend whether to save, and ask one crystallize question. It must not claim
+that a checkpoint, push, proposal, or merge happened unless facts prove it.
+
+## Routing Rules
+
+Hard gates win before closeout: required updates, broken repo wiring, repair
+blockers, validation blockers, private-data boundaries, destructive-operation
+requests, provider mutation, publishing, spend, and customer contact.
+
+After hard gates, close the session in this order:
+
+1. Status scan: read `mb status --json --peek`, then `mb checkpoint --plan
+   --json`, then `mb validate --json`.
+2. Checkpoint plan: summarize changed surfaces, proposed subject, validation
+   blockers, and whether saving is possible.
+3. Session summary: state what happened in business language first. Name
+   decisions, research, offer/core changes, pushes, outcomes, and unsaved work.
+4. Final thought capture: ask once. Save a brief research note only after
+   explicit approval.
+5. Crystallize: if meaningful activity happened, run deep crystallize when the
+   runtime has a subagent/Task surface; otherwise run crystallize-lite in the
+   current thread. Do not silently skip crystallize because the adapter lacks
+   Claude's Task tool.
+6. Save state: answer "is that it?" with the owner-facing state before
+   technical details.
+7. Approval-gated save: validate the checkpoint subject, ask before saving,
+   and save only through `mb checkpoint`.
+8. Warm close: end with one sentence naming the most important saved or drafted
+   business outcome. Do not plan tomorrow.
+
+Owner-facing save states:
+
+- `drafted`: work exists but is not yet saved as durable business memory.
+- `saved locally`: work is saved in the local business folder history.
+- `ready to send up`: work is saved locally and ready for shared backup or
+  review.
+- `sent for review`: work has been sent to the shared proposal/review lane.
+- `landed in main`: work is accepted in the main business area.
+- `blocked by unrelated cleanup`: the session work is ready, but separate
+  cleanup or drift blocks a clean save or handoff.
+
+Use these states even when the underlying facts mention commits, branches,
+pull requests, merges, working trees, or remotes. Technical details come after
+the business state unless the operator asks for plumbing.
+
+## Read Boundaries
+
+Read deterministic `mb` facts before raw markdown or git details. After the
+fact pass, read only files needed for the closeout:
+
+- files named by checkpoint changed-file facts;
+- relevant `research/`, `decisions/`, `core/`, `bets/`, `pushes/`, `log/`, and
+  `documents/` files changed in the session;
+- safe prior crystallize notes when they help avoid repeating the same
+  question;
+- safe provider-readiness summaries from `mb connect` only when status says
+  provider state affects the closeout.
+
+Raw git history is fallback/detail only when `mb` facts are unavailable or when
+the runtime needs site-code history the CLI does not expose. Do not inspect
+secrets, raw provider exports, raw finance/legal records, raw transcripts,
+customer/member records, local runtime settings, private maintainer notes, or
+credentials.
+
+## Write Boundaries
+
+The workflow may write business files only after the operator approves the
+specific write. Valid write targets live in the business repo:
+
+- `research/` for final thoughts or crystallize notes;
+- `decisions/` when the operator explicitly turns an insight into a decision;
+- `core/` only when the operator accepts an update to durable truth;
+- `bets/`, `pushes/`, `log/`, or `documents/` when the closeout identifies an
+  approved session artifact;
+- the checkpoint created by `mb checkpoint` after approval.
+
+The workflow source does not authorize raw `git add`, raw `git commit`,
+provider writes, publishing, spending, customer contact, public issue/proposal
+submission, runtime adapter edits, or Main Branch engine repo changes.
+
+## Approval Gates
+
+Ask before:
+
+- applying updates, repairs, migrations, provider setup, or cleanup;
+- creating, editing, moving, deleting, or archiving business files;
+- saving final thoughts, crystallize notes, decisions, logs, bets, pushes, or
+  core updates;
+- validating and saving a checkpoint;
+- publishing, opening a public issue, submitting a proposal, spending money,
+  mutating provider state, or contacting customers;
+- reading or moving private, restricted, local-only, finance, legal, customer,
+  member, credential, raw transcript, or raw provider data.
+
+Never ask the operator to paste secrets into repo files or workflow sources.
+Never commit raw dumps, full transcripts, private customer/member data,
+credential material, session cookies, or unsupported provider exports.
+
+## Handoff Format
+
+When closing a session, include a compact closeout:
+
+```text
+Closeout state: <drafted, saved locally, ready to send up, sent for review, landed in main, or blocked by unrelated cleanup>.
+Status scan: <status/checkpoint/validate facts read>.
+Session summary: <3-6 bullets or one compact paragraph>.
+Final thought: <none, captured, or approved research note target>.
+Crystallize: <deep, lite, skipped with reason>.
+Checkpoint plan: <subject, changed surfaces, blockers, approval needed>.
+Warm close: <one sentence>.
+```
+
+Use business language first. Avoid "working tree clean", "branch pushed", "PR
+merged", or similar plumbing as the lead answer unless the operator asked for
+plumbing. The closeout answer should make clear whether the work is drafted,
+saved locally, ready to send up, sent for review, landed in main, or blocked by
+unrelated cleanup.
+
+## Validation Commands
+
+Before changing this workflow or its runtime shells, run:
+
+```bash
+cd mb
+python -m pytest tests/test_workflows.py -q
+```
+
+For repo-level validation, run:
+
+```bash
+scripts/check.sh
+```
+
+If generated global Codex skill data, packaged workflow data, or runtime
+discovery changes, add package/install and runtime/manual smoke evidence.
+
+## Runtime-Specific Notes
+
+Claude Code may use slash-command-native language and a Task/subagent surface
+for deep crystallize when meaningful activity happened. The Task/subagent is
+adapter behavior; the shared workflow contract is the status scan, checkpoint
+plan, session summary, final thought capture, crystallize intent,
+approval-gated save, save-state language, and warm close.
+
+Codex uses global Main Branch skills and natural-language routes. Codex should
+run crystallize-lite in-thread or use available subagent tooling when present.
+If the current Codex session has no subagent surface, name that limitation and
+still produce one specific crystallize question from the session facts. Do not
+tell Codex users to run Claude slash commands.
+
+Both runtimes should answer "is that it?" with the owner-facing save state
+first, then technical details only as a receipt.

--- a/workflows/mb-end/workflow.md
+++ b/workflows/mb-end/workflow.md
@@ -24,14 +24,17 @@ json_facts:
   - update
   - readiness
   - drift.items
-  - runtime.codex
+  - runtime.codex_cli
   - runtime.claude_code
   - journal
   - since_last_check
-  - checkpoint
-  - checkpoint.changed_files
-  - checkpoint.blockers
-  - checkpoint.proposed_subject
+  - checkpoint.pending
+  - checkpoint.pending.changed_files
+  - checkpoint.pending.blockers
+  - checkpoint.pending.proposed_subject
+  - summary.changed_files
+  - safety.blocks
+  - proposal.message
   - validation
 approval_gates:
   - updates_repairs_migrations
@@ -105,14 +108,17 @@ The runtime shell must preserve these paths from the workflow source:
 - `update`
 - `readiness`
 - `drift.items`
-- `runtime.codex`
+- `runtime.codex_cli`
 - `runtime.claude_code`
 - `journal`
 - `since_last_check`
-- `checkpoint`
-- `checkpoint.changed_files`
-- `checkpoint.blockers`
-- `checkpoint.proposed_subject`
+- `checkpoint.pending`
+- `checkpoint.pending.changed_files`
+- `checkpoint.pending.blockers`
+- `checkpoint.pending.proposed_subject`
+- `summary.changed_files`
+- `safety.blocks`
+- `proposal.message`
 - `validation`
 
 Treat these as facts, not strategy. The runtime may explain what changed,


### PR DESCRIPTION
## Summary

Adds a canonical shared `mb-end` closeout workflow source and checks Claude/Codex closeout shells against it. The closeout route now preserves status scan, checkpoint planning, final thought capture, crystallize behavior, owner-facing save states, and approval-gated saves across supported daily-loop surfaces.

## Linked issue

Closes #739
Refs #735
Refs #741

## Why

`mb-end` had drifted between a rich Claude closeout ritual and a thinner Codex route. Main Branch needs one shared workflow contract so business save-state language and approval boundaries stay consistent across runtimes.

## Commits by concern

- [ ] Each commit body bullet-lists the changes in that commit
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`

Commit:

- `ad8186c [add] Migrate mb-end closeout workflow`

## Validation

Pre-push gate from repo root:

```bash
scripts/check.sh
```

- [x] Level 1 static: `scripts/check.sh` passes
- [x] Level 2 CLI contract: focused Typer/CliRunner tests, exit codes, `--json` behavior, TTY vs non-TTY (if CLI behavior touched)
- [x] Level 3 package/install smoke (if packaging touched)
- [x] Level 4 fixture repo (if init/onboard/status/start/update touched)
- [x] Level 5 runtime smoke / dogfood harness / simulation-tier (if runtime, first-run, skill discovery, or release validation touched)
- [x] SKILL.md ≤500 lines (if any skill touched)
- [ ] Package-visible release gate evidence before tag/publish (if preparing a release)
- [ ] Supply-chain review (if `.github/workflows/`, `.github/dependabot.yml`, `mb/pyproject.toml` deps, or `id-token`/`permissions` blocks touched — see [docs/supply-chain-policy.md](../docs/supply-chain-policy.md))

Level 1 static: `scripts/check.sh` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: terminal excerpt `814 passed`, mypy success, ruff success, coverage 83.45%, skill validation ok.

Level 2 workflow contract: `cd mb && python3 -m pytest tests/test_workflows.py tests/test_doctor.py::test_doctor_repair_plan_reports_custom_codex_agents_missing_source_item -q` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: terminal excerpt `31 passed in 2.35s`.

Level 3 package/install: `(cd mb && python3 -m build)` plus wheel install smoke in `/tmp/mainbranch-smoke-448-y9RTnJ` — runtime: `/tmp/mainbranch-smoke-448-y9RTnJ/bin/mb` — exit: 0 — log: `mb 0.3.38`, `mb skill list` includes `mb-end`, and installed `mb workflow list --runtime codex --json` reports `end-checkpoint-save` as `shared_workflow_source` with `workflows/mb-end/workflow.md`.

Level 4 fixture repo: installed wheel `mb onboard --yes --name "Test Business" --path "$tmpdir/test-business"`, `mb doctor`, `mb status --json --peek`, `mb start --json`, `mb validate`, and generated `AGENTS.md` checks — runtime: `/tmp/mainbranch-smoke-448-y9RTnJ/bin/mb` — exit: 0 — log: fixture `/tmp/mainbranch-fixture-448-egpmbx/test-business`; generated `AGENTS.md` contains `Codex End Route`, `workflows/mb-end/workflow.md`, and the owner save-state vocabulary.

Level 5 runtime/manual: interactive Claude Code and Codex UI launch not run from this Conductor workspace — runtime: generated shell snapshots and installed fixture guidance — exit: 0 for snapshot/workflow checks — log: `mb-end` Claude/Codex snapshots, installed global Codex guidance, and fresh fixture `AGENTS.md` verified.

Package-visible release gate evidence is not required; this PR prepares unreleased workflow/runtime guidance but does not tag or publish a release. Supply-chain review is not required because no workflow, dependency, or permission files changed.

## Success metric

Editing `workflows/mb-end/workflow.md` changes both checked Claude and Codex `mb-end` behavior, or workflow tests fail when required facts, approval gates, read/write boundaries, closeout flow, or save-state language drift.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [ ] N/A — change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [x] No
- [ ] Yes — migration note below

## Public / private boundary

No private operator strategy, machine-specific maintainer paths, secrets, credentials, raw provider data, customer/member data, or private runtime internals were committed. Public-facing additions are workflow source, generated guidance, snapshots, tests, and changelog only.
