### PR TITLE
[update] mb validate: group cross-ref warnings into owner-facing summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ### Changed
 
+- Grouped cross-reference and related-link validation warnings into owner-facing
+  clusters: `mb validate` JSON now carries `blocker_count`,
+  `mechanical_warning_count`, `operator_warning_count`, and an `owner_summary`
+  one-liner that separates blockers from bulk-repairable related-link mirror
+  noise. `mb validate` human output no longer dumps hundreds/thousands of
+  warnings by default — it shows blockers plus the grouped summary, and `-v`
+  restores the full per-file detail. Full machine-readable detail stays in
+  `--json` for power users and repair commands. Closes #790.
 - Changed daily start/status JSON to separate repo/runtime readiness from
   business-memory completeness, align `mb start --json` next actions with
   status-ranked owner actions when runtime handoff is ready, clarify Codex

--- a/mb/mb/validate.py
+++ b/mb/mb/validate.py
@@ -1508,12 +1508,17 @@ def _owner_summary(
     mechanical_warning_count: int,
     operator_warning_count: int,
 ) -> str:
-    """One-line owner framing that separates blockers from bulk mirror noise."""
+    """One-line owner framing that separates blockers from bulk-repairable noise.
+
+    Mechanical warnings cover both related-link mirrors and migration drift, so
+    the rollup label stays generic; per-category ``operator_summary`` carries the
+    specific mirror vs migration repair guidance.
+    """
     parts: list[str] = []
     if blocker_count:
         parts.append(f"{blocker_count} blocker(s) to fix")
     if mechanical_warning_count:
-        parts.append(f"{mechanical_warning_count} bulk-repairable related-link mirror warning(s)")
+        parts.append(f"{mechanical_warning_count} bulk-repairable warning(s)")
     if operator_warning_count:
         parts.append(f"{operator_warning_count} warning(s) to review")
     if not parts:
@@ -2035,7 +2040,7 @@ def render_human(report: dict[str, Any], verbose: bool = False) -> None:
                     f" — {item.get('operator_summary', '')}"
                 )
         if mechanical:
-            console.print("  [yellow]Bulk-repairable mirrors[/yellow]:")
+            console.print("  [yellow]Bulk-repairable (mechanical)[/yellow]:")
             for name, item in mechanical[:3]:
                 console.print(
                     f"    - {name}: {item.get('warnings', 0)} warning(s)"

--- a/mb/mb/validate.py
+++ b/mb/mb/validate.py
@@ -1474,16 +1474,51 @@ def _validation_categories(files: list[dict[str, Any]]) -> dict[str, Any]:
     )
     top_category = next(iter(ordered), "")
     top_entry = ordered.get(top_category, {})
+    blocker_count = sum(int(item.get("errors", 0)) for item in ordered.values())
+    mechanical_warning_count = sum(
+        int(item.get("warnings", 0))
+        for item in ordered.values()
+        if item.get("audience") == "mechanical"
+    )
+    operator_warning_count = sum(
+        int(item.get("warnings", 0))
+        for item in ordered.values()
+        if item.get("audience") != "mechanical"
+    )
     return {
-        "schema_version": "1.0",
+        "schema_version": "1.1",
         "total_categories": len(ordered),
         "top_category": top_category,
         "top_repair": top_entry.get("repair", ""),
         "top_audience": top_entry.get("audience", ""),
         "top_operator_summary": top_entry.get("operator_summary", ""),
+        "blocker_count": blocker_count,
+        "mechanical_warning_count": mechanical_warning_count,
+        "operator_warning_count": operator_warning_count,
+        "owner_summary": _owner_summary(
+            blocker_count, mechanical_warning_count, operator_warning_count
+        ),
         "by_category": ordered,
         "safe_to_share": True,
     }
