### PR TITLE
feat(engine): worktree-aware link_status — explain the wiring gap where operators hit it (#804)

### DIFF
--- a/LOOP-STATE.md
+++ b/LOOP-STATE.md
@@ -140,10 +140,18 @@ Canon (read on first iteration of a fresh session):
   mb was used least — the deterministic plane must meet operators
   inside worktrees/fleets/dashboards. Eleven new issues filed from the
   report's [new] items; evidence comments on #803/#818/#820 (#832).
-- 2026-06-11: #828 done — beginner-setup.md now carries the canonical
-  README paste-prompt (one prompt, two doors; new lockstep test keeps
-  them byte-identical), mb-setup recognizes the README prompt and
-  follows its arc (interview → first win → stop-and-show). This PR.
+- 2026-06-11: #828 done (#844 merged) — beginner-setup.md carries the
+  README paste-prompt (one prompt, two doors; lockstep test keeps them
+  byte-identical), mb-setup recognizes the README prompt and follows
+  its arc. CI's operator-docs language gate caught one word ("canonical")
+  — the business-language rule working as designed.
+- 2026-06-11: #804 slice — `link_status()` is now worktree-aware:
+  detects a linked worktree (git-dir vs git-common-dir), exposes
+  `is_linked_worktree`, and when wiring is broken in a worktree the
+  summary explains that worktrees never inherit the machine-local
+  wiring and names `mb skill link --repo .` — flows through to
+  `mb start`, `mb status` ranked actions, and `mb doctor` untouched.
+  This PR.
 
 ## Next intent
 

--- a/mb/mb/engine.py
+++ b/mb/mb/engine.py
@@ -754,6 +754,38 @@ def link_skills(repo: str | Path) -> dict[str, Any]:
     }
 
 
