### PR TITLE
[add] MoneyPath routing gates

### DIFF
--- a/.claude/reference/business-primitives/offer-bet-push-proof.md
+++ b/.claude/reference/business-primitives/offer-bet-push-proof.md
@@ -66,6 +66,16 @@ Create or update a **bet** when the operator is testing a direction with a
 deadline, appetite, target, evidence, or verdict. Examples: "test Petaluma HVAC
 for two weeks," "see if founder calls beat async audits," "try a $49 workshop."
 
+Apply **MoneyPath gates** before execution spend:
+
+- time-boxed test with money at risk -> route to `/mb-bet` and require a
+  MoneyPath anchor before execution;
+- durable offer truth only -> update offer files; no ledger anchor is required;
+- offer sharpening that causes spend -> open or link a bet and require
+  MoneyPath before execution;
+- material or strategic appetite -> require an accepted decision and kill
+  rubric before execution.
+
 Create or update an **offer** only when the business is ready to preserve what
 it sells or may sell repeatedly. Examples: confirmed promise, pricing,
 mechanism, deliverables, guarantee, qualification rules, or checkout/fulfillment

--- a/.claude/skills/mb-start/SKILL.md
+++ b/.claude/skills/mb-start/SKILL.md
@@ -6,9 +6,7 @@ loops: [sense, decide]
 
 # Start
 
-Single entry point for Main Branch. Detect business state, current intent, save/sync posture, and the smallest useful next route.
-
-**Recommended workflow:** Start Claude in your business repo, run `/mb-start`. It handles everything. Claude Code discovers Main Branch through project-local `.claude/skills/mb-*` bridge links; `additionalDirectories` grants file access to the installed package or source checkout.
+Single entry point for Main Branch. Detect business state, intent, save/sync posture, and the smallest useful next route.
 
 ## Router and language contract
 
@@ -22,10 +20,9 @@ git terms, checkpoint ids, branch names, `origin`, `ahead`, `behind`, `rebase`,
 and `commit` out of the first response unless the user asks for technical detail
 or the exact command must be shown.
 
-When summarizing repo state, count records under `pushes/` (current) and flag
-`campaigns/` separately as legacy compatibility. If `core/vocabulary.md` defines
-display words, speak the operator's word in conversation while still using
-actual file paths in commands.
+When summarizing repo state, count `pushes/` records and flag `campaigns/`
+only as legacy compatibility. Use `core/vocabulary.md` display words in
+conversation while preserving actual paths in commands.
 
 **CLI facts first:** Once the business repo path is known, run
 `mb status --json --peek` before asking setup or routing questions. Treat JSON
@@ -49,6 +46,11 @@ Required commands:
 
 Required fact paths:
 - `money_path`
+- `money_path.policy`
+- `money_path.policy.thresholds_declared`
+- `money_path.active_bets`
+- `money_path.active_bets.unanchored`
+- `money_path.active_bets.over_cap`
 - `money_path.objects.proof.quality`
 - `validation.file_contracts`
 - `content_strategy`
@@ -496,5 +498,3 @@ treat business `.vip/local.yaml` as audit input only, and do not write it.
 - [references/tool-status-audit.md](references/tool-status-audit.md) — Step 5 provider/readiness audit
 - [references/triage-agent.md](references/triage-agent.md) — Triage agent prompts and synthesis
 - [references/launch-orchestration.md](references/launch-orchestration.md) — guided offer-launch path
-## Remember
-Router, not worker. Detect → route → let the skill do the work. One clarifying question max. Skill loads its own context — main stays lean.

--- a/.claude/skills/mb-start/references/router-and-language.md
+++ b/.claude/skills/mb-start/references/router-and-language.md
@@ -174,6 +174,12 @@ hledger, receipts, tax, payroll, revenue report.
 Route:
 
 - Run `mb books check "$REPO_PATH" --json` before inventing structure.
+- For betting, spend, or risk intent, start from `mb status --json --peek`.
+  Read `money_path.policy` and `money_path.active_bets` before recommending
+  execution. If an active bet is unanchored, over cap, or thresholds are
+  missing, route to `/mb-bet` or `/mb-think` before spend.
+- For offer or pricing work that would cause spend, use the offer/bet/push/proof
+  rubric before deciding whether this is durable offer truth or a MoneyPath bet.
 - Keep raw ledgers, statements, credentials, account numbers, payroll rows, tax
   IDs, and exact private numbers out of the public/team-safe business repo.
 - Preserve public topology terms: hub repo, child repo, hub registry

--- a/.claude/skills/mb-status/SKILL.md
+++ b/.claude/skills/mb-status/SKILL.md
@@ -27,6 +27,11 @@ Required commands:
 Required fact paths:
 
 - `money_path`
+- `money_path.policy`
+- `money_path.policy.thresholds_declared`
+- `money_path.active_bets`
+- `money_path.active_bets.unanchored`
+- `money_path.active_bets.over_cap`
 - `money_path.objects.proof.quality`
 - `validation.file_contracts`
 - `content_strategy`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   `mb start --json`, and onboarding status so agents can guide same-repo,
   separate-business-repo, or child/lightweight-repo setup decisions without
   inventing repo profiles. Closes #631.
+- Added MoneyPath appetite-threshold and active-bet exposure facts to
+  `mb status --json --peek`, with safe aggregate routing for missing
+  thresholds, unanchored bets, and over-cap bets. Closes #645.
 
 ### Fixed
 

