### PR TITLE
[docs] validate: explain -v in --help

### DIFF
--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -1747,7 +1747,12 @@ def validate_cmd(
         "--repo",
         help="Repo to validate. Alias for the positional PATH used by older scripts.",
     ),
-    verbose: bool = typer.Option(False, "-v", "--verbose"),
+    verbose: bool = typer.Option(
+        False,
+        "-v",
+        "--verbose",
+        help="Show full per-file detail; by default warnings-only files collapse into the summary.",
+    ),
     cross_refs: bool = typer.Option(
         False,
         "--cross-refs",


### PR DESCRIPTION
## Summary
Add help text to `mb validate -v/--verbose` so operators discover it restores full per-file detail after the owner-facing warning grouping (#792), without reading the CHANGELOG.

## Linked issue
Refs #790

## Why
Audit before the 0.3.42 release flagged that `-v` had no `--help` text describing the collapse/restore behavior. One-line clarification; documents existing shipped behavior.

## Validation
- ruff format + check: pass; `mb validate --help` renders the new text.
- No behavior/type change; CI runs the full gate.

## CHANGELOG
- [x] N/A — documents existing #792 behavior already in `[0.3.42]`; no behavior change.

## Public / private boundary
No secrets/paths/strategy.