### PR TITLE
[fix] Patch lifecycle guidance drift

### DIFF
--- a/.claude/skills/mb-start/SKILL.md
+++ b/.claude/skills/mb-start/SKILL.md
@@ -43,13 +43,11 @@ shell over that source.
 **Shared contract markers:** Keep these aligned with the shared source.
 
 Required commands:
-
 - `mb status --json --peek`
 - `mb start --json`
 - `mb doctor repair --plan`
 
 Required fact paths:
-
 - `money_path`
 - `money_path.objects.proof.quality`
 - `validation.file_contracts`
@@ -71,8 +69,10 @@ Required fact paths:
 - `brain.bets.due_soon`
 - `brain.bets.overdue`
 - `brain.bets.exit_criteria`
+- `brain.bets.exit_criteria.missing`
+- `brain.bets.exit_criteria.triggered_failure_signals`
+- `brain.bets.exit_criteria.triggered_double_down_signals`
 - `vocabulary`
-
 Approval gates: `updates_repairs_migrations`, `file_writes`, `checkpoint`,
 `provider_mutation`, `publishing_or_spend`, `customer_contact`, `private_data`,
 `destructive_operations`, and `status_marker`.

--- a/.claude/skills/mb-status/SKILL.md
+++ b/.claude/skills/mb-status/SKILL.md
@@ -47,6 +47,9 @@ Required fact paths:
 - `brain.bets.due_soon`
 - `brain.bets.overdue`
 - `brain.bets.exit_criteria`
+- `brain.bets.exit_criteria.missing`
+- `brain.bets.exit_criteria.triggered_failure_signals`
+- `brain.bets.exit_criteria.triggered_double_down_signals`
 - `vocabulary`
 
 Approval gates: `updates_repairs_migrations`, `file_writes`, `checkpoint`,

--- a/.claude/skills/mb-think/SKILL.md
+++ b/.claude/skills/mb-think/SKILL.md
@@ -8,7 +8,7 @@ loops: [sense, decide, ship]
 
 Research, decide, and codify knowledge into reference files.
 
----
+**Shared source:** `workflows/mb-think/workflow.md`; preserve `runtime.codex_cli`, research depth recommendation, source-specific research files, decision/codify routing, public/private handling, and checkpoint approval. Do not tell Codex users to run Claude Code entrypoints.
 
 ## Don't Overthink Think
 

--- a/mb/mb/codex.py
+++ b/mb/mb/codex.py
@@ -1187,6 +1187,7 @@ Shared source required JSON fact paths:
 - `money_path.objects.active_push`
 - `money_path.objects.outcome_feedback_loop`
 - `money_path.ranked_actions`
+- `validation.file_contracts`
 - `content_strategy`
 - `ranked_actions`
 - `update`

--- a/mb/mb/workflows.py
+++ b/mb/mb/workflows.py
@@ -102,6 +102,8 @@ REQUIRED_SHELL_PHRASES_BY_WORKFLOW: dict[str, dict[str, str]] = {
         "runtime mismatch gate": "runtime mismatch",
         "status marker approval": "status marker",
         "owner-facing state": "business language first",
+        "bet trigger facts": "brain.bets",
+        "bet lifecycle routing": "double-down",
     },
     "mb-setup": {
         "setup intent": "setup intent",
@@ -511,13 +513,16 @@ def _daily_codex_route_text(workflow: WorkflowSource) -> str:
             "operations, and destructive-operation requests.\n"
             "3. Use `ranked_actions`, `since_last_check`, `journal`, `money_path`, "
             "`content_strategy`, `validation.file_contracts`, `onboarding`, "
-            "`readiness`, `update`, and `drift.items` as cited facts.\n"
+            "`readiness`, `update`, `drift.items`, and `brain.bets` as cited facts.\n"
             "4. Route offer-shape gaps from `validation.file_contracts` to `mb-think` "
             "after hard gates, and ask before durable writes.\n"
-            "5. Present one clear business route and the signal behind it. Mutate the "
+            "5. Use due-soon and overdue bet deadlines, missing exit criteria, triggered "
+            "failure signals, and triggered double-down signals for update, kill, close, "
+            "double-down, or narrate routing.\n"
+            "6. Present one clear business route and the signal behind it. Mutate the "
             "status marker only when the operator explicitly approves recording the "
             "daily check-in.\n"
-            "6. Ask before business-file writes, checkpoints, repairs, updates, migrations, "
+            "7. Ask before business-file writes, checkpoints, repairs, updates, migrations, "
             "provider mutation, publishing, spend, customer contact, destructive operations, "
             "or public issue/proposal submission."
         )
@@ -558,13 +563,16 @@ def _daily_claude_route_text(workflow: WorkflowSource) -> str:
             "operations, and destructive-operation requests.\n"
             "3. Use `ranked_actions`, `since_last_check`, `journal`, `money_path`, "
             "`content_strategy`, `validation.file_contracts`, `onboarding`, "
