### PR TITLE
[fix] Patch lifecycle skill drift

### DIFF
--- a/.claude/skills/mb-end/SKILL.md
+++ b/.claude/skills/mb-end/SKILL.md
@@ -99,7 +99,7 @@ This is not an audit. It is a thoughtful friend helping you close the session.
    5c. Spawn crystallize agent (Task tool)
    5d. Present output to user as-is
    5e. If user engages: stay with it (engagement protocol)
-   5f. Always save crystallize output as research file
+   5f. Propose saving crystallize output as a research file
 6. Checkpoint & close
 ```
 
@@ -303,9 +303,11 @@ If the user engages with the crystallize question, the main conversation handles
 
 See [references/crystallize-agent.md](references/crystallize-agent.md) for the full engagement protocol with examples.
 
-### 5f. Always Save the Crystallize Output
+### 5f. Propose Saving the Crystallize Output
 
-**This is not optional.** Every crystallize moment gets saved as a research file. Future crystallize agents read these for temporal pattern recognition.
+Crystallize output can help future sessions see what keeps coming up, but it is
+still a business-file write. Offer to save it as a research file and wait for
+explicit operator approval before writing.
 
 ```markdown
 ---
@@ -329,9 +331,11 @@ status: complete
 [Which files were updated as a result, or "None"]
 ```
 
-Save to: `research/YYYY-MM-DD-end-of-day-crystallize.md`
+Proposed save target: `research/YYYY-MM-DD-end-of-day-crystallize.md`
 
-If an insight was substantial enough to update reference directly (soul.md, offer.md, etc.), do so and note it in the crystallize file.
+If an insight is substantial enough to update reference directly (`core/soul.md`,
+`core/offer.md`, etc.), name the proposed target and ask for approval before
+editing. If approved, note the updated file in the crystallize file.
 
 ---
 
@@ -366,7 +370,8 @@ If yes:
 - Validate the intended subject with `mb checkpoint --validate "..." --json`.
 - After approval, save with `mb checkpoint --message "..." --yes`.
 - Use beginner-safe language: "saved checkpoint," not "ran git commit."
-- Include the crystallize research file in the checkpoint if one was created.
+- Include the crystallize research file in the checkpoint if the operator
+  approved creating one.
 Do not run raw `git add` or `git commit`.
 
 If no: Leave the work unchanged. Some people prefer to checkpoint at the start

--- a/.claude/skills/mb-start/SKILL.md
+++ b/.claude/skills/mb-start/SKILL.md
@@ -35,6 +35,56 @@ integrations, GitHub, team, bets, dirty git, since-last-check,
 `ranked_actions`. Use GitHub activity `author_display` / `author_known` when
 naming people. Parse the full JSON once; do not slice status output with `head`
 or `sed` in the normal path.
+
+**Shared source:** The portable daily start/status workflow contract lives in
+`workflows/mb-start-status/workflow.md`. This Claude skill is the Claude Code
+shell over that source.
+
+**Shared contract markers:** Keep these aligned with the shared source.
+
+Required commands:
+
+- `mb status --json --peek`
+- `mb start --json`
+- `mb doctor repair --plan`
+
+Required fact paths:
+
+- `money_path`
+- `money_path.objects.proof.quality`
+- `validation.file_contracts`
+- `content_strategy`
+- `ranked_actions`
+- `update`
+- `readiness`
+- `drift.items`
+- `runtime.codex_cli`
+- `runtime.claude_code`
+- `since_last_check`
+- `journal`
+- `checkpoint`
+- `onboarding`
+- `integrations`
+- `github`
+- `brain.bets`
+- `brain.bets.active`
+- `brain.bets.due_soon`
+- `brain.bets.overdue`
+- `brain.bets.exit_criteria`
+- `vocabulary`
+
+Approval gates: `updates_repairs_migrations`, `file_writes`, `checkpoint`,
+`provider_mutation`, `publishing_or_spend`, `customer_contact`, `private_data`,
+`destructive_operations`, and `status_marker`.
+
+Public/private boundaries: `no_secrets`, `no_raw_provider_exports`,
+`no_customer_member_data`, `no_private_runtime_settings`, and
+`no_raw_finance_legal_records`.
+
+Core route: status facts first, runtime mismatch gates before business routing,
+one owner-facing recommendation, business language first, and explicit approval
+before mutating the status marker or doing durable writes.
+
 **Continuity facts:** Use `since_last_check.journal`, top-level `journal`,
 GitHub activity, and `checkpoint` from status to explain "where we left off."
 Do not run raw `git log` unless status says journal facts are unavailable. If
@@ -87,35 +137,18 @@ providers, spending money, changing topology, or creating checkpoints.
 
 ---
 
-## CRITICAL: Repo Selection Rules
+## Repo Selection Rules
 
-**CWD-first wins.** If current Main Branch markers exist in CWD, the user is already in their business repo — no selection needed. Just confirm: "Working in **[repo-name]**." If CWD looks like an old Main Branch repo, keep CWD as migration input. Run `mb status --json --peek` and `mb doctor repair --plan` before fallback config or discovery. Do not write to old repo structure; tell the operator to follow the repair/migration plan.
+CWD-first wins. If current Main Branch markers exist in CWD, confirm the repo and
+continue. If CWD looks like old repo shape, keep CWD as migration input and run
+`mb status --json --peek` plus `mb doctor repair --plan` before discovery.
 
-**Only ask which repo when CWD is NOT a business repo** (fallback to config). In that case, list ALL validated repos from `recent_repos`:
-
-> "Found your repos:
->
-> 1. [default-repo-name] (saved default)
-> 2. [other-repo-name]
-> 3. Switch to different repo
->
-> (hit a number)"
-
-**If only one repo in config:**
-
-> "Found your saved repo:
->
-> 1. [saved-repo-name] (saved)
-> 2. Switch to different repo
->
-> (hit a number)"
-
-**DO NOT skip this question when in fallback mode.** Users have multiple repos. The saved default is a suggestion, not automatic.
-
-**After user selects a repo from legacy fallback config:** Treat the selected
-repo as session-scoped unless a current `mb` command exposes an explicit
-persistence path. Do not write `default_repo` into `~/.config/vip/local.yaml`,
-and do not create or update `.vip/config.yaml`.
+Only ask which repo when CWD is not a business repo. In fallback mode, list all
+validated `recent_repos`, include a switch option, and do not treat the saved
+default as automatic. Treat legacy config selections as session-scoped unless a
+current `mb` command exposes an explicit persistence path. Do not write
+`default_repo` into `~/.config/vip/local.yaml`, and do not create or update
+`.vip/config.yaml`.
 
 ---
 
@@ -125,16 +158,9 @@ Always use numbered lists for multi-choice: business repo selection, skill
 routing, launch blockers, and provider setup.
 
 Use one active choice namespace per turn. If top recommendations are numbered,
-do not also number offers or skill routes in the same response. Use offer
-slugs/names (`community`, `newsletter`, `all`) or letters for the secondary
-set, and make the prompt explicit:
-
-> "Reply `1` for the top recommendation, or reply with an offer slug like
-> `community`."
-
-Never present two visible choices where the same number means different
-actions. If the operator replies with an ambiguous number, ask what they meant
-before taking action.
+use offer slugs/names or letters for secondary choices. Never present two
+visible choices where the same number means different actions; ask when a reply
+is ambiguous.
 
 ---
 
@@ -168,19 +194,21 @@ mb status --json --peek
 - `ranked_actions` is the deterministic list of one to three business moves.
   Surface the first action as the recommendation, including its reason and
   cited signal summaries.
+- `brain.bets.active`, `brain.bets.due_soon`, `brain.bets.overdue`, and
+  `brain.bets.exit_criteria` are the deterministic bet trigger facts. Use them
+  for active, due-soon, overdue, missing-exit, triggered kill, triggered
+  double-down, close, update, and narrate moments before inventing bet state
+  from prose.
 - `money_path` maps customer progress, offer, proof, CTA, channel, push,
-  playbook, page readiness, and outcome feedback. Use levels, objects, and
-  ranked actions as evidence; do not call the offer "good" or "will convert."
-  Cite `money_path.objects.proof.quality` facts: generic testimonials, outcomes, offer linkage, typicality, and outcome feedback.
-- `validation.file_contracts` maps business-file shape gaps. For offer gaps, route to `/mb-think` and ask before editing durable offer files.
-- `content_strategy` maps the simple file and optional layers before markdown parsing.
-- `readiness` gates whether setup/repair work must happen before output skills.
-- `drift.items` names stale or broken status signals and repair commands.
+  playbook, page readiness, and outcome feedback. Use it as evidence; cite
+  `money_path.objects.proof.quality` facts instead of claiming an offer will
+  convert.
+- `validation.file_contracts`, `content_strategy`, `readiness`, and
+  `drift.items` map file gaps, content layers, setup gates, and repair commands.
 - `onboarding.summary` and `onboarding.checklist` replace separate onboarding
   probes unless the status report is unavailable.
-- `journal`, `since_last_check.journal`, `integrations.github`,
-  `integrations.providers`, `github.sections`, `measurement`, and
-  `brain.bets` supply continuity facts for routing and triage.
+- `journal`, `since_last_check.journal`, `integrations`, `github`,
+  `measurement`, and `brain.bets` supply continuity facts for routing.
 
 Only run a narrower fallback command such as `mb onboard status --json`,
 `mb doctor`, `mb validate --cross-refs`, or `mb connect doctor --json` when status
@@ -341,13 +369,10 @@ without making the repo feel audited or behind.
 
 ## Step 7: Defer Full Context Loading
 
-**Do NOT read full reference files into main.** Readiness (Step 6) already scored them — that's enough for routing. Full context loading happens in the selected skill or triage agents, not here.
-
-**Why:** Reading soul.md + offer.md + audience.md + voice.md into main burns 15-30K tokens that get duplicated when the skill re-reads them. The triage test showed /mb-start hitting 61% context before any work began. Main stays lean; skills/agents load what they need.
-
-**What main knows after Step 6:** Readiness scores, which files exist, composite score, gaps. That's enough to present the menu and gate routing.
-
-**Exception:** Read `[repo]/CLAUDE.md` (the business brain) — it's small and needed for personality/routing awareness. Skip the 4 full core files.
+Do not read full reference files into main. Status readiness already names the
+scores, files, and gaps needed for routing. The selected skill or triage agent
+loads deep context. Exception: read `[repo]/CLAUDE.md` when present because it
+is small and helps with routing tone.
 
 **Onboarding exception:** When onboarding is incomplete and current `core/`
 files already exist, read enough of those files to avoid asking for facts the
@@ -371,38 +396,15 @@ find "$REPO_PATH/core/offers" -mindepth 2 -maxdepth 2 -name "offer.md" 2>/dev/nu
 ```
 
 If `core/offers` is absent and `core/` is also absent, do not infer the offer
