### PR TITLE
[release] Prepare and publish v0.3.42

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mainbranch",
-  "version": "0.3.41",
+  "version": "0.3.42",
   "description": "Main Branch Claude Code skills for running a business from markdown files in git.",
   "author": {
     "name": "Noontide"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+## [0.3.42] - 2026-05-29
+
 ### Added
 
 - Made repo `role` the single intentional classifier and started enforcing it.

--- a/mb/mb/__init__.py
+++ b/mb/mb/__init__.py
@@ -7,6 +7,6 @@ file stays a thin dispatcher.
 
 from __future__ import annotations
 
-__version__ = "0.3.41"
+__version__ = "0.3.42"
 
 __all__ = ["__version__"]

--- a/mb/pyproject.toml
+++ b/mb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mainbranch"
-version = "0.3.41"
+version = "0.3.42"
 description = "Main Branch engine umbrella - scaffolds, validates, and graphs business-as-files repos. Claude Code first, runtime-agnostic by design."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
Release-prep for v0.3.42: bump the four version-bearing files and date the CHANGELOG section. Release-only diff.

## Linked issue
Closes #798

## Why
Package-visible release bundling the work merged since `oe-v0.3.41`.

## Contents (`CHANGELOG [0.3.42] - 2026-05-29`)
- Repo `role` as the single classifier + missing-role enforcement (#795 / Refs #765)
- `tighten_bet_exit_criteria` ranked action (#793, Closes #789)
- MoneyPath action prominence recalibration (#794, Closes #785)
- `mb validate` owner-facing warning grouping + new JSON fields (#792, Closes #790)
- Daily start/status readiness separation (#791, Closes #788)
- `mb validate -v` help text (#799, Refs #790)

## Commits by concern
- `[release] Prepare v0.3.42` — `mb/pyproject.toml`, `mb/mb/__init__.py`, `.claude-plugin/plugin.json` → `0.3.42`; `CHANGELOG.md` dated.

## Validation (evidence under `.agent/release-evidence/0.3.42/`)
- Level 0 preflight: `test_claude_plugin_manifest_points_at_prefixed_skills` — pass.
- Level 1 static: `scripts/check.sh` — runtime: mb/.venv — exit: 0 — `check.out` (mypy clean, 917 passed).
- Level 3 package/install: `python3 -m build` + fresh venv install of `mainbranch-0.3.42-py3-none-any.whl` — exit: 0 — `install.out`/`firstrun.out`: `mb 0.3.42`, `mb init`+`status` ok (topology schema + role fields present), `mb validate --json` new grouping fields present, `mb books check --fixture --json` → `result_status: ok` (base/no-hledger mode).
- Level 5 runtime dogfood: deferred — recommend running `release_acceptance` against the published PyPI artifact in post-publish verification (claude CLI + API budget). Print-proxy only otherwise.
- Pre-release alignment sweep: ALIGNED (no doc edits required).
- Content audit (PRs since oe-v0.3.41): SHIP-CLEAN; CHANGELOG complete, `[Unreleased]` empty, supply-chain action bump (#797) policy-aligned.

## Success metric
`pip install mainbranch==0.3.42` yields installed `mb --version` → `mb 0.3.42`, first-run init+status pass, and the GitHub Release + PyPI + Linear release agree.

## CHANGELOG
- [x] Dated `[0.3.42] - 2026-05-29`; `[Unreleased]` empty.

## Breaking changes
- [x] No

## Public / private boundary
Release-only diff. No secrets, paths, or strategy. Evidence stays under gitignored `.agent/`.