### PR TITLE
[update] Prepare 0.3.41 release

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mainbranch",
-  "version": "0.3.40",
+  "version": "0.3.41",
   "description": "Main Branch Claude Code skills for running a business from markdown files in git.",
   "author": {
     "name": "Noontide"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+## [0.3.41] - 2026-05-28
+
+v0.3.41 packages the fact-grounded, owner-facing next-action intelligence train.
+It makes `mb status` / `mb start` and the core lifecycle routes better at
+surfacing one useful next move from deterministic facts without widening into
+repo profiles, provider mutation, scraping, export, or collaborator handoff.
+
 ### Added
 
 - Added deterministic repo-boundary helper facts to `mb status --json --peek`,
@@ -20,12 +27,30 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 - Added MoneyPath appetite-threshold and active-bet exposure facts to
   `mb status --json --peek`, with safe aggregate routing for missing
   thresholds, unanchored bets, and over-cap bets. Closes #645.
+- Added optional safe MoneyPath threshold inputs to `mb onboard` and
+  `mb onboard plan`, preserving interim answers in gitignored
+  `.mb/onboarding.json` and writing confirmed policy to `core/finance/books.md`.
+  Closes #646.
+- Added a public-safe MoneyPath archetype dogfood report covering solo
+  founder/creator, agency/service, and product/SaaS repos. The report records
+  MoneyPath levels, top actions, recommendation interpretation, false
+  positives, false negatives, and follow-up calibration notes. Closes #532.
+
+### Changed
+
+- Changed daily start/status guidance to preserve `brain.bets.*` trigger facts
+  for active, overdue, due-soon, missing-exit, failure-signal, and
+  double-down-signal routing. Closes #763.
+- Changed `mb-think` guidance to use the current `runtime.codex_cli` fact path
+  instead of the stale `runtime.codex` path. Closes #763.
 
 ### Fixed
 
 - Added a guided `pipx install --force mainbranch==<latest>` recovery step when
   `mb update` detects that `pipx upgrade mainbranch` failed because pipx could
   not parse a saved local wheel/package spec. Closes #778.
+- Fixed Claude `/mb-end` crystallize guidance so durable write language remains
+  approval-gated. Closes #763.
 
 ## [0.3.40] - 2026-05-27
 

--- a/mb/mb/__init__.py
+++ b/mb/mb/__init__.py
@@ -7,6 +7,6 @@ file stays a thin dispatcher.
 
 from __future__ import annotations
 
-__version__ = "0.3.40"
+__version__ = "0.3.41"
 
 __all__ = ["__version__"]

--- a/mb/pyproject.toml
+++ b/mb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mainbranch"
-version = "0.3.40"
+version = "0.3.41"
 description = "Main Branch engine umbrella - scaffolds, validates, and graphs business-as-files repos. Claude Code first, runtime-agnostic by design."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Prepares the `0.3.41` Main Branch release for the next-action intelligence train.

Refs #781.

## Included

- Bumps package version metadata to `0.3.41`.
- Bumps the Claude plugin manifest version to `0.3.41`.
- Moves the current changelog train into `## [0.3.41] - 2026-05-28`.
- Records the shipped train: pipx recovery, repo-boundary helper facts, MoneyPath appetite/active-bet exposure, onboarding threshold capture, MoneyPath archetype dogfood, and lifecycle skill drift fixes.

## Validation

- `cd mb && /Library/Frameworks/Python.framework/Versions/3.13/bin/python3 -m pytest tests/test_cli.py::test_version_flag tests/test_update.py::test_update_check_current_release_still_exposes_notes_url -q` -> 2 passed
- `PYTHON=/Library/Frameworks/Python.framework/Versions/3.13/bin/python3 scripts/check.sh` -> passed, 882 tests, skill validate 15/15
- `cd mb && /Library/Frameworks/Python.framework/Versions/3.13/bin/python3 -m build` -> built wheel and sdist
- Fresh wheel venv smoke:
  - `mb --version` -> `mb 0.3.41`
  - `mb skill validate --all --json` -> 15 skills, 15 passed, 0 errors, 0 warnings
  - `mb workflow list --runtime codex --json` -> ok, 13 items, includes ads and Google Ads launch playbook inventory

## Release Notes

This PR is release prep only. The release tracker should remain open until the GitHub Release, publish workflow, PyPI verification, and post-publish dogfood smoke are complete.