-from old paths. If CWD looks like an old Main Branch repo, run
-`mb status --json --peek` and/or `mb doctor repair --plan` from CWD and treat
-it as migration input.
+from old paths; treat old shape as migration input after `mb status --json
+--peek` or `mb doctor repair --plan`.
 
-**If no offers/ folder:** Single-offer mode. Skip to Step 2. Read from `core/`.
-
-**If offers/ found:** Multi-offer mode.
-1. Check current CLI status facts first. If a future `mb` JSON field exposes
-   active-offer local state, prefer that. Do not silently route from
-   `.vip/local.yaml`.
-2. If legacy active-offer state is present, do not treat it as the source of truth. Say:
-   "This repo has old active-offer session state. Continue with that offer,
-   work brand-level, or switch?" Avoid echoing raw `.vip` values unless the
-   user asks to inspect the file.
-3. If no active offer is set, present offers by slug/name, not numbers when
-   ranked actions or routes are already numbered:
-   - `community` — paid community
-   - `newsletter` — newsletter
-   - `all` — brand-level work from `core/`
-4. Treat the user's selection as session-scoped until they explicitly confirm
-   persistence. Say what will happen before writing local state:
-   "For this session I'll use **[offer]**. Save that as the active offer for
-   future sessions too?"
-5. Keep the selection session-scoped. Do not write `.vip/local.yaml` as the
-   active-offer mechanism. If a future `mb` command exposes an explicit
-   session-state contract, use that only after confirmation.
-
-**Shortcut:** `/mb-start [offer-name]` selects that offer for this session after
-validating the folder exists. Ask before saving future active-offer state.
-
-**"all" selection:** Use brand-level `core/` context for this session. Ask
-before persisting any future local state that clears an active offer.
+No `core/offers/` means single-offer mode. If offers exist, use current CLI
+status facts first, never silently route from `.vip/local.yaml`, present choices
+by slug/name when route numbers are already visible, and keep selection
+session-scoped unless the operator approves a current `mb` persistence command.
+`/mb-start [offer-name]` can select a validated offer for this session. `all`
+means brand-level `core/` context.
 
 ---
 
