### PR TITLE
[add] Rank active bets missing exit criteria

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+### Added
+
+- Added a `tighten_bet_exit_criteria` ranked action so active bets without
+  predeclared kill/double-down criteria surface as an owner-facing next move in
+  `mb status --json --peek` instead of staying buried in raw `brain.bets` facts.
+  Routes to `/mb-bet` and keeps writes approval-gated. Closes #789.
+
 ### Changed
 
 - Changed daily start/status JSON to separate repo/runtime readiness from

--- a/mb/mb/ranker.py
+++ b/mb/mb/ranker.py
@@ -24,6 +24,7 @@ WEIGHTS: dict[str, int] = {
     "playbook_health_gaps": 84,
     "file_contract_gaps": 86,
     "relationship_health_gaps": 82,
+    "bets_missing_exit_criteria": 80,
     "money_path_gaps": 72,
     "due_bets": 58,
     "stale_decisions": 50,
@@ -321,6 +322,40 @@ def _add_drift_actions(actions: list[dict[str, Any]], report: dict[str, Any]) ->
 
 def _add_bet_actions(actions: list[dict[str, Any]], report: dict[str, Any]) -> None:
     bets = _dict(_dict(report.get("brain")).get("bets"))
+
+    missing_exit = [_dict(item) for item in _list(_dict(bets.get("exit_criteria")).get("missing"))]
+    if missing_exit:
+        score = WEIGHTS["bets_missing_exit_criteria"] + min(len(missing_exit) * 3, 12)
+        safe_to_share = all(bool(item.get("public")) for item in missing_exit)
+        actions.append(
+            _action(
+                action_id="tighten_bet_exit_criteria",
+                title="Tighten active bet exit criteria",
+                command="/mb-bet update",
+                severity="warn",
+                score=score,
+                reason=(
+                    f"{len(missing_exit)} active bet(s) have no kill or double-down criteria. "
+                    "Tighten the bet before launching more work."
+                ),
+                operator_summary=(
+                    f"{len(missing_exit)} active bet(s) are running without a predeclared exit "
+                    "rubric. Add kill and double-down criteria so the bet can be cut or scaled on "
+                    "evidence instead of gut feel."
+                ),
+                signals=[
+                    _signal(
+                        "brain.bets.exit_criteria.missing",
+                        severity="warn",
+                        summary="active bets are missing predeclared exit criteria",
+                        evidence=[_bet_evidence(item) for item in missing_exit[:5]],
+                        weight=WEIGHTS["bets_missing_exit_criteria"],
+                        safe_to_share=safe_to_share,
+                    )
+                ],
+            )
+        )
+
     overdue = [_dict(item) for item in _list(bets.get("overdue"))]
     if overdue:
         score = WEIGHTS["overdue_bets"] + min(len(overdue) * 3, 15)

--- a/mb/tests/test_ranker.py
+++ b/mb/tests/test_ranker.py
@@ -248,3 +248,129 @@ def test_ranker_action_carries_audience_and_operator_summary() -> None:
     )
     assert overridden["audience"] == "informational"
     assert overridden["operator_summary"] == "Just a status note."
