### PR TITLE
docs(setup): canonicalize the paste-prompt across README and beginner-setup (#828)

### DIFF
--- a/.claude/skills/mb-setup/SKILL.md
+++ b/.claude/skills/mb-setup/SKILL.md
@@ -23,11 +23,15 @@ durable readiness contract. Explain providers as business capabilities, not
 developer config, and end with exact commands.
 
 **Pasted setup guide = setup intent.** If the user pastes this guide, the
-beginner setup guide, or a bootstrap prompt with business/folder intent, treat
-it as setup intent, not as a document to save. Do not offer to save it as a
-document. Check `mb --version`; if missing, stop with `pipx install
-mainbranch`. If present, inspect `mb onboard --help`, explain the target
-folder, and ask before any write.
+beginner setup guide, the README "Set up with AI" prompt ("I want Main
+Branch: AI business memory I own as files..."), or any bootstrap prompt with
+business/folder intent, treat it as setup intent, not as a document to save.
+Do not offer to save it as a document. Check `mb --version`; if missing, stop
+with `pipx install mainbranch`. If present, inspect `mb onboard --help`,
+explain the target folder, and ask before any write. When the pasted prompt
+carries its own arc (brief interview, then install → doctor → onboard → seed
+core files → teach the daily loop), follow that arc: interview first, stop at
+the named first win, and show what was set up.
 
 **GitHub-backed setup preflight.** GitHub is strongly recommended because it
 gives Main Branch a free cloud backup, shared history, task/proposal layer, and

--- a/LOOP-STATE.md
+++ b/LOOP-STATE.md
@@ -138,8 +138,12 @@ Canon (read on first iteration of a fresh session):
   day), unverified provider writes (live money), save-state not
   worktree-real. Meta-signal: on the days the business shipped most,
   mb was used least — the deterministic plane must meet operators
-  inside worktrees/fleets/dashboards. New issues filed from the
-  report's [new] items. This PR.
+  inside worktrees/fleets/dashboards. Eleven new issues filed from the
+  report's [new] items; evidence comments on #803/#818/#820 (#832).
+- 2026-06-11: #828 done — beginner-setup.md now carries the canonical
+  README paste-prompt (one prompt, two doors; new lockstep test keeps
+  them byte-identical), mb-setup recognizes the README prompt and
+  follows its arc (interview → first win → stop-and-show). This PR.
 
 ## Next intent
 

--- a/docs/beginner-setup.md
+++ b/docs/beginner-setup.md
@@ -50,30 +50,32 @@ If that account is wrong, stop before creating the GitHub-backed setup and run
 
 ## Setup with an agent
 
-If you are starting from an empty folder, open or select that folder in Claude
-Code or Codex and paste this:
+This is the same prompt as the README's "Set up with AI (recommended)"
+section — one canonical prompt, two doors. Open your strongest model
+(Claude Fable with the 1M context window works great; on Codex, pick the
+strongest model with extra reasoning) and paste this:
 
 ```text
-I want to set up Main Branch for this business in this folder.
-
-Treat this as setup intent, not as a document to save.
-
-First, check whether `mb` is available. If it is not installed, stop and tell me
-the exact install step. If it is installed, inspect the setup command before
-running it.
-
-Use this folder as the business folder unless I say otherwise. Before any write,
-explain what will be created or changed and ask for approval.
-
-If I ask for GitHub backup or sync, first check whether GitHub CLI is installed,
-authenticated, and signed in to the account I expect.
-
-After setup, run read-only health checks, summarize what was created in plain
-business language, and tell me the next safest action.
+I want Main Branch: AI business memory I own as files in one folder
+(https://github.com/noontide-co/mainbranch). First read the entire README,
+then explore the repo enough to understand the architecture (the mb CLI is
+the deterministic control plane; skills are the judgment layer; my business
+lives in its own folder, never in the engine; bets, research, decisions,
+pushes, playbooks, outcomes, and checkpoints are the primitives; writing
+files, publishing, spending, and customer contact stay my call). Then
+interview me briefly about my business, my offer, and my audience. Then:
+install the engine, run `mb doctor` and fix anything it flags, run
+`mb onboard` to create my business folder, seed my core files from the
+interview, and teach me the daily loop — /mb-start to open, /mb-end to
+close. Get me to a business folder with offer, audience, and voice drafted
+and a clean `mb status`, then stop and show me what you set up.
 ```
 
 Do not save that prompt as a markdown document. It tells the agent to start
-setup.
+setup. The agent keeps the safety rails regardless of the prompt: writes are
+explained and approved first, GitHub-backed setup checks `gh auth status`
+and the signed-in account, and setup ends with read-only health checks in
+plain business language.
 
 ---
 

--- a/docs/beginner-setup.md
+++ b/docs/beginner-setup.md
@@ -51,7 +51,7 @@ If that account is wrong, stop before creating the GitHub-backed setup and run
 ## Setup with an agent
 
 This is the same prompt as the README's "Set up with AI (recommended)"
-section — one canonical prompt, two doors. Open your strongest model
+section — the same prompt, two doors. Open your strongest model
 (Claude Fable with the 1M context window works great; on Codex, pick the
 strongest model with extra reasoning) and paste this:
 

--- a/mb/tests/test_first_run_setup_contract.py
+++ b/mb/tests/test_first_run_setup_contract.py
@@ -27,11 +27,15 @@ def test_beginner_setup_uses_owner_friendly_setup_prompt() -> None:
     required = [
         "## Setup with an agent",
         "Open or select the business folder in Claude Code or Codex.",
-        "I want to set up Main Branch for this business in this folder.",
-        "Treat this as setup intent, not as a document to save.",
-        "check whether `mb` is available",
-        "Use this folder as the business folder unless I say otherwise.",
-        "GitHub CLI is installed, authenticated, and signed in to the account I expect",
+        # The canonical paste-prompt — one prompt, two doors (README +
+        # beginner setup). Keep these in lockstep with README.md.
+        "I want Main Branch: AI business memory I own as files in one folder",
+        "interview me briefly about my business, my offer, and my audience",
+        "run `mb doctor` and fix anything it flags",
+        "then stop and show me what you set up",
+        # Safety rails stay documented around the prompt.
+        "writes are explained and approved first",
+        "GitHub-backed setup checks `gh auth status`",
         "GitHub does not need to cost anything",
         "the business brain has cloud backup and readable saved history",
         "AI tools with GitHub connectors can read the business brain",
@@ -43,6 +47,20 @@ def test_beginner_setup_uses_owner_friendly_setup_prompt() -> None:
     for phrase in required:
         assert phrase in normalized
     assert "mb onboard --github --push" not in normalized
+
+
+def test_beginner_setup_prompt_matches_readme_prompt() -> None:
+    """One canonical prompt: the README and beginner-setup fenced prompts
+    must stay byte-identical so the two doors never drift."""
+
+    def _fenced_prompt(text: str) -> str:
+        start = text.index("I want Main Branch: AI business memory")
+        end = text.index("```", start)
+        return " ".join(text[start:end].split())
+
+    readme_prompt = _fenced_prompt(_read("README.md"))
+    setup_prompt = _fenced_prompt(_read("docs/beginner-setup.md"))
+    assert readme_prompt == setup_prompt
 
 
 def test_runtime_guidance_routes_pasted_setup_to_onboarding() -> None:


### PR DESCRIPTION
## What

#828, both halves:

1. **One canonical prompt.** `docs/beginner-setup.md` "Setup with an agent" now carries the exact README "Set up with AI" prompt. The old defensive prompt's safety properties (check mb installed, approval-gated writes, gh auth preflight, read-only closeout) move to prose around the prompt — they're enforced by mb-setup's contract, not by prompt text.
2. **Recognition.** `mb-setup` SKILL.md's "Pasted setup guide = setup intent" rule now names the README prompt explicitly and follows its arc: interview first, stop at the named first win, show what was set up. (mb-start untouched — it's at the 500-line cap and already routes setup intent to mb-setup.)

New contract test `test_beginner_setup_prompt_matches_readme_prompt` pins the two fenced prompts byte-identical, so the doors can't drift apart.

## Evidence

- `test_first_run_setup_contract.py`: 5 passed (assertions updated to pin the canonical prompt).
- `test_onboard.py` + `test_init.py`: 33 passed.
- `mb skill validate --all --json`: green; mb-setup SKILL.md at 494/500 lines.

Closes #828

🤖 Generated with [Claude Code](https://claude.com/claude-code)