### PR TITLE
[add] mb-bet shared workflow source

### DIFF
--- a/.claude/skills/mb-bet/SKILL.md
+++ b/.claude/skills/mb-bet/SKILL.md
@@ -6,6 +6,64 @@ loops: [decide, reflect, ship]
 
 # Bet
 
+**Shared source:** The portable workflow contract lives in
+`workflows/mb-bet/workflow.md`. This Claude skill is the Claude Code shell over
+that source.
+
+**Shared contract markers:** Keep these aligned with the shared source.
+
+Required commands:
+
+- `mb status --json --peek`
+- `mb start --json`
+- `mb doctor repair --plan`
+- `mb validate --cross-refs --json`
+- `mb checkpoint --plan --json`
+- `mb similar-bets "<thesis>" --repo . --json`
+- `mb books exposure --repo . --bet bets/YYYY-MM-DD-slug.md --json`
+- `mb books exposure --repo . --active --json`
+
+Required fact paths:
+
+- `money_path`
+- `money_path.objects.proof.quality`
+- `validation.file_contracts`
+- `content_strategy`
+- `ranked_actions`
+- `update`
+- `readiness`
+- `drift.items`
+- `brain.bets`
+- `brain.bets.active`
+- `brain.bets.due_soon`
+- `brain.bets.overdue`
+- `brain.bets.exit_criteria`
+- `relationship_health.sections.bets`
+- `relationship_health.gaps`
+- `checkpoint.pending`
+- `checkpoint.pending.blockers`
+- `books`
+- `runtime.codex_cli`
+- `runtime.claude_code`
+
+Approval gates: `updates_repairs_migrations`, `file_writes`, `checkpoint`,
+`provider_mutation`, `publishing_or_spend`, `customer_contact`, `private_data`,
+`destructive_operations`, `structured_collection`, and
+`public_issue_or_proposal`.
+
+Public/private boundaries: `no_secrets`, `no_raw_provider_exports`,
+`no_raw_transcripts`, `no_customer_member_data`,
+`no_private_runtime_settings`, `no_private_dms_or_gated_communities`,
+`no_raw_finance_legal_records`, and `no_raw_ledger_rows`.
+
+Core flow: Bet is a time-boxed wager, not an offer or push. Preserve new,
+update, close, list, and narrate modes.
+Marker phrase: new, update, close, list, and narrate.
+Keep `bets/YYYY-MM-DD-slug.md` and the strict contract for typed links and
+reverse `linked_bets`; aggregate exposure privacy; public-safe narration;
+`mb validate --cross-refs`; checkpoint plan; and the Codex support boundary of
+read-only planning until runtime smoke proves lifecycle writes.
+
 Business bets are hub nodes in `bets/`. They connect decisions, research,
 pushes, logs, documents, and outcomes without replacing any of them. Legacy
 `campaigns/` records may still be linked for old repos, but new coordinated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ### Changed
 
+- Migrated the mb-bet lifecycle to a shared workflow source with checked Claude
+  and Codex shells, preserving read-only Codex boundaries until runtime smoke
+  proves write support. Closes #751.
 - Purged retired folder-taxonomy vocabulary from current agent-facing guidance
   and generated business-repo instructions, keeping old `reference/*`,
   `campaigns/`, and `outputs/` handling in explicit migration/repair contexts.