@@ -495,5 +497,4 @@ treat business `.vip/local.yaml` as audit input only, and do not write it.
 - [references/launch-orchestration.md](references/launch-orchestration.md) — guided offer-launch path
 
 ## Remember
-
 Router, not worker. Detect → route → let the skill do the work. One clarifying question max. Skill loads its own context — main stays lean.

--- a/.claude/skills/mb-start/references/triage-agent.md
+++ b/.claude/skills/mb-start/references/triage-agent.md
@@ -616,7 +616,7 @@ status: complete
 [Whether the recommendation was followed -- updated at /mb-end if possible]
 ```
 
-**Why save:** Future triage agents read these for temporal pattern recognition. "Last time we recommended voice.md work and you chose /mb-ads instead -- did that work out?" Prevents repetitive recommendations and enables the system to learn user preferences.
+**Why save:** Future triage agents read these to spot what keeps happening over time. "Last time we recommended voice.md work and you chose /mb-ads instead -- did that work out?" This prevents repeated recommendations and helps the system learn user preferences.
 
 ---
 

--- a/.claude/skills/mb-status/SKILL.md
+++ b/.claude/skills/mb-status/SKILL.md
@@ -12,6 +12,55 @@ repo-health checks in prose.
 **CLI facts first:** Run `mb status --json --peek` before answering, then use
 that JSON as the source of truth.
 
+**Shared source:** The portable daily start/status workflow contract lives in
+`workflows/mb-start-status/workflow.md`. This Claude skill is the Claude Code
+status shell over that source.
+
+**Shared contract markers:** Keep these aligned with the shared source.
+
+Required commands:
+
+- `mb status --json --peek`
+- `mb start --json`
+- `mb doctor repair --plan`
+
+Required fact paths:
+
+- `money_path`
+- `money_path.objects.proof.quality`
+- `validation.file_contracts`
+- `content_strategy`
+- `ranked_actions`
+- `update`
+- `readiness`
+- `drift.items`
+- `runtime.codex_cli`
+- `runtime.claude_code`
+- `since_last_check`
+- `journal`
+- `checkpoint`
+- `onboarding`
+- `integrations`
+- `github`
+- `brain.bets`
+- `brain.bets.active`
+- `brain.bets.due_soon`
+- `brain.bets.overdue`
+- `brain.bets.exit_criteria`
+- `vocabulary`
+
+Approval gates: `updates_repairs_migrations`, `file_writes`, `checkpoint`,
+`provider_mutation`, `publishing_or_spend`, `customer_contact`, `private_data`,
+`destructive_operations`, and `status_marker`.
+
+Public/private boundaries: `no_secrets`, `no_raw_provider_exports`,
+`no_customer_member_data`, `no_private_runtime_settings`, and
+`no_raw_finance_legal_records`.
+
+Core route: status facts first, runtime mismatch gates before business routing,
+one owner-facing recommendation, business language first, and explicit approval
+before mutating the status marker or doing durable writes.
+
 ## Workflow
 
 1. Confirm you are in the business repo. If not, ask the operator to `cd` into
@@ -44,6 +93,10 @@ mb status --json --peek
    layered channel/account/person files, stale platform rules, or disconnected
    content layers. Do not infer that health by parsing markdown yourself unless
    status says the section is unavailable.
+   Use `brain.bets.active`, `brain.bets.due_soon`, `brain.bets.overdue`, and
+   `brain.bets.exit_criteria` for active, due-soon, overdue, missing-exit,
+   triggered kill, triggered double-down, close, update, and narrate moments
+   before inventing bet state from prose.
    If `vocabulary.terms.push` defines display words, use them in
    operator-facing prose without changing current paths, frontmatter, JSON
    keys, validator rules, or command names.

--- a/.claude/skills/mb-think/SKILL.md
+++ b/.claude/skills/mb-think/SKILL.md
@@ -26,6 +26,55 @@ Something came your way — a video, a voice memo, a vague feeling, a problem to
 decision, codify pass, or major reference-file update, ask whether to checkpoint.
 Run `mb checkpoint --plan --json`, show the proposed message, validate with `mb checkpoint --validate "..." --json`, then save with `mb checkpoint --message "..." --yes` only after approval; no hidden checkpoints.
 
+**Shared source:** The portable thinking workflow contract lives in
+`workflows/mb-think/workflow.md`. This Claude skill is the Claude Code shell
+over that source.
+
+**Shared contract markers:** Keep these aligned with the shared source.
+
+Required commands:
+
+- `mb status --json --peek`
+- `mb start --json`
+- `mb doctor repair --plan`
+- `mb connect doctor --json`
+- `mb checkpoint --plan --json`
+
+Required fact paths:
+
+- `money_path`
+- `money_path.objects.offer`
+- `money_path.objects.proof`
+- `money_path.objects.proof.quality`
+- `money_path.objects.product_ladder`
+- `money_path.objects.cta_path`
+- `money_path.objects.channel_strategy`
+- `money_path.objects.active_push`
+- `money_path.objects.outcome_feedback_loop`
+- `money_path.ranked_actions`
+- `validation.file_contracts`
+- `content_strategy`
+- `ranked_actions`
+- `update`
+- `readiness`
+- `drift.items`
+- `books`
+- `runtime.codex_cli`
+- `runtime.claude_code`
+
+Approval gates: `updates_repairs_migrations`, `file_writes`, `checkpoint`,
+`provider_mutation`, `publishing_or_spend`, `customer_contact`, `private_data`,
+`destructive_operations`, `structured_collection`, and `public_issue_or_proposal`.
+
+Public/private boundaries: `no_secrets`, `no_raw_provider_exports`,
+`no_raw_transcripts`, `no_customer_member_data`,
+`no_private_runtime_settings`, `no_private_dms_or_gated_communities`, and
+`no_raw_finance_legal_records`.
+
+Core route: research depth recommendation, parallel research files when multiple
+source types are needed, decision, codify, stale source cleanup,
+public/private handling, checkpoint approval, and explicit write approval. Do not tell Codex users to run Claude Code entrypoints.
+
 When research identifies a reusable growth mechanic such as a comment-keyword,
 DM-keyword, public reply/link, resource delivery, provider setup recipe, or
 approval gate, route the durable plan into
@@ -201,37 +250,12 @@ When routing to research mode, detect research TYPE from user intent:
 6. Never block on missing optional tools
 ```
 
