### PR TITLE
[add] Repo-boundary helper facts

### DIFF
--- a/.claude/skills/mb-start/SKILL.md
+++ b/.claude/skills/mb-start/SKILL.md
@@ -64,6 +64,7 @@ Required fact paths:
 - `onboarding`
 - `integrations`
 - `github`
+- `topology.repo_boundary`
 - `brain.bets`
 - `brain.bets.active`
 - `brain.bets.due_soon`
@@ -495,6 +496,5 @@ treat business `.vip/local.yaml` as audit input only, and do not write it.
 - [references/tool-status-audit.md](references/tool-status-audit.md) — Step 5 provider/readiness audit
 - [references/triage-agent.md](references/triage-agent.md) — Triage agent prompts and synthesis
 - [references/launch-orchestration.md](references/launch-orchestration.md) — guided offer-launch path
-
 ## Remember
 Router, not worker. Detect → route → let the skill do the work. One clarifying question max. Skill loads its own context — main stays lean.

--- a/.claude/skills/mb-status/SKILL.md
+++ b/.claude/skills/mb-status/SKILL.md
@@ -42,6 +42,7 @@ Required fact paths:
 - `onboarding`
 - `integrations`
 - `github`
+- `topology.repo_boundary`
 - `brain.bets`
 - `brain.bets.active`
 - `brain.bets.due_soon`
@@ -100,6 +101,9 @@ mb status --json --peek
    `brain.bets.exit_criteria` for active, due-soon, overdue, missing-exit,
    triggered kill, triggered double-down, close, update, and narrate moments
    before inventing bet state from prose.
+   Use `topology.repo_boundary` when the operator is deciding whether work
+   belongs in this business repo, a separate business repo, or a
+   child/lightweight repo.
    If `vocabulary.terms.push` defines display words, use them in
    operator-facing prose without changing current paths, frontmatter, JSON
    keys, validator rules, or command names.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+### Added
+
+- Added deterministic repo-boundary helper facts to `mb status --json --peek`,
+  `mb start --json`, and onboarding status so agents can guide same-repo,
+  separate-business-repo, or child/lightweight-repo setup decisions without
+  inventing repo profiles. Closes #631.
+
 ### Fixed
 
 - Added a guided `pipx install --force mainbranch==<latest>` recovery step when

--- a/docs/child-repo-descriptors.md
+++ b/docs/child-repo-descriptors.md
@@ -176,5 +176,16 @@ and checkpoint context. Agents should switch to the child repo when editing
 that child repo's code, site, product, client deliverable, sidecar, or ops
 files.
 
+`mb status --json --peek`, `mb start --json`, and onboarding expose a
+`repo_boundary` helper that keeps the choice small:
+
+- use the same business repo when brand, team, voice, access, accounts, and
+  operating history are shared;
+- create a separate business repo when the work has its own entity, team,
+  accounts, audience, brand, or operating history;
+- create a child/lightweight repo when the work is an execution surface for
+  the business, such as a site, product, client deliverable, finance/legal
+  boundary, ops repo, or integration sidecar.
+
 Before deleting, renaming, merging, or moving an offer folder, child repo, or
 topology entry, ask the operator for an explicit decision or migration plan.

--- a/mb/mb/onboard.py
+++ b/mb/mb/onboard.py
@@ -15,6 +15,7 @@ from mb import checkpoint as checkpoint_mod
 from mb import codex as codex_mod
 from mb import connect as connect_mod
 from mb import init as init_mod
+from mb import topology as topology_mod
 from mb.engine import link_skills, link_status
 
 LEVELS = {"beginner", "intermediate", "power"}
@@ -830,6 +831,7 @@ def onboarding_status(repo: str | Path = ".") -> dict[str, Any]:
     state = loaded or _initial_state(repo=target)
     markers = _repo_markers(target)
     checklist = _checklist(target, state, markers)
+    topology = topology_mod.collect(target)
     required = [step for step in checklist if step.get("required", True)]
     complete = [step for step in required if step["status"] == "complete"]
     next_step = next((step for step in checklist if step["status"] != "complete"), None)
@@ -842,6 +844,7 @@ def onboarding_status(repo: str | Path = ".") -> dict[str, Any]:
         "profile": state.get("profile") or {},
         "contract": state.get("contract") or {},
         "boundaries": state.get("boundaries") or BOUNDARIES,