--- a/mb/mb/codex.py
+++ b/mb/mb/codex.py
@@ -193,7 +193,12 @@ CODEX_GLOBAL_SKILL_DESCRIPTIONS = {
 CODEX_GLOBAL_SKILL_FACTS: dict[str, tuple[str, ...]] = {
     **CODEX_SLASH_COMMAND_FACTS,
     "main-branch": REQUIRED_FACT_COMMANDS,
-    "mb-bet": ("mb status --json --peek", "mb validate --json"),
+    "mb-bet": (
+        "mb status --json --peek",
+        "mb start --json",
+        "mb validate --cross-refs --json",
+        "mb checkpoint --plan --json",
+    ),
     "mb-ads": ("mb status --json --peek", "mb connect doctor --json"),
     "mb-organic": ("mb status --json --peek",),
     "mb-site": ("mb status --json --peek", "mb site check --json"),
@@ -225,6 +230,7 @@ CODEX_THINK_SOURCE_WORKFLOW = "workflows/mb-think/workflow.md"
 CODEX_START_STATUS_SOURCE_WORKFLOW = "workflows/mb-start-status/workflow.md"
 CODEX_SETUP_SOURCE_WORKFLOW = "workflows/mb-setup/workflow.md"
 CODEX_MAINTENANCE_REPAIR_SOURCE_WORKFLOW = "workflows/mb-maintenance-repair/workflow.md"
+CODEX_BET_SOURCE_WORKFLOW = "workflows/mb-bet/workflow.md"
 CODEX_THINK_REQUIRED_MB_COMMANDS = (
     "mb status --json --peek",
     "mb start --json",
@@ -323,6 +329,60 @@ CODEX_END_PUBLIC_PRIVATE_BOUNDARIES = (
     "no_private_runtime_settings",
     "no_raw_finance_legal_records",
 )
+CODEX_BET_REQUIRED_MB_COMMANDS = (
+    "mb status --json --peek",
+    "mb start --json",
+    "mb doctor repair --plan",
+    "mb validate --cross-refs --json",
+    "mb checkpoint --plan --json",
+    'mb similar-bets "<thesis>" --repo . --json',
+    "mb books exposure --repo . --bet bets/YYYY-MM-DD-slug.md --json",
+    "mb books exposure --repo . --active --json",
+)
+CODEX_BET_REQUIRED_JSON_FACTS = (
+    "money_path",
+    "money_path.objects.proof.quality",
+    "validation.file_contracts",
+    "content_strategy",
+    "ranked_actions",
+    "update",
+    "readiness",
+    "drift.items",
+    "brain.bets",
+    "brain.bets.active",
+    "brain.bets.due_soon",
+    "brain.bets.overdue",
+    "brain.bets.exit_criteria",
+    "relationship_health.sections.bets",
+    "relationship_health.gaps",
+    "checkpoint.pending",
+    "checkpoint.pending.blockers",
+    "books",
+    "runtime.codex_cli",
+    "runtime.claude_code",
+)
+CODEX_BET_APPROVAL_GATES = (
+    "updates_repairs_migrations",
+    "file_writes",
+    "checkpoint",
+    "provider_mutation",
+    "publishing_or_spend",
+    "customer_contact",
+    "private_data",
+    "destructive_operations",
+    "structured_collection",
+    "public_issue_or_proposal",
+)
+CODEX_BET_PUBLIC_PRIVATE_BOUNDARIES = (
+    "no_secrets",
+    "no_raw_provider_exports",
+    "no_raw_transcripts",
+    "no_customer_member_data",
+    "no_private_runtime_settings",
+    "no_private_dms_or_gated_communities",
+    "no_raw_finance_legal_records",
+    "no_raw_ledger_rows",
+)
 CODEX_SHARED_WORKFLOW_SKILLS = {
     "mb-start": CODEX_START_STATUS_SOURCE_WORKFLOW,
     "mb-status": CODEX_START_STATUS_SOURCE_WORKFLOW,
@@ -331,6 +391,7 @@ CODEX_SHARED_WORKFLOW_SKILLS = {
     "mb-doctor": CODEX_MAINTENANCE_REPAIR_SOURCE_WORKFLOW,
     "mb-think": CODEX_THINK_SOURCE_WORKFLOW,
     "mb-end": CODEX_END_SOURCE_WORKFLOW,
+    "mb-bet": CODEX_BET_SOURCE_WORKFLOW,
 }
 REQUIRED_LIFECYCLE_GUIDANCE = (
     "## Codex Lifecycle Workflow Index",
@@ -625,20 +686,34 @@ CODEX_WORKFLOW_INVENTORY: tuple[dict[str, Any], ...] = (
         "claude_surface": "/mb-bet",
         "claude_skill_sources": ("mb-bet",),
         "codex_status": "read_only_planning",
-        "source_status": "pending_shared_source_migration",
-        "codex_surface": "Read-only facts and business-file planning only",
+        "source_status": "shared_workflow_source",
+        "codex_surface": "Read-only planning and file guidance through global mb-bet skill",
         "codex_entrypoints": ("main-branch mb-bet",),
-        "commands": ("mb status --json --peek", "mb validate --json"),
+        "shared_source": CODEX_BET_SOURCE_WORKFLOW,
+        "commands": CODEX_BET_REQUIRED_MB_COMMANDS,
+        "contract_checks": (
+            "intent",
+            "required_mb_commands",
+            "required_json_facts",
+            "approval_gates",
+            "read_boundaries",
+            "write_boundaries",
+            "bet_lifecycle_modes",
+            "bet_file_contract",
+            "typed_links_and_reverse_links",
+            "cross_ref_validation",
+            "aggregate_exposure_privacy",
+            "public_narration_boundary",
+            "codex_read_only_planning_boundary",
+            "core_flow",
+            "public_private_boundaries",
+        ),
         "status_reason": (
-            "Bet creation, update, close, and narrate write durable business memory; "
-            "Codex execution needs a shared bet workflow source first."
+            "Bet lifecycle substance has a shared source, but Codex remains "
+            "read-only planning and file guidance until runtime smoke proves "
+            "lifecycle writes."
         ),
-        "next_required_issue": "#751",
-        "follow_up_issue": "https://github.com/noontide-co/mainbranch/issues/751",
-        "notes": (
-            "Codex may inspect and discuss bets. A generated Codex shell should "
-            "wait for a shared bet workflow source."
-        ),
+        "notes": "Codex may inspect bet facts, explain contract gaps, and propose guarded edits.",
     },
     {
         "id": "ads",

--- a/mb/mb/workflows.py
+++ b/mb/mb/workflows.py
@@ -111,6 +111,18 @@ REQUIRED_SHELL_PHRASES_BY_WORKFLOW: dict[str, dict[str, str]] = {
         "safe-to-apply state": "safe-to-apply",
         "post-repair status": "rerun `mb status --json --peek`",
     },
+    "mb-bet": {
+        "bet lifecycle modes": "new, update, close, list, and narrate",
+        "bet file contract": "bets/YYYY-MM-DD-slug.md",
+        "bet not offer or push": "Bet is a time-boxed wager",
+        "strict bet contract": "strict contract",
+        "reverse links": "linked_bets",
+        "cross-ref validation": "mb validate --cross-refs",
+        "exposure privacy": "aggregate exposure",
+        "public narration": "public-safe narration",
+        "checkpoint boundary": "checkpoint plan",
+        "Codex support boundary": "read-only planning",
+    },
 }
 CODEX_FORBIDDEN_PHRASES_BY_WORKFLOW: dict[str, tuple[str, ...]] = {
     "mb-think": (
@@ -150,6 +162,15 @@ CODEX_FORBIDDEN_PHRASES_BY_WORKFLOW: dict[str, tuple[str, ...]] = {
         "Claude Code slash commands work inside Codex",
         "Claude slash commands",
         "slash-command parity",
+    ),
+    "mb-bet": (
+        "Run `/mb-bet`",
+        "Claude Code skills work in Codex",
+        "Claude Code slash commands work inside Codex",
+        "Claude slash commands",
+        "slash-command parity",
+        "Codex can create bets",
+        "Codex can close bets",
     ),
 }
 PUBLIC_PRIVATE_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
@@ -416,6 +437,8 @@ def render_claude_shell(workflow: WorkflowSource) -> str:
         return _render_think_claude_shell(workflow)
     if workflow.name == "mb-end":
         return _render_end_claude_shell(workflow)
+    if workflow.name == "mb-bet":
+        return _render_bet_claude_shell(workflow)
     if workflow.name in {"mb-start-status", "mb-setup", "mb-maintenance-repair"}:
         return _render_daily_claude_shell(workflow)
     return _render_start_money_path_claude_shell(workflow)
@@ -669,6 +692,8 @@ def render_codex_shell(workflow: WorkflowSource) -> str:
         return _render_think_codex_shell(workflow)
     if workflow.name == "mb-end":
         return _render_end_codex_shell(workflow)
+    if workflow.name == "mb-bet":
+        return _render_bet_codex_shell(workflow)
     if workflow.name in {"mb-start-status", "mb-setup", "mb-maintenance-repair"}:
         return _render_daily_codex_shell(workflow)
     return _render_start_money_path_codex_shell(workflow)
@@ -919,6 +944,155 @@ Approval needed before writes: yes.
 ```
 Do not tell Codex users to run Claude Code entrypoints. Runtime smoke is
 required before docs say this selected workflow is supported in Codex.
+"""
+    return output
+
+
+def _render_bet_claude_shell(workflow: WorkflowSource) -> str:
+    """Render a Claude Code shell snapshot for the bet lifecycle workflow."""
+
+    output = f"""# Generated Claude Shell: {workflow.title}
+
+Source workflow: `{_display_path(workflow.path)}`
+Runtime support: `claude_code: supported_shell`
+Approval gates: {_inline_code_list(workflow.approval_gates)}
+Public/private boundaries: {_inline_code_list(workflow.public_private_boundaries)}
+
+Use from `/mb-bet` when the operator wants to create, update, close, list, or
+narrate bets. Preserve the existing Claude skill's mode language, approval
+gates, artifact routing, and finance/privacy boundaries.
+
+This snapshot does not replace shipped `.claude/skills/mb-bet/SKILL.md`.
+
+## Required mb Commands
+
+{_bullet_list(workflow.required_mb_commands)}
+
+## Required JSON Fact Paths
+
+{_bullet_list(workflow.json_facts)}
+
+## Routing
+
+1. Read deterministic facts first: status, start when runtime facts matter,
+   repair plan when blockers appear, validation, relationship health,
+   checkpoint plan, similar-bets for repeated material theses, and aggregate
+   exposure for financially material bets.
+2. Bet is a time-boxed wager, not an offer or push. Offers are durable things
+   sold; pushes coordinate execution. Bets carry hypothesis, appetite, target,
+   deadline, evidence, kill or double-down logic, and verdict.
+3. Support new, update, close, list, and narrate modes. Create or edit
+   `bets/YYYY-MM-DD-slug.md` only after approval, and keep the strict contract:
+   frontmatter fields, body sections, typed links, reverse `linked_bets`, and
+   `## Related links`.
+4. For updates, append dated evidence and links without filling `result` unless
+   there is a measured result. For close, record verdict, learning, outcomes,
+   and graduation route without rewriting failed bets as success.
+5. Use `mb validate --cross-refs --json` after bet or link edits. Use the
+   checkpoint plan before offering an approval-gated save.
+6. For financially material bets, use aggregate exposure only. Never paste raw
+   ledger rows, payees, account names, vault paths, transaction memos, provider
+   exports, customer/member records, or secrets.
+7. Public-safe narration must come from accepted repo truth. Do not invent
+   metrics, results, testimonials, channels, or proof. If `public: false`, ask
+   before drafting public copy.
+8. Do not publish, spend, contact customers, mutate providers, create dashboard
+   work, or promote bet learning into offer truth without accepted evidence,
+   an accepted decision, and explicit approval.
+
+## Handoff Shape
+
+```text
+Bet mode: <new, update, close, list, or narrate>.
+Facts read: <status/start/validate/relationship/exposure/similar-bets facts>.
+Bet: <path, status, deadline, appetite, metric, target>.
+Evidence: <new evidence, missing evidence, or measured result>.
+Exit posture: <kill, double-down, continue, close, or unclear>.
+Connections: <decisions, research, pushes, outcomes, offers, or none>.
+Public posture: <public-safe, private, needs approval, or not narration>.
+Write plan: <files to create/edit or none>.
+Approval needed before writes: <yes/no and exact action>.
+Next business action: <one clear owner-facing step>.
+```
+
+Use business language first. Keep legacy campaign links compatibility-only;
+new execution routes through pushes. Codex support stays read-only planning
+until runtime smoke proves bet lifecycle writes.
+"""
+    return output
+
+
+def _render_bet_codex_shell(workflow: WorkflowSource) -> str:
+    """Render Codex CLI guidance for the bet lifecycle workflow."""
+
+    output = f"""# Generated Codex Workflow Guidance: {workflow.title}
+
+Source workflow: `{_display_path(workflow.path)}`
+Runtime support: `codex_cli: {workflow.runtime_support.get("codex_cli", "")}`
+Approval gates: {_inline_code_list(workflow.approval_gates)}
+Public/private boundaries: {_inline_code_list(workflow.public_private_boundaries)}
+
+Codex uses the global Main Branch `mb-bet` skill as a read-only planning and
+file-guidance route. This guidance is generated from the engine workflow source
+and does not claim supported lifecycle writes or Claude Code entrypoints in
+Codex.
+
+## Required mb Commands
+
+{_bullet_list(workflow.required_mb_commands)}
+
+## Required JSON Fact Paths
+
+{_bullet_list(workflow.json_facts)}
+
+## Codex Route
+
+1. Use the business repo `AGENTS.md` bootstrap posture: read facts first, keep
+   writes approval-gated, and translate git/provider details into business
+   language.
+2. Read deterministic facts before raw markdown: status, start when runtime
+   facts matter, repair plan when blockers appear, validation, relationship
+   health, checkpoint plan, similar-bets for repeated material theses, and
+   aggregate exposure for financially material bets.
+3. Bet is a time-boxed wager, not an offer or push. Offers are durable things
+   sold; pushes coordinate execution. Bets carry hypothesis, appetite, target,
+   deadline, evidence, kill or double-down logic, and verdict.
+4. Guide new, update, close, list, and narrate modes from the shared contract,
+   but do not claim Codex can perform lifecycle writes until runtime smoke
+   proves that surface. Present proposed file edits and ask for explicit
+   approval before any durable write.
+5. Keep the strict contract for `bets/YYYY-MM-DD-slug.md`: frontmatter fields,
+   body sections, typed links, reverse `linked_bets`, and `## Related links`.
+6. Use `mb validate --cross-refs --json` after approved bet or link edits. Use
+   the checkpoint plan before offering an approval-gated save.
+7. For financially material bets, use aggregate exposure only. Never paste raw
+   ledger rows, payees, account names, vault paths, transaction memos, provider
+   exports, customer/member records, or secrets.
+8. Public-safe narration must come from accepted repo truth. Do not invent
+   metrics, results, testimonials, channels, or proof. If `public: false`, ask
+   before drafting public copy.
+9. Do not publish, spend, contact customers, mutate providers, create dashboard
+   work, or promote bet learning into offer truth without accepted evidence,
+   an accepted decision, and explicit approval.
+
+## Handoff Shape
+
+```text
+Bet mode: <new, update, close, list, or narrate>.
+Facts read: <status/start/validate/relationship/exposure/similar-bets facts>.
+Bet: <path, status, deadline, appetite, metric, target>.
+Evidence: <new evidence, missing evidence, or measured result>.
+Exit posture: <kill, double-down, continue, close, or unclear>.
+Connections: <decisions, research, pushes, outcomes, offers, or none>.
+Public posture: <public-safe, private, needs approval, or not narration>.
+Write plan: <files to create/edit or none>.
+Approval needed before writes: <yes/no and exact action>.
+Next business action: <one clear owner-facing step>.
+```
+
+Use business language first. Keep legacy campaign links compatibility-only;
+new execution routes through pushes. Runtime smoke is required before docs say
+this lifecycle is supported for Codex writes.
 """
     return output
 

--- a/mb/mb/workflows.py
+++ b/mb/mb/workflows.py
@@ -1068,14 +1068,15 @@ Codex.
 3. Bet is a time-boxed wager, not an offer or push. Offers are durable things
    sold; pushes coordinate execution. Bets carry hypothesis, appetite, target,
    deadline, evidence, kill or double-down logic, and verdict.
-4. Guide new, update, close, list, and narrate modes from the shared contract,
-   but do not claim Codex can perform lifecycle writes until runtime smoke
-   proves that surface. Present proposed file edits and ask for explicit
-   approval before any durable write.
+4. Guide new, update, close, list, and narrate modes from the shared contract.
+   Codex may draft patch-shaped recommendations and exact file targets, then
+   stop before changing files.
 5. Keep the strict contract for `bets/YYYY-MM-DD-slug.md`: frontmatter fields,
    body sections, typed links, reverse `linked_bets`, and `## Related links`.
-6. Use `mb validate --cross-refs --json` after approved bet or link edits. Use
-   the checkpoint plan before offering an approval-gated save.
+6. If the operator wants the proposed changes applied, route them to Claude
+   Code `/mb-bet` or another supported write surface until Codex lifecycle-write
+   smoke proves this route. Do not run checkpoint commands or post-change
+   validation as if Codex edited files.
 7. For financially material bets, use aggregate exposure only. Never paste raw
    ledger rows, payees, account names, vault paths, transaction memos, provider
    exports, customer/member records, or secrets.

--- a/mb/mb/workflows.py
+++ b/mb/mb/workflows.py
@@ -41,6 +41,10 @@ REQUIRED_RUNTIME_SUPPORT = {
     "claude_code": "supported_shell",
     "codex_cli": "owner_loop_shell",
 }
+ALLOWED_RUNTIME_SUPPORT_VALUES = {
+    "claude_code": {"supported_shell"},
+    "codex_cli": {"owner_loop_shell", "read_only_planning"},
+}
 MINIMUM_MB_COMMANDS = {
     "mb status --json --peek",
     "mb start --json",
@@ -300,8 +304,15 @@ def validate_workflow(path: Path) -> list[str]:
     else:
         for runtime, expected in REQUIRED_RUNTIME_SUPPORT.items():
             actual = runtime_support.get(runtime)
-            if actual != expected:
-                errors.append(f"runtime_support.{runtime} must be {expected!r}, got {actual!r}")
+            allowed = ALLOWED_RUNTIME_SUPPORT_VALUES.get(runtime, {expected})
+            if actual not in allowed:
+                if len(allowed) == 1:
+                    errors.append(f"runtime_support.{runtime} must be {expected!r}, got {actual!r}")
+                else:
+                    errors.append(
+                        f"runtime_support.{runtime} must be one of "
+                        f"{sorted(allowed)!r}, got {actual!r}"
+                    )
 
     runtime_surfaces = frontmatter.get("runtime_surfaces")
     if not isinstance(runtime_surfaces, dict):

--- a/mb/tests/fixtures/workflows/mb-bet.claude.md
+++ b/mb/tests/fixtures/workflows/mb-bet.claude.md
@@ -1,0 +1,93 @@
+# Generated Claude Shell: Bet Lifecycle
+
+Source workflow: `workflows/mb-bet/workflow.md`
+Runtime support: `claude_code: supported_shell`
+Approval gates: `updates_repairs_migrations`, `file_writes`, `checkpoint`, `provider_mutation`, `publishing_or_spend`, `customer_contact`, `private_data`, `destructive_operations`, `structured_collection`, `public_issue_or_proposal`
+Public/private boundaries: `no_secrets`, `no_raw_provider_exports`, `no_raw_transcripts`, `no_customer_member_data`, `no_private_runtime_settings`, `no_private_dms_or_gated_communities`, `no_raw_finance_legal_records`, `no_raw_ledger_rows`
+
+Use from `/mb-bet` when the operator wants to create, update, close, list, or
+narrate bets. Preserve the existing Claude skill's mode language, approval
+gates, artifact routing, and finance/privacy boundaries.
+
+This snapshot does not replace shipped `.claude/skills/mb-bet/SKILL.md`.
+
+## Required mb Commands
+
+- `mb status --json --peek`
+- `mb start --json`
+- `mb doctor repair --plan`
+- `mb validate --cross-refs --json`
+- `mb checkpoint --plan --json`
+- `mb similar-bets "<thesis>" --repo . --json`
+- `mb books exposure --repo . --bet bets/YYYY-MM-DD-slug.md --json`
+- `mb books exposure --repo . --active --json`
+
+## Required JSON Fact Paths
+
+- `money_path`
+- `money_path.objects.proof.quality`
+- `validation.file_contracts`
+- `content_strategy`
+- `ranked_actions`
+- `update`
+- `readiness`
+- `drift.items`
+- `brain.bets`
+- `brain.bets.active`
+- `brain.bets.due_soon`
+- `brain.bets.overdue`
+- `brain.bets.exit_criteria`
+- `relationship_health.sections.bets`
+- `relationship_health.gaps`
+- `checkpoint.pending`
+- `checkpoint.pending.blockers`
+- `books`
+- `runtime.codex_cli`
+- `runtime.claude_code`
+
+## Routing
+
+1. Read deterministic facts first: status, start when runtime facts matter,
+   repair plan when blockers appear, validation, relationship health,
+   checkpoint plan, similar-bets for repeated material theses, and aggregate
+   exposure for financially material bets.
+2. Bet is a time-boxed wager, not an offer or push. Offers are durable things
+   sold; pushes coordinate execution. Bets carry hypothesis, appetite, target,
+   deadline, evidence, kill or double-down logic, and verdict.
+3. Support new, update, close, list, and narrate modes. Create or edit
+   `bets/YYYY-MM-DD-slug.md` only after approval, and keep the strict contract:
+   frontmatter fields, body sections, typed links, reverse `linked_bets`, and
+   `## Related links`.
+4. For updates, append dated evidence and links without filling `result` unless
+   there is a measured result. For close, record verdict, learning, outcomes,
+   and graduation route without rewriting failed bets as success.
+5. Use `mb validate --cross-refs --json` after bet or link edits. Use the
+   checkpoint plan before offering an approval-gated save.
+6. For financially material bets, use aggregate exposure only. Never paste raw
+   ledger rows, payees, account names, vault paths, transaction memos, provider
+   exports, customer/member records, or secrets.
+7. Public-safe narration must come from accepted repo truth. Do not invent
+   metrics, results, testimonials, channels, or proof. If `public: false`, ask
+   before drafting public copy.
+8. Do not publish, spend, contact customers, mutate providers, create dashboard
+   work, or promote bet learning into offer truth without accepted evidence,
+   an accepted decision, and explicit approval.
+
+## Handoff Shape
+
+```text
+Bet mode: <new, update, close, list, or narrate>.
+Facts read: <status/start/validate/relationship/exposure/similar-bets facts>.
+Bet: <path, status, deadline, appetite, metric, target>.
+Evidence: <new evidence, missing evidence, or measured result>.
+Exit posture: <kill, double-down, continue, close, or unclear>.
+Connections: <decisions, research, pushes, outcomes, offers, or none>.
+Public posture: <public-safe, private, needs approval, or not narration>.
+Write plan: <files to create/edit or none>.
+Approval needed before writes: <yes/no and exact action>.
+Next business action: <one clear owner-facing step>.
+```
+
+Use business language first. Keep legacy campaign links compatibility-only;
+new execution routes through pushes. Codex support stays read-only planning
+until runtime smoke proves bet lifecycle writes.

--- a/mb/tests/fixtures/workflows/mb-bet.codex.md
+++ b/mb/tests/fixtures/workflows/mb-bet.codex.md
@@ -1,7 +1,7 @@
 # Generated Codex Workflow Guidance: Bet Lifecycle
 
 Source workflow: `workflows/mb-bet/workflow.md`
-Runtime support: `codex_cli: owner_loop_shell`
+Runtime support: `codex_cli: read_only_planning`
 Approval gates: `updates_repairs_migrations`, `file_writes`, `checkpoint`, `provider_mutation`, `publishing_or_spend`, `customer_contact`, `private_data`, `destructive_operations`, `structured_collection`, `public_issue_or_proposal`
 Public/private boundaries: `no_secrets`, `no_raw_provider_exports`, `no_raw_transcripts`, `no_customer_member_data`, `no_private_runtime_settings`, `no_private_dms_or_gated_communities`, `no_raw_finance_legal_records`, `no_raw_ledger_rows`
 

--- a/mb/tests/fixtures/workflows/mb-bet.codex.md
+++ b/mb/tests/fixtures/workflows/mb-bet.codex.md
@@ -1,0 +1,94 @@
+# Generated Codex Workflow Guidance: Bet Lifecycle
+
+Source workflow: `workflows/mb-bet/workflow.md`
+Runtime support: `codex_cli: owner_loop_shell`
+Approval gates: `updates_repairs_migrations`, `file_writes`, `checkpoint`, `provider_mutation`, `publishing_or_spend`, `customer_contact`, `private_data`, `destructive_operations`, `structured_collection`, `public_issue_or_proposal`
+Public/private boundaries: `no_secrets`, `no_raw_provider_exports`, `no_raw_transcripts`, `no_customer_member_data`, `no_private_runtime_settings`, `no_private_dms_or_gated_communities`, `no_raw_finance_legal_records`, `no_raw_ledger_rows`
+
+Codex uses the global Main Branch `mb-bet` skill as a read-only planning and
+file-guidance route. This guidance is generated from the engine workflow source
+and does not claim supported lifecycle writes or Claude Code entrypoints in
+Codex.
+
+## Required mb Commands
+
+- `mb status --json --peek`
+- `mb start --json`
+- `mb doctor repair --plan`
+- `mb validate --cross-refs --json`
+- `mb checkpoint --plan --json`
+- `mb similar-bets "<thesis>" --repo . --json`
+- `mb books exposure --repo . --bet bets/YYYY-MM-DD-slug.md --json`
+- `mb books exposure --repo . --active --json`
+
+## Required JSON Fact Paths
+
+- `money_path`
+- `money_path.objects.proof.quality`
+- `validation.file_contracts`
+- `content_strategy`
+- `ranked_actions`
+- `update`
+- `readiness`
+- `drift.items`
+- `brain.bets`
+- `brain.bets.active`
+- `brain.bets.due_soon`
+- `brain.bets.overdue`
+- `brain.bets.exit_criteria`
+- `relationship_health.sections.bets`
+- `relationship_health.gaps`
+- `checkpoint.pending`
+- `checkpoint.pending.blockers`
+- `books`
+- `runtime.codex_cli`
+- `runtime.claude_code`
+
+## Codex Route
+
+1. Use the business repo `AGENTS.md` bootstrap posture: read facts first, keep
+   writes approval-gated, and translate git/provider details into business
+   language.
+2. Read deterministic facts before raw markdown: status, start when runtime
+   facts matter, repair plan when blockers appear, validation, relationship
+   health, checkpoint plan, similar-bets for repeated material theses, and
+   aggregate exposure for financially material bets.
+3. Bet is a time-boxed wager, not an offer or push. Offers are durable things
+   sold; pushes coordinate execution. Bets carry hypothesis, appetite, target,
+   deadline, evidence, kill or double-down logic, and verdict.
+4. Guide new, update, close, list, and narrate modes from the shared contract,
+   but do not claim Codex can perform lifecycle writes until runtime smoke
+   proves that surface. Present proposed file edits and ask for explicit
+   approval before any durable write.
+5. Keep the strict contract for `bets/YYYY-MM-DD-slug.md`: frontmatter fields,
+   body sections, typed links, reverse `linked_bets`, and `## Related links`.
+6. Use `mb validate --cross-refs --json` after approved bet or link edits. Use
+   the checkpoint plan before offering an approval-gated save.
+7. For financially material bets, use aggregate exposure only. Never paste raw
+   ledger rows, payees, account names, vault paths, transaction memos, provider
+   exports, customer/member records, or secrets.
+8. Public-safe narration must come from accepted repo truth. Do not invent
+   metrics, results, testimonials, channels, or proof. If `public: false`, ask
+   before drafting public copy.
+9. Do not publish, spend, contact customers, mutate providers, create dashboard
+   work, or promote bet learning into offer truth without accepted evidence,
+   an accepted decision, and explicit approval.
+
+## Handoff Shape
+
+```text
+Bet mode: <new, update, close, list, or narrate>.
+Facts read: <status/start/validate/relationship/exposure/similar-bets facts>.
+Bet: <path, status, deadline, appetite, metric, target>.
+Evidence: <new evidence, missing evidence, or measured result>.
+Exit posture: <kill, double-down, continue, close, or unclear>.
+Connections: <decisions, research, pushes, outcomes, offers, or none>.
+Public posture: <public-safe, private, needs approval, or not narration>.
+Write plan: <files to create/edit or none>.
+Approval needed before writes: <yes/no and exact action>.
+Next business action: <one clear owner-facing step>.
+```
+
+Use business language first. Keep legacy campaign links compatibility-only;
+new execution routes through pushes. Runtime smoke is required before docs say
+this lifecycle is supported for Codex writes.

--- a/mb/tests/fixtures/workflows/mb-bet.codex.md
+++ b/mb/tests/fixtures/workflows/mb-bet.codex.md
@@ -56,14 +56,15 @@ Codex.
 3. Bet is a time-boxed wager, not an offer or push. Offers are durable things
    sold; pushes coordinate execution. Bets carry hypothesis, appetite, target,
    deadline, evidence, kill or double-down logic, and verdict.
-4. Guide new, update, close, list, and narrate modes from the shared contract,
-   but do not claim Codex can perform lifecycle writes until runtime smoke
-   proves that surface. Present proposed file edits and ask for explicit
-   approval before any durable write.
+4. Guide new, update, close, list, and narrate modes from the shared contract.
+   Codex may draft patch-shaped recommendations and exact file targets, then
+   stop before changing files.
 5. Keep the strict contract for `bets/YYYY-MM-DD-slug.md`: frontmatter fields,
    body sections, typed links, reverse `linked_bets`, and `## Related links`.
-6. Use `mb validate --cross-refs --json` after approved bet or link edits. Use
-   the checkpoint plan before offering an approval-gated save.
+6. If the operator wants the proposed changes applied, route them to Claude
+   Code `/mb-bet` or another supported write surface until Codex lifecycle-write
+   smoke proves this route. Do not run checkpoint commands or post-change
+   validation as if Codex edited files.
 7. For financially material bets, use aggregate exposure only. Never paste raw
    ledger rows, payees, account names, vault paths, transaction memos, provider
    exports, customer/member records, or secrets.

--- a/mb/tests/test_workflows.py
+++ b/mb/tests/test_workflows.py
@@ -27,7 +27,9 @@ SETUP_WORKFLOW = REPO_ROOT / "workflows" / "mb-setup" / "workflow.md"
 MAINTENANCE_REPAIR_WORKFLOW = REPO_ROOT / "workflows" / "mb-maintenance-repair" / "workflow.md"
 THINK_WORKFLOW = REPO_ROOT / "workflows" / "mb-think" / "workflow.md"
 END_WORKFLOW = REPO_ROOT / "workflows" / "mb-end" / "workflow.md"
+BET_WORKFLOW = REPO_ROOT / "workflows" / "mb-bet" / "workflow.md"
 SHIPPED_END_SKILL = REPO_ROOT / ".claude" / "skills" / "mb-end" / "SKILL.md"
+SHIPPED_BET_SKILL = REPO_ROOT / ".claude" / "skills" / "mb-bet" / "SKILL.md"
 FIXTURES = REPO_ROOT / "mb" / "tests" / "fixtures" / "workflows"
 AGENTS_TEMPLATE = REPO_ROOT / "mb" / "mb" / "_data" / "templates" / "AGENTS.md.tmpl"
 WORKFLOW_PATHS = [
@@ -37,6 +39,7 @@ WORKFLOW_PATHS = [
     MAINTENANCE_REPAIR_WORKFLOW,
     THINK_WORKFLOW,
     END_WORKFLOW,
+    BET_WORKFLOW,
 ]
 
 
@@ -133,12 +136,31 @@ def test_generated_end_claude_and_codex_snapshots_match_fixtures() -> None:
     )
 
 
+def test_generated_bet_claude_and_codex_snapshots_match_fixtures() -> None:
+    workflow = load_workflow(BET_WORKFLOW)
+
+    assert render_claude_shell(workflow) == (FIXTURES / "mb-bet.claude.md").read_text(
+        encoding="utf-8"
+    )
+    assert render_codex_shell(workflow) == (FIXTURES / "mb-bet.codex.md").read_text(
+        encoding="utf-8"
+    )
+
+
 def test_shipped_claude_end_skill_preserves_shared_workflow_contract() -> None:
     workflow = load_workflow(END_WORKFLOW)
     skill_text = SHIPPED_END_SKILL.read_text(encoding="utf-8")
 
     assert shell_drift_errors(workflow, skill_text) == []
     assert "workflows/mb-end/workflow.md" in skill_text
+
+
+def test_shipped_claude_bet_skill_preserves_shared_workflow_contract() -> None:
+    workflow = load_workflow(BET_WORKFLOW)
+    skill_text = SHIPPED_BET_SKILL.read_text(encoding="utf-8")
+
+    assert shell_drift_errors(workflow, skill_text) == []
+    assert "workflows/mb-bet/workflow.md" in skill_text
 
 
 def test_supported_shells_preserve_required_commands_and_json_facts() -> None:
@@ -191,6 +213,18 @@ def test_codex_contract_markers_match_end_workflow_source() -> None:
     assert tuple(workflow.approval_gates) == codex_mod.CODEX_END_APPROVAL_GATES
     assert (
         tuple(workflow.public_private_boundaries) == codex_mod.CODEX_END_PUBLIC_PRIVATE_BOUNDARIES
+    )
+
+
+def test_codex_contract_markers_match_bet_workflow_source() -> None:
+    workflow = load_workflow(BET_WORKFLOW)
+
+    assert codex_mod.CODEX_BET_SOURCE_WORKFLOW == "workflows/mb-bet/workflow.md"
+    assert tuple(workflow.required_mb_commands) == codex_mod.CODEX_BET_REQUIRED_MB_COMMANDS
+    assert tuple(workflow.json_facts) == codex_mod.CODEX_BET_REQUIRED_JSON_FACTS
+    assert tuple(workflow.approval_gates) == codex_mod.CODEX_BET_APPROVAL_GATES
+    assert (
+        tuple(workflow.public_private_boundaries) == codex_mod.CODEX_BET_PUBLIC_PRIVATE_BOUNDARIES
     )
 
 
@@ -454,7 +488,14 @@ def test_codex_workflow_inventory_command_lists_supported_and_pending_surfaces()
     assert by_id["ads"]["source_status"] == "blocked_by_provider_gates"
     assert by_id["ads"]["source_of_truth"]["next_required_issue"] == "#750"
     assert by_id["ads"]["source_of_truth"]["follow_up_issue"].endswith("/issues/750")
-    assert by_id["bets"]["source_of_truth"]["next_required_issue"] == "#751"
+    assert by_id["bets"]["codex_status"] == "read_only_planning"
+    assert by_id["bets"]["source_status"] == "shared_workflow_source"
+    assert by_id["bets"]["source_of_truth"]["shared_source"] == "workflows/mb-bet/workflow.md"
+    assert by_id["bets"]["source_of_truth"]["next_required_issue"] is None
+    assert by_id["bets"]["codex_entrypoints"] == ["main-branch mb-bet"]
+    assert (
+        "codex_read_only_planning_boundary" in by_id["bets"]["source_of_truth"]["contract_checks"]
+    )
     assert by_id["organic-content"]["source_of_truth"]["next_required_issue"] == "#752"
     assert by_id["site"]["source_of_truth"]["next_required_issue"] == "#749"
     assert by_id["google-ads-search-launch-playbook"]["surface_type"] == "playbook"
@@ -616,6 +657,7 @@ def test_codex_shared_global_skills_are_rendered_from_workflow_sources() -> None
         (MAINTENANCE_REPAIR_WORKFLOW, "mb-doctor"),
         (THINK_WORKFLOW, "mb-think"),
         (END_WORKFLOW, "mb-end"),
+        (BET_WORKFLOW, "mb-bet"),
     ):
         workflow = load_workflow(path)
         text = codex_mod.render_codex_global_skill_md(name)
@@ -628,6 +670,36 @@ def test_codex_shared_global_skills_are_rendered_from_workflow_sources() -> None
         assert "main-branch-owner-loop" not in text
         assert "plugin" not in text.lower()
         assert "slash" not in text.lower()
+
+
+def test_bet_runtime_shells_surface_lifecycle_contract_and_boundaries() -> None:
+    workflow = load_workflow(BET_WORKFLOW)
+
+    for shell in (render_claude_shell(workflow), render_codex_shell(workflow)):
+        assert "Bet is a time-boxed wager" in shell
+        assert "new, update, close, list, and narrate" in shell
+        assert "bets/YYYY-MM-DD-slug.md" in shell
+        assert "linked_bets" in shell
+        assert "aggregate exposure" in shell
+        assert "public-safe narration" in shell.lower()
+        assert "provider" in shell
+        assert "customer" in shell
+        assert "dashboard" in shell
+        assert "ledger rows" in shell
+
+
+def test_bet_codex_shell_keeps_read_only_planning_boundary() -> None:
+    workflow = load_workflow(BET_WORKFLOW)
+    shell = render_codex_shell(workflow)
+
+    assert codex_shell_policy_errors(workflow, shell) == []
+    assert "read-only planning" in shell
+    assert "file-guidance route" in shell
+    assert "does not claim supported lifecycle writes" in shell
+    assert "Runtime smoke is required before docs say" in shell
+    assert "this lifecycle is supported for Codex writes" in shell
+    assert "Run `/mb-bet`" not in shell
+    assert "slash" not in shell.lower()
 
 
 def test_codex_workflow_inventory_accounts_for_every_bundled_claude_skill() -> None:

--- a/mb/tests/test_workflows.py
+++ b/mb/tests/test_workflows.py
@@ -693,6 +693,8 @@ def test_bet_codex_shell_keeps_read_only_planning_boundary() -> None:
     shell = render_codex_shell(workflow)
 
     assert codex_shell_policy_errors(workflow, shell) == []
+    assert "Runtime support: `codex_cli: read_only_planning`" in shell
+    assert "owner_loop_shell" not in shell
     assert "read-only planning" in shell
     assert "file-guidance route" in shell
     assert "does not claim supported lifecycle writes" in shell

--- a/mb/tests/test_workflows.py
+++ b/mb/tests/test_workflows.py
@@ -700,8 +700,36 @@ def test_bet_codex_shell_keeps_read_only_planning_boundary() -> None:
     assert "does not claim supported lifecycle writes" in shell
     assert "Runtime smoke is required before docs say" in shell
     assert "this lifecycle is supported for Codex writes" in shell
+    assert "patch-shaped recommendations" in shell
+    assert "stop before changing files" in shell
+    assert "supported write surface" in shell
     assert "Run `/mb-bet`" not in shell
     assert "slash" not in shell.lower()
+
+
+def test_read_only_planning_codex_shells_do_not_execute_write_language() -> None:
+    workflow = load_workflow(BET_WORKFLOW)
+    shell = render_codex_shell(workflow).lower()
+
+    forbidden = (
+        "approved durable write",
+        "approved bet edits",
+        "approved bet or link edits",
+        "after approved edits",
+        "after approved bet",
+        "before any durable write",
+        "after any durable write",
+        "checkpoint save",
+        "approval-gated save",
+        "offering a save",
+        "offering an approval-gated save",
+        "after bet or link edits",
+        "after approved bet or link edits",
+        "use the checkpoint plan before offering",
+    )
+
+    for phrase in forbidden:
+        assert phrase not in shell
 
 
 def test_codex_workflow_inventory_accounts_for_every_bundled_claude_skill() -> None:

--- a/workflows/mb-bet/workflow.md
+++ b/workflows/mb-bet/workflow.md
@@ -8,7 +8,7 @@ loops:
   - ship
 runtime_support:
   claude_code: supported_shell
-  codex_cli: owner_loop_shell
+  codex_cli: read_only_planning
 runtime_surfaces:
   claude_code: .claude/skills/mb-bet/SKILL.md
   codex_cli: global Main Branch mb-bet skill
@@ -299,6 +299,6 @@ gates, artifact routing, and finance/privacy boundaries from that shell.
 Codex uses the global Main Branch `mb-bet` skill generated from this workflow
 source. Codex support remains read-only planning and file guidance until runtime
 smoke proves lifecycle writes. It may inspect deterministic facts, explain bet
-contract gaps, propose edits, and ask for approval, but it must not claim
-supported lifecycle execution, provider mutation, publishing, spend, customer
-contact, or Claude Code entrypoints.
+contract gaps, propose guarded edits, and ask for approval, but it must not
+claim supported lifecycle execution, provider mutation, publishing, spend,
+customer contact, dashboard work, or Claude Code entrypoints.

--- a/workflows/mb-bet/workflow.md
+++ b/workflows/mb-bet/workflow.md
@@ -1,0 +1,304 @@
+---
+name: mb-bet
+title: Bet Lifecycle
+description: "Create, update, close, list, and narrate time-boxed Main Branch bets from deterministic facts and business-file contracts."
+loops:
+  - decide
+  - reflect
+  - ship
+runtime_support:
+  claude_code: supported_shell
+  codex_cli: owner_loop_shell
+runtime_surfaces:
+  claude_code: .claude/skills/mb-bet/SKILL.md
+  codex_cli: global Main Branch mb-bet skill
+required_mb_commands:
+  - mb status --json --peek
+  - mb start --json
+  - mb doctor repair --plan
+  - mb validate --cross-refs --json
+  - mb checkpoint --plan --json
+  - mb similar-bets "<thesis>" --repo . --json
+  - mb books exposure --repo . --bet bets/YYYY-MM-DD-slug.md --json
+  - mb books exposure --repo . --active --json
+json_facts:
+  - money_path
+  - money_path.objects.proof.quality
+  - validation.file_contracts
+  - content_strategy
+  - ranked_actions
+  - update
+  - readiness
+  - drift.items
+  - brain.bets
+  - brain.bets.active
+  - brain.bets.due_soon
+  - brain.bets.overdue
+  - brain.bets.exit_criteria
+  - relationship_health.sections.bets
+  - relationship_health.gaps
+  - checkpoint.pending
+  - checkpoint.pending.blockers
+  - books
+  - runtime.codex_cli
+  - runtime.claude_code
+approval_gates:
+  - updates_repairs_migrations
+  - file_writes
+  - checkpoint
+  - provider_mutation
+  - publishing_or_spend
+  - customer_contact
+  - private_data
+  - destructive_operations
+  - structured_collection
+  - public_issue_or_proposal
+public_private_boundaries:
+  - no_secrets
+  - no_raw_provider_exports
+  - no_raw_transcripts
+  - no_customer_member_data
+  - no_private_runtime_settings
+  - no_private_dms_or_gated_communities
+  - no_raw_finance_legal_records
+  - no_raw_ledger_rows
+writes_business_files: true
+provider_mutation: false
+publishing_or_spend: false
+---
+
+# Bet Lifecycle
+
+## Intent And Triggers
+
+Use this workflow when the operator wants to frame, inspect, update, close, list,
+or narrate a Main Branch bet. A bet is a time-boxed wager with an appetite,
+target, deadline, evidence path, and verdict. It is not an offer and it is not a
+push.
+
+Preserve these product distinctions:
+
+- Offer: the durable thing sold.
+- Push: coordinated execution.
+- Bet: the wager that tests a hypothesis and may link to pushes.
+
+A bet can graduate into an offer, push, decision, content pillar, workflow, or
+outcome only when accepted evidence or an accepted decision supports that move.
+Failed bets close with learning instead of being rewritten into success.
+
+Supported modes:
+
+- `new`: frame a bet and create `bets/YYYY-MM-DD-slug.md`.
+- `update`: append evidence, update links, and keep the verdict open.
+- `close`: record the measured result, verdict, learning, and graduation route.
+- `list`: summarize active, due, overdue, blocked, and exit-triggered bets.
+- `narrate`: draft public-safe narration from accepted repo truth.
+
+## Required Mb Commands
+
+- `mb status --json --peek`
+- `mb start --json`
+- `mb doctor repair --plan`
+- `mb validate --cross-refs --json`
+- `mb checkpoint --plan --json`
+- `mb similar-bets "<thesis>" --repo . --json`
+- `mb books exposure --repo . --bet bets/YYYY-MM-DD-slug.md --json`
+- `mb books exposure --repo . --active --json`
+
+Read `mb status --json --peek` before direct file reads. Use `mb start --json`
+when runtime readiness or handoff facts matter. Use `mb doctor repair --plan`
+when status facts name repair or migration blockers. Use cross-reference
+validation after bet link edits. Use checkpoint planning before offering to
+save changes.
+
+Use similar-bets before creating a new material bet when the thesis may repeat
+prior work. Use books exposure only when the bet is financially material or the
+bet has a declared `money_path.bet_id`.
+
+## Required JSON Fact Paths
+
+- `money_path`
+- `money_path.objects.proof.quality`
+- `validation.file_contracts`
+- `content_strategy`
+- `ranked_actions`
+- `update`
+- `readiness`
+- `drift.items`
+- `brain.bets`
+- `brain.bets.active`
+- `brain.bets.due_soon`
+- `brain.bets.overdue`
+- `brain.bets.exit_criteria`
+- `relationship_health.sections.bets`
+- `relationship_health.gaps`
+- `checkpoint.pending`
+- `checkpoint.pending.blockers`
+- `books`
+- `runtime.codex_cli`
+- `runtime.claude_code`
+
+`validation.file_contracts` is the guided-route source for bet contract gaps.
+`brain.bets` is the deterministic source for active, due, overdue, missing-exit,
+and triggered kill or double-down signals. Relationship health facts identify
+missing reverse links and stale business connections before the agent invents
+relationships from prose.
+
+## Routing Rules
+
+Start with deterministic facts, then read only the relevant bet and linked
+business files. Keep owner-facing language in business terms: wager, appetite,
+target, evidence, deadline, verdict, learning, and next action.
+
+Mode routing:
+
+1. For `new`, ask only for missing essentials: hypothesis, appetite, target,
+   deadline, metric, kill rule, and initial execution plan. If the idea sounds
+   like a new offer, ask whether the operator wants a wager or an offer
+   candidate. Do not create, move, or delete offer files without an accepted
+   decision or explicit instruction.
+2. For `update`, read the bet and linked files, append a dated evidence note,
+   update link fields, and keep `result` blank unless there is a real measured
+   result.
+3. For `close`, ask for the actual result if evidence is thin, then set
+   `status` to `closed` or `canceled`, fill `result`, add learning, and name the
+   verdict. If the bet changes offer truth, propose a follow-up decision before
+   editing the offer.
+4. For `list`, summarize active bets by deadline, status, target, metric,
+   appetite, exposure posture, exit criteria, triggered kill or double-down
+   signals, public posture, blocked state, and overdue state. End with the next
+   bet needing attention.
+5. For `narrate`, draft public-safe narration only from accepted bet, decision,
+   research, push, outcome, and offer truth. Do not invent metrics, testimonials,
+   channels, or results. If `public: false`, ask before drafting public copy and
+   offer a private retrospective instead.
+
+Primary bet files live in `bets/`. Link fields are typed business connections:
+`linked_decisions`, `linked_research`, `linked_pushes`, and `linked_outcomes`.
+`linked_campaigns` exists only for legacy compatibility; new work should route
+execution through pushes and keep legacy fields empty unless repairing old
+repos. Add `linked_bets` reverse links to linked files when the schema supports
+them.
+
+Use the body-level `## Related links` mirror to keep human-readable links aligned
+with typed frontmatter. When links are missing or stale, present `mb doctor
+repair --plan` before applying any repair.
+
+## Read Boundaries
+
+Read:
+
+- deterministic status, start, validation, relationship, checkpoint, and
+  exposure facts first;
+- the target bet file and directly linked decisions, research, pushes, outcomes,
+  logs, documents, and offers;
+- similar past bets when a new material thesis may repeat earlier work;
+- aggregate exposure output for financially material bets.
+
+Do not read or paste raw private finance rows, provider exports, transcripts,
+private direct messages, gated community content, customer/member records, vault
+paths, account numbers, payees, or ledger memos. Route those through summarized
+operator-provided evidence or deterministic aggregate facts.
+
+## Write Boundaries
+
+This workflow may write business files only after approval. Durable write
+targets are:
+
+- `bets/YYYY-MM-DD-slug.md`;
+- typed links on directly related decisions, research, pushes, outcomes, and
+  offers when the relationship is accepted;
+- body-level `## Related links` mirrors;
+- an approved checkpoint after validation and checkpoint planning.
+
+Do not create provider mutations, publish content, spend money, contact
+customers, send email, mutate dashboards, or create account changes. Do not
+graduate a bet into an offer, decision, push, content pillar, workflow, or
+outcome without accepted evidence or an accepted decision.
+
+Bet frontmatter should keep the strict contract:
+
+- `status`
+- `opened`
+- `deadline`
+- `appetite`
+- `appetite_tier`
+- `hypothesis`
+- `metric`
+- `target`
+- `result`
+- `owner`
+- `money_path`
+- `kill_rubric`
+- `linked_decisions`
+- `linked_research`
+- `linked_pushes`
+- `linked_campaigns`
+- `linked_outcomes`
+- `public`
+- `channels`
+- `tags`
+
+Bet bodies should keep these sections: `Why This Bet`, `Hypothesis`, `Work
+Plan`, `Evidence Log`, `Result`, `Narration Notes`, and `Related links`.
+
+## Approval Gates
+
+Always ask before:
+
+- `updates_repairs_migrations`
+- `file_writes`
+- `checkpoint`
+- `provider_mutation`
+- `publishing_or_spend`
+- `customer_contact`
+- `private_data`
+- `destructive_operations`
+- `structured_collection`
+- `public_issue_or_proposal`
+
+Approval must be explicit before creating or editing bet files, repairing links,
+adding reverse links, applying migration or doctor repairs, saving checkpoints,
+using structured collection, submitting a public issue or proposal, drafting
+public narration from `public: false` bets, or promoting bet learning into offer
+truth.
+
+## Handoff Format
+
+```text
+Bet mode: <new, update, close, list, or narrate>.
+Facts read: <status/start/validate/relationship/exposure/similar-bets facts>.
+Bet: <path, status, deadline, appetite, metric, target>.
+Evidence: <new evidence, missing evidence, or measured result>.
+Exit posture: <kill, double-down, continue, close, or unclear>.
+Connections: <decisions, research, pushes, outcomes, offers, or none>.
+Public posture: <public-safe, private, needs approval, or not narration>.
+Write plan: <files to create/edit or none>.
+Approval needed before writes: <yes/no and exact action>.
+Next business action: <one clear owner-facing step>.
+```
+
+## Validation Commands
+
+After bet or link edits:
+
+1. Run `mb validate --cross-refs --json`.
+2. If the checkpoint surface is available, run `mb checkpoint --plan --json`.
+3. Show blockers in owner-facing language before offering to save.
+4. Save only after approval, using checkpoint tooling rather than raw git
+   commands.
+5. End by rerunning `mb status --json --peek` when the operator needs the
+   refreshed bet state.
+
+## Runtime-Specific Notes
+
+Claude Code uses `.claude/skills/mb-bet/SKILL.md` as the project-local shell for
+this workflow. Preserve the existing business flow, mode language, approval
+gates, artifact routing, and finance/privacy boundaries from that shell.
+
+Codex uses the global Main Branch `mb-bet` skill generated from this workflow
+source. Codex support remains read-only planning and file guidance until runtime
+smoke proves lifecycle writes. It may inspect deterministic facts, explain bet
+contract gaps, propose edits, and ask for approval, but it must not claim
+supported lifecycle execution, provider mutation, publishing, spend, customer
+contact, or Claude Code entrypoints.


### PR DESCRIPTION
## Summary

Migrates `mb-bet` from a Claude-only worked skill into a shared workflow source with checked Claude and Codex shells. Codex global `mb-bet` now loads as a planning/file-guidance route and explicitly stays `read_only_planning` until write/runtime smoke proves lifecycle writes.

## Linked issue

Closes #751
Refs #743, #756, #760
MAIN-459 is the architecture dependency for file contracts, guided routes, and owner-facing status facts.

## Why

After the shared skill architecture batch, `mb-bet` needed the same canonical source model without losing the existing business flow. This PR preserves the Claude skill substance while moving durable lifecycle rules, approval gates, bet/offer/push boundaries, link routing, checkpoint discipline, and finance/privacy constraints into `workflows/mb-bet/workflow.md`.

## Commits by concern

- [ ] Each commit body bullet-lists the changes in that commit
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`

Commit list:

- `e80ab2b [add] Migrate mb-bet workflow source MAIN-455`
- `79f4938 [fix] Align mb-bet Codex support boundary MAIN-455`
- `5fd568c [fix] Keep Codex mb-bet read-only MAIN-455`

## Validation

Pre-push gate from repo root:

```bash
scripts/check.sh
```

- [x] Level 1 static: `scripts/check.sh` passes
- [x] Level 2 CLI contract: focused Typer/CliRunner tests, exit codes, `--json` behavior, TTY vs non-TTY (if CLI behavior touched)
- [ ] Level 3 package/install smoke (if packaging touched)
- [ ] Level 4 fixture repo (if init/onboard/status/start/update touched)
- [x] Level 5 runtime smoke / dogfood harness / simulation-tier (if runtime, first-run, skill discovery, or release validation touched)
- [x] SKILL.md ≤500 lines (if any skill touched)
- [ ] Package-visible release gate evidence before tag/publish (if preparing a release)
- [ ] Supply-chain review (if `.github/workflows/`, `.github/dependabot.yml`, `mb/pyproject.toml` deps, or `id-token`/`permissions` blocks touched — see [docs/supply-chain-policy.md](../docs/supply-chain-policy.md))

Level 1 static: `scripts/check.sh` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: `0` — log: `95 files already formatted`; `All checks passed!`; `Success: no issues found in 94 source files`; pytest `840 passed in 429.43s`; `mb skill validate --all --json` completed with errors `0`.
Level 2 workflow shell contract: `cd mb && pytest tests/test_workflows.py -q` — runtime: default `pytest` on local Python 3.13 — exit: `0` — log: `45 passed in 0.63s`.
Level 2 skill contract: `cd mb && python3 -m mb skill validate mb-bet --json` — runtime: `python3` — exit: `0` — log: `mb-bet` `ok: true`, line_count `370`.
Level 5 read-only Codex discovery smoke: `codex exec -C <fresh business repo> --sandbox read-only --skip-git-repo-check --ephemeral ...` — runtime: `codex-cli 0.133.0` with temp repo `mb` wrapper to this branch — exit: `0` — log: `.context/codex-bet-readonly-smoke.out`; `mb-bet` global skill `ok: true`, support `read_only_planning`, no supported lifecycle-write claim, no files written by Codex.
Level 3 was not required because packaging, entrypoints, and bundled data install mechanics did not change.
Level 4 was not required because onboard/init/status/start/update fixture behavior did not change.
Level 5 write smoke was not run because this PR intentionally does not claim Codex lifecycle write support; it proves read-only discovery only.
Supply-chain review was not required because no workflow, dependency, token, or permissions files changed.

## Success metric

`mb-bet` appears in workflow inventory as `shared_workflow_source` while still reporting Codex as `read_only_planning`, and drift tests prove the workflow source, shipped Claude shell markers, generated Codex shell, and support-boundary copy stay aligned. The generated read-only Codex shell proposes patch-shaped recommendations, routes actual writes to Claude Code `/mb-bet` or another supported write surface, and has a guardrail test forbidding write/save language.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [ ] N/A — change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [x] No
- [ ] Yes — migration note below

## Public / private boundary

No private operator strategy, machine-specific paths, provider credentials, customer/member records, raw finance rows, or runtime internals were committed. The PR guards against old taxonomy, fake Codex command-surface claims, broad workflow parity, provider mutation, publishing, spend, customer contact, and dashboard authority through workflow copy and tests.