+
+
+def test_ranker_surfaces_active_bets_missing_exit_criteria() -> None:
+    report = _base_report()
+    report["brain"] = {
+        "bets": {
+            "overdue": [],
+            "due_soon": [],
+            "exit_criteria": {
+                "missing": [
+                    {
+                        "path": "bets/2026-05-16-launch.md",
+                        "title": "Launch the cohort",
+                        "deadline": "2026-06-30",
+                        "public": False,
+                    },
+                    {
+                        "path": "bets/2026-05-18-ads.md",
+                        "title": "Paid acquisition test",
+                        "deadline": "",
+                        "public": False,
+                    },
+                ]
+            },
+        }
+    }
+
+    actions = ranker.rank_status_report(report)
+    action = next(action for action in actions if action["id"] == "tighten_bet_exit_criteria")
+
+    assert action["command"] == "/mb-bet update"
+    assert action["priority"] == "high"
+    assert action["audience"] == "operator_decision"
+    assert action["operator_summary"]
+    assert action["signals"][0]["id"] == "brain.bets.exit_criteria.missing"
+    assert action["signals"][0]["evidence"] == [
+        "Launch the cohort (2026-06-30)",
+        "Paid acquisition test (no deadline)",
+    ]
+    # Private bet names must not be marked shareable.
+    assert action["safe_to_share"] is False
+
+
+def test_ranker_bet_exit_criteria_shareable_only_when_all_public() -> None:
+    report = _base_report()
+    report["brain"] = {
+        "bets": {
+            "overdue": [],
+            "due_soon": [],
+            "exit_criteria": {
+                "missing": [
+                    {
+                        "path": "bets/2026-05-16-launch.md",
+                        "title": "Launch the cohort",
+                        "deadline": "2026-06-30",
+                        "public": True,
+                    }
+                ]
+            },
+        }
+    }
+
+    actions = ranker.rank_status_report(report)
+    action = next(action for action in actions if action["id"] == "tighten_bet_exit_criteria")
+
+    assert action["safe_to_share"] is True
+
+
+def test_ranker_bet_exit_criteria_stays_below_repair_blockers() -> None:
+    report = _base_report()
+    report["update"] = {
+        "severity": "required",
+        "command": "pipx upgrade mainbranch",
+        "reason": "Installed version is below the supported floor.",
+        "installed": "0.1.0",
+        "latest": "0.2.6",
+    }
+    report["brain"] = {
+        "bets": {
+            "overdue": [],
+            "due_soon": [],
+            "exit_criteria": {
+                "missing": [
+                    {
+                        "path": "bets/2026-05-16-launch.md",
+                        "title": "Launch the cohort",
+                        "deadline": "2026-06-30",
+                        "public": False,
+                    }
+                ]
+            },
+        }
+    }
+
+    actions = ranker.rank_status_report(report)
+
+    assert actions[0]["id"] == "mainbranch_update_required"
+    tighten = next(action for action in actions if action["id"] == "tighten_bet_exit_criteria")
+    assert tighten["score"] < actions[0]["score"]
+
+
+def test_ranker_surfaces_missing_exit_criteria_even_with_overdue_bets() -> None:
+    report = _base_report()
+    report["brain"] = {
+        "bets": {
+            "overdue": [{"title": "Stale bet", "deadline": "2026-05-01", "days_overdue": 5}],
+            "due_soon": [],
+            "exit_criteria": {
+                "missing": [
+                    {
+                        "path": "bets/2026-05-16-launch.md",
+                        "title": "Launch the cohort",
+                        "deadline": "2026-06-30",
+                        "public": False,
+                    }
+                ]
+            },
+        }
+    }
+
+    actions = ranker.rank_status_report(report)
+    ids = {action["id"] for action in actions}
+
+    # The overdue early-return must not suppress the missing-criteria action.
+    assert "tighten_bet_exit_criteria" in ids
+    assert "update_overdue_bets" in ids