-            "`readiness`, `update`, and `drift.items` as cited facts.\n"
+            "`readiness`, `update`, `drift.items`, and `brain.bets` as cited facts.\n"
             "4. Route offer-shape gaps from `validation.file_contracts` to `/mb-think` "
             "after hard gates, and ask before durable writes.\n"
-            "5. Present one clear business route and the signal behind it. Mutate the "
+            "5. Use due-soon and overdue bet deadlines, missing exit criteria, triggered "
+            "failure signals, and triggered double-down signals for update, kill, close, "
+            "double-down, or narrate routing.\n"
+            "6. Present one clear business route and the signal behind it. Mutate the "
             "status marker only when the operator explicitly approves recording the "
             "daily check-in.\n"
-            "6. Ask before business-file writes, checkpoints, repairs, updates, migrations, "
+            "7. Ask before business-file writes, checkpoints, repairs, updates, migrations, "
             "provider mutation, publishing, spend, customer contact, destructive operations, "
             "or public issue/proposal submission."
         )

--- a/mb/tests/fixtures/workflows/mb-start-status.claude.md
+++ b/mb/tests/fixtures/workflows/mb-start-status.claude.md
@@ -38,16 +38,20 @@ This snapshot does not replace shipped `.claude/skills` prose.
 - `brain.bets.due_soon`
 - `brain.bets.overdue`
 - `brain.bets.exit_criteria`
+- `brain.bets.exit_criteria.missing`
+- `brain.bets.exit_criteria.triggered_failure_signals`
+- `brain.bets.exit_criteria.triggered_double_down_signals`
 - `vocabulary`
 
 ## Routing
 
 1. Start from status facts before raw markdown: readiness, drift, runtime wiring, update state, ranked actions, and since-last-check context.
 2. Run hard gates before routing: required updates, runtime mismatch, repair blockers, readiness blockers, private-data boundaries, unsafe provider operations, and destructive-operation requests.
-3. Use `ranked_actions`, `since_last_check`, `journal`, `money_path`, `content_strategy`, `validation.file_contracts`, `onboarding`, `readiness`, `update`, and `drift.items` as cited facts.
+3. Use `ranked_actions`, `since_last_check`, `journal`, `money_path`, `content_strategy`, `validation.file_contracts`, `onboarding`, `readiness`, `update`, `drift.items`, and `brain.bets` as cited facts.
 4. Route offer-shape gaps from `validation.file_contracts` to `/mb-think` after hard gates, and ask before durable writes.
-5. Present one clear business route and the signal behind it. Mutate the status marker only when the operator explicitly approves recording the daily check-in.
-6. Ask before business-file writes, checkpoints, repairs, updates, migrations, provider mutation, publishing, spend, customer contact, destructive operations, or public issue/proposal submission.
+5. Use due-soon and overdue bet deadlines, missing exit criteria, triggered failure signals, and triggered double-down signals for update, kill, close, double-down, or narrate routing.
+6. Present one clear business route and the signal behind it. Mutate the status marker only when the operator explicitly approves recording the daily check-in.
+7. Ask before business-file writes, checkpoints, repairs, updates, migrations, provider mutation, publishing, spend, customer contact, destructive operations, or public issue/proposal submission.
 
 ## Handoff Shape
 

--- a/mb/tests/fixtures/workflows/mb-start-status.codex.md
+++ b/mb/tests/fixtures/workflows/mb-start-status.codex.md
@@ -41,16 +41,20 @@ workflows are available in Codex.
 - `brain.bets.due_soon`
 - `brain.bets.overdue`
 - `brain.bets.exit_criteria`
+- `brain.bets.exit_criteria.missing`
+- `brain.bets.exit_criteria.triggered_failure_signals`
+- `brain.bets.exit_criteria.triggered_double_down_signals`
 - `vocabulary`
 
 ## Codex Route
 
 1. Use the business repo `AGENTS.md` bootstrap posture: read facts first, keep writes approval-gated, and translate git/provider details into business language.
 2. Run hard gates before routing: required updates, runtime mismatch, repair blockers, readiness blockers, private-data boundaries, unsafe provider operations, and destructive-operation requests.
-3. Use `ranked_actions`, `since_last_check`, `journal`, `money_path`, `content_strategy`, `validation.file_contracts`, `onboarding`, `readiness`, `update`, and `drift.items` as cited facts.
+3. Use `ranked_actions`, `since_last_check`, `journal`, `money_path`, `content_strategy`, `validation.file_contracts`, `onboarding`, `readiness`, `update`, `drift.items`, and `brain.bets` as cited facts.
 4. Route offer-shape gaps from `validation.file_contracts` to `mb-think` after hard gates, and ask before durable writes.
