### PR TITLE
test(status): fix time-dependent CI failure (overdue fixture bet displaces ranked action)

### DIFF
--- a/mb/tests/test_status.py
+++ b/mb/tests/test_status.py
@@ -1977,12 +1977,18 @@ def test_status_relationship_health_flags_active_bet_and_offer_gaps(
         "---\nslug: coaching\nstatus: running\n---\n\n# Coaching\n",
         encoding="utf-8",
     )
+    # Time-stable deadline (same convention as the brain-payload test below): the
+    # hardcoded 2026-05-31 deadline made this bet OVERDUE once real time passed it,
+    # and the overdue-bet action then outranked review_relationship_health out of
+    # the MAX_ACTIONS=3 cap — failing the ranked_actions assertion on every PR
+    # after that date. The bet must stay active-but-not-overdue forever.
+    deadline = date.today().replace(year=date.today().year + 1)
     (repo / "bets" / "2026-05-01-launch.md").write_text(
         (
             "---\n"
             "status: open\n"
             "opened: 2026-05-01\n"
-            "deadline: 2026-05-31\n"
+            f"deadline: {deadline.isoformat()}\n"
             "appetite: 2 weeks\n"
             "hypothesis: A launch push will create calls.\n"
             "metric: calls\n"


### PR DESCRIPTION
CI is red for ALL PRs since 2026-05-31: the relationship-health test's fixture bet deadline (2026-05-31) went overdue in real time, the overdue-bet action displaced review_relationship_health from the MAX_ACTIONS=3 ranked list, and the membership assertion fails. Main's green checks are just older runs. Fix: dynamic future deadline per the file's existing convention. Verified failing-on-clean-main today → passing with fix; full test_status.py 98 passed. Unblocks #821 and every queued PR.