### PR TITLE
feat(image): provider-pluggable image rail (openai default, fal.ai option)

### DIFF
--- a/.claude/skills/mb-ads/SKILL.md
+++ b/.claude/skills/mb-ads/SKILL.md
@@ -228,8 +228,8 @@ for ad readiness, source bites, playbook routing, review boards, and
 mb connect doctor --json
 ```
 
-Use status/connect facts first for Google/Workspace readiness. For the first
-OpenAI rail smoke, use `mb image smoke-openai --repo "$BUSINESS_REPO" --json`; see [references/image-generation-workflow.md](references/image-generation-workflow.md)
+Use status/connect facts first for Google/Workspace readiness. For provider rail
+smokes, use `mb image smoke-openai --repo "$BUSINESS_REPO" --json` (default rail) or `mb image smoke-fal` (explicitly selected fal.ai rail); see [references/image-generation-workflow.md](references/image-generation-workflow.md)
 for the `--generate`, credential, media-storage, and `image-index.md` boundary.
 Never ask the operator to paste API keys into chat or public issue text.
 

--- a/.claude/skills/mb-ads/references/image-generation-workflow.md
+++ b/.claude/skills/mb-ads/references/image-generation-workflow.md
@@ -584,15 +584,16 @@ Use the provider and model verified for this run. Do not hard-code a private
 environment file, assume a provider is configured, or claim Main Branch supports
 image generation because this reference exists.
 
-Current provider notes checked 2026-05-13 against the accepted creative media
-generation decision:
+Current provider notes checked 2026-05-13 (fal.ai row checked 2026-06-10)
+against the accepted creative media generation decision:
 `decisions/2026-05-13-creative-media-generation-rails.md`.
 
 | Provider | Model family | Use |
 | --- | --- | --- |
-| OpenAI Image API / Responses API | `gpt-image-2` | First readiness target for fixture-safe static image generation/editing. Use only when configured for the run and record the exact model/snapshot. |
+| OpenAI Image API / Responses API | `gpt-image-2` | Default smoked rail for fixture-safe static image generation/editing. Use only when configured for the run and record the exact model/snapshot. |
+| fal.ai sync API (`fal.run`) | `fal-ai/flux/dev` (FLUX) | Explicitly selected alternative smoked rail with the same approval, credential, review, and `image-index.md` boundary as the OpenAI rail. Selection is explicit config; a local `FAL_KEY` never auto-selects fal.ai. |
 | Google Gemini API | Nano Banana image-model family | Candidate comparison rail for future work. Do not treat it as proven ad-grade output until a smoke/test run records the current exact model ID, prompt, output, review notes, and final asset quality. |
-| BFL FLUX.2 / ComfyUI | FLUX.2 family | Candidate local/private or heavy-reference rail after the OpenAI rail and metadata contract are stable. |
+| BFL FLUX.2 / ComfyUI | FLUX.2 family | Candidate local/private or heavy-reference rail beyond the smoked fal.ai FLUX endpoint, after the metadata contract proves out. |
 | Manual provider use | `manual` | Safe fallback when no approved provider is configured. Save prompts and asset records for the operator to use manually. |
 
 If model names or pricing matter to the recommendation, check the provider's
@@ -706,18 +707,27 @@ claim. The first shipped smoke surface is narrower:
 ```bash
 mb image smoke-openai --repo "$BUSINESS_REPO" --json
 mb image smoke-openai --repo "$BUSINESS_REPO" --generate --json
