### PR TITLE
[update] Calibrate MoneyPath action prominence in mb status ranker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,17 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ### Changed
 
+- Calibrated MoneyPath action prominence so a path-to-money question is not
+  buried under safe onboarding or repo-operation actions. On an operational repo
+  (`mb status` ranker), finishing onboarding inputs no longer outranks
+  validation, bet, active-push, or path-to-money signals, and the top MoneyPath
+  bottleneck reserves a `ranked_actions` slot by displacing only the weakest
+  hygiene action — required repair/update/validation blockers always keep their
+  slots. Field-tested proof (level >= 4) now ranks `strengthen-proof-quality`
+  below packaging/channel moves instead of ahead of them, and
+  `repair-books-exposure` only fires when an active bet declares MoneyPath
+  anchoring (committed spend) rather than for exploratory bets. No private
+  financial values are added to reports or JSON. Closes #785.
 - Grouped cross-reference and related-link validation warnings into owner-facing
   clusters: `mb validate` JSON now carries `blocker_count`,
   `mechanical_warning_count`, `operator_warning_count`, and an `owner_summary`

--- a/mb/mb/ranker.py
+++ b/mb/mb/ranker.py
@@ -13,6 +13,7 @@ WEIGHTS: dict[str, int] = {
     "skill_wiring_broken": 110,
     "git_repo_missing": 105,
     "onboarding_incomplete": 95,
+    "onboarding_incomplete_operational": 56,
     "overdue_bets": 90,
     "unhealthy_integrations": 85,
     "github_context_repair": 80,
@@ -66,7 +67,91 @@ def rank_status_report(
     ranked = sorted(actions, key=_action_sort_key)
     if not ranked:
         ranked = [_low_signal_action(report)]
+    ranked = _ensure_money_path_visible(ranked, report, limit)
     return ranked[:limit]
+
+
+def _repo_operational(report: dict[str, Any]) -> bool:
+    """True when the repo is already a working Main Branch business repo.
+
+    Operational means the safe-blocker preconditions are met: the folder has the
+    business-repo markers, git is initialized, skill wiring (if present) is
+    healthy, and no update is required. In that state onboarding completion is a
+    polish item, not a gate, and path-to-money guidance should be visible.
+    """
+
+    repo = _dict(report.get("repo"))
+    git = _dict(report.get("git"))
+    runtime = _dict(report.get("runtime"))
+    skill_wiring = _dict(runtime.get("skill_wiring"))
+    update = _dict(report.get("update"))
+    return (
+        bool(repo.get("looks_like_mainbranch_repo"))
+        and bool(git.get("inside_work_tree"))
+        and (not skill_wiring or bool(skill_wiring.get("ok")))
+        and str(update.get("severity") or "") != "required"
+    )
+
+
+# Soft onboarding / repo-operation / hygiene actions that may yield a top slot to
+# the leading MoneyPath bottleneck on an operational repo. Required safe blockers
+# and business-pressure signals (bets, overdue/due bets, money finance) are not
+# here, so they are never displaced.
+_MONEY_PATH_DISPLACEABLE_IDS = frozenset(
+    {
+        "resume_onboarding",
+        "review_playbook_health",
+        "review_relationship_health",
+        "review_local_git_changes",
+        "review_since_last_check",
+        "review_stale_decisions",
+        "refresh_stale_research",
+        "review_github_attention",
+        "work_assigned_github_tasks",
+        "unstick_blocked_or_stale_tasks",
+    }
+)
+
+
+def _ensure_money_path_visible(
+    ranked: list[dict[str, Any]],
+    report: dict[str, Any],
+    limit: int,
+) -> list[dict[str, Any]]:
+    """Reserve a top slot for the leading MoneyPath action on operational repos.
+
+    When the repo is operational and the top MoneyPath bottleneck would otherwise
+    fall below ``limit``, it takes the slot of the weakest soft onboarding /
+    repo-operation / hygiene action in the top band so a path-to-money question
+    surfaces it alongside, not underneath, those actions. Required safe blockers
+    and business-pressure signals (bets, money finance) keep their slots.
+    """
+
+    if limit <= 0 or not _repo_operational(report):
+        return ranked
+    money = next(
+        (
+            action
+            for action in ranked
+            if str(action.get("id") or "").startswith("review_money_path")
+        ),
+        None,
+    )
+    if money is None or money in ranked[:limit]:
+        return ranked
+    top = ranked[:limit]
+    displaceable = [
+        action for action in top if str(action.get("id") or "") in _MONEY_PATH_DISPLACEABLE_IDS
+    ]
+    if not displaceable:
+        # Top band is all blockers/business signals. Leave them; money path is not
+        # buried under hygiene, it simply ranks below higher-pressure work.
+        return ranked
+    victim = min(displaceable, key=lambda action: _as_int(action.get("score")))
+    new_top = [action for action in top if action is not victim] + [money]
+    new_top_ids = {id(action) for action in new_top}
+    rest = [action for action in ranked if id(action) not in new_top_ids]
+    return sorted(new_top, key=_action_sort_key) + sorted(rest, key=_action_sort_key)
 
 
 def _add_readiness_actions(actions: list[dict[str, Any]], report: dict[str, Any]) -> None:
@@ -196,6 +281,15 @@ def _add_readiness_actions(actions: list[dict[str, Any]], report: dict[str, Any]
     onboarding_summary = _dict(onboarding.get("summary"))
     if onboarding_summary.get("status") == "in_progress":
         missing_inputs = [str(item) for item in _list(onboarding_summary.get("missing_inputs"))]
+        # Onboarding is a soft warn. Once the repo is already operational, finishing
+        # remaining onboarding inputs should not automatically bury path-to-money,
+        # validation, bet, or active-push signals, so demote it below the
+        # business-pressure band while keeping it leading on fresh/unshaped repos.
+        onboarding_weight = (
+            WEIGHTS["onboarding_incomplete_operational"]
+            if _repo_operational(report)
+            else WEIGHTS["onboarding_incomplete"]
+        )
         actions.append(
             _action(
                 action_id="resume_onboarding",
@@ -204,7 +298,7 @@ def _add_readiness_actions(actions: list[dict[str, Any]], report: dict[str, Any]
                     onboarding_summary.get("next_recommended_action") or "mb onboard status"
                 ),
                 severity="warn",
-                score=WEIGHTS["onboarding_incomplete"] + min(len(missing_inputs), 10),
+                score=onboarding_weight + min(len(missing_inputs), 10),
                 reason=(
                     f"{_as_int(onboarding_summary.get('completed_required'))}/"
                     f"{_as_int(onboarding_summary.get('total_required'))} required onboarding "

--- a/mb/mb/status.py
+++ b/mb/mb/status.py
@@ -2792,6 +2792,10 @@ def _money_path_ranked_actions(
         ),
     ]
     actions: list[dict[str, Any]] = []
+    # Strong proof (level >= 4) with only quality nits should not outrank
+    # packaging/channel/push moves. Hold its strengthen action and re-insert it
+    # below those moves, just above the page-readiness/outcome tail.
+    deferred_strong_proof: dict[str, Any] | None = None
     for action_id, title, key, fallback_reason, route in candidates:
         component = objects.get(key) or {}
         level = int(component.get("level") or 0)
@@ -2840,23 +2844,27 @@ def _money_path_ranked_actions(
                 proof_quality_gaps.append("outcome_feedback")
             if not proof_quality_gaps:
                 continue
-            actions.append(
-                {
-                    "id": "strengthen-proof-quality",
-                    "title": "Strengthen proof quality",
-                    "reason": (
-                        "Proof exists, but testimonials are generic or not linked to an "
-                        "offer, outcome, typicality, or claim."
-                    ),
-                    "route": "/mb-think",
-                    "source": "money_path.objects.proof.quality",
-                    "component": "proof",
-                    "confidence": "medium",
-                    "effort_hint": "medium",
-                    "missing": proof_quality_gaps[:5],
-                    "safe_to_share": True,
-                }
-            )
+            strengthen_proof = {
+                "id": "strengthen-proof-quality",
+                "title": "Strengthen proof quality",
+                "reason": (
+                    "Proof exists, but testimonials are generic or not linked to an "
+                    "offer, outcome, typicality, or claim."
+                ),
+                "route": "/mb-think",
+                "source": "money_path.objects.proof.quality",
+                "component": "proof",
+                "confidence": "medium",
+                "effort_hint": "medium",
+                "missing": proof_quality_gaps[:5],
+                "safe_to_share": True,
+            }
+            if level >= 4:
+                # Proof is already field-tested. Polishing it ranks below
+                # packaging/channel/push moves; hold it for the tail.
+                deferred_strong_proof = strengthen_proof
+            else:
+                actions.append(strengthen_proof)
             continue
         elif level >= 2:
             continue
@@ -2874,6 +2882,17 @@ def _money_path_ranked_actions(
                 "safe_to_share": True,
             }
         )
+    if deferred_strong_proof is not None:
+        tail_components = {"page_readiness", "outcome_feedback_loop"}
+        insert_at = next(
+            (
+                index
+                for index, action in enumerate(actions)
+                if action.get("component") in tail_components
+            ),
+            len(actions),
+        )
+        actions.insert(insert_at, deferred_strong_proof)
     return actions[:5]
 
 
@@ -2936,10 +2955,18 @@ def _money_path_active_bet_exposure(repo: Path, report: dict[str, Any]) -> dict[
     )
     currency = str(policy.get("currency") or "USD")
     exposure_window_days = int(policy.get("exposure_window_days") or 7)
+    # A bet that declares MoneyPath anchoring as required has committed (or is
+    # about to commit) execution spend. Exploratory pricing/product bets that
+    # have not done so should not trigger eager ledger-repair nudges.
+    requires_anchor = any(
+        isinstance(item.get("money_path"), dict) and bool(item["money_path"].get("required"))
+        for item in active
+    )
     summary: dict[str, Any] = {
         "count": len(active),
         "anchored": 0,
         "unanchored": 0,
+        "requires_anchor": requires_anchor,
         "gross_exposure": _money_amount(commodity=currency),
         "this_week_at_risk": _money_amount(commodity=currency),
         "over_cap": [],
@@ -3035,12 +3062,19 @@ def _money_path_finance_actions(
                 "safe_to_share": True,
             }
         )
-    if active_bets.get("ledger_unavailable") and active_count:
+    if (
+        active_bets.get("ledger_unavailable")
+        and active_count
+        and active_bets.get("requires_anchor")
+    ):
         actions.append(
             {
                 "id": "repair-books-exposure",
                 "title": "Repair books exposure checks",
-                "reason": "Active bets exist, but Main Branch cannot check private ledger anchors.",
+                "reason": (
+                    "An active bet requires MoneyPath anchoring, but Main Branch "
+                    "cannot check private ledger anchors."
+                ),
                 "route": "mb books doctor --plan --json",
                 "component": "financial_exposure",
                 "source": "money_path.active_bets.ledger_unavailable",

--- a/mb/mb/status.py
+++ b/mb/mb/status.py
@@ -2883,6 +2883,10 @@ def _money_path_ranked_actions(
             }
         )
     if deferred_strong_proof is not None:
+        # Re-insert just above the page-readiness/outcome tail. With 5+ higher
+        # priority moves ahead of it (and no tail action to anchor against), the
+        # final [:5] cut can drop strong-proof polish entirely -- by design, it is
+        # the lowest-urgency move once proof is already field-tested.
         tail_components = {"page_readiness", "outcome_feedback_loop"}
         insert_at = next(
             (

--- a/mb/tests/test_ranker.py
+++ b/mb/tests/test_ranker.py
@@ -349,6 +349,152 @@ def test_ranker_bet_exit_criteria_stays_below_repair_blockers() -> None:
     assert tighten["score"] < actions[0]["score"]
 
 
+def _onboarding_in_progress() -> dict[str, object]:
+    return {
+        "summary": {
+            "status": "in_progress",
+            "missing_inputs": ["offer"],
+            "completed_required": 1,
+            "total_required": 3,
+            "next_recommended_action": "mb onboard status",
+        }
+    }
+
+
+def _money_path_cta_action() -> dict[str, object]:
+    return {
+        "ranked_actions": [
+            {
+                "id": "define-cta-path",
+                "title": "Define the CTA path",
+                "reason": "Offer and audience facts need a next step.",
+                "route": "/mb-think",
+                "component": "cta_path",
+                "confidence": "high",
+                "missing": ["conversion_endpoint"],
+                "safe_to_share": True,
+            }
+        ]
+    }
+
+
+def test_ranker_demotes_onboarding_below_money_path_when_operational() -> None:
+    report = _base_report()
+    report["onboarding"] = _onboarding_in_progress()
+    report["money_path"] = _money_path_cta_action()
+
+    actions = ranker.rank_status_report(report)
+    ids = [action["id"] for action in actions]
+
+    assert "review_money_path_cta_path" in ids
+    assert "resume_onboarding" in ids
+    money_path = next(a for a in actions if a["id"] == "review_money_path_cta_path")
+    onboarding = next(a for a in actions if a["id"] == "resume_onboarding")
+    # On an operational repo, finishing onboarding inputs must not outrank the
+    # path-to-money bottleneck.
+    assert money_path["score"] > onboarding["score"]
+    assert ids.index("review_money_path_cta_path") < ids.index("resume_onboarding")
+
+
+def test_ranker_keeps_onboarding_leading_when_repo_not_operational() -> None:
+    report = _base_report()
+    report["repo"] = {"looks_like_mainbranch_repo": False, "missing_markers": ["core/"]}
+    report["onboarding"] = _onboarding_in_progress()
+
+    actions = ranker.rank_status_report(report)
+    onboarding = next(a for a in actions if a["id"] == "resume_onboarding")
+
+    # Not operational: onboarding keeps its full weight band (>= 95) so a fresh or
+    # unshaped repo still leads with finishing setup.
+    assert onboarding["score"] >= ranker.WEIGHTS["onboarding_incomplete"]
+
+
+def test_ranker_surfaces_money_path_over_hygiene_but_keeps_blocker() -> None:
+    report = _base_report()
+    report["drift"] = {
+        "items": [
+            {
+                "id": "validation_debt",
+                "severity": "error",
+                "summary": "Validation findings need repair.",
+                "evidence": ["core/offer.md: missing required frontmatter"],
+            }
+        ]
+    }
+    report["playbook_health"] = {
+        "gaps": [
+            {
+                "id": "pushes_without_playbook",
+                "severity": "warn",
+                "summary": "1 active push needs a playbook run.",
+                "safe_to_share": True,
+            }
+        ]
+    }
+    report["relationship_health"] = {
+        "gaps": [
+            {
+                "id": "bet_without_push",
+                "severity": "warn",
+                "summary": "An active bet has no linked push.",
+                "safe_to_share": True,
+            }
+        ]
+    }
+    report["money_path"] = _money_path_cta_action()
+
+    actions = ranker.rank_status_report(report)
+    ids = {action["id"] for action in actions}
+
+    # The validation error blocker is preserved; the path-to-money bottleneck
+    # surfaces by displacing the weakest hygiene action, not the blocker.
+    assert "repair_validation_debt" in ids
+    assert "review_money_path_cta_path" in ids
+    assert "review_relationship_health" not in ids
+
+
+def test_ranker_never_displaces_business_pressure_for_money_path() -> None:
+    report = _base_report()
+    report["drift"] = {
+        "items": [
+            {
+                "id": "validation_debt",
+                "severity": "error",
+                "summary": "Validation findings need repair.",
+                "evidence": ["core/offer.md: missing required frontmatter"],
+            }
+        ]
+    }
+    report["brain"] = {
+        "bets": {
+            "overdue": [{"title": "Stale bet", "deadline": "2026-05-01", "days_overdue": 5}],
+            "due_soon": [],
+            "exit_criteria": {
+                "missing": [
+                    {
+                        "path": "bets/2026-05-16-launch.md",
+                        "title": "Launch the cohort",
+                        "deadline": "2026-06-30",
+                        "public": False,
+                    }
+                ]
+            },
+        }
+    }
+    report["money_path"] = _money_path_cta_action()
+
+    actions = ranker.rank_status_report(report)
+    ids = {action["id"] for action in actions}
+
+    # Operational repo, but the top band is a validation blocker plus two bet
+    # signals with no hygiene action to yield. Money path must not displace any of
+    # them; blockers and business pressure keep their slots.
+    assert "repair_validation_debt" in ids
+    assert "tighten_bet_exit_criteria" in ids
+    assert "update_overdue_bets" in ids
+    assert "review_money_path_cta_path" not in ids
+
+
 def test_ranker_surfaces_missing_exit_criteria_even_with_overdue_bets() -> None:
     report = _base_report()
     report["brain"] = {

--- a/mb/tests/test_status.py
+++ b/mb/tests/test_status.py
@@ -1259,6 +1259,130 @@ def test_status_money_path_level_five_proof_requires_outcome_feedback(
     )
 
 
+def test_status_money_path_strong_proof_ranks_below_channel(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+    # Shaped offer/audience/customer-progress, field-tested proof, but no channel
+    # or active push yet -- the agency archetype shape from the dogfood.
+    _write_money_path_core(repo)
+    proof = repo / "core" / "proof"
+    proof.mkdir(parents=True, exist_ok=True)
+    (proof / "testimonials.md").write_text(
+        (
+            "# Testimonials\n\n"
+            "## Founder A\n"
+            "Permissioned public source: sales call. Before: stuck rebuilding context. "
+            "Outcome: booked 3 calls within 2 weeks using the workflow. "
+            "Objection: worried about time.\n\n"
+            "## Founder B\n"
+            "Approved for public source: interview. Previously scattered launches. "
+            "Result: saved 5 hours in 10 days through the process.\n"
+        ),
+        encoding="utf-8",
+    )
+    (proof / "typicality.md").write_text(
+        (
+            "# Typicality\n\n"
+            "Average case: most users need one setup week before speed improves. "
+            "Caveat: outcomes vary. Common failure context: poor fit when no offer "
+            "exists. Time to outcome is usually 2 weeks.\n"
+        ),
+        encoding="utf-8",
+    )
+
+    report = status_mod.run(path=str(repo), update_marker=False)
+
+    assert report["money_path"]["objects"]["proof"]["level"] == 4
+    ids = [action["id"] for action in report["money_path"]["ranked_actions"]]
+    # Field-tested proof should not bury packaging/channel moves. Channel gap ranks
+    # ahead of polishing already-strong proof.
+    assert "connect-channel-strategy" in ids
+    assert "strengthen-proof-quality" in ids
+    assert ids.index("connect-channel-strategy") < ids.index("strengthen-proof-quality")
+
+
+def _write_active_bet(repo: Path, slug: str, *, committed: bool) -> None:
+    money_path_block = "money_path:\n  required: true\n  bet_id: launch\n" if committed else ""
+    (repo / "bets" / f"{slug}.md").write_text(
+        (
+            "---\n"
+            "status: open\n"
+            "opened: 2026-05-16\n"
+            "deadline: 2026-12-01\n"
+            "appetite: 2 weeks\n"
+            f"{money_path_block}"
+            "hypothesis: A pricing test creates calls.\n"
+            "metric: calls\n"
+            "target: 3 calls\n"
+            "result: ''\n"
+            "public: false\n"
+            "channels: []\n"
+            "tags: []\n"
+            "exit_criteria:\n"
+            "  kill: drop if under 1 call\n"
+            "  double_down: scale past 5 calls\n"
+            "---\n\n"
+            "# Active bet\n"
+        ),
+        encoding="utf-8",
+    )
+
+
+def _raise_exposure(**_kwargs: object) -> dict[str, object]:
+    raise RuntimeError("ledger unavailable")
+
+
+def test_status_money_path_books_repair_skips_exploratory_bets(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
+    monkeypatch.setattr(
+        status_mod.books_mod,  # type: ignore[attr-defined]
+        "exposure",
+        _raise_exposure,
+    )
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+    _write_active_bet(repo, "2026-05-16-explore", committed=False)
+
+    report = status_mod.run(path=str(repo), update_marker=False)
+
+    active_bets = report["money_path"]["active_bets"]
+    assert active_bets["ledger_unavailable"] is True
+    assert active_bets["requires_anchor"] is False
+    ids = {action["id"] for action in report["money_path"]["ranked_actions"]}
+    # An exploratory bet that has not committed spend should not trigger an eager
+    # ledger-repair nudge.
+    assert "repair-books-exposure" not in ids
+
+
+def test_status_money_path_books_repair_fires_for_committed_bet(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
+    monkeypatch.setattr(
+        status_mod.books_mod,  # type: ignore[attr-defined]
+        "exposure",
+        _raise_exposure,
+    )
+    repo = tmp_path / "acme"
+    init_run(path=str(repo), name="Acme")
+    _write_active_bet(repo, "2026-05-16-committed", committed=True)
+
+    report = status_mod.run(path=str(repo), update_marker=False)
+
+    active_bets = report["money_path"]["active_bets"]
+    assert active_bets["ledger_unavailable"] is True
+    assert active_bets["requires_anchor"] is True
+    repair = next(
+        action
+        for action in report["money_path"]["ranked_actions"]
+        if action["id"] == "repair-books-exposure"
+    )
+    # Owner-facing reason names the committed-anchor trigger; no private amounts.
+    assert "requires MoneyPath anchoring" in repair["reason"]
+    assert repair["safe_to_share"] is True
+
+
 def test_status_money_path_detects_multi_offer_product_ladder(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(status_mod, "_which", _without_github_or_claude)
     repo = tmp_path / "acme"


### PR DESCRIPTION
## Summary

Path-to-money guidance no longer gets buried under safe onboarding or repo-operation actions in `mb status`: once a repo is operational the ranker surfaces the top MoneyPath bottleneck alongside required blockers, deprioritizes proof-polish on already-strong proof, and stops nudging ledger repair for exploratory bets.

## Linked issue

Closes #785

## Why

The 2026-05-28 MoneyPath archetype dogfood found that even in shaped, operational repos the owner-facing ranking led with onboarding/repo-hygiene and buried path-to-money, validation, bet, and active-push signals — so a "what makes money next?" question felt less business-guided than it should. It also flagged two over-eager moves: `strengthen-proof-quality` ranking ahead of packaging/channel gaps for proof-level-4 repos, and `repair-books-exposure` firing for exploratory bets before spend is committed.

## Commits by concern

- `[update]` ranker: demote `onboarding_incomplete` on an operational repo so a soft onboarding warn no longer outranks validation/bet/active-push/money-path signals; reserve a `ranked_actions` slot for the top `review_money_path_*` action by displacing only the weakest hygiene action — required repair/update/validation blockers always keep their slots. status: defer `strengthen-proof-quality` below packaging/channel moves when proof level >= 4; add `requires_anchor` bool so `repair-books-exposure` fires only when an active bet declares MoneyPath anchoring (committed spend).
- `[add]` focused tests in `test_ranker.py` (onboarding demotion + operational guard, money-path-over-hygiene with blocker preserved, business-pressure never displaced) and `test_status.py` (strong-proof-below-channel, books-exposure exploratory-skip vs committed-fire).
- `[docs]` CHANGELOG `[Unreleased]` entry.

## Validation

`Level 1 static: scripts/check.sh — runtime: python3 (system 3.13.7) — exit: 0 — log: /tmp/check_full2.log (ruff format + ruff check + mypy clean, 901 passed in 496s)`

- Level 2 CLI contract: covered — ranker/status assertions run through `status_mod.run` and `CliRunner` (`--json --peek`) in the new tests.
- Level 4 fixture repo: covered — new status tests build fixture repos via `init_run` + `status_mod.run`.
- Level 3 package/install smoke: not required — no packaging touched.
- Level 5 runtime/dogfood: not required — deterministic ranker/status logic only; no first-run, skill discovery, invocation, or release-validation surface changed.

## Success metric

On an operational repo with onboarding incomplete plus a MoneyPath bottleneck, `mb status` ranked_actions shows the top MoneyPath action alongside (not underneath) the required blockers; proof-level-4 repos rank channel/packaging gaps ahead of `strengthen-proof-quality`; `repair-books-exposure` is absent for exploratory bets and present for committed (anchor-required) bets.

## CHANGELOG

- [x] Updated `CHANGELOG.md` `[Unreleased]` section.

## Breaking changes

- [x] No

## Public / private boundary

No private operator strategy, financial values, or machine-specific paths committed. `requires_anchor` is a bool; `safe_to_share` flags preserved; no raw amounts enter reports or JSON. No public contract (AGENTS.md / compatibility / workflows) needed changes — this is deterministic ranking calibration within the existing `mb status` JSON shape, and no retired paths, runtime claims, or provider-authority claims were introduced.