### PR TITLE
[update] Render Codex skills from shared sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   checked Claude and Codex shell snapshots covering status scan, checkpoint
   planning, final thought capture, crystallize, owner-facing save states, and
   approval-gated saves. Refs MAIN-448, #739.
+- Changed generated Codex global skills for shared-source routes to render from
+  the canonical workflow source, with inventory fields distinguishing shared
+  sources, Claude shells, Codex global skills, read-only planning, and pending
+  migrations. Refs MAIN-449, #740.
 - Changed `mb workflow list --json` to expose the canonical workflow
   architecture and a source-of-truth status for each Codex route, distinguishing
   shared workflow sources, temporary source-skill mirrors, pending migrations,

--- a/mb/mb/codex.py
+++ b/mb/mb/codex.py
@@ -20,6 +20,7 @@ from typing import Any
 
 from mb import __version__
 from mb import engine as engine_mod
+from mb.workflows import WorkflowSource, load_workflow, render_codex_shell
 
 AGENTS_TEMPLATE = "AGENTS.md.tmpl"
 AGENTS_RELATIVE_PATH = "AGENTS.md"
@@ -300,6 +301,10 @@ CODEX_END_PUBLIC_PRIVATE_BOUNDARIES = (
     "no_private_runtime_settings",
     "no_raw_finance_legal_records",
 )