-### Fallback Examples
+### Fallback Principle
 
-**YouTube without Apify:**
-> "YouTube transcript mining needs Apify MCP. Options:
-> 1. Set up Apify now (5 min)
-> 2. Paste transcript manually
-> 3. Skip this video"
-
-**X/Twitter without Grok:**
-> "X sentiment research is best with Grok, but I can use web search instead. Results will be less real-time. Proceed with web search?"
-
-**Deep research without Gemini:**
-> "Running comprehensive research using Claude Code web search. This may take longer than Gemini deep research."
-
-**Local file without whisper:**
-> "Local transcription needs a whisper variant. Check: `which mlx_whisper` or `which whisper-cli`. Or upload to a transcription service and paste the result."
-
-**Ad account data without connection:**
-> "Ad account research works best with live Meta ad account context. It is optional and only available after `mb connect` reports the official Meta path ready. Options:
-> 1. Run `mb connect plan`
-> 2. Check Ads Manager manually and paste what you find
-> 3. Skip account data, research from reference files only"
-
-**Winning-ad research without optional tools:**
-> "Winning-ad research can still run from manual exports, screenshots, pasted
-> reviews, or transcripts. Apify/Grok can speed up public comment and X research
-> when configured, but they are optional."
-
-### Key Principle
-
-**Never block on missing tools.** WebSearch + codebase search are ALWAYS available. External tools enhance but don't gate research.
+Never block on missing optional tools. Use web/codebase search, pasted source
+material, manual exports, or the provider repair command from `mb connect`.
+See [references/tool-detection.md](references/tool-detection.md) for exact
+tool-specific fallback wording.
 
 ---
 