+        "repo_boundary": topology["repo_boundary"],
         "checklist": checklist,
         "summary": {
             "status": "ready" if len(complete) == len(required) else "in_progress",

--- a/mb/mb/start.py
+++ b/mb/mb/start.py
@@ -14,6 +14,7 @@ from mb import books as books_mod
 from mb import checkpoint as checkpoint_mod
 from mb import codex as codex_mod
 from mb import journal as journal_mod
+from mb import topology as topology_mod
 from mb import vocabulary
 from mb.engine import install_mode, link_status
 from mb.freshness import format_update_alert, package_update_status
@@ -84,6 +85,7 @@ def _git_status(repo: Path) -> dict[str, Any]:
 
     branch = _run_command(["git", "branch", "--show-current"], cwd=repo)
     status = _run_command(["git", "status", "--porcelain"], cwd=repo)
+    remote = _run_command(["git", "config", "--get", "remote.origin.url"], cwd=repo)
     dirty_lines = (
         [line for line in status["stdout"].splitlines() if line.strip()] if status["ok"] else []
     )
@@ -94,6 +96,7 @@ def _git_status(repo: Path) -> dict[str, Any]:
         "dirty": bool(dirty_lines),
         "dirty_count": len(dirty_lines),
         "dirty_files": dirty_lines[:10],
+        "remote": remote["stdout"].strip() if remote["ok"] else "",
         "error": "" if status["ok"] else status["stderr"].strip(),
     }
 
@@ -358,6 +361,7 @@ def run(repo: str = ".", launch: bool = False) -> dict[str, Any]:
     push_report = push_facts(repo_path)
     vocabulary_report = vocabulary.facts(repo_path)
     books = books_mod.readiness(repo_path)
+    topology = topology_mod.collect(repo_path, git_remote=str(git.get("remote") or ""))
     checks = _build_checks(repo_shape, git, claude_path, wiring, codex, update)
     hard_failures = _hard_failures(checks)
     handoff_ready = not hard_failures
@@ -407,6 +411,16 @@ def run(repo: str = ".", launch: bool = False) -> dict[str, Any]:
         "checkpoint": checkpoint,
         "journal": journal,
         "books": books,
+        "topology": {
+            "schema": topology["schema"],
+            "safe_to_share": True,
+            "summary": topology["summary"],
+            "current_repo": topology["current_repo"],
+            "repo_boundary": topology["repo_boundary"],
+            "child_counts": topology["child_counts"],
+            "restricted_repos": topology["restricted_repos"],
+            "findings": topology["findings"],
+        },
         "pushes": push_report["records"],
         "active_pushes": push_report["active"],
         "push_count": push_report["count"],

--- a/mb/mb/status.py
+++ b/mb/mb/status.py
@@ -4129,6 +4129,7 @@ def run(
         "registry": topology_payload["registry"],
         "descriptor": topology_payload["descriptor"],
         "current_repo": topology_payload["current_repo"],
+        "repo_boundary": topology_payload["repo_boundary"],
         "child_counts": topology_payload["child_counts"],
         "restricted_repos": topology_payload["restricted_repos"],
         "findings": topology_payload["findings"],

--- a/mb/mb/topology.py
+++ b/mb/mb/topology.py
@@ -668,6 +668,121 @@ def restricted_repo_summary(registry: dict[str, Any]) -> list[dict[str, Any]]:
     return notes
 
 
+def repo_boundary_decision_helper(
+    *,
+    registry: dict[str, Any],
+    descriptor: dict[str, Any],
+    current_view: dict[str, Any],
+    child_counts: dict[str, Any],
+) -> dict[str, Any]:
+    """Return the owner-facing repo-boundary decision helper.
+
+    This is a decision aid, not a repo-profile schema. It gives setup/start
+    surfaces a stable way to explain whether work belongs in the current
+    business repo, a separate business repo, or a child/lightweight repo.
+    """
+    choices = [
+        {
+            "id": "same_business_repo",
+            "label": "same business repo",
+            "use_when": ("brand, team, voice, access, accounts, and operating history are shared"),
+            "owner_language": (
+                "Keep the work here when future sessions should read the same "
+                "business memory before deciding."
+            ),
+            "next_step": "Use this business repo and continue with `mb-start`.",
+        },
+        {
+            "id": "separate_business_repo",
+            "label": "separate business repo",
+            "use_when": (
+                "the work has its own entity, team, accounts, audience, brand, or operating history"
+            ),
+            "owner_language": (
+                "Create a separate Main Branch business repo when mixing the "
+                "memory would make either business harder to reason about."
+            ),
+            "next_step": (
+                "Run `mb onboard --name <business> --path <folder>` in the new business folder."
+            ),
+        },
+        {
+            "id": "child_lightweight_repo",
+            "label": "child/lightweight repo",
+            "use_when": (
+                "the work is an execution surface for this business, such as "
+                "a site, product, client deliverable, finance/legal boundary, "
+                "ops repo, or integration sidecar"
+            ),
+            "owner_language": (
+                "Use a child repo when the files or access boundary differ, "
+                "but the strategy still reports back to this business brain."
+            ),
+            "next_step": (
+                "Record the relationship in `core/operations/repo-topology.md` "
+                "and add `.mainbranch/repo.json` in the child when useful."
+            ),
+        },
+    ]
+
+    current_role = str(current_view.get("role") or "")
+    descriptor_found = bool(descriptor.get("found"))
+    descriptor_safe = bool(descriptor.get("safe_to_share", True))
+    registry_found = bool(registry.get("found"))
+    child_total = int(child_counts.get("total", 0) or 0)
+    if current_view.get("is_hub"):
+        state = "hub_business_repo"
+        recommended_choice = "same_business_repo"
+        next_action = (
+            "Use this repo for strategy, offers, bets, pushes, decisions, and "
+            "checkpoint context. Create or link child repos only when an "
+            "execution surface needs a separate file or access boundary."
+        )
+    elif descriptor_found or (current_role and current_role != "business"):
+        state = "child_or_execution_repo"
+        recommended_choice = "child_lightweight_repo"
+        next_action = (
+            "Do execution work in this repo, but return to the hub business repo "
+            "for strategy, offers, bets, pushes, decisions, and checkpoints."
+        )
+        parent = ""
+        if descriptor_safe:
+            parent = current_view.get("parent_remote_full_name") or descriptor.get(
+                "parent", {}
+            ).get("remote_full_name", "")
+        if parent:
+            next_action += f" Hub handle: {parent}."
+    elif registry_found or child_total:
+        state = "business_repo_with_topology"
+        recommended_choice = "same_business_repo"
+        next_action = (
+            "Use this repo as the hub business brain. Check the topology "
+            "registry before creating or editing child repos."
+        )
+    else:
+        state = "single_business_repo"
+        recommended_choice = "same_business_repo"
+        next_action = (
+            "Use one business repo by default. Split only when brand, team, "
+            "accounts, access, or operating history diverge; use a child repo "
+            "for execution files that still report to this business."
+        )
+
+    return {
+        "schema": "mb.repo_boundary_helper.v0",
+        "state": state,
+        "recommended_choice": recommended_choice,
+        "choices": choices,
+        "next_action": next_action,
+        "docs": [
+            "docs/child-repo-descriptors.md",
+            "docs/repo-visibility-rubric.md",
+            "core/operations/repo-topology.md",
+        ],
+        "safe_to_share": descriptor_safe,
+    }
+
+
 # ---------------------------------------------------------------------------
 # Drift findings
 # ---------------------------------------------------------------------------
@@ -973,6 +1088,12 @@ def collect(
     exclude_slug = str(view.get("slug") or "") if view.get("matched") and view.get("is_hub") else ""
     counts = child_role_counts(registry, exclude_slug=exclude_slug)
     boundary_notes = restricted_repo_summary(registry)
+    repo_boundary = repo_boundary_decision_helper(
+        registry=registry,
+        descriptor=descriptor,
+        current_view=view,
+        child_counts=counts,
+    )
     findings = drift_findings(
         registry=registry,
         descriptor=descriptor,
@@ -1007,6 +1128,7 @@ def collect(
         },
         "descriptor": descriptor,
         "current_repo": view,
+        "repo_boundary": repo_boundary,
         "child_counts": counts,
         "restricted_repos": boundary_notes,
         "findings": findings,

--- a/mb/tests/fixtures/status/schema-v1-basic.json
+++ b/mb/tests/fixtures/status/schema-v1-basic.json
@@ -1,6 +1,244 @@
 {
-  "schema_version": "1.0",
   "schema_name": "mainbranch.status",
+  "schema_version": "1.0",
+  "section_keys": {
+    "books": [
+      "chart_of_accounts",
+      "configured",
+      "hledger",
+      "ignore",
+      "mention",
+      "next_command",
+      "policy",
+      "recommended_route",
+      "safe_to_share",
+      "schema_version",
+      "source",
+      "state",
+      "summary",
+      "unsafe_artifacts",
+      "vault"
+    ],
+    "brain": [
+      "bets",
+      "counts",
+      "pushes",
+      "recent_decisions",
+      "recent_research",
+      "stale_decisions",
+      "stale_research"
+    ],
+    "content_strategy": [
+      "counts",
+      "findings",
+      "index",
+      "layers",
+      "overall_state",
+      "safe_to_share",
+      "schema_version",
+      "simple_entry_point",
+      "summary"
+    ],
+    "drift": [
+      "items",
+      "ok",
+      "summary"
+    ],
+    "git": [
+      "ahead",
+      "available",
+      "behind",
+      "branch",
+      "commit",
+      "default_branch",
+      "dirty",
+      "dirty_count",
+      "dirty_files",
+      "error",
+      "inside_work_tree",
+      "remote",
+      "summary",
+      "upstream",
+      "workflow_mode",
+      "worktree_root"
+    ],
+    "git_activity": [
+      "available",
+      "error",
+      "items"
+    ],
+    "github": [
+      "assigned_issues",
+      "authenticated",
+      "available",
+      "context",
+      "degraded",
+      "errors",
+      "recent_merged_prs",
+      "repo",
+      "review_requests",
+      "sections",
+      "source",
+      "summary"
+    ],
+    "install": [
+      "detail",
+      "mode",
+      "ok",
+      "version"
+    ],
+    "integrations": [
+      "config_path",
+      "github",
+      "ok",
+      "providers",
+      "repo",
+      "repo_id",
+      "safe_to_share",
+      "summary",
+      "user_scope_path"
+    ],
+    "journal": [
+      "available",
+      "error",
+      "events",
+      "groups",
+      "ok",
+      "repo",
+      "safe_to_share",
+      "schema_version",
+      "summary"
+    ],
+    "marker_update": [
+      "attempted",
+      "ok",
+      "path",
+      "reason"
+    ],
+    "measurement": [
+      "available",
+      "repair",
+      "repair_command",
+      "safe_to_share",
+      "state",
+      "summary"
+    ],
+    "money_path": [
+      "objects",
+      "overall_label",
+      "overall_level",
+      "ranked_actions",
+      "safe_to_share",
+      "schema_version",
+      "summary"
+    ],
+    "onboarding": [
+      "boundaries",
+      "checklist",
+      "contract",
+      "ok",
+      "profile",
+      "repo",
+      "repo_boundary",
+      "state_exists",
+      "state_path",
+      "state_valid",
+      "summary"
+    ],
+    "playbook_health": [
+      "gaps",
+      "ok",
+      "safe_to_share",
+      "sections",
+      "source",
+      "summary"
+    ],
+    "readiness": [
+      "checks",
+      "level",
+      "next_actions",
+      "score"
+    ],
+    "relationship_health": [
+      "gaps",
+      "ok",
+      "registry_version",
+      "safe_to_share",
+      "sections",
+      "source",
+      "summary"
+    ],
+    "repo": [
+      "looks_like_mainbranch_repo",
+      "markers",
+      "missing_markers",
+      "path"
+    ],
+    "runtime": [
+      "claude_code",
+      "codex_cli",
+      "skill_wiring"
+    ],
+    "since_last_check": [
+      "brain_count_changes",
+      "current_seen_at",
+      "error",
+      "first_run",
+      "git",
+      "journal",
+      "marker_gitignore",
+      "marker_path",
+      "ok",
+      "previous_seen_at",
+      "safe_to_share",
+      "summary"
+    ],
+    "team": [
+      "github",
+      "members",
+      "ok",
+      "path",
+      "safe_to_share",
+      "schema_version",
+      "summary"
+    ],
+    "update": [
+      "checked_at",
+      "command",
+      "installed",
+      "latest",
+      "latest_source",
+      "minimum_supported",
+      "post_update_commands",
+      "reason",
+      "release_notes_url",
+      "severity",
+      "update_check_command"
+    ],
+    "validation": [
+      "cross_refs",
+      "file_contracts",
+      "legacy_repair",
+      "migration_drift",
+      "ok",
+      "safe_to_share",
+      "state",
+      "summary",
+      "validation_categories"
+    ],
+    "vocabulary": [
+      "errors",
+      "exists",
+      "ok",
+      "path",
+      "source",
+      "status",
+      "summary",
+      "terms",
+      "type",
+      "warnings"
+    ]
+  },
   "top_level_keys": [
     "active_campaigns",
     "active_pushes",
@@ -41,242 +279,5 @@
     "update",
     "validation",
     "vocabulary"
-  ],
-  "section_keys": {
-    "repo": [
-      "looks_like_mainbranch_repo",
-      "markers",
-      "missing_markers",
-      "path"
-    ],
-    "install": [
-      "detail",
-      "mode",
-      "ok",
-      "version"
-    ],
-    "update": [
-      "checked_at",
-      "command",
-      "installed",
-      "latest",
-      "latest_source",
-      "minimum_supported",
-      "post_update_commands",
-      "reason",
-      "release_notes_url",
-      "severity",
-      "update_check_command"
-    ],
-    "runtime": [
-      "claude_code",
-      "codex_cli",
-      "skill_wiring"
-    ],
-    "git": [
-      "ahead",
-      "available",
-      "behind",
-      "branch",
-      "commit",
-      "default_branch",
-      "dirty",
-      "dirty_count",
-      "dirty_files",
-      "error",
-      "inside_work_tree",
-      "remote",
-      "summary",
-      "upstream",
-      "workflow_mode",
-      "worktree_root"
-    ],
-    "git_activity": [
-      "available",
-      "error",
-      "items"
-    ],
-    "journal": [
-      "available",
-      "error",
-      "events",
-      "groups",
-      "ok",
-      "repo",
-      "safe_to_share",
-      "schema_version",
-      "summary"
-    ],
-    "brain": [
-      "bets",
-      "counts",
-      "pushes",
-      "recent_decisions",
-      "recent_research",
-      "stale_decisions",
-      "stale_research"
-    ],
-    "books": [
-      "chart_of_accounts",
-      "configured",
-      "hledger",
-      "ignore",
-      "mention",
-      "next_command",
-      "policy",
-      "recommended_route",
-      "safe_to_share",
-      "schema_version",
-      "source",
-      "state",
-      "summary",
-      "unsafe_artifacts",
-      "vault"
-    ],
-    "vocabulary": [
-      "errors",
-      "exists",
-      "ok",
-      "path",
-      "source",
-      "status",
-      "summary",
-      "terms",
-      "type",
-      "warnings"
-    ],
-    "team": [
-      "github",
-      "members",
-      "ok",
-      "path",
-      "safe_to_share",
-      "schema_version",
-      "summary"
-    ],
-    "onboarding": [
-      "boundaries",
-      "checklist",
-      "contract",
-      "ok",
-      "profile",
-      "repo",
-      "state_exists",
-      "state_path",
-      "state_valid",
-      "summary"
-    ],
-    "integrations": [
-      "config_path",
-      "github",
-      "ok",
-      "providers",
-      "repo",
-      "repo_id",
-      "safe_to_share",
-      "summary",
-      "user_scope_path"
-    ],
-    "measurement": [
-      "available",
-      "repair",
-      "repair_command",
-      "safe_to_share",
-      "state",
-      "summary"
-    ],
-    "github": [
-      "assigned_issues",
-      "authenticated",
-      "available",
-      "context",
-      "degraded",
-      "errors",
-      "recent_merged_prs",
-      "repo",
-      "review_requests",
-      "sections",
-      "source",
-      "summary"
-    ],
-    "content_strategy": [
-      "counts",
-      "findings",
-      "index",
-      "layers",
-      "overall_state",
-      "safe_to_share",
-      "schema_version",
-      "simple_entry_point",
-      "summary"
-    ],
-    "money_path": [
-      "objects",
-      "overall_label",
-      "overall_level",
-      "ranked_actions",
-      "safe_to_share",
-      "schema_version",
-      "summary"
-    ],
-    "since_last_check": [
-      "brain_count_changes",
-      "current_seen_at",
-      "error",
-      "first_run",
-      "git",
-      "journal",
-      "marker_gitignore",
-      "marker_path",
-      "ok",
-      "previous_seen_at",
-      "safe_to_share",
-      "summary"
-    ],
-    "drift": [
-      "items",
-      "ok",
-      "summary"
-    ],
-    "readiness": [
-      "checks",
-      "level",
-      "next_actions",
-      "score"
-    ],
-    "relationship_health": [
-      "gaps",
-      "ok",
-      "registry_version",
-      "safe_to_share",
-      "sections",
-      "source",
-      "summary"
-    ],
-    "playbook_health": [
-      "gaps",
-      "ok",
-      "safe_to_share",
-      "sections",
-      "source",
-      "summary"
-    ],
-    "validation": [
-      "cross_refs",
-      "file_contracts",
-      "legacy_repair",
-      "migration_drift",
-      "ok",
-      "safe_to_share",
-      "state",
-      "summary",
-      "validation_categories"
-    ],
-    "marker_update": [
-      "attempted",
-      "ok",
-      "path",
-      "reason"
-    ]
-  }
+  ]
 }

--- a/mb/tests/fixtures/workflows/mb-setup.claude.md
+++ b/mb/tests/fixtures/workflows/mb-setup.claude.md
@@ -29,6 +29,8 @@ This snapshot does not replace shipped `.claude/skills` prose.
 - `runtime.codex_cli`
 - `runtime.claude_code`
 - `onboarding`
+- `onboarding.repo_boundary`
+- `topology.repo_boundary`
 - `checkpoint`
 - `vocabulary`
 

--- a/mb/tests/fixtures/workflows/mb-setup.codex.md
+++ b/mb/tests/fixtures/workflows/mb-setup.codex.md
@@ -32,6 +32,8 @@ workflows are available in Codex.
 - `runtime.codex_cli`
 - `runtime.claude_code`
 - `onboarding`
+- `onboarding.repo_boundary`
+- `topology.repo_boundary`
 - `checkpoint`
 - `vocabulary`
 

--- a/mb/tests/fixtures/workflows/mb-start-status.claude.md
+++ b/mb/tests/fixtures/workflows/mb-start-status.claude.md
@@ -33,6 +33,7 @@ This snapshot does not replace shipped `.claude/skills` prose.
 - `onboarding`
 - `integrations`
 - `github`
+- `topology.repo_boundary`
 - `brain.bets`
 - `brain.bets.active`
 - `brain.bets.due_soon`

--- a/mb/tests/fixtures/workflows/mb-start-status.codex.md
+++ b/mb/tests/fixtures/workflows/mb-start-status.codex.md
@@ -36,6 +36,7 @@ workflows are available in Codex.
 - `onboarding`
 - `integrations`
 - `github`
+- `topology.repo_boundary`
 - `brain.bets`
 - `brain.bets.active`
 - `brain.bets.due_soon`

--- a/mb/tests/test_onboard.py
+++ b/mb/tests/test_onboard.py
@@ -216,6 +216,8 @@ def test_onboard_cli_yes_json_smoke(tmp_path: Path, monkeypatch) -> None:
     assert payload["setup_complete"]["github_requested"] is False
     assert (repo / ".mb" / "onboarding.json").exists()
     assert payload["onboarding"]["summary"]["status"] == "in_progress"
+    assert payload["onboarding"]["repo_boundary"]["schema"] == "mb.repo_boundary_helper.v0"
+    assert payload["onboarding"]["repo_boundary"]["recommended_choice"] == "same_business_repo"
     assert ".mb/onboarding.json" in (repo / ".gitignore").read_text(encoding="utf-8")
     assert ".vip/local.yaml" in (repo / ".gitignore").read_text(encoding="utf-8")
 

--- a/mb/tests/test_start.py
+++ b/mb/tests/test_start.py
@@ -146,6 +146,8 @@ def test_start_json_reports_codex_global_skill_handoff(tmp_path: Path, monkeypat
     assert report["checkpoint"]["pending"]["status"] == "ready"
     assert report["books"]["schema_version"] == "1.0"
     assert report["books"]["safe_to_share"] is True
+    assert report["topology"]["repo_boundary"]["schema"] == "mb.repo_boundary_helper.v0"
+    assert report["topology"]["repo_boundary"]["recommended_choice"] == "same_business_repo"
     assert report["push_count"] == 0
     assert report["deprecated_campaign_keys"] is True
     assert report["push_compatibility"]["legacy_campaigns_read"] is True

--- a/mb/tests/test_status.py
+++ b/mb/tests/test_status.py
@@ -3285,6 +3285,8 @@ def test_status_exposes_topology_section_when_registry_missing(tmp_path: Path, m
     assert topology["summary"]["registry_found"] is False
     assert topology["summary"]["warnings"] == 0
     assert topology["current_repo"]["matched"] is False
+    assert topology["repo_boundary"]["state"] == "single_business_repo"
+    assert topology["repo_boundary"]["recommended_choice"] == "same_business_repo"
     assert topology["registry"]["found"] is False
     assert topology["registry"]["ok"] is False
     assert topology["local"]["repo_path"] == str(repo.resolve())
@@ -3304,6 +3306,8 @@ def test_status_exposes_topology_section_with_valid_registry(tmp_path: Path, mon
 
     assert topology["summary"]["registry_ok"] is True
     assert topology["summary"]["child_repo_count"] >= 1
+    assert topology["repo_boundary"]["schema"] == "mb.repo_boundary_helper.v0"
+    assert topology["repo_boundary"]["recommended_choice"] == "same_business_repo"
     # The hub itself should match by github_owner/repo_name fall-through (no
     # remote configured in tmp git), or fall through to descriptor. Either way
     # the registry recorded the hub role for this owner/repo pair.

--- a/mb/tests/test_topology.py
+++ b/mb/tests/test_topology.py
@@ -531,6 +531,15 @@ def test_collect_returns_safe_payload(tmp_path: Path) -> None:
     assert payload["summary"]["current_repo_matched"] is True
     assert payload["summary"]["child_repo_count"] == 2
     assert payload["current_repo"]["slug"] == "example"
+    helper = payload["repo_boundary"]
+    assert helper["schema"] == "mb.repo_boundary_helper.v0"
+    assert helper["state"] == "hub_business_repo"
+    assert helper["recommended_choice"] == "same_business_repo"
+    assert {choice["id"] for choice in helper["choices"]} == {
+        "same_business_repo",
+        "separate_business_repo",
+        "child_lightweight_repo",
+    }
     # public-safe payload must not embed any absolute paths
     assert "/Users/" not in json.dumps(payload)
 
@@ -541,5 +550,60 @@ def test_collect_handles_missing_registry(tmp_path: Path) -> None:
     assert payload["summary"]["registry_ok"] is False
     assert payload["current_repo"]["matched"] is False
     assert payload["restricted_repos"] == []
+    assert payload["repo_boundary"]["state"] == "single_business_repo"
+    assert payload["repo_boundary"]["recommended_choice"] == "same_business_repo"
     # missing registry alone is informational, not a warning
     assert payload["summary"]["warnings"] == 0
+
+
+def test_repo_boundary_helper_recognizes_child_descriptor(tmp_path: Path) -> None:
+    _write_repo_json(
+        tmp_path,
+        {
+            "schema": topology.CHILD_REPO_SCHEMA,
+            "role": "site",
+            "display_name": "Workshop site",
+            "github_owner": "example-co",
+            "repo_name": "workshop-site",
+            "parent": {
+                "github_owner": "example-co",
+                "repo_name": "example",
+                "remote": "github:example-co/example",
+            },
+        },
+    )
+
+    payload = topology.collect(tmp_path)
+
+    helper = payload["repo_boundary"]
+    assert helper["state"] == "child_or_execution_repo"
+    assert helper["recommended_choice"] == "child_lightweight_repo"
+    assert "return to the hub business repo" in helper["next_action"]
+
+
+def test_repo_boundary_helper_redacts_unsafe_child_parent_handle(tmp_path: Path) -> None:
+    _write_repo_json(
+        tmp_path,
+        {
+            "schema": topology.CHILD_REPO_SCHEMA,
+            "role": "site",
+            "display_name": "Private client site",
+            "github_owner": "client-co",
+            "repo_name": "private-site",
+            "safe_to_share": False,
+            "parent": {
+                "github_owner": "example-co",
+                "repo_name": "example",
+                "remote": "github:example-co/example",
+            },
+        },
+    )
+
+    payload = topology.collect(tmp_path)
+
+    helper = payload["repo_boundary"]
+    assert helper["state"] == "child_or_execution_repo"
+    assert helper["recommended_choice"] == "child_lightweight_repo"
+    assert helper["safe_to_share"] is False
+    assert "Hub handle:" not in helper["next_action"]
+    assert "example-co/example" not in json.dumps(helper)

--- a/workflows/mb-setup/workflow.md
+++ b/workflows/mb-setup/workflow.md
@@ -27,6 +27,8 @@ json_facts:
   - runtime.codex_cli
   - runtime.claude_code
   - onboarding
+  - onboarding.repo_boundary
+  - topology.repo_boundary
   - checkpoint
   - vocabulary
 approval_gates:
@@ -95,6 +97,8 @@ The runtime shell must preserve these paths from the workflow source:
 - `runtime.codex_cli`
 - `runtime.claude_code`
 - `onboarding`
+- `onboarding.repo_boundary`
+- `topology.repo_boundary`
 - `checkpoint`
 - `vocabulary`
 
@@ -114,6 +118,10 @@ target folder is an existing Main Branch repo, use `onboarding`, `readiness`,
 `drift.items`, and `mb doctor repair --plan` to resume setup or repair instead
 of starting over. If the operator requests GitHub backup or push setup, check
 GitHub CLI authentication and account identity before any GitHub write.
+Use `onboarding.repo_boundary` or `topology.repo_boundary` when the operator is
+unsure whether related work belongs in this repo, a separate business repo, or
+a child/lightweight repo. Do not build repo profiles here; explain the
+boundary choice and ask before setup writes.
 
 After approved setup, run `mb status --json --peek` and `mb start --json`.
 Summarize the owner outcome first: folder created or connected, business brain

--- a/workflows/mb-start-status/workflow.md
+++ b/workflows/mb-start-status/workflow.md
@@ -31,6 +31,7 @@ json_facts:
   - onboarding
   - integrations
   - github
+  - topology.repo_boundary
   - brain.bets
   - brain.bets.active
   - brain.bets.due_soon
@@ -110,6 +111,7 @@ The runtime shell must preserve these paths from the workflow source:
 - `onboarding`
 - `integrations`
 - `github`
+- `topology.repo_boundary`
 - `brain.bets`
 - `brain.bets.active`
 - `brain.bets.due_soon`
@@ -139,6 +141,9 @@ workflow; route offer-shape gaps to `mb-think` and ask before durable writes.
 Use `money_path` for customer progress, offer, proof, CTA, channel, push, page
 readiness, playbook, and outcome feedback questions. Use `content_strategy` for
 content strategy, channel, account, freshness, or disconnected-layer questions.
+Use `topology.repo_boundary` when the operator is unsure whether work belongs
+in this business repo, a separate business repo, or a child/lightweight repo;
+route from the helper instead of inventing a repo-profile answer.
 Use `brain.bets` for active, due-soon, overdue, missing exit criteria,
 triggered kill, triggered double-down, close, update, and narrate moments
 before inventing bet state from prose. Use `onboarding` to resume setup without


### PR DESCRIPTION
## Summary

Closes #631.
Refs #781.

Adds deterministic repo-boundary helper facts so agents can answer whether work belongs in the same business repo, a separate business repo, or a child/lightweight repo without inventing repo profiles.

What changed:
- Adds `topology.repo_boundary` to `mb status --json --peek`.
- Adds `topology.repo_boundary` to `mb start --json`.
- Adds `onboarding.repo_boundary` to onboarding status.
- Documents the helper in `docs/child-repo-descriptors.md`.
- Updates shared setup/start-status workflow sources, generated fixtures, and shipped Claude guidance to preserve the new fact path.
- Keeps the helper privacy-aware: unsafe child descriptors do not copy parent hub handles into the helper and mark `safe_to_share: false`.

## Validation

- `cd mb && /Library/Frameworks/Python.framework/Versions/3.13/bin/python3 -m pytest tests/test_topology.py tests/test_status.py tests/test_start.py tests/test_onboard.py tests/test_workflows.py tests/test_start_router_contract.py -q` -> 232 passed.
- `PATH="/Library/Frameworks/Python.framework/Versions/3.13/bin:$PATH" scripts/check.sh` -> passed: format, lint, mypy, 871 tests, packaged skill validation.
- Read-only subagent review found no remaining blockers after the unsafe-descriptor privacy fix.

## Notes

- This is intentionally not a repo-profile schema. It is a compact setup/start/status decision helper.
- No provider mutation, scraping, export, collaborator handoff, runtime invocation, or write authority changed.
