### PR TITLE
[update] Purge legacy taxonomy guidance

### DIFF
--- a/.claude/reference/business-primitives/offer-bet-push-proof.md
+++ b/.claude/reference/business-primitives/offer-bet-push-proof.md
@@ -44,9 +44,10 @@ Business-readable explanation:
 | Per-push playbook run | `pushes/<slug>/playbooks/<playbook>.md` |
 | Rationale for changing truth | `decisions/YYYY-MM-DD-slug.md` |
 
-Older repos may have `reference/` compatibility bridges or offer-specific files
-such as `core/offers/<slug>/testimonials.md`. Read those as legacy context, but
-write new proof under `core/proof/` or `core/offers/<slug>/proof/`.
+Older repos may have `reference/` migration input or offer-specific files such
+as `core/offers/<slug>/testimonials.md`. Run `mb doctor repair --plan` before
+relying on old paths, and write new proof under `core/proof/` or
+`core/offers/<slug>/proof/`.
 
 Primary proof targets:
 

--- a/.claude/skills/mb-ads/SKILL.md
+++ b/.claude/skills/mb-ads/SKILL.md
@@ -79,7 +79,7 @@ provider checks that `mb` already owns.
 
 **NEVER search the filesystem. NEVER use Explore or Task agents to find repos. NEVER scan ~/Documents/GitHub/.**
 
-**CWD-first:** If `core/` exists in CWD, you're already in the business repo — use it. If old `reference/*` paths appear without `core/`, run `mb doctor repair --plan` and treat them as migration input before relying on them.
+**CWD-first:** If current Main Branch markers exist in CWD, use it. If CWD looks like an old Main Branch repo, run `mb status --json --peek` and/or `mb doctor repair --plan` before saved config or discovery. Do not write to old repo structure.
 
 If CWD is NOT a business repo:
 

--- a/.claude/skills/mb-ads/SKILL.md
+++ b/.claude/skills/mb-ads/SKILL.md
@@ -79,7 +79,7 @@ provider checks that `mb` already owns.
 
 **NEVER search the filesystem. NEVER use Explore or Task agents to find repos. NEVER scan ~/Documents/GitHub/.**
 
-**CWD-first:** If `core/` or legacy `reference/core/` exists in CWD, you're already in the business repo — use it.
+**CWD-first:** If `core/` exists in CWD, you're already in the business repo — use it. If old `reference/*` paths appear without `core/`, run `mb doctor repair --plan` and treat them as migration input before relying on them.
 
 If CWD is NOT a business repo:
 
@@ -332,13 +332,9 @@ Before loading reference files, resolve active offer context with
 3. If an offer is selected and `core/offers/[offer]/offer.md` exists, load it as the active offer.
 4. If no offer is selected AND `core/offers/` exists: ask which offer.
 5. If no `core/offers/` folder: use `core/offer.md` (single-offer mode)
-6. Legacy fallback: if the repo does not have `core/`, read the old
-   `reference/core/` and `reference/offers/` paths.
-
-In current repos, `reference/core` and `reference/offers` are compatibility
-bridges to `core/` and `core/offers/`. Treat them as aliases, not duplicate
-files: read through them only as fallback, and never ask the user to update both
-paths.
+6. If the repo does not have `core/`, do not infer current offer context from
+   old paths. Run `mb doctor repair --plan`; use `reference/*` only as legacy
+   migration input.
 
 **Always-core files:** `soul.md`, `voice.md`, `content-strategy.md`
 **Content strategy layers:** when present, use
@@ -486,7 +482,7 @@ If context was compacted mid-task, check:
 1. **Which offer?** Use a future `mb` JSON active-offer field if present; otherwise ask the user to restore offer context. Do not silently route from `.vip/local.yaml`.
 2. **What entry point?** Full pipeline, copy only, hook library, video scripts, review, account check
 3. **What stage?** Planning angles, writing hooks, generating prompts, reviewing, pulling account data
-4. **What's done?** Check `pushes/` (and legacy `campaigns/` on unmigrated repos) for partial work
+4. **What's done?** Check `pushes/` for partial work. If old `campaigns/` records exist, run `mb migrate campaigns --plan` before relying on them.
 5. **Ad account status?** Re-run `mb status --json --peek`; if needed, run `mb connect doctor --json`
 6. **Resume:** Continue from the last completed step
 

--- a/.claude/skills/mb-ads/references/preflight-algorithm.md
+++ b/.claude/skills/mb-ads/references/preflight-algorithm.md
@@ -49,9 +49,8 @@ offer and audience files:
 2. If an offer is selected and `core/offers/{offer}/offer.md` exists, score that file
 3. Otherwise fall back to `core/offer.md`
 4. Same resolution for `audience.md`
-5. Legacy fallback: if `core/` is absent, read old `reference/core/` and
-   `reference/offers/` paths. In current repos, those are compatibility bridges
-   to current `core/` paths, not duplicate files.
+5. If `core/` is absent, run `mb doctor repair --plan` and treat old
+   `reference/*` paths as migration input before relying on them.
 
 See `docs/system-architecture.md` (current path resolution) for the full algorithm.
 

--- a/.claude/skills/mb-end/SKILL.md
+++ b/.claude/skills/mb-end/SKILL.md
@@ -114,7 +114,7 @@ A quick `/mb-end` (user says "just commit and close") can be steps 1-3 and 6. Bu
 
 ## Step 1: Find the Business Repo
 
-**CWD-first:** If `core/` exists in CWD, you're already in the business repo — use it. If old `reference/*` paths appear without `core/`, run `mb doctor repair --plan` before relying on them. Otherwise, read `~/.config/vip/local.yaml` for `default_repo` only as a legacy machine-local fallback.
+**CWD-first:** If current Main Branch markers exist in CWD, use it. If CWD looks like an old Main Branch repo, run `mb status --json --peek` and `mb doctor repair --plan` before saved config or discovery. Do not write to old repo structure; tell the operator to follow the repair/migration plan. Otherwise, read `~/.config/vip/local.yaml` for `default_repo` only as a legacy machine-local fallback.
 
 **If no repo found:** Skip to a simple close. No business repo means no git activity to scan.
 

--- a/.claude/skills/mb-end/SKILL.md
+++ b/.claude/skills/mb-end/SKILL.md
@@ -114,7 +114,7 @@ A quick `/mb-end` (user says "just commit and close") can be steps 1-3 and 6. Bu
 
 ## Step 1: Find the Business Repo
 
-**CWD-first:** If `core/` or legacy `reference/core/` exists in CWD, you're already in the business repo — use it. Otherwise, read `~/.config/vip/local.yaml` for `default_repo` only as a legacy machine-local fallback.
+**CWD-first:** If `core/` exists in CWD, you're already in the business repo — use it. If old `reference/*` paths appear without `core/`, run `mb doctor repair --plan` before relying on them. Otherwise, read `~/.config/vip/local.yaml` for `default_repo` only as a legacy machine-local fallback.
 
 **If no repo found:** Skip to a simple close. No business repo means no git activity to scan.
 

--- a/.claude/skills/mb-help/SKILL.md
+++ b/.claude/skills/mb-help/SKILL.md
@@ -17,7 +17,7 @@ for repair facts before giving prose-only advice.
 ## Workflow
 
 1. **Triage** — Parse user's question/brain-dump
-2. **Detect business type** — Check current `core/*.md` files (Skool? Ecommerce?). If old `reference/*` paths appear, treat them as migration input and run `mb doctor repair --plan` before relying on them.
+2. **Detect business type** — Check current business files (Skool? Ecommerce?). If CWD looks like an old Main Branch repo, treat it as migration input and run `mb status --json --peek` and/or `mb doctor repair --plan` before relying on it.
 3. **Load reference** — Find topic in references/ table below
 4. **Answer** — Explain "why" not just "what"
 5. **Route** — End with next skill or action
@@ -84,7 +84,7 @@ for repair facts before giving prose-only advice.
 | How do I close a session? | Run `/mb-end`. It summarizes what happened, asks if you have final thoughts, offers a crystallize moment if you made decisions, and guides an approved checkpoint instead of raw git commits. Bookend to `/mb-start`. |
 | What is multi-offer? | Multiple products under one brand, one business folder. Each offer gets its own `core/offers/[name]/offer.md`. Soul and voice stay in `core/` because they're brand-level. Use when you sell multiple things (community + newsletter + done-for-you). If you have no `core/offers/` folder, you're in single-offer mode — everything reads from `core/` and nothing changes. |
 | How do I switch offers? | Say `/mb-start [offer-name]` or answer when /mb-start prompts. The choice is session-scoped unless you explicitly approve saving it as local active-offer state. |
-| Where do offer files go? | In a single-offer repo, `core/offer.md` is the durable offer truth. In a multi-offer repo, `core/offer.md` is the portfolio thesis and `core/offers/[name]/offer.md` holds offer-specific details. Use current paths only; if old `reference/*` paths exist, run `mb doctor repair --plan` before relying on them. |
+| Where do offer files go? | In a single-offer repo, `core/offer.md` is the durable offer truth. In a multi-offer repo, `core/offer.md` is the portfolio thesis and `core/offers/[name]/offer.md` holds offer-specific details. Use current paths only; if CWD looks like an old Main Branch repo, run the repair/migration plan before relying on it. |
 | What stays in core with multiple offers? | `soul.md` (always), `voice.md` (always), `audience.md` (base, with optional per-offer overrides), `content-strategy.md` (business-level content strategy), and optional `core/marketing/` / `core/people/` layers. |
 | Where does proof go? | Company-wide testimonials go in `core/proof/testimonials.md`, average-case context in `core/proof/typicality.md`, and angles in `core/proof/angles/`. Offer-specific proof uses matching files under `core/offers/[name]/proof/`. Use structured permission and offer-link fields when proof should be detectable by `mb status`. |
 | Can I delete or rename an old offer folder? | Ask first. Offer folders are durable business history. Rename, delete, merge, or move them only after an accepted decision, approved migration plan, or explicit operator instruction. |