+mb image smoke-fal --repo "$BUSINESS_REPO" --json
+mb image smoke-fal --repo "$BUSINESS_REPO" --generate --json
 ```
 
 Run without `--generate` to create a safe blocked record. Add `--generate` only
-after the operator approves one fixture-safe provider call and local OpenAI
+after the operator approves one fixture-safe provider call and local provider
 credentials are available outside chat and tracked repo files.
+
+Provider selection is explicit: each smoke command names exactly one provider,
+and the OpenAI rail stays the default. `mb image smoke-fal` uses the fal.run
+sync endpoint with a local `FAL_KEY` (environment-first); the presence of a
+`FAL_KEY` never switches the OpenAI surfaces to fal.ai.
 
 ---
 
 ## Generation via Python SDK
 
-The `mb image smoke-openai` command owns the first fixture-safe smoke path.
-When generation is approved, it uses the OpenAI Python SDK shape below and
+The `mb image smoke-openai` command owns the default fixture-safe smoke path;
+`mb image smoke-fal` follows the same record and storage boundary over the
+fal.run REST endpoint without an extra SDK dependency.
+When generation is approved, the OpenAI rail uses the Python SDK shape below and
 writes the binary to configured media storage while committing only the
 push-local `image-index.md` record. MCP servers, runtime-native image tools, or
 another SDK can be used only when they are configured for the run and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+### Added
+
+- Made the fixture-safe image rail provider-pluggable behind an explicit
+  provider registry in `image_rail.py`. `mb image smoke-openai` keeps
+  byte-identical default behavior, and a new `mb image smoke-fal` surface
+  smokes the fal.ai FLUX sync endpoint (`fal-ai/flux/dev`) with the same
+  approval gate, review board, media-storage boundary, and committed
+  `image-index.md` record. Provider selection is explicit config only — a
+  local `FAL_KEY` (read environment-first, never printed or committed) never
+  auto-selects fal.ai, and the concept-review/safety/placement logic stays
+  provider-agnostic.
+
 ### Fixed
 
 - Fixed `bundled_skills()` treating any directory under the engine root's

--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -1767,6 +1767,69 @@ def image_smoke_openai_cmd(
     raise typer.Exit(0)
 
 
+@image_app.command("smoke-fal")
+def image_smoke_fal_cmd(
+    repo: str = typer.Option(
+        ".",
+        "--repo",
+        help="Business repo where the fake push-local image-index.md should be written.",
+    ),
+    push_slug: str = typer.Option(
+        image_rail_mod.DEFAULT_FAL_PUSH_SLUG,
+        "--push-slug",
+        help="Fake push slug for the fixture-safe smoke record.",
+    ),
+    docs_checked: str = typer.Option(
+        "",
+        "--docs-checked",
+        help="Provider docs checked date. Defaults to today in UTC.",
+    ),
+    media_root: str = typer.Option(
+        ".mb/media",
+        "--media-root",
+        help=(
+            "Private media storage root for the review board and any approved "
+            "9-candidate --generate batch binaries."
+        ),
+    ),
+    generate: bool = typer.Option(
+        False,
+        "--generate",
+        help=("Call fal.ai only when a local FAL_KEY exists and the operator approved generation."),
+    ),
+    json_out: bool = typer.Option(False, "--json", help="Machine-readable output."),
+) -> None:
+    """Smoke the explicitly selected fal.ai FLUX rail with fake fixture context."""
+    result = image_rail_mod.smoke_fal(
+        repo=repo,
+        push_slug=push_slug,
+        docs_checked=docs_checked or _today_utc(),
+        media_root=media_root,
+        generate=generate,
+    )
+    if json_out:
+        typer.echo(
+            _json_payload(
+                result,
+                command="image smoke-fal",
+                schema_name="mainbranch.image.smoke_fal.v1",
+            )
+        )
+    elif result["state"] == "generated":
+        typer.echo("fal.ai image rail smoke generated a fixture-safe asset.")
+        typer.echo(f"record: {result['record_path']}")
+        typer.echo(f"review board: {result['review_board_path']}")
+        typer.echo(f"media:  {result['output_reference']}")
+        typer.echo("binary committed: false")
+    else:
+        typer.echo("fal.ai image rail smoke blocked safely.")
+        typer.echo(f"record: {result['record_path']}")
+        typer.echo(f"review board: {result['review_board_path']}")
+        typer.echo(f"reason: {result['blocker_code']}")
+        typer.echo("I will not ask you to paste provider keys into chat or repo files.")
+    raise typer.Exit(0)
+
+
 @app.command("validate")
 def validate_cmd(
     path: str = typer.Argument(".", help="Repo to validate."),

--- a/mb/mb/image_rail.py
+++ b/mb/mb/image_rail.py
@@ -5,8 +5,11 @@ from __future__ import annotations
 import base64
 import importlib
 import importlib.util
+import json
 import os
 import struct
+import urllib.request
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Literal
@@ -22,6 +25,10 @@ DEFAULT_MODEL_SNAPSHOT = "gpt-image-2-2026-04-21"
 DEFAULT_SIZE = "1024x1536"
 DEFAULT_QUALITY = "medium"
 DEFAULT_TIMEOUT_SECONDS = 60
+DEFAULT_FAL_PUSH_SLUG = "2026-06-10-fal-image-rail-smoke"
+DEFAULT_FAL_ASSET_ID = "fake-fal-image-001"
+DEFAULT_FAL_MODEL = "fal-ai/flux/dev"
+DEFAULT_FAL_QUALITY = "default"
 DEFAULT_PROMPT = """\
 Create a fixture-safe Facebook feed image-ad base for a fictional business
 operating system called Northstar Ledger. Visualize the customer phrase
@@ -119,6 +126,94 @@ PLACEMENT_PRESETS: dict[str, dict[str, Any]] = {
 SmokeState = Literal["generated", "blocked"]
 
 
+@dataclass(frozen=True)
+class ImageProvider:
+    """Image rail provider registry entry.
+
+    Provider selection is explicit: each smoke surface names exactly one
+    provider id, and ``openai`` stays the default rail. Local credential
+    presence (for example ``FAL_KEY``) never auto-selects a provider.
+    ``blocker_fn`` and ``generate_fn`` name module attributes so tests can
+    patch the same seams the OpenAI rail already exposes.
+    """
+
+    id: str
+    name: str
+    model: str
+    model_snapshot: str | None
+    size: str
+    quality: str
+    endpoint: str
+    credential_env: str
+    credential_ref: str
+    default_push_slug: str
+    default_asset_id: str
+    index_lede: str
+    failure_hint: str
+    blocker_fn: str
+    generate_fn: str
+
+
+IMAGE_PROVIDERS: dict[str, ImageProvider] = {
+    "openai": ImageProvider(
+        id="openai",
+        name="OpenAI",
+        model=DEFAULT_MODEL,
+        model_snapshot=DEFAULT_MODEL_SNAPSHOT,
+        size=DEFAULT_SIZE,
+        quality=DEFAULT_QUALITY,
+        endpoint="v1/images/generations",
+        credential_env="OPENAI_API_KEY",
+        credential_ref="openai:image-generation",
+        default_push_slug=DEFAULT_PUSH_SLUG,
+        default_asset_id=DEFAULT_ASSET_ID,
+        index_lede="the first narrow OpenAI image rail",
+        failure_hint=(
+            "Check the local provider account, organization verification, quota, "
+            "model access, and network state."
+        ),
+        blocker_fn="_provider_blocker",
+        generate_fn="_generate_openai_image",
+    ),
+    "fal": ImageProvider(
+        id="fal",
+        name="fal.ai",
+        model=DEFAULT_FAL_MODEL,
+        model_snapshot=None,
+        size=DEFAULT_SIZE,
+        quality=DEFAULT_FAL_QUALITY,
+        endpoint="fal.run/fal-ai/flux/dev",
+        credential_env="FAL_KEY",
+        credential_ref="fal:image-generation",
+        default_push_slug=DEFAULT_FAL_PUSH_SLUG,
+        default_asset_id=DEFAULT_FAL_ASSET_ID,
+        index_lede="the narrow fal.ai FLUX image rail",
+        failure_hint=("Check the local fal.ai account, quota, model access, and network state."),
+        blocker_fn="_fal_provider_blocker",
+        generate_fn="_generate_fal_image",
+    ),
+}
+
+
+def image_provider(provider_id: str) -> ImageProvider:
+    """Return the explicitly selected provider spec; unknown ids fail loudly."""
+
+    spec = IMAGE_PROVIDERS.get(provider_id)
+    if spec is None:
+        known = ", ".join(sorted(IMAGE_PROVIDERS))
+        raise ValueError(
+            f"Unknown image provider {provider_id!r}. Configured providers: {known}. "
+            "Provider selection is explicit; local credentials never auto-select a provider."
+        )
+    return spec
+
+
+def _provider_fn(name: str) -> Any:
+    """Resolve a provider hook through module globals so test patches apply."""
+
+    return globals()[name]
+
+
 def _utc_now() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
 
@@ -196,6 +291,63 @@ def _generate_openai_image(prompt: str, *, model: str, size: str, quality: str) 
     if not encoded:
         raise RuntimeError("OpenAI image response did not include b64_json output")
     return base64.b64decode(encoded)
+
+
+def _fal_provider_blocker(generate: bool) -> tuple[str, str]:
+    if not generate:
+        return (
+            "generation_not_approved",
+            (
+                "Provider generation was not requested. Re-run with --generate only after "
+                "the operator approves the provider call and local credential boundary."
+            ),
+        )
+    if not os.environ.get("FAL_KEY"):
+        return (
+            "missing_fal_key",
+            (
+                "FAL_KEY is not set in the local runtime. Do not paste provider "
+                "keys into chat or committed repo files."
+            ),
+        )
+    return "", ""
+
+
+def _generate_fal_image(prompt: str, *, model: str, size: str, quality: str) -> bytes:
+    del quality  # fal FLUX endpoints tune steps/guidance, not an OpenAI-style quality knob.
+    width_text, _, height_text = size.partition("x")
+    request_body = json.dumps(
+        {
+            "prompt": prompt,
+            "image_size": {"width": int(width_text), "height": int(height_text)},
+            "num_images": 1,
+            "output_format": "png",
+        }
+    ).encode("utf-8")
+    request = urllib.request.Request(
+        f"https://fal.run/{model}",
+        data=request_body,
+        headers={
+            "Authorization": f"Key {os.environ['FAL_KEY']}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=DEFAULT_TIMEOUT_SECONDS) as response:
+        payload = json.loads(response.read().decode("utf-8"))
+    images = payload.get("images") if isinstance(payload, dict) else None
+    image_url = ""
+    if isinstance(images, list) and images and isinstance(images[0], dict):
+        image_url = str(images[0].get("url") or "")
+    if not image_url:
+        raise RuntimeError("fal.ai image response did not include an image url")
+    if image_url.startswith("data:"):
+        _, _, encoded = image_url.partition(",")
+        return base64.b64decode(encoded)
+    if not image_url.startswith("https://"):
+        raise RuntimeError("fal.ai image response returned a non-https image url")
+    with urllib.request.urlopen(image_url, timeout=DEFAULT_TIMEOUT_SECONDS) as image_response:
+        return bytes(image_response.read())
 
 
 def _png_dimensions(image_bytes: bytes) -> dict[str, int] | None:
@@ -1731,6 +1883,7 @@ def _candidate_score(concept: dict[str, Any]) -> int:
 
 def _visual_calibration_result(
     *,
+    spec: ImageProvider,
     concepts: list[dict[str, Any]],
     assets: list[dict[str, Any]],
     generated_count: int,
@@ -1774,8 +1927,8 @@ def _visual_calibration_result(
     return {
         "state": state,
         "generated_count": generated_count,
-        "provider": "openai",
-        "model": DEFAULT_MODEL,
+        "provider": spec.id,
+        "model": spec.model,
         "binary_committed": False,
         "review_board_written": True,
         "review_board_path": review_board_path,
@@ -1795,6 +1948,7 @@ def _visual_calibration_result(
 
 def _dashboard_readiness(
     *,
+    spec: ImageProvider,
     push_slug: str,
     ad_readiness: dict[str, Any],
     image_generation_gate: dict[str, Any],
@@ -1823,9 +1977,9 @@ def _dashboard_readiness(
     if int(visual_calibration.get("generated_count") or 0) == 0:
         next_actions.extend(
             [
-                "confirm_openai_image_credential_state",
+                f"confirm_{spec.id}_image_credential_state",
                 "get_operator_approval_for_live_provider_call",
-                "rerun_smoke_openai_with_generate",
+                f"rerun_smoke_{spec.id}_with_generate",
             ]
         )
     elif visual_calibration.get("all_rejected") is True:
@@ -1884,8 +2038,8 @@ def _dashboard_readiness(
             "next_actions": "dashboard_readiness.next_actions",
         },
         "provider_readiness": {
-            "provider": "openai",
-            "model": DEFAULT_MODEL,
+            "provider": spec.id,
+            "model": spec.model,
             "credential_states": credential_states,
             "blocker_codes": blocker_codes,
             "required_before_generation": image_generation_gate[
@@ -1908,6 +2062,7 @@ def _dashboard_readiness(
 
 def _asset_record(
     *,
+    spec: ImageProvider,
     push_slug: str,
     asset_id: str,
     concept_id: str,
@@ -1929,15 +2084,15 @@ def _asset_record(
         "asset_id": asset_id,
         "concept_id": concept_id,
         "rail": "provider",
-        "provider": "openai",
+        "provider": spec.id,
         "model": model,
-        "model_snapshot": DEFAULT_MODEL_SNAPSHOT,
-        "endpoint": "v1/images/generations",
+        "model_snapshot": spec.model_snapshot,
+        "endpoint": spec.endpoint,
         "docs_checked": docs_checked,
         "state": state,
         "blocker_code": blocker_code or None,
         "blocker": blocker or None,
-        "credential_ref": "openai:image-generation",
+        "credential_ref": spec.credential_ref,
         "credential_state": credential_state,
         "prompt_key": prompt_key,
         "prompt": prompt.strip(),
@@ -1990,7 +2145,7 @@ def _asset_record(
         "safe_to_share": True,
         "generated_at": generated_at,
         "operator_notes": (
-            "Fixture-safe OpenAI image rail smoke. Commit this record only; keep any "
+            f"Fixture-safe {spec.name} image rail smoke. Commit this record only; keep any "
             "generated binary in configured private media storage."
         ),
     }
@@ -2054,11 +2209,11 @@ def _render_review_board(
     return "\n".join(lines) + "\n"
 
 
-def _render_index(record: dict[str, Any]) -> str:
+def _render_index(record: dict[str, Any], *, spec: ImageProvider) -> str:
     yaml_text = yaml.safe_dump(record, sort_keys=False, allow_unicode=False)
     return (
-        "# Image Index - OpenAI Image Rail Smoke\n\n"
-        "This fixture-safe record proves the first narrow OpenAI image rail "
+        f"# Image Index - {spec.name} Image Rail Smoke\n\n"
+        f"This fixture-safe record proves {spec.index_lede} "
         "with reviewable Facebook image-ad concepts, safe logical media "
         "references, and no generated binaries, secrets, private paths, or "
         "provider request credentials committed.\n\n"
@@ -2068,15 +2223,16 @@ def _render_index(record: dict[str, Any]) -> str:
     )
 
 
-def smoke_openai(
+def _smoke_image_provider(
+    spec: ImageProvider,
     *,
     repo: str,
-    push_slug: str = DEFAULT_PUSH_SLUG,
+    push_slug: str,
     docs_checked: str,
     media_root: str = ".mb/media",
     generate: bool = False,
 ) -> dict[str, Any]:
-    """Run or block the narrow OpenAI image rail smoke and write an asset record."""
+    """Run or block one explicitly selected image rail smoke and write an asset record."""
 
     repo_path = Path(repo).resolve()
     push_dir = repo_path / "pushes" / push_slug
@@ -2085,8 +2241,8 @@ def smoke_openai(
     index_path = push_dir / "image-index.md"
     generated_at = _utc_now()
 
-    blocker_code, blocker = _provider_blocker(generate)
-    credential_state = "configured_env" if os.environ.get("OPENAI_API_KEY") else "missing_env"
+    blocker_code, blocker = _provider_fn(spec.blocker_fn)(generate)
+    credential_state = "configured_env" if os.environ.get(spec.credential_env) else "missing_env"
     default_state: SmokeState = "blocked" if blocker_code else "generated"
 
     concepts = fixture_facebook_image_concepts(push_slug)
@@ -2096,7 +2252,7 @@ def smoke_openai(
     generated_dimensions: dict[str, int] | None = None
     for index, concept in enumerate(concepts, start=1):
         concept_id = str(concept.get("concept_id") or f"candidate-{index:03d}")
-        asset_id = DEFAULT_ASSET_ID if index == 1 else f"{concept_id}-001"
+        asset_id = spec.default_asset_id if index == 1 else f"{concept_id}-001"
         output_reference = _logical_output(push_slug, asset_id)
         concept_state = default_state
         concept_blocker_code = blocker_code
@@ -2106,19 +2262,18 @@ def smoke_openai(
             out_path = _media_path(repo_path, media_root, push_slug, asset_id)
             out_path.parent.mkdir(parents=True, exist_ok=True)
             try:
-                image_bytes = _generate_openai_image(
+                image_bytes = _provider_fn(spec.generate_fn)(
                     str(concept.get("prompt") or DEFAULT_PROMPT),
-                    model=DEFAULT_MODEL,
-                    size=DEFAULT_SIZE,
-                    quality=DEFAULT_QUALITY,
+                    model=spec.model,
+                    size=spec.size,
+                    quality=spec.quality,
                 )
             except Exception as exc:  # noqa: BLE001 - provider errors must become sanitized records.
                 concept_state = "blocked"
                 concept_blocker_code = "provider_request_failed"
                 concept_blocker = (
-                    f"OpenAI image generation failed before a usable image was written "
-                    f"({exc.__class__.__name__}). Check the local provider account, "
-                    f"organization verification, quota, model access, and network state."
+                    f"{spec.name} image generation failed before a usable image was written "
+                    f"({exc.__class__.__name__}). {spec.failure_hint}"
                 )
             else:
                 concept_dimensions = _png_dimensions(image_bytes)
@@ -2128,6 +2283,7 @@ def smoke_openai(
                 binary_written_count += 1
         asset_records.append(
             _asset_record(
+                spec=spec,
                 push_slug=push_slug,
                 asset_id=asset_id,
                 concept_id=concept_id,
@@ -2140,9 +2296,9 @@ def smoke_openai(
                 output_reference=output_reference,
                 prompt=str(concept.get("prompt") or DEFAULT_PROMPT),
                 prompt_key=str(concept.get("prompt_key") or DEFAULT_PROMPT_KEY),
-                model=DEFAULT_MODEL,
-                size=DEFAULT_SIZE,
-                quality=DEFAULT_QUALITY,
+                model=spec.model,
+                size=spec.size,
+                quality=spec.quality,
                 generated_dimensions=concept_dimensions,
             )
         )
@@ -2164,6 +2320,7 @@ def smoke_openai(
         encoding="utf-8",
     )
     visual_calibration = _visual_calibration_result(
+        spec=spec,
         concepts=concepts,
         assets=asset_records,
         generated_count=generated_count,
@@ -2172,6 +2329,7 @@ def smoke_openai(
     ad_readiness = _ad_readiness_gate()
     image_generation_gate = _image_generation_gate()
     dashboard_readiness = _dashboard_readiness(
+        spec=spec,
         push_slug=push_slug,
         ad_readiness=ad_readiness,
         image_generation_gate=image_generation_gate,
@@ -2222,15 +2380,15 @@ def smoke_openai(
         "concepts": concepts,
         "assets": asset_records,
     }
-    index_path.write_text(_render_index(record), encoding="utf-8")
+    index_path.write_text(_render_index(record, spec=spec), encoding="utf-8")
     result_blocker_code = blocker_code or None
     if state == "blocked" and result_blocker_code is None and asset_records:
         result_blocker_code = asset_records[0].get("blocker_code")
 
     return {
         "ok": True,
-        "provider": "openai",
-        "model": DEFAULT_MODEL,
+        "provider": spec.id,
+        "model": spec.model,
         "state": state,
         "blocker_code": result_blocker_code,
         "candidate_count": len(concepts),
@@ -2244,17 +2402,17 @@ def smoke_openai(
         "record_path": _repo_relative(index_path, repo_path),
         "review_board_written": True,
         "review_board_path": review_board_ref,
-        "output_reference": _logical_output(push_slug, DEFAULT_ASSET_ID),
+        "output_reference": _logical_output(push_slug, spec.default_asset_id),
         "storage_backend": "mb-media",
         "dimensions": {
-            "requested_size": DEFAULT_SIZE,
+            "requested_size": spec.size,
             "requested_aspect_ratio": "2:3",
             "placement": "facebook_feed_portrait_4x5",
             "placement_aspect_ratio": PLACEMENT_PRESETS["facebook_feed_portrait_4x5"][
                 "aspect_ratio"
             ],
             "format": "png",
-            "quality": DEFAULT_QUALITY,
+            "quality": spec.quality,
         },
         "generated_dimensions": generated_dimensions,
         "binary_written": binary_written_count > 0,
@@ -2263,3 +2421,43 @@ def smoke_openai(
         "safe_to_share": True,
         "docs_checked": docs_checked,
     }
+
+
+def smoke_openai(
+    *,
+    repo: str,
+    push_slug: str = DEFAULT_PUSH_SLUG,
+    docs_checked: str,
+    media_root: str = ".mb/media",
+    generate: bool = False,
+) -> dict[str, Any]:
+    """Run or block the narrow OpenAI image rail smoke and write an asset record."""
+
+    return _smoke_image_provider(
+        image_provider("openai"),
+        repo=repo,
+        push_slug=push_slug,
+        docs_checked=docs_checked,
+        media_root=media_root,
+        generate=generate,
+    )
+
+
+def smoke_fal(
+    *,
+    repo: str,
+    push_slug: str = DEFAULT_FAL_PUSH_SLUG,
+    docs_checked: str,
+    media_root: str = ".mb/media",
+    generate: bool = False,
+) -> dict[str, Any]:
+    """Run or block the narrow fal.ai FLUX image rail smoke and write an asset record."""
+
+    return _smoke_image_provider(
+        image_provider("fal"),
+        repo=repo,
+        push_slug=push_slug,
+        docs_checked=docs_checked,
+        media_root=media_root,
+        generate=generate,
+    )

--- a/mb/mb/image_rail.py
+++ b/mb/mb/image_rail.py
@@ -8,6 +8,7 @@ import importlib.util
 import json
 import os
 import struct
+import urllib.error
 import urllib.request
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -315,6 +316,9 @@ def _fal_provider_blocker(generate: bool) -> tuple[str, str]:
 
 def _generate_fal_image(prompt: str, *, model: str, size: str, quality: str) -> bytes:
     del quality  # fal FLUX endpoints tune steps/guidance, not an OpenAI-style quality knob.
+    fal_key = os.environ.get("FAL_KEY", "")
+    if not fal_key:
+        raise RuntimeError("FAL_KEY is not set in the local runtime")
     width_text, _, height_text = size.partition("x")
     request_body = json.dumps(
         {
@@ -328,13 +332,18 @@ def _generate_fal_image(prompt: str, *, model: str, size: str, quality: str) -> 
         f"https://fal.run/{model}",
         data=request_body,
         headers={
-            "Authorization": f"Key {os.environ['FAL_KEY']}",
+            "Authorization": f"Key {fal_key}",
             "Content-Type": "application/json",
         },
         method="POST",
     )
-    with urllib.request.urlopen(request, timeout=DEFAULT_TIMEOUT_SECONDS) as response:
-        payload = json.loads(response.read().decode("utf-8"))
+    try:
+        with urllib.request.urlopen(request, timeout=DEFAULT_TIMEOUT_SECONDS) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        # `from None` drops the HTTPError, whose response body may echo
+        # request details; only the status code may reach logs or records.
+        raise RuntimeError(f"fal.ai request failed with HTTP {exc.code}") from None
     images = payload.get("images") if isinstance(payload, dict) else None
     image_url = ""
     if isinstance(images, list) and images and isinstance(images[0], dict):
@@ -346,8 +355,11 @@ def _generate_fal_image(prompt: str, *, model: str, size: str, quality: str) -> 
         return base64.b64decode(encoded)
     if not image_url.startswith("https://"):
         raise RuntimeError("fal.ai image response returned a non-https image url")
-    with urllib.request.urlopen(image_url, timeout=DEFAULT_TIMEOUT_SECONDS) as image_response:
-        return bytes(image_response.read())
+    try:
+        with urllib.request.urlopen(image_url, timeout=DEFAULT_TIMEOUT_SECONDS) as image_response:
+            return bytes(image_response.read())
+    except urllib.error.HTTPError as exc:
+        raise RuntimeError(f"fal.ai image download failed with HTTP {exc.code}") from None
 
 
 def _png_dimensions(image_bytes: bytes) -> dict[str, int] | None:

--- a/mb/tests/test_image_rail.py
+++ b/mb/tests/test_image_rail.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import base64
 import json
 from pathlib import Path
 from typing import Any, cast
 
+import pytest
 import yaml
 from typer.testing import CliRunner
 
@@ -438,6 +440,295 @@ def test_openai_image_smoke_provider_failure_writes_sanitized_blocker(
     assert "RuntimeError" in text
     assert "secret-bearing provider details" not in text
     assert "test-key-not-written" not in text
+
+
+def test_fal_image_smoke_writes_safe_blocked_record(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.delenv("FAL_KEY", raising=False)
+    repo = tmp_path / "biz"
+    repo.mkdir()
+
+    result = runner.invoke(
+        app,
+        [
+            "image",
+            "smoke-fal",
+            "--repo",
+            str(repo),
+            "--push-slug",
+            "2026-06-10-fake-fal-smoke",
+            "--docs-checked",
+            "2026-06-10",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["provider"] == "fal"
+    assert payload["model"] == "fal-ai/flux/dev"
+    assert payload["state"] == "blocked"
+    assert payload["blocker_code"] == "generation_not_approved"
+    assert payload["candidate_count"] == 9
+    assert payload["generated_count"] == 0
+    assert payload["output_record_written"] is True
+    assert payload["review_board_written"] is True
+    assert payload["binary_committed"] is False
+
+    index_path = repo / "pushes" / "2026-06-10-fake-fal-smoke" / "image-index.md"
+    record = _record_from_index(index_path)
+    asset = record["assets"][0]
+
+    assert record["schema"] == "mainbranch.image_index.v0"
+    assert record["visual_calibration_result"]["provider"] == "fal"
+    assert record["visual_calibration_result"]["model"] == "fal-ai/flux/dev"
+    assert record["dashboard_readiness"]["provider_readiness"]["provider"] == "fal"
+    assert "confirm_fal_image_credential_state" in record["dashboard_readiness"]["next_actions"]
+    assert "rerun_smoke_fal_with_generate" in record["dashboard_readiness"]["next_actions"]
+    assert asset["provider"] == "fal"
+    assert asset["model"] == "fal-ai/flux/dev"
+    assert asset["model_snapshot"] is None
+    assert asset["endpoint"] == "fal.run/fal-ai/flux/dev"
+    assert asset["credential_ref"] == "fal:image-generation"
+    assert asset["credential_state"] == "missing_env"
+    assert asset["asset_id"] == image_rail_mod.DEFAULT_FAL_ASSET_ID
+
+    text = index_path.read_text(encoding="utf-8")
+    assert "# Image Index - fal.ai Image Rail Smoke" in text
+    assert str(tmp_path) not in text
+    assert "FAL_KEY=" not in text
+    assert not list((repo / ".mb" / "media").rglob("*.png"))
+
+
+def test_fal_image_smoke_generate_without_key_blocks_cleanly(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.delenv("FAL_KEY", raising=False)
+    repo = tmp_path / "biz"
+    repo.mkdir()
+
+    result = runner.invoke(
+        app,
+        [
+            "image",
+            "smoke-fal",
+            "--repo",
+            str(repo),
+            "--push-slug",
+            "2026-06-10-fake-fal-smoke",
+            "--docs-checked",
+            "2026-06-10",
+            "--generate",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["state"] == "blocked"
+    assert payload["blocker_code"] == "missing_fal_key"
+    assert payload["generated_count"] == 0
+
+    index_path = repo / "pushes" / "2026-06-10-fake-fal-smoke" / "image-index.md"
+    record = _record_from_index(index_path)
+    asset = record["assets"][0]
+    assert asset["blocker_code"] == "missing_fal_key"
+    assert "Do not paste provider keys" in asset["blocker"]
+
+
+def test_fal_image_smoke_generated_path_keeps_binary_in_media_cache(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    repo = tmp_path / "biz"
+    repo.mkdir()
+    monkeypatch.setenv("FAL_KEY", "test-fal-key-not-written")
+    monkeypatch.setattr(image_rail_mod, "_fal_provider_blocker", lambda generate: ("", ""))
+    monkeypatch.setattr(
+        image_rail_mod,
+        "_generate_fal_image",
+        lambda prompt, *, model, size, quality: (
+            b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x04\x00\x00\x00\x06\x00fake-png-tail"
+        ),
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "image",
+            "smoke-fal",
+            "--repo",
+            str(repo),
+            "--push-slug",
+            "2026-06-10-fake-fal-smoke",
+            "--docs-checked",
+            "2026-06-10",
+            "--generate",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["state"] == "generated"
+    assert payload["provider"] == "fal"
+    assert payload["candidate_count"] == 9
+    assert payload["generated_count"] == 9
+    assert payload["best_candidate"] == image_rail_mod.DEFAULT_FAL_ASSET_ID
+    assert payload["generated_dimensions"] == {"width": 1024, "height": 1536}
+    assert payload["binary_written"] is True
+    assert payload["binary_committed"] is False
+
+    media_path = (
+        repo
+        / ".mb"
+        / "media"
+        / "pushes"
+        / "2026-06-10-fake-fal-smoke"
+        / "images"
+        / "fake-fal-image-001.png"
+    )
+    assert media_path.read_bytes().startswith(b"\x89PNG\r\n\x1a\n")
+
+    index_path = repo / "pushes" / "2026-06-10-fake-fal-smoke" / "image-index.md"
+    record = _record_from_index(index_path)
+    assert all(asset["state"] == "generated" for asset in record["assets"])
+    text = index_path.read_text(encoding="utf-8")
+    assert str(media_path) not in text
+    assert "test-fal-key-not-written" not in text
+
+
+def test_fal_key_presence_does_not_auto_select_fal_provider(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv("FAL_KEY", "test-fal-key-not-written")
+    repo = tmp_path / "biz"
+    repo.mkdir()
+
+    result = runner.invoke(
+        app,
+        [
+            "image",
+            "smoke-openai",
+            "--repo",
+            str(repo),
+            "--push-slug",
+            "2026-05-13-fake-openai-smoke",
+            "--docs-checked",
+            "2026-06-10",
+            "--generate",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["provider"] == "openai"
+    assert payload["blocker_code"] == "missing_openai_api_key"
+
+
+def test_image_provider_factory_rejects_unknown_provider() -> None:
+    with pytest.raises(ValueError) as excinfo:
+        image_rail_mod.image_provider("midjourney")
+
+    message = str(excinfo.value)
+    assert "midjourney" in message
+    assert "fal" in message
+    assert "openai" in message
+    assert "explicit" in message
+
+
+def test_generate_fal_image_decodes_data_uri_response(monkeypatch) -> None:
+    monkeypatch.setenv("FAL_KEY", "test-fal-key-not-written")
+    png_bytes = b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x04\x00\x00\x00\x06\x00fake"
+    encoded = base64.b64encode(png_bytes).decode("ascii")
+    captured: dict[str, Any] = {}
+
+    class _FakeResponse:
+        def __init__(self, body: bytes) -> None:
+            self._body = body
+
+        def read(self) -> bytes:
+            return self._body
+
+        def __enter__(self) -> _FakeResponse:
+            return self
+
+        def __exit__(self, *exc_info: object) -> None:
+            return None
+
+    def fake_urlopen(request, timeout=None):
+        captured["request"] = request
+        captured["timeout"] = timeout
+        body = json.dumps({"images": [{"url": f"data:image/png;base64,{encoded}"}]})
+        return _FakeResponse(body.encode("utf-8"))
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    image_bytes = image_rail_mod._generate_fal_image(
+        "fixture-safe fal prompt",
+        model="fal-ai/flux/dev",
+        size="1024x1536",
+        quality="default",
+    )
+
+    assert image_bytes == png_bytes
+    request = captured["request"]
+    assert request.full_url == "https://fal.run/fal-ai/flux/dev"
+    assert request.get_header("Authorization") == "Key test-fal-key-not-written"
+    request_payload = json.loads(request.data.decode("utf-8"))
+    assert request_payload["prompt"] == "fixture-safe fal prompt"
+    assert request_payload["image_size"] == {"width": 1024, "height": 1536}
+    assert request_payload["num_images"] == 1
+
+
+def test_generate_fal_image_rejects_missing_or_insecure_image_url(monkeypatch) -> None:
+    monkeypatch.setenv("FAL_KEY", "test-fal-key-not-written")
+
+    class _FakeResponse:
+        def __init__(self, body: bytes) -> None:
+            self._body = body
+
+        def read(self) -> bytes:
+            return self._body
+
+        def __enter__(self) -> _FakeResponse:
+            return self
+
+        def __exit__(self, *exc_info: object) -> None:
+            return None
+
+    responses = iter(
+        [
+            json.dumps({"images": []}).encode("utf-8"),
+            json.dumps({"images": [{"url": "http://insecure.example/fake.png"}]}).encode("utf-8"),
+        ]
+    )
+
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda request, timeout=None: _FakeResponse(next(responses)),
+    )
+
+    with pytest.raises(RuntimeError, match="did not include an image url"):
+        image_rail_mod._generate_fal_image(
+            "fixture-safe fal prompt",
+            model="fal-ai/flux/dev",
+            size="1024x1536",
+            quality="default",
+        )
+    with pytest.raises(RuntimeError, match="non-https image url"):
+        image_rail_mod._generate_fal_image(
+            "fixture-safe fal prompt",
+            model="fal-ai/flux/dev",
+            size="1024x1536",
+            quality="default",
+        )
 
 
 def test_image_concept_review_catches_unsafe_fixture_case() -> None:


### PR DESCRIPTION
## What

Makes the fixture-safe image rail provider-pluggable. `image_rail.py` gains a small provider factory — a frozen `ImageProvider` registry entry plus an `IMAGE_PROVIDERS` map and `image_provider(provider_id)` lookup — with two entries:

- **`openai`** (default): the existing `gpt-image-2` rail, unchanged.
- **`fal`**: the fal.ai FLUX sync endpoint (`POST https://fal.run/fal-ai/flux/dev`, `Authorization: Key <FAL_KEY>`), exposed as a new `mb image smoke-fal` command mirroring `mb image smoke-openai`. Implemented over stdlib `urllib` — no new dependency.

