### PR TITLE
[update] Prepare 0.3.40 release

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mainbranch",
-  "version": "0.3.39",
+  "version": "0.3.40",
   "description": "Main Branch Claude Code skills for running a business from markdown files in git.",
   "author": {
     "name": "Noontide"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+## [0.3.40] - 2026-05-27
+
+v0.3.40 packages the shared workflow migration batch for the daily Main Branch
+routes and the first canonical Google Ads launch playbook source.
+
+### Added
+
+- Added a public business-file contract spec and the first reusable
+  file-contract engine slice. `mb validate --json` and `mb status --json
+  --peek` now expose offer-shape findings with owner-facing messages and
+  guided routes to existing Main Branch workflows. Refs MAIN-459, #756.
+
 ### Changed
 
 - Migrated `mb-ads` to a shared workflow source with checked Claude and Codex
@@ -37,13 +49,6 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   and generated business-repo instructions, keeping old `reference/*`,
   `campaigns/`, and `outputs/` handling in explicit migration/repair contexts.
   Refs MAIN-460, #759.
-
-### Added
-
-- Added a public business-file contract spec and the first reusable
-  file-contract engine slice. `mb validate --json` and `mb status --json
-  --peek` now expose offer-shape findings with owner-facing messages and
-  guided routes to existing Main Branch workflows. Refs MAIN-459, #756.
 
 ### Fixed
 

--- a/mb/mb/__init__.py
+++ b/mb/mb/__init__.py
@@ -7,6 +7,6 @@ file stays a thin dispatcher.
 
 from __future__ import annotations
 
-__version__ = "0.3.39"
+__version__ = "0.3.40"
 
 __all__ = ["__version__"]

--- a/mb/pyproject.toml
+++ b/mb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mainbranch"
-version = "0.3.39"
+version = "0.3.40"
 description = "Main Branch engine umbrella - scaffolds, validates, and graphs business-as-files repos. Claude Code first, runtime-agnostic by design."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Prepare the 0.3.40 release by bumping package/plugin version sites and moving the shared workflow migration batch into a dated changelog section.

## Linked issue

Closes #776

## Why

The shared workflow migration batch is ready for release prep, and the release surfaces need to agree before tag/publish validation can run.

## Commits by concern

- [x] `8d840bb [update] Prepare MAIN-468 release 0.3.40` updates version files and the changelog release section.
- [x] Reviewer reading `git log --oneline main..HEAD` sees the shape of the work.
- [x] Commit subject uses this repo's bracketed vocabulary.

## Validation

Pre-push gate from repo root:

```bash
scripts/check.sh
```

- [x] Level 1 static: `scripts/check.sh` - runtime: `python3` 3.13.7 - exit: 0 - log: `.agent/release-evidence/0.3.40/check.out` (`867 passed`, coverage 83.68%, skill validation 15/15).
- [x] Level 2 CLI contract: release-file preflight `cd mb && python3 -m pytest tests/test_smoke_coverage.py::test_claude_plugin_manifest_points_at_prefixed_skills -q` - runtime: `python3` - exit: 0 - log: `.agent/release-evidence/0.3.40/preflight.out` (`1 passed`).
- [x] Level 3 package/install smoke: `(cd mb && python3 -m build)` plus fresh venv install of `mainbranch-0.3.40-py3-none-any.whl` - runtime: `python3` / `/tmp/mainbranch-0.3.40-smoke/bin/mb` - exit: 0 - logs: `.agent/release-evidence/0.3.40/build.out`, `install.out`, `smoke.out`; installed `mb --version` returned `mb 0.3.40`, skill validation passed 15/15, workflow list exposed `playbooks/google-ads-search-launch/playbook.md`, and `mb doctor repair --plan --only codex --json` returned `result_status: ok`.
- [ ] Level 4 fixture repo: not separately required; Level 3 smoke created a fresh business repo for the Codex doctor repair plan.
- [ ] Level 5 runtime smoke / dogfood harness / simulation-tier: not run in this PR; package-visible release acceptance remains a pre-tag/publish release gate per `docs/release-simulations.md`.
- [ ] SKILL.md <=500 lines: N/A, no skill files changed.
- [ ] Package-visible release gate evidence before tag/publish: pending release-owner pre-tag/publish flow, not part of this release-prep PR.
- [x] Supply-chain review: `mb/pyproject.toml` changed only `project.version`; no dependency, workflow, permissions, or `id-token` changes.

## Success metric

Reviewers can tag and publish 0.3.40 from a branch where version-bearing files agree, the changelog describes the release cluster, the wheel contains shared workflow/playbook sources, and installed-wheel smoke passes.

## CHANGELOG

- [x] Updated `CHANGELOG.md` with a dated `0.3.40` release section.

## Breaking changes

- [x] No
- [ ] Yes - migration note below

## Public / private boundary

Only public release metadata changed. Local validation evidence stayed under ignored `.agent/`; no private operator strategy, machine-specific preferences, secrets, or runtime internals were committed.