+
+
+def _owner_summary(
+    blocker_count: int,
+    mechanical_warning_count: int,
+    operator_warning_count: int,
+) -> str:
+    """One-line owner framing that separates blockers from bulk mirror noise."""
+    parts: list[str] = []
+    if blocker_count:
+        parts.append(f"{blocker_count} blocker(s) to fix")
+    if mechanical_warning_count:
+        parts.append(f"{mechanical_warning_count} bulk-repairable related-link mirror warning(s)")
+    if operator_warning_count:
+        parts.append(f"{operator_warning_count} warning(s) to review")
+    if not parts:
+        return "No validation issues."
+    return ", ".join(parts) + "."
 
 
 def _check_status_transition(
@@ -1951,8 +1986,16 @@ def render_human(report: dict[str, Any], verbose: bool = False) -> None:
     for f in report["files"]:
         by_schema.setdefault(f["schema"], []).append(f)
     for schema, items in by_schema.items():
-        console.print(f"\n[bold]{schema}[/bold]")
+        ok_n = sum(1 for f in items if not f["errors"] and not f.get("warnings"))
+        warn_n = sum(1 for f in items if not f["errors"] and f.get("warnings"))
+        fail_n = sum(1 for f in items if f["errors"])
+        console.print(f"\n[bold]{schema}[/bold]  {ok_n} ok, {warn_n} warn, {fail_n} fail")
         for f in items:
+            if not verbose and not f["errors"]:
+                # Collapse warning-only and ok files by default; the grouped
+                # summary below carries compact examples and repair guidance so
+                # a few thousand cross-ref/mirror warnings never flood the loop.
+                continue
             if f["errors"]:
                 mark = "[red]fail[/red]"
             elif f.get("warnings"):
@@ -1960,24 +2003,58 @@ def render_human(report: dict[str, Any], verbose: bool = False) -> None:
             else:
                 mark = "[green]ok[/green]"
             console.print(f"  {mark}  {f['path']}")
-            if f["errors"] or f.get("warnings") or verbose:
-                for e in f["errors"]:
-                    console.print(f"        - {e}")
+            for e in f["errors"]:
+                console.print(f"        - {e}")
+            if verbose:
                 for warning in f.get("warnings", []):
                     console.print(f"        - {warning}")
     legacy_repair = report.get("legacy_repair")
     categories = report.get("validation_categories") or {}
     by_category = categories.get("by_category") or {}
     if by_category:
-        console.print("\n[bold yellow]Validation categories[/bold yellow]")
-        for name, item in list(by_category.items())[:6]:
-            console.print(
-                f"  - {name}: {item.get('count', 0)} "
-                f"({item.get('errors', 0)} error(s), {item.get('warnings', 0)} warning(s))"
-            )
+        console.print("\n[bold yellow]Validation summary[/bold yellow]")
+        owner_summary = categories.get("owner_summary")
+        if owner_summary:
+            console.print(f"  {owner_summary}")
+        blockers = [(n, i) for n, i in by_category.items() if i.get("errors")]
+        mechanical = [
+            (n, i)
+            for n, i in by_category.items()
+            if not i.get("errors") and i.get("warnings") and i.get("audience") == "mechanical"
+        ]
+        other = [
+            (n, i)
+            for n, i in by_category.items()
+            if not i.get("errors") and i.get("warnings") and i.get("audience") != "mechanical"
+        ]
+        if blockers:
+            console.print("  [red]Blockers (fix these)[/red]:")
+            for name, item in blockers[:5]:
+                console.print(
+                    f"    - {name}: {item.get('errors', 0)} error(s)"
+                    f" — {item.get('operator_summary', '')}"
+                )
+        if mechanical:
+            console.print("  [yellow]Bulk-repairable mirrors[/yellow]:")
+            for name, item in mechanical[:3]:
+                console.print(
+                    f"    - {name}: {item.get('warnings', 0)} warning(s)"
+                    f" — {item.get('operator_summary', '')}"
+                )
+        if other:
+            console.print("  Other warnings:")
+            for name, item in other[:5]:
+                console.print(
+                    f"    - {name}: {item.get('warnings', 0)} warning(s)"
+                    f" — {item.get('operator_summary', '')}"
+                )
         top_repair = categories.get("top_repair")
         if top_repair:
             console.print(f"  next: {top_repair}")
+        if not verbose and (mechanical or other):
+            console.print(
+                "  Run `mb validate --cross-refs -v` or `--json` for the full per-file list."
+            )
     if legacy_repair:
         console.print("\n[bold yellow]Legacy frontmatter repair[/bold yellow]")
         console.print(f"  {legacy_repair['message']}")

--- a/mb/tests/test_validate.py
+++ b/mb/tests/test_validate.py
@@ -10,7 +10,7 @@ from typer.testing import CliRunner
 
 from mb import relationships
 from mb.cli import app
-from mb.validate import render_human, run
+from mb.validate import _owner_summary, render_human, run
 
 runner = CliRunner()
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -2248,8 +2248,7 @@ def test_many_mirror_warnings_keep_grouped_summary_small(tmp_path: Path) -> None
     assert categories["blocker_count"] == 0
     assert categories["mechanical_warning_count"] == 40
     assert categories["operator_warning_count"] == 0
-    assert "bulk-repairable" in categories["owner_summary"]
-    assert "40" in categories["owner_summary"]
+    assert "40 bulk-repairable warning(s)" in categories["owner_summary"]
 
 
 def test_owner_summary_splits_blockers_from_mechanical(tmp_path: Path) -> None:
@@ -2267,7 +2266,16 @@ def test_owner_summary_splits_blockers_from_mechanical(tmp_path: Path) -> None:
     assert categories["mechanical_warning_count"] == 5
     summary = categories["owner_summary"]
     assert "blocker(s) to fix" in summary
-    assert "bulk-repairable related-link mirror" in summary
+    assert "5 bulk-repairable warning(s)" in summary
+
+
+def test_owner_summary_label_is_generic_for_all_mechanical_warnings() -> None:
+    # `mechanical` covers related-link mirrors AND migration drift, so the rollup
+    # label must not claim every mechanical warning is a related-link mirror.
+    summary = _owner_summary(0, 1, 0)
+    assert summary == "1 bulk-repairable warning(s)."
+    assert "mirror" not in summary
+    assert _owner_summary(0, 0, 0) == "No validation issues."
 
 
 def test_render_human_collapses_warnings_by_default(tmp_path: Path, capsys) -> None:
@@ -2280,8 +2288,8 @@ def test_render_human_collapses_warnings_by_default(tmp_path: Path, capsys) -> N
     # (rich may wrap long warning text, so assert on the stable path token).
     assert default_out.count("2026-04-29-link-") == 0
     # The grouped summary still names the cluster and the bulk-repair framing.
-    assert "Bulk-repairable mirrors" in default_out
-    assert "bulk-repairable" in default_out
+    assert "Bulk-repairable (mechanical)" in default_out
+    assert "bulk-repairable warning(s)" in default_out
 
     render_human(report, verbose=True)
     verbose_out = capsys.readouterr().out

--- a/mb/tests/test_validate.py
+++ b/mb/tests/test_validate.py
@@ -10,7 +10,7 @@ from typer.testing import CliRunner
 
 from mb import relationships
 from mb.cli import app
-from mb.validate import run
+from mb.validate import render_human, run
 
 runner = CliRunner()
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -2202,3 +2202,88 @@ def test_validation_categories_carry_audience_and_operator_summary(tmp_path: Pat
     assert entry["audience"] == "operator_decision"
     assert entry["operator_summary"]
     assert entry["repair"]  # legacy field still present
+
+
+def _many_missing_mirrors(tmp_path: Path, count: int) -> None:
+    """Write one shared research target plus `count` decisions that link it
+    without mirroring the link in ## Related links — one mirror warning each."""
+    _write(
+        tmp_path / "research" / "2026-04-29-topic-source.md",
+        "---\ndate: 2026-04-29\ntopic: topic\nsource: source\n---\n# Topic\n",
+    )
+    for index in range(count):
+        _write(
+            tmp_path / "decisions" / f"2026-04-29-link-{index:03d}.md",
+            (
+                "---\n"
+                "date: 2026-04-29\n"
+                "status: accepted\n"
+                "linked_research:\n"
+                "  - research/2026-04-29-topic-source.md\n"
+                "---\n"
+                f"# Link {index}\n"
+            ),
+        )
+
+
+def test_many_mirror_warnings_keep_grouped_summary_small(tmp_path: Path) -> None:
+    _many_missing_mirrors(tmp_path, 40)
+
+    report = run(path=str(tmp_path), cross_refs=True)
+
+    # Full machine-readable detail is preserved for power users / repair commands.
+    assert report["summary"]["warnings"] == 40
+    assert len(report["cross_refs"]["warnings"]) == 40
+
+    categories = report["validation_categories"]
+    by_category = categories["by_category"]
+    # All 40 warnings collapse into a single grouped cluster with capped examples.
+    assert set(by_category) == {"missing_related_link_mirror"}
+    cluster = by_category["missing_related_link_mirror"]
+    assert cluster["count"] == 40
+    assert cluster["audience"] == "mechanical"
+    assert len(cluster["examples"]) <= 5
+
+    # New owner-facing rollup separates blockers from bulk-repairable mirrors.
+    assert categories["blocker_count"] == 0
+    assert categories["mechanical_warning_count"] == 40
+    assert categories["operator_warning_count"] == 0
+    assert "bulk-repairable" in categories["owner_summary"]
+    assert "40" in categories["owner_summary"]
+
+
+def test_owner_summary_splits_blockers_from_mechanical(tmp_path: Path) -> None:
+    _many_missing_mirrors(tmp_path, 5)
+    # A blocking frontmatter error: offer missing required slug.
+    _write(
+        tmp_path / "core" / "offers" / "broken" / "offer.md",
+        "---\nstatus: running\n---\n# Offer\n",
+    )
+
+    report = run(path=str(tmp_path), cross_refs=True)
+    categories = report["validation_categories"]
+
+    assert categories["blocker_count"] >= 1
+    assert categories["mechanical_warning_count"] == 5
+    summary = categories["owner_summary"]
+    assert "blocker(s) to fix" in summary
+    assert "bulk-repairable related-link mirror" in summary
+
+
+def test_render_human_collapses_warnings_by_default(tmp_path: Path, capsys) -> None:
+    _many_missing_mirrors(tmp_path, 40)
+    report = run(path=str(tmp_path), cross_refs=True)
+
+    render_human(report, verbose=False)
+    default_out = capsys.readouterr().out
+    # No per-file warning lines for the 40 warning-only files by default
+    # (rich may wrap long warning text, so assert on the stable path token).
+    assert default_out.count("2026-04-29-link-") == 0
+    # The grouped summary still names the cluster and the bulk-repair framing.
+    assert "Bulk-repairable mirrors" in default_out
+    assert "bulk-repairable" in default_out
+
+    render_human(report, verbose=True)
+    verbose_out = capsys.readouterr().out
+    # Verbose restores the full per-file detail for power users.
+    assert verbose_out.count("2026-04-29-link-") == 40


### PR DESCRIPTION
## Summary

`mb validate` now groups cross-reference and related-link warnings into owner-facing clusters: the JSON summary splits blockers from bulk-repairable mirror noise, and human output no longer dumps hundreds/thousands of warnings by default.

## Linked issue

Closes #790

## Why

Post-`0.3.41` dogfood showed `mb validate --cross-refs --json` expanding to 3 errors and 1528 warnings. The cross-ref data is useful but too noisy for owner-facing guidance and easy for agents to mishandle — operators need a compact top set, grouped reasons, and a clear blocker-vs-bulk-mirror distinction instead of a flat dump.

## Commits by concern

- `[update]` Group cross-ref warnings into owner-facing blocker vs mirror clusters — adds `blocker_count`, `mechanical_warning_count`, `operator_warning_count`, and `owner_summary` to the grouped JSON summary (existing `top_*`/`by_category` preserved); reworks `render_human` to collapse warning-only files by default while always showing blockers, with `-v` restoring full per-file detail.
- `[add]` Tests for grouped cross-ref summary staying small at scale — 40 missing mirrors collapse into one capped cluster; asserts the new rollup fields and that `render_human` is compact by default / full under verbose.
- `[docs]` Note owner-facing cross-ref warning grouping in `CHANGELOG.md` `[Unreleased]`.

## Validation

- Level 1 static: `scripts/check.sh` — runtime: python3 — exit: 0 — log: ruff format+check, mypy, pytest+coverage (≥79%), `mb skill validate` 15/15 passed.
- Level 2 CLI contract: `pytest tests/test_validate.py` 91 passed (incl. 3 new); `tests/test_status.py`/`test_start.py`/`test_doctor.py` green (status consumes the grouped summary). `--json` shape verified additive; `render_human` default vs `-v` covered.
- Level 3 package/install: not required — no packaging, entrypoint, or bundled-data change.
- Level 4 fixture repo: not required — no init/onboard/status/start/update behavior change.
- Level 5 runtime smoke: not required — no runtime discovery, first-run, skill, or release-validation change. JSON/CLI contract only.

## Success metric

`mb validate --cross-refs` on a repo with thousands of mirror warnings shows blockers plus a compact grouped summary by default; agents read blocker-vs-mechanical split from JSON without iterating every category; full detail stays in `--json` / `-v`.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section.

## Breaking changes

- [x] No — JSON additions are additive; `top_*`/`by_category` keys unchanged. `mb validate --json` keeps full per-file warnings.

## Public / private boundary

No private operator strategy, machine-specific paths, or runtime internals. Public CLI/JSON behavior, tests, and CHANGELOG only.