-5. Present one clear business route and the signal behind it. Mutate the status marker only when the operator explicitly approves recording the daily check-in.
-6. Ask before business-file writes, checkpoints, repairs, updates, migrations, provider mutation, publishing, spend, customer contact, destructive operations, or public issue/proposal submission.
+5. Use due-soon and overdue bet deadlines, missing exit criteria, triggered failure signals, and triggered double-down signals for update, kill, close, double-down, or narrate routing.
+6. Present one clear business route and the signal behind it. Mutate the status marker only when the operator explicitly approves recording the daily check-in.
+7. Ask before business-file writes, checkpoints, repairs, updates, migrations, provider mutation, publishing, spend, customer contact, destructive operations, or public issue/proposal submission.
 
 ## Handoff Shape
 

--- a/mb/tests/test_workflows.py
+++ b/mb/tests/test_workflows.py
@@ -269,6 +269,68 @@ def test_shipped_claude_organic_skill_preserves_shared_workflow_contract() -> No
     assert "workflows/mb-organic/workflow.md" in skill_text
 
 
+def test_shipped_claude_start_skill_preserves_core_trigger_markers() -> None:
+    workflow = load_workflow(START_STATUS_WORKFLOW)
+    skill_text = SHIPPED_START_SKILL.read_text(encoding="utf-8")
+
+    assert "workflows/mb-start-status/workflow.md" in skill_text
+    for marker in (
+        "brain.bets",
+        "due-soon",
+        "overdue",
+        "kill",
+        "double-down",
+        "close",
+        "narrate",
+    ):
+        assert marker in skill_text
+        if marker != "Do not tell Codex users to run Claude Code entrypoints.":
+            assert marker.lower() in workflow.body.lower() or marker in workflow.json_facts
+    assert "missing-exit" in skill_text
+    assert "missing exit criteria" in workflow.body
+    assert "status marker" in skill_text
+    assert "status_marker" in workflow.approval_gates
+
+
+def test_shipped_claude_think_skill_preserves_core_workflow_markers() -> None:
+    workflow = load_workflow(THINK_WORKFLOW)
+    skill_text = SHIPPED_THINK_SKILL.read_text(encoding="utf-8")
+
+    assert "workflows/mb-think/workflow.md" in skill_text
+    for marker in (
+        "runtime.codex_cli",
+        "research depth recommendation",
+        "source-specific research files",
+        "decision",
+        "codify",
+        "public/private",
+        "checkpoint approval",
+        "Do not tell Codex users to run Claude Code entrypoints.",
+    ):
+        assert marker in skill_text
+        if marker != "Do not tell Codex users to run Claude Code entrypoints.":
+            assert marker.lower() in workflow.body.lower() or marker in workflow.json_facts
+
+
+def test_think_guidance_uses_codex_cli_runtime_fact_path() -> None:
+    workflow = load_workflow(THINK_WORKFLOW)
+    stale_fact = "runtime." + "codex"
+    texts = [
+        workflow.body,
+        "\n".join(workflow.json_facts),
+        "\n".join(codex_mod.CODEX_THINK_REQUIRED_JSON_FACTS),
+        AGENTS_TEMPLATE.read_text(encoding="utf-8"),
+        (FIXTURES / "mb-think.claude.md").read_text(encoding="utf-8"),
+        (FIXTURES / "mb-think.codex.md").read_text(encoding="utf-8"),
+        SHIPPED_THINK_SKILL.read_text(encoding="utf-8"),
+    ]
+
+    for text in texts:
+        assert "runtime.codex_cli" in text
+        assert f"- `{stale_fact}`" not in text
+        assert f"  - {stale_fact}\n" not in text
+
+
 def test_supported_shells_preserve_required_commands_and_json_facts() -> None:
     for path in WORKFLOW_PATHS:
         workflow = load_workflow(path)

--- a/workflows/mb-start-status/workflow.md
+++ b/workflows/mb-start-status/workflow.md
@@ -36,6 +36,9 @@ json_facts:
   - brain.bets.due_soon
   - brain.bets.overdue
   - brain.bets.exit_criteria
+  - brain.bets.exit_criteria.missing
+  - brain.bets.exit_criteria.triggered_failure_signals
+  - brain.bets.exit_criteria.triggered_double_down_signals
   - vocabulary
 approval_gates:
   - updates_repairs_migrations
@@ -112,6 +115,9 @@ The runtime shell must preserve these paths from the workflow source:
 - `brain.bets.due_soon`
 - `brain.bets.overdue`
 - `brain.bets.exit_criteria`
+- `brain.bets.exit_criteria.missing`
+- `brain.bets.exit_criteria.triggered_failure_signals`
+- `brain.bets.exit_criteria.triggered_double_down_signals`
 - `vocabulary`
 
 Treat these as facts, not strategy. The runtime may recommend the next route,
