### PR TITLE
[update] Prepare 0.3.39 release

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mainbranch",
-  "version": "0.3.38",
+  "version": "0.3.39",
   "description": "Main Branch Claude Code skills for running a business from markdown files in git.",
   "author": {
     "name": "Noontide"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+## [0.3.39] - 2026-05-26
+
 ### Changed
 
 - Changed `mb workflow list --json` to classify business workflow and playbook

--- a/mb/mb/__init__.py
+++ b/mb/mb/__init__.py
@@ -7,6 +7,6 @@ file stays a thin dispatcher.
 
 from __future__ import annotations
 
-__version__ = "0.3.38"
+__version__ = "0.3.39"
 
 __all__ = ["__version__"]

--- a/mb/pyproject.toml
+++ b/mb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mainbranch"
-version = "0.3.38"
+version = "0.3.39"
 description = "Main Branch engine umbrella - scaffolds, validates, and graphs business-as-files repos. Claude Code first, runtime-agnostic by design."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Prepare `mainbranch` / `mb` 0.3.39.

This release ships the shared daily skill workflow batch: shared workflow sources for the daily loop, generated Codex global skills from those sources, owner-facing closeout language, and honest business/playbook inventory status.

## In Scope

- Version bump to 0.3.39 across package, plugin manifest, and changelog.
- Release notes for shared daily workflow sources, Codex generated global skills, and business/playbook classification.
- Validation against the built 0.3.39 wheel and fresh fixture repos.

## Out Of Scope

- File Contracts + Guided Routes; this is the next architecture batch.
- Full business workflow migration for ads, organic, site, and playbooks.
- Codex plugin slash-command support. Codex remains global skills plus deterministic `mb` facts.

## Issues

Closes #744.
Refs #738, #739, #740, #742, #743.
Refs #735, #741.

## Validation

- Level 0 release-file preflight: `cd mb && python3 -m pytest tests/test_smoke_coverage.py::test_claude_plugin_manifest_points_at_prefixed_skills -q` — exit 0 — log: `.agent/release-evidence/0.3.39/release-file-preflight.out`.
- Level 1 static: `scripts/check.sh` — exit 0 — log: `.agent/release-evidence/0.3.39/check.out`.
- Level 2 focused CLI: `pytest tests/test_workflows.py tests/test_status.py tests/test_start.py tests/test_doctor.py tests/test_update.py tests/test_checkpoint*.py -q` — exit 0, 281 passed — log: `.agent/release-evidence/0.3.39/focused-cli.out`.
- Level 3 package/install: built `mainbranch-0.3.39-py3-none-any.whl`, installed into `/tmp/mainbranch-smoke-039`, ran `mb --version`, `mb skill list`, `mb skill validate --all --json`, `mb workflow list --json`, `mb workflow list --runtime codex --json`, and `mb books check --fixture --json` — exit 0 — logs: `.agent/release-evidence/0.3.39/build.out`, `install-smoke.out`.
- Level 4 fixture repo: fresh `mb onboard`, `mb doctor`, `mb doctor repair --plan`, `mb status --json --peek`, `mb start --json`, `mb workflow list --runtime codex --json`, `mb checkpoint --plan --json`, `mb validate --json` — exit 0 — log: `.agent/release-evidence/0.3.39/fixture-smoke.out`.
- Level 5 Claude proxy runtime: `scripts/claude-runtime-dogfood.py --install-mode wheel --wheel mb/dist/mainbranch-0.3.39-py3-none-any.whl --run-claude-print --simulation-tier prerelease_candidate --max-budget-usd 0.75` — exit 0, 11/11 heuristic checks — evidence: `.agent/release-evidence/0.3.39/claude-prerelease/`.
- Level 5 Claude release acceptance proxy: same harness with `--simulation-tier release_acceptance` — exit 0, 10/11 heuristic checks. Manual review found `loop_routing` was a proxy false negative; transcript includes explicit route/ordered next steps. Evidence: `.agent/release-evidence/0.3.39/claude-release-acceptance-wheel/`.
- Level 5 Codex runtime: installed candidate wheel into pipx, refreshed real Codex global skills, then ran read-only `codex exec` from a fresh clean business repo for `mb-start` and `mb-end` — both exit 0. `mb-start` reported Codex runtime ready; `mb-end` reported `landed in main, with nothing unsaved locally`. Logs: `.agent/release-evidence/0.3.39/codex-clean-mb-start.out`, `codex-clean-mb-end.out`.

## Notes

Interactive Claude Code TUI smoke was not run in this branch; print-mode evidence remains proxy evidence by policy. Codex CLI runtime smoke was run with `codex exec` and the real global Codex skill surface after installing the candidate wheel into pipx.

Public/private boundary: evidence remains under `.agent/`; PR body summarizes only public-safe facts.
