### PR TITLE
[update] Migrate mb-organic workflow source

### DIFF
--- a/.claude/skills/mb-organic/SKILL.md
+++ b/.claude/skills/mb-organic/SKILL.md
@@ -8,6 +8,68 @@ loops: [ship]
 
 Create organic content scripts in your voice — Reels, TikToks, carousels, static posts.
 
+**Shared source:** The portable workflow contract lives in
+`workflows/mb-organic/workflow.md`. This Claude skill is the Claude Code shell
+over that source.
+
+**Shared contract markers:** Keep these aligned with the shared source.
+
+Required commands:
+
+- `mb status --json --peek`
+- `mb start --json`
+- `mb doctor repair --plan`
+- `mb validate --cross-refs --json`
+- `mb checkpoint --plan --json`
+
+Required fact paths:
+
+- `money_path`
+- `money_path.objects.proof.quality`
+- `money_path.objects.channel_strategy`
+- `money_path.objects.active_push`
+- `validation.file_contracts`
+- `content_strategy`
+- `content_strategy.overall_state`
+- `content_strategy.simple_entry_point`
+- `content_strategy.layers`
+- `content_strategy.layers.distribution`
+- `content_strategy.layers.channels`
+- `content_strategy.layers.accounts`
+- `content_strategy.layers.people`
+- `content_strategy.findings`
+- `ranked_actions`
+- `update`
+- `readiness`
+- `drift.items`
+- `relationship_health.gaps`
+- `checkpoint.pending`
+- `checkpoint.pending.blockers`
+- `runtime.codex_cli`
+- `runtime.claude_code`
+
+Approval gates: `updates_repairs_migrations`, `file_writes`, `checkpoint`,
+`provider_mutation`, `publishing_or_spend`, `customer_contact`, `private_data`,
+`destructive_operations`, `structured_collection`, and
+`public_issue_or_proposal`.
+
+Public/private boundaries: `no_secrets`, `no_raw_provider_exports`,
+`no_raw_transcripts`, `no_customer_member_data`,
+`no_private_runtime_settings`, `no_private_dms_or_gated_communities`, and
+`no_raw_finance_legal_records`.
+
+Core flow: support plan, video, carousel, static, sales-video-repurpose, or
+review.
+Marker phrase: plan, video, carousel, static, sales-video-repurpose, or review.
+If the operator wants mining or source collection, route to `mb-think`.
+Use `content_strategy.overall_state` and
+`money_path.objects.proof.quality` before drafting; keep source/privacy
+boundaries visible; route coordinated drafts to
+`pushes/<YYYY-MM-DD-slug>/organic-batch-001.md`; Do not publish, schedule,
+upload, mutate provider accounts, spend, auto-DM, auto-reply, or contact
+customers. Codex support stays read-only planning until runtime smoke proves
+organic drafting writes.
+
 **Need help?** Type `/mb-help` + your question anytime. If conversation compacts, `/mb-help` reloads fresh context.
 
 **CLI facts first:** Run `mb status --json --peek` from the business repo before

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ### Changed
 
+- Migrated `mb-organic` to a shared workflow source with checked Claude and
+  Codex shells, preserving read-only Codex boundaries for planning, source
+  privacy, publishing, account mutation, and customer-contact gates. Closes
+  #752.
 - Migrated the mb-bet lifecycle to a shared workflow source with checked Claude
   and Codex shells, preserving read-only Codex boundaries until runtime smoke
   proves write support. Closes #751.

--- a/mb/mb/codex.py
+++ b/mb/mb/codex.py
@@ -231,6 +231,7 @@ CODEX_START_STATUS_SOURCE_WORKFLOW = "workflows/mb-start-status/workflow.md"
 CODEX_SETUP_SOURCE_WORKFLOW = "workflows/mb-setup/workflow.md"
 CODEX_MAINTENANCE_REPAIR_SOURCE_WORKFLOW = "workflows/mb-maintenance-repair/workflow.md"
 CODEX_BET_SOURCE_WORKFLOW = "workflows/mb-bet/workflow.md"