@@ -133,10 +139,10 @@ workflow; route offer-shape gaps to `mb-think` and ask before durable writes.
 Use `money_path` for customer progress, offer, proof, CTA, channel, push, page
 readiness, playbook, and outcome feedback questions. Use `content_strategy` for
 content strategy, channel, account, freshness, or disconnected-layer questions.
-Use `brain.bets` for active, due-soon, overdue, missing-exit, triggered kill,
-triggered double-down, close, update, and narrate moments before inventing bet
-state from prose. Use `onboarding` to resume setup without inventing a new
-interview.
+Use `brain.bets` for active, due-soon, overdue, missing exit criteria,
+triggered kill, triggered double-down, close, update, and narrate moments
+before inventing bet state from prose. Use `onboarding` to resume setup without
+inventing a new interview.
 
 Give one clear route: frame a bet, think through a decision, advance a push,
 draft a playbook, repair the repo, review provider readiness, inspect a


### PR DESCRIPTION
## Summary

Patch the core lifecycle guidance so `mb-start`, `mb-think`, and `mb-end` preserve the current shared workflow contract across Claude and Codex surfaces.

## Linked issue

Closes #767

## Why

The pre-release drift audit found that shipped guidance and generated Codex guidance had diverged from current facts: `mb-think` still referenced the stale `runtime.codex` path, daily start/status risked dropping bet lifecycle trigger facts, and `/mb-end` described crystallize/core updates as unconditional writes instead of approval-gated proposals.

## Commits by concern

- [x] `76fa80e [fix] MAIN-464 Patch lifecycle drift`
  - Normalizes `mb-think` guidance to `runtime.codex_cli` across workflow source, generated Codex guidance, fixtures, and tests.
  - Restores daily-start bet lifecycle trigger facts/routing for active, due-soon, overdue, missing exit criteria, kill/update/close, double-down/update/narrate paths.
  - Makes shipped Claude `/mb-end` crystallize and core-update writes approval-gated.
  - Adds shipped-skill drift guards for `mb-start` and `mb-think`.
- [x] Each commit body bullet-lists the changes in that commit
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work
- [x] Commit subjects use `[add]`, `[update]`, `[fix]`, `[remove]`, `[refactor]`, `[docs]`, or `[chore]`

## Validation

Pre-push gate from repo root:

```bash
scripts/check.sh
```

Level 1 static: `scripts/check.sh` — runtime: `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3` — exit: 0 — log: formatter/lint/type-check passed; pytest collected 848 items and exited 0; `mb skill validate --all --json` reported 15/15 skills passed.

Level 2 workflow/guidance contract: `cd mb && python3 -m pytest tests/test_workflows.py::test_think_guidance_uses_codex_cli_runtime_fact_path -q` — runtime: `python3` — exit: 0 — log: `1 passed in 0.30s`.

Level 2 stale fact scan: `rg -n --pcre2 'runtime\.codex(?!_cli)' workflows .claude/skills templates mb/tests mb/mb || true` — runtime: shell — exit: 0 — log: no matches.

- [x] Level 1 static: `scripts/check.sh` passes
- [x] Level 2 CLI contract: focused Typer/CliRunner tests, exit codes, `--json` behavior, TTY vs non-TTY (if CLI behavior touched)
- [ ] Level 3 package/install smoke (if packaging touched) — not required; no packaging, entrypoint, or bundled-data discovery change.
- [ ] Level 4 fixture repo (if init/onboard/status/start/update touched) — not required; this patches guidance/workflow drift, not fixture repo behavior.
- [ ] Level 5 runtime smoke / dogfood harness / simulation-tier (if runtime, first-run, skill discovery, or release validation touched) — not required; no runtime discovery/invocation or release validation behavior changed.
- [x] SKILL.md ≤500 lines (if any skill touched)
- [ ] Package-visible release gate evidence before tag/publish (if preparing a release) — not preparing a release.
- [ ] Supply-chain review (if `.github/workflows/`, `.github/dependabot.yml`, `mb/pyproject.toml` deps, or `id-token`/`permissions` blocks touched — see [docs/supply-chain-policy.md](../docs/supply-chain-policy.md)) — not required; no supply-chain files touched.

## Success metric

Generated and shipped lifecycle guidance preserves `runtime.codex_cli`, explicit bet trigger facts, and approval-gated crystallize/core-update writes, with tests that fail if those markers drift again.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section, OR
- [ ] N/A — change is invisible to users (internal refactor, CI-only, etc.)

## Breaking changes

- [x] No
- [ ] Yes — migration note below

## Public / private boundary

No private operator strategy, machine-specific paths, account data, or runtime internals were committed. The branch removes stale runtime vocabulary from public guidance surfaces and adds tests to guard current workflow names and approval boundaries.
