### PR TITLE
ci: concurrency cancel, job timeouts, docs naming lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,16 @@ on:
 permissions:
   contents: read
 
+# Cancel superseded runs on PR re-push; never cancel main-branch runs.
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   python:
     name: Python (mb umbrella)
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:
@@ -51,6 +57,7 @@ jobs:
   skill-validate:
     name: SKILL.md line-count gate
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: mb
@@ -79,6 +86,41 @@ jobs:
           done < <(cd .. && find .claude/playbooks -name SKILL.md 2>/dev/null)
           exit $fail
 
+  docs-lint:
+    # Mirrors the docs naming gate in scripts/check.sh so a PR can't pass CI
+    # with a filename that fails the local check. Keep the two in sync.
+    name: Docs naming convention
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+      - name: Lowercase kebab-case filenames under docs/
+        run: |
+          fail=0
+          while IFS= read -r rel; do
+            base="$(basename "$rel")"
+            if [ "$rel" = "docs/README.md" ]; then
+              continue
+            fi
+            case "$rel" in
+              docs/reports/*)
+                if [[ "$base" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}- ]]; then
+                  rest="${base#????-??-??-}"
+                  if [[ ! "$rest" =~ ^[a-z0-9]+(-[a-z0-9]+)*\.md$ ]]; then
+                    echo "::error file=$rel::after the YYYY-MM-DD- prefix, use lowercase kebab-case."
+                    fail=1
+                  fi
+                  continue
+                fi
+                ;;
+            esac
+            if [[ ! "$base" =~ ^[a-z0-9]+(-[a-z0-9]+)*\.md$ ]]; then
+              echo "::error file=$rel::use lowercase kebab-case (only docs/README.md may be all-caps)."
+              fail=1
+            fi
+          done < <(find docs -type f -name '*.md' | sort)
+          exit $fail
+
   wheel-install-smoke:
     # Release-path smoke test. The python matrix runs against an editable
     # install (``pip install -e .``), which can't catch packaging drift —
@@ -98,6 +140,7 @@ jobs:
     # setup.py copies that data into mb/_engine/.claude/ at build time.
     name: wheel-install-smoke
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     defaults:
       run:
         working-directory: mb

--- a/LOOP-STATE.md
+++ b/LOOP-STATE.md
@@ -112,15 +112,19 @@ Canon (read on first iteration of a fresh session):
   683 operator prompts, 06-01→06-11) with a 12-day-chunk mining plan +
   privacy-guard distiller spec. (c) Morning Paper install pattern —
   verdict: steal; six-move paste-prompt anatomy documented.
-- 2026-06-11: README "Set up with AI (recommended)" section added — the
-  Morning Paper six-move paste-prompt adapted to Main Branch. This PR.
+- 2026-06-11: README "Set up with AI (recommended)" section merged (#824) —
+  the Morning Paper six-move paste-prompt adapted to Main Branch.
+- 2026-06-11: CI hardening — concurrency cancel-in-progress on PR re-push,
+  job timeouts (25/15/30/5 min), docs-lint job mirroring check.sh's docs
+  naming gate. This PR.
 
 ## Next intent
 
-- CI hardening slices from the audit, one small PR each: (1) docs-lint job
-  in CI (mirrors check.sh lines 30–56), (2) concurrency cancel-in-progress,
-  (3) job timeouts, (4) `scripts/release-preflight.sh` (3-file version sync
-  + manifest pytest) referenced from release-agent-contract.md.
+- CI hardening remainder: `scripts/release-preflight.sh` (3-file version
+  sync + manifest pytest) referenced from release-agent-contract.md.
+- After the docs-lint job proves green on a real PR: add "Docs naming
+  convention" to required status checks in branch protection (admin
+  mutation — loop will do it unless Devon objects).
 - Setup-prompt follow-through: canonicalize the prompt (replace the
   defensive one in docs/beginner-setup.md lines 51–77) + teach
   mb-setup/mb-start to recognize the pasted README prompt as setup intent.


### PR DESCRIPTION
## What

Three hardening gaps from today's CI audit, one ci.yml PR:

1. **Concurrency cancel** — `group: ci-<PR#|ref>`, `cancel-in-progress` only for `pull_request` events. Re-pushing a PR cancels the superseded run; main-branch runs are never cancelled.
2. **Job timeouts** — python 25 min, skill-validate 15, wheel-install-smoke 30, docs-lint 5. Hangs now fail fast instead of consuming GitHub's 6-hour default.
3. **docs-lint job** — mirrors the docs naming gate in `scripts/check.sh` (lowercase kebab-case under docs/, dated-report exception, docs/README.md exception) with `::error file=` annotations. Closes the local/CI drift where a misnamed doc passed CI.

Not added to required status checks yet — queued in LOOP-STATE to flip after this job proves green on a real PR.

## Evidence

- `yaml.safe_load` passes on the edited workflow.
- docs-lint logic dry-run against current `docs/` tree: exit 0.
- This PR itself exercises the new docs-lint job and the concurrency group.

## Loop bookkeeping

LOOP-STATE.md: shipped entries for #824 + this PR, next-intent updated (release-preflight script remains), required-check flip noted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)