## Explicit-selection doctrine

Provider selection is explicit config only. Each smoke surface names exactly one provider id and `openai` stays the default rail. The presence of a local `FAL_KEY` never auto-selects fal.ai — a test pins this (`test_fal_key_presence_does_not_auto_select_fal_provider`). The fal key is sourced environment-first (`FAL_KEY`), is never printed, and never lands in committed records; the asset record carries only safe metadata (`credential_ref: fal:image-generation`, `credential_state`), matching the credential boundary in `decisions/2026-05-13-creative-media-generation-rails.md`.

## Byte-compatible default

`smoke_openai` now delegates to the shared `_smoke_image_provider` core, and its output was verified byte-identical against pre-refactor golden captures (blocked-default, blocked-generate-without-key, and mocked-generated paths: result payload, `image-index.md`, review board, and media binaries all diff clean with a frozen timestamp). The existing test monkeypatch seams (`_provider_blocker`, `_generate_openai_image`) keep their exact signatures; the registry resolves hooks through module globals so patches still apply.

The concept-review / safety / placement logic is provider-agnostic and untouched — both rails run the same gates, review board, media-storage boundary, and committed `image-index.md` record.

## Test coverage

Extends `mb/tests/test_image_rail.py` with 7 fal tests in the existing fixture-safe pattern (no network, no real keys):