@@ -290,23 +314,10 @@ Gather from codebase, web, user input, local recordings.
 
 **Do NOT run research agents in background** (`run_in_background: true`) — background agents cannot access MCP tools (Apify, etc.) and cannot prompt for permissions.
 
-**Mining sources:**
-
-| Source | How | Output suffix |
-|--------|-----|---------------|
-| YouTube videos | Apify transcript MCP | `-yt-mining.md` |
-| X/Twitter sentiment | Grok X Insights MCP ([grok-social.md](references/grok-social.md)) | `-x-social.md` |
-| Local video/audio | whisper-cpp ([local-transcription.md](references/local-transcription.md)) | `-local-mining.md` |
-| Voice memos | whisper-cpp | `-voice-mining.md` |
-| Authenticated community, calls, Drive/provider exports, mixed private sources | Source inventory + manifest-first filters ([source-ingestion.md](references/source-ingestion.md)) | `-source-mining.md` |
-| Instagram mining | Apify or manual | `-ig-mining.md` |
-| Ad account data | Verified Meta Ads account context | `-ad-account.md` |
-| Competitor sites | Browser MCP or web fetch | `-competitor-mining.md` |
-| Keyword gate | SERP/search sidecar, planner CSV, or WebSearch | `-keyword-gate.md` |
-| Your own emails/DMs | Paste into conversation | `-internal-mining.md` |
-| Deep research | Build prompt → Gemini/GPT | `-gemini.md` or `-gpt.md` |
-| Codebase exploration | Grep, read, subagents | `-claude-code.md` |
-| Documents (PDF, DOCX, PPTX) | markitdown / pandoc / marker ([document-ingestion.md](references/document-ingestion.md)) | `-doc-extraction.md` |
+**Mining sources:** Use [research-routing-quick-ref.md](references/research-routing-quick-ref.md)
+and the source-specific references for tool choice and output suffixes.
+Authenticated community, calls, Drive/provider exports, and other private
+source mixes route through [source-ingestion.md](references/source-ingestion.md).
 
 ### 3. Synthesize (Required)
 
@@ -480,19 +491,6 @@ Use `/mb-think` when the answer requires investigation and the choice needs docu
 
 ## Why This Matters
 
-The repo is a precision instrument. The think cycle exists to filter — not to cram everything in. Research gets synthesized, decisions get distilled, and only the sharpest insights survive into reference. Curation over collection.
-
-Reference files aren't just documentation. They're how you stay connected to why you do this.
-
-Angles evolve. Each research session may surface a new emotional entry point, a new enemy to name, a new lifestyle aspiration. The angle library in `core/proof/angles/` is additive — it grows as understanding deepens. Treating angles as locked is an anti-pattern.
-
-When AI makes information infinite, curation is the moat. The think cycle is curation in action — filtering signal from noise, codifying what matters, discarding what doesn't. Every reference file update is a curation decision.
-
-The act of researching, deciding, and codifying forces you to articulate:
-- **Why you do this** — Not the marketing reason. The real reason.
-- **Who actually benefits** — Not demographics. Real people whose lives change.
-- **What transformation you enable** — Not features. The before/after.
-
-Research and decisions go stale. Reference files compound. Every update makes all downstream content better.
-
-If the overlaps between your interests and your offer don't make sense, maybe you have the wrong offer. The think cycle should feel like pull, not push.
+Keep what changes the business. Leave the rest in research. Reference files get
+stronger when each accepted decision makes the offer, proof, audience, voice, or
+content strategy clearer.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ### Changed
 
+- Tightened core lifecycle skill guidance so `mb-think` uses the real
+  `runtime.codex_cli` fact path, daily start/status preserves explicit bet
+  trigger facts, and `/mb-end` crystallize writes remain approval-gated.
+  Closes #767.
 - Migrated `mb-organic` to a shared workflow source with checked Claude and
   Codex shells, preserving read-only Codex boundaries for planning, source
   privacy, publishing, account mutation, and customer-contact gates. Closes

--- a/mb/mb/_data/templates/AGENTS.md.tmpl
+++ b/mb/mb/_data/templates/AGENTS.md.tmpl
@@ -246,7 +246,7 @@ Shared source required JSON fact paths:
 - `readiness`
 - `drift.items`
 - `books`
-- `runtime.codex`
+- `runtime.codex_cli`
 - `runtime.claude_code`
 
 Shared source gates: `updates_repairs_migrations`, `file_writes`,

