### PR TITLE
[fix] Clean duplicate mb-think shared marker

### DIFF
--- a/.claude/skills/mb-think/SKILL.md
+++ b/.claude/skills/mb-think/SKILL.md
@@ -8,8 +8,6 @@ loops: [sense, decide, ship]
 
 Research, decide, and codify knowledge into reference files.
 
-**Shared source:** `workflows/mb-think/workflow.md`; preserve `runtime.codex_cli`, research depth recommendation, source-specific research files, decision/codify routing, public/private handling, and checkpoint approval. Do not tell Codex users to run Claude Code entrypoints.
-
 ## Don't Overthink Think
 
 This skill is for: **"I don't know what happens next. I just need to start."**
@@ -71,9 +69,11 @@ Public/private boundaries: `no_secrets`, `no_raw_provider_exports`,
 `no_private_runtime_settings`, `no_private_dms_or_gated_communities`, and
 `no_raw_finance_legal_records`.
 
-Core route: research depth recommendation, parallel research files when multiple
-source types are needed, decision, codify, stale source cleanup,
-public/private handling, checkpoint approval, and explicit write approval. Do not tell Codex users to run Claude Code entrypoints.
+Core route: research depth recommendation, parallel research files for
+source-specific research files when multiple source types are needed, decision,
+codify, stale source cleanup, public/private handling, checkpoint plan,
+checkpoint approval, and explicit write approval.
+Do not tell Codex users to run Claude Code entrypoints.
 
 When research identifies a reusable growth mechanic such as a comment-keyword,
 DM-keyword, public reply/link, resource delivery, provider setup recipe, or


### PR DESCRIPTION
## Summary

Cleans up the only extra artifact left by the duplicate MAIN-464 merges: `mb-think` had two separate shared-source declarations. This keeps the full shared-contract marker block and folds the guard phrases from the duplicate one-liner into that block.

## Why

Both duplicate lifecycle PRs landed. The final state was functionally safe, but `mb-think` carried redundant shared-source context. This keeps the guidance tighter without weakening the drift guards.

## Validation

- `cd mb && /Library/Frameworks/Python.framework/Versions/3.13/bin/python3 -m pytest tests/test_workflows.py::test_shipped_claude_think_skill_preserves_shared_workflow_contract tests/test_workflows.py::test_shipped_claude_think_skill_preserves_core_workflow_markers tests/test_workflows.py::test_think_runtime_guidance_uses_codex_cli_fact_path -q` -> `3 passed`
- `cd mb && /Library/Frameworks/Python.framework/Versions/3.13/bin/python3 -m mb skill validate --all --json` -> `15/15` skills passed, `0` warnings

## Scope

No behavior change. No runtime or packaging changes.