- blocked safe record without `FAL_KEY` and without `--generate`
- `--generate` without `FAL_KEY` blocks cleanly with `missing_fal_key` (the fal smoke "skips" safely when the key is unset)
- mocked generated path keeps binaries in the gitignored media cache and keeps the key out of committed records
- `FAL_KEY` presence does not auto-select fal on the openai surface
- unknown provider id fails loudly in the factory
- fal REST unit coverage: request URL/auth-header/body shape, data-URI decode, missing and non-https image-url rejection

Full gate: `ruff format --check`, `ruff check`, `mypy mb tests` (strict), and pytest all green for this change — 922 passed, coverage 84.43% (gate 79%). Two pre-existing failures (`test_link_skills_removes_legacy_project_symlink`, `test_status_relationship_health_flags_active_bet_and_offer_gaps`) reproduce identically on a clean `main` checkout in the same local environment and are unrelated to this change.

## Docs

- mb-ads provider-choice table and smoke surface docs now list the fal.ai rail as an explicitly selected alternative (SKILL.md stays exactly at the 500-line gate by rewriting in place).
- CHANGELOG `[Unreleased]` entry added.

## Deliberate non-goals

- No generic model router, no auto-selection, no `mb connect` provider state (per the creative-media-rails decision).
- No queue-based `queue.fal.run` flow — the simpler sync endpoint is the first smoked surface.
- No new Python dependency (no `fal-client`, no `requests`).
- No live-network test; the repo's test doctrine is fixture-safe smokes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)