--- a/mb/tests/test_status.py
+++ b/mb/tests/test_status.py
@@ -2680,6 +2680,104 @@ def test_status_brain_flags_active_bets_without_predeclared_exit_criteria(
     assert brain["bets"]["exit_criteria"]["missing"][0]["path"] == "bets/2026-05-16-open.md"
 
 
+def test_status_ranks_active_bets_missing_exit_criteria(tmp_path: Path, monkeypatch) -> None:
+    """Active bets without a kill/double-down rubric should surface as a ranked
+    action that routes to /mb-bet, not stay buried in raw brain.bets facts."""
+    monkeypatch.setattr(status_mod, "_which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setattr(
+        status_mod,
+        "_git_info",
+        lambda repo: {
+            "available": True,
+            "inside_work_tree": True,
+            "branch": "main",
+            "commit": "abc123",
+            "dirty": False,
+            "dirty_count": 0,
+            "dirty_files": [],
+            "remote": "https://github.com/example/acme.git",
+            "error": "",
+        },
+    )
+    monkeypatch.setattr(
+        status_mod,
+        "_git_recent_activity",
+        lambda repo, git: {"available": True, "items": [], "error": ""},
+    )
+    monkeypatch.setattr(
+        status_mod,
+        "_github",
+        lambda repo, git, **kwargs: {
+            "available": True,
+            "authenticated": True,
+            "degraded": False,
+            "source": "gh",
+            "repo": "example/acme",
+            "summary": {
+                "assigned_tasks": 0,
+                "attention_requests": 0,
+                "open_proposals": 0,
+                "shipped_this_week": 0,
+                "recently_closed_tasks": 0,
+                "blocked_or_stale_tasks": 0,
+            },
+            "sections": {
+                "assigned_tasks": [],
+                "attention_requests": [],
+                "open_proposals": [],
+                "shipped_this_week": [],
+                "recently_closed_tasks": [],
+                "blocked_or_stale_tasks": [],
+            },
+            "errors": [],
+            "assigned_issues": [],
+            "review_requests": [],
+            "recent_merged_prs": [],
+            "context": {"ok": True, "state": "ready"},
+        },
+    )
+    monkeypatch.setattr(
+        status_mod.onboard_mod,  # type: ignore[attr-defined]
+        "onboarding_status",
+        lambda repo: {"summary": {"status": "ready"}, "checklist": []},
+    )
+    repo = tmp_path / "repo"
+    init_run(path=str(repo), name="Acme")
+    # Future deadline so only the missing-exit-criteria signal fires (not due/overdue).
+    (repo / "bets" / "2026-05-16-open.md").write_text(
+        (
+            "---\n"
+            "status: open\n"
+            "opened: 2026-05-16\n"
+            "deadline: 2026-12-01\n"
+            "appetite: 2 weeks\n"
+            "hypothesis: A test creates calls.\n"
+            "metric: calls\n"
+            "target: 3 calls\n"
+            "result: ''\n"
+            "public: false\n"
+            "channels: []\n"
+            "tags: []\n"
+            "---\n\n"
+            "# Open bet\n"
+        ),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["status", str(repo), "--json", "--peek"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    actions = {action["id"]: action for action in payload["ranked_actions"]}
+    assert "tighten_bet_exit_criteria" in actions
+    action = actions["tighten_bet_exit_criteria"]
+    assert action["command"] == "/mb-bet update"
+    assert action["audience"] == "operator_decision"
+    assert action["operator_summary"]
+    # Private bet, so the action must not be marked safe to share publicly.
+    assert action["safe_to_share"] is False
+
+
 def test_status_frontmatter_reader_accepts_delimiter_whitespace(tmp_path: Path) -> None:
     path = tmp_path / "note.md"
     path.write_text("--- \nstatus: open\n--- \n# Note\n", encoding="utf-8")
@@ -2807,6 +2905,15 @@ def test_status_ranker_mentions_due_bets(tmp_path: Path, monkeypatch) -> None:
             "metric: replies\n"
             "target: 3 replies\n"
             "result: ''\n"
+            "kill_rubric:\n"
+            "  failure_signals:\n"
+            "    - metric: replies\n"
+            "      comparator: '<'\n"
+            "      threshold: 1\n"
+            "  double_down_signals:\n"
+            "    - metric: replies\n"
+            "      comparator: '>='\n"
+            "      threshold: 5\n"
             "linked_decisions: []\n"
             "linked_research: []\n"
             "linked_campaigns: []\n"


### PR DESCRIPTION
## Summary

`mb status --json --peek` now promotes a `tighten_bet_exit_criteria` ranked action so active bets without a predeclared kill/double-down rubric become an owner-facing next move instead of staying buried in raw `brain.bets` facts.

## Linked issue

Closes #789

## Why

The post-`0.3.41` dogfood confirmed `brain.bets` exposes "all active bets missing exit criteria", but that signal never surfaced as a ranked action — top actions were onboarding, validation debt, and playbook health. Active bets without explicit kill/double-down criteria are high-leverage business risk; the intelligence existed but did not turn into owner-facing action.

## Commits by concern

- `[add] Rank active bets missing exit criteria` — new `tighten_bet_exit_criteria` action in `ranker.py`; fires off `brain.bets.exit_criteria.missing`, independent of overdue/due-soon deadlines (placed before the overdue early-return), routes to `/mb-bet`, weight `bets_missing_exit_criteria=80` (below repair blockers, above due-bets/money-path), evidence marked share-safe only when every flagged bet is `public`.
- `[add] Tests for bet exit-criteria ranked action` — ranker + `mb status --json --peek` coverage: presence, `/mb-bet` route, share-safety gating, ranks below repair blockers, surfaces even with overdue bets; gave the existing due-bets fixture an explicit `kill_rubric` so it isolates the due-soon concern.
- `[update] Changelog for bet exit-criteria action` — `[Unreleased]` entry.

## Validation

- Level 1 static (changed surface): `python3 -m ruff format --check` + `ruff check` + `mypy mb/ranker.py` — runtime: python3 — exit: 0 — all checks passed.
- Level 2 CLI contract: `python3 -m pytest tests/test_ranker.py tests/test_status.py -q` — runtime: python3 — exit: 0 — log: `106 passed in 122.36s`. Covers `--json --peek` ranked_actions wiring, audience/operator_summary contract, share-safety.
- Full `scripts/check.sh` (whole-repo ruff+mypy+pytest coverage+skill-validate+doc-naming) was launched from repo root but ran past the session window without returning; the changed-surface gates above are green. Re-run `scripts/check.sh` locally to confirm whole-repo coverage before merge.
- Levels 3–5 not required: no packaging, init/onboard, runtime-discovery, or skill prose changes — only deterministic ranker logic + tests + changelog.

## Success metric

A repo with active bets lacking a `kill_rubric` shows `tighten_bet_exit_criteria` in `mb status --json --peek` `ranked_actions`, routed to `/mb-bet`, without it outranking genuine repair work.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section.

## Breaking changes

- [x] No

## Public / private boundary

No private operator strategy, machine-specific paths, or runtime internals committed. Bet evidence is marked `safe_to_share` only when every flagged bet is `public`; private bet names stay non-shareable. Writes remain approval-gated (routing/fact-surfacing only, no automatic bet edits).