--- a/.claude/skills/mb-help/SKILL.md
+++ b/.claude/skills/mb-help/SKILL.md
@@ -17,7 +17,7 @@ for repair facts before giving prose-only advice.
 ## Workflow
 
 1. **Triage** — Parse user's question/brain-dump
-2. **Detect business type** — Check `core/*.md` (Skool? Ecommerce?), with legacy `reference/core/*.md` fallback only if `core/` is absent
+2. **Detect business type** — Check current `core/*.md` files (Skool? Ecommerce?). If old `reference/*` paths appear, treat them as migration input and run `mb doctor repair --plan` before relying on them.
 3. **Load reference** — Find topic in references/ table below
 4. **Answer** — Explain "why" not just "what"
 5. **Route** — End with next skill or action
@@ -84,7 +84,7 @@ for repair facts before giving prose-only advice.
 | How do I close a session? | Run `/mb-end`. It summarizes what happened, asks if you have final thoughts, offers a crystallize moment if you made decisions, and guides an approved checkpoint instead of raw git commits. Bookend to `/mb-start`. |
 | What is multi-offer? | Multiple products under one brand, one business folder. Each offer gets its own `core/offers/[name]/offer.md`. Soul and voice stay in `core/` because they're brand-level. Use when you sell multiple things (community + newsletter + done-for-you). If you have no `core/offers/` folder, you're in single-offer mode — everything reads from `core/` and nothing changes. |
 | How do I switch offers? | Say `/mb-start [offer-name]` or answer when /mb-start prompts. The choice is session-scoped unless you explicitly approve saving it as local active-offer state. |
-| Where do offer files go? | In a single-offer repo, `core/offer.md` is the durable offer truth. In a multi-offer repo, `core/offer.md` is the portfolio thesis and `core/offers/[name]/offer.md` holds offer-specific details. Legacy `reference/offers` and `reference/core` may point at those folders as compatibility bridges; do not edit both. |
+| Where do offer files go? | In a single-offer repo, `core/offer.md` is the durable offer truth. In a multi-offer repo, `core/offer.md` is the portfolio thesis and `core/offers/[name]/offer.md` holds offer-specific details. Use current paths only; if old `reference/*` paths exist, run `mb doctor repair --plan` before relying on them. |
 | What stays in core with multiple offers? | `soul.md` (always), `voice.md` (always), `audience.md` (base, with optional per-offer overrides), `content-strategy.md` (business-level content strategy), and optional `core/marketing/` / `core/people/` layers. |
 | Where does proof go? | Company-wide testimonials go in `core/proof/testimonials.md`, average-case context in `core/proof/typicality.md`, and angles in `core/proof/angles/`. Offer-specific proof uses matching files under `core/offers/[name]/proof/`. Use structured permission and offer-link fields when proof should be detectable by `mb status`. |
 | Can I delete or rename an old offer folder? | Ask first. Offer folders are durable business history. Rename, delete, merge, or move them only after an accepted decision, approved migration plan, or explicit operator instruction. |

--- a/.claude/skills/mb-organic/SKILL.md
+++ b/.claude/skills/mb-organic/SKILL.md
@@ -177,7 +177,7 @@ perfectly without them.
 
 **Congruence check:** If `core/operations/funnel/skool-surfaces.md` exists, read it. Organic content should echo the same positioning and claims visible on the Skool about page and pricing cards. No contradictions between organic and the landing experience.
 
-**CWD-first:** If `core/` exists in CWD, you're already in the business repo. Otherwise, run `mb status --json --peek` and use its repo/readiness facts if available. If status cannot identify a repo, ask the user or run `/mb-setup`. If old `reference/*` paths appear without `core/`, run `mb doctor repair --plan` before relying on them.
+**CWD-first:** If current Main Branch markers exist in CWD, use it. If CWD looks like an old Main Branch repo, run `mb status --json --peek` and/or `mb doctor repair --plan` before saved config or discovery. Do not write to old repo structure. Otherwise, run `mb status --json --peek` and use its repo/readiness facts if available. If status cannot identify a repo, ask the user or run `/mb-setup`.
 
 Missing files? See [references/first-time-setup.md](references/first-time-setup.md).
 
@@ -347,7 +347,7 @@ See [references/static-template.md](references/static-template.md).
 
 ## Voice Adaptation
 
-Read `core/voice.md`. If old `reference/*` paths appear without `core/`, run `mb doctor repair --plan` before relying on them. Match tone, use their vocabulary, avoid their "never say" list.
+Read current voice context. If CWD looks like an old Main Branch repo, run `mb status --json --peek` and/or `mb doctor repair --plan` before relying on it. Match tone, use their vocabulary, avoid their "never say" list.
 
 **Authenticity:** Sounds like creator (not copywriter). Uses contractions. Matches energy. No AI tells ("dive into", "unlock", "game-changer").
 

--- a/.claude/skills/mb-organic/SKILL.md
+++ b/.claude/skills/mb-organic/SKILL.md
@@ -137,13 +137,9 @@ Before loading reference files, resolve active offer context with
 3. If an offer is selected and `core/offers/[offer]/offer.md` exists, load it as the active offer.
 4. If no offer is selected AND `core/offers/` exists: ask which offer.
 5. If no `core/offers/` folder: use `core/offer.md` (single-offer mode)
-6. Legacy fallback: if the repo does not have `core/`, read the old
-   `reference/core/` and `reference/offers/` paths.
-
-In current repos, `reference/core` and `reference/offers` are compatibility
-bridges to `core/` and `core/offers/`. Treat them as aliases, not duplicate
-files. Read through them only as fallback, and write once to the current
-`core/` path when reference updates are needed.
+6. If the repo does not have `core/`, do not infer current offer context from
+   old paths. Run `mb doctor repair --plan`; use `reference/*` only as legacy
+   migration input.
 
 **Always-core files:** `soul.md`, `voice.md`, `content-strategy.md`
 **Content strategy layers:** read `core/marketing/distribution-strategy.md`,
@@ -181,7 +177,7 @@ perfectly without them.
 
 **Congruence check:** If `core/operations/funnel/skool-surfaces.md` exists, read it. Organic content should echo the same positioning and claims visible on the Skool about page and pricing cards. No contradictions between organic and the landing experience.
 
-**CWD-first:** If `core/` or legacy `reference/core/` exists in CWD, you're already in the business repo. Otherwise, run `mb status --json --peek` and use its repo/readiness facts if available. If status cannot identify a repo, ask the user or run `/mb-setup`.
+**CWD-first:** If `core/` exists in CWD, you're already in the business repo. Otherwise, run `mb status --json --peek` and use its repo/readiness facts if available. If status cannot identify a repo, ask the user or run `/mb-setup`. If old `reference/*` paths appear without `core/`, run `mb doctor repair --plan` before relying on them.
 
 Missing files? See [references/first-time-setup.md](references/first-time-setup.md).
 
@@ -351,7 +347,7 @@ See [references/static-template.md](references/static-template.md).
 
 ## Voice Adaptation
 
-Read `core/voice.md` (or legacy `reference/core/voice.md` only when `core/` is absent). Match tone, use their vocabulary, avoid their "never say" list.
+Read `core/voice.md`. If old `reference/*` paths appear without `core/`, run `mb doctor repair --plan` before relying on them. Match tone, use their vocabulary, avoid their "never say" list.
 
 **Authenticity:** Sounds like creator (not copywriter). Uses contractions. Matches energy. No AI tells ("dive into", "unlock", "game-changer").
 

--- a/.claude/skills/mb-organic/references/first-time-setup.md
+++ b/.claude/skills/mb-organic/references/first-time-setup.md
@@ -152,6 +152,6 @@ Once you have the three core files:
 
 The skill will guide you from there.
 
-If the repo has no `core/` folder, use legacy `reference/core/` as a temporary
-read fallback until the repo is migrated. In current repos, `reference/core` is
-a compatibility bridge to `core/`, not a second file to edit.
+If the repo has no `core/` folder, run `mb doctor repair --plan` and use
+legacy `reference/*` only as migration input until the repo is migrated. Do not
+edit old paths as a second source of truth.

--- a/.claude/skills/mb-organic/references/minimal-voice-template.md
+++ b/.claude/skills/mb-organic/references/minimal-voice-template.md
@@ -2,8 +2,8 @@
 
 Copy this template to `core/voice.md` and fill in your details.
 
-If this is an old repo without `core/`, `reference/core/voice.md` is the legacy
-fallback. In current repos, `reference/core` points at `core/`; do not maintain
+If this is an old repo without `core/`, run `mb doctor repair --plan` before
+relying on `reference/core/voice.md`. Do not maintain
 both paths separately.
 
 ---

