### PR TITLE
[add] Collect MoneyPath thresholds during onboarding

### DIFF
--- a/docs/books.md
+++ b/docs/books.md
@@ -172,6 +172,30 @@ payees, account names, or balances. Leave the thresholds blank until the
 operator chooses them; Main Branch should then ask before material execution
 spend.
 
+`mb onboard` can collect this policy during setup when the operator chooses to
+declare it. The safe fields are currency, storage mode, a broad experiment
+budget band, appetite threshold amounts, material-approval posture, and whether
+non-trivial bets should require ledger anchors by default:
+
+```bash
+mb onboard --yes --name "My Business" --path my-business \
+  --operating-currency USD \
+  --books-storage-mode solo-local \
+  --monthly-experiment-budget-band 500-2k \
+  --trivial-max-amount 100 \
+  --small-max-amount 1000 \
+  --material-max-amount 5000 \
+  --strategic-min-amount 5000 \
+  --approval-required-for-material yes \
+  --ledger-anchor-default yes
+```
+
+Interim answers live in gitignored `.mb/onboarding.json`. Confirmed thresholds
+are written to `core/finance/books.md` because they are policy declarations, not
+raw finances. If even threshold policy is private for a business, use
+`--threshold-privacy private` or leave thresholds blank; Main Branch will keep
+running and ask before material bets instead of inventing numbers.
+
 `core/finance/chart-of-accounts.md` describes the account roots the
 operator uses (`assets`, `liabilities`, `equity`, `income`,
 `expenses`) and the naming convention beneath them. It does not list

--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -486,6 +486,56 @@ def onboard_cmd(
         "--desired-outcome",
         help="Short target outcome for onboarding progress.",
     ),
