### PR TITLE
[update] Share daily Codex workflow sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ### Changed
 
+- Changed daily start/status, setup, update, and repair Codex routes to use
+  canonical shared workflow sources, with checked Claude and Codex shell
+  snapshots and workflow inventory entries naming the source files. Refs
+  MAIN-451, #742.
 - Changed `mb-end` to use a canonical shared closeout workflow source, with
   checked Claude and Codex shell snapshots covering status scan, checkpoint
   planning, final thought capture, crystallize, owner-facing save states, and

--- a/mb/mb/codex.py
+++ b/mb/mb/codex.py
@@ -205,6 +205,9 @@ CODEX_GLOBAL_SKILL_SUPPORT: dict[str, str] = {
     "mb-skill-review": "intentionally_unsupported",
 }
 CODEX_THINK_SOURCE_WORKFLOW = "workflows/mb-think/workflow.md"
+CODEX_START_STATUS_SOURCE_WORKFLOW = "workflows/mb-start-status/workflow.md"
+CODEX_SETUP_SOURCE_WORKFLOW = "workflows/mb-setup/workflow.md"
+CODEX_MAINTENANCE_REPAIR_SOURCE_WORKFLOW = "workflows/mb-maintenance-repair/workflow.md"
 CODEX_THINK_REQUIRED_MB_COMMANDS = (
     "mb status --json --peek",
     "mb start --json",
@@ -302,6 +305,11 @@ CODEX_END_PUBLIC_PRIVATE_BOUNDARIES = (
     "no_raw_finance_legal_records",
 )
 CODEX_SHARED_WORKFLOW_SKILLS = {
+    "mb-start": CODEX_START_STATUS_SOURCE_WORKFLOW,
+    "mb-status": CODEX_START_STATUS_SOURCE_WORKFLOW,
+    "mb-setup": CODEX_SETUP_SOURCE_WORKFLOW,
+    "mb-update": CODEX_MAINTENANCE_REPAIR_SOURCE_WORKFLOW,
+    "mb-doctor": CODEX_MAINTENANCE_REPAIR_SOURCE_WORKFLOW,
     "mb-think": CODEX_THINK_SOURCE_WORKFLOW,
     "mb-end": CODEX_END_SOURCE_WORKFLOW,
 }
@@ -406,15 +414,24 @@ CODEX_WORKFLOW_INVENTORY: tuple[dict[str, Any], ...] = (
         "claude_surface": "/mb-start, /mb-status",
         "claude_skill_sources": ("mb-start", "mb-status"),
         "codex_status": "supported",
-        "source_status": "temporary_source_skill_mirror",
+        "source_status": "shared_workflow_source",
         "codex_surface": "main-branch skill routes: mb-start, mb-status",
         "codex_entrypoints": ("main-branch mb-start", "main-branch mb-status"),
-        "commands": ("mb status --json --peek", "mb start --json"),
+        "shared_source": CODEX_START_STATUS_SOURCE_WORKFLOW,
+        "commands": ("mb status --json --peek", "mb start --json", "mb doctor repair --plan"),
         "contract_checks": (
+            "intent",
             "required_mb_commands",
+            "required_json_facts",
+            "approval_gates",
+            "read_boundaries",
+            "write_boundaries",
             "runtime_mismatch_gate",
             "read_before_write_boundary",
             "one_next_route_core_flow",
+            "status_marker_approval",
+            "core_flow",
+            "public_private_boundaries",
         ),
         "notes": (
             "Codex starts from deterministic status/start facts, translates them "
@@ -422,28 +439,73 @@ CODEX_WORKFLOW_INVENTORY: tuple[dict[str, Any], ...] = (
         ),
     },
     {
-        "id": "daily-setup-repair-update",
-        "label": "Setup, update, doctor, and repair planning",
-        "claude_surface": "/mb-setup, /mb-update, /mb-start repair routing",
-        "claude_skill_sources": ("mb-setup", "mb-update"),
+        "id": "daily-setup",
+        "label": "Setup and onboarding",
+        "claude_surface": "/mb-setup",
+        "claude_skill_sources": ("mb-setup",),
         "codex_status": "supported",
-        "source_status": "temporary_source_skill_mirror",
-        "codex_surface": "main-branch skill routes: mb-setup, mb-update, mb-doctor",
+        "source_status": "shared_workflow_source",
+        "codex_surface": "main-branch skill route: mb-setup",
+        "codex_entrypoints": ("main-branch mb-setup",),
+        "shared_source": CODEX_SETUP_SOURCE_WORKFLOW,
+        "commands": (
+            "mb --version",
+            "mb onboard --help",
+            "mb status --json --peek",
+            "mb start --json",
+            "mb doctor repair --plan",
+        ),
+        "contract_checks": (
+            "intent",
+            "required_mb_commands",
+            "required_json_facts",
+            "approval_gates",
+            "read_boundaries",
+            "write_boundaries",
+            "target_folder_confirmation",
+            "setup_intent_boundary",
+            "core_flow",
+            "public_private_boundaries",
+        ),
+        "notes": (
+            "Codex treats setup prompts as onboarding intent, confirms the target "
+            "folder, and asks before setup writes, GitHub creation, or checkpoints."
+        ),
+    },
+    {
+        "id": "daily-maintenance-repair",
+        "label": "Update, doctor, and repair planning",
+        "claude_surface": "/mb-update, /mb-start repair routing",
+        "claude_skill_sources": ("mb-update",),
+        "codex_status": "supported",
+        "source_status": "shared_workflow_source",
+        "codex_surface": "main-branch skill routes: mb-update, mb-doctor",
         "codex_entrypoints": (
-            "main-branch mb-setup",
             "main-branch mb-update",
             "main-branch mb-doctor",
         ),
+        "shared_source": CODEX_MAINTENANCE_REPAIR_SOURCE_WORKFLOW,
         "commands": (
             "mb --version",
+            "mb status --json --peek",
+            "mb start --json",
+            "mb doctor repair --plan",
             "mb doctor repair --plan --json",
             "mb update --check --json",
         ),
         "contract_checks": (
+            "intent",
             "required_mb_commands",
+            "required_json_facts",
             "approval_gates",
+            "read_boundaries",
+            "write_boundaries",
             "read_before_write_boundary",
             "repair_plan_core_flow",
+            "safe_to_apply_state",
+            "runtime_mismatch_gate",
+            "core_flow",
+            "public_private_boundaries",
         ),
         "notes": (
             "Codex may inspect plans and explain next steps. Applying updates, "

--- a/mb/mb/workflows.py
+++ b/mb/mb/workflows.py
@@ -93,6 +93,24 @@ REQUIRED_SHELL_PHRASES_BY_WORKFLOW: dict[str, dict[str, str]] = {
         "save states": "drafted",
         "warm close": "warm close",
     },
+    "mb-start-status": {
+        "ranked next route": "ranked_actions",
+        "runtime mismatch gate": "runtime mismatch",
+        "status marker approval": "status marker",
+        "owner-facing state": "business language first",
+    },
+    "mb-setup": {
+        "setup intent": "setup intent",
+        "target folder confirmation": "target folder",
+        "approval-gated writes": "ask before running a write command",
+        "owner outcome": "owner outcome",
+    },
+    "mb-maintenance-repair": {
+        "repair plan": "repair plan",
+        "package update approval": "package updates are explicit operator actions",
+        "safe-to-apply state": "safe-to-apply",
+        "post-repair status": "rerun `mb status --json --peek`",
+    },
 }
 CODEX_FORBIDDEN_PHRASES_BY_WORKFLOW: dict[str, tuple[str, ...]] = {
     "mb-think": (
@@ -109,6 +127,29 @@ CODEX_FORBIDDEN_PHRASES_BY_WORKFLOW: dict[str, tuple[str, ...]] = {
         "Claude slash commands",
         "slash-command parity",
         "skip crystallize",
+    ),
+    "mb-start-status": (
+        "Run `/mb-start`",
+        "Run `/mb-status`",
+        "Claude Code skills work in Codex",
+        "Claude Code slash commands work inside Codex",
+        "Claude slash commands",
+        "slash-command parity",
+    ),
+    "mb-setup": (
+        "Run `/mb-setup`",
+        "Claude Code skills work in Codex",
+        "Claude Code slash commands work inside Codex",
+        "Claude slash commands",
+        "slash-command parity",
+    ),
+    "mb-maintenance-repair": (
+        "Run `/mb-update`",
+        "Run `/mb-doctor`",
+        "Claude Code skills work in Codex",
+        "Claude Code slash commands work inside Codex",
+        "Claude slash commands",
+        "slash-command parity",
     ),
 }
 PUBLIC_PRIVATE_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
@@ -375,7 +416,186 @@ def render_claude_shell(workflow: WorkflowSource) -> str:
         return _render_think_claude_shell(workflow)
     if workflow.name == "mb-end":
         return _render_end_claude_shell(workflow)
+    if workflow.name in {"mb-start-status", "mb-setup", "mb-maintenance-repair"}:
+        return _render_daily_claude_shell(workflow)
     return _render_start_money_path_claude_shell(workflow)
+
+
+def _daily_claude_use_text(workflow: WorkflowSource) -> str:
+    if workflow.name == "mb-start-status":
+        return (
+            "Use from `/mb-start` or `/mb-status` when the operator starts the day, "
+            "returns to a repo, asks what changed, or asks what to do next. Preserve "
+            "fact-first routing, update/repair gates, one clear next route, and "
+            "business language first."
+        )
+    if workflow.name == "mb-setup":
+        return (
+            "Use from `/mb-setup` when the operator wants to create or connect a "
+            "business repo. Treat pasted setup prompts as setup intent, confirm the "
+            "target folder, and ask before running a write command."
+        )
+    return (
+        "Use from `/mb-update`, `/mb-start` repair routing, or doctor guidance when "
+        "the operator needs update, repair, migration, or runtime wiring help. Explain "
+        "the repair plan in business language first and ask before apply commands."
+    )
+
+
+def _daily_codex_route_text(workflow: WorkflowSource) -> str:
+    if workflow.name == "mb-start-status":
+        return (
+            "1. Use the business repo `AGENTS.md` bootstrap posture: read facts first, "
+            "keep writes approval-gated, and translate git/provider details into business "
+            "language.\n"
+            "2. Run hard gates before routing: required updates, runtime mismatch, repair "
+            "blockers, readiness blockers, private-data boundaries, unsafe provider "
+            "operations, and destructive-operation requests.\n"
+            "3. Use `ranked_actions`, `since_last_check`, `journal`, `money_path`, "
+            "`content_strategy`, `onboarding`, `readiness`, `update`, and `drift.items` "
+            "as cited facts.\n"
+            "4. Present one clear business route and the signal behind it. Mutate the "
+            "status marker only when the operator explicitly approves recording the "
+            "daily check-in.\n"
+            "5. Ask before business-file writes, checkpoints, repairs, updates, migrations, "
+            "provider mutation, publishing, spend, customer contact, destructive operations, "
+            "or public issue/proposal submission."
+        )
+    if workflow.name == "mb-setup":
+        return (
+            "1. Treat setup prompts as setup intent and onboarding intent, not as documents "
+            "to save.\n"
+            "2. Confirm the target folder and inspect setup capability before writes.\n"
+            "3. If `mb` is missing, stop and give the install command. If GitHub backup "
+            "is requested, check GitHub CLI auth before any GitHub write.\n"
+            "4. Ask before running a write command such as onboarding, repo creation, "
+            "file scaffolding, GitHub remote/push, repair apply, migration apply, or "
+            "checkpoint save.\n"
+            "5. After approved setup, rerun status/start facts and report the owner "
+            "outcome before command receipts."
+        )
+    return (
+        "1. Inspect update and repair state before advice: version, status, start, "
+        "update check, and repair plan facts.\n"
+        "2. Stop on runtime mismatch or missing `mb` before business routing.\n"
+        "3. Explain what is stale, why it matters, affected surface, write set, and "
+        "safe-to-apply state before exact commands.\n"
+        "4. Package updates are explicit operator actions. Repair applies, migrations, "
+        "global skill writes, skill links, gitignore changes, and untracking require "
+        "approval.\n"
+        "5. After an approved update or repair, rerun `mb status --json --peek` before "
+        "routing back into business work."
+    )
+
+
+def _daily_claude_route_text(workflow: WorkflowSource) -> str:
+    if workflow.name == "mb-start-status":
+        return (
+            "1. Start from status facts before raw markdown: readiness, drift, "
+            "runtime wiring, update state, ranked actions, and since-last-check context.\n"
+            "2. Run hard gates before routing: required updates, runtime mismatch, repair "
+            "blockers, readiness blockers, private-data boundaries, unsafe provider "
+            "operations, and destructive-operation requests.\n"
+            "3. Use `ranked_actions`, `since_last_check`, `journal`, `money_path`, "
+            "`content_strategy`, `onboarding`, `readiness`, `update`, and `drift.items` "
+            "as cited facts.\n"
+            "4. Present one clear business route and the signal behind it. Mutate the "
+            "status marker only when the operator explicitly approves recording the "
+            "daily check-in.\n"
+            "5. Ask before business-file writes, checkpoints, repairs, updates, migrations, "
+            "provider mutation, publishing, spend, customer contact, destructive operations, "
+            "or public issue/proposal submission."
+        )
+    if workflow.name == "mb-setup":
+        return (
+            "1. Treat setup prompts as setup intent and onboarding intent, not as documents "
+            "to save.\n"
+            "2. Confirm the target folder and inspect setup capability before writes.\n"
+            "3. If `mb` is missing, stop and give the install command. If GitHub backup "
+            "is requested, check GitHub CLI auth before any GitHub write.\n"
+            "4. Ask before running a write command such as onboarding, repo creation, "
+            "file scaffolding, GitHub remote/push, repair apply, migration apply, or "
+            "checkpoint save.\n"
+            "5. After approved setup, rerun status/start facts and report the owner "
+            "outcome before command receipts."
+        )
+    return (
+        "1. Inspect update and repair state before advice: version, status, start, "
+        "update check, and repair plan facts.\n"
+        "2. Stop on runtime mismatch or missing `mb` before business routing.\n"
+        "3. Explain what is stale, why it matters, affected surface, write set, and "
+        "safe-to-apply state before exact commands.\n"
+        "4. Package updates are explicit operator actions. Repair applies, migrations, "
+        "skill links, gitignore changes, and untracking require approval.\n"
+        "5. After an approved update or repair, rerun `mb status --json --peek` before "
+        "routing back into business work."
+    )
+
+
+def _daily_handoff_template(workflow: WorkflowSource) -> str:
+    if workflow.name == "mb-start-status":
+        return """Daily state: <ready, needs attention, blocked, or not a Main Branch repo>.
+Facts read: <status/start/repair facts used>.
+What changed: <since-last-check or journal summary>.
+Main signal: <ranked action, readiness, drift, MoneyPath, content strategy, or onboarding fact>.
+Recommended route: <one business route and why>.
+Approval needed before writes: <yes/no and what action>."""
+    if workflow.name == "mb-setup":
+        return """Setup state: <not started, target confirmed, created, connected, ready,
+or blocked>.
+Target folder: <business folder or needs confirmation>.
+Facts read: <version/help/status/start/repair facts used>.
+Created or planned: <folders, guidance, GitHub backup, checkpoint, or none>.
+Owner outcome: <business brain ready, needs approval, or blocked reason>.
+Next safe action: <one command or route>.
+Approval needed before writes: <yes/no and what action>."""
+    return """Maintenance state: <current, update available, repair needed, blocked, or applied>.
+Facts read: <version/status/start/update/repair facts used>.
+Affected surface: <install, Claude wiring, Codex guidance, migration,
+validation, gitignore, or checkpoint hook>.
+Plan: <read-only command, write command, files touched, and safe-to-apply state>.
+Owner impact: <why this matters in business language>.
+Next safe action: <one command or route>.
+Approval needed before writes: <yes/no and what action>."""
+
+
+def _render_daily_claude_shell(workflow: WorkflowSource) -> str:
+    """Render a Claude Code shell snapshot for daily operating workflows."""
+
+    output = f"""# Generated Claude Shell: {workflow.title}
+
+Source workflow: `{_display_path(workflow.path)}`
+Runtime support: `claude_code: supported_shell`
+Approval gates: {_inline_code_list(workflow.approval_gates)}
+Public/private boundaries: {_inline_code_list(workflow.public_private_boundaries)}
+
+{_daily_claude_use_text(workflow)}
+
+This snapshot does not replace shipped `.claude/skills` prose.
+
+## Required mb Commands
+
+{_bullet_list(workflow.required_mb_commands)}
+
+## Required JSON Fact Paths
+
+{_bullet_list(workflow.json_facts)}
+
+## Routing
+
+{_daily_claude_route_text(workflow)}
+
+## Handoff Shape
+
+```text
+{_daily_handoff_template(workflow)}
+```
+
+Use business language first. Technical commands, runtime wiring, provider refs,
+and file paths are receipts after the owner-facing state unless the operator asks
+for plumbing.
+"""
+    return output
 
 
 def _render_start_money_path_claude_shell(workflow: WorkflowSource) -> str:
@@ -445,7 +665,52 @@ def render_codex_shell(workflow: WorkflowSource) -> str:
         return _render_think_codex_shell(workflow)
     if workflow.name == "mb-end":
         return _render_end_codex_shell(workflow)
+    if workflow.name in {"mb-start-status", "mb-setup", "mb-maintenance-repair"}:
+        return _render_daily_codex_shell(workflow)
     return _render_start_money_path_codex_shell(workflow)
+
+
+def _render_daily_codex_shell(workflow: WorkflowSource) -> str:
+    """Render Codex CLI guidance for daily operating workflows."""
+
+    output = f"""# Generated Codex Workflow Guidance: {workflow.title}
+
+Source workflow: `{_display_path(workflow.path)}`
+Runtime support: `codex_cli: {workflow.runtime_support.get("codex_cli", "")}`
+Approval gates: {_inline_code_list(workflow.approval_gates)}
+Public/private boundaries: {_inline_code_list(workflow.public_private_boundaries)}
+
+Codex is first-class for the proven owner loop only. This guidance is generated
+from the engine workflow source for business-repo `AGENTS.md`; the business repo
+does not need to contain `{_display_path(workflow.path)}`. Treat this rendered
+route as the Codex shell for natural-language daily operating tasks. It does not
+claim Claude Code runtime entrypoints work inside Codex or that all Main Branch
+workflows are available in Codex.
+
+## Required mb Commands
+
+{_bullet_list(workflow.required_mb_commands)}
+
+## Required JSON Fact Paths
+
+{_bullet_list(workflow.json_facts)}
+
+## Codex Route
+
+{_daily_codex_route_text(workflow)}
+
+## Handoff Shape
+
+```text
+{_daily_handoff_template(workflow)}
+```
+
+Use business language first. Technical commands, runtime wiring, provider refs,
+and file paths are receipts after the owner-facing state unless the operator asks
+for plumbing. Do not tell Codex users to run Claude Code entrypoints. Runtime
+smoke is required before docs say this selected workflow is supported in Codex.
+"""
+    return output
 
 
 def _render_start_money_path_codex_shell(workflow: WorkflowSource) -> str:

--- a/mb/tests/fixtures/workflows/mb-maintenance-repair.claude.md
+++ b/mb/tests/fixtures/workflows/mb-maintenance-repair.claude.md
@@ -1,0 +1,64 @@
+# Generated Claude Shell: Maintenance Update And Repair
+
+Source workflow: `workflows/mb-maintenance-repair/workflow.md`
+Runtime support: `claude_code: supported_shell`
+Approval gates: `updates_repairs_migrations`, `file_writes`, `checkpoint`, `provider_mutation`, `publishing_or_spend`, `customer_contact`, `private_data`, `destructive_operations`, `package_update`, `repair_apply`
+Public/private boundaries: `no_secrets`, `no_raw_provider_exports`, `no_customer_member_data`, `no_private_runtime_settings`, `no_raw_finance_legal_records`
+
+Use from `/mb-update`, `/mb-start` repair routing, or doctor guidance when the operator needs update, repair, migration, or runtime wiring help. Explain the repair plan in business language first and ask before apply commands.
+
+This snapshot does not replace shipped `.claude/skills` prose.
+
+## Required mb Commands
+
+- `mb --version`
+- `mb status --json --peek`
+- `mb start --json`
+- `mb doctor repair --plan`
+- `mb doctor repair --plan --json`
+- `mb update --check --json`
+
+## Required JSON Fact Paths
+
+- `money_path`
+- `money_path.objects.proof.quality`
+- `content_strategy`
+- `ranked_actions`
+- `update`
+- `readiness`
+- `drift.items`
+- `runtime.codex_cli`
+- `runtime.claude_code`
+- `surface_refresh`
+- `codex_adapter`
+- `repair.sections`
+- `repair.actions`
+- `repair.actions[].mode`
+- `repair.actions[].safe_to_apply`
+- `repair.actions[].writes`
+- `validation`
+
+## Routing
+
+1. Inspect update and repair state before advice: version, status, start, update check, and repair plan facts.
+2. Stop on runtime mismatch or missing `mb` before business routing.
+3. Explain what is stale, why it matters, affected surface, write set, and safe-to-apply state before exact commands.
+4. Package updates are explicit operator actions. Repair applies, migrations, skill links, gitignore changes, and untracking require approval.
+5. After an approved update or repair, rerun `mb status --json --peek` before routing back into business work.
+
+## Handoff Shape
+
+```text
+Maintenance state: <current, update available, repair needed, blocked, or applied>.
+Facts read: <version/status/start/update/repair facts used>.
+Affected surface: <install, Claude wiring, Codex guidance, migration,
+validation, gitignore, or checkpoint hook>.
+Plan: <read-only command, write command, files touched, and safe-to-apply state>.
+Owner impact: <why this matters in business language>.
+Next safe action: <one command or route>.
+Approval needed before writes: <yes/no and what action>.
+```
+
+Use business language first. Technical commands, runtime wiring, provider refs,
+and file paths are receipts after the owner-facing state unless the operator asks
+for plumbing.

--- a/mb/tests/fixtures/workflows/mb-maintenance-repair.codex.md
+++ b/mb/tests/fixtures/workflows/mb-maintenance-repair.codex.md
@@ -1,0 +1,68 @@
+# Generated Codex Workflow Guidance: Maintenance Update And Repair
+
+Source workflow: `workflows/mb-maintenance-repair/workflow.md`
+Runtime support: `codex_cli: owner_loop_shell`
+Approval gates: `updates_repairs_migrations`, `file_writes`, `checkpoint`, `provider_mutation`, `publishing_or_spend`, `customer_contact`, `private_data`, `destructive_operations`, `package_update`, `repair_apply`
+Public/private boundaries: `no_secrets`, `no_raw_provider_exports`, `no_customer_member_data`, `no_private_runtime_settings`, `no_raw_finance_legal_records`
+
+Codex is first-class for the proven owner loop only. This guidance is generated
+from the engine workflow source for business-repo `AGENTS.md`; the business repo
+does not need to contain `workflows/mb-maintenance-repair/workflow.md`. Treat this rendered
+route as the Codex shell for natural-language daily operating tasks. It does not
+claim Claude Code runtime entrypoints work inside Codex or that all Main Branch
+workflows are available in Codex.
+
+## Required mb Commands
+
+- `mb --version`
+- `mb status --json --peek`
+- `mb start --json`
+- `mb doctor repair --plan`
+- `mb doctor repair --plan --json`
+- `mb update --check --json`
+
+## Required JSON Fact Paths
+
+- `money_path`
+- `money_path.objects.proof.quality`
+- `content_strategy`
+- `ranked_actions`
+- `update`
+- `readiness`
+- `drift.items`
+- `runtime.codex_cli`
+- `runtime.claude_code`
+- `surface_refresh`
+- `codex_adapter`
+- `repair.sections`
+- `repair.actions`
+- `repair.actions[].mode`
+- `repair.actions[].safe_to_apply`
+- `repair.actions[].writes`
+- `validation`
+
+## Codex Route
+
+1. Inspect update and repair state before advice: version, status, start, update check, and repair plan facts.
+2. Stop on runtime mismatch or missing `mb` before business routing.
+3. Explain what is stale, why it matters, affected surface, write set, and safe-to-apply state before exact commands.
+4. Package updates are explicit operator actions. Repair applies, migrations, global skill writes, skill links, gitignore changes, and untracking require approval.
+5. After an approved update or repair, rerun `mb status --json --peek` before routing back into business work.
+
+## Handoff Shape
+
+```text
+Maintenance state: <current, update available, repair needed, blocked, or applied>.
+Facts read: <version/status/start/update/repair facts used>.
+Affected surface: <install, Claude wiring, Codex guidance, migration,
+validation, gitignore, or checkpoint hook>.
+Plan: <read-only command, write command, files touched, and safe-to-apply state>.
+Owner impact: <why this matters in business language>.
+Next safe action: <one command or route>.
+Approval needed before writes: <yes/no and what action>.
+```
+
+Use business language first. Technical commands, runtime wiring, provider refs,
+and file paths are receipts after the owner-facing state unless the operator asks
+for plumbing. Do not tell Codex users to run Claude Code entrypoints. Runtime
+smoke is required before docs say this selected workflow is supported in Codex.

--- a/mb/tests/fixtures/workflows/mb-setup.claude.md
+++ b/mb/tests/fixtures/workflows/mb-setup.claude.md
@@ -1,0 +1,58 @@
+# Generated Claude Shell: Repo Setup
+
+Source workflow: `workflows/mb-setup/workflow.md`
+Runtime support: `claude_code: supported_shell`
+Approval gates: `updates_repairs_migrations`, `file_writes`, `checkpoint`, `provider_mutation`, `publishing_or_spend`, `customer_contact`, `private_data`, `destructive_operations`, `github_repo_create`
+Public/private boundaries: `no_secrets`, `no_raw_provider_exports`, `no_customer_member_data`, `no_private_runtime_settings`, `no_raw_finance_legal_records`
+
+Use from `/mb-setup` when the operator wants to create or connect a business repo. Treat pasted setup prompts as setup intent, confirm the target folder, and ask before running a write command.
+
+This snapshot does not replace shipped `.claude/skills` prose.
+
+## Required mb Commands
+
+- `mb --version`
+- `mb onboard --help`
+- `mb status --json --peek`
+- `mb start --json`
+- `mb doctor repair --plan`
+
+## Required JSON Fact Paths
+
+- `money_path`
+- `money_path.objects.proof.quality`
+- `content_strategy`
+- `ranked_actions`
+- `update`
+- `readiness`
+- `drift.items`
+- `runtime.codex_cli`
+- `runtime.claude_code`
+- `onboarding`
+- `checkpoint`
+- `vocabulary`
+
+## Routing
+
+1. Treat setup prompts as setup intent and onboarding intent, not as documents to save.
+2. Confirm the target folder and inspect setup capability before writes.
+3. If `mb` is missing, stop and give the install command. If GitHub backup is requested, check GitHub CLI auth before any GitHub write.
+4. Ask before running a write command such as onboarding, repo creation, file scaffolding, GitHub remote/push, repair apply, migration apply, or checkpoint save.
+5. After approved setup, rerun status/start facts and report the owner outcome before command receipts.
+
+## Handoff Shape
+
+```text
+Setup state: <not started, target confirmed, created, connected, ready,
+or blocked>.
+Target folder: <business folder or needs confirmation>.
+Facts read: <version/help/status/start/repair facts used>.
+Created or planned: <folders, guidance, GitHub backup, checkpoint, or none>.
+Owner outcome: <business brain ready, needs approval, or blocked reason>.
+Next safe action: <one command or route>.
+Approval needed before writes: <yes/no and what action>.
+```
+
+Use business language first. Technical commands, runtime wiring, provider refs,
+and file paths are receipts after the owner-facing state unless the operator asks
+for plumbing.

--- a/mb/tests/fixtures/workflows/mb-setup.codex.md
+++ b/mb/tests/fixtures/workflows/mb-setup.codex.md
@@ -1,0 +1,62 @@
+# Generated Codex Workflow Guidance: Repo Setup
+
+Source workflow: `workflows/mb-setup/workflow.md`
+Runtime support: `codex_cli: owner_loop_shell`
+Approval gates: `updates_repairs_migrations`, `file_writes`, `checkpoint`, `provider_mutation`, `publishing_or_spend`, `customer_contact`, `private_data`, `destructive_operations`, `github_repo_create`
+Public/private boundaries: `no_secrets`, `no_raw_provider_exports`, `no_customer_member_data`, `no_private_runtime_settings`, `no_raw_finance_legal_records`
+
+Codex is first-class for the proven owner loop only. This guidance is generated
+from the engine workflow source for business-repo `AGENTS.md`; the business repo
+does not need to contain `workflows/mb-setup/workflow.md`. Treat this rendered
+route as the Codex shell for natural-language daily operating tasks. It does not
+claim Claude Code runtime entrypoints work inside Codex or that all Main Branch
+workflows are available in Codex.
+
+## Required mb Commands
+
+- `mb --version`
+- `mb onboard --help`
+- `mb status --json --peek`
+- `mb start --json`
+- `mb doctor repair --plan`
+
+## Required JSON Fact Paths
+
+- `money_path`
+- `money_path.objects.proof.quality`
+- `content_strategy`
+- `ranked_actions`
+- `update`
+- `readiness`
+- `drift.items`
+- `runtime.codex_cli`
+- `runtime.claude_code`
+- `onboarding`
+- `checkpoint`
+- `vocabulary`
+
+## Codex Route
+
+1. Treat setup prompts as setup intent and onboarding intent, not as documents to save.
+2. Confirm the target folder and inspect setup capability before writes.
+3. If `mb` is missing, stop and give the install command. If GitHub backup is requested, check GitHub CLI auth before any GitHub write.
+4. Ask before running a write command such as onboarding, repo creation, file scaffolding, GitHub remote/push, repair apply, migration apply, or checkpoint save.
+5. After approved setup, rerun status/start facts and report the owner outcome before command receipts.
+
+## Handoff Shape
+
+```text
+Setup state: <not started, target confirmed, created, connected, ready,
+or blocked>.
+Target folder: <business folder or needs confirmation>.
+Facts read: <version/help/status/start/repair facts used>.
+Created or planned: <folders, guidance, GitHub backup, checkpoint, or none>.
+Owner outcome: <business brain ready, needs approval, or blocked reason>.
+Next safe action: <one command or route>.
+Approval needed before writes: <yes/no and what action>.
+```
+
+Use business language first. Technical commands, runtime wiring, provider refs,
+and file paths are receipts after the owner-facing state unless the operator asks
+for plumbing. Do not tell Codex users to run Claude Code entrypoints. Runtime
+smoke is required before docs say this selected workflow is supported in Codex.

--- a/mb/tests/fixtures/workflows/mb-start-status.claude.md
+++ b/mb/tests/fixtures/workflows/mb-start-status.claude.md
@@ -1,0 +1,58 @@
+# Generated Claude Shell: Daily Start And Status
+
+Source workflow: `workflows/mb-start-status/workflow.md`
+Runtime support: `claude_code: supported_shell`
+Approval gates: `updates_repairs_migrations`, `file_writes`, `checkpoint`, `provider_mutation`, `publishing_or_spend`, `customer_contact`, `private_data`, `destructive_operations`, `status_marker`
+Public/private boundaries: `no_secrets`, `no_raw_provider_exports`, `no_customer_member_data`, `no_private_runtime_settings`, `no_raw_finance_legal_records`
+
+Use from `/mb-start` or `/mb-status` when the operator starts the day, returns to a repo, asks what changed, or asks what to do next. Preserve fact-first routing, update/repair gates, one clear next route, and business language first.
+
+This snapshot does not replace shipped `.claude/skills` prose.
+
+## Required mb Commands
+
+- `mb status --json --peek`
+- `mb start --json`
+- `mb doctor repair --plan`
+
+## Required JSON Fact Paths
+
+- `money_path`
+- `money_path.objects.proof.quality`
+- `content_strategy`
+- `ranked_actions`
+- `update`
+- `readiness`
+- `drift.items`
+- `runtime.codex_cli`
+- `runtime.claude_code`
+- `since_last_check`
+- `journal`
+- `checkpoint`
+- `onboarding`
+- `integrations`
+- `github`
+- `vocabulary`
+
+## Routing
+
+1. Start from status facts before raw markdown: readiness, drift, runtime wiring, update state, ranked actions, and since-last-check context.
+2. Run hard gates before routing: required updates, runtime mismatch, repair blockers, readiness blockers, private-data boundaries, unsafe provider operations, and destructive-operation requests.
+3. Use `ranked_actions`, `since_last_check`, `journal`, `money_path`, `content_strategy`, `onboarding`, `readiness`, `update`, and `drift.items` as cited facts.
+4. Present one clear business route and the signal behind it. Mutate the status marker only when the operator explicitly approves recording the daily check-in.
+5. Ask before business-file writes, checkpoints, repairs, updates, migrations, provider mutation, publishing, spend, customer contact, destructive operations, or public issue/proposal submission.
+
+## Handoff Shape
+
+```text
+Daily state: <ready, needs attention, blocked, or not a Main Branch repo>.
+Facts read: <status/start/repair facts used>.
+What changed: <since-last-check or journal summary>.
+Main signal: <ranked action, readiness, drift, MoneyPath, content strategy, or onboarding fact>.
+Recommended route: <one business route and why>.
+Approval needed before writes: <yes/no and what action>.
+```
+
+Use business language first. Technical commands, runtime wiring, provider refs,
+and file paths are receipts after the owner-facing state unless the operator asks
+for plumbing.

--- a/mb/tests/fixtures/workflows/mb-start-status.codex.md
+++ b/mb/tests/fixtures/workflows/mb-start-status.codex.md
@@ -1,0 +1,62 @@
+# Generated Codex Workflow Guidance: Daily Start And Status
+
+Source workflow: `workflows/mb-start-status/workflow.md`
+Runtime support: `codex_cli: owner_loop_shell`
+Approval gates: `updates_repairs_migrations`, `file_writes`, `checkpoint`, `provider_mutation`, `publishing_or_spend`, `customer_contact`, `private_data`, `destructive_operations`, `status_marker`
+Public/private boundaries: `no_secrets`, `no_raw_provider_exports`, `no_customer_member_data`, `no_private_runtime_settings`, `no_raw_finance_legal_records`
+
+Codex is first-class for the proven owner loop only. This guidance is generated
+from the engine workflow source for business-repo `AGENTS.md`; the business repo
+does not need to contain `workflows/mb-start-status/workflow.md`. Treat this rendered
+route as the Codex shell for natural-language daily operating tasks. It does not
+claim Claude Code runtime entrypoints work inside Codex or that all Main Branch
+workflows are available in Codex.
+
+## Required mb Commands
+
+- `mb status --json --peek`
+- `mb start --json`
+- `mb doctor repair --plan`
+
+## Required JSON Fact Paths
+
+- `money_path`
+- `money_path.objects.proof.quality`
+- `content_strategy`
+- `ranked_actions`
+- `update`
+- `readiness`
+- `drift.items`
+- `runtime.codex_cli`
+- `runtime.claude_code`
+- `since_last_check`
+- `journal`
+- `checkpoint`
+- `onboarding`
+- `integrations`
+- `github`
+- `vocabulary`
+
+## Codex Route
+
+1. Use the business repo `AGENTS.md` bootstrap posture: read facts first, keep writes approval-gated, and translate git/provider details into business language.
+2. Run hard gates before routing: required updates, runtime mismatch, repair blockers, readiness blockers, private-data boundaries, unsafe provider operations, and destructive-operation requests.
+3. Use `ranked_actions`, `since_last_check`, `journal`, `money_path`, `content_strategy`, `onboarding`, `readiness`, `update`, and `drift.items` as cited facts.
+4. Present one clear business route and the signal behind it. Mutate the status marker only when the operator explicitly approves recording the daily check-in.
+5. Ask before business-file writes, checkpoints, repairs, updates, migrations, provider mutation, publishing, spend, customer contact, destructive operations, or public issue/proposal submission.
+
+## Handoff Shape
+
+```text
+Daily state: <ready, needs attention, blocked, or not a Main Branch repo>.
+Facts read: <status/start/repair facts used>.
+What changed: <since-last-check or journal summary>.
+Main signal: <ranked action, readiness, drift, MoneyPath, content strategy, or onboarding fact>.
+Recommended route: <one business route and why>.
+Approval needed before writes: <yes/no and what action>.
+```
+
+Use business language first. Technical commands, runtime wiring, provider refs,
+and file paths are receipts after the owner-facing state unless the operator asks
+for plumbing. Do not tell Codex users to run Claude Code entrypoints. Runtime
+smoke is required before docs say this selected workflow is supported in Codex.

--- a/mb/tests/test_onboard.py
+++ b/mb/tests/test_onboard.py
@@ -6,7 +6,6 @@ import json
 import os
 import shutil
 import subprocess
-import sys
 from pathlib import Path
 
 import pytest
@@ -744,7 +743,7 @@ def test_onboard_cli_github_push_fixture_leaves_generated_mb_state_clean(
     fake_gh = fake_bin / "gh"
     remote = tmp_path / "remote.git"
     fake_gh.write_text(
-        f"""#!{sys.executable}
+        """#!/usr/bin/env python3
 import json
 import os
 import subprocess

--- a/mb/tests/test_workflows.py
+++ b/mb/tests/test_workflows.py
@@ -22,6 +22,9 @@ from mb.workflows import (
 runner = CliRunner()
 REPO_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW = REPO_ROOT / "workflows" / "mb-start-money-path" / "workflow.md"
+START_STATUS_WORKFLOW = REPO_ROOT / "workflows" / "mb-start-status" / "workflow.md"
+SETUP_WORKFLOW = REPO_ROOT / "workflows" / "mb-setup" / "workflow.md"
+MAINTENANCE_REPAIR_WORKFLOW = REPO_ROOT / "workflows" / "mb-maintenance-repair" / "workflow.md"
 THINK_WORKFLOW = REPO_ROOT / "workflows" / "mb-think" / "workflow.md"
 END_WORKFLOW = REPO_ROOT / "workflows" / "mb-end" / "workflow.md"
 SHIPPED_END_SKILL = REPO_ROOT / ".claude" / "skills" / "mb-end" / "SKILL.md"
@@ -29,6 +32,9 @@ FIXTURES = REPO_ROOT / "mb" / "tests" / "fixtures" / "workflows"
 AGENTS_TEMPLATE = REPO_ROOT / "mb" / "mb" / "_data" / "templates" / "AGENTS.md.tmpl"
 WORKFLOW_PATHS = [
     WORKFLOW,
+    START_STATUS_WORKFLOW,
+    SETUP_WORKFLOW,
+    MAINTENANCE_REPAIR_WORKFLOW,
     THINK_WORKFLOW,
     END_WORKFLOW,
 ]
@@ -90,6 +96,19 @@ def test_generated_start_money_path_claude_and_codex_snapshots_match_fixtures() 
     assert render_codex_shell(workflow) == (FIXTURES / "mb-start-money-path.codex.md").read_text(
         encoding="utf-8"
     )
+
+
+def test_generated_daily_claude_and_codex_snapshots_match_fixtures() -> None:
+    for path in (START_STATUS_WORKFLOW, SETUP_WORKFLOW, MAINTENANCE_REPAIR_WORKFLOW):
+        workflow = load_workflow(path)
+        fixture_stem = path.parent.name
+
+        assert render_claude_shell(workflow) == (FIXTURES / f"{fixture_stem}.claude.md").read_text(
+            encoding="utf-8"
+        )
+        assert render_codex_shell(workflow) == (FIXTURES / f"{fixture_stem}.codex.md").read_text(
+            encoding="utf-8"
+        )
 
 
 def test_generated_think_claude_and_codex_snapshots_match_fixtures() -> None:
@@ -313,8 +332,24 @@ def test_codex_workflow_inventory_command_lists_supported_and_pending_surfaces()
         "main-branch mb-start",
         "main-branch mb-status",
     ]
-    assert by_id["daily-start-status"]["source_status"] == "temporary_source_skill_mirror"
-    assert by_id["daily-start-status"]["source_of_truth"]["shared_source"] is None
+    assert by_id["daily-start-status"]["source_status"] == "shared_workflow_source"
+    assert (
+        by_id["daily-start-status"]["source_of_truth"]["shared_source"]
+        == "workflows/mb-start-status/workflow.md"
+    )
+    assert by_id["daily-setup"]["source_status"] == "shared_workflow_source"
+    assert (
+        by_id["daily-setup"]["source_of_truth"]["shared_source"] == "workflows/mb-setup/workflow.md"
+    )
+    assert by_id["daily-maintenance-repair"]["source_status"] == "shared_workflow_source"
+    assert (
+        by_id["daily-maintenance-repair"]["source_of_truth"]["shared_source"]
+        == "workflows/mb-maintenance-repair/workflow.md"
+    )
+    assert by_id["daily-maintenance-repair"]["codex_entrypoints"] == [
+        "main-branch mb-update",
+        "main-branch mb-doctor",
+    ]
     assert by_id["end-checkpoint-save"]["source_status"] == "shared_workflow_source"
     assert (
         by_id["end-checkpoint-save"]["source_of_truth"]["shared_source"]
@@ -326,6 +361,12 @@ def test_codex_workflow_inventory_command_lists_supported_and_pending_surfaces()
     assert by_id["daily-start-status"]["claude_skill_sources"] == [
         ".claude/skills/mb-start/SKILL.md",
         ".claude/skills/mb-status/SKILL.md",
+    ]
+    assert by_id["daily-setup"]["claude_skill_sources"] == [
+        ".claude/skills/mb-setup/SKILL.md",
+    ]
+    assert by_id["daily-maintenance-repair"]["claude_skill_sources"] == [
+        ".claude/skills/mb-update/SKILL.md",
     ]
     assert by_id["ads"]["codex_status"] == "read_only_planning"
     assert by_id["ads"]["source_status"] == "pending_shared_source_migration"
@@ -413,12 +454,20 @@ def test_codex_global_skills_hide_legacy_plugin_and_fake_slash_claims() -> None:
 
 
 def test_codex_shared_global_skills_are_rendered_from_workflow_sources() -> None:
-    for path, name in ((THINK_WORKFLOW, "mb-think"), (END_WORKFLOW, "mb-end")):
+    for path, name in (
+        (START_STATUS_WORKFLOW, "mb-start"),
+        (START_STATUS_WORKFLOW, "mb-status"),
+        (SETUP_WORKFLOW, "mb-setup"),
+        (MAINTENANCE_REPAIR_WORKFLOW, "mb-update"),
+        (MAINTENANCE_REPAIR_WORKFLOW, "mb-doctor"),
+        (THINK_WORKFLOW, "mb-think"),
+        (END_WORKFLOW, "mb-end"),
+    ):
         workflow = load_workflow(path)
         text = codex_mod.render_codex_global_skill_md(name)
 
         assert "Follow the generated Codex shell below" in text
-        assert f"Source workflow: `workflows/{name}/workflow.md`" in text
+        assert f"Source workflow: `{path.relative_to(REPO_ROOT).as_posix()}`" in text
         assert render_codex_shell(workflow).strip() in text
         assert shell_drift_errors(workflow, text) == []
         assert codex_shell_policy_errors(workflow, text) == []

--- a/workflows/mb-maintenance-repair/workflow.md
+++ b/workflows/mb-maintenance-repair/workflow.md
@@ -1,0 +1,217 @@
+---
+name: mb-maintenance-repair
+title: Maintenance Update And Repair
+description: Inspect update, doctor, runtime wiring, and repair plans from deterministic facts, then apply only after explicit operator approval.
+loops: [sense, decide, ship]
+runtime_support:
+  claude_code: supported_shell
+  codex_cli: owner_loop_shell
+  future: planned
+runtime_surfaces:
+  claude_code: .claude/skills/mb-update/SKILL.md and /mb-start repair routing
+  codex_cli: global main-branch mb-update and mb-doctor skills
+required_mb_commands:
+  - mb --version
+  - mb status --json --peek
+  - mb start --json
+  - mb doctor repair --plan
+  - mb doctor repair --plan --json
+  - mb update --check --json
+json_facts:
+  - money_path
+  - money_path.objects.proof.quality
+  - content_strategy
+  - ranked_actions
+  - update
+  - readiness
+  - drift.items
+  - runtime.codex_cli
+  - runtime.claude_code
+  - surface_refresh
+  - codex_adapter
+  - repair.sections
+  - repair.actions
+  - repair.actions[].mode
+  - repair.actions[].safe_to_apply
+  - repair.actions[].writes
+  - validation
+approval_gates:
+  - updates_repairs_migrations
+  - file_writes
+  - checkpoint
+  - provider_mutation
+  - publishing_or_spend
+  - customer_contact
+  - private_data
+  - destructive_operations
+  - package_update
+  - repair_apply
+public_private_boundaries:
+  - no_secrets
+  - no_raw_provider_exports
+  - no_customer_member_data
+  - no_private_runtime_settings
+  - no_raw_finance_legal_records
+writes_business_files: false
+provider_mutation: false
+publishing_or_spend: false
+---
+
+# Maintenance Update And Repair
+
+This workflow source is the portable contract for Main Branch maintenance:
+inspect update and repair facts, explain the plan in business language, then
+apply only after explicit operator approval.
+
+## Intent And Triggers
+
+Use this workflow when the operator asks to update Main Branch, fix setup,
+repair Claude Code or Codex wiring, inspect doctor output, resolve stale repo
+guidance, handle migration drift, or understand why start/status is blocked.
+
+Do not use this workflow for first-run business setup, broad strategy,
+provider account mutation, publishing, spend, customer contact, or automatic
+repair applies.
+
+## Required Mb Commands
+
+Run or preserve these deterministic facts before recommending maintenance work:
+
+- `mb --version`
+- `mb status --json --peek`
+- `mb start --json`
+- `mb doctor repair --plan`
+- `mb doctor repair --plan --json`
+- `mb update --check --json`
+
+`mb update --check --json` supplies update availability and planned surface
+refresh. `mb doctor repair --plan --json` supplies sections, actions, write
+sets, and safety flags. These commands provide facts and plans; they do not
+authorize writes.
+
+## Required JSON Fact Paths
+
+The runtime shell must preserve these paths from the workflow source:
+
+- `money_path`
+- `money_path.objects.proof.quality`
+- `content_strategy`
+- `ranked_actions`
+- `update`
+- `readiness`
+- `drift.items`
+- `runtime.codex_cli`
+- `runtime.claude_code`
+- `surface_refresh`
+- `codex_adapter`
+- `repair.sections`
+- `repair.actions`
+- `repair.actions[].mode`
+- `repair.actions[].safe_to_apply`
+- `repair.actions[].writes`
+- `validation`
+
+Treat these as facts, not permission. The runtime may explain what is stale,
+blocked, repairable, skipped, or safe-to-apply, but it must not claim an update,
+repair, migration, or validation fix happened unless facts prove it.
+
+## Routing Rules
+
+Hard gates win before maintenance advice: missing `mb`, runtime mismatch,
+package update requirement, broken repo wiring, private-data boundaries,
+destructive-operation requests, provider mutation, publishing, spend, and
+customer contact.
+
+Explain repair/update state in business language first: what is stale, why it
+matters, what will be touched, and what the operator must approve. Quote exact
+commands second. Package updates are explicit operator actions outside doctor
+repair. `mb doctor repair --apply --only claude`, `--only codex`, or reviewed
+all-agent repair should match the affected surface. Migration applies require
+review of the migration preview and explicit approval.
+
+After an approved update or repair, rerun `mb status --json --peek` before
+routing back into business work.
+
+## Read Boundaries
+
+Read deterministic `mb` facts, update checks, repair plans, validation
+summaries, and runtime wiring facts. Read generated guidance only when the plan
+or validation says it is stale or missing.
+
+Do not inspect secrets, raw provider exports, raw finance/legal records,
+customer/member records, local runtime settings beyond generated readiness
+facts, private maintainer notes, or credentials.
+
+## Write Boundaries
+
+The workflow may apply writes only after the operator approves the specific
+command and scope. Possible write targets include generated repo guidance,
+Claude Code project skill links, global Codex skills, `.gitignore`, `.mb/`
+operational state, checkpoint hook files, migration outputs, and package
+install state.
+
+The workflow source does not authorize provider writes, publishing, spending,
+customer contact, raw secret storage, unsupported runtime adapters, or
+unreviewed destructive cleanup.
+
+## Approval Gates
+
+Ask before:
+
+- running package updates or package-changing commands;
+- applying doctor repair, skill repair, skill link, Codex global skill writes,
+  migrations, or setup cleanup;
+- creating, editing, moving, deleting, archiving, or untracking files;
+- saving a checkpoint after maintenance;
+- mutating provider state, publishing, spending money, or contacting customers;
+- reading or moving private, restricted, local-only, finance, legal, customer,
+  member, credential, or raw provider data.
+
+Never ask the operator to paste secrets into repo files or workflow sources.
+
+## Handoff Format
+
+When handing off a maintenance plan, include a compact repair receipt:
+
+```text
+Maintenance state: <current, update available, repair needed, blocked, or applied>.
+Facts read: <version/status/start/update/repair facts used>.
+Affected surface: <install, Claude wiring, Codex guidance, migration, validation, gitignore, or checkpoint hook>.
+Plan: <read-only command, write command, files touched, and safe-to-apply state>.
+Owner impact: <why this matters in business language>.
+Next safe action: <one command or route>.
+Approval needed before writes: <yes/no and what action>.
+```
+
+Use business language first. Exact commands and file paths are receipts after
+the owner impact unless the operator asks for plumbing.
+
+## Validation Commands
+
+Before changing this workflow or its runtime shells, run:
+
+```bash
+cd mb
+python -m pytest tests/test_workflows.py tests/test_update.py tests/test_doctor.py -q
+```
+
+For repo-level validation, run:
+
+```bash
+scripts/check.sh
+```
+
+If package update behavior, generated repo guidance, global Codex skills, or
+runtime discovery changes, add package/install and runtime/manual smoke
+evidence.
+
+## Runtime-Specific Notes
+
+Claude Code may use slash-command-native language for `/mb-update` and repair
+routing from `/mb-start`. Preserve exact repair commands, restart guidance, and
+the rule that failed updates stop the session until repaired.
+
+Codex uses generated global `mb-update` and `mb-doctor` skills. It should run
+read-only facts first, quote exact commands from the plan, ask before any
+write/apply command, stop on runtime mismatch, and avoid claiming Claude Code
+entrypoints or broader runtime parity.

--- a/workflows/mb-setup/workflow.md
+++ b/workflows/mb-setup/workflow.md
@@ -1,0 +1,202 @@
+---
+name: mb-setup
+title: Repo Setup
+description: Turn setup intent into a Main Branch business repo through explicit target selection, bounded context gathering, approval-gated writes, and post-setup facts.
+loops: [sense, decide, ship]
+runtime_support:
+  claude_code: supported_shell
+  codex_cli: owner_loop_shell
+  future: planned
+runtime_surfaces:
+  claude_code: .claude/skills/mb-setup/SKILL.md
+  codex_cli: global main-branch mb-setup skill
+required_mb_commands:
+  - mb --version
+  - mb onboard --help
+  - mb status --json --peek
+  - mb start --json
+  - mb doctor repair --plan
+json_facts:
+  - money_path
+  - money_path.objects.proof.quality
+  - content_strategy
+  - ranked_actions
+  - update
+  - readiness
+  - drift.items
+  - runtime.codex_cli
+  - runtime.claude_code
+  - onboarding
+  - checkpoint
+  - vocabulary
+approval_gates:
+  - updates_repairs_migrations
+  - file_writes
+  - checkpoint
+  - provider_mutation
+  - publishing_or_spend
+  - customer_contact
+  - private_data
+  - destructive_operations
+  - github_repo_create
+public_private_boundaries:
+  - no_secrets
+  - no_raw_provider_exports
+  - no_customer_member_data
+  - no_private_runtime_settings
+  - no_raw_finance_legal_records
+writes_business_files: true
+provider_mutation: false
+publishing_or_spend: false
+---
+
+# Repo Setup
+
+This workflow source is the portable contract for first-run setup and
+onboarding: identify the business folder, explain what will be created, ask
+before writes, then verify the resulting business brain from `mb` facts.
+
+## Intent And Triggers
+
+Use this workflow when the operator asks to set up Main Branch, create a
+business brain, connect an existing folder, paste a setup guide, describe a new
+business repo, or ask how to get Claude Code or Codex ready for a business.
+
+Do not treat pasted setup prompts as documents to save. Treat them as setup
+intent. Do not use this workflow for package updates, repair applies outside
+setup, provider mutation, publishing, spend, customer contact, or broad
+business strategy.
+
+## Required Mb Commands
+
+Run or preserve these deterministic facts before setup advice or writes:
+
+- `mb --version`
+- `mb onboard --help`
+- `mb status --json --peek`
+- `mb start --json`
+- `mb doctor repair --plan`
+
+If `mb` is missing, stop and give the install command. Use `mb onboard --help`
+to inspect setup capability before proposing a write command. Use status/start
+facts after setup, or before repair when the target repo already exists.
+
+## Required JSON Fact Paths
+
+The runtime shell must preserve these paths from the workflow source:
+
+- `money_path`
+- `money_path.objects.proof.quality`
+- `content_strategy`
+- `ranked_actions`
+- `update`
+- `readiness`
+- `drift.items`
+- `runtime.codex_cli`
+- `runtime.claude_code`
+- `onboarding`
+- `checkpoint`
+- `vocabulary`
+
+Treat these as setup and readiness facts, not strategy. The runtime may explain
+what is ready, incomplete, or blocked, but it must not invent business truth or
+store private local details in tracked files.
+
+## Routing Rules
+
+Hard gates win before setup writes: missing `mb`, unknown target folder,
+runtime mismatch, private-data boundaries, destructive-operation requests,
+provider mutation, publishing, spend, and customer contact.
+
+When the target folder is empty or uninitialized, explain which folder will
+become the business brain and ask before running a write command. When the
+target folder is an existing Main Branch repo, use `onboarding`, `readiness`,
+`drift.items`, and `mb doctor repair --plan` to resume setup or repair instead
+of starting over. If the operator requests GitHub backup or push setup, check
+GitHub CLI authentication and account identity before any GitHub write.
+
+After approved setup, run `mb status --json --peek` and `mb start --json`.
+Summarize the owner outcome first: folder created or connected, business brain
+ready, baseline checkpoint state, GitHub backup state when requested, and next
+safe action. Put command output and git/GitHub details second.
+
+## Read Boundaries
+
+Read setup intent, target-folder facts, `mb` help output, and deterministic
+status/start facts. For existing repos, read only the core files needed to avoid
+asking duplicate setup questions.
+
+Do not ask for full finances, credentials, raw customer/member exports, private
+provider payloads, private local paths for public docs, or secrets. Do not
+inspect private files outside the target business folder unless the operator
+explicitly asks and the content belongs in setup.
+
+## Write Boundaries
+
+The workflow may write business repo files only after the operator approves the
+specific setup action. Valid setup writes include scaffolded Main Branch
+folders, generated repo guidance, `.gitignore`, optional GitHub backup setup,
+and an approved baseline checkpoint.
+
+The workflow source does not authorize provider account mutation, publishing,
+spend, customer contact, raw secret storage, unsupported runtime adapters, or
+Main Branch engine repo edits.
+
+## Approval Gates
+
+Ask before:
+
+- running `mb onboard`, `mb init`, or any command that writes setup files;
+- creating a GitHub repo, adding a remote, pushing, or changing visibility;
+- creating, editing, moving, deleting, or archiving business files;
+- saving a baseline checkpoint;
+- applying repairs or migrations in an existing repo;
+- reading private source material or moving it into the business repo;
+- publishing, spending money, mutating provider state, or contacting customers.
+
+Never ask the operator to paste secrets into repo files or workflow sources.
+
+## Handoff Format
+
+When setup completes or pauses, include a compact setup receipt:
+
+```text
+Setup state: <not started, target confirmed, created, connected, ready, or blocked>.
+Target folder: <business folder or needs confirmation>.
+Facts read: <version/help/status/start/repair facts used>.
+Created or planned: <folders, guidance, GitHub backup, checkpoint, or none>.
+Owner outcome: <business brain ready, needs approval, or blocked reason>.
+Next safe action: <one command or route>.
+Approval needed before writes: <yes/no and what action>.
+```
+
+Use business language first. Terminal commands, remotes, branches, and runtime
+wiring are receipts after the owner outcome.
+
+## Validation Commands
+
+Before changing this workflow or its runtime shells, run:
+
+```bash
+cd mb
+python -m pytest tests/test_workflows.py tests/test_init.py -q
+```
+
+For repo-level validation, run:
+
+```bash
+scripts/check.sh
+```
+
+If onboarding templates, packaged data, or global Codex skills change, add
+package/install and fixture repo smoke evidence.
+
+## Runtime-Specific Notes
+
+Claude Code may use slash-command-native language for `/mb-setup` and may link
+to setup references. Preserve CWD detection, write-boundary warnings,
+bounded-context gathering, and checkpoint approval.
+
+Codex uses the generated global `mb-setup` skill. It should explain setup in
+business language, run read-only facts first, ask before write commands, and
+avoid claiming Claude Code entrypoints or broader runtime parity.

--- a/workflows/mb-start-status/workflow.md
+++ b/workflows/mb-start-status/workflow.md
@@ -1,0 +1,214 @@
+---
+name: mb-start-status
+title: Daily Start And Status
+description: Ground daily start, status, what changed, and next-route prompts in deterministic Main Branch facts before business routing.
+loops: [sense, decide, ship]
+runtime_support:
+  claude_code: supported_shell
+  codex_cli: owner_loop_shell
+  future: planned
+runtime_surfaces:
+  claude_code: .claude/skills/mb-start/SKILL.md and .claude/skills/mb-status/SKILL.md
+  codex_cli: global main-branch mb-start and mb-status skills
+required_mb_commands:
+  - mb status --json --peek
+  - mb start --json
+  - mb doctor repair --plan
+json_facts:
+  - money_path
+  - money_path.objects.proof.quality
+  - content_strategy
+  - ranked_actions
+  - update
+  - readiness
+  - drift.items
+  - runtime.codex_cli
+  - runtime.claude_code
+  - since_last_check
+  - journal
+  - checkpoint
+  - onboarding
+  - integrations
+  - github
+  - vocabulary
+approval_gates:
+  - updates_repairs_migrations
+  - file_writes
+  - checkpoint
+  - provider_mutation
+  - publishing_or_spend
+  - customer_contact
+  - private_data
+  - destructive_operations
+  - status_marker
+public_private_boundaries:
+  - no_secrets
+  - no_raw_provider_exports
+  - no_customer_member_data
+  - no_private_runtime_settings
+  - no_raw_finance_legal_records
+writes_business_files: false
+provider_mutation: false
+publishing_or_spend: false
+---
+
+# Daily Start And Status
+
+This workflow source is the portable contract for the normal daily Main Branch
+entry point: start from facts, explain what changed, surface readiness and
+drift, then route one clear next business move.
+
+## Intent And Triggers
+
+Use this workflow when the operator starts the day, returns to a business repo,
+asks what to do next, asks what changed, asks for status, asks whether anything
+is stale, or asks whether the repo is ready for work.
+
+Do not use this workflow for a full research run, setup write, repair apply,
+package update, checkpoint save, provider mutation, publishing, spend, customer
+contact, or direct model execution from `mb`.
+
+## Required Mb Commands
+
+Run or preserve these deterministic facts before interpreting business files:
+
+- `mb status --json --peek`
+- `mb start --json`
+- `mb doctor repair --plan`
+
+`mb status --json --peek` is the default first read. Use `mb start --json` when
+runtime handoff, repo-boundary, or adapter-readiness facts matter. Use
+`mb doctor repair --plan` when status reports drift, stale guidance, broken
+wiring, or setup/repair blockers.
+
+## Required JSON Fact Paths
+
+The runtime shell must preserve these paths from the workflow source:
+
+- `money_path`
+- `money_path.objects.proof.quality`
+- `content_strategy`
+- `ranked_actions`
+- `update`
+- `readiness`
+- `drift.items`
+- `runtime.codex_cli`
+- `runtime.claude_code`
+- `since_last_check`
+- `journal`
+- `checkpoint`
+- `onboarding`
+- `integrations`
+- `github`
+- `vocabulary`
+
+Treat these as facts, not strategy. The runtime may recommend the next route,
+but it must not claim conversion quality, provider readiness, checkpoint state,
+or runtime support beyond the facts.
+
+## Routing Rules
+
+Hard gates win before business routing: required updates, runtime mismatch,
+broken repo wiring, repair blockers, validation blockers, private-data
+boundaries, unsafe provider operations, destructive-operation requests, and
+approval-gated status marker writes.
+
+After hard gates, lead with the top `ranked_actions` entry when the operator
+asks what to do next. Use `since_last_check` and `journal` when the operator
+asks what changed. Use `money_path` for customer progress, offer, proof, CTA,
+channel, push, page readiness, playbook, and outcome feedback questions. Use
+`content_strategy` for content strategy, channel, account, freshness, or
+disconnected-layer questions. Use `onboarding` to resume setup without
+inventing a new interview.
+
+Give one clear route: frame a bet, think through a decision, advance a push,
+draft a playbook, repair the repo, review provider readiness, inspect a
+specific offer, or plan a checkpoint. In status mode, do not mutate the
+last-check marker unless the operator explicitly says this is the daily
+check-in and wants it recorded.
+
+## Read Boundaries
+
+Read deterministic `mb` facts before raw markdown. After the fact pass, read
+only the business files needed for the route:
+
+- active offer, audience, proof, product ladder, CTA, and content strategy;
+- relevant decisions, research, bets, pushes, logs, and documents;
+- safe provider-readiness summaries when status says a provider affects the
+  route.
+
+Do not inspect secrets, raw provider exports, raw finance/legal records,
+customer/member records, local runtime settings, private maintainer notes, or
+credentials.
+
+## Write Boundaries
+
+This workflow does not write business files by itself. It may hand off to a
+workflow that writes business files after operator approval. The status marker
+is local operational state and may be updated only when the operator explicitly
+approves recording the daily check-in.
+
+The workflow source does not authorize setup writes, repair applies, package
+updates, migrations, checkpoints, provider writes, public issue/proposal
+submission, publishing, spend, customer contact, or Main Branch engine edits.
+
+## Approval Gates
+
+Ask before:
+
+- applying updates, repairs, migrations, setup writes, or provider setup;
+- creating, editing, moving, deleting, or archiving business files;
+- saving a checkpoint;
+- mutating the status marker;
+- publishing, opening a public issue, submitting a proposal, spending money,
+  mutating provider state, or contacting customers;
+- reading or moving private, restricted, local-only, finance, legal, customer,
+  member, credential, or raw provider data.
+
+Never ask the operator to paste secrets into repo files or workflow sources.
+
+## Handoff Format
+
+When handing off from start or status, include a compact snapshot:
+
+```text
+Daily state: <ready, needs attention, blocked, or not a Main Branch repo>.
+Facts read: <status/start/repair facts used>.
+What changed: <since-last-check or journal summary>.
+Main signal: <ranked action, readiness, drift, MoneyPath, content strategy, or onboarding fact>.
+Recommended route: <one business route and why>.
+Approval needed before writes: <yes/no and what action>.
+```
+
+Use business language first. Git, branches, runtime wiring, provider refs, and
+repair commands are details after the owner-facing state unless the operator
+asks for plumbing.
+
+## Validation Commands
+
+Before changing this workflow or its runtime shells, run:
+
+```bash
+cd mb
+python -m pytest tests/test_workflows.py -q
+```
+
+For repo-level validation, run:
+
+```bash
+scripts/check.sh
+```
+
+If generated global Codex skills, repo guidance, or runtime discovery changes,
+add package/install and runtime/manual smoke evidence.
+
+## Runtime-Specific Notes
+
+Claude Code may use slash-command-native language for `/mb-start` and
+`/mb-status`. Preserve the fact-first status preamble, update and repair gates,
+session-scoped offer selection, numbered options, and compaction recovery.
+
+Codex uses global Main Branch skills and natural-language routes. Codex should
+use the generated global `mb-start` and `mb-status` skills, start from read-only
+`mb` facts, stop on runtime mismatch, and avoid claiming Claude Code entrypoints
+or broader workflow parity.


### PR DESCRIPTION
## Summary

Migrates daily start/status, setup, update, and repair Codex routes onto canonical shared workflow sources. The generated Claude and Codex shells, global Codex skill adapters, and workflow inventory now name and test those sources.

## Linked issue

Closes #742
Refs #738
Refs #740

## Why

These supported Codex routes were still partly hand-maintained across adapter prose and inventory rows, which made drift likely as MAIN-449 expanded the shared workflow generator. Moving the route contract into shared sources makes required facts, approval gates, owner-language rules, and runtime-specific boundaries visible and testable.

## Commits by concern

- [x] Each commit body bullet-lists the changes in that commit
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`

Commit list:
- `4f2134a [update] Move daily Codex routes to shared workflows`

## Validation

Pre-push gate from repo root:

```bash
scripts/check.sh
```

Evidence:
- Level 1 static: `uv run --project mb --extra dev scripts/check.sh` — runtime: repo-local uv Python 3.13.7 environment — exit: 0 — log: `92 files already formatted`; `All checks passed!`; `Success: no issues found in 91 source files`; `817 passed`.
- Level 2 CLI contract: `uv run --project mb pytest mb/tests/test_workflows.py mb/tests/test_start.py mb/tests/test_status.py mb/tests/test_update.py mb/tests/test_doctor.py -q` — runtime: repo-local uv Python 3.13.7 environment — exit: 0 — log: `236 passed`.
- Level 2 fixture harness portability: `uv run --project mb --extra dev pytest mb/tests/test_workflows.py mb/tests/test_onboard.py::test_onboard_cli_github_push_fixture_leaves_generated_mb_state_clean -q` — runtime: repo-local uv Python 3.13.7 environment — exit: 0 — log: `34 passed`.
- Level 3 package/install smoke: `cd mb && uv run --with build python -m build` — runtime: uv build isolation — exit: 0 — log: `Successfully built mainbranch-0.3.38.tar.gz and mainbranch-0.3.38-py3-none-any.whl`.
- Level 3 installed wheel smoke: `mb --version`, `mb skill list`, installed-package `render_codex_global_skill_md` for mb-start, mb-status, mb-setup, mb-update, mb-doctor, mb-think, and mb-end — runtime: temporary Python 3.13 venv — exit: 0 — log: `mb 0.3.38`; global skill render loop printed `ok` for all checked routes.
- Level 5 Codex runtime smoke: `codex exec --ephemeral --sandbox workspace-write -C <fresh-business-repo> <read-only mb-start/status prompt>` — runtime: Codex CLI 0.133.0 with repo-local Main Branch 0.3.38 on PATH — exit: 0 — log: sanitized excerpt `loaded mb-status global skill with Source workflow: workflows/mb-start-status/workflow.md; ran command -v mb, mb --version, mb status --json --peek, mb start --json, mb doctor repair --plan; fixture git status clean before and after; reported runtime_mismatch and wrote no files`.

- [x] Level 1 static: `scripts/check.sh` passes
- [x] Level 2 CLI contract: focused Typer/CliRunner tests, exit codes, `--json` behavior, TTY vs non-TTY (if CLI behavior touched)
- [x] Level 3 package/install smoke (if packaging touched)
- [ ] Level 4 fixture repo (if init/onboard/status/start/update touched) — not required; this PR changes shared workflow sources and Codex rendering, not business repo scaffold behavior.
- [x] Level 5 runtime smoke / dogfood harness / simulation-tier (if runtime, first-run, skill discovery, or release validation touched) — Codex exec smoke verified global skill discovery, shared-source shell text, read-only fact commands, clean repo before/after, and correct hard-stop behavior on a local runtime path mismatch.
- [ ] SKILL.md ≤500 lines (if any skill touched) — not required; no bundled `SKILL.md` files changed.
- [ ] Package-visible release gate evidence before tag/publish (if preparing a release) — not required; this is not a release PR.
- [ ] Supply-chain review (if `.github/workflows/`, `.github/dependabot.yml`, `mb/pyproject.toml` deps, or `id-token`/`permissions` blocks touched — see [docs/supply-chain-policy.md](../docs/supply-chain-policy.md)) — not required; no supply-chain surfaces changed.

## Success metric

Start/status/setup/update/repair are no longer supported but hand-maintained twice: `mb workflow list --json` names shared workflow sources for the migrated routes, and tests fail if generated Claude or Codex shells drift from those sources.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [ ] N/A — change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [x] No
- [ ] Yes — migration note below

## Public / private boundary

No private operator strategy, machine-specific paths, secrets, raw provider data, or local runtime internals were committed. Public docs and changelog entries describe the shared workflow source migration generically.