--- a/.claude/skills/mb-setup/SKILL.md
+++ b/.claude/skills/mb-setup/SKILL.md
@@ -230,9 +230,9 @@ mkdir -p research decisions bets log pushes documents
 ```
 
 Do not create a new `reference/` folder in new repos. If an old repo
-already has `reference/core` or `reference/offers`, treat those paths as legacy
-compatibility aliases and write user context once under `core/` or
-`core/offers/`.
+already has `reference/core` or `reference/offers`, treat those paths as
+legacy migration input and run `mb doctor repair --plan` before relying on
+them. Write user context once under `core/` or `core/offers/`.
 
 **Multi-offer only (if user has multiple offers from Step 2.5):**
 
@@ -433,7 +433,7 @@ If conversation compacts mid-setup:
 - "You created the folder structure but we haven't sorted content"
 
 **For Claude:** When resuming:
-1. Check if business repo exists (look for `core/`, with legacy `reference/core/` fallback)
+1. Check if business repo exists (look for current `core/`; if old `reference/*` paths exist, run `mb doctor repair --plan`)
 2. If exists, check which files are populated vs empty
 3. Resume from the appropriate step based on what's done
 4. Confirm with user: "I see [business-name] with [X] files. Looks like we're at step [N]. Continue?"

--- a/.claude/skills/mb-setup/SKILL.md
+++ b/.claude/skills/mb-setup/SKILL.md
@@ -70,9 +70,9 @@ For first-time setup, do not default to "switch workspace now." Prefer option 1 
 
 ### Check Main Branch Updates and Detect CWD (FIRST)
 
-**Repair Main Branch wiring + detect CWD before context gathering.** Three cases: CWD is the business folder (happy path), CWD is the Main Branch source checkout (migration), or CWD is neither (ask user).
+**Repair Main Branch wiring + detect CWD before context gathering.** Four cases: CWD is the business folder (happy path), CWD is an old Main Branch repo needing repair/migration, CWD is the Main Branch source checkout (engine migration), or CWD is neither (ask user).
 
-See **[references/cwd-detection.md](references/cwd-detection.md)** for the full repair path and all three cases (Case 1 happy path, Case 2 engine migration, Case 3 ask). This must happen BEFORE any context gathering — if conversation compacts later, the essential config is already saved.
+See **[references/cwd-detection.md](references/cwd-detection.md)** for the full repair path and all four cases (Case 1 happy path, Case 2 old repo repair, Case 3 engine migration, Case 4 ask). This must happen BEFORE any context gathering — if conversation compacts later, the essential config is already saved.
 
 ---
 
@@ -229,10 +229,10 @@ mkdir -p core core/offers core/finance core/brand core/proof/angles core/operati
 mkdir -p research decisions bets log pushes documents
 ```
 
-Do not create a new `reference/` folder in new repos. If an old repo
-already has `reference/core` or `reference/offers`, treat those paths as
-legacy migration input and run `mb doctor repair --plan` before relying on
-them. Write user context once under `core/` or `core/offers/`.
+Do not create old repo structure in new repos. If an existing folder looks like
+an old Main Branch repo, treat that structure as migration input and run
+`mb doctor repair --plan` before relying on it. Write user context once under
+current business files.
 
 **Multi-offer only (if user has multiple offers from Step 2.5):**
 
@@ -412,7 +412,7 @@ See `references/git-workflow.md` for the full guide.
 ## References
 
 - **Repo Visibility Rubric:** `references/repo-visibility-rubric.md` — Private-by-default, the one visibility question for site repos, and what visibility does not decide
-- **CWD Detection:** `references/cwd-detection.md` — Check Main Branch updates + Case 1/2/3 flows for detecting where the user is
+- **CWD Detection:** `references/cwd-detection.md` — Check Main Branch updates + Case 1/2/3/4 flows for detecting where the user is
 - **File Education:** `references/file-education.md` — What to teach the user about each core file, priority order, visual style scaffolding
 - **Context Gathering:** `references/context-gathering.md` — Checklists by business type, completeness criteria
 - **Templates:** `references/templates.md` — All file templates
@@ -433,7 +433,7 @@ If conversation compacts mid-setup:
 - "You created the folder structure but we haven't sorted content"
 
 **For Claude:** When resuming:
-1. Check if business repo exists (look for current `core/`; if old `reference/*` paths exist, run `mb doctor repair --plan`)
+1. Check if business repo exists (look for current markers; if CWD looks like an old Main Branch repo, run `mb status --json --peek` and `mb doctor repair --plan` from CWD before fallback)
 2. If exists, check which files are populated vs empty
 3. Resume from the appropriate step based on what's done
 4. Confirm with user: "I see [business-name] with [X] files. Looks like we're at step [N]. Continue?"

--- a/.claude/skills/mb-setup/references/cwd-detection.md
+++ b/.claude/skills/mb-setup/references/cwd-detection.md
@@ -32,7 +32,7 @@ reported but not changed.
 ## Detect Where We Are
 
 ```bash
-test -d "core" -o -d "reference/core" && echo "IS_BUSINESS_REPO"
+test -d "core" && echo "IS_BUSINESS_REPO"
 test -f ".claude/skills/mb-setup/SKILL.md" && echo "IS_MAINBRANCH_SOURCE"
 ```
 

--- a/.claude/skills/mb-setup/references/cwd-detection.md
+++ b/.claude/skills/mb-setup/references/cwd-detection.md
@@ -31,8 +31,13 @@ reported but not changed.
 
 ## Detect Where We Are
 
+Detect current repos first, then old repo migration input, then source
+checkouts:
+
 ```bash
 test -d "core" && echo "IS_BUSINESS_REPO"
+# Old repo migration input, not current paths.
+if test ! -d "core" && { test -d "reference/core" || test -d "reference/offers" || test -d "reference/domain"; }; then echo "IS_OLD_BUSINESS_REPO"; fi
 test -f ".claude/skills/mb-setup/SKILL.md" && echo "IS_MAINBRANCH_SOURCE"
 ```
 
@@ -54,7 +59,25 @@ pipx install mainbranch
 
 Then re-run the preferred repair path.
 
-### Case 2: CWD Is The Main Branch Source Checkout
+### Case 2: CWD Is an Old Main Branch Repo
+
+Say:
+
+> "You're in an old Main Branch repo. I'll read it as migration input, then
+> show the repair plan before any normal workflow."
+
+Run from this CWD before falling back to saved config or discovery:
+
+```bash
+mb status --json --peek
+mb doctor repair --plan
+```
+
+Do not call `reference/core`, `reference/offers`, or `reference/domain`
+current paths. Do not write new business truth there. Tell the operator to
+follow the repair/migration plan.
+
+### Case 3: CWD Is The Main Branch Source Checkout
 
 Say:
 
@@ -73,7 +96,7 @@ mb start --repo /absolute/path/to/business-repo --json
 If direct writes are blocked by the runtime sandbox, tell the user to open a
 workspace rooted at the business repo and run the same commands there.
 
-### Case 3: CWD Is Neither
+### Case 4: CWD Is Neither
 
 Ask whether the user wants to create a new business repo or connect an existing
 one.

--- a/.claude/skills/mb-site/SKILL.md
+++ b/.claude/skills/mb-site/SKILL.md
@@ -124,7 +124,7 @@ code commits still use that site's normal git flow.
 
 Use [`references/site-repo-workflow.md`](references/site-repo-workflow.md).
 
-- **Business repo mode:** CWD has `core/`. Say: "I'm reading business context here and will create or select a site repo." If old `reference/*` paths appear without `core/`, run `mb doctor repair --plan` before relying on them.
+- **Business repo mode:** CWD has current Main Branch markers. Say: "I'm reading business context here and will create or select a site repo." If CWD looks like an old Main Branch repo, run `mb status --json --peek` and/or `mb doctor repair --plan` before saved config or discovery. Do not write to old repo structure.
 - **Site repo mode:** CWD has `.mainbranch/repo.json` or legacy `.mainbranch/source.json`. Say: "I'm editing the site here and reading business context from the linked business repo."
 
 Business repo mode plans, researches, drafts the brief, picks an offer, records push/site state, and creates or selects the site repo. Site repo mode edits code, reviews pages, previews, deploys, and runs `mb site check`.

--- a/.claude/skills/mb-site/SKILL.md
+++ b/.claude/skills/mb-site/SKILL.md
@@ -33,9 +33,9 @@ are not duplicated in the business repo.
 Reverse references from the site repo should use the role-neutral
 `.mainbranch/repo.json` descriptor with engine push paths
 (`linked.pushes: ["pushes/<...>/push.md"]`). Existing site repos may still use
-`.mainbranch/source.json`; its `campaign_path` compatibility key should point
-at the current push record when possible. Legacy repos that still have
-`campaigns/` continue to resolve via compatibility read.
+`.mainbranch/source.json`; its historical `campaign_path` key should point
+at the current push record when possible. Treat old `campaigns/` records as
+migration input and run `mb migrate campaigns --plan` before relying on them.
 
 If `core/vocabulary.md` defines display words (e.g. `terms.push.singular:
 launch`), speak the operator's word in conversation while still writing
@@ -124,7 +124,7 @@ code commits still use that site's normal git flow.
 
 Use [`references/site-repo-workflow.md`](references/site-repo-workflow.md).
 
-- **Business repo mode:** CWD has `core/` or legacy `reference/core/`. Say: "I'm reading business context here and will create or select a site repo."
+- **Business repo mode:** CWD has `core/`. Say: "I'm reading business context here and will create or select a site repo." If old `reference/*` paths appear without `core/`, run `mb doctor repair --plan` before relying on them.
 - **Site repo mode:** CWD has `.mainbranch/repo.json` or legacy `.mainbranch/source.json`. Say: "I'm editing the site here and reading business context from the linked business repo."
 
 Business repo mode plans, researches, drafts the brief, picks an offer, records push/site state, and creates or selects the site repo. Site repo mode edits code, reviews pages, previews, deploys, and runs `mb site check`.

--- a/.claude/skills/mb-site/references/troubleshooting.md
+++ b/.claude/skills/mb-site/references/troubleshooting.md
@@ -81,8 +81,9 @@ legacy repos.
 If a legacy `source.json` has `business_repo`, that path must point to a
 business repo with current `core/` files. A new `.mainbranch/repo.json`
 descriptor should use safe GitHub handles and, at most, an optional relative
-`parent.local_checkout` hint. If old `reference/*` paths appear without
-`core/`, run `mb doctor repair --plan` before relying on them.
+`parent.local_checkout` hint. If CWD looks like an old Main Branch repo, treat
+it as migration input and run `mb status --json --peek` and/or
+`mb doctor repair --plan` before relying on it.
 
 ## Site Looks Generic Or AI-Written
 

--- a/.claude/skills/mb-site/references/troubleshooting.md
+++ b/.claude/skills/mb-site/references/troubleshooting.md
@@ -81,8 +81,8 @@ legacy repos.
 If a legacy `source.json` has `business_repo`, that path must point to a
 business repo with current `core/` files. A new `.mainbranch/repo.json`
 descriptor should use safe GitHub handles and, at most, an optional relative
-`parent.local_checkout` hint. Legacy `reference/core` and `reference/offers`
-paths are compatibility bridges only.
+`parent.local_checkout` hint. If old `reference/*` paths appear without
+`core/`, run `mb doctor repair --plan` before relying on them.
 
 ## Site Looks Generic Or AI-Written
 

--- a/.claude/skills/mb-site/references/website-build.md
+++ b/.claude/skills/mb-site/references/website-build.md
@@ -81,7 +81,7 @@ git push -u origin main
 - **Cloudflare Pages (default):** `python3 .claude/skills/mb-site/scripts/pages.py create-project <name> --repo-owner <owner> --repo-name <repo> --branch main` — git-connected, auto-deploys on push. Configure build command (`pnpm build`) + output directory (`out` or `dist`) in the CF dashboard once.
 - **Netlify (legacy):** see [`deployment.md`](deployment.md). Key settings: Build command = `pnpm build`, Publish directory = `out`, NODE_VERSION = `20`.
 
-**10. Detect business repo.** Ask: "Where is your business repo with core business files?" Confirm the path has `core/` files. If old `reference/*` paths appear without `core/`, run `mb doctor repair --plan` before relying on them. If the business repo has `core/offers/`, ask which offer this site is for.
+**10. Detect business repo.** Ask: "Where is your business repo with current business files?" Confirm the path has current Main Branch markers. If CWD looks like an old Main Branch repo, treat it as migration input and run `mb status --json --peek` and/or `mb doctor repair --plan` before relying on it. If the business repo has multiple offers, ask which offer this site is for.
 
 **11. Save config.** Prefer repo-local `.mainbranch/repo.json`:
 

--- a/.claude/skills/mb-site/references/website-build.md
+++ b/.claude/skills/mb-site/references/website-build.md
@@ -81,7 +81,7 @@ git push -u origin main
 - **Cloudflare Pages (default):** `python3 .claude/skills/mb-site/scripts/pages.py create-project <name> --repo-owner <owner> --repo-name <repo> --branch main` — git-connected, auto-deploys on push. Configure build command (`pnpm build`) + output directory (`out` or `dist`) in the CF dashboard once.
 - **Netlify (legacy):** see [`deployment.md`](deployment.md). Key settings: Build command = `pnpm build`, Publish directory = `out`, NODE_VERSION = `20`.
 
-**10. Detect business repo.** Ask: "Where is your business repo with core business files?" Confirm the path has `core/` files, with legacy `reference/core/` fallback only if `core/` is absent. If the business repo has `core/offers/`, ask which offer this site is for. Treat `reference/core` and `reference/offers` as compatibility bridges, not duplicate files.
+**10. Detect business repo.** Ask: "Where is your business repo with core business files?" Confirm the path has `core/` files. If old `reference/*` paths appear without `core/`, run `mb doctor repair --plan` before relying on them. If the business repo has `core/offers/`, ask which offer this site is for.
 
 **11. Save config.** Prefer repo-local `.mainbranch/repo.json`:
 

--- a/.claude/skills/mb-start/SKILL.md
+++ b/.claude/skills/mb-start/SKILL.md
@@ -88,7 +88,7 @@ providers, spending money, changing topology, or creating checkpoints.
 
 ## CRITICAL: Repo Selection Rules
 
-**CWD-first wins.** If `core/` or legacy `reference/core/` exists in CWD, the user is already in their business repo — no selection needed. Just confirm: "Working in **[repo-name]**."
+**CWD-first wins.** If `core/` exists in CWD, the user is already in their business repo — no selection needed. Just confirm: "Working in **[repo-name]**." If old `reference/*` paths appear without `core/`, run `mb doctor repair --plan` and treat them as migration input before relying on them.
 
 **Only ask which repo when CWD is NOT a business repo** (fallback to config). In that case, list ALL validated repos from `recent_repos`:
 
@@ -112,7 +112,7 @@ providers, spending money, changing topology, or creating checkpoints.
 **DO NOT skip this question when in fallback mode.** Users have multiple repos. The saved default is a suggestion, not automatic.
 
 **Exceptions (skip selection entirely):**
-- CWD has `core/` or legacy `reference/core/` — user chose their repo by cd'ing into it
+- CWD has `core/` — user chose their repo by cd'ing into it
 - User explicitly ran `/mb-start [repo-name]` with a specific path
 
 **After user selects a repo from legacy fallback config:** Treat the selected
@@ -220,7 +220,7 @@ The user starts Claude in their business repo. Check CWD first before falling ba
 **Quick gist:**
 
 ```
-1. test -d "core" || test -d "reference/core"  → THIS IS the business repo. Skip to config.
+1. test -d "core"  → THIS IS the business repo. Skip to config.
 2. test -f ".claude/skills/mb-start/SKILL.md"  → user is in a Main Branch source checkout; migrate.
 3. Otherwise → fall back to `~/.config/vip/local.yaml` only as legacy
    machine-local repo memory.
@@ -372,9 +372,9 @@ setup shape or naming is unclear.
 find "$REPO_PATH/core/offers" -mindepth 2 -maxdepth 2 -name "offer.md" 2>/dev/null
 ```
 
-If `core/offers` is absent and `core/` is also absent, legacy
-`reference/offers` is fallback only. In current repos it bridges to
-`core/offers`.
+If `core/offers` is absent and `core/` is also absent, do not infer the offer
+from old paths. Run `mb doctor repair --plan` and treat any `reference/*`
+content as migration input.
 
 **If no offers/ folder:** Single-offer mode. Skip to Step 2. Read from `core/`.
 
@@ -413,8 +413,8 @@ Use `readiness`, `onboarding`, `drift.items`, `money_path`, and `ranked_actions`
 from status first. Prefer `money_path.ranked_actions` for path gaps unless the
 top-level ranked action already incorporates it.
 
-Fallback: check `core/*.md`, then legacy `reference/core/*.md` only when
-`core/` is absent. No folder → `/mb-setup`. If two or more
+Fallback: check `core/*.md`. If `core/` is absent but old `reference/*` paths
+exist, run `mb doctor repair --plan` before routing. No folder → `/mb-setup`. If two or more
 core files are missing/thin, route to `/mb-think codify`; otherwise route by
 intent. Use [readiness-assessment.md](references/readiness-assessment.md) for
 the exact fallback thresholds.

--- a/.claude/skills/mb-start/SKILL.md
+++ b/.claude/skills/mb-start/SKILL.md
@@ -88,7 +88,7 @@ providers, spending money, changing topology, or creating checkpoints.
 
 ## CRITICAL: Repo Selection Rules
 
-**CWD-first wins.** If `core/` exists in CWD, the user is already in their business repo — no selection needed. Just confirm: "Working in **[repo-name]**." If old `reference/*` paths appear without `core/`, run `mb doctor repair --plan` and treat them as migration input before relying on them.
+**CWD-first wins.** If current Main Branch markers exist in CWD, the user is already in their business repo — no selection needed. Just confirm: "Working in **[repo-name]**." If CWD looks like an old Main Branch repo, keep CWD as migration input. Run `mb status --json --peek` and `mb doctor repair --plan` before fallback config or discovery. Do not write to old repo structure; tell the operator to follow the repair/migration plan.
 
 **Only ask which repo when CWD is NOT a business repo** (fallback to config). In that case, list ALL validated repos from `recent_repos`:
 
@@ -110,10 +110,6 @@ providers, spending money, changing topology, or creating checkpoints.
 > (hit a number)"
 
 **DO NOT skip this question when in fallback mode.** Users have multiple repos. The saved default is a suggestion, not automatic.
-
-**Exceptions (skip selection entirely):**
-- CWD has `core/` — user chose their repo by cd'ing into it
-- User explicitly ran `/mb-start [repo-name]` with a specific path
 
 **After user selects a repo from legacy fallback config:** Treat the selected
 repo as session-scoped unless a current `mb` command exposes an explicit
@@ -221,8 +217,10 @@ The user starts Claude in their business repo. Check CWD first before falling ba
 
 ```
 1. test -d "core"  → THIS IS the business repo. Skip to config.
-2. test -f ".claude/skills/mb-start/SKILL.md"  → user is in a Main Branch source checkout; migrate.
-3. Otherwise → fall back to `~/.config/vip/local.yaml` only as legacy
+2. old Main Branch repo markers without current markers → old repo; run
+   `mb status --json --peek` and `mb doctor repair --plan` from CWD.
+3. test -f ".claude/skills/mb-start/SKILL.md"  → user is in a Main Branch source checkout; migrate.
+4. Otherwise → fall back to `~/.config/vip/local.yaml` only as legacy
    machine-local repo memory.
 ```
 
@@ -373,8 +371,9 @@ find "$REPO_PATH/core/offers" -mindepth 2 -maxdepth 2 -name "offer.md" 2>/dev/nu
 ```
 
 If `core/offers` is absent and `core/` is also absent, do not infer the offer
-from old paths. Run `mb doctor repair --plan` and treat any `reference/*`
-content as migration input.
+from old paths. If CWD looks like an old Main Branch repo, run
+`mb status --json --peek` and/or `mb doctor repair --plan` from CWD and treat
+it as migration input.
 
 **If no offers/ folder:** Single-offer mode. Skip to Step 2. Read from `core/`.
 
@@ -413,8 +412,8 @@ Use `readiness`, `onboarding`, `drift.items`, `money_path`, and `ranked_actions`
 from status first. Prefer `money_path.ranked_actions` for path gaps unless the
 top-level ranked action already incorporates it.
 
-Fallback: check `core/*.md`. If `core/` is absent but old `reference/*` paths
-exist, run `mb doctor repair --plan` before routing. No folder → `/mb-setup`. If two or more
+Fallback: check `core/*.md`. If CWD looks like an old Main Branch repo, run
+`mb status --json --peek` and/or `mb doctor repair --plan` before routing. No folder → `/mb-setup`. If two or more
 core files are missing/thin, route to `/mb-think codify`; otherwise route by
 intent. Use [readiness-assessment.md](references/readiness-assessment.md) for
 the exact fallback thresholds.

--- a/.claude/skills/mb-start/references/config-system.md
+++ b/.claude/skills/mb-start/references/config-system.md
@@ -193,7 +193,7 @@ cat ~/.claude/settings.json 2>/dev/null | grep business_repo_path
 
 ## Missing Legacy Config
 
-If repo has `core/` or legacy `reference/core/` but no `.vip/config.yaml`:
+If repo has `core/` but no `.vip/config.yaml`:
 
 Do not create it. Use `mb status --json --peek`, `mb onboard status --json`,
 `mb connect plan`, and current repo files instead.
@@ -281,7 +281,7 @@ Users rename folders, move repos, or clone to new locations. Config paths go sta
 **Before presenting ANY repo as a numbered option, verify the path exists:**
 
 ```bash
-if test -d "[path]/core" || test -d "[path]/reference/core"; then echo "valid"; else echo "invalid"; fi
+if test -d "[path]/core"; then echo "valid"; else echo "invalid"; fi
 ```
 
 Never show a dead path. Never load a dead path and show "0/18 EMPTY" for a repo that simply moved.
@@ -291,7 +291,7 @@ Never show a dead path. Never load a dead path and show "0/18 EMPTY" for a repo 
 When a config path is invalid:
 
 1. **Check parent directory** — if the parent exists, the folder was likely renamed
-2. **Scan siblings** — look for `core/` or legacy `reference/core/` in adjacent folders
+2. **Scan siblings** — look for current `core/` in adjacent folders
 3. **If match found** — tell the user: "Looks like **[old-name]** moved to
    **[new-name]**. I'll use that for this session."
 4. **If no match** — silently drop the stale entry from the list

--- a/.claude/skills/mb-start/references/config-system.md
+++ b/.claude/skills/mb-start/references/config-system.md
@@ -262,10 +262,16 @@ That pattern can silently delete fields (like `user.*`, `vip_path`, or future ke
 Config is always optional. Skills work without it.
 
 ```
-1. Try legacy local.yaml only when CWD and current settings do not identify a repo.
-2. Use `mb status --json --peek`, `mb connect`, and repo files for current facts
-3. Path invalid? → attempt session-only recovery, then rediscover
-4. Parse error? → warn, then rediscover
+1. If CWD has current `core/`, use CWD and current repo facts.
+2. If CWD has old `reference/core`, `reference/offers`, or `reference/domain`
+   without `core/`, run `mb status --json --peek` and `mb doctor repair --plan`
+   from that CWD before saved config or discovery. Treat old paths as
+   migration input only.
+3. Try legacy local.yaml only when CWD and current settings do not identify a
+   current repo or old repo migration input.
+4. Use `mb status --json --peek`, `mb connect`, and repo files for current facts
+5. Path invalid? → attempt session-only recovery, then rediscover
+6. Parse error? → warn, then rediscover
 ```
 
 **Principle:** Config is a speed optimization, not a requirement.
@@ -281,7 +287,13 @@ Users rename folders, move repos, or clone to new locations. Config paths go sta
 **Before presenting ANY repo as a numbered option, verify the path exists:**
 
 ```bash
-if test -d "[path]/core"; then echo "valid"; else echo "invalid"; fi
+if test -d "[path]/core"; then
+  echo "current"
+elif test -d "[path]/reference/core" || test -d "[path]/reference/offers" || test -d "[path]/reference/domain"; then
+  echo "old-repo-needs-repair"
+else
+  echo "invalid"
+fi
 ```
 
 Never show a dead path. Never load a dead path and show "0/18 EMPTY" for a repo that simply moved.

--- a/.claude/skills/mb-start/references/readiness-assessment.md
+++ b/.claude/skills/mb-start/references/readiness-assessment.md
@@ -78,9 +78,8 @@ shared active-offer contract. If CLI/status facts do not resolve the offer, ask
 which offer the current work is about or score brand-level context for routing
 only. Do not silently route from `.vip/local.yaml`; treat it as audit input.
 
-Legacy fallback: if the repo has no `core/`, read `reference/core/` and
-`reference/offers/`. In current repos those paths are compatibility bridges to
-current `core/` paths. Do not score or report them as duplicate files.
+If the repo has no `core/`, do not score old paths as current truth. Run
+`mb doctor repair --plan`; use `reference/*` only as legacy migration input.
 
 ### Composite Score
 

--- a/.claude/skills/mb-start/references/repo-detection.md
+++ b/.claude/skills/mb-start/references/repo-detection.md
@@ -1,8 +1,8 @@
 # Repo Detection (Step 2)
 
-CWD-first detection of the business repo, with legacy fallback only when CWD is
-not a business repo. The user starts Claude in their business repo — check CWD
-first before falling back to old local config.
+CWD-first detection of the business repo. The user starts Claude in their
+business repo — check current `core/` first before falling back to old local
+config.
 
 ---
 
@@ -10,7 +10,7 @@ first before falling back to old local config.
 
 ```
 1. Check CWD for business repo fingerprint:
-   test -d "core" || test -d "reference/core"
+   test -d "core"
    ├── YES → This IS the business repo. Use CWD. Skip to config loading.
    └── NO → Continue to step 2.
 
@@ -61,9 +61,10 @@ config:
 
 **Validate EVERY path before showing it to the user.** Never present a dead
 path as an option. For each path in `default_repo` and `recent_repos`, check
-`test -d "[path]/core" || test -d "[path]/reference/core"`. If invalid, hide
-it for this session and explain that the old local fallback may be stale. Do
-not rewrite legacy config during repo detection. See
+`test -d "[path]/core"`. If invalid, hide it for this session and explain that
+the old local fallback may be stale. If old `reference/*` paths appear without
+`core/`, run `mb doctor repair --plan` before relying on them. Do not rewrite
+legacy config during repo detection. See
 [config-system.md](config-system.md) for fallback rules.
 
 **ALWAYS present numbered options** — even with ONE repo found:
@@ -85,14 +86,14 @@ not rewrite legacy config during repo detection. See
 
 Use fallbacks in order:
 
-1. **Scan additionalDirectories** for paths containing `core/` or legacy `reference/core/`
+1. **Scan additionalDirectories** for paths containing current `core/`
 2. **Use bash to find repos** (if step 1 fails)
    ```bash
    find ~/Documents/GitHub -maxdepth 3 -type d \( -name "reference" -o -name "core" \) -print 2>/dev/null
    ```
 3. **Ask the user** (if nothing found)
 
-**Verify with Read, not Glob:** Use `Read` on `[path]/core/soul.md` or legacy `[path]/reference/core/soul.md` to confirm it's a business repo. `soul.md` belongs in `core/` for current repos.
+**Verify with Read, not Glob:** Use `Read` on `[path]/core/soul.md` to confirm it's a business repo. `soul.md` belongs in `core/` for current repos.
 
 **Skip the Main Branch source checkout** - any path containing `.claude/skills/mb-start/SKILL.md` is not the operator's business folder.
 

--- a/.claude/skills/mb-start/references/repo-detection.md
+++ b/.claude/skills/mb-start/references/repo-detection.md
@@ -1,8 +1,8 @@
 # Repo Detection (Step 2)
 
 CWD-first detection of the business repo. The user starts Claude in their
-business repo — check current `core/` first before falling back to old local
-config.
+business repo — check current `core/` first, then old repo migration
+fingerprints, before falling back to old local config.
 
 ---
 
@@ -14,12 +14,19 @@ config.
    ├── YES → This IS the business repo. Use CWD. Skip to config loading.
    └── NO → Continue to step 2.
 
-2. Check CWD for Main Branch source-checkout fingerprint (old workflow):
-   test -f ".claude/skills/mb-start/SKILL.md"
-   ├── YES → User is in a Main Branch source checkout (old workflow). Trigger migration guidance.
+2. Check CWD for old Main Branch repo fingerprints:
+   test -d "reference/core" / "reference/offers" / "reference/domain"
+   ├── YES → This is an old Main Branch repo. Use CWD as migration input.
+   │          Run mb status --json --peek and mb doctor repair --plan.
+   │          Do not call old paths current. Do not write to them.
    └── NO → Continue to step 3.
 
-3. Fall back to legacy machine-local config:
+3. Check CWD for Main Branch source-checkout fingerprint (old workflow):
+   test -f ".claude/skills/mb-start/SKILL.md"
+   ├── YES → User is in a Main Branch source checkout (old workflow). Trigger migration guidance.
+   └── NO → Continue to step 4.
+
+4. Fall back to legacy machine-local config:
    Read ~/.config/vip/local.yaml → default_repo + recent_repos
    ├── Found valid repo(s)? → Present options (see below)
    └── Nothing valid? → Discovery or /mb-setup
@@ -50,21 +57,27 @@ facts through `mb`:
 2. If legacy .vip YAML exists
    ├── Run mb doctor repair --plan --json to audit key families
    └── Do not treat .vip/config.yaml as current team settings
+
+3. If CWD was selected because old reference paths exist without core/
+   ├── Keep CWD as the migration input for mb status/doctor
+   ├── Tell the operator to follow the repair/migration plan
+   └── Do not write new business truth into reference/*
 ```
 
 ---
 
 ## Multi-Repo Selection (When CWD Is NOT a Business Repo)
 
-If CWD detection fails (step 3 above), present options from legacy local
+If CWD detection fails (step 4 above), present options from legacy local
 config:
 
 **Validate EVERY path before showing it to the user.** Never present a dead
 path as an option. For each path in `default_repo` and `recent_repos`, check
-`test -d "[path]/core"`. If invalid, hide it for this session and explain that
-the old local fallback may be stale. If old `reference/*` paths appear without
-`core/`, run `mb doctor repair --plan` before relying on them. Do not rewrite
-legacy config during repo detection. See
+`test -d "[path]/core"`. If invalid, check for old `reference/core`,
+`reference/offers`, or `reference/domain`; if present, describe the path as an
+old Main Branch repo that needs the repair/migration plan before use. Hide
+other invalid paths for this session and explain that the old local fallback
+may be stale. Do not rewrite legacy config during repo detection. See
 [config-system.md](config-system.md) for fallback rules.
 
 **ALWAYS present numbered options** — even with ONE repo found:
@@ -93,7 +106,7 @@ Use fallbacks in order:
    ```
 3. **Ask the user** (if nothing found)
 
-**Verify with Read, not Glob:** Use `Read` on `[path]/core/soul.md` to confirm it's a business repo. `soul.md` belongs in `core/` for current repos.
+**Verify with Read, not Glob:** Use `Read` on `[path]/core/soul.md` to confirm it's a current business repo. `soul.md` belongs in `core/` for current repos. If only old `reference/core`, `reference/offers`, or `reference/domain` exists, treat the folder as migration input and run the repair plan before any normal workflow.
 
 **Skip the Main Branch source checkout** - any path containing `.claude/skills/mb-start/SKILL.md` is not the operator's business folder.
 

--- a/.claude/skills/mb-start/references/triage-agent.md
+++ b/.claude/skills/mb-start/references/triage-agent.md
@@ -100,7 +100,7 @@ Gather these in main and pass as structured text in each agent's prompt:
 | Past triage file names | `ls research/*-start-triage.md 2>/dev/null` | ~5 lines | Agent 3 |
 | Past crystallize file names | `ls research/*-end-of-day-crystallize.md 2>/dev/null` | ~5 lines | Agent 3 |
 | active offer | From a future `mb` JSON active-offer field if present, otherwise explicit session/user selection | 1 line | All 3 agents |
-| Push lifecycle listing | `grep -rl "status: draft\|status: planned\|status: active" pushes/ campaigns/ 2>/dev/null` | ~10 lines | Agent 2 |
+| Push lifecycle listing | `grep -rl "status: draft\|status: planned\|status: active" pushes/ 2>/dev/null`; use status/doctor facts for old migrated records | ~10 lines | Agent 2 |
 | Primitive map | File lists grouped by the map below | ~40 lines | All 3 agents |
 
 **What agents may read themselves (in their own context, NOT in main):**
@@ -117,8 +117,8 @@ sanitized file for the current task.
   `core/offers/<slug>/audience.md`, and offer-specific proof or angles.
 - Bet truth: `bets/*.md`, especially status, deadline, metric, target,
   linked files, result, and verdict.
-- Execution truth: `pushes/<slug>/push.md` and artifacts. Read `campaigns/`
-  only as legacy compatibility and name it that way.
+- Execution truth: `pushes/<slug>/push.md` and artifacts. If status or doctor
+  reports old migrated records, treat them as legacy migration input.
 - Evidence: `research/`, `decisions/`, `core/proof/`, offer proof, `log/`,
   and `documents/`.
 - Relationship checks: `mb status --json --peek`; add `mb graph`,
@@ -260,14 +260,13 @@ frontmatter and first 10 lines of each.]
 
 === PUSH LIFECYCLE STATE ===
 
-[Files in pushes/ (and legacy campaigns/) grouped by frontmatter status:
+[Files in pushes/ grouped by frontmatter status:
 draft, planned, active, paused, completed,
-canceled, archived. Stale legacy statuses like "scheduled" or
-"published" come from pre-push records and signal that the operator
-should run `mb migrate campaigns --plan`.
-Use: grep -rl "status: draft" pushes/ campaigns/ 2>/dev/null
+canceled, archived. If status or doctor reports old records with stale states
+such as "scheduled" or "published", the operator should run the migration plan.
+Use: grep -rl "status: draft" pushes/ 2>/dev/null
 or "No pushes with lifecycle status" if none have status field.
-Also list most recent 5 items in pushes/ (or campaigns/ on legacy repos).]
+Also list most recent 5 items in pushes/.]
 
 === PRIMITIVE MAP ===
 
@@ -302,7 +301,7 @@ Analyze these dimensions:
    Long gap between core updates and push generation = missed opportunity.
 
 5. **Velocity pattern:** What's the ratio of enrichment work (research/,
-   core/ changes) to push work (pushes/, or legacy campaigns/)? All
+   core/ changes) to push work (pushes/)? All
    enrichment with no push output = stuck in thinking. All push output
    with no enrichment = running on stale context.
 

--- a/.claude/skills/mb-think/SKILL.md
+++ b/.claude/skills/mb-think/SKILL.md
@@ -103,13 +103,9 @@ with `.claude/reference/business-primitives/offer-bet-push-proof.md`:
 3. If an offer is selected and `core/offers/[offer]/offer.md` exists, load it as the active offer.
 4. If no offer is selected AND `core/offers/` exists: ask which offer.
 5. If no `core/offers/` folder: use `core/offer.md` (single-offer mode)
-6. Legacy fallback: if the repo does not have `core/`, read the old
-   `reference/core/` and `reference/offers/` paths.
-
-In current repos, `reference/core` and `reference/offers` are compatibility
-bridges to `core/` and `core/offers/`. Treat them as aliases, not duplicate
-files: write once to the current `core/` path and never ask the user to edit
-both.
+6. If the repo does not have `core/`, do not infer current offer context from
+   old paths. Run `mb doctor repair --plan`; use `reference/*` only as legacy
+   migration input.
 
 **Always-core files:** `soul.md`, `voice.md`, `content-strategy.md`. See [codify-phase.md](references/codify-phase.md) for content strategy layers.
 **Offer-aware files:** `offer.md`, `audience.md`

--- a/.claude/skills/mb-think/references/codify-phase.md
+++ b/.claude/skills/mb-think/references/codify-phase.md
@@ -181,11 +181,10 @@ when testimonials should be detectable by `mb status`. If the change is still
 being tested, update or open a bet instead of rewriting durable offer truth. If
 unsure, ask the user.
 
-**Compatibility bridges:** In current repos, `reference/core` points at
-`core/` and `reference/offers` points at `core/offers/`. These are aliases for
-older skill paths, not duplicate files. Write once to the current `core/` or
-`core/offers/` target. Only use `reference/core/` or `reference/offers/` as a
-legacy fallback when `core/` is absent.
+**Legacy paths:** Write once to the current `core/` or `core/offers/` target.
+If old `reference/*` paths appear without `core/`, run
+`mb doctor repair --plan` and treat them as migration input before relying on
+them.
 
 ---
 

--- a/.claude/skills/mb-think/references/recovery.md
+++ b/.claude/skills/mb-think/references/recovery.md
@@ -105,8 +105,8 @@ Check recent `research/` and `decisions/` files for offer-specific prefixes
 Confirm with user: "Were you working on [offer]?"
 
 If the repo has `core/offers/` but no active offer is clear, ask before
-proceeding: "Which offer are you working on?" Use legacy `reference/offers/`
-only when `core/` is absent.
+proceeding: "Which offer are you working on?" If old `reference/*` paths appear
+without `core/`, run `mb doctor repair --plan` before relying on them.
 
 ---
 

--- a/.claude/skills/mb-think/references/research-phase.md
+++ b/.claude/skills/mb-think/references/research-phase.md
@@ -17,8 +17,8 @@ Use `.claude/reference/business-primitives/offer-bet-push-proof.md` before
 starting research. If a future `mb` JSON field exposes active offer state, use
 it. Otherwise, if `core/offers/` exists but no active offer is selected, ask
 which offer this research relates to or whether it is brand-level work; do not
-silently route from `.vip/local.yaml`. Use legacy `reference/offers/` only when
-`core/` is absent.
+silently route from `.vip/local.yaml`. If old `reference/*` paths appear without
+`core/`, run `mb doctor repair --plan` before relying on them.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+### Changed
+
+- Purged retired folder-taxonomy vocabulary from current agent-facing guidance
+  and generated business-repo instructions, keeping old `reference/*`,
+  `campaigns/`, and `outputs/` handling in explicit migration/repair contexts.
+  Refs MAIN-460, #759.
+
 ### Removed
 
 - Retired the provisional `ship-bet` and `weekly-review` skeletons from bundled

--- a/decisions/2026-04-29-mb-vip-v0-1-0-master.md
+++ b/decisions/2026-04-29-mb-vip-v0-1-0-master.md
@@ -2,6 +2,7 @@
 type: decision
 date: 2026-04-29
 status: superseded
+agent_visibility: historical_context_only
 topic: mb-vip v0.1.0 — engine-side master decision (skill composition, repo shape, PyPI packaging, /mb-site upgrade, conductor preferences)
 mirrors: noontide-projects/decisions/2026-04-29-main-branch-v0-1-0-master.md
 superseded_by:

--- a/decisions/2026-05-06-campaign-primitive-and-architecture-model.md
+++ b/decisions/2026-05-06-campaign-primitive-and-architecture-model.md
@@ -2,6 +2,7 @@
 type: decision
 date: 2026-05-06
 status: accepted
+agent_visibility: historical_context_only
 topic: Campaign primitive and architecture model
 linked_issues:
   - https://github.com/noontide-co/mainbranch/issues/321

--- a/decisions/2026-05-06-main-branch-operating-spine.md
+++ b/decisions/2026-05-06-main-branch-operating-spine.md
@@ -23,7 +23,7 @@ decision passes through this filter.
 | Layer | Archetype | Job |
 | --- | --- | --- |
 | **The system itself** (CLI, validate, status, doctor, graph) | YC + Linear taste — opinionated minimalism, sharp primitives, refuses bad defaults | Quiet, fast, decisive. Earns trust through restraint. |
-| **The operator's daily push** (campaigns, ads, organic, sites) | ClickFunnels + Hormozi craft — volume, reps, offer-discipline, double down on winners | The system makes shipping easier, not slower. Reps are the unit. |
+| **The operator's daily push** (pushes, ads, organic, sites) | ClickFunnels + Hormozi craft — volume, reps, offer-discipline, double down on winners | The system makes shipping easier, not slower. Reps are the unit. |
 | **The operator's identity** (bets, soul, voice, weekly state) | Robbins / Naval / Buffett — long-arc vision, identity-level commitment, one-paragraph state of the business | The system protects this from the noise. Identity is reference, not a goal. |
 
 **The rule when they fight:** taste wins on the system surface, volume wins
@@ -63,14 +63,14 @@ them.
 
 4. **Lifecycle includes doubling down.** Most systems treat "completed" as
    the end. Real operators find a winner and pour fuel. This is a
-   first-class state, not an implicit "start a new campaign."
+   first-class state, not an implicit "start another push."
 
 5. **Surface what matters most this week.** Not everything you could do.
    One push, one lever, one number. `mb status` is a triage, not a
    dashboard.
 
 6. **Identity is reference, not a goal.** `core/soul.md` is who the
-   operator is. `bets/` are what they're trying. `campaigns/` are what
+   operator is. `bets/` are what they're trying. `pushes/` are what
    they're shipping. The system does not blur these layers, and it
    writes `core/` files in timeless language.
 

--- a/docs/operator-loops.md
+++ b/docs/operator-loops.md
@@ -80,7 +80,7 @@ reference-file reads sit here.
   topology-drift previews)
 - `mb graph` (with `repo` nodes and hub/child relationship edges)
 - `mb connect status`
-- `core/`, `research/`, `decisions/`, `pushes/`, legacy `campaigns/`, `log/`, `documents/`
+- `core/`, `research/`, `decisions/`, `pushes/`, `log/`, `documents/`
 - GitHub issues, pull requests, release history
 - linked business, site, offer, finance, ops, and client repos when the team
   chooses separate operating boundaries, surfaced through topology facts

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -118,10 +118,10 @@ The work clusters into a few durable buckets:
 - **Business-readable history.** Checkpoints should feel like saved business
   progress, not developer ceremony. The git journal should become a readable
   timeline for status, handoff, retros, and future dashboards.
-- **Pushes and growth workflows.** Ads, organic content, sales videos, sites, research,
-  bets, and coordinated pushes remain the strongest shipped wedge. `pushes/` is
-  the official folder for coordinated work; `campaigns/` remains a
-  compatibility read for older repos.
+- **Pushes and growth workflows.** Ads, organic content, sales videos, sites,
+  research, bets, and coordinated pushes remain the strongest shipped wedge.
+  `pushes/` is the official folder for coordinated work; old structural paths
+  surface through migration and repair facts when present.
 - **Research depth.** Offer, market, and content work should escalate source
   collection deliberately: memory first when enough, repo context next, public
   research when the answer depends on current outside facts, and deeper

--- a/mb/README.md
+++ b/mb/README.md
@@ -27,7 +27,7 @@ mb --version
 | `mb doctor` | Diagnostic. Checks Claude Code, gh auth, network, librsvg, runtime wiring, and package freshness. Warns on cloud-backed finance paths and offers educational triage. |
 | `mb status` | Daily briefing. Summarizes repo shape, install/runtime readiness, recent brain files, recent git activity, and GitHub tasks/proposals when `gh` is authenticated. Supports `--json`. |
 | `mb start` | Runtime handoff. Verifies the current business repo, git, Claude Code, and `/mb-start` skill wiring, then prints the exact `claude` command or launches it with `--launch`. Supports `--json`. |
-| `mb validate` | Frontmatter shape check across `core/`, `research/`, `decisions/`, `bets/`, `log/`, `pushes/`, legacy `campaigns/`, and `documents/`. Exit 1 on any fail. |
+| `mb validate` | Frontmatter shape check across current business repo folders, with compatibility reads for old migrated surfaces where needed. Exit 1 on any fail. |
 | `mb graph` | Walk linked_research / linked_decisions / supersedes; emit Graphviz DOT to stdout. `--open` shells to `dot` + `open`. |
 | `mb similar-bets` | Find similar past bets and offer outcomes from repo truth. |
 | `mb checkpoint` | Plan or save a business-readable git checkpoint. |

--- a/mb/mb/_data/templates/AGENTS.md.tmpl
+++ b/mb/mb/_data/templates/AGENTS.md.tmpl
@@ -368,8 +368,9 @@ the operator asks for plumbing.
   work.
 - If onboarding is incomplete, use the `onboarding.summary` and checklist from
   status instead of inventing a setup interview.
-- If legacy `campaigns/` records exist, surface the doctor warning and suggest
-  `mb migrate campaigns --plan` before creating new coordinated work.
+- Use current Main Branch paths for new work. If status or doctor facts report
+  old structural paths, treat them as migration input and follow the repair
+  plan before creating new coordinated work.
 - If the operator asks for publishing, spend, provider mutation, customer
   contact, migration, checkpoint creation, or file writes, plan first and ask
   for explicit approval.

--- a/mb/mb/_data/templates/CLAUDE.md.tmpl
+++ b/mb/mb/_data/templates/CLAUDE.md.tmpl
@@ -120,10 +120,9 @@ detail:" line after the owner meaning.
 - `pushes/` — coordinated pushes (launches, drops, challenges, promos, etc.)
 - `documents/` — anything that doesn't belong above
 
-If your repo has a legacy `campaigns/` folder from before the push primitive
-decision, `mb` continues to read it. New coordinated work should land in
-`pushes/`. Run `mb doctor` to see whether your repo is on the current shape
-and `mb migrate campaigns --plan` to preview a safe move.
+Use current Main Branch paths for new work. If `mb status` or `mb doctor`
+reports old structural paths, treat them as migration input and follow the
+repair plan before relying on them.
 
 ## Hub and child repos
 

--- a/mb/mb/codex.py
+++ b/mb/mb/codex.py
@@ -1161,8 +1161,9 @@ the operator asks for plumbing.
   work.
 - If onboarding is incomplete, use the `onboarding.summary` and checklist from
   status instead of inventing a setup interview.
-- If legacy `campaigns/` records exist, surface the doctor warning and suggest
-  `mb migrate campaigns --plan` before creating new coordinated work.
+- Use current Main Branch paths for new work. If status or doctor facts report
+  old structural paths, treat them as migration input and follow the repair
+  plan before creating new coordinated work.
 - If the operator asks for publishing, spend, provider mutation, customer
   contact, migration, checkpoint creation, or file writes, plan first and ask
   for explicit approval.

--- a/mb/tests/test_init.py
+++ b/mb/tests/test_init.py
@@ -261,10 +261,22 @@ def test_init_scaffolds_folders(tmp_path: Path) -> None:
     assert "Never commit API keys" in claude_md
     assert "`bets/`" in claude_md
     # CLAUDE.md teaches the canonical push primitive and the optional
-    # vocabulary file; legacy campaigns/ appears only as compatibility.
+    # vocabulary file without carrying retired folder vocabulary into every
+    # fresh repo.
     assert "`pushes/`" in claude_md
     assert "core/vocabulary.md" in claude_md
-    assert "legacy `campaigns/`" in claude_md
+    retired_generated_terms = (
+        "reference/core",
+        "reference/offers",
+        "reference/domain",
+        "campaigns/",
+        "outputs/",
+        "ship-bet",
+        "weekly-review",
+    )
+    for term in retired_generated_terms:
+        assert term not in claude_md
+        assert term not in agents_md
     _assert_claude_md_cli_first_contract(claude_md)
     _assert_claude_md_primitive_routing_contract(claude_md)
     _assert_agents_md_codex_start_contract(agents_md)

--- a/mb/tests/test_taxonomy_guardrails.py
+++ b/mb/tests/test_taxonomy_guardrails.py
@@ -1,0 +1,96 @@
+"""Guard current agent guidance from retired Main Branch taxonomy."""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+CURRENT_GUIDANCE_FILES = [
+    *sorted((REPO_ROOT / ".claude" / "skills").rglob("*.md")),
+    *sorted((REPO_ROOT / ".claude" / "reference" / "business-primitives").rglob("*.md")),
+    REPO_ROOT / "docs" / "operator-loops.md",
+    REPO_ROOT / "docs" / "roadmap.md",
+    REPO_ROOT / "mb" / "README.md",
+]
+
+GENERATED_GUIDANCE_FILES = [
+    REPO_ROOT / "mb" / "mb" / "_data" / "templates" / "CLAUDE.md.tmpl",
+    REPO_ROOT / "mb" / "mb" / "_data" / "templates" / "AGENTS.md.tmpl",
+]
+
+RETIRED_STRUCTURAL_TERMS = (
+    "reference/core",
+    "reference/offers",
+    "reference/domain",
+    "campaigns/",
+    "outputs/",
+    "ship-bet",
+    "weekly-review",
+)
+
+EXPLICIT_LEGACY_CONTEXT = (
+    "legacy",
+    "old ",
+    "older ",
+    "migration",
+    "migrate",
+    "doctor",
+    "repair",
+    "compatibility",
+    "historical",
+    "retired",
+)
+
+FORBIDDEN_ALIAS_PHRASES = (
+    "compatibility bridges",
+    "compatibility aliases",
+    "treat them as aliases",
+    "aliases, not duplicate",
+    'test -d "core" || test -d "reference/core"',
+)
+
+
+def _window(lines: list[str], line_number: int) -> str:
+    start = max(0, line_number - 3)
+    end = min(len(lines), line_number + 2)
+    return " ".join(lines[start:end]).lower()
+
+
+def test_current_guidance_uses_retired_paths_only_in_explicit_legacy_context() -> None:
+    violations: list[str] = []
+    for path in CURRENT_GUIDANCE_FILES:
+        text = path.read_text()
+        lines = text.splitlines()
+        for index, line in enumerate(lines, start=1):
+            lowered = line.lower()
+            if not any(term in lowered for term in RETIRED_STRUCTURAL_TERMS):
+                continue
+            context = _window(lines, index)
+            if not any(marker in context for marker in EXPLICIT_LEGACY_CONTEXT):
+                rel = path.relative_to(REPO_ROOT)
+                violations.append(f"{rel}:{index}: {line.strip()}")
+
+    assert violations == []
+
+
+def test_current_guidance_does_not_teach_legacy_aliases() -> None:
+    violations: list[str] = []
+    for path in CURRENT_GUIDANCE_FILES + GENERATED_GUIDANCE_FILES:
+        text = path.read_text().lower()
+        for phrase in FORBIDDEN_ALIAS_PHRASES:
+            if phrase in text:
+                rel = path.relative_to(REPO_ROOT)
+                violations.append(f"{rel}: {phrase}")
+
+    assert violations == []
+
+
+def test_generated_guidance_omits_retired_structural_terms() -> None:
+    violations: list[str] = []
+    for path in GENERATED_GUIDANCE_FILES:
+        text = path.read_text().lower()
+        for term in RETIRED_STRUCTURAL_TERMS:
+            if term in text:
+                rel = path.relative_to(REPO_ROOT)
+                violations.append(f"{rel}: {term}")
+
+    assert violations == []

--- a/mb/tests/test_taxonomy_guardrails.py
+++ b/mb/tests/test_taxonomy_guardrails.py
@@ -2,6 +2,8 @@
 
 from pathlib import Path
 
+from mb import codex as codex_mod
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 CURRENT_GUIDANCE_FILES = [
@@ -11,6 +13,8 @@ CURRENT_GUIDANCE_FILES = [
     REPO_ROOT / "docs" / "roadmap.md",
     REPO_ROOT / "mb" / "README.md",
 ]
+
+PRIMARY_SKILL_FILES = sorted((REPO_ROOT / ".claude" / "skills").glob("*/SKILL.md"))
 
 GENERATED_GUIDANCE_FILES = [
     REPO_ROOT / "mb" / "mb" / "_data" / "templates" / "CLAUDE.md.tmpl",
@@ -25,6 +29,12 @@ RETIRED_STRUCTURAL_TERMS = (
     "outputs/",
     "ship-bet",
     "weekly-review",
+)
+
+RETIRED_REPO_STRUCTURE_TERMS = (
+    "reference/core",
+    "reference/offers",
+    "reference/domain",
 )
 
 EXPLICIT_LEGACY_CONTEXT = (
@@ -55,6 +65,24 @@ def _window(lines: list[str], line_number: int) -> str:
     return " ".join(lines[start:end]).lower()
 
 
+def _generated_guidance_texts() -> list[tuple[str, str]]:
+    rendered_global_skills = [
+        (
+            f"render_codex_global_skill_md:{skill_name}",
+            codex_mod.render_codex_global_skill_md(skill_name),
+        )
+        for skill_name in codex_mod.CODEX_GLOBAL_SKILL_NAMES
+    ]
+    return [
+        *[
+            (str(path.relative_to(REPO_ROOT)), path.read_text())
+            for path in GENERATED_GUIDANCE_FILES
+        ],
+        ("render_agents_md", codex_mod.render_agents_md(REPO_ROOT)),
+        *rendered_global_skills,
+    ]
+
+
 def test_current_guidance_uses_retired_paths_only_in_explicit_legacy_context() -> None:
     violations: list[str] = []
     for path in CURRENT_GUIDANCE_FILES:
@@ -68,6 +96,18 @@ def test_current_guidance_uses_retired_paths_only_in_explicit_legacy_context() -
             if not any(marker in context for marker in EXPLICIT_LEGACY_CONTEXT):
                 rel = path.relative_to(REPO_ROOT)
                 violations.append(f"{rel}:{index}: {line.strip()}")
+
+    assert violations == []
+
+
+def test_primary_skills_do_not_name_retired_repo_structure() -> None:
+    violations: list[str] = []
+    for path in PRIMARY_SKILL_FILES:
+        text = path.read_text().lower()
+        for term in RETIRED_REPO_STRUCTURE_TERMS:
+            if term in text:
+                rel = path.relative_to(REPO_ROOT)
+                violations.append(f"{rel}: {term}")
 
     assert violations == []
 
@@ -86,11 +126,10 @@ def test_current_guidance_does_not_teach_legacy_aliases() -> None:
 
 def test_generated_guidance_omits_retired_structural_terms() -> None:
     violations: list[str] = []
-    for path in GENERATED_GUIDANCE_FILES:
-        text = path.read_text().lower()
+    for name, rendered_text in _generated_guidance_texts():
+        text = rendered_text.lower()
         for term in RETIRED_STRUCTURAL_TERMS:
             if term in text:
-                rel = path.relative_to(REPO_ROOT)
-                violations.append(f"{rel}: {term}")
+                violations.append(f"{name}: {term}")
 
     assert violations == []


### PR DESCRIPTION
## Summary

Purges retired folder-taxonomy vocabulary from current agent-facing Main Branch guidance and generated business-repo instructions. Old `reference/*`, `campaigns/`, and `outputs/` handling remains in explicit migration, repair, or historical contexts.

## Linked issue

Closes #759
Refs #756, #743

## Why

Broad agent search could still surface retired structural names as plausible current write targets, even though the current product model is `core/`, `core/offers/`, `research/`, `decisions/`, `bets/`, `pushes/`, `playbooks/`, `log/`, and `documents/`. This keeps engine compatibility for old repos while removing legacy topology from the normal skill path.

## Commits by concern

- [x] `1f830f9 [update] Purge legacy taxonomy guidance`
  - rewrites current skill and generated guidance away from retired path aliases
  - marks key historical decisions with `agent_visibility: historical_context_only`
  - adds taxonomy regression tests for current and generated guidance
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`

## Validation

Pre-push gate from repo root:

```bash
scripts/check.sh
```

Level 1 static: `scripts/check.sh` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: `0` — log: `93 files already formatted`; `All checks passed!`; mypy success; `826` pytest items passed; `mb skill validate --all --json` reported `errors: 0`, `warnings: 0`.

Level 2 CLI contract: `pytest tests/test_taxonomy_guardrails.py tests/test_init.py -q` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: `0` — log: `9 passed in 1.98s`.

Level 3 package/install smoke: `(cd mb && /Library/Frameworks/Python.framework/Versions/3.13/bin/python3 -m build) && /Library/Frameworks/Python.framework/Versions/3.13/bin/python3 -m venv /tmp/mainbranch-smoke-main-460 && /tmp/mainbranch-smoke-main-460/bin/pip install mb/dist/*.whl && /tmp/mainbranch-smoke-main-460/bin/mb --version && /tmp/mainbranch-smoke-main-460/bin/mb skill list` — runtime: `/tmp/mainbranch-smoke-main-460/bin/python` — exit: `0` — log: wheel built, installed, `mb --version` and `mb skill list` succeeded.

Level 4 fixture repo: `/tmp/mainbranch-smoke-main-460/bin/mb onboard --yes --name "Taxonomy Smoke" --path "$tmpdir/test-business" && cd "$tmpdir/test-business" && /tmp/mainbranch-smoke-main-460/bin/mb doctor && /tmp/mainbranch-smoke-main-460/bin/mb status && /tmp/mainbranch-smoke-main-460/bin/mb start --json && /tmp/mainbranch-smoke-main-460/bin/mb validate` — runtime: `/tmp/mainbranch-smoke-main-460/bin/mb` — exit: `0` — log: fresh installed-wheel repo onboard, doctor, status, start JSON, and validate all succeeded.

Level 5 runtime smoke: not required because this branch changes guidance prose, generated templates, docs, and regression checks; it does not change slash-command discovery or runtime invocation behavior.

- [x] Level 1 static: `scripts/check.sh` passes
- [x] Level 2 CLI contract: focused guidance/template regression tests passed
- [x] Level 3 package/install smoke
- [x] Level 4 fixture repo
- [ ] Level 5 runtime smoke / dogfood harness / simulation-tier (not required; no runtime discovery or invocation change)
- [x] SKILL.md <=500 lines
- [ ] Package-visible release gate evidence before tag/publish (not preparing a release)
- [ ] Supply-chain review (not touched)

## Success metric

Current skills and generated `AGENTS.md` / `CLAUDE.md` no longer teach retired structural paths as aliases, bridges, choices, or normal write targets, and regression tests fail if those terms re-enter current guidance outside explicit legacy/migration contexts.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [ ] N/A — change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [x] No
- [ ] Yes — migration note below

## Public / private boundary

No private operator strategy, machine-specific paths, secrets, credentials, customer/member data, or Conductor-local preference details were committed. The branch keeps legacy repo support in migration/repair facts rather than publishing private local workflow context.