+    operating_currency: str = typer.Option(
+        "",
+        "--operating-currency",
+        help="Safe MoneyPath currency code, such as USD.",
+    ),
+    books_storage_mode: str = typer.Option(
+        "",
+        "--books-storage-mode",
+        help="Books storage mode: solo-local, team-private-repo, advanced-vault.",
+    ),
+    monthly_experiment_budget_band: str = typer.Option(
+        "",
+        "--monthly-experiment-budget-band",
+        help="Safe budget band: under-500, 500-2k, 2k-10k, over-10k, private.",
+    ),
+    threshold_privacy: str = typer.Option(
+        "",
+        "--threshold-privacy",
+        help="Threshold posture: declared, private, unknown, or blank.",
+    ),
+    trivial_max_amount: str = typer.Option(
+        "",
+        "--trivial-max-amount",
+        help="Optional safe max amount for trivial bets.",
+    ),
+    small_max_amount: str = typer.Option(
+        "",
+        "--small-max-amount",
+        help="Optional safe max amount for small bets.",
+    ),
+    material_max_amount: str = typer.Option(
+        "",
+        "--material-max-amount",
+        help="Optional safe max amount for material bets.",
+    ),
+    strategic_min_amount: str = typer.Option(
+        "",
+        "--strategic-min-amount",
+        help="Optional safe min amount for strategic bets.",
+    ),
+    approval_required_for_material: str = typer.Option(
+        "",
+        "--approval-required-for-material",
+        help="Whether material bets need accepted-decision approval: yes/no.",
+    ),
+    ledger_anchor_default: str = typer.Option(
+        "",
+        "--ledger-anchor-default",
+        help="Whether non-trivial bets need ledger anchors by default: yes/no.",
+    ),
     github_repo: str = typer.Option(
         "",
         "--github",
@@ -558,6 +608,16 @@ def onboard_cmd(
             business_type=business_type,
             success_stage=success_stage,
             desired_outcome=desired_outcome,
+            operating_currency=operating_currency,
+            books_storage_mode=books_storage_mode,
+            monthly_experiment_budget_band=monthly_experiment_budget_band,
+            threshold_privacy=threshold_privacy,
+            trivial_max_amount=trivial_max_amount,
+            small_max_amount=small_max_amount,
+            material_max_amount=material_max_amount,
+            strategic_min_amount=strategic_min_amount,
+            approval_required_for_material=approval_required_for_material,
+            ledger_anchor_default=ledger_anchor_default,
             github_repo=github_repo,
             github_visibility=github_visibility,
             github_push=github_push,
@@ -640,6 +700,40 @@ def onboard_plan_cmd(
         help="Current success stage: prelaunch, working, successful, scaling, or unknown.",
     ),
     desired_outcome: str = typer.Option("", "--desired-outcome", help="Short target outcome."),
+    operating_currency: str = typer.Option(
+        "",
+        "--operating-currency",
+        help="Safe MoneyPath currency code, such as USD.",
+    ),
+    books_storage_mode: str = typer.Option(
+        "",
+        "--books-storage-mode",
+        help="Books storage mode: solo-local, team-private-repo, advanced-vault.",
+    ),
+    monthly_experiment_budget_band: str = typer.Option(
+        "",
+        "--monthly-experiment-budget-band",
+        help="Safe budget band: under-500, 500-2k, 2k-10k, over-10k, private.",
+    ),
+    threshold_privacy: str = typer.Option(
+        "",
+        "--threshold-privacy",
+        help="Threshold posture: declared, private, unknown, or blank.",
+    ),
+    trivial_max_amount: str = typer.Option("", "--trivial-max-amount"),
+    small_max_amount: str = typer.Option("", "--small-max-amount"),
+    material_max_amount: str = typer.Option("", "--material-max-amount"),
+    strategic_min_amount: str = typer.Option("", "--strategic-min-amount"),
+    approval_required_for_material: str = typer.Option(
+        "",
+        "--approval-required-for-material",
+        help="Whether material bets need accepted-decision approval: yes/no.",
+    ),
+    ledger_anchor_default: str = typer.Option(
+        "",
+        "--ledger-anchor-default",
+        help="Whether non-trivial bets need ledger anchors by default: yes/no.",
+    ),
     json_out: bool = typer.Option(False, "--json", help="Machine-readable output."),
 ) -> None:
     """Create or update the lightweight onboarding progress plan."""
@@ -651,6 +745,16 @@ def onboard_plan_cmd(
             business_type=business_type,
             success_stage=success_stage,
             desired_outcome=desired_outcome,
+            operating_currency=operating_currency,
+            books_storage_mode=books_storage_mode,
+            monthly_experiment_budget_band=monthly_experiment_budget_band,
+            threshold_privacy=threshold_privacy,
+            trivial_max_amount=trivial_max_amount,
+            small_max_amount=small_max_amount,
+            material_max_amount=material_max_amount,
+            strategic_min_amount=strategic_min_amount,
+            approval_required_for_material=approval_required_for_material,
+            ledger_anchor_default=ledger_anchor_default,
         )
     except ValueError as exc:
         typer.echo(f"mb onboard plan: {exc}", err=True)

--- a/mb/mb/onboard.py
+++ b/mb/mb/onboard.py
@@ -832,6 +832,8 @@ def _frontmatter_and_body(path: Path) -> tuple[dict[str, Any], str]:
 
 
 def _write_books_policy_from_onboarding(repo: Path, money_path: dict[str, Any]) -> bool:
+    if money_path.get("threshold_privacy") == "private":
+        return False
     tiers = _threshold_tiers_from_inputs(money_path)
     if not tiers:
         return False
@@ -848,7 +850,10 @@ def _write_books_policy_from_onboarding(repo: Path, money_path: dict[str, Any]) 
     fm["storage_mode"] = (
         money_path.get("books_storage_mode") or fm.get("storage_mode") or "solo-local"
     )
-    fm.setdefault("vault_location", ".mb/private/books/")
+    if fm["storage_mode"] in books_mod.NON_LOCAL_STORAGE_MODES:
+        fm.setdefault("vault_location", "")
+    else:
+        fm.setdefault("vault_location", ".mb/private/books/")
     fm.setdefault("github_backup", False)
     fm.setdefault("encrypted_backup", False)
     fm.setdefault("class_b_data", True)
@@ -856,7 +861,9 @@ def _write_books_policy_from_onboarding(repo: Path, money_path: dict[str, Any]) 
     money: dict[str, Any] = raw_money if isinstance(raw_money, dict) else {}
     money.setdefault("scale_basis", "rolling_30_day_gross_outflow")
     money.setdefault("exposure_window_days", 7)
-    money["appetite_thresholds"] = tiers
+    raw_existing_tiers = money.get("appetite_thresholds")
+    existing_tiers = raw_existing_tiers if isinstance(raw_existing_tiers, dict) else {}
+    money["appetite_thresholds"] = {**existing_tiers, **tiers}
     fm["money_path"] = money
     path.write_text(
         "---\n" + yaml.safe_dump(fm, sort_keys=False) + "---\n\n" + body.lstrip("\n"),

--- a/mb/mb/onboard.py
+++ b/mb/mb/onboard.py
@@ -851,7 +851,10 @@ def _write_books_policy_from_onboarding(repo: Path, money_path: dict[str, Any]) 
         money_path.get("books_storage_mode") or fm.get("storage_mode") or "solo-local"
     )
     if fm["storage_mode"] in books_mod.NON_LOCAL_STORAGE_MODES:
-        fm.setdefault("vault_location", "")
+        if str(fm.get("vault_location") or "").strip() == ".mb/private/books/":
+            fm["vault_location"] = ""
+        else:
+            fm.setdefault("vault_location", "")
     else:
         fm.setdefault("vault_location", ".mb/private/books/")
     fm.setdefault("github_backup", False)

--- a/mb/mb/onboard.py
+++ b/mb/mb/onboard.py
@@ -11,6 +11,9 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+import yaml
+
+from mb import books as books_mod
 from mb import checkpoint as checkpoint_mod
 from mb import codex as codex_mod
 from mb import connect as connect_mod
@@ -24,6 +27,15 @@ ONBOARDING_STATE_RELATIVE_PATH = Path(".mb") / "onboarding.json"
 ONBOARDING_STATE_VERSION = 1
 TEAM_SIZES = {"unknown", "solo", "small_team", "larger_team"}
 SUCCESS_STAGES = {"unknown", "prelaunch", "working", "successful", "scaling"}
+BOOKS_STORAGE_MODES = {"", "solo-local", "team-private-repo", "advanced-vault"}
+BUDGET_BANDS = {"", "under-500", "500-2k", "2k-10k", "over-10k", "private"}
+THRESHOLD_PRIVACY = {"", "declared", "private", "unknown"}
+AMOUNT_FIELDS = (
+    "trivial_max_amount",
+    "small_max_amount",
+    "material_max_amount",
+    "strategic_min_amount",
+)
 
 BOUNDARIES = {
     "collect_now": [
@@ -434,6 +446,7 @@ def _initial_state(
     business_type: str = "",
     success_stage: str = "unknown",
     desired_outcome: str = "",
+    money_path: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     now = _now()
     return {
@@ -448,6 +461,7 @@ def _initial_state(
             "success_stage": _normalize_success_stage(success_stage),
             "desired_outcome": desired_outcome.strip(),
         },
+        "money_path": money_path or {},
         "contract": {
             "state_path": str(ONBOARDING_STATE_RELATIVE_PATH),
             "canonical_business_truth": [
@@ -491,6 +505,13 @@ def _merge_state(existing: dict[str, Any] | None, updates: dict[str, Any]) -> di
             else:
                 profile.setdefault(key, value)
         state["profile"] = profile
+        money_path = dict(state.get("money_path") or {})
+        for key, value in (updates.get("money_path") or {}).items():
+            if value not in {"", None}:
+                money_path[key] = value
+            else:
+                money_path.setdefault(key, value)
+        state["money_path"] = money_path
         state["source"] = updates.get("source", "mb onboard")
     return state
 
@@ -503,6 +524,16 @@ def write_plan(
     business_type: str = "",
     success_stage: str = "unknown",
     desired_outcome: str = "",
+    operating_currency: str = "",
+    books_storage_mode: str = "",
+    monthly_experiment_budget_band: str = "",
+    threshold_privacy: str = "",
+    trivial_max_amount: float | int | str | None = None,
+    small_max_amount: float | int | str | None = None,
+    material_max_amount: float | int | str | None = None,
+    strategic_min_amount: float | int | str | None = None,
+    approval_required_for_material: bool | str | None = None,
+    ledger_anchor_default: bool | str | None = None,
 ) -> dict[str, Any]:
     """Create or update the lightweight onboarding progress plan."""
     target = Path(repo).expanduser().resolve()
@@ -515,6 +546,18 @@ def write_plan(
         business_type=business_type,
         success_stage=success_stage,
         desired_outcome=desired_outcome,
+        money_path=_money_path_inputs(
+            operating_currency=operating_currency,
+            books_storage_mode=books_storage_mode,
+            monthly_experiment_budget_band=monthly_experiment_budget_band,
+            threshold_privacy=threshold_privacy,
+            trivial_max_amount=trivial_max_amount,
+            small_max_amount=small_max_amount,
+            material_max_amount=material_max_amount,
+            strategic_min_amount=strategic_min_amount,
+            approval_required_for_material=approval_required_for_material,
+            ledger_anchor_default=ledger_anchor_default,
+        ),
     )
     state = _merge_state(existing, updates)
     path = _state_path(target)
@@ -616,6 +659,210 @@ def _normalize_level(level: str) -> str:
     if normalized and normalized not in LEVELS and normalized != "auto":
         raise ValueError("level must be beginner, intermediate, power, or auto")
     return normalized or "auto"
+
+
+def _normalize_currency(value: str) -> str:
+    currency = (value or "").strip().upper()
+    if not currency:
+        return ""
+    if not re.fullmatch(r"[A-Z]{3}", currency):
+        raise ValueError("operating-currency must be a 3-letter currency code such as USD")
+    return currency
+
+
+def _normalize_budget_band(value: str) -> str:
+    normalized = (value or "").strip().lower().replace("$", "").replace(",", "")
+    normalized = normalized.replace(" ", "-").replace("_", "-")
+    aliases = {
+        "under-500": "under-500",
+        "<500": "under-500",
+        "500-2000": "500-2k",
+        "500-to-2k": "500-2k",
+        "2k-10k": "2k-10k",
+        "2000-10000": "2k-10k",
+        "over-10000": "over-10k",
+        "over-10k": "over-10k",
+    }
+    normalized = aliases.get(normalized, normalized)
+    if normalized not in BUDGET_BANDS:
+        raise ValueError(
+            "monthly-experiment-budget-band must be under-500, 500-2k, "
+            "2k-10k, over-10k, private, or blank"
+        )
+    return normalized
+
+
+def _normalize_threshold_privacy(value: str) -> str:
+    normalized = (value or "").strip().lower()
+    if normalized not in THRESHOLD_PRIVACY:
+        raise ValueError("threshold-privacy must be declared, private, unknown, or blank")
+    return normalized
+
+
+def _parse_optional_amount(value: float | int | str | None, *, field: str) -> float | None:
+    if value in {None, ""}:
+        return None
+    if isinstance(value, bool):
+        raise ValueError(f"{field} must be a positive number")
+    try:
+        amount = float(str(value).replace(",", "").strip())
+    except ValueError as exc:
+        raise ValueError(f"{field} must be a positive number") from exc
+    if amount <= 0:
+        raise ValueError(f"{field} must be a positive number")
+    return int(amount) if amount.is_integer() else amount
+
+
+def _parse_optional_bool(value: bool | str | None, *, field: str) -> bool | None:
+    if value in {None, ""}:
+        return None
+    if isinstance(value, bool):
+        return value
+    normalized = str(value).strip().lower()
+    if normalized in {"1", "true", "yes", "y", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "n", "off"}:
+        return False
+    raise ValueError(f"{field} must be yes, no, true, false, or blank")
+
+
+def _money_path_inputs(
+    *,
+    operating_currency: str = "",
+    books_storage_mode: str = "",
+    monthly_experiment_budget_band: str = "",
+    threshold_privacy: str = "",
+    trivial_max_amount: float | int | str | None = None,
+    small_max_amount: float | int | str | None = None,
+    material_max_amount: float | int | str | None = None,
+    strategic_min_amount: float | int | str | None = None,
+    approval_required_for_material: bool | str | None = None,
+    ledger_anchor_default: bool | str | None = None,
+) -> dict[str, Any]:
+    storage_mode = (books_storage_mode or "").strip()
+    if storage_mode not in BOOKS_STORAGE_MODES:
+        raise ValueError(
+            "books-storage-mode must be solo-local, team-private-repo, advanced-vault, or blank"
+        )
+    amounts = {
+        "trivial_max_amount": _parse_optional_amount(
+            trivial_max_amount, field="trivial-max-amount"
+        ),
+        "small_max_amount": _parse_optional_amount(small_max_amount, field="small-max-amount"),
+        "material_max_amount": _parse_optional_amount(
+            material_max_amount, field="material-max-amount"
+        ),
+        "strategic_min_amount": _parse_optional_amount(
+            strategic_min_amount, field="strategic-min-amount"
+        ),
+    }
+    approval_required = _parse_optional_bool(
+        approval_required_for_material,
+        field="approval-required-for-material",
+    )
+    ledger_default = _parse_optional_bool(ledger_anchor_default, field="ledger-anchor-default")
+    money_path = {
+        "operating_currency": _normalize_currency(operating_currency),
+        "books_storage_mode": storage_mode,
+        "monthly_experiment_budget_band": _normalize_budget_band(monthly_experiment_budget_band),
+        "threshold_privacy": _normalize_threshold_privacy(threshold_privacy),
+        "approval_required_for_material": approval_required,
+        "ledger_anchor_default": ledger_default,
+        **amounts,
+    }
+    return {key: value for key, value in money_path.items() if value not in {"", None}}
+
+
+def _has_threshold_amounts(money_path: dict[str, Any]) -> bool:
+    return any(money_path.get(field) not in {"", None} for field in AMOUNT_FIELDS)
+
+
+def _threshold_tiers_from_inputs(money_path: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    ledger_default = bool(money_path.get("ledger_anchor_default", True))
+    approval_required = bool(money_path.get("approval_required_for_material", True))
+    tiers: dict[str, dict[str, Any]] = {}
+    if money_path.get("trivial_max_amount") is not None:
+        tiers["trivial"] = {
+            "max_amount": money_path["trivial_max_amount"],
+            "approval": "operator",
+            "ledger_required": False,
+        }
+    if money_path.get("small_max_amount") is not None:
+        tiers["small"] = {
+            "max_amount": money_path["small_max_amount"],
+            "approval": "operator",
+            "ledger_required": ledger_default,
+        }
+    if money_path.get("material_max_amount") is not None:
+        tiers["material"] = {
+            "max_amount": money_path["material_max_amount"],
+            "approval": "accepted_decision" if approval_required else "operator",
+            "ledger_required": ledger_default,
+        }
+    if money_path.get("strategic_min_amount") is not None:
+        tiers["strategic"] = {
+            "min_amount": money_path["strategic_min_amount"],
+            "approval": "accepted_decision",
+            "ledger_required": ledger_default,
+            "requires_exit_rubric": True,
+        }
+    return tiers
+
+
+def _books_policy_has_thresholds(repo: Path) -> bool:
+    fm, err = books_mod._read_frontmatter(repo / "core" / "finance" / "books.md")
+    if err or not fm:
+        return False
+    policy = books_mod._money_path_policy_from_frontmatter(fm)
+    return bool(policy.get("thresholds_declared"))
+
+
+def _frontmatter_and_body(path: Path) -> tuple[dict[str, Any], str]:
+    if not path.exists():
+        return {}, "# Bookkeeping\n\nThis file declares public-safe MoneyPath policy only.\n"
+    text = path.read_text(encoding="utf-8")
+    if not text.startswith("---"):
+        return {}, text
+    end = text.find("\n---", 3)
+    if end == -1:
+        return {}, text
+    parsed = yaml.safe_load(text[3:end].strip()) or {}
+    body = text[end + 4 :].lstrip("\n")
+    return parsed if isinstance(parsed, dict) else {}, body
+
+
+def _write_books_policy_from_onboarding(repo: Path, money_path: dict[str, Any]) -> bool:
+    tiers = _threshold_tiers_from_inputs(money_path)
+    if not tiers:
+        return False
+    path = repo / "core" / "finance" / "books.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fm, body = _frontmatter_and_body(path)
+    fm.setdefault("type", "books")
+    fm.setdefault("ledger", "hledger")
+    fm["operating_currency"] = (
+        money_path.get("operating_currency") or fm.get("operating_currency") or "USD"
+    )
+    fm.setdefault("fiscal_year_start", "01-01")
+    fm.setdefault("reporting_cadence", "monthly")
+    fm["storage_mode"] = (
+        money_path.get("books_storage_mode") or fm.get("storage_mode") or "solo-local"
+    )
+    fm.setdefault("vault_location", ".mb/private/books/")
+    fm.setdefault("github_backup", False)
+    fm.setdefault("encrypted_backup", False)
+    fm.setdefault("class_b_data", True)
+    raw_money = fm.get("money_path")
+    money: dict[str, Any] = raw_money if isinstance(raw_money, dict) else {}
+    money.setdefault("scale_basis", "rolling_30_day_gross_outflow")
+    money.setdefault("exposure_window_days", 7)
+    money["appetite_thresholds"] = tiers
+    fm["money_path"] = money
+    path.write_text(
+        "---\n" + yaml.safe_dump(fm, sort_keys=False) + "---\n\n" + body.lstrip("\n"),
+        encoding="utf-8",
+    )
+    return True
 
 
 def _normalize_mode(mode: str, existing: bool) -> str:
@@ -767,10 +1014,16 @@ def _step(
 
 def _checklist(repo: Path, state: dict[str, Any], markers: dict[str, bool]) -> list[dict[str, Any]]:
     profile = dict(state.get("profile") or {})
+    money_path = dict(state.get("money_path") or {})
     core_inputs = _core_inputs(repo)
     missing_core = [key for key, ok in core_inputs.items() if not ok]
     wiring = link_status(repo)
     checkpoint_hook = checkpoint_mod.hook_status(repo)
+    threshold_status = (
+        money_path.get("threshold_privacy") == "private"
+        or _has_threshold_amounts(money_path)
+        or _books_policy_has_thresholds(repo)
+    )
     return [
         _step(
             step_id="repo_scaffold",
@@ -802,6 +1055,20 @@ def _checklist(repo: Path, state: dict[str, Any], markers: dict[str, bool]) -> l
             ),
         ),
         _team_step(profile, repo),
+        _step(
+            step_id="money_path_thresholds",
+            title="MoneyPath appetite thresholds",
+            complete=threshold_status,
+            missing_inputs=[]
+            if threshold_status
+            else ["money_path.appetite_thresholds or private threshold choice"],
+            next_action=(
+                "Optionally collect safe appetite thresholds; never collect revenue, "
+                "balances, payees, payroll, raw ledger rows, or customer payments."
+            ),
+            owner="agent",
+            required=False,
+        ),
         _step(
             step_id="runtime_handoff",
             title="Runtime handoff",
@@ -842,6 +1109,7 @@ def onboarding_status(repo: str | Path = ".") -> dict[str, Any]:
         "state_exists": loaded is not None,
         "state_valid": loaded is not None or not _state_path(target).exists(),
         "profile": state.get("profile") or {},
+        "money_path": state.get("money_path") or {},
         "contract": state.get("contract") or {},
         "boundaries": state.get("boundaries") or BOUNDARIES,
         "repo_boundary": topology["repo_boundary"],
@@ -871,12 +1139,34 @@ def run(
     business_type: str = "",
     success_stage: str = "unknown",
     desired_outcome: str = "",
+    operating_currency: str = "",
+    books_storage_mode: str = "",
+    monthly_experiment_budget_band: str = "",
+    threshold_privacy: str = "",
+    trivial_max_amount: float | int | str | None = None,
+    small_max_amount: float | int | str | None = None,
+    material_max_amount: float | int | str | None = None,
+    strategic_min_amount: float | int | str | None = None,
+    approval_required_for_material: bool | str | None = None,
+    ledger_anchor_default: bool | str | None = None,
     github_repo: str = "",
     github_visibility: str = "private",
     github_push: bool = False,
 ) -> dict[str, Any]:
     """Create or connect a business repo and verify the Claude Code handoff."""
     target = Path(path).expanduser().resolve()
+    money_path_inputs = _money_path_inputs(
+        operating_currency=operating_currency,
+        books_storage_mode=books_storage_mode,
+        monthly_experiment_budget_band=monthly_experiment_budget_band,
+        threshold_privacy=threshold_privacy,
+        trivial_max_amount=trivial_max_amount,
+        small_max_amount=small_max_amount,
+        material_max_amount=material_max_amount,
+        strategic_min_amount=strategic_min_amount,
+        approval_required_for_material=approval_required_for_material,
+        ledger_anchor_default=ledger_anchor_default,
+    )
     before = _repo_markers(target)
     normalized_mode = _normalize_mode(mode, _looks_initialized(before))
 
@@ -918,6 +1208,13 @@ def run(
             action = "repaired"
         else:
             action = "created"
+
+    if (
+        target.exists()
+        and not errors
+        and _write_books_policy_from_onboarding(target, money_path_inputs)
+    ):
+        created.append("core/finance/books.md")
 
     after = _repo_markers(target)
     wiring = link_status(target)
@@ -976,6 +1273,16 @@ def run(
             business_type=business_type,
             success_stage=success_stage,
             desired_outcome=desired_outcome,
+            operating_currency=operating_currency,
+            books_storage_mode=books_storage_mode,
+            monthly_experiment_budget_band=monthly_experiment_budget_band,
+            threshold_privacy=threshold_privacy,
+            trivial_max_amount=trivial_max_amount,
+            small_max_amount=small_max_amount,
+            material_max_amount=material_max_amount,
+            strategic_min_amount=strategic_min_amount,
+            approval_required_for_material=approval_required_for_material,
+            ledger_anchor_default=ledger_anchor_default,
         )
         if target.exists() and not errors
         else onboarding_status(target)

--- a/mb/tests/fixtures/status/schema-v1-basic.json
+++ b/mb/tests/fixtures/status/schema-v1-basic.json
@@ -138,6 +138,7 @@
       "boundaries",
       "checklist",
       "contract",
+      "money_path",
       "ok",
       "profile",
       "repo",

--- a/mb/tests/test_onboard.py
+++ b/mb/tests/test_onboard.py
@@ -341,6 +341,106 @@ def test_onboard_plan_updates_profile_without_raw_business_state(
     assert "chat transcripts" in " ".join(state["contract"]["never_store_here"])
 
 
+def test_onboard_plan_stores_safe_moneypath_threshold_context_without_books_write(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(onboard_mod, "_which", _tool_path)
+    repo = tmp_path / "solo"
+    onboard_mod.run(path=str(repo), name="Solo Co", mode="new", level="power")
+
+    result = runner.invoke(
+        app,
+        [
+            "onboard",
+            "plan",
+            "--repo",
+            str(repo),
+            "--operating-currency",
+            "usd",
+            "--books-storage-mode",
+            "solo-local",
+            "--monthly-experiment-budget-band",
+            "500-2k",
+            "--trivial-max-amount",
+            "100",
+            "--small-max-amount",
+            "1000",
+            "--threshold-privacy",
+            "declared",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["money_path"]["operating_currency"] == "USD"
+    assert payload["money_path"]["monthly_experiment_budget_band"] == "500-2k"
+    assert payload["money_path"]["trivial_max_amount"] == 100
+    assert not (repo / "core" / "finance" / "books.md").exists()
+    state_text = (repo / ".mb" / "onboarding.json").read_text(encoding="utf-8")
+    assert "revenue" not in state_text
+    assert "balance" not in state_text
+    assert ".mb/onboarding.json" in (repo / ".gitignore").read_text(encoding="utf-8")
+
+
+def test_onboard_yes_writes_confirmed_safe_moneypath_thresholds_to_books_policy(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(onboard_mod, "_which", _tool_path)
+    repo = tmp_path / "acme"
+
+    result = onboard_mod.run(
+        path=str(repo),
+        name="Acme",
+        mode="new",
+        level="power",
+        operating_currency="usd",
+        books_storage_mode="solo-local",
+        trivial_max_amount="100",
+        small_max_amount="1000",
+        material_max_amount="5000",
+        strategic_min_amount="5000",
+        approval_required_for_material="yes",
+        ledger_anchor_default="yes",
+    )
+
+    assert result["ok"] is True
+    assert "core/finance/books.md" in result["created"]
+    books_text = (repo / "core" / "finance" / "books.md").read_text(encoding="utf-8")
+    assert "operating_currency: USD" in books_text
+    assert "appetite_thresholds:" in books_text
+    assert "material:" in books_text
+    assert "approval: accepted_decision" in books_text
+    assert "requires_exit_rubric: true" in books_text
+    assert "payee" not in books_text
+    assert "balance" not in books_text
+
+    report = status_mod.run(path=str(repo), update_marker=False)
+    assert report["money_path"]["policy"]["thresholds_declared"] is True
+
+
+def test_onboard_private_threshold_choice_keeps_thresholds_optional(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(onboard_mod, "_which", _tool_path)
+    repo = tmp_path / "private"
+    onboard_mod.run(
+        path=str(repo),
+        name="Private Co",
+        mode="new",
+        level="power",
+        threshold_privacy="private",
+    )
+
+    payload = onboard_mod.onboarding_status(repo)
+    threshold_step = next(
+        step for step in payload["checklist"] if step["id"] == "money_path_thresholds"
+    )
+    assert threshold_step["status"] == "complete"
+    assert threshold_step["required"] is False
+    assert not (repo / "core" / "finance" / "books.md").exists()
+
+
 def test_onboard_yes_does_not_overwrite_existing_team_size(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(onboard_mod, "_which", _tool_path)
     monkeypatch.setattr(onboard_mod, "is_interactive", lambda: False)

--- a/mb/tests/test_onboard.py
+++ b/mb/tests/test_onboard.py
@@ -483,6 +483,35 @@ def test_onboard_non_local_books_storage_does_not_fake_local_vault(
     assert ".mb/private/books/" not in books_text
 
 
+def test_onboard_non_local_storage_switch_clears_generated_local_vault(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(onboard_mod, "_which", _tool_path)
+    repo = tmp_path / "storage-switch"
+
+    onboard_mod.run(
+        path=str(repo),
+        name="Storage Switch Co",
+        mode="new",
+        level="power",
+        books_storage_mode="solo-local",
+        trivial_max_amount="100",
+    )
+    onboard_mod.run(
+        path=str(repo),
+        name="Storage Switch Co",
+        mode="connect",
+        level="power",
+        books_storage_mode="team-private-repo",
+        small_max_amount="1000",
+    )
+
+    books_text = (repo / "core" / "finance" / "books.md").read_text(encoding="utf-8")
+    assert "storage_mode: team-private-repo" in books_text
+    assert "vault_location: ''" in books_text
+    assert ".mb/private/books/" not in books_text
+
+
 def test_onboard_partial_threshold_rerun_preserves_existing_tiers(
     tmp_path: Path, monkeypatch
 ) -> None:

--- a/mb/tests/test_onboard.py
+++ b/mb/tests/test_onboard.py
@@ -441,6 +441,81 @@ def test_onboard_private_threshold_choice_keeps_thresholds_optional(
     assert not (repo / "core" / "finance" / "books.md").exists()
 
 
+def test_onboard_private_threshold_choice_does_not_commit_amounts(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(onboard_mod, "_which", _tool_path)
+    repo = tmp_path / "private-amount"
+
+    onboard_mod.run(
+        path=str(repo),
+        name="Private Amount Co",
+        mode="new",
+        level="power",
+        threshold_privacy="private",
+        trivial_max_amount="100",
+    )
+
+    assert not (repo / "core" / "finance" / "books.md").exists()
+    state_text = (repo / ".mb" / "onboarding.json").read_text(encoding="utf-8")
+    assert '"threshold_privacy": "private"' in state_text
+    assert '"trivial_max_amount": 100' in state_text
+
+
+def test_onboard_non_local_books_storage_does_not_fake_local_vault(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(onboard_mod, "_which", _tool_path)
+    repo = tmp_path / "team-books"
+
+    onboard_mod.run(
+        path=str(repo),
+        name="Team Books Co",
+        mode="new",
+        level="power",
+        books_storage_mode="team-private-repo",
+        trivial_max_amount="100",
+    )
+
+    books_text = (repo / "core" / "finance" / "books.md").read_text(encoding="utf-8")
+    assert "storage_mode: team-private-repo" in books_text
+    assert "vault_location: ''" in books_text
+    assert ".mb/private/books/" not in books_text
+
+
+def test_onboard_partial_threshold_rerun_preserves_existing_tiers(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(onboard_mod, "_which", _tool_path)
+    repo = tmp_path / "tier-merge"
+
+    onboard_mod.run(
+        path=str(repo),
+        name="Tier Merge Co",
+        mode="new",
+        level="power",
+        trivial_max_amount="100",
+        small_max_amount="1000",
+        material_max_amount="5000",
+        strategic_min_amount="5000",
+    )
+    onboard_mod.run(
+        path=str(repo),
+        name="Tier Merge Co",
+        mode="connect",
+        level="power",
+        trivial_max_amount="200",
+    )
+
+    books_text = (repo / "core" / "finance" / "books.md").read_text(encoding="utf-8")
+    assert "trivial:" in books_text
+    assert "max_amount: 200" in books_text
+    assert "small:" in books_text
+    assert "max_amount: 1000" in books_text
+    assert "material:" in books_text
+    assert "strategic:" in books_text
+
+
 def test_onboard_yes_does_not_overwrite_existing_team_size(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(onboard_mod, "_which", _tool_path)
     monkeypatch.setattr(onboard_mod, "is_interactive", lambda: False)


### PR DESCRIPTION
Closes #646
Refs #781

## Summary
- Add optional safe MoneyPath threshold inputs to `mb onboard` and `mb onboard plan`.
- Persist interim answers in gitignored `.mb/onboarding.json`.
- Write confirmed appetite threshold policy to `core/finance/books.md` using the MoneyPath policy shape from #783.
- Keep private/unknown threshold paths valid and avoid raw finance collection.
- Update books docs, onboarding tests, and the status schema fixture.

## Privacy boundary
- Does not collect or write revenue, balances, payees, payroll, account names, customer payments, raw ledger rows, tokens, provider data, or private paths.

## Validation
- `cd mb && /Library/Frameworks/Python.framework/Versions/3.13/bin/python3 -m pytest tests/test_onboard.py tests/test_books.py::test_books_check_reports_money_path_thresholds tests/test_status.py::test_status_money_path_reports_active_bet_exposure -q` -> 25 passed
- `cd mb && /Library/Frameworks/Python.framework/Versions/3.13/bin/python3 -m pytest tests/test_onboard.py tests/test_status.py::test_status_schema_v1_matches_golden_fixture tests/test_status.py::test_status_money_path_reports_active_bet_exposure tests/test_ranker.py -q` -> 33 passed
- `cd mb && /Library/Frameworks/Python.framework/Versions/3.13/bin/python3 -m ruff check mb/onboard.py mb/cli.py tests/test_onboard.py` -> passed
- `scripts/check.sh` -> passed: 878 tests, packaged skill validate 15/15, 0 warnings