+CODEX_ORGANIC_SOURCE_WORKFLOW = "workflows/mb-organic/workflow.md"
 CODEX_THINK_REQUIRED_MB_COMMANDS = (
     "mb status --json --peek",
     "mb start --json",
@@ -383,6 +384,59 @@ CODEX_BET_PUBLIC_PRIVATE_BOUNDARIES = (
     "no_raw_finance_legal_records",
     "no_raw_ledger_rows",
 )
+CODEX_ORGANIC_REQUIRED_MB_COMMANDS = (
+    "mb status --json --peek",
+    "mb start --json",
+    "mb doctor repair --plan",
+    "mb validate --cross-refs --json",
+    "mb checkpoint --plan --json",
+)
+CODEX_ORGANIC_REQUIRED_JSON_FACTS = (
+    "money_path",
+    "money_path.objects.proof.quality",
+    "money_path.objects.channel_strategy",
+    "money_path.objects.active_push",
+    "validation.file_contracts",
+    "content_strategy",
+    "content_strategy.overall_state",
+    "content_strategy.simple_entry_point",
+    "content_strategy.layers",
+    "content_strategy.layers.distribution",
+    "content_strategy.layers.channels",
+    "content_strategy.layers.accounts",
+    "content_strategy.layers.people",
+    "content_strategy.findings",
+    "ranked_actions",
+    "update",
+    "readiness",
+    "drift.items",
+    "relationship_health.gaps",
+    "checkpoint.pending",
+    "checkpoint.pending.blockers",
+    "runtime.codex_cli",
+    "runtime.claude_code",
+)
+CODEX_ORGANIC_APPROVAL_GATES = (
+    "updates_repairs_migrations",
+    "file_writes",
+    "checkpoint",
+    "provider_mutation",
+    "publishing_or_spend",
+    "customer_contact",
+    "private_data",
+    "destructive_operations",
+    "structured_collection",
+    "public_issue_or_proposal",
+)
+CODEX_ORGANIC_PUBLIC_PRIVATE_BOUNDARIES = (
+    "no_secrets",
+    "no_raw_provider_exports",
+    "no_raw_transcripts",
+    "no_customer_member_data",
+    "no_private_runtime_settings",
+    "no_private_dms_or_gated_communities",
+    "no_raw_finance_legal_records",
+)
 CODEX_SHARED_WORKFLOW_SKILLS = {
     "mb-start": CODEX_START_STATUS_SOURCE_WORKFLOW,
     "mb-status": CODEX_START_STATUS_SOURCE_WORKFLOW,
@@ -392,6 +446,7 @@ CODEX_SHARED_WORKFLOW_SKILLS = {
     "mb-think": CODEX_THINK_SOURCE_WORKFLOW,
     "mb-end": CODEX_END_SOURCE_WORKFLOW,
     "mb-bet": CODEX_BET_SOURCE_WORKFLOW,
+    "mb-organic": CODEX_ORGANIC_SOURCE_WORKFLOW,
 }
 REQUIRED_LIFECYCLE_GUIDANCE = (
     "## Codex Lifecycle Workflow Index",
@@ -741,19 +796,40 @@ CODEX_WORKFLOW_INVENTORY: tuple[dict[str, Any], ...] = (
         "claude_surface": "/mb-organic and related playbooks",
         "claude_skill_sources": ("mb-organic",),
         "codex_status": "read_only_planning",
-        "source_status": "pending_shared_source_migration",
-        "codex_surface": "Read-only planning only",
+        "source_status": "shared_workflow_source",
+        "codex_surface": "Read-only planning and file guidance through global mb-organic skill",
         "codex_entrypoints": ("main-branch mb-organic",),
-        "commands": ("mb status --json --peek",),
-        "status_reason": (
-            "Codex can plan from content strategy facts, but drafting/review/routing "
-            "needs a shared organic workflow source before parity claims."
+        "shared_source": CODEX_ORGANIC_SOURCE_WORKFLOW,
+        "commands": CODEX_ORGANIC_REQUIRED_MB_COMMANDS,
+        "contract_checks": (
+            "intent",
+            "required_mb_commands",
+            "required_json_facts",
+            "approval_gates",
+            "read_boundaries",
+            "write_boundaries",
+            "organic_modes",
+            "content_strategy_json_paths",
+            "mining_handoff",
+            "source_privacy_boundaries",
+            "artifact_routing",
+            "proof_quality_boundary",
+            "publishing_boundary",
+            "account_mutation_boundary",
+            "codex_read_only_planning_boundary",
+            "core_flow",
+            "public_private_boundaries",
         ),
-        "next_required_issue": "#752",
-        "follow_up_issue": "https://github.com/noontide-co/mainbranch/issues/752",
+        "status_reason": (
+            "Organic workflow substance has a shared source, but Codex remains "
+            "read-only planning and file guidance until runtime smoke proves "
+            "organic drafting writes."
+        ),
         "notes": (
-            "Codex may route content strategy questions through think/codify, "
-            "but publishing and newsletter dogfood remain outside this parity slice."
+            "Codex may inspect content strategy and proof facts, propose guarded "
+            "drafts, review existing drafts, and name exact file targets. No "
+            "publishing, scheduling, upload, account mutation, spend, or customer "
+            "contact is supported."
         ),
     },
     {

--- a/mb/mb/workflows.py
+++ b/mb/mb/workflows.py
@@ -127,6 +127,17 @@ REQUIRED_SHELL_PHRASES_BY_WORKFLOW: dict[str, dict[str, str]] = {
         "checkpoint boundary": "checkpoint plan",
         "Codex support boundary": "read-only planning",
     },
+    "mb-organic": {
+        "organic modes": "plan, video, carousel, static, sales-video-repurpose, or review",
+        "mining handoff": "route to `mb-think`",
+        "content strategy paths": "content_strategy.overall_state",
+        "artifact routing": "pushes/<YYYY-MM-DD-slug>/organic-batch-001.md",
+        "proof quality boundary": "money_path.objects.proof.quality",
+        "source privacy boundary": "source/privacy",
+        "publishing boundary": "Do not publish",
+        "account mutation boundary": "mutate provider accounts",
+        "Codex support boundary": "read-only planning",
+    },
 }
 CODEX_FORBIDDEN_PHRASES_BY_WORKFLOW: dict[str, tuple[str, ...]] = {
     "mb-think": (
@@ -175,6 +186,17 @@ CODEX_FORBIDDEN_PHRASES_BY_WORKFLOW: dict[str, tuple[str, ...]] = {
         "slash-command parity",
         "Codex can create bets",
         "Codex can close bets",
+    ),
+    "mb-organic": (
+        "Run `/mb-organic`",
+        "Claude Code skills work in Codex",
+        "Claude Code slash commands work inside Codex",
+        "Claude slash commands",
+        "slash-command parity",
+        "Codex can publish",
+        "Codex can schedule",
+        "Codex can mutate provider accounts",
+        "Codex can contact customers",
     ),
 }
 PUBLIC_PRIVATE_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
@@ -450,6 +472,8 @@ def render_claude_shell(workflow: WorkflowSource) -> str:
         return _render_end_claude_shell(workflow)
     if workflow.name == "mb-bet":
         return _render_bet_claude_shell(workflow)
+    if workflow.name == "mb-organic":
+        return _render_organic_claude_shell(workflow)
     if workflow.name in {"mb-start-status", "mb-setup", "mb-maintenance-repair"}:
         return _render_daily_claude_shell(workflow)
     return _render_start_money_path_claude_shell(workflow)
@@ -705,6 +729,8 @@ def render_codex_shell(workflow: WorkflowSource) -> str:
         return _render_end_codex_shell(workflow)
     if workflow.name == "mb-bet":
         return _render_bet_codex_shell(workflow)
+    if workflow.name == "mb-organic":
+        return _render_organic_codex_shell(workflow)
     if workflow.name in {"mb-start-status", "mb-setup", "mb-maintenance-repair"}:
         return _render_daily_codex_shell(workflow)
     return _render_start_money_path_codex_shell(workflow)
@@ -1105,6 +1131,161 @@ Next business action: <one clear owner-facing step>.
 Use business language first. Keep legacy campaign links compatibility-only;
 new execution routes through pushes. Runtime smoke is required before docs say
 this lifecycle is supported for Codex writes.
+"""
+    return output
+
+
+def _render_organic_claude_shell(workflow: WorkflowSource) -> str:
+    """Render a Claude Code shell snapshot for the organic content workflow."""
+
+    output = f"""# Generated Claude Shell: {workflow.title}
+
+Source workflow: `{_display_path(workflow.path)}`
+Runtime support: `claude_code: supported_shell`
+Approval gates: {_inline_code_list(workflow.approval_gates)}
+Public/private boundaries: {_inline_code_list(workflow.public_private_boundaries)}
+
+Use from `/mb-organic` when the operator wants organic content planning,
+scripts, carousels, static posts, sales-video repurposing, or content review.
+Preserve the existing Claude skill's mode language, mining handoff, voice
+adaptation, content strategy integration, artifact routing, and source/privacy
+boundaries.
+
+This snapshot does not replace shipped `.claude/skills/mb-organic/SKILL.md`.
+
+## Required mb Commands
+
+{_bullet_list(workflow.required_mb_commands)}
+
+## Required JSON Fact Paths
+
+{_bullet_list(workflow.json_facts)}
+
+## Routing
+
+1. Read deterministic facts first: status, start when runtime facts matter,
+   repair plan when blockers appear, content strategy health, proof quality,
+   relationship gaps, validation, and checkpoint plan.
+2. For mining handoff, route to `mb-think` for mining, scraping, competitor
+   research, transcript extraction, and outside source collection. Organic drafts from accepted
+   `research/` handoffs, operator excerpts, approved transcripts, and current
+   business truth.
+3. Support plan, video, carousel, static, sales-video-repurpose, or review
+   modes. Use content_strategy.overall_state, content_strategy.simple_entry_point,
+   content_strategy.layers, and content_strategy.findings before parsing raw
+   strategy files.
+4. Draft from active offer, audience, voice, content strategy, relevant
+   channel/account/person layers, research, sales-video notes, active pushes,
+   and money_path.objects.proof.quality. Do not call proof good, bad,
+   persuasive, high-converting, or ready to win.
+5. Route coordinated content to `pushes/<YYYY-MM-DD-slug>/push.md`, draft
+   batches to `pushes/<YYYY-MM-DD-slug>/organic-batch-001.md`, and provider
+   mechanics to `pushes/<YYYY-MM-DD-slug>/playbooks/<playbook>.md` as plans.
+6. Use `mb validate --cross-refs --json` after approved push, draft, playbook,
+   typed-link, or related-link edits. Use the checkpoint plan before offering
+   an approval-gated save.
+7. Keep source/privacy boundaries explicit. Never paste raw provider exports,
+   private DMs, gated community threads, raw customer/member records, raw
+   transcripts, account details, session cookies, finance/legal records, or
+   secrets.
+8. Do not publish, schedule, upload to accounts, mutate provider accounts,
+   spend, auto-DM, auto-reply, contact customers, or execute provider setup.
+
+## Handoff Shape
+
+```text
+Organic mode: <plan, video, carousel, static, sales-video-repurpose, or review>.
+Facts read: <status/start/content-strategy/proof/checkpoint facts>.
+Source base: <offer, audience, voice, research, sales video, push, account, or missing>.
+Channel/account: <platform/account/person layer or not selected>.
+Content strategy: <healthy, thin, stale, disconnected, or missing>.
+Proof/privacy posture: <public-safe, internal-only, missing permission, or needs summary>.
+Artifact route: <push path, batch path, playbook path, or none>.
+Write plan: <files to create/edit or planning only>.
+Approval needed before writes: <yes/no and exact action>.
+Next business action: <one clear owner-facing step>.
+```
+
+Use business language first. New coordinated work uses pushes. Legacy content
+structures are migration input only. Codex support stays read-only planning
+until runtime smoke proves organic drafting writes.
+"""
+    return output
+
+
+def _render_organic_codex_shell(workflow: WorkflowSource) -> str:
+    """Render Codex CLI guidance for the organic content workflow."""
+
+    output = f"""# Generated Codex Workflow Guidance: {workflow.title}
+
+Source workflow: `{_display_path(workflow.path)}`
+Runtime support: `codex_cli: {workflow.runtime_support.get("codex_cli", "")}`
+Approval gates: {_inline_code_list(workflow.approval_gates)}
+Public/private boundaries: {_inline_code_list(workflow.public_private_boundaries)}
+
+Codex uses the global Main Branch `mb-organic` skill as a read-only planning
+and file-guidance route. This guidance is generated from the engine workflow
+source and does not claim supported organic drafting writes, publishing,
+account mutation, customer contact, or Claude Code entrypoints in Codex.
+
+## Required mb Commands
+
+{_bullet_list(workflow.required_mb_commands)}
+
+## Required JSON Fact Paths
+
+{_bullet_list(workflow.json_facts)}
+
+## Codex Route
+
+1. Use the business repo `AGENTS.md` bootstrap posture: read facts first, keep
+   writes approval-gated, and translate git/provider details into business
+   language.
+2. Read deterministic facts before raw markdown: status, start when runtime
+   facts matter, repair plan when blockers appear, content strategy health,
+   proof quality, relationship gaps, validation, and checkpoint plan.
+3. For mining handoff, route to `mb-think` in Codex-native language for mining,
+   scraping, competitor research, transcript extraction, and outside source
+   collection. Organic may plan from accepted `research/` handoffs, operator
+   excerpts, approved transcripts, and current business truth.
+4. Guide plan, video, carousel, static, sales-video-repurpose, or review modes
+   from the shared contract. Use content_strategy.overall_state,
+   content_strategy.simple_entry_point, content_strategy.layers, and
+   content_strategy.findings before parsing raw strategy files.
+5. Codex may draft patch-shaped recommendations, sample copy, review notes,
+   and exact file targets, then stop before changing files.
+6. Name artifact routes as plans only: `pushes/<YYYY-MM-DD-slug>/push.md`,
+   `pushes/<YYYY-MM-DD-slug>/organic-batch-001.md`, and
+   `pushes/<YYYY-MM-DD-slug>/playbooks/<playbook>.md`.
+7. If the operator wants the proposed content applied, route them to Claude
+   Code `/mb-organic` or another supported write surface until Codex
+   organic-write smoke proves this route. Do not run checkpoint commands or
+   post-change validation as if Codex edited files.
+8. Keep source/privacy boundaries explicit. Never paste raw provider exports,
+   private DMs, gated community threads, raw customer/member records, raw
+   transcripts, account details, session cookies, finance/legal records, or
+   secrets.
+9. Do not publish, schedule, upload to accounts, mutate provider accounts,
+   spend, auto-DM, auto-reply, contact customers, or execute provider setup.
+
+## Handoff Shape
+
+```text
+Organic mode: <plan, video, carousel, static, sales-video-repurpose, or review>.
+Facts read: <status/start/content-strategy/proof/checkpoint facts>.
+Source base: <offer, audience, voice, research, sales video, push, account, or missing>.
+Channel/account: <platform/account/person layer or not selected>.
+Content strategy: <healthy, thin, stale, disconnected, or missing>.
+Proof/privacy posture: <public-safe, internal-only, missing permission, or needs summary>.
+Artifact route: <push path, batch path, playbook path, or none>.
+Write plan: <files to create/edit or planning only>.
+Approval needed before writes: <yes/no and exact action>.
+Next business action: <one clear owner-facing step>.
+```
+
+Use business language first. New coordinated work uses pushes. Legacy content
+structures are migration input only. Runtime smoke is required before docs say
+this workflow is supported for Codex writes.
 """
     return output
 

--- a/mb/tests/fixtures/workflows/mb-organic.claude.md
+++ b/mb/tests/fixtures/workflows/mb-organic.claude.md
@@ -1,0 +1,97 @@
+# Generated Claude Shell: Organic Content
+
+Source workflow: `workflows/mb-organic/workflow.md`
+Runtime support: `claude_code: supported_shell`
+Approval gates: `updates_repairs_migrations`, `file_writes`, `checkpoint`, `provider_mutation`, `publishing_or_spend`, `customer_contact`, `private_data`, `destructive_operations`, `structured_collection`, `public_issue_or_proposal`
+Public/private boundaries: `no_secrets`, `no_raw_provider_exports`, `no_raw_transcripts`, `no_customer_member_data`, `no_private_runtime_settings`, `no_private_dms_or_gated_communities`, `no_raw_finance_legal_records`
+
+Use from `/mb-organic` when the operator wants organic content planning,
+scripts, carousels, static posts, sales-video repurposing, or content review.
+Preserve the existing Claude skill's mode language, mining handoff, voice
+adaptation, content strategy integration, artifact routing, and source/privacy
+boundaries.
+
+This snapshot does not replace shipped `.claude/skills/mb-organic/SKILL.md`.
+
+## Required mb Commands
+
+- `mb status --json --peek`
+- `mb start --json`
+- `mb doctor repair --plan`
+- `mb validate --cross-refs --json`
+- `mb checkpoint --plan --json`
+
+## Required JSON Fact Paths
+
+- `money_path`
+- `money_path.objects.proof.quality`
+- `money_path.objects.channel_strategy`
+- `money_path.objects.active_push`
+- `validation.file_contracts`
+- `content_strategy`
+- `content_strategy.overall_state`
+- `content_strategy.simple_entry_point`
+- `content_strategy.layers`
+- `content_strategy.layers.distribution`
+- `content_strategy.layers.channels`
+- `content_strategy.layers.accounts`
+- `content_strategy.layers.people`
+- `content_strategy.findings`
+- `ranked_actions`
+- `update`
+- `readiness`
+- `drift.items`
+- `relationship_health.gaps`
+- `checkpoint.pending`
+- `checkpoint.pending.blockers`
+- `runtime.codex_cli`
+- `runtime.claude_code`
+
+## Routing
+
+1. Read deterministic facts first: status, start when runtime facts matter,
+   repair plan when blockers appear, content strategy health, proof quality,
+   relationship gaps, validation, and checkpoint plan.
+2. For mining handoff, route to `mb-think` for mining, scraping, competitor
+   research, transcript extraction, and outside source collection. Organic drafts from accepted
+   `research/` handoffs, operator excerpts, approved transcripts, and current
+   business truth.
+3. Support plan, video, carousel, static, sales-video-repurpose, or review
+   modes. Use content_strategy.overall_state, content_strategy.simple_entry_point,
+   content_strategy.layers, and content_strategy.findings before parsing raw
+   strategy files.
+4. Draft from active offer, audience, voice, content strategy, relevant
+   channel/account/person layers, research, sales-video notes, active pushes,
+   and money_path.objects.proof.quality. Do not call proof good, bad,
+   persuasive, high-converting, or ready to win.
+5. Route coordinated content to `pushes/<YYYY-MM-DD-slug>/push.md`, draft
+   batches to `pushes/<YYYY-MM-DD-slug>/organic-batch-001.md`, and provider
+   mechanics to `pushes/<YYYY-MM-DD-slug>/playbooks/<playbook>.md` as plans.
+6. Use `mb validate --cross-refs --json` after approved push, draft, playbook,
+   typed-link, or related-link edits. Use the checkpoint plan before offering
+   an approval-gated save.
+7. Keep source/privacy boundaries explicit. Never paste raw provider exports,
+   private DMs, gated community threads, raw customer/member records, raw
+   transcripts, account details, session cookies, finance/legal records, or
+   secrets.
+8. Do not publish, schedule, upload to accounts, mutate provider accounts,
+   spend, auto-DM, auto-reply, contact customers, or execute provider setup.
+
+## Handoff Shape
+
+```text
+Organic mode: <plan, video, carousel, static, sales-video-repurpose, or review>.
+Facts read: <status/start/content-strategy/proof/checkpoint facts>.
+Source base: <offer, audience, voice, research, sales video, push, account, or missing>.
+Channel/account: <platform/account/person layer or not selected>.
+Content strategy: <healthy, thin, stale, disconnected, or missing>.
+Proof/privacy posture: <public-safe, internal-only, missing permission, or needs summary>.
+Artifact route: <push path, batch path, playbook path, or none>.
+Write plan: <files to create/edit or planning only>.
+Approval needed before writes: <yes/no and exact action>.
+Next business action: <one clear owner-facing step>.
+```
+
+Use business language first. New coordinated work uses pushes. Legacy content
+structures are migration input only. Codex support stays read-only planning
+until runtime smoke proves organic drafting writes.

--- a/mb/tests/fixtures/workflows/mb-organic.codex.md
+++ b/mb/tests/fixtures/workflows/mb-organic.codex.md
@@ -1,0 +1,96 @@
+# Generated Codex Workflow Guidance: Organic Content
+
+Source workflow: `workflows/mb-organic/workflow.md`
+Runtime support: `codex_cli: read_only_planning`
+Approval gates: `updates_repairs_migrations`, `file_writes`, `checkpoint`, `provider_mutation`, `publishing_or_spend`, `customer_contact`, `private_data`, `destructive_operations`, `structured_collection`, `public_issue_or_proposal`
+Public/private boundaries: `no_secrets`, `no_raw_provider_exports`, `no_raw_transcripts`, `no_customer_member_data`, `no_private_runtime_settings`, `no_private_dms_or_gated_communities`, `no_raw_finance_legal_records`
+
+Codex uses the global Main Branch `mb-organic` skill as a read-only planning
+and file-guidance route. This guidance is generated from the engine workflow
+source and does not claim supported organic drafting writes, publishing,
+account mutation, customer contact, or Claude Code entrypoints in Codex.
+
+## Required mb Commands
+
+- `mb status --json --peek`
+- `mb start --json`
+- `mb doctor repair --plan`
+- `mb validate --cross-refs --json`
+- `mb checkpoint --plan --json`
+
+## Required JSON Fact Paths
+
+- `money_path`
+- `money_path.objects.proof.quality`
+- `money_path.objects.channel_strategy`
+- `money_path.objects.active_push`
+- `validation.file_contracts`
+- `content_strategy`
+- `content_strategy.overall_state`
+- `content_strategy.simple_entry_point`
+- `content_strategy.layers`
+- `content_strategy.layers.distribution`
+- `content_strategy.layers.channels`
+- `content_strategy.layers.accounts`
+- `content_strategy.layers.people`
+- `content_strategy.findings`
+- `ranked_actions`
+- `update`
+- `readiness`
+- `drift.items`
+- `relationship_health.gaps`
+- `checkpoint.pending`
+- `checkpoint.pending.blockers`
+- `runtime.codex_cli`
+- `runtime.claude_code`
+
+## Codex Route
+
+1. Use the business repo `AGENTS.md` bootstrap posture: read facts first, keep
+   writes approval-gated, and translate git/provider details into business
+   language.
+2. Read deterministic facts before raw markdown: status, start when runtime
+   facts matter, repair plan when blockers appear, content strategy health,
+   proof quality, relationship gaps, validation, and checkpoint plan.
+3. For mining handoff, route to `mb-think` in Codex-native language for mining,
+   scraping, competitor research, transcript extraction, and outside source
+   collection. Organic may plan from accepted `research/` handoffs, operator
+   excerpts, approved transcripts, and current business truth.
+4. Guide plan, video, carousel, static, sales-video-repurpose, or review modes
+   from the shared contract. Use content_strategy.overall_state,
+   content_strategy.simple_entry_point, content_strategy.layers, and
+   content_strategy.findings before parsing raw strategy files.
+5. Codex may draft patch-shaped recommendations, sample copy, review notes,
+   and exact file targets, then stop before changing files.
+6. Name artifact routes as plans only: `pushes/<YYYY-MM-DD-slug>/push.md`,
+   `pushes/<YYYY-MM-DD-slug>/organic-batch-001.md`, and
+   `pushes/<YYYY-MM-DD-slug>/playbooks/<playbook>.md`.
+7. If the operator wants the proposed content applied, route them to Claude
+   Code `/mb-organic` or another supported write surface until Codex
+   organic-write smoke proves this route. Do not run checkpoint commands or
+   post-change validation as if Codex edited files.
+8. Keep source/privacy boundaries explicit. Never paste raw provider exports,
+   private DMs, gated community threads, raw customer/member records, raw
+   transcripts, account details, session cookies, finance/legal records, or
+   secrets.
+9. Do not publish, schedule, upload to accounts, mutate provider accounts,
+   spend, auto-DM, auto-reply, contact customers, or execute provider setup.
+
+## Handoff Shape
+
+```text
+Organic mode: <plan, video, carousel, static, sales-video-repurpose, or review>.
+Facts read: <status/start/content-strategy/proof/checkpoint facts>.
+Source base: <offer, audience, voice, research, sales video, push, account, or missing>.
+Channel/account: <platform/account/person layer or not selected>.
+Content strategy: <healthy, thin, stale, disconnected, or missing>.
+Proof/privacy posture: <public-safe, internal-only, missing permission, or needs summary>.
+Artifact route: <push path, batch path, playbook path, or none>.
+Write plan: <files to create/edit or planning only>.
+Approval needed before writes: <yes/no and exact action>.
+Next business action: <one clear owner-facing step>.
+```
+
+Use business language first. New coordinated work uses pushes. Legacy content
+structures are migration input only. Runtime smoke is required before docs say
+this workflow is supported for Codex writes.

--- a/mb/tests/test_workflows.py
+++ b/mb/tests/test_workflows.py
@@ -28,8 +28,10 @@ MAINTENANCE_REPAIR_WORKFLOW = REPO_ROOT / "workflows" / "mb-maintenance-repair" 
 THINK_WORKFLOW = REPO_ROOT / "workflows" / "mb-think" / "workflow.md"
 END_WORKFLOW = REPO_ROOT / "workflows" / "mb-end" / "workflow.md"
 BET_WORKFLOW = REPO_ROOT / "workflows" / "mb-bet" / "workflow.md"
+ORGANIC_WORKFLOW = REPO_ROOT / "workflows" / "mb-organic" / "workflow.md"
 SHIPPED_END_SKILL = REPO_ROOT / ".claude" / "skills" / "mb-end" / "SKILL.md"
 SHIPPED_BET_SKILL = REPO_ROOT / ".claude" / "skills" / "mb-bet" / "SKILL.md"
+SHIPPED_ORGANIC_SKILL = REPO_ROOT / ".claude" / "skills" / "mb-organic" / "SKILL.md"
 FIXTURES = REPO_ROOT / "mb" / "tests" / "fixtures" / "workflows"
 AGENTS_TEMPLATE = REPO_ROOT / "mb" / "mb" / "_data" / "templates" / "AGENTS.md.tmpl"
 WORKFLOW_PATHS = [
@@ -40,6 +42,7 @@ WORKFLOW_PATHS = [
     THINK_WORKFLOW,
     END_WORKFLOW,
     BET_WORKFLOW,
+    ORGANIC_WORKFLOW,
 ]
 
 
@@ -147,6 +150,17 @@ def test_generated_bet_claude_and_codex_snapshots_match_fixtures() -> None:
     )
 
 
+def test_generated_organic_claude_and_codex_snapshots_match_fixtures() -> None:
+    workflow = load_workflow(ORGANIC_WORKFLOW)
+
+    assert render_claude_shell(workflow) == (FIXTURES / "mb-organic.claude.md").read_text(
+        encoding="utf-8"
+    )
+    assert render_codex_shell(workflow) == (FIXTURES / "mb-organic.codex.md").read_text(
+        encoding="utf-8"
+    )
+
+
 def test_shipped_claude_end_skill_preserves_shared_workflow_contract() -> None:
     workflow = load_workflow(END_WORKFLOW)
     skill_text = SHIPPED_END_SKILL.read_text(encoding="utf-8")
@@ -161,6 +175,14 @@ def test_shipped_claude_bet_skill_preserves_shared_workflow_contract() -> None:
 
     assert shell_drift_errors(workflow, skill_text) == []
     assert "workflows/mb-bet/workflow.md" in skill_text
+
+
+def test_shipped_claude_organic_skill_preserves_shared_workflow_contract() -> None:
+    workflow = load_workflow(ORGANIC_WORKFLOW)
+    skill_text = SHIPPED_ORGANIC_SKILL.read_text(encoding="utf-8")
+
+    assert shell_drift_errors(workflow, skill_text) == []
+    assert "workflows/mb-organic/workflow.md" in skill_text
 
 
 def test_supported_shells_preserve_required_commands_and_json_facts() -> None:
@@ -225,6 +247,19 @@ def test_codex_contract_markers_match_bet_workflow_source() -> None:
     assert tuple(workflow.approval_gates) == codex_mod.CODEX_BET_APPROVAL_GATES
     assert (
         tuple(workflow.public_private_boundaries) == codex_mod.CODEX_BET_PUBLIC_PRIVATE_BOUNDARIES
+    )
+
+
+def test_codex_contract_markers_match_organic_workflow_source() -> None:
+    workflow = load_workflow(ORGANIC_WORKFLOW)
+
+    assert codex_mod.CODEX_ORGANIC_SOURCE_WORKFLOW == "workflows/mb-organic/workflow.md"
+    assert tuple(workflow.required_mb_commands) == codex_mod.CODEX_ORGANIC_REQUIRED_MB_COMMANDS
+    assert tuple(workflow.json_facts) == codex_mod.CODEX_ORGANIC_REQUIRED_JSON_FACTS
+    assert tuple(workflow.approval_gates) == codex_mod.CODEX_ORGANIC_APPROVAL_GATES
+    assert (
+        tuple(workflow.public_private_boundaries)
+        == codex_mod.CODEX_ORGANIC_PUBLIC_PRIVATE_BOUNDARIES
     )
 
 
@@ -496,7 +531,18 @@ def test_codex_workflow_inventory_command_lists_supported_and_pending_surfaces()
     assert (
         "codex_read_only_planning_boundary" in by_id["bets"]["source_of_truth"]["contract_checks"]
     )
-    assert by_id["organic-content"]["source_of_truth"]["next_required_issue"] == "#752"
+    assert by_id["organic-content"]["codex_status"] == "read_only_planning"
+    assert by_id["organic-content"]["source_status"] == "shared_workflow_source"
+    assert (
+        by_id["organic-content"]["source_of_truth"]["shared_source"]
+        == "workflows/mb-organic/workflow.md"
+    )
+    assert by_id["organic-content"]["source_of_truth"]["next_required_issue"] is None
+    assert by_id["organic-content"]["codex_entrypoints"] == ["main-branch mb-organic"]
+    assert (
+        "source_privacy_boundaries"
+        in by_id["organic-content"]["source_of_truth"]["contract_checks"]
+    )
     assert by_id["site"]["source_of_truth"]["next_required_issue"] == "#749"
     assert by_id["google-ads-search-launch-playbook"]["surface_type"] == "playbook"
     assert by_id["google-ads-search-launch-playbook"]["playbook_status"] == "draft_manual"
@@ -658,6 +704,7 @@ def test_codex_shared_global_skills_are_rendered_from_workflow_sources() -> None
         (THINK_WORKFLOW, "mb-think"),
         (END_WORKFLOW, "mb-end"),
         (BET_WORKFLOW, "mb-bet"),
+        (ORGANIC_WORKFLOW, "mb-organic"),
     ):
         workflow = load_workflow(path)
         text = codex_mod.render_codex_global_skill_md(name)
@@ -704,6 +751,41 @@ def test_bet_codex_shell_keeps_read_only_planning_boundary() -> None:
     assert "stop before changing files" in shell
     assert "supported write surface" in shell
     assert "Run `/mb-bet`" not in shell
+    assert "slash" not in shell.lower()
+
+
+def test_organic_runtime_shells_surface_content_contract_and_boundaries() -> None:
+    workflow = load_workflow(ORGANIC_WORKFLOW)
+
+    for shell in (render_claude_shell(workflow), render_codex_shell(workflow)):
+        assert "plan, video, carousel, static, sales-video-repurpose, or review" in shell
+        assert "route to `mb-think`" in shell
+        assert "content_strategy.overall_state" in shell
+        assert "money_path.objects.proof.quality" in shell
+        assert "pushes/<YYYY-MM-DD-slug>/organic-batch-001.md" in shell
+        assert "source/privacy" in shell.lower()
+        assert "Do not publish" in shell
+        assert "mutate provider accounts" in shell
+        assert "contact customers" in shell
+
+
+def test_organic_codex_shell_keeps_read_only_planning_boundary() -> None:
+    workflow = load_workflow(ORGANIC_WORKFLOW)
+    shell = render_codex_shell(workflow)
+
+    assert codex_shell_policy_errors(workflow, shell) == []
+    assert "Runtime support: `codex_cli: read_only_planning`" in shell
+    assert "read-only planning" in shell
+    assert "file-guidance route" in shell
+    assert "does not claim supported organic drafting writes" in shell
+    assert "Runtime smoke is required before docs say" in shell
+    assert "this workflow is supported for Codex writes" in shell
+    assert "patch-shaped recommendations" in shell
+    assert "stop before changing files" in shell
+    assert "supported write surface" in shell
+    assert "Do not publish" in shell
+    assert "mutate provider accounts" in shell
+    assert "Run `/mb-organic`" not in shell
     assert "slash" not in shell.lower()
 
 

--- a/workflows/mb-organic/workflow.md
+++ b/workflows/mb-organic/workflow.md
@@ -1,0 +1,275 @@
+---
+name: mb-organic
+title: Organic Content
+description: "Plan organic content, route mining handoffs, draft scripts, review source/privacy boundaries, and name approval-gated artifact writes from deterministic Main Branch facts."
+loops:
+  - sense
+  - ship
+runtime_support:
+  claude_code: supported_shell
+  codex_cli: read_only_planning
+runtime_surfaces:
+  claude_code: .claude/skills/mb-organic/SKILL.md
+  codex_cli: global Main Branch mb-organic skill
+required_mb_commands:
+  - mb status --json --peek
+  - mb start --json
+  - mb doctor repair --plan
+  - mb validate --cross-refs --json
+  - mb checkpoint --plan --json
+json_facts:
+  - money_path
+  - money_path.objects.proof.quality
+  - money_path.objects.channel_strategy
+  - money_path.objects.active_push
+  - validation.file_contracts
+  - content_strategy
+  - content_strategy.overall_state
+  - content_strategy.simple_entry_point
+  - content_strategy.layers
+  - content_strategy.layers.distribution
+  - content_strategy.layers.channels
+  - content_strategy.layers.accounts
+  - content_strategy.layers.people
+  - content_strategy.findings
+  - ranked_actions
+  - update
+  - readiness
+  - drift.items
+  - relationship_health.gaps
+  - checkpoint.pending
+  - checkpoint.pending.blockers
+  - runtime.codex_cli
+  - runtime.claude_code
+approval_gates:
+  - updates_repairs_migrations
+  - file_writes
+  - checkpoint
+  - provider_mutation
+  - publishing_or_spend
+  - customer_contact
+  - private_data
+  - destructive_operations
+  - structured_collection
+  - public_issue_or_proposal
+public_private_boundaries:
+  - no_secrets
+  - no_raw_provider_exports
+  - no_raw_transcripts
+  - no_customer_member_data
+  - no_private_runtime_settings
+  - no_private_dms_or_gated_communities
+  - no_raw_finance_legal_records
+writes_business_files: true
+provider_mutation: false
+publishing_or_spend: false
+---
+
+# Organic Content
+
+## Intent And Triggers
+
+Use this workflow when the operator wants to create organic content scripts,
+social posts, carousels, static posts, newsletter or community planning, or
+creator-style excerpts from sales videos. Organic content is Ship work: drafts
+and plans may become business artifacts, but posting, scheduling, DM automation,
+reply automation, account mutation, and customer contact stay outside this
+workflow.
+
+Supported modes:
+
+- `plan`: choose topics, channels, account fit, and a content batch route.
+- `video`: draft Reels, TikTok, Shorts, or creator-style scripts.
+- `carousel`: draft slide-by-slide carousel copy.
+- `static`: draft a single post or caption.
+- `sales-video-repurpose`: turn approved sales-video material into short-form
+  clips, excerpts, carousel adaptations, or post drafts.
+- `review`: check drafts against voice, proof, source, privacy, CTA, and
+  approval boundaries.
+
+Mining, scraping, competitor research, transcript extraction, and public/source
+collection are not organic drafting. Route those to `mb-think` first so source
+observations land in `research/` before this workflow drafts from them.
+
+## Required Mb Commands
+
+- `mb status --json --peek`
+- `mb start --json`
+- `mb doctor repair --plan`
+- `mb validate --cross-refs --json`
+- `mb checkpoint --plan --json`
+
+Read `mb status --json --peek` before direct markdown reads. Use `mb start
+--json` when runtime readiness, repo boundary, or handoff facts matter. Use `mb
+doctor repair --plan` when status facts name repair or migration blockers. Use
+cross-reference validation after push, playbook, or related-link edits. Use
+checkpoint planning before offering to save approved content work.
+
+## Required JSON Fact Paths
+
+- `money_path`
+- `money_path.objects.proof.quality`
+- `money_path.objects.channel_strategy`
+- `money_path.objects.active_push`
+- `validation.file_contracts`
+- `content_strategy`
+- `content_strategy.overall_state`
+- `content_strategy.simple_entry_point`
+- `content_strategy.layers`
+- `content_strategy.layers.distribution`
+- `content_strategy.layers.channels`
+- `content_strategy.layers.accounts`
+- `content_strategy.layers.people`
+- `content_strategy.findings`
+- `ranked_actions`
+- `update`
+- `readiness`
+- `drift.items`
+- `relationship_health.gaps`
+- `checkpoint.pending`
+- `checkpoint.pending.blockers`
+- `runtime.codex_cli`
+- `runtime.claude_code`
+
+Use `content_strategy.overall_state`, `simple_entry_point`, `layers`, and
+`findings` as the deterministic source for strategy health before parsing raw
+strategy files. Use `money_path.objects.proof.quality` before turning proof
+into posts, videos, outcome claims, or social proof. Treat proof facts as
+signals, not conversion judgment.
+
+## Routing Rules
+
+Start with deterministic facts, then read only the content source files needed
+for the requested channel, account, offer, person, push, or draft.
+
+Mode routing:
+
+1. For mining, scraping, competitor research, transcript extraction, or outside
+   source collection, route to `mb-think`. Organic may receive a research
+   handoff from `research/`, but it does not collect or scrape source material.
+2. For `plan`, use content strategy health, ranked actions, active push facts,
+   and account/channel layers to recommend one content route. Ask only for
+   missing essentials: target audience, offer or CTA, channel/account, topic,
+   batch name, and review moment.
+3. For `video`, `carousel`, and `static`, draft from accepted repo truth:
+   offer, audience, voice, content strategy, proof facts, relevant research,
+   active push, channel/account layers, and person voice when named.
+4. For `sales-video-repurpose`, use only approved sales-video material,
+   transcripts, operator excerpts, or research handoffs. Route source ingestion
+   or transcript extraction back to `mb-think`.
+5. For `review`, check source support, proof claims, privacy, voice, platform
+   fit, CTA, and publishing boundaries. Do not describe a draft as
+   high-converting or ready to win.
+
+Offer context resolves from current `mb` facts and current files. In multi-offer
+repos, read the named offer under `core/offers/<offer>/` when present. In
+single-offer repos, use `core/offer.md`. If active offer context is unclear, ask
+instead of inferring from legacy state.
+
+## Read Boundaries
+
+Read:
+
+- deterministic status, start, content strategy, proof-quality, relationship,
+  and checkpoint facts first;
+- `core/content-strategy.md`;
+- relevant layers under `core/marketing/distribution-strategy.md`,
+  `core/marketing/channels/<channel>.md`,
+  `core/marketing/accounts/<platform>-<account>.md`, and
+  `core/people/<person>.md` when the work names a channel, account, person, or
+  weekly content plan;
+- `core/voice.md`, active offer/audience files, and approved proof summaries;
+- selected research files, sales-video notes, active push files, playbooks,
+  documents, and logs when they directly support the draft.
+
+Do not read or paste raw provider exports, private DMs, gated community
+threads, raw customer/member records, raw transcripts, account details, session
+cookies, finance/legal records, secrets, or private local runtime settings.
+Route sensitive material through approved summaries, manifests, or operator
+provided excerpts.
+
+## Write Boundaries
+
+This workflow may write business files only after approval. Durable write
+targets are:
+
+- `pushes/<YYYY-MM-DD-slug>/push.md` for coordinated content pushes;
+- `pushes/<YYYY-MM-DD-slug>/organic-batch-001.md` or a similar batch artifact
+  for drafted organic scripts;
+- `pushes/<YYYY-MM-DD-slug>/playbooks/<playbook>.md` for comment-keyword,
+  DM-keyword, reply/link, resource-delivery, newsletter-send, or provider setup
+  plans;
+- typed links and body-level `## Related links` mirrors on directly related
+  pushes, research, decisions, bets, outcomes, logs, or documents;
+- approved checkpoints after validation and checkpoint planning.
+
+Do not publish posts, schedule posts, send newsletters, auto-DM, auto-reply,
+contact customers, mutate provider accounts, upload assets to accounts, spend
+money, or execute provider setup. Drafting a CTA or resource-delivery mechanic
+is allowed as a plan; execution needs explicit provider gates outside this
+workflow.
+
+New coordinated work uses `pushes/`. If legacy content records exist in old
+structures, present repair or migration planning before creating new content
+there.
+
+## Approval Gates
+
+Always ask before:
+
+- `updates_repairs_migrations`
+- `file_writes`
+- `checkpoint`
+- `provider_mutation`
+- `publishing_or_spend`
+- `customer_contact`
+- `private_data`
+- `destructive_operations`
+- `structured_collection`
+- `public_issue_or_proposal`
+
+Approval must be explicit before creating or editing pushes, drafts, playbooks,
+typed links, related-link mirrors, migrations, repair applies, structured
+source collection, public issue/proposal submission, or checkpoints.
+
+## Handoff Format
+
+```text
+Organic mode: <plan, video, carousel, static, sales-video-repurpose, or review>.
+Facts read: <status/start/content-strategy/proof/checkpoint facts>.
+Source base: <offer, audience, voice, research, sales video, push, account, or missing>.
+Channel/account: <platform/account/person layer or not selected>.
+Content strategy: <healthy, thin, stale, disconnected, or missing>.
+Proof/privacy posture: <public-safe, internal-only, missing permission, or needs summary>.
+Artifact route: <push path, batch path, playbook path, or none>.
+Write plan: <files to create/edit or planning only>.
+Approval needed before writes: <yes/no and exact action>.
+Next business action: <one clear owner-facing step>.
+```
+
+## Validation Commands
+
+After approved push, draft, playbook, typed-link, or related-link edits:
+
+1. Run `mb validate --cross-refs --json`.
+2. If the checkpoint surface is available, run `mb checkpoint --plan --json`.
+3. Show blockers in owner-facing language before offering to save.
+4. Save only after approval, using checkpoint tooling rather than raw git
+   commands.
+5. End by rerunning `mb status --json --peek` when the operator needs refreshed
+   content strategy, active push, or checkpoint state.
+
+## Runtime-Specific Notes
+
+Claude Code uses `.claude/skills/mb-organic/SKILL.md` as the project-local shell
+for this workflow. Preserve the existing mode language, mining handoff, voice
+adaptation, content strategy integration, sales-video repurposing, artifact
+routing, approval gates, and source/privacy boundaries from that shell.
+
+Codex uses the global Main Branch `mb-organic` skill generated from this
+workflow source. Codex support remains read-only planning and file guidance
+until runtime smoke proves organic drafting writes. It may inspect deterministic
+facts, explain content strategy and proof/privacy gaps, propose guarded drafts,
+review existing drafts, and name exact file targets, but it must not claim
+supported organic execution, publish, schedule, upload, mutate provider
+accounts, spend, contact customers, or offer Claude Code entrypoints.


### PR DESCRIPTION
<!--
  Thanks for contributing to Main Branch.

  See CONTRIBUTING.md for branch + PR shape, concern-based commit
  organization, and pre-push gates. Keep PRs scoped — one logical
  change per PR, ideally 3–5 commits by concern.
-->

## Summary

Migrates `mb-organic` to a canonical shared workflow source with checked Claude and Codex shell snapshots. Codex remains read-only planning/file guidance for organic work, with publishing, scheduling, upload, provider mutation, spend, and customer contact explicitly out of bounds.

## Linked issue

Closes #752

## Why

`mb-organic` still carried its durable workflow contract primarily in the Claude skill, which made Codex guidance and workflow inventory depend on temporary pending-migration language. This PR moves the portable contract into `workflows/mb-organic/workflow.md` while preserving the worked Claude skill substance and adding tests that guard the Codex support boundary.

## Commits by concern

- [ ] Each commit body bullet-lists the changes in that commit
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`

Commits:

- `bd12827 [update] Migrate mb-organic workflow source`

The first checkbox is left unchecked because the existing pushed commit has no body; this PR does not rewrite pushed history.

## Validation

Pre-push gate from repo root:

```bash
scripts/check.sh
```

- [x] Level 1 static: `scripts/check.sh` passes
- [x] Level 2 CLI contract: focused Typer/CliRunner tests, exit codes, `--json` behavior, TTY vs non-TTY (if CLI behavior touched)
- [ ] Level 3 package/install smoke (if packaging touched)
- [ ] Level 4 fixture repo (if init/onboard/status/start/update touched)
- [ ] Level 5 runtime smoke / dogfood harness / simulation-tier (if runtime, first-run, skill discovery, or release validation touched)
- [x] SKILL.md ≤500 lines (if any skill touched)
- [ ] Package-visible release gate evidence before tag/publish (if preparing a release)
- [ ] Supply-chain review (if `.github/workflows/`, `.github/dependabot.yml`, `mb/pyproject.toml` deps, or `id-token`/`permissions` blocks touched — see [docs/supply-chain-policy.md](../docs/supply-chain-policy.md))

Evidence:

- Level 1 static: `scripts/check.sh` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: `95 files already formatted`; `Success: no issues found in 94 source files`; full pytest reached `tests/test_workflows.py::test_workflow_source_and_snapshots_stay_public_safe PASSED`; skill validation summary reported `errors: 0`, `warnings: 0`.
- Level 2 workflow contract: `cd mb && pytest tests/test_workflows.py -q` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: `50 passed in 0.80s`.
- Level 3 package/install: not required; this branch does not change packaging, entrypoints, install behavior, or bundled-data discovery outside the workflow source/fixture contract.
- Level 4 fixture repo: not required; this branch does not change init, onboard, status, start, update, or migration behavior.
- Level 5 runtime smoke: not required; this branch does not claim new Codex write/runtime parity, and the new Codex route remains read-only planning/file guidance until future runtime smoke.
- SKILL.md line gate: covered by `scripts/check.sh`; `mb-organic` remains under the 500-line gate.
- Supply-chain review: not required; this branch does not touch workflows, dependency metadata, or permissions/id-token blocks.

## Success metric

`mb workflow list --runtime codex --json` reports `organic-content` with `source_status: shared_workflow_source`, `shared_source: workflows/mb-organic/workflow.md`, and read-only Codex support boundaries guarded by workflow tests.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [ ] N/A — change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [x] No
- [ ] Yes — migration note below

No user migration required.

## Public / private boundary

No private operator strategy, machine-specific paths, provider credentials, raw account data, customer/member data, or private runtime internals were committed. The new workflow source, generated fixtures, Codex inventory, and Claude skill markers preserve current path vocabulary and guard against broader runtime claims or provider authority claims.
