### PR TITLE
[release] Prepare v0.3.43

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mainbranch",
-  "version": "0.3.42",
+  "version": "0.3.43",
   "description": "Main Branch Claude Code skills for running a business from markdown files in git.",
   "author": {
     "name": "Noontide"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,24 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+## [0.3.43] - 2026-06-11
+
 ### Added
 
+- Added `mb connect token <provider>` as the scripted credential read path:
+  prints the stored primary credential to stdout (and nothing else), errors
+  and repair hints to stderr, falls back from repo config to user scope so
+  worktrees and scheduled tasks resolve the same credential as the primary
+  checkout. `--json` is rejected — the raw-token-on-stdout contract is the
+  pipe-safety guarantee. Collectors and scheduled tasks should consume
+  credentials through this instead of walking user-scope.yaml and calling
+  `security` directly. Closes #812.
+- Added a "Set up with AI (recommended)" README section: paste-one-prompt
+  onboarding (read the repo, brief interview, install → doctor → onboard →
+  seed core files → teach the daily loop, stop at a named first win),
+  modeled on the Morning Paper install pattern.
+- Added `scripts/release-preflight.sh` automating the release-file version
+  preflight from the release agent contract. Closes #826.
 - Added `mb dashboard build/open` as a local read-only dashboard surface over
   safe repo, status, provider, push, and image-index facts, including business
   readiness, ad readiness, creative candidate state, provider readiness, and

--- a/LOOP-STATE.md
+++ b/LOOP-STATE.md
@@ -123,7 +123,14 @@ Canon (read on first iteration of a fresh session):
   "integrate impeccable/Corey as curated dependencies."
 - 2026-06-11: test prompts handed to Devon for the BOR / Awake Happy /
   Morning Paper loop sessions (worktree-skill repair field test, setup-
-  prompt cold read, plugin Stage 1 smoke after v0.3.43). This PR.
+  prompt cold read, plugin Stage 1 smoke after v0.3.43).
+- 2026-06-11: #603 dashboard validated + merged after month-old staleness
+  review (read-only verified, redaction tested; fix added: `.mb/dashboard/`
+  now self-ignores so generated HTML can't be committed). Closes the #599
+  implementation; dup #189 closed earlier.
+- 2026-06-11: release prep v0.3.43 — version bumps, CHANGELOG section
+  (incl. backfilled `mb connect token` entry that #823 missed),
+  `scripts/release-preflight.sh` (#826) + contract pointer. This PR.
 
 ## Next intent
 
@@ -131,11 +138,10 @@ Working practice (from Devon's 2026-06-11 grants): validate → merge without
 asking; every slice references its issue and closes it via PR body; new
 findings become issues (LOOP-STATE keeps ordering, issues keep content).
 
-- #603 (dashboard PR, month old): staleness review in flight — merge after
-  rebase, fix, or close-and-salvage into #599 per verdict.
-- Release prep v0.3.43: today's merges (#823 #811 #824 #825 #809 #802 #810)
-  are unreleased; cut the release so the business loops can `mb update`
-  into them. Build `scripts/release-preflight.sh` (#826) as part of prep.
+- After the v0.3.43 prep PR merges: create the `oe-v0.3.43` GitHub release
+  (CHANGELOG body auto-extracts). **PyPI publish then waits at the `pypi`
+  environment approval gate — Devon clicks approve.** Post-publish: verify
+  per docs/post-release-alignment.md, then run the post-release prompts.
 - #827: docs-lint ran green on real PRs today — flip to required check.
 - #828 setup-prompt canonicalization; #804 via #811 Stage 2 (plugin-aware
   `link_status()`, tracked settings wiring, auto-heal hint).

--- a/docs/release-agent-contract.md
+++ b/docs/release-agent-contract.md
@@ -43,12 +43,16 @@ every version-bearing release file in one pass:
 - `mb/mb/__init__.py` `__version__` matches the release version;
 - `.claude-plugin/plugin.json` `version` matches the release version.
 
-Then run the cheapest targeted guard for those sites:
+All of that is automated:
 
 ```bash
-cd mb
-python3 -m pytest tests/test_smoke_coverage.py::test_claude_plugin_manifest_points_at_prefixed_skills -q
+scripts/release-preflight.sh oe-vX.Y.Z   # or bare X.Y.Z; no arg = files must agree
 ```
+
+The script asserts the three version files agree (and agree with the tag when
+passed), checks `CHANGELOG.md` has the dated section, and runs the targeted
+manifest guard
+(`tests/test_smoke_coverage.py::test_claude_plugin_manifest_points_at_prefixed_skills`).
 
 If this preflight fails, fix the release files before the full gate. Do not
 spend a full `scripts/check.sh` run discovering a mismatched release version.

--- a/mb/mb/__init__.py
+++ b/mb/mb/__init__.py
@@ -7,6 +7,6 @@ file stays a thin dispatcher.
 
 from __future__ import annotations
 
-__version__ = "0.3.42"
+__version__ = "0.3.43"
 
 __all__ = ["__version__"]

--- a/mb/pyproject.toml
+++ b/mb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mainbranch"
-version = "0.3.42"
+version = "0.3.43"
 description = "Main Branch engine umbrella - scaffolds, validates, and graphs business-as-files repos. Claude Code first, runtime-agnostic by design."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/scripts/release-preflight.sh
+++ b/scripts/release-preflight.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Release-file preflight (release-agent-contract.md Rule 0, issue #826).
+#
+# Asserts the three version-bearing release files agree — and agree with the
+# release tag when one is passed — then runs the cheapest targeted guard for
+# the plugin manifest. Run this before scripts/check.sh on a release-prep
+# branch; do not spend a 10-minute gate discovering a version mismatch.
+#
+# Usage:
+#   scripts/release-preflight.sh              # files must agree with each other
+#   scripts/release-preflight.sh 0.3.43       # ...and with this version
+#   scripts/release-preflight.sh oe-v0.3.43   # tag form accepted
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+expected="${1:-}"
+expected="${expected#oe-v}"
+
+pyproject_version="$(sed -n 's/^version = "\(.*\)"$/\1/p' "$ROOT/mb/pyproject.toml" | head -n1)"
+init_version="$(sed -n 's/^__version__ = "\(.*\)"$/\1/p' "$ROOT/mb/mb/__init__.py" | head -n1)"
+plugin_version="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["version"])' "$ROOT/.claude-plugin/plugin.json")"
+
+fail=0
+echo "mb/pyproject.toml        version    = $pyproject_version"
+echo "mb/mb/__init__.py        __version__ = $init_version"
+echo ".claude-plugin/plugin.json version  = $plugin_version"
+
+if [ -z "$pyproject_version" ] || [ -z "$init_version" ] || [ -z "$plugin_version" ]; then
+  echo "release-preflight: could not read all three version strings." >&2
+  fail=1
+fi
+if [ "$pyproject_version" != "$init_version" ] || [ "$pyproject_version" != "$plugin_version" ]; then
+  echo "release-preflight: version files disagree." >&2
+  fail=1
+fi
+if [ -n "$expected" ] && [ "$pyproject_version" != "$expected" ]; then
+  echo "release-preflight: files say $pyproject_version but the release is $expected." >&2
+  fail=1
+fi
+
+if grep -n "## \[$pyproject_version\]" "$ROOT/CHANGELOG.md" > /dev/null; then
+  echo "CHANGELOG.md             has a [$pyproject_version] section"
+else
+  echo "release-preflight: CHANGELOG.md has no [$pyproject_version] section." >&2
+  fail=1
+fi
+
+if [ "$fail" -ne 0 ]; then
+  echo "release-preflight: FAILED — fix release files before running scripts/check.sh." >&2
+  exit 1
+fi
+
+cd "$ROOT/mb"
+python3 -m pytest tests/test_smoke_coverage.py::test_claude_plugin_manifest_points_at_prefixed_skills -q
+
+echo "release-preflight: OK ($pyproject_version)"


### PR DESCRIPTION
## What

Release prep for `oe-v0.3.43` — today's nine merges, packaged:

- `mb connect token <provider>` (#812/#823) — CHANGELOG entry backfilled here (the feature PR missed it)
- Symlink root-cause fix + plugin-first skills-distribution decision (#811)
- README "Set up with AI (recommended)" paste-prompt onboarding (#824)
- CI hardening: concurrency cancel, job timeouts, docs-lint (#825)
- Provider-pluggable image rail with fal.ai + security hardening (#809)
- mb-site SEO reference layer (#810)
- `mb dashboard build/open` with self-ignoring output dir (#603)
- `scripts/release-preflight.sh` automating contract Rule 0 (closes #826)

## Evidence

- `scripts/release-preflight.sh 0.3.43`: OK (3-file version agreement + CHANGELOG section + manifest guard)
- `scripts/check.sh`: **937 passed, 0 failed**, skill validation 15/15, coverage gate met — first fully green local run (the pre-existing symlink test failure was fixed by #811)

## After merge

Create GitHub release `oe-v0.3.43` (CHANGELOG body auto-extracts). PyPI publish waits at the `pypi` environment approval gate for Devon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)