### PR TITLE
feat(connect): mb connect token <provider> — scripted credential read path (#812)

### DIFF
--- a/LOOP-STATE.md
+++ b/LOOP-STATE.md
@@ -17,6 +17,33 @@ Canon (read on first iteration of a fresh session):
 - Check-in cadence: Devon reviews every few hours. Park anything ambiguous
   in **Flagged for Devon** instead of guessing.
 
+### Steering input — transcribed from Devon, 2026-06-11 chat (loop wrote this down verbatim-in-spirit; Devon may edit)
+
+- Bigger frame: we are revamping Main Branch from the learnings of three live
+  businesses — Booked Out Roofers, Awake Happy, The Morning Paper. Each runs
+  its own loop session; they feed engine improvements. Fix what feels
+  over-built, strengthen what the businesses proved.
+- **Audit (first-class ask):** audit the open PRs, the CI checks run on every
+  PR, and the post-release setup. The ideas are right; execution can be
+  strengthened, tapered, or better enforced. Loop has judgment latitude here.
+- **Session-log mining:** valuable Claude Code session logs live on this
+  machine — especially one week-long BOR session (idea → built business →
+  first leads). Mine them for engine signals. Subagents/workflows encouraged
+  for large scrapes.
+- **Plugin setup:** research and decide the right Claude Code + Codex plugin
+  setup (a known hole); loop does the research and makes the call for Devon.
+- **Setup revamp:** first-run setup should be "copy-paste this one prompt"
+  (modeled on the Morning Paper install): tell the user to pick strongest
+  settings (Claude: Fable 1M + extra reasoning; Codex: 5.5 + extra
+  reasoning), then paste one prompt that explains Main Branch, opens the
+  files, and teaches CLI/skills/primitives/GitHub from first principles.
+  Loop to evaluate ("steal it or tell me").
+- **Validated primitives:** Cloudflare, Resend, Apify are proven. Consider
+  redoing/integrating impeccable + Corey's marketing skills with ours.
+- Permissions granted: read keychain to understand provider state (never
+  print a token), look at Facebook/Google ads, Cloudflare, fal.ai
+  CLIs/MCPs; use subagents and workflows freely.
+
 ## Priority order (from the 2026-06-11 decision)
 
 1. **#812 `mb connect token <provider>`** — smallest slice; unblocks every
@@ -49,13 +76,33 @@ Canon (read on first iteration of a fresh session):
 ## Flagged for Devon
 
 - (10 open questions live in the 2026-06-11 decision; loop appends new ones here)
+- Open PRs #801, #802, #809, #810, #811 all fail Python CI on runs dated
+  before the #822 time-dependent-test fix merged; likely fixed by rebasing
+  onto main. #809/#810/#811 are your feature branches — want the loop to
+  rebase + babysit them, or leave them to you?
+- `tests/test_engine.py::test_link_skills_removes_legacy_project_symlink`
+  fails on this machine even on clean main (passes in CI) — environment-
+  specific symlink behavior; possibly related territory to #804 worktree
+  skills bug. Loop will look at it alongside #804 unless told otherwise.
+- Priority order after the 2026-06-11 chat steering: loop is treating the
+  audit (PRs/CI/post-release) + session-log-mining as the next slices ahead
+  of #804, since Devon called the audit "first-class." Confirm or reorder.
 
 ## Shipped
 
 - 2026-06-11: decision merged (noontide#173); issues #812–#820 filed; spine
   send-truth (bookedoutroofers#99) + privacy chat disclosure (#98) live;
   unattended-cron allow rules set in ~/.claude/settings.json.
+- 2026-06-11: LOOP-STATE seed merged (#821). 15-min loop live on this machine.
+- 2026-06-11: #812 `mb connect token <provider>` — scripted credential read
+  path (stdout-only token, stderr errors, repo→user-scope fallback, --json
+  rejected as pipe-unsafe). This PR.
 
 ## Next intent
 
-- Spec + implement #812 `mb connect token` as the first PR.
+- Audit pass per 2026-06-11 chat steering: (a) inventory CI checks + branch
+  protection + post-release automation and propose strengthen/taper changes;
+  (b) inventory Claude Code session logs on this machine and plan the BOR
+  week-long-session mining (workflow fan-out). Then #804 worktree skills bug.
+- Migrate the BOR daily-brief keychain block to `mb connect token` once #812
+  ships in a release (read-only change in the bookedoutroofers repo).

--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -1070,7 +1070,10 @@ def issue_open_cmd(
 def connect_cmd(
     target: str = typer.Argument(
         "",
-        help="Provider to connect, or `list` / `plan` / `status` / `doctor` / `test` / `hydrate`.",
+        help=(
+            "Provider to connect, or `list` / `plan` / `status` / `doctor` / `test` / "
+            "`token` / `hydrate`."
+        ),
     ),
     provider: str = typer.Argument(
         "",
@@ -1170,6 +1173,31 @@ def connect_cmd(
         else:
             connect_mod.render_hydrate_result(result)
         raise typer.Exit(0 if result["ok"] else 1)
+    if target == "token":
+        if not provider:
+            typer.echo("mb connect token: provider required", err=True)
+            raise typer.Exit(2)
+        if json_out:
+            typer.echo(
+                "mb connect token: --json is not supported; the token is printed raw to stdout",
+                err=True,
+            )
+            raise typer.Exit(2)
+        try:
+            result = connect_mod.read_token(provider, repo)
+        except ValueError as exc:
+            typer.echo(f"mb connect token: {exc}", err=True)
+            raise typer.Exit(2) from exc
+        except connect_mod.ConfigBoundaryError as exc:
+            _connect_boundary_exit("mb connect token", exc)
+        if not result["ok"]:
+            typer.echo(f"mb connect token: {result['error']}", err=True)
+            if result["repair_command"]:
+                typer.echo(f"repair: {result['repair_command']}", err=True)
+            raise typer.Exit(1)
+        # The token is the entire stdout contract; nothing else may print here.
+        typer.echo(result["token"])
+        raise typer.Exit(0)
     if target == "test":
         if not provider:
             typer.echo("mb connect test: provider required", err=True)

--- a/mb/mb/connect.py
+++ b/mb/mb/connect.py
@@ -1282,16 +1282,72 @@ def hydrate(
     }
 
 
-def _stored_secret(provider: Provider, entry: dict[str, Any]) -> str:
+def _entry_secret_value(entry: dict[str, Any], field: str) -> str:
     stored_secrets = entry.get("secrets") if isinstance(entry.get("secrets"), dict) else {}
-    if not provider.required_secrets:
-        return ""
-    primary = provider.required_secrets[0]
-    raw = stored_secrets.get(primary) if isinstance(stored_secrets, dict) else None
+    raw = stored_secrets.get(field) if isinstance(stored_secrets, dict) else None
     raw = raw if isinstance(raw, dict) else {}
     ref = str(raw.get("ref") or "")
     backend = str(raw.get("backend") or "local-file")
     return SecretStore(backend).get(ref) if ref else ""
+
+
+def _stored_secret(provider: Provider, entry: dict[str, Any]) -> str:
+    if not provider.required_secrets:
+        return ""
+    return _entry_secret_value(entry, provider.required_secrets[0])
+
+
+def read_token(provider_id: str, repo: str | Path = ".") -> dict[str, Any]:
+    """Resolve the stored primary credential for scripted consumers.
+
+    The returned ``token`` exists to be written to stdout exactly once;
+    callers must never log it, persist it, or embed it in shareable output.
+    Falls back to user scope when the repo config has no entry, so worktrees
+    and scheduled tasks resolve the same credential as the primary checkout.
+    """
+    provider = normalize_provider(provider_id)
+    if not provider.required_secrets:
+        raise ValueError(f"provider {provider.id!r} stores no secrets")
+    field = provider.required_secrets[0]
+    target = Path(repo).resolve()
+    config = _read_config(target)
+    identity = _repo_identity(target)
+    repo_id = str(config.get("repo_id") or identity["repo_id"])
+    entry = config["providers"].get(provider.id)
+    source = "repo"
+    if not isinstance(entry, dict):
+        entry = _user_scope_provider_entry(repo_id, provider.id)
+        source = "user"
+    if not isinstance(entry, dict):
+        return {
+            "ok": False,
+            "provider": provider.id,
+            "field": field,
+            "source": "",
+            "token": "",
+            "error": f"{provider.name} is not connected",
+            "repair_command": f"mb connect {provider.id} --token-stdin",
+        }
+    token = _entry_secret_value(entry, field)
+    if not token:
+        return {
+            "ok": False,
+            "provider": provider.id,
+            "field": field,
+            "source": source,
+            "token": "",
+            "error": f"{provider.name} credential is missing or unreadable from the secret store",
+            "repair_command": f"mb connect {provider.id} --token-stdin",
+        }
+    return {
+        "ok": True,
+        "provider": provider.id,
+        "field": field,
+        "source": source,
+        "token": token,
+        "error": "",
+        "repair_command": "",
+    }
 
 
 def _provider_error_summary(provider_name: str, upstream: dict[str, Any]) -> str:

--- a/mb/tests/test_connect.py
+++ b/mb/tests/test_connect.py
@@ -1565,3 +1565,87 @@ def test_macos_keychain_backend_uses_security(monkeypatch) -> None:
     assert calls
     assert calls[0][:3] == ["security", "add-generic-password", "-a"]
     assert "cf-token" in calls[0]
+
+
+def test_connect_token_prints_secret_to_stdout(tmp_path: Path, monkeypatch) -> None:
+    _local_secret_env(monkeypatch, tmp_path)
+    repo = tmp_path / "biz"
+    repo.mkdir()
+    connect_mod.connect_provider("cloudflare", repo=repo, token="cf-test-token")
+
+    result = runner.invoke(app, ["connect", "token", "cloudflare", "--repo", str(repo)])
+
+    assert result.exit_code == 0
+    assert result.stdout == "cf-test-token\n"
+
+
+def test_connect_token_falls_back_to_user_scope(tmp_path: Path, monkeypatch) -> None:
+    _local_secret_env(monkeypatch, tmp_path)
+    repo = tmp_path / "biz"
+    repo.mkdir()
+    connect_mod.connect_provider("cloudflare", repo=repo, token="cf-user-token", scope="user")
+    (repo / ".mb" / "connect.yaml").unlink()
+
+    result = runner.invoke(app, ["connect", "token", "cloudflare", "--repo", str(repo)])
+
+    assert result.exit_code == 0
+    assert result.stdout == "cf-user-token\n"
+
+
+def test_connect_token_not_connected_fails(tmp_path: Path, monkeypatch) -> None:
+    _local_secret_env(monkeypatch, tmp_path)
+    repo = tmp_path / "biz"
+    repo.mkdir()
+
+    result = runner.invoke(app, ["connect", "token", "cloudflare", "--repo", str(repo)])
+
+    assert result.exit_code == 1
+    assert result.stdout == ""
+    assert "not connected" in result.stderr
+    assert "mb connect cloudflare --token-stdin" in result.stderr
+
+
+def test_connect_token_missing_stored_secret_fails(tmp_path: Path, monkeypatch) -> None:
+    _local_secret_env(monkeypatch, tmp_path)
+    repo = tmp_path / "biz"
+    repo.mkdir()
+    connect_mod.connect_provider("cloudflare", repo=repo)
+
+    result = runner.invoke(app, ["connect", "token", "cloudflare", "--repo", str(repo)])
+
+    assert result.exit_code == 1
+    assert result.stdout == ""
+    assert "missing or unreadable" in result.stderr
+
+
+def test_connect_token_requires_provider(tmp_path: Path, monkeypatch) -> None:
+    _local_secret_env(monkeypatch, tmp_path)
+
+    result = runner.invoke(app, ["connect", "token"])
+
+    assert result.exit_code == 2
+    assert "provider required" in result.stderr
+
+
+def test_connect_token_rejects_json(tmp_path: Path, monkeypatch) -> None:
+    _local_secret_env(monkeypatch, tmp_path)
+    repo = tmp_path / "biz"
+    repo.mkdir()
+    connect_mod.connect_provider("cloudflare", repo=repo, token="cf-test-token")
+
+    result = runner.invoke(app, ["connect", "token", "cloudflare", "--repo", str(repo), "--json"])
+
+    assert result.exit_code == 2
+    assert result.stdout == ""
+    assert "--json is not supported" in result.stderr
+
+
+def test_connect_token_rejects_secretless_provider(tmp_path: Path, monkeypatch) -> None:
+    _local_secret_env(monkeypatch, tmp_path)
+    repo = tmp_path / "biz"
+    repo.mkdir()
+
+    result = runner.invoke(app, ["connect", "token", "hledger", "--repo", str(repo)])
+
+    assert result.exit_code == 2
+    assert "stores no secrets" in result.stderr


### PR DESCRIPTION
## What

Adds `mb connect token <provider>`: the scripted credential READ path from #812.

- Token printed to **stdout only** — nothing else ever lands on stdout, so `TOKEN=$(mb connect token cloudflare)` is safe.
- Errors + repair hints go to stderr. Exit 1 = not connected / secret unreadable; exit 2 = usage error (missing provider, secretless provider, `--json`).
- `--json` is explicitly rejected: wrapping the token in JSON would invite logging it; the raw-stdout contract is the pipe-safety guarantee.
- Resolution order matches `mb connect status`: repo `.mb/connect.yaml` first, then user-scope fallback — so worktrees and scheduled tasks resolve the same credential as the primary checkout.
- `_stored_secret` refactored to share `_entry_secret_value` with the new path. No behavior change for existing callers.

## Why

`mb connect` owned the keychain store but exposed no read path; the dogfood business daily brief inlines a fragile python walk of user-scope.yaml + `security find-generic-password`. Every pulse collector depends on this primitive (decisions/2026-06-11-mb-three-layer-architecture-and-pulse.md).

## Evidence

- 7 new CLI tests in `mb/tests/test_connect.py` (stdout contract, user-scope fallback, all failure exits).
- `scripts/check.sh`: 923 passed, 1 failed — `test_engine.py::test_link_skills_removes_legacy_project_symlink`, which also fails on clean `main` on this machine and passes in CI (environment-specific; flagged in LOOP-STATE.md).

## Loop bookkeeping

LOOP-STATE.md updated in this PR: shipped/next-intent/flagged sections, plus a transcription of Devon's 2026-06-11 chat steering (audit, session-log mining, plugin setup, one-prompt setup revamp).

Closes #812

🤖 Generated with [Claude Code](https://claude.com/claude-code)