--- a/docs/books.md
+++ b/docs/books.md
@@ -135,6 +135,27 @@ vault_location: ".mb/private/books/"
 github_backup: false
 encrypted_backup: false
 class_b_data: true
+money_path:
+  scale_basis: rolling_30_day_gross_outflow
+  exposure_window_days: 7
+  appetite_thresholds:
+    trivial:
+      max_amount: 100
+      approval: operator
+      ledger_required: false
+    small:
+      max_amount: 1000
+      approval: operator
+      ledger_required: true
+    material:
+      max_amount: 5000
+      approval: accepted_decision
+      ledger_required: true
+    strategic:
+      min_amount: 5000
+      approval: accepted_decision
+      ledger_required: true
+      requires_exit_rubric: true
 ---
 
 # Bookkeeping
@@ -143,6 +164,13 @@ This business uses an hledger journal kept in a private bookkeeping vault.
 This file is the public-safe pointer. The journal itself is not
 committed here.
 ```
+
+The optional `money_path.appetite_thresholds` block declares decision
+thresholds only. It lets `mb status --json --peek` summarize active bet
+exposure, unanchored bets, and over-cap bets without exposing raw ledger rows,
+payees, account names, or balances. Leave the thresholds blank until the
+operator chooses them; Main Branch should then ask before material execution
+spend.
 
 `core/finance/chart-of-accounts.md` describes the account roots the
 operator uses (`assets`, `liabilities`, `equity`, `income`,

--- a/docs/examples/books/books.md
+++ b/docs/examples/books/books.md
@@ -9,6 +9,27 @@ vault_location: ".mb/private/books/"
 github_backup: false
 encrypted_backup: false
 class_b_data: true
+money_path:
+  scale_basis: rolling_30_day_gross_outflow
+  exposure_window_days: 7
+  appetite_thresholds:
+    trivial:
+      max_amount: 100
+      approval: operator
+      ledger_required: false
+    small:
+      max_amount: 1000
+      approval: operator
+      ledger_required: true
+    material:
+      max_amount: 5000
+      approval: accepted_decision
+      ledger_required: true
+    strategic:
+      min_amount: 5000
+      approval: accepted_decision
+      ledger_required: true
+      requires_exit_rubric: true
 ---
 
 # Bookkeeping — Sample

--- a/mb/mb/books.py
+++ b/mb/mb/books.py
@@ -53,6 +53,7 @@ BOOKS_IGNORE_ENTRIES = (
 
 VALID_STORAGE_MODES = frozenset({"solo-local", "team-private-repo", "advanced-vault"})
 NON_LOCAL_STORAGE_MODES = frozenset({"team-private-repo", "advanced-vault"})
+APPETITE_TIERS = ("trivial", "small", "material", "strategic")
 
 BUNDLED_FIXTURE_NAME = "acme-fixture.journal"
 DOCS_BOOKS_PATH = "docs/books.md"
@@ -238,6 +239,91 @@ def _safe_bool(value: Any) -> bool:
     if isinstance(value, str):
         return value.strip().lower() in {"1", "true", "yes", "on"}
     return bool(value)
+
+
+def _number_or_none(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int | float):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value.replace(",", "").strip())
+        except ValueError:
+            return None
+    return None
+
+
+def _money_path_policy_from_frontmatter(fm: dict[str, Any]) -> dict[str, Any]:
+    raw = fm.get("money_path")
+    money_path = raw if isinstance(raw, dict) else {}
+    thresholds = money_path.get("appetite_thresholds")
+    raw_thresholds = thresholds if isinstance(thresholds, dict) else {}
+    tiers: dict[str, dict[str, Any]] = {}
+    for tier in APPETITE_TIERS:
+        raw_tier = raw_thresholds.get(tier)
+        if not isinstance(raw_tier, dict):
+            continue
+        tiers[tier] = {
+            "min_amount": _number_or_none(raw_tier.get("min_amount")),
+            "max_amount": _number_or_none(raw_tier.get("max_amount")),
+            "approval": str(raw_tier.get("approval") or "").strip(),
+            "ledger_required": _safe_bool(raw_tier.get("ledger_required")),
+            "requires_exit_rubric": _safe_bool(raw_tier.get("requires_exit_rubric")),
+        }
+    currency = str(
+        money_path.get("currency") or fm.get("operating_currency") or fm.get("currency") or "USD"
+    ).strip()
+    exposure_window = money_path.get("exposure_window_days")
+    return {
+        "path": "core/finance/books.md",
+        "currency": currency or "USD",
+        "scale_basis": str(money_path.get("scale_basis") or "rolling_30_day_gross_outflow").strip(),
+        "exposure_window_days": int(exposure_window)
+        if isinstance(exposure_window, int) and exposure_window > 0
+        else 7,
+        "thresholds_declared": bool(tiers),
+        "tier_names": list(tiers),
+        "tiers": tiers,
+    }
+
+
+def _money_path_threshold_findings(policy: dict[str, Any]) -> list[dict[str, Any]]:
+    if policy.get("thresholds_declared"):
+        return [
+            _finding(
+                id="books-money-path-thresholds-ok",
+                title="MoneyPath appetite thresholds are declared",
+                state="ok",
+                detail="core/finance/books.md declares MoneyPath appetite thresholds.",
+                audience="informational",
+                operator_summary="MoneyPath appetite thresholds are declared.",
+            )
+        ]
+    return [
+        _finding(
+            id="books-money-path-thresholds-missing",
+            title="MoneyPath appetite thresholds are missing",
+            state="ok",
+            detail=(
+                "core/finance/books.md does not declare money_path.appetite_thresholds. "
+                "Main Branch can still run, but material bets should ask for thresholds "
+                "before execution spend."
+            ),
+            audience="operator_decision",
+            operator_summary=(
+                "Declare MoneyPath appetite thresholds before treating material spend as routed."
+            ),
+            repair="Add money_path.appetite_thresholds to core/finance/books.md.",
+        )
+    ]
+
+
+def _threshold_for_appetite(policy: dict[str, Any], appetite_tier: str) -> dict[str, Any] | None:
+    raw_tiers = policy.get("tiers")
+    tiers: dict[str, Any] = raw_tiers if isinstance(raw_tiers, dict) else {}
+    threshold = tiers.get(appetite_tier)
+    return threshold if isinstance(threshold, dict) else None
 
 
 def _vault_info(repo: Path, fm: dict[str, Any]) -> dict[str, Any]:
@@ -576,6 +662,7 @@ def _detect_books_policy(repo: Path) -> tuple[dict[str, Any], list[dict[str, Any
                 operator_summary=(f"Books policy in place; storage mode is {storage_mode}."),
             )
         )
+    findings.extend(_money_path_threshold_findings(_money_path_policy_from_frontmatter(fm)))
     return fm, findings
 
 
@@ -1087,6 +1174,14 @@ def _money_path_for_bet(path: Path, fm: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _bet_appetite_tier(fm: dict[str, Any]) -> str:
+    direct = str(fm.get("appetite_tier") or "").strip().lower()
+    if direct in APPETITE_TIERS:
+        return direct
+    appetite = str(fm.get("appetite") or "").strip().lower()
+    return appetite if appetite in APPETITE_TIERS else ""
+
+
 def _decimal_mantissa_from_number(value: Any, places: int = 2) -> int | None:
     if isinstance(value, bool):
         return None
@@ -1255,7 +1350,7 @@ def _exposure_error(
 
 
 def _bet_exposure(
-    repo: Path, journal: Path, bet_path: Path
+    repo: Path, journal: Path, bet_path: Path, policy: dict[str, Any]
 ) -> tuple[dict[str, Any], list[dict[str, Any]]]:
     fm, frontmatter_error = _bet_frontmatter(repo, bet_path)
     if frontmatter_error is not None:
@@ -1263,6 +1358,8 @@ def _bet_exposure(
     resolved = bet_path if bet_path.is_absolute() else repo / bet_path
     rel = resolved.resolve().relative_to(repo.resolve()).as_posix()
     money_path = _money_path_for_bet(resolved, fm)
+    appetite_tier = _bet_appetite_tier(fm)
+    threshold = _threshold_for_appetite(policy, appetite_tier) if appetite_tier else None
     bet_id = str(money_path.get("bet_id") or resolved.stem)
     findings: list[dict[str, Any]] = []
     if not money_path["declared"]:
@@ -1352,11 +1449,49 @@ def _bet_exposure(
                         ),
                     )
                 )
+    threshold_amount = None
+    over_appetite_threshold = False
+    if threshold is not None and threshold.get("max_amount") is not None:
+        threshold_mantissa = _decimal_mantissa_from_number(threshold.get("max_amount"), places or 2)
+        if threshold_mantissa is not None:
+            threshold_amount = _amount_from_parts(
+                commodity=str(policy.get("currency") or commodity or "USD"),
+                mantissa=threshold_mantissa,
+                places=places or 2,
+            )
+            if str(policy.get("currency") or commodity or "USD") == commodity:
+                over_appetite_threshold = gross_mantissa > threshold_mantissa
+                if over_appetite_threshold:
+                    findings.append(
+                        _finding(
+                            id="bet-exposure-over-appetite-threshold",
+                            title="Bet exposure is over its MoneyPath appetite threshold",
+                            state="warn",
+                            detail=(
+                                f"{rel} gross exposure is over the configured "
+                                f"{appetite_tier} appetite threshold."
+                            ),
+                            audience="operator_decision",
+                            operator_summary=(
+                                "Review this bet before more execution spend; exposure is over cap."
+                            ),
+                        )
+                    )
     exposure = {
         "path": rel,
         "title": str(fm.get("title") or resolved.stem),
         "status": str(fm.get("status") or ""),
+        "appetite_tier": appetite_tier,
         "money_path": money_path,
+        "scale_gate": {
+            "appetite_tier": appetite_tier,
+            "threshold": threshold,
+            "threshold_amount": threshold_amount,
+            "approval": str((threshold or {}).get("approval") or ""),
+            "ledger_required": bool((threshold or {}).get("ledger_required")),
+            "requires_exit_rubric": bool((threshold or {}).get("requires_exit_rubric")),
+            "over_cap": over_appetite_threshold,
+        },
         "anchor": {
             "tag": f"bet:{bet_id}",
             "query": f"tag:bet={bet_id}",
@@ -1386,6 +1521,7 @@ def exposure(
     repo_path = Path(repo).resolve()
     mode = "active" if active else "single"
     fm, policy_findings = _detect_books_policy(repo_path)
+    money_path_policy = _money_path_policy_from_frontmatter(fm)
     error_findings = [finding for finding in policy_findings if finding["state"] == "error"]
     if error_findings:
         return _exposure_error(repo=repo_path, mode=mode, findings=error_findings)
@@ -1456,7 +1592,7 @@ def exposure(
         )
     ]
     for bet_path in bet_paths:
-        exposure_item, bet_findings = _bet_exposure(repo_path, journal, bet_path)
+        exposure_item, bet_findings = _bet_exposure(repo_path, journal, bet_path, money_path_policy)
         if exposure_item:
             exposures.append(exposure_item)
         findings.extend(bet_findings)
@@ -1477,6 +1613,9 @@ def exposure(
             f"Checked {len(exposures)} bet exposure record(s); "
             f"{transaction_count} anchored transaction(s) found."
         ),
+        "policy": {
+            "money_path": money_path_policy,
+        },
         "exposures": exposures,
         "findings": findings,
         "errors": errors,
@@ -1894,6 +2033,7 @@ def run(
         "state": state,
         "repo": str(repo_path),
         "storage_mode": storage_mode,
+        "money_path_policy": _money_path_policy_from_frontmatter(fm),
         "fixture_validated": validate_fixture,
         "summary": summary,
         "findings": findings,
@@ -1924,6 +2064,7 @@ def status(repo: str | Path = ".") -> dict[str, Any]:
     missing_ignore = _books_ignore_missing(entries)
     vault = _vault_info(repo_path, fm)
     storage_mode = check_report.get("storage_mode") or _policy_storage_mode(fm)
+    money_path_policy = _money_path_policy_from_frontmatter(fm)
     status_summary = "Books setup passed." if state == "ok" else _summary(state, findings)
 
     return {
@@ -1941,6 +2082,8 @@ def status(repo: str | Path = ".") -> dict[str, Any]:
             "path": "core/finance/books.md",
             "storage_mode": storage_mode,
             "valid_storage_mode": bool(storage_mode in VALID_STORAGE_MODES),
+            "currency": money_path_policy["currency"],
+            "money_path": money_path_policy,
         },
         "vault": vault,
         "ignore": {
@@ -2050,6 +2193,7 @@ def readiness(repo: str | Path = ".") -> dict[str, Any]:
             "present": bool(policy.get("present")),
             "storage_mode": str(policy.get("storage_mode") or ""),
             "valid_storage_mode": bool(policy.get("valid_storage_mode")),
+            "money_path": policy.get("money_path") or {},
         },
         "vault": {
             "configured": bool(vault.get("configured")),

--- a/mb/mb/ranker.py
+++ b/mb/mb/ranker.py
@@ -504,6 +504,7 @@ def _add_money_path_actions(actions: list[dict[str, Any]], report: dict[str, Any
     first = money_actions[0]
     score = WEIGHTS["money_path_gaps"]
     component = str(first.get("component") or "money_path")
+    signal_id = str(first.get("source") or f"money_path.objects.{component}")
     missing = [str(item) for item in _list(first.get("missing"))]
     actions.append(
         _action(
@@ -516,7 +517,7 @@ def _add_money_path_actions(actions: list[dict[str, Any]], report: dict[str, Any
             reason=str(first.get("reason") or "MoneyPath found a business-path gap."),
             signals=[
                 _signal(
-                    f"money_path.objects.{component}",
+                    signal_id,
                     severity="info",
                     summary=str(first.get("reason") or "MoneyPath component needs review."),
                     evidence=missing,

--- a/mb/mb/status.py
+++ b/mb/mb/status.py
@@ -2903,6 +2903,187 @@ def _money_path_overall_level(objects: dict[str, dict[str, Any]]) -> int:
     return 4
 
 
+def _money_amount(
+    *, commodity: str = "USD", decimal_mantissa: int = 0, decimal_places: int = 2
+) -> dict[str, Any]:
+    scale = 10**decimal_places
+    whole = abs(decimal_mantissa) // scale
+    fraction = abs(decimal_mantissa) % scale
+    sign = "-" if decimal_mantissa < 0 else ""
+    if commodity == "USD" and decimal_places == 2:
+        display = f"{sign}${whole:,}.{fraction:02d}"
+    elif decimal_places > 0:
+        display = f"{sign}{whole:,}.{fraction:0{decimal_places}d} {commodity}".strip()
+    else:
+        display = f"{sign}{whole:,} {commodity}".strip()
+    return {
+        "commodity": commodity,
+        "decimal_mantissa": decimal_mantissa,
+        "decimal_places": decimal_places,
+        "display": display,
+    }
+
+
+def _money_path_active_bet_exposure(repo: Path, report: dict[str, Any]) -> dict[str, Any]:
+    raw_brain = report.get("brain")
+    brain = raw_brain if isinstance(raw_brain, dict) else {}
+    raw_bets = brain.get("bets")
+    bets = raw_bets if isinstance(raw_bets, dict) else {}
+    active = [item for item in bets.get("active", []) if isinstance(item, dict)]
+    books = report.get("books") if isinstance(report.get("books"), dict) else {}
+    policy = (
+        ((books.get("policy") or {}).get("money_path") or {}) if isinstance(books, dict) else {}
+    )
+    currency = str(policy.get("currency") or "USD")
+    exposure_window_days = int(policy.get("exposure_window_days") or 7)
+    summary: dict[str, Any] = {
+        "count": len(active),
+        "anchored": 0,
+        "unanchored": 0,
+        "gross_exposure": _money_amount(commodity=currency),
+        "this_week_at_risk": _money_amount(commodity=currency),
+        "over_cap": [],
+        "ledger_unavailable": False,
+        "checked": False,
+    }
+    if not active:
+        return summary
+    try:
+        exposure_report = books_mod.exposure(repo=repo, active=True)
+    except Exception:
+        return {**summary, "ledger_unavailable": True}
+    if not exposure_report.get("ok") and not exposure_report.get("exposures"):
+        return {**summary, "ledger_unavailable": True}
+    exposures = [item for item in exposure_report.get("exposures", []) if isinstance(item, dict)]
+    total_mantissa = 0
+    total_places = 2
+    week_mantissa = 0
+    today = date.today()
+    for item in exposures:
+        raw_anchor = item.get("anchor")
+        anchor = raw_anchor if isinstance(raw_anchor, dict) else {}
+        if anchor.get("present"):
+            summary["anchored"] += 1
+        raw_money_path = item.get("money_path")
+        money_path = raw_money_path if isinstance(raw_money_path, dict) else {}
+        if not anchor.get("present") and money_path.get("required"):
+            summary["unanchored"] += 1
+        raw_totals = item.get("totals")
+        totals = raw_totals if isinstance(raw_totals, dict) else {}
+        raw_gross = totals.get("gross_outflow")
+        gross = raw_gross if isinstance(raw_gross, dict) else {}
+        if gross.get("commodity") == currency:
+            total_places = int(gross.get("decimal_places") or total_places)
+            total_mantissa += int(gross.get("decimal_mantissa") or 0)
+            deadline = str(
+                next(
+                    (bet.get("deadline") for bet in active if bet.get("path") == item.get("path")),
+                    "",
+                )
+            )
+            try:
+                deadline_date = date.fromisoformat(deadline)
+            except ValueError:
+                deadline_date = None
+            if (
+                deadline_date is not None
+                and 0 <= (deadline_date - today).days <= exposure_window_days
+            ):
+                week_mantissa += int(gross.get("decimal_mantissa") or 0)
+        raw_scale_gate = item.get("scale_gate")
+        scale_gate = raw_scale_gate if isinstance(raw_scale_gate, dict) else {}
+        if scale_gate.get("over_cap"):
+            summary["over_cap"].append(
+                {
+                    "path": str(item.get("path") or ""),
+                    "title": str(item.get("title") or ""),
+                    "appetite_tier": str(scale_gate.get("appetite_tier") or ""),
+                    "gross_exposure": gross,
+                    "threshold": scale_gate.get("threshold_amount"),
+                    "safe_to_share": True,
+                }
+            )
+    summary["checked"] = True
+    summary["gross_exposure"] = _money_amount(
+        commodity=currency, decimal_mantissa=total_mantissa, decimal_places=total_places
+    )
+    summary["this_week_at_risk"] = _money_amount(
+        commodity=currency, decimal_mantissa=week_mantissa, decimal_places=total_places
+    )
+    return summary
+
+
+def _money_path_finance_actions(
+    *, policy: dict[str, Any], active_bets: dict[str, Any], policy_present: bool
+) -> list[dict[str, Any]]:
+    actions: list[dict[str, Any]] = []
+    active_count = int(active_bets.get("count") or 0)
+    if (policy_present or active_count) and not policy.get("thresholds_declared"):
+        actions.append(
+            {
+                "id": "declare-appetite-thresholds",
+                "title": "Declare MoneyPath appetite thresholds",
+                "reason": (
+                    "MoneyPath cannot compare active bet exposure to your appetite until "
+                    "core/finance/books.md declares thresholds."
+                ),
+                "route": "/mb-think",
+                "component": "financial_exposure",
+                "source": "money_path.policy.thresholds_declared",
+                "confidence": "medium",
+                "missing": ["core/finance/books.md money_path.appetite_thresholds"],
+                "safe_to_share": True,
+            }
+        )
+    if active_bets.get("ledger_unavailable") and active_count:
+        actions.append(
+            {
+                "id": "repair-books-exposure",
+                "title": "Repair books exposure checks",
+                "reason": "Active bets exist, but Main Branch cannot check private ledger anchors.",
+                "route": "mb books doctor --plan --json",
+                "component": "financial_exposure",
+                "source": "money_path.active_bets.ledger_unavailable",
+                "confidence": "medium",
+                "missing": ["hledger exposure check"],
+                "safe_to_share": True,
+            }
+        )
+    if int(active_bets.get("unanchored") or 0):
+        actions.append(
+            {
+                "id": "anchor-active-bet-exposure",
+                "title": "Anchor active bet exposure",
+                "reason": (
+                    "One or more active bets require MoneyPath anchors before execution spend."
+                ),
+                "route": "/mb-bet",
+                "component": "financial_exposure",
+                "source": "money_path.active_bets.unanchored",
+                "confidence": "high",
+                "missing": ["ledger bet anchors"],
+                "safe_to_share": True,
+            }
+        )
+    if active_bets.get("over_cap"):
+        actions.append(
+            {
+                "id": "review-over-cap-bets",
+                "title": "Review bets over appetite",
+                "reason": "One or more active bets are over the configured MoneyPath appetite cap.",
+                "route": "/mb-bet",
+                "component": "financial_exposure",
+                "source": "money_path.active_bets.over_cap",
+                "confidence": "high",
+                "missing": [
+                    str(item.get("path") or "") for item in active_bets.get("over_cap", [])
+                ],
+                "safe_to_share": True,
+            }
+        )
+    return actions
+
+
 def _money_path(repo: Path, report: dict[str, Any]) -> dict[str, Any]:
     brain = report.get("brain") or {}
     push_report = brain.get("pushes") or {}
@@ -2959,6 +3140,19 @@ def _money_path(repo: Path, report: dict[str, Any]) -> dict[str, Any]:
     }
     objects = {component: collected_objects[component] for component in MONEY_PATH_COMPONENTS}
     overall_level = _money_path_overall_level(objects)
+    books = report.get("books") if isinstance(report.get("books"), dict) else {}
+    policy = (
+        ((books.get("policy") or {}).get("money_path") or {}) if isinstance(books, dict) else {}
+    )
+    policy_present = (
+        bool((books.get("policy") or {}).get("present")) if isinstance(books, dict) else False
+    )
+    active_bets = _money_path_active_bet_exposure(repo, report)
+    finance_actions = _money_path_finance_actions(
+        policy=policy,
+        active_bets=active_bets,
+        policy_present=policy_present,
+    )
     return {
         "schema_version": MONEY_PATH_SCHEMA_VERSION,
         "overall_level": overall_level,
@@ -2967,8 +3161,10 @@ def _money_path(repo: Path, report: dict[str, Any]) -> dict[str, Any]:
             "MoneyPath reports legibility, support, connection, and instrumentation "
             "from repo facts."
         ),
+        "policy": policy,
+        "active_bets": active_bets,
         "objects": objects,
-        "ranked_actions": _money_path_ranked_actions(objects, overall_level),
+        "ranked_actions": [*finance_actions, *_money_path_ranked_actions(objects, overall_level)],
         "safe_to_share": True,
     }
 

--- a/mb/tests/fixtures/status/schema-v1-basic.json
+++ b/mb/tests/fixtures/status/schema-v1-basic.json
@@ -124,9 +124,11 @@
       "summary"
     ],
     "money_path": [
+      "active_bets",
       "objects",
       "overall_label",
       "overall_level",
+      "policy",
       "ranked_actions",
       "safe_to_share",
       "schema_version",

--- a/mb/tests/fixtures/workflows/mb-start-money-path.claude.md
+++ b/mb/tests/fixtures/workflows/mb-start-money-path.claude.md
@@ -21,6 +21,11 @@ This snapshot does not replace shipped `.claude/skills` prose.
 ## Required JSON Fact Paths
 
 - `money_path`
+- `money_path.policy`
+- `money_path.policy.thresholds_declared`
+- `money_path.active_bets`
+- `money_path.active_bets.unanchored`
+- `money_path.active_bets.over_cap`
 - `money_path.objects.offer`
 - `money_path.objects.proof`
 - `money_path.objects.proof.quality`

--- a/mb/tests/fixtures/workflows/mb-start-money-path.codex.md
+++ b/mb/tests/fixtures/workflows/mb-start-money-path.codex.md
@@ -21,6 +21,11 @@ path-to-money advice.
 ## Required JSON Fact Paths
 
 - `money_path`
+- `money_path.policy`
+- `money_path.policy.thresholds_declared`
+- `money_path.active_bets`
+- `money_path.active_bets.unanchored`
+- `money_path.active_bets.over_cap`
 - `money_path.objects.offer`
 - `money_path.objects.proof`
 - `money_path.objects.proof.quality`

--- a/mb/tests/fixtures/workflows/mb-start-status.claude.md
+++ b/mb/tests/fixtures/workflows/mb-start-status.claude.md
@@ -18,6 +18,11 @@ This snapshot does not replace shipped `.claude/skills` prose.
 ## Required JSON Fact Paths
 
 - `money_path`
+- `money_path.policy`
+- `money_path.policy.thresholds_declared`
+- `money_path.active_bets`
+- `money_path.active_bets.unanchored`
+- `money_path.active_bets.over_cap`
 - `money_path.objects.proof.quality`
 - `validation.file_contracts`
 - `content_strategy`

--- a/mb/tests/fixtures/workflows/mb-start-status.codex.md
+++ b/mb/tests/fixtures/workflows/mb-start-status.codex.md
@@ -21,6 +21,11 @@ workflows are available in Codex.
 ## Required JSON Fact Paths
 
 - `money_path`
+- `money_path.policy`
+- `money_path.policy.thresholds_declared`
+- `money_path.active_bets`
+- `money_path.active_bets.unanchored`
+- `money_path.active_bets.over_cap`
 - `money_path.objects.proof.quality`
 - `validation.file_contracts`
 - `content_strategy`

--- a/mb/tests/test_books.py
+++ b/mb/tests/test_books.py
@@ -111,6 +111,38 @@ ledger: hledger
     assert report["errors"] == []
 
 
+def test_books_check_reports_money_path_thresholds(tmp_path: Path) -> None:
+    repo = _init_business_repo(tmp_path)
+    _write(
+        repo / "core/finance/books.md",
+        """---
+type: books
+ledger: hledger
+operating_currency: USD
+storage_mode: solo-local
+vault_location: ".mb/private/books/"
+money_path:
+  scale_basis: rolling_30_day_gross_outflow
+  exposure_window_days: 7
+  appetite_thresholds:
+    small:
+      max_amount: 1000
+      approval: operator
+      ledger_required: true
+---
+
+# Books
+""",
+    )
+    _write(repo / ".gitignore", ".mb/private/\n")
+    report = books_mod.run(repo=str(repo))
+
+    assert report["money_path_policy"]["thresholds_declared"] is True
+    assert report["money_path_policy"]["tiers"]["small"]["max_amount"] == 1000.0
+    findings = _findings_by_id(report)
+    assert findings["books-money-path-thresholds-ok"]["state"] == "ok"
+
+
 def test_books_check_flags_committed_ledger_file(tmp_path: Path) -> None:
     repo = _init_business_repo(tmp_path)
     _write(repo / "core/finance/notes.md", "# notes\n")
@@ -569,6 +601,80 @@ tags: []
     assert "PRIVATE_LEDGER_CONTENT" not in result.output
     assert str(repo) not in result.output
     assert str(repo / ".mb/private/books") not in result.output
+
+
+def test_books_exposure_flags_over_appetite_threshold(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _init_business_repo(tmp_path)
+    _write(
+        repo / "core/finance/books.md",
+        """---
+type: books
+ledger: hledger
+storage_mode: solo-local
+vault_location: ".mb/private/books/"
+money_path:
+  appetite_thresholds:
+    small:
+      max_amount: 100
+      approval: operator
+      ledger_required: true
+---
+
+# Books
+""",
+    )
+    _write(repo / ".mb/private/books/main.journal", "; PRIVATE_LEDGER_CONTENT\n")
+    _write(
+        repo / "bets/2026-05-16-offer-test.md",
+        """---
+status: open
+opened: 2026-05-16
+deadline: 2026-05-30
+appetite_tier: small
+money_path:
+  required: true
+  bet_id: 2026-05-16-offer-test
+linked_decisions: []
+linked_research: []
+linked_pushes: []
+linked_outcomes: []
+public: false
+channels: []
+tags: []
+---
+# Offer test
+""",
+    )
+    transactions = [
+        {
+            "tpostings": [
+                {
+                    "paccount": "Expenses:Marketing",
+                    "pamount": [
+                        {
+                            "acommodity": "USD",
+                            "aquantity": {"decimalMantissa": 12500, "decimalPlaces": 2},
+                        }
+                    ],
+                }
+            ],
+        }
+    ]
+    monkeypatch.setattr("mb.books.shutil.which", lambda name: "/fake/hledger")
+    _hledger_exposure_dispatcher(monkeypatch, transactions)
+
+    result = runner.invoke(app, ["books", "exposure", "--repo", str(repo), "--active", "--json"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    exposure = payload["exposures"][0]
+    assert exposure["scale_gate"]["over_cap"] is True
+    assert exposure["scale_gate"]["threshold_amount"]["display"] == "$100.00"
+    assert "bet-exposure-over-appetite-threshold" in {
+        finding["id"] for finding in payload["findings"]
+    }
 
 
 def test_books_exposure_active_warns_when_required_anchor_missing(

--- a/mb/tests/test_ranker.py
+++ b/mb/tests/test_ranker.py
@@ -196,6 +196,32 @@ def test_ranker_surfaces_money_path_below_repair_blockers() -> None:
     assert money_path["score"] < actions[0]["score"]
 
 
+def test_ranker_preserves_money_path_action_source() -> None:
+    report = _base_report()
+    report["money_path"] = {
+        "ranked_actions": [
+            {
+                "id": "declare-appetite-thresholds",
+                "title": "Declare MoneyPath appetite thresholds",
+                "reason": "Thresholds are missing.",
+                "route": "/mb-think",
+                "component": "financial_exposure",
+                "source": "money_path.policy.thresholds_declared",
+                "confidence": "medium",
+                "missing": ["core/finance/books.md money_path.appetite_thresholds"],
+                "safe_to_share": True,
+            }
+        ]
+    }
+
+    actions = ranker.rank_status_report(report)
+
+    money_path = next(
+        action for action in actions if action["id"] == "review_money_path_financial_exposure"
+    )
+    assert money_path["signals"][0]["id"] == "money_path.policy.thresholds_declared"
+
+
 def test_ranker_action_carries_audience_and_operator_summary() -> None:
     action = ranker._action(
         action_id="any.id",

--- a/mb/tests/test_status.py
+++ b/mb/tests/test_status.py
@@ -459,6 +459,110 @@ def test_status_books_readiness_redacts_private_paths_and_contents(
     assert "PRIVATE_LEDGER_CONTENT" not in payload
 
 
+def test_status_money_path_reports_active_bet_exposure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+    (repo / "core/finance/books.md").write_text(
+        """---
+type: books
+ledger: hledger
+storage_mode: solo-local
+vault_location: ".mb/private/books/"
+money_path:
+  appetite_thresholds:
+    small:
+      max_amount: 100
+      approval: operator
+      ledger_required: true
+---
+
+# Books
+""",
+        encoding="utf-8",
+    )
+    (repo / ".mb/private/books").mkdir(parents=True)
+    (repo / ".mb/private/books/main.journal").write_text("; PRIVATE\n", encoding="utf-8")
+    (repo / ".gitignore").write_text(".mb/private/\n", encoding="utf-8")
+    deadline = date.today()
+    (repo / "bets").mkdir(exist_ok=True)
+    (repo / "bets/2026-05-16-offer-test.md").write_text(
+        (
+            "---\n"
+            "status: open\n"
+            "opened: 2026-05-16\n"
+            f"deadline: {deadline.isoformat()}\n"
+            "appetite_tier: small\n"
+            "money_path:\n"
+            "  required: true\n"
+            "  bet_id: 2026-05-16-offer-test\n"
+            "linked_decisions: []\n"
+            "linked_research: []\n"
+            "linked_pushes: []\n"
+            "linked_outcomes: []\n"
+            "public: false\n"
+            "channels: []\n"
+            "tags: []\n"
+            "---\n\n# Offer test\n"
+        ),
+        encoding="utf-8",
+    )
+
+    class _FakeCompleted:
+        def __init__(self, stdout: str = "", returncode: int = 0) -> None:
+            self.returncode = returncode
+            self.stdout = stdout
+            self.stderr = ""
+
+    real_run = subprocess.run
+
+    def _fake_hledger(args: Any, *rest: Any, **kwargs: Any) -> Any:
+        argv = list(args) if isinstance(args, (list, tuple)) else [args]
+        if argv and Path(str(argv[0])).name == "hledger":
+            if "check" in argv:
+                return _FakeCompleted()
+            if "print" in argv:
+                return _FakeCompleted(
+                    json.dumps(
+                        [
+                            {
+                                "tpostings": [
+                                    {
+                                        "paccount": "Expenses:Marketing",
+                                        "pamount": [
+                                            {
+                                                "acommodity": "USD",
+                                                "aquantity": {
+                                                    "decimalMantissa": 12500,
+                                                    "decimalPlaces": 2,
+                                                },
+                                            }
+                                        ],
+                                    }
+                                ]
+                            }
+                        ]
+                    )
+                )
+        return real_run(args, *rest, **kwargs)
+
+    monkeypatch.setattr("mb.books.shutil.which", lambda name: "/fake/hledger")
+    monkeypatch.setattr("mb.books.subprocess.run", _fake_hledger)
+
+    report = status_mod.run(path=str(repo), update_marker=False)
+
+    money_path = report["money_path"]
+    assert money_path["policy"]["thresholds_declared"] is True
+    assert money_path["active_bets"]["count"] == 1
+    assert money_path["active_bets"]["anchored"] == 1
+    assert money_path["active_bets"]["gross_exposure"]["display"] == "$125.00"
+    assert money_path["active_bets"]["this_week_at_risk"]["display"] == "$125.00"
+    assert money_path["active_bets"]["over_cap"][0]["path"] == "bets/2026-05-16-offer-test.md"
+    assert money_path["ranked_actions"][0]["id"] == "review-over-cap-bets"
+
+
 def test_status_money_path_single_offer_structured_caps_without_proof(
     tmp_path: Path, monkeypatch
 ) -> None:

--- a/workflows/mb-start-money-path/workflow.md
+++ b/workflows/mb-start-money-path/workflow.md
@@ -16,6 +16,11 @@ required_mb_commands:
   - mb doctor repair --plan
 json_facts:
   - money_path
+  - money_path.policy
+  - money_path.policy.thresholds_declared
+  - money_path.active_bets
+  - money_path.active_bets.unanchored
+  - money_path.active_bets.over_cap
   - money_path.objects.offer
   - money_path.objects.proof
   - money_path.objects.proof.quality
@@ -89,6 +94,11 @@ broken wiring.
 The runtime shell must preserve these paths from the workflow source:
 
 - `money_path`
+- `money_path.policy`
+- `money_path.policy.thresholds_declared`
+- `money_path.active_bets`
+- `money_path.active_bets.unanchored`
+- `money_path.active_bets.over_cap`
 - `money_path.objects.offer`
 - `money_path.objects.proof`
 - `money_path.objects.proof.quality`

--- a/workflows/mb-start-status/workflow.md
+++ b/workflows/mb-start-status/workflow.md
@@ -16,6 +16,11 @@ required_mb_commands:
   - mb doctor repair --plan
 json_facts:
   - money_path
+  - money_path.policy
+  - money_path.policy.thresholds_declared
+  - money_path.active_bets
+  - money_path.active_bets.unanchored
+  - money_path.active_bets.over_cap
   - money_path.objects.proof.quality
   - validation.file_contracts
   - content_strategy
@@ -96,6 +101,11 @@ wiring, or setup/repair blockers.
 The runtime shell must preserve these paths from the workflow source:
 
 - `money_path`
+- `money_path.policy`
+- `money_path.policy.thresholds_declared`
+- `money_path.active_bets`
+- `money_path.active_bets.unanchored`
+- `money_path.active_bets.over_cap`
 - `money_path.objects.proof.quality`
 - `validation.file_contracts`
 - `content_strategy`


### PR DESCRIPTION
Closes #645
Refs #781

## Summary
- Add safe MoneyPath appetite-threshold policy facts from `core/finance/books.md`.
- Surface active bet exposure aggregates in `mb status --json --peek` without raw ledger rows, payees, balances, private paths, or account names.
- Route missing thresholds, unanchored bets, ledger-unavailable exposure checks, and over-cap bets through existing `mb-think` / `mb-bet` / books repair paths.
- Update books docs, shipped Claude routing guidance, shared workflow fact contracts, generated fixtures, and tests.

## Validation
- `cd mb && /Library/Frameworks/Python.framework/Versions/3.13/bin/python3 -m pytest tests/test_books.py tests/test_status.py::test_status_money_path_reports_active_bet_exposure tests/test_ranker.py -q` -> 56 passed
- `cd mb && /Library/Frameworks/Python.framework/Versions/3.13/bin/python3 -m pytest tests/test_books.py tests/test_status.py tests/test_ranker.py tests/test_start.py tests/test_start_router_contract.py -q` -> 170 passed
- `cd mb && /Library/Frameworks/Python.framework/Versions/3.13/bin/python3 -m pytest tests/test_workflows.py::test_generated_start_money_path_claude_and_codex_snapshots_match_fixtures tests/test_workflows.py::test_generated_daily_claude_and_codex_snapshots_match_fixtures tests/test_workflows.py::test_shipped_claude_start_skill_preserves_shared_workflow_contract tests/test_workflows.py::test_shipped_claude_status_skill_preserves_shared_workflow_contract -q` -> passed
- `PATH="/Library/Frameworks/Python.framework/Versions/3.13/bin:$PATH" scripts/check.sh` -> passed, 875 passed, packaged skill validate 15/15 with 0 warnings