+CODEX_SHARED_WORKFLOW_SKILLS = {
+    "mb-think": CODEX_THINK_SOURCE_WORKFLOW,
+    "mb-end": CODEX_END_SOURCE_WORKFLOW,
+}
 REQUIRED_LIFECYCLE_GUIDANCE = (
     "## Codex Lifecycle Workflow Index",
     "## Codex Status Workflow",
@@ -349,10 +354,29 @@ CODEX_PLUGIN_REQUIRED_MARKERS = (
 )
 CODEX_WORKFLOW_STATUS_VOCABULARY = (
     "supported",
+    "read_only_planning",
     "pending_shared_source_migration",
     "generated_shell_pending",
     "intentionally_unsupported",
 )
+CODEX_SURFACE_KIND_VOCABULARY = (
+    "shared_source",
+    "claude_skill",
+    "codex_global_skill",
+    "read_only_planning",
+    "pending_shared_source_migration",
+    "intentionally_unsupported",
+)
+CODEX_SURFACE_KIND_DESCRIPTIONS = {
+    "shared_source": "canonical workflow source under workflows/<workflow>/workflow.md",
+    "claude_skill": "Claude Code runtime shell under .claude/skills/<name>/SKILL.md",
+    "codex_global_skill": "generated Codex global skill shell under the Codex skills root",
+    "read_only_planning": (
+        "Codex may inspect facts and plan, but must not claim full workflow parity"
+    ),
+    "pending_shared_source_migration": "workflow substance still needs a shared source migration",
+    "intentionally_unsupported": "outside the current Codex daily-loop support target",
+}
 CODEX_SOURCE_STATUS_VOCABULARY = (
     "shared_workflow_source",
     "temporary_source_skill_mirror",
@@ -498,9 +522,10 @@ CODEX_WORKFLOW_INVENTORY: tuple[dict[str, Any], ...] = (
         "label": "Bet lifecycle",
         "claude_surface": "/mb-bet",
         "claude_skill_sources": ("mb-bet",),
-        "codex_status": "pending_shared_source_migration",
+        "codex_status": "read_only_planning",
         "source_status": "pending_shared_source_migration",
         "codex_surface": "Read-only facts and business-file planning only",
+        "codex_entrypoints": ("main-branch mb-bet",),
         "commands": ("mb status --json --peek", "mb validate --json"),
         "notes": (
             "Codex may inspect and discuss bets. A generated Codex shell should "
@@ -512,9 +537,10 @@ CODEX_WORKFLOW_INVENTORY: tuple[dict[str, Any], ...] = (
         "label": "Ads and paid creative",
         "claude_surface": "/mb-ads",
         "claude_skill_sources": ("mb-ads",),
-        "codex_status": "pending_shared_source_migration",
+        "codex_status": "read_only_planning",
         "source_status": "pending_shared_source_migration",
         "codex_surface": "Read-only planning only",
+        "codex_entrypoints": ("main-branch mb-ads",),
         "commands": ("mb status --json --peek", "mb connect doctor --json"),
         "notes": "No provider mutation, spend, upload, or publishing is supported in Codex.",
     },
@@ -523,9 +549,10 @@ CODEX_WORKFLOW_INVENTORY: tuple[dict[str, Any], ...] = (
         "label": "Organic content and newsletter planning",
         "claude_surface": "/mb-organic and related playbooks",
         "claude_skill_sources": ("mb-organic",),
-        "codex_status": "pending_shared_source_migration",
+        "codex_status": "read_only_planning",
         "source_status": "pending_shared_source_migration",
         "codex_surface": "Read-only planning only",
+        "codex_entrypoints": ("main-branch mb-organic",),
         "commands": ("mb status --json --peek",),
         "notes": (
             "Codex may route content strategy questions through think/codify, "
@@ -537,9 +564,10 @@ CODEX_WORKFLOW_INVENTORY: tuple[dict[str, Any], ...] = (
         "label": "Site and page production",
         "claude_surface": "/mb-site",
         "claude_skill_sources": ("mb-site",),
-        "codex_status": "pending_shared_source_migration",
+        "codex_status": "read_only_planning",
         "source_status": "pending_shared_source_migration",
         "codex_surface": "Read-only planning and site readiness facts only",
+        "codex_entrypoints": ("main-branch mb-site",),
         "commands": ("mb status --json --peek", "mb site check --json"),
         "notes": "Codex must not claim site build, deploy, domain, or publishing parity.",
     },
@@ -560,7 +588,7 @@ CODEX_WORKFLOW_INVENTORY: tuple[dict[str, Any], ...] = (
         "claude_surface": "google-ads-search-launch playbook",
         "claude_skill_sources": (),
         "claude_playbook_sources": ("google-ads-search-launch",),
-        "codex_status": "pending_shared_source_migration",
+        "codex_status": "read_only_planning",
         "source_status": "pending_shared_source_migration",
         "codex_surface": "Read-only planning only",
         "codex_entrypoints": ("google-ads-search-launch",),
@@ -575,7 +603,7 @@ CODEX_WORKFLOW_INVENTORY: tuple[dict[str, Any], ...] = (
         "claude_surface": "ship-bet playbook",
         "claude_skill_sources": (),
         "claude_playbook_sources": ("ship-bet",),
-        "codex_status": "pending_shared_source_migration",
+        "codex_status": "read_only_planning",
         "source_status": "pending_shared_source_migration",
         "codex_surface": "Read-only planning only",
         "codex_entrypoints": ("ship-bet",),
@@ -590,7 +618,7 @@ CODEX_WORKFLOW_INVENTORY: tuple[dict[str, Any], ...] = (
         "claude_surface": "weekly-review playbook",
         "claude_skill_sources": (),
         "claude_playbook_sources": ("weekly-review",),
-        "codex_status": "pending_shared_source_migration",
+        "codex_status": "read_only_planning",
         "source_status": "pending_shared_source_migration",
         "codex_surface": "Read-only planning only",
         "codex_entrypoints": ("weekly-review",),
@@ -1195,6 +1223,22 @@ def _commands_for_inventory_item(item: dict[str, Any]) -> tuple[str, ...]:
     return tuple(str(command) for command in commands)
 
 
+def _workflow_source_path(relative_path: str) -> Path:
+    root = engine_mod.engine_root()
+    if root is not None:
+        candidate = root / relative_path
+        if candidate.is_file():
+            return candidate
+    return Path(__file__).resolve().parents[2] / relative_path
+
+
+def _load_shared_workflow_for_skill(name: str) -> WorkflowSource | None:
+    relative_path = CODEX_SHARED_WORKFLOW_SKILLS.get(name)
+    if relative_path is None:
+        return None
+    return load_workflow(_workflow_source_path(relative_path))
+
+
 def _claude_skill_sources_for_inventory_item(item: dict[str, Any]) -> tuple[str, ...]:
     sources = item.get("claude_skill_sources") or ()
     names = sources if isinstance(sources, tuple) else tuple(str(source) for source in sources)
@@ -1209,10 +1253,12 @@ def _claude_playbook_sources_for_inventory_item(item: dict[str, Any]) -> tuple[s
 
 def _source_of_truth_for_inventory_item(item: dict[str, Any]) -> dict[str, Any]:
     status = str(item["source_status"])
+    surface_kinds = _surface_kinds_for_inventory_item(item)
     return {
         "status": status,
         "description": CODEX_SOURCE_STATUS_DESCRIPTIONS[status],
         "shared_source": item.get("shared_source"),
+        "surface_kinds": surface_kinds,
         "claude_sources": list(
             _claude_skill_sources_for_inventory_item(item)
             + _claude_playbook_sources_for_inventory_item(item)
@@ -1221,6 +1267,25 @@ def _source_of_truth_for_inventory_item(item: dict[str, Any]) -> dict[str, Any]:
         "contract_checks": [str(check) for check in item.get("contract_checks", ())],
         "follow_up_issue": item.get("follow_up_issue"),
     }
+
+
+def _surface_kinds_for_inventory_item(item: dict[str, Any]) -> list[str]:
+    kinds: list[str] = []
+    if item.get("shared_source"):
+        kinds.append("shared_source")
+    if item.get("claude_skill_sources") or item.get("claude_playbook_sources"):
+        kinds.append("claude_skill")
+    if item.get("codex_entrypoints"):
+        kinds.append("codex_global_skill")
+    codex_status = str(item.get("codex_status", ""))
+    source_status = str(item.get("source_status", ""))
+    if codex_status == "read_only_planning":
+        kinds.append("read_only_planning")
+    if source_status == "pending_shared_source_migration":
+        kinds.append("pending_shared_source_migration")
+    if codex_status == "intentionally_unsupported":
+        kinds.append("intentionally_unsupported")
+    return kinds
 
 
 def workflow_inventory(*, runtime: str = "codex") -> dict[str, Any]:
@@ -1235,6 +1300,7 @@ def workflow_inventory(*, runtime: str = "codex") -> dict[str, Any]:
         copied["codex_entrypoints"] = [
             str(entrypoint) for entrypoint in item.get("codex_entrypoints", ())
         ]
+        copied["surface_kinds"] = _surface_kinds_for_inventory_item(item)
         copied["source_of_truth"] = _source_of_truth_for_inventory_item(item)
         items.append(copied)
     statuses = sorted(
@@ -1280,6 +1346,8 @@ def workflow_inventory(*, runtime: str = "codex") -> dict[str, Any]:
         "statuses": statuses,
         "source_statuses": source_statuses,
         "source_status_descriptions": CODEX_SOURCE_STATUS_DESCRIPTIONS,
+        "surface_kinds": list(CODEX_SURFACE_KIND_VOCABULARY),
+        "surface_kind_descriptions": CODEX_SURFACE_KIND_DESCRIPTIONS,
         "items": items,
         "safe_to_share": True,
     }
@@ -1322,6 +1390,8 @@ def render_workflow_inventory_md() -> str:
         "Status meanings:\n\n"
         "- `supported`: Codex can use this surface through global Main Branch skills "
         "grounded in deterministic `mb` facts.\n"
+        "- `read_only_planning`: Codex can inspect facts and help plan, but must "
+        "not claim full workflow parity until a shared source migration lands.\n"
         "- `pending_shared_source_migration`: Codex may plan from read-only facts, "
         "but a runtime shell should wait for a shared workflow source.\n"
         "- `generated_shell_pending`: a shared source exists, but a generated Codex "
@@ -1338,6 +1408,9 @@ def render_workflow_inventory_md() -> str:
         "Canonical architecture: shared workflow source -> Claude Code shell -> "
         "Codex shell -> inventory/tests. Temporary mirrors are explicit so "
         "reviewers can see which routes still need migration.\n\n"
+        "Surface kinds in `mb workflow list --json`: `shared_source`, "
+        "`claude_skill`, `codex_global_skill`, `read_only_planning`, "
+        "`pending_shared_source_migration`, and `intentionally_unsupported`.\n\n"
         "The global Main Branch skill bundle is installed by "
         "`mb doctor repair --only codex`; business repos keep only lightweight "
         "`AGENTS.md` guidance. After repair, open a fresh Codex thread in the "
@@ -1518,6 +1591,16 @@ def render_codex_slash_commands() -> dict[str, str]:
     }
 
 
+def _render_shared_workflow_global_skill_adapter(workflow: WorkflowSource) -> str:
+    rendered_shell = render_codex_shell(workflow).strip()
+    return (
+        "Follow the generated Codex shell below. It is rendered from the canonical "
+        "shared workflow source, so workflow substance belongs in that source and "
+        "Codex differences stay in this adapter layer.\n\n"
+        f"{rendered_shell}"
+    )
+
+
 def render_codex_global_skill_md(name: str = CODEX_GLOBAL_SKILL_NAME) -> str:
     """Render one global Main Branch Codex skill."""
 
@@ -1531,7 +1614,8 @@ def render_codex_global_skill_md(name: str = CODEX_GLOBAL_SKILL_NAME) -> str:
         raise ValueError(f"unknown Codex global skill: {name}")
     description = CODEX_GLOBAL_SKILL_DESCRIPTIONS[name]
     support_level = CODEX_GLOBAL_SKILL_SUPPORT[name]
-    facts = CODEX_GLOBAL_SKILL_FACTS[name]
+    workflow = _load_shared_workflow_for_skill(name)
+    facts = tuple(workflow.required_mb_commands) if workflow else CODEX_GLOBAL_SKILL_FACTS[name]
     if name == CODEX_GLOBAL_SKILL_NAME:
         argument_hint = (
             "[mb-start|mb-status|mb-setup|mb-update|mb-doctor|mb-think|mb-end|mb-help|other-route]"
@@ -1543,59 +1627,64 @@ def render_codex_global_skill_md(name: str = CODEX_GLOBAL_SKILL_NAME) -> str:
     else:
         argument_hint = "[target]"
         title = name
-        supported_guidance = {
-            "mb-start": (
-                "Summarize the business state, readiness, ranked actions, and one "
-                "clear next route. Use `mb start --json` when runtime handoff or "
-                "Codex readiness matters."
-            ),
-            "mb-status": (
-                "Answer from status facts: readiness, drift, recent work, "
-                "since-last-check, MoneyPath, content strategy, provider signals, "
-                "and ranked actions."
-            ),
-            "mb-setup": (
-                "Treat setup prompts as onboarding intent. Explain the target folder "
-                "and ask before running any command that writes files."
-            ),
-            "mb-update": (
-                "Report whether an update is required or recommended. Ask before "
-                "running update, repair, migration, or package-changing commands."
-            ),
-            "mb-doctor": (
-                "Explain the repair plan in business language first. Quote exact "
-                "safe commands and ask before applying any write action."
-            ),
-            "mb-think": (
-                "Use the Codex Think Route in `AGENTS.md`. Choose the smallest honest "
-                "research depth, read only needed business files, and ask before "
-                "codifying or checkpointing."
-            ),
-            "mb-end": (
-                "Use the shared closeout workflow. Run the status scan and checkpoint "
-                "plan, summarize the session, capture a final thought, do "
-                "crystallize-lite or an available subagent pass, name the owner-facing "
-                "save state, and ask before saving."
-            ),
-            "mb-help": (
-                "Show the supported, pending, and unsupported Codex workflow surfaces. "
-                "Do not claim parity for surfaces the inventory does not mark supported."
-            ),
-        }
-        if name in supported_guidance:
-            route_guidance = supported_guidance[name]
-        elif support_level == "read_only_planning":
-            route_guidance = (
-                "Use this as a read-only planning route in Codex. Ground the answer "
-                "in the facts below, name what Claude Code can do more fully when "
-                "relevant, and ask before writing files or touching providers."
-            )
+        if workflow is not None:
+            route_guidance = _render_shared_workflow_global_skill_adapter(workflow)
         else:
-            route_guidance = (
-                "This workflow is inventoried for completeness but is not a supported "
-                "Codex execution route yet. Explain the support boundary and route "
-                "the operator to Claude Code or another supported Main Branch path."
-            )
+            supported_guidance = {
+                "mb-start": (
+                    "Summarize the business state, readiness, ranked actions, and one "
+                    "clear next route. Use `mb start --json` when runtime handoff or "
+                    "Codex readiness matters."
+                ),
+                "mb-status": (
+                    "Answer from status facts: readiness, drift, recent work, "
+                    "since-last-check, MoneyPath, content strategy, provider signals, "
+                    "and ranked actions."
+                ),
+                "mb-setup": (
+                    "Treat setup prompts as onboarding intent. Explain the target folder "
+                    "and ask before running any command that writes files."
+                ),
+                "mb-update": (
+                    "Report whether an update is required or recommended. Ask before "
+                    "running update, repair, migration, or package-changing commands."
+                ),
+                "mb-doctor": (
+                    "Explain the repair plan in business language first. Quote exact "
+                    "safe commands and ask before applying any write action."
+                ),
+                "mb-think": (
+                    "Use the Codex Think Route in `AGENTS.md`. Choose the smallest honest "
+                    "research depth, read only needed business files, and ask before "
+                    "codifying or checkpointing."
+                ),
+                "mb-end": (
+                    "Use the shared closeout workflow. Run the status scan and checkpoint "
+                    "plan, summarize the session, capture a final thought, do "
+                    "crystallize-lite or an available subagent pass, name the owner-facing "
+                    "save state, and ask before saving."
+                ),
+                "mb-help": (
+                    "Show the supported, pending, and unsupported Codex workflow surfaces. "
+                    "Do not claim parity for surfaces the inventory does not mark supported."
+                ),
+            }
+            if name in supported_guidance:
+                route_guidance = supported_guidance[name]
+            elif support_level == "read_only_planning":
+                route_guidance = (
+                    "Use this as a read-only planning route in Codex. Ground the answer "
+                    "in the facts below, name what Claude Code can do more fully when "
+                    "relevant, and ask before writing files or touching providers. This "
+                    "route is pending shared source migration and is not full workflow "
+                    "parity."
+                )
+            else:
+                route_guidance = (
+                    "This workflow is inventoried for completeness but is not a supported "
+                    "Codex execution route yet. Explain the support boundary and route "
+                    "the operator to Claude Code or another supported Main Branch path."
+                )
     fact_lines = "\n".join(f"- `{command}`" for command in facts)
     return f"""---
 name: {name}

--- a/mb/mb/workflows.py
+++ b/mb/mb/workflows.py
@@ -79,7 +79,9 @@ REQUIRED_SHELL_PHRASES_BY_WORKFLOW: dict[str, dict[str, str]] = {
         "public/private boundary": "public/private",
         "approval gates": "approval",
         "checkpoint approval": "checkpoint",
-        "Codex slash-command boundary": "Do not tell Codex users to run Claude slash commands.",
+        "Codex runtime-entrypoint boundary": (
+            "Do not tell Codex users to run Claude Code entrypoints."
+        ),
     },
     "mb-end": {
         "status scan": "status scan",
@@ -96,11 +98,15 @@ CODEX_FORBIDDEN_PHRASES_BY_WORKFLOW: dict[str, tuple[str, ...]] = {
     "mb-think": (
         "Run `/mb-think`",
         "Claude Code skills work in Codex",
+        "Claude Code slash commands work inside Codex",
+        "Claude slash commands",
         "slash-command parity",
     ),
     "mb-end": (
         "Run `/mb-end`",
         "Claude Code skills work in Codex",
+        "Claude Code slash commands work inside Codex",
+        "Claude slash commands",
         "slash-command parity",
         "skip crystallize",
     ),
@@ -453,8 +459,8 @@ Approval gates: {_inline_code_list(workflow.approval_gates)}
 Public/private boundaries: {_inline_code_list(workflow.public_private_boundaries)}
 
 Codex is first-class for the proven owner loop only. This guidance is a
-generated owner-loop shell; it does not mean `/mb-start` slash commands work
-inside Codex and it does not claim all Main Branch workflow support.
+generated owner-loop shell; it does not mean Claude Code runtime entrypoints
+work inside Codex and it does not claim all Main Branch workflow support.
 
 Start from deterministic `mb` facts before reading business markdown or giving
 path-to-money advice.
@@ -478,7 +484,7 @@ path-to-money advice.
 3. Use `money_path`, `money_path.objects.proof.quality`, `content_strategy`,
    `ranked_actions`, `update`, `readiness`, and `drift.items` as cited facts.
 4. If a thinking/codification step is needed, propose the route in Codex-native
-   language instead of pretending Claude slash commands are available.
+   language instead of pretending Claude Code runtime entrypoints are available.
 5. Ask before writing business files, saving checkpoints, opening public
    issues, publishing, mutating providers, spending money, or contacting
    customers.
@@ -569,7 +575,7 @@ Approval needed before writes: yes.
 ```
 
 Use business language. Do not say an offer is bad, will convert, or will not
-convert. Do not tell Codex users to run Claude slash commands.
+convert. Do not tell Codex users to run Claude Code entrypoints.
 """
     return output
 
@@ -588,8 +594,8 @@ Codex is first-class for the proven owner loop only. This guidance is generated
 from the engine workflow source for business-repo `AGENTS.md`; the business repo
 does not need to contain `{_display_path(workflow.path)}`. Treat this rendered
 route as the Codex shell for natural-language thinking tasks. It does not claim
-Claude Code slash commands work inside Codex or that all Main Branch workflows
-are available in Codex.
+Claude Code runtime entrypoints work inside Codex or that all Main Branch
+workflows are available in Codex.
 
 ## Required mb Commands
 
@@ -643,8 +649,8 @@ Stop condition: <what is enough signal>.
 Durable targets: <research/, decisions/, core/, bets/, pushes/, log/, or documents/>.
 Approval needed before writes: yes.
 ```
-Do not tell Codex users to run Claude slash commands. Runtime smoke is required
-before docs say this selected workflow is supported or available in Codex.
+Do not tell Codex users to run Claude Code entrypoints. Runtime smoke is
+required before docs say this selected workflow is supported in Codex.
 """
     return output
 
@@ -726,8 +732,8 @@ Codex is first-class for the proven owner loop only. This guidance is generated
 from the engine workflow source for business-repo `AGENTS.md`; the business repo
 does not need to contain `{_display_path(workflow.path)}`. Treat this rendered
 route as the Codex shell for natural-language closeout tasks. It does not claim
-Claude Code slash commands work inside Codex or that all Main Branch workflows
-are available in Codex.
+Claude Code runtime entrypoints work inside Codex or that all Main Branch
+workflows are available in Codex.
 
 ## Required mb Commands
 
@@ -774,7 +780,7 @@ Warm close: <one sentence>.
 
 Use business language first. Git, branch, pull request, merge, and working-tree
 details are secondary unless the operator asks for plumbing. Do not tell Codex
-users to run Claude slash commands. Runtime smoke is required before docs say
+users to run Claude Code entrypoints. Runtime smoke is required before docs say
 this selected workflow is supported or available in Codex.
 """
     return output

--- a/mb/setup.py
+++ b/mb/setup.py
@@ -41,6 +41,16 @@ def _copy_generated_data(target_root: Path) -> None:
         if plugin_target.exists():
             shutil.rmtree(plugin_target)
         shutil.copytree(plugin_source, plugin_target)
+    workflow_source = REPO_ROOT / "workflows"
+    if workflow_source.exists():
+        workflow_target = engine_root / "workflows"
+        if workflow_target.exists():
+            shutil.rmtree(workflow_target)
+        shutil.copytree(
+            workflow_source,
+            workflow_target,
+            ignore=shutil.ignore_patterns("__pycache__", ".DS_Store"),
+        )
 
 
 class build_py(_build_py):

--- a/mb/tests/fixtures/workflows/mb-end.codex.md
+++ b/mb/tests/fixtures/workflows/mb-end.codex.md
@@ -9,8 +9,8 @@ Codex is first-class for the proven owner loop only. This guidance is generated
 from the engine workflow source for business-repo `AGENTS.md`; the business repo
 does not need to contain `workflows/mb-end/workflow.md`. Treat this rendered
 route as the Codex shell for natural-language closeout tasks. It does not claim
-Claude Code slash commands work inside Codex or that all Main Branch workflows
-are available in Codex.
+Claude Code runtime entrypoints work inside Codex or that all Main Branch
+workflows are available in Codex.
 
 ## Required mb Commands
 
@@ -79,5 +79,5 @@ Warm close: <one sentence>.
 
 Use business language first. Git, branch, pull request, merge, and working-tree
 details are secondary unless the operator asks for plumbing. Do not tell Codex
-users to run Claude slash commands. Runtime smoke is required before docs say
+users to run Claude Code entrypoints. Runtime smoke is required before docs say
 this selected workflow is supported or available in Codex.

--- a/mb/tests/fixtures/workflows/mb-start-money-path.codex.md
+++ b/mb/tests/fixtures/workflows/mb-start-money-path.codex.md
@@ -6,8 +6,8 @@ Approval gates: `updates_repairs_migrations`, `file_writes`, `checkpoint`, `prov
 Public/private boundaries: `no_secrets`, `no_raw_provider_exports`, `no_customer_member_data`, `no_private_runtime_settings`, `no_private_maintainer_notes`
 
 Codex is first-class for the proven owner loop only. This guidance is a
-generated owner-loop shell; it does not mean `/mb-start` slash commands work
-inside Codex and it does not claim all Main Branch workflow support.
+generated owner-loop shell; it does not mean Claude Code runtime entrypoints
+work inside Codex and it does not claim all Main Branch workflow support.
 
 Start from deterministic `mb` facts before reading business markdown or giving
 path-to-money advice.
@@ -47,7 +47,7 @@ path-to-money advice.
 3. Use `money_path`, `money_path.objects.proof.quality`, `content_strategy`,
    `ranked_actions`, `update`, `readiness`, and `drift.items` as cited facts.
 4. If a thinking/codification step is needed, propose the route in Codex-native
-   language instead of pretending Claude slash commands are available.
+   language instead of pretending Claude Code runtime entrypoints are available.
 5. Ask before writing business files, saving checkpoints, opening public
    issues, publishing, mutating providers, spending money, or contacting
    customers.

--- a/mb/tests/fixtures/workflows/mb-think.claude.md
+++ b/mb/tests/fixtures/workflows/mb-think.claude.md
@@ -82,4 +82,4 @@ Approval needed before writes: yes.
 ```
 
 Use business language. Do not say an offer is bad, will convert, or will not
-convert. Do not tell Codex users to run Claude slash commands.
+convert. Do not tell Codex users to run Claude Code entrypoints.

--- a/mb/tests/fixtures/workflows/mb-think.codex.md
+++ b/mb/tests/fixtures/workflows/mb-think.codex.md
@@ -9,8 +9,8 @@ Codex is first-class for the proven owner loop only. This guidance is generated
 from the engine workflow source for business-repo `AGENTS.md`; the business repo
 does not need to contain `workflows/mb-think/workflow.md`. Treat this rendered
 route as the Codex shell for natural-language thinking tasks. It does not claim
-Claude Code slash commands work inside Codex or that all Main Branch workflows
-are available in Codex.
+Claude Code runtime entrypoints work inside Codex or that all Main Branch
+workflows are available in Codex.
 
 ## Required mb Commands
 
@@ -85,5 +85,5 @@ Stop condition: <what is enough signal>.
 Durable targets: <research/, decisions/, core/, bets/, pushes/, log/, or documents/>.
 Approval needed before writes: yes.
 ```
-Do not tell Codex users to run Claude slash commands. Runtime smoke is required
-before docs say this selected workflow is supported or available in Codex.
+Do not tell Codex users to run Claude Code entrypoints. Runtime smoke is
+required before docs say this selected workflow is supported in Codex.

--- a/mb/tests/test_workflows.py
+++ b/mb/tests/test_workflows.py
@@ -285,6 +285,7 @@ def test_codex_workflow_inventory_command_lists_supported_and_pending_surfaces()
     statuses = set(data["statuses"])
     assert {
         "supported",
+        "read_only_planning",
         "pending_shared_source_migration",
         "generated_shell_pending",
         "intentionally_unsupported",
@@ -326,7 +327,7 @@ def test_codex_workflow_inventory_command_lists_supported_and_pending_surfaces()
         ".claude/skills/mb-start/SKILL.md",
         ".claude/skills/mb-status/SKILL.md",
     ]
-    assert by_id["ads"]["codex_status"] == "pending_shared_source_migration"
+    assert by_id["ads"]["codex_status"] == "read_only_planning"
     assert by_id["ads"]["source_status"] == "pending_shared_source_migration"
     assert by_id["wiki"]["codex_status"] == "intentionally_unsupported"
     assert by_id["wiki"]["source_status"] == "intentionally_unsupported"
@@ -347,6 +348,21 @@ def test_codex_workflow_inventory_command_lists_supported_and_pending_surfaces()
         "pending_shared_source_migration",
         "intentionally_unsupported",
     }.issubset(set(data["source_statuses"]))
+    assert {
+        "shared_source",
+        "claude_skill",
+        "codex_global_skill",
+        "read_only_planning",
+        "pending_shared_source_migration",
+    }.issubset(set(data["surface_kinds"]))
+    assert {"shared_source", "claude_skill", "codex_global_skill"}.issubset(
+        set(by_id["think-codify"]["surface_kinds"])
+    )
+    assert {
+        "codex_global_skill",
+        "read_only_planning",
+        "pending_shared_source_migration",
+    }.issubset(set(by_id["ads"]["surface_kinds"]))
     assert "plugin" not in data
     assert data["global_skill"]["path"] == codex_mod.CODEX_GLOBAL_SKILL_RELATIVE_PATH
     assert "mb-start" in data["global_skill"]["routes"]
@@ -363,6 +379,7 @@ def test_codex_workflow_inventory_source_status_contract_is_explicit() -> None:
         assert isinstance(source["claude_sources"], list)
         assert isinstance(source["codex_sources"], list)
         assert isinstance(source["contract_checks"], list)
+        assert isinstance(source["surface_kinds"], list)
         if item["codex_status"] == "supported":
             assert item["source_status"] in {
                 "shared_workflow_source",
@@ -389,9 +406,25 @@ def test_codex_global_skills_hide_legacy_plugin_and_fake_slash_claims() -> None:
 
     assert "main-branch-owner-loop" not in combined
     assert "plugin readiness" not in combined.lower()
+    assert "slash" not in combined.lower()
     assert "slash commands are available" not in combined.lower()
     assert "slash-command parity" not in combined.lower()
     assert "Claude Code command surfaces are available" in combined
+
+
+def test_codex_shared_global_skills_are_rendered_from_workflow_sources() -> None:
+    for path, name in ((THINK_WORKFLOW, "mb-think"), (END_WORKFLOW, "mb-end")):
+        workflow = load_workflow(path)
+        text = codex_mod.render_codex_global_skill_md(name)
+
+        assert "Follow the generated Codex shell below" in text
+        assert f"Source workflow: `workflows/{name}/workflow.md`" in text
+        assert render_codex_shell(workflow).strip() in text
+        assert shell_drift_errors(workflow, text) == []
+        assert codex_shell_policy_errors(workflow, text) == []
+        assert "main-branch-owner-loop" not in text
+        assert "plugin" not in text.lower()
+        assert "slash" not in text.lower()
 
 
 def test_codex_workflow_inventory_accounts_for_every_bundled_claude_skill() -> None:


### PR DESCRIPTION
## Summary

Generated Codex global skills for shared-source routes now render from the canonical workflow source, and the Codex workflow inventory names shared sources, Claude shells, Codex global skill surfaces, read-only planning, and pending migrations separately.

## Linked issue

Closes #740
Refs #738, #739, #742

## Why

Codex global skills were at risk of becoming a second hand-maintained workflow layer beside Claude. This keeps workflow substance in `workflows/<name>/workflow.md`, limits Codex differences to adapter shells, and leaves ads/site/organic/bet/playbook routes as read-only planning until their shared-source migrations land.

## Commits by concern

- [x] Each commit body bullet-lists the changes in that commit
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`

Commit list:
- `94b71a6 [update] Render Codex skills from shared sources`

## Validation

Pre-push gate from repo root:

```bash
scripts/check.sh
```

- [x] Level 1 static: `scripts/check.sh` passes
- [x] Level 2 CLI contract: focused Typer/CliRunner tests, exit codes, `--json` behavior, TTY vs non-TTY (if CLI behavior touched)
- [x] Level 3 package/install smoke (if packaging touched)
- [x] Level 4 fixture repo (if init/onboard/status/start/update touched)
- [ ] Level 5 runtime smoke / dogfood harness / simulation-tier (if runtime, first-run, skill discovery, or release validation touched)
- [x] SKILL.md ≤500 lines (if any skill touched)
- [ ] Package-visible release gate evidence before tag/publish (if preparing a release)
- [ ] Supply-chain review (if `.github/workflows/`, `.github/dependabot.yml`, `mb/pyproject.toml` deps, or `id-token`/`permissions` blocks touched — see [docs/supply-chain-policy.md](../docs/supply-chain-policy.md))

Level 1 static: `scripts/check.sh` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: excerpt `92 files already formatted`, `All checks passed!`, `Success: no issues found in 91 source files`, `816 passed`.
Level 2 workflow CLI/tests: `cd mb && pytest tests/test_workflows.py -q` — runtime: `python3` — exit: 0 — log: excerpt `32 passed in 0.46s`.
Level 3 package/install: `cd mb && python3 -m build && /tmp/mainbranch-smoke/bin/pip install dist/*.whl && /tmp/mainbranch-smoke/bin/mb --version && /tmp/mainbranch-smoke/bin/mb skill list && /tmp/mainbranch-smoke/bin/mb workflow list --runtime codex --json` — runtime: `/tmp/mainbranch-smoke/bin/python` — exit: 0 — log: excerpt `mb 0.3.38`, shared-source routes show `['shared_source', 'claude_skill', 'codex_global_skill']`, ads/site show `read_only_planning` plus `pending_shared_source_migration`.
Level 4 fixture repo: `/tmp/mainbranch-smoke/bin/mb onboard --yes --name "Test Business" --path "$tmpdir/test-business" && mb doctor && mb status && mb start --json && mb validate` — runtime: `/tmp/mainbranch-smoke/bin/mb` — exit: 0 — log: excerpt `fixture smoke ok`.
Level 5 runtime smoke: not run; interactive Claude/Codex TUI smoke was not available in this PR flow, so the closest evidence is packaged install, generated global-skill render checks, fixture `mb doctor` Codex readiness, and fixture business-repo CLI smoke.
Package-visible release gate evidence: not required; this PR prepares unreleased code only and does not tag or publish.
Supply-chain review: not required; no GitHub Actions, dependency, `id-token`, or workflow permission files changed.

## Success metric

A supported shared-source route's Codex global skill is generated from the same canonical workflow source as the Claude shell, and tests fail if either runtime shell drifts from the workflow source or claims unsupported Codex surfaces.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [ ] N/A — change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [x] No
- [ ] Yes — migration note below

## Public / private boundary

No private operator strategy, machine-specific paths, credentials, raw customer/member data, or private runtime internals were committed. The `.context/` cold-start note remains local scratch and is not part of the PR.