--- a/mb/mb/codex.py
+++ b/mb/mb/codex.py
@@ -257,7 +257,7 @@ CODEX_THINK_REQUIRED_JSON_FACTS = (
     "readiness",
     "drift.items",
     "books",
-    "runtime.codex",
+    "runtime.codex_cli",
     "runtime.claude_code",
 )
 CODEX_THINK_APPROVAL_GATES = (
@@ -1193,7 +1193,7 @@ Shared source required JSON fact paths:
 - `readiness`
 - `drift.items`
 - `books`
-- `runtime.codex`
+- `runtime.codex_cli`
 - `runtime.claude_code`
 
 Shared source gates: `updates_repairs_migrations`, `file_writes`,

--- a/mb/tests/fixtures/workflows/mb-start-status.claude.md
+++ b/mb/tests/fixtures/workflows/mb-start-status.claude.md
@@ -33,6 +33,11 @@ This snapshot does not replace shipped `.claude/skills` prose.
 - `onboarding`
 - `integrations`
 - `github`
+- `brain.bets`
+- `brain.bets.active`
+- `brain.bets.due_soon`
+- `brain.bets.overdue`
+- `brain.bets.exit_criteria`
 - `vocabulary`
 
 ## Routing

--- a/mb/tests/fixtures/workflows/mb-start-status.codex.md
+++ b/mb/tests/fixtures/workflows/mb-start-status.codex.md
@@ -36,6 +36,11 @@ workflows are available in Codex.
 - `onboarding`
 - `integrations`
 - `github`
+- `brain.bets`
+- `brain.bets.active`
+- `brain.bets.due_soon`
+- `brain.bets.overdue`
+- `brain.bets.exit_criteria`
 - `vocabulary`
 
 ## Codex Route

--- a/mb/tests/fixtures/workflows/mb-think.claude.md
+++ b/mb/tests/fixtures/workflows/mb-think.claude.md
@@ -38,7 +38,7 @@ This snapshot does not replace shipped `.claude/skills/mb-think/SKILL.md`.
 - `readiness`
 - `drift.items`
 - `books`
-- `runtime.codex`
+- `runtime.codex_cli`
 - `runtime.claude_code`
 
 ## Routing

--- a/mb/tests/fixtures/workflows/mb-think.codex.md
+++ b/mb/tests/fixtures/workflows/mb-think.codex.md
@@ -39,7 +39,7 @@ workflows are available in Codex.
 - `readiness`
 - `drift.items`
 - `books`
-- `runtime.codex`
+- `runtime.codex_cli`
 - `runtime.claude_code`
 
 ## Codex Route

--- a/mb/tests/test_doctor.py
+++ b/mb/tests/test_doctor.py
@@ -838,7 +838,7 @@ def test_doctor_repair_plan_reports_custom_codex_agents_missing_source_item(
     init_run(path=str(repo), name="Acme")
     agents = repo / "AGENTS.md"
     agents.write_text(
-        agents.read_text(encoding="utf-8").replace("- `runtime.codex`\n", "", 1)
+        agents.read_text(encoding="utf-8").replace("- `runtime.codex_cli`\n", "", 1)
         + "\n## Local Notes\n\nKeep this operator-specific note.\n",
         encoding="utf-8",
     )
@@ -851,7 +851,7 @@ def test_doctor_repair_plan_reports_custom_codex_agents_missing_source_item(
     agents_check = next(check for check in section["checks"] if check["name"] == "AGENTS.md")
     assert agents_check["state"] == "warn"
     assert agents_check["lifecycle_discovery_ok"] is False
-    assert "- `runtime.codex`" in agents_check["missing_lifecycle_guidance"]
+    assert "- `runtime.codex_cli`" in agents_check["missing_lifecycle_guidance"]
     actions = {action["id"]: action for action in payload["actions"]}
     assert "codex-agents-md" in actions
 

--- a/mb/tests/test_workflows.py
+++ b/mb/tests/test_workflows.py
@@ -29,6 +29,8 @@ THINK_WORKFLOW = REPO_ROOT / "workflows" / "mb-think" / "workflow.md"
 END_WORKFLOW = REPO_ROOT / "workflows" / "mb-end" / "workflow.md"
 BET_WORKFLOW = REPO_ROOT / "workflows" / "mb-bet" / "workflow.md"
 ORGANIC_WORKFLOW = REPO_ROOT / "workflows" / "mb-organic" / "workflow.md"
+SHIPPED_START_SKILL = REPO_ROOT / ".claude" / "skills" / "mb-start" / "SKILL.md"
+SHIPPED_THINK_SKILL = REPO_ROOT / ".claude" / "skills" / "mb-think" / "SKILL.md"
 SHIPPED_END_SKILL = REPO_ROOT / ".claude" / "skills" / "mb-end" / "SKILL.md"
 SHIPPED_BET_SKILL = REPO_ROOT / ".claude" / "skills" / "mb-bet" / "SKILL.md"
 SHIPPED_ORGANIC_SKILL = REPO_ROOT / ".claude" / "skills" / "mb-organic" / "SKILL.md"
@@ -161,12 +163,84 @@ def test_generated_organic_claude_and_codex_snapshots_match_fixtures() -> None:
     )
 
 
+def test_shipped_claude_start_skill_preserves_shared_workflow_contract() -> None:
+    workflow = load_workflow(START_STATUS_WORKFLOW)
+    skill_text = SHIPPED_START_SKILL.read_text(encoding="utf-8")
+
+    assert shell_drift_errors(workflow, skill_text) == []
+    assert "workflows/mb-start-status/workflow.md" in skill_text
+
+
+def test_shipped_claude_think_skill_preserves_shared_workflow_contract() -> None:
+    workflow = load_workflow(THINK_WORKFLOW)
+    skill_text = SHIPPED_THINK_SKILL.read_text(encoding="utf-8")
+
+    assert shell_drift_errors(workflow, skill_text) == []
+    assert "workflows/mb-think/workflow.md" in skill_text
+    assert "- `runtime.codex_cli`" in skill_text
+    assert "- `runtime.codex`" not in skill_text
+
+
 def test_shipped_claude_end_skill_preserves_shared_workflow_contract() -> None:
     workflow = load_workflow(END_WORKFLOW)
     skill_text = SHIPPED_END_SKILL.read_text(encoding="utf-8")
 
     assert shell_drift_errors(workflow, skill_text) == []
     assert "workflows/mb-end/workflow.md" in skill_text
+
+
+def test_shipped_claude_end_skill_keeps_crystallize_writes_approval_gated() -> None:
+    skill_text = SHIPPED_END_SKILL.read_text(encoding="utf-8")
+    forbidden = (
+        "### 5f. Always Save the Crystallize Output",
+        "This is not optional.",
+        "Every crystallize moment gets saved as a research file",
+        "If an insight was substantial enough to update reference directly",
+    )
+
+    for phrase in forbidden:
+        assert phrase not in skill_text
+    assert "explicit operator approval before writing" in skill_text
+    assert "ask for approval before\nediting" in skill_text
+
+
+def test_think_runtime_guidance_uses_codex_cli_fact_path() -> None:
+    workflow = load_workflow(THINK_WORKFLOW)
+    texts = [
+        workflow.path.read_text(encoding="utf-8"),
+        AGENTS_TEMPLATE.read_text(encoding="utf-8"),
+        render_claude_shell(workflow),
+        render_codex_shell(workflow),
+        SHIPPED_THINK_SKILL.read_text(encoding="utf-8"),
+    ]
+
+    for text in texts:
+        assert "- `runtime.codex_cli`" in text
+        assert "- `runtime.codex`" not in text
+
+
+def test_start_status_preserves_bet_trigger_fact_paths() -> None:
+    workflow = load_workflow(START_STATUS_WORKFLOW)
+    required = {
+        "brain.bets",
+        "brain.bets.active",
+        "brain.bets.due_soon",
+        "brain.bets.overdue",
+        "brain.bets.exit_criteria",
+    }
+    shells = [
+        workflow.path.read_text(encoding="utf-8"),
+        render_claude_shell(workflow),
+        render_codex_shell(workflow),
+        SHIPPED_START_SKILL.read_text(encoding="utf-8"),
+    ]
+
+    assert required.issubset(set(workflow.json_facts))
+    for text in shells:
+        for fact in sorted(required):
+            assert f"- `{fact}`" in text
+    assert "triggered kill" in workflow.path.read_text(encoding="utf-8")
+    assert "triggered double-down" in workflow.path.read_text(encoding="utf-8")
 
 
 def test_shipped_claude_bet_skill_preserves_shared_workflow_contract() -> None:

--- a/mb/tests/test_workflows.py
+++ b/mb/tests/test_workflows.py
@@ -30,6 +30,7 @@ END_WORKFLOW = REPO_ROOT / "workflows" / "mb-end" / "workflow.md"
 BET_WORKFLOW = REPO_ROOT / "workflows" / "mb-bet" / "workflow.md"
 ORGANIC_WORKFLOW = REPO_ROOT / "workflows" / "mb-organic" / "workflow.md"
 SHIPPED_START_SKILL = REPO_ROOT / ".claude" / "skills" / "mb-start" / "SKILL.md"
+SHIPPED_STATUS_SKILL = REPO_ROOT / ".claude" / "skills" / "mb-status" / "SKILL.md"
 SHIPPED_THINK_SKILL = REPO_ROOT / ".claude" / "skills" / "mb-think" / "SKILL.md"
 SHIPPED_END_SKILL = REPO_ROOT / ".claude" / "skills" / "mb-end" / "SKILL.md"
 SHIPPED_BET_SKILL = REPO_ROOT / ".claude" / "skills" / "mb-bet" / "SKILL.md"
@@ -171,6 +172,14 @@ def test_shipped_claude_start_skill_preserves_shared_workflow_contract() -> None
     assert "workflows/mb-start-status/workflow.md" in skill_text
 
 
+def test_shipped_claude_status_skill_preserves_shared_workflow_contract() -> None:
+    workflow = load_workflow(START_STATUS_WORKFLOW)
+    skill_text = SHIPPED_STATUS_SKILL.read_text(encoding="utf-8")
+
+    assert shell_drift_errors(workflow, skill_text) == []
+    assert "workflows/mb-start-status/workflow.md" in skill_text
+
+
 def test_shipped_claude_think_skill_preserves_shared_workflow_contract() -> None:
     workflow = load_workflow(THINK_WORKFLOW)
     skill_text = SHIPPED_THINK_SKILL.read_text(encoding="utf-8")
@@ -233,6 +242,7 @@ def test_start_status_preserves_bet_trigger_fact_paths() -> None:
         render_claude_shell(workflow),
         render_codex_shell(workflow),
         SHIPPED_START_SKILL.read_text(encoding="utf-8"),
+        SHIPPED_STATUS_SKILL.read_text(encoding="utf-8"),
     ]
 
     assert required.issubset(set(workflow.json_facts))

--- a/workflows/mb-start-status/workflow.md
+++ b/workflows/mb-start-status/workflow.md
@@ -31,6 +31,11 @@ json_facts:
   - onboarding
   - integrations
   - github
+  - brain.bets
+  - brain.bets.active
+  - brain.bets.due_soon
+  - brain.bets.overdue
+  - brain.bets.exit_criteria
   - vocabulary
 approval_gates:
   - updates_repairs_migrations
@@ -102,6 +107,11 @@ The runtime shell must preserve these paths from the workflow source:
 - `onboarding`
 - `integrations`
 - `github`
+- `brain.bets`
+- `brain.bets.active`
+- `brain.bets.due_soon`
+- `brain.bets.overdue`
+- `brain.bets.exit_criteria`
 - `vocabulary`
 
 Treat these as facts, not strategy. The runtime may recommend the next route,
@@ -123,7 +133,10 @@ workflow; route offer-shape gaps to `mb-think` and ask before durable writes.
 Use `money_path` for customer progress, offer, proof, CTA, channel, push, page
 readiness, playbook, and outcome feedback questions. Use `content_strategy` for
 content strategy, channel, account, freshness, or disconnected-layer questions.
-Use `onboarding` to resume setup without inventing a new interview.
+Use `brain.bets` for active, due-soon, overdue, missing-exit, triggered kill,
+triggered double-down, close, update, and narrate moments before inventing bet
+state from prose. Use `onboarding` to resume setup without inventing a new
+interview.
 
 Give one clear route: frame a bet, think through a decision, advance a push,
 draft a playbook, repair the repo, review provider readiness, inspect a

--- a/workflows/mb-think/workflow.md
+++ b/workflows/mb-think/workflow.md
@@ -34,7 +34,7 @@ json_facts:
   - readiness
   - drift.items
   - books
-  - runtime.codex
+  - runtime.codex_cli
   - runtime.claude_code
 approval_gates:
   - updates_repairs_migrations
@@ -123,7 +123,7 @@ The runtime shell must preserve these paths from the workflow source:
 - `readiness`
 - `drift.items`
 - `books`
-- `runtime.codex`
+- `runtime.codex_cli`
 - `runtime.claude_code`
 
 Treat these as facts, not strategy. The CLI reports legibility, connection,


### PR DESCRIPTION
## Summary

Tightens core lifecycle guidance before release: `mb-think` now points at `runtime.codex_cli`, daily start/status keeps the bet trigger facts visible, and Claude `/mb-end` crystallize writes are approval-gated. The shipped `/mb-start`, `/mb-status`, and `/mb-think` skills now have drift guards against the shared workflow contracts.

## Linked issue

Closes #767

Supersedes #770.

## Why

The MAIN-461 audit found small but release-relevant drift between shared workflow truth, generated Codex guidance, and shipped Claude skills. This patch keeps the fix narrow so the daily lifecycle surfaces stay factual without starting the broader proactive-trigger redesign.

## Commits by concern

- [ ] Each commit body bullet-lists the changes in that commit
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`

Commit list:

- `eca4252 [fix] Patch lifecycle skill drift`
- `0801f61 [fix] Guard mb-status lifecycle drift`

## Validation

Level 1 static: `scripts/check.sh` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: `95 files already formatted`; `All checks passed!`; `Success: no issues found in 94 source files`; `851 passed`.

Level 1 skill validation: `cd mb && python3 -m mb skill validate --all --json` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: `skills: 15, passed: 15, failed: 0`; `mb-start` 500 lines; `mb-status` 140 lines; `mb-think` 496 lines.

Level 2 workflow contract: `cd mb && python3 -m pytest tests/test_workflows.py -q` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: `56 passed in 0.75s`.

Level 2 workflow/doctor contract: `cd mb && python3 -m pytest tests/test_workflows.py tests/test_doctor.py -q` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: `127 passed in 179.94s`.

Level 2 source-ingestion/workflow regression: `cd mb && python3 -m pytest tests/test_source_ingestion_workflow.py::test_think_skill_routes_authenticated_sources_to_self_contained_reference tests/test_workflows.py tests/test_doctor.py -q` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: `128 passed in 169.94s`.

Level 3 package/install smoke: not required; no packaging, entrypoint, bundled-data discovery, or install/update behavior changed.

Level 4 fixture repo: not required; no init/onboard/status/start CLI behavior changed.

Level 5 runtime smoke: not required; no runtime discovery, invocation, first-run, or release-validation claim changed. This PR changes LLM-facing guidance text plus shipped-skill drift guards for `/mb-start`, `/mb-status`, `/mb-think`, and `/mb-end` approval language.

## Success metric

Shared workflow source, generated Codex guidance, shipped Claude skills, fixtures, and tests all agree on `runtime.codex_cli`, approval-gated crystallize writes, and `brain.bets.*` trigger facts across both `/mb-start` and `/mb-status`.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [ ] N/A — change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [x] No
- [ ] Yes — migration note below

## Public / private boundary

No private operator strategy, machine-specific paths, provider secrets, or raw runtime internals were committed. Agent guidance/workflow changes do not introduce old taxonomy claims, unsupported runtime parity claims, or provider authority claims; the corrected Codex fact path and shipped-skill drift contracts for `/mb-start`, `/mb-status`, and `/mb-think` are guarded by tests.