+def _is_linked_worktree(target: Path) -> bool:
+    """True when ``target`` is a linked git worktree (not the primary checkout)."""
+
+    def _rev_parse(arg: str) -> str:
+        try:
+            proc = subprocess.run(
+                ["git", "rev-parse", arg],
+                cwd=target,
+                capture_output=True,
+                text=True,
+                timeout=3,
+                check=False,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return ""
+        return proc.stdout.strip() if proc.returncode == 0 else ""
+
+    git_dir = _rev_parse("--git-dir")
+    common_dir = _rev_parse("--git-common-dir")
+    if not git_dir or not common_dir:
+        return False
+    git_dir_path = (
+        (target / git_dir).resolve() if not Path(git_dir).is_absolute() else Path(git_dir).resolve()
+    )
+    common_dir_path = (
+        (target / common_dir).resolve()
+        if not Path(common_dir).is_absolute()
+        else Path(common_dir).resolve()
+    )
+    return git_dir_path != common_dir_path
+
+
 def link_status(repo: str | Path) -> dict[str, Any]:
     """Return whether ``repo`` can discover Main Branch skills."""
     target = Path(repo).resolve()
@@ -798,14 +830,24 @@ def link_status(repo: str | Path) -> dict[str, Any]:
         missing.append("project-local /mb-start bridge")
     if not shadow_report["ok"]:
         missing.append("personal Claude skill shadow")
-    summary = (
-        "Main Branch start wiring is ready."
-        if not missing
-        else "Missing Main Branch start wiring: " + ", ".join(missing) + "."
-    )
+    is_linked_worktree = _is_linked_worktree(target)
+    if not missing:
+        summary = "Main Branch start wiring is ready."
+    elif is_linked_worktree:
+        # The wiring is gitignored, so a fresh worktree never carries it.
+        # Name that explicitly: operators read this as "skills disappeared".
+        summary = (
+            "This is a git worktree, and Main Branch wiring is machine-local "
+            "state that worktrees do not inherit — every fresh worktree starts "
+            "without it. Missing: " + ", ".join(missing) + ". "
+            "Run `mb skill link --repo .` here, then reload skills."
+        )
+    else:
+        summary = "Missing Main Branch start wiring: " + ", ".join(missing) + "."
 
     return {
         "ok": settings_has_engine and start_link_ok and shadow_report["ok"],
+        "is_linked_worktree": is_linked_worktree,
         "repo": str(target),
         "engine_root": root_str or None,
         "settings_path": str(settings_path),

--- a/mb/tests/test_doctor.py
+++ b/mb/tests/test_doctor.py
@@ -376,7 +376,9 @@ def test_doctor_repair_apply_restores_missing_claude_worktree_start_wiring(
     actions = {action["id"]: action for action in plan["actions"]}
 
     assert section["state"] == "error"
-    assert "Missing Main Branch start wiring" in start_check["summary"]
+    assert "git worktree" in start_check["summary"]
+    assert "worktrees do not inherit" in start_check["summary"]
+    assert "mb skill link --repo ." in start_check["summary"]
     assert "project-local /mb-start bridge" in start_check["summary"]
     assert start_check["fallback_commands"] == [
         "mb start --json",

--- a/mb/tests/test_engine.py
+++ b/mb/tests/test_engine.py
@@ -406,3 +406,35 @@ def test_link_status_explains_stale_engine_path_from_other_install(
     assert result["stale_from_other_install"] is True
     assert result["current_mb"]["path"] == "/tmp/new/mb"
     assert result["repair_command"] == "mb skill link --repo ."
+
+
+def test_link_status_explains_worktree_wiring_gap(tmp_path: Path) -> None:
+    import subprocess
+
+    repo = tmp_path / "biz"
+    repo.mkdir()
+
+    def git(*args: str) -> None:
+        subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True, text=True)
+
+    git("init")
+    git("config", "user.email", "test@example.com")
+    git("config", "user.name", "Test User")
+    (repo / "README.md").write_text("hi\n", encoding="utf-8")
+    git("add", "README.md")
+    git("commit", "-m", "baseline")
+    worktree = repo / ".claude" / "worktrees" / "fresh"
+    git("worktree", "add", "-b", "fresh", str(worktree))
+
+    status = engine_mod.link_status(worktree)
+
+    assert status["ok"] is False
+    assert status["is_linked_worktree"] is True
+    assert "git worktree" in status["summary"]
+    assert "worktrees do not inherit" in status["summary"]
+    assert "mb skill link --repo ." in status["summary"]
+
+    primary = engine_mod.link_status(repo)
+    assert primary["is_linked_worktree"] is False
+    if not primary["ok"]:
+        assert "worktree" not in primary["summary"]


### PR DESCRIPTION
## What

The cheapest-highest-leverage move from #804 (proposed fix 1) plus the live-business mining report's friction theme 7: when an operator lands in a fresh worktree and the skills are "gone", every mb surface now explains the mechanism instead of just reporting breakage.

- `_is_linked_worktree()`: git-dir vs git-common-dir comparison (same pattern as `status._git_info`), 3s timeout, false on any git failure.
- `link_status()` output gains `is_linked_worktree`.
- Broken wiring + worktree → summary: "This is a git worktree, and Main Branch wiring is machine-local state that worktrees do not inherit — every fresh worktree starts without it. Missing: …. Run `mb skill link --repo .` here, then reload skills."
- Primary-checkout breakage keeps the existing summary. Flows through `mb start` checks, `mb status` `broken_skill_wiring` ranked action, and `mb doctor` claude-wiring section with no consumer changes.

Not in this slice: Stage 2 of the plugin-first migration (tracked `.claude/settings.json` wiring, plugin-aware "wired" definition) — #804 stays open for that.

## Evidence

- New `test_link_status_explains_worktree_wiring_gap` (real git worktree fixture; asserts worktree summary + flag, and that the primary checkout never gets worktree framing).
- Updated `test_doctor_repair_apply_restores_missing_claude_worktree_start_wiring` to pin the new summary.
- engine + start + doctor + status suites: 204 passed. mypy strict clean.

Refs #804

🤖 Generated with [Claude Code](https://claude.com/claude-code)