### PR TITLE
feat(connect): Stripe and Resend as first-class providers (#833)

### DIFF
--- a/LOOP-STATE.md
+++ b/LOOP-STATE.md
@@ -150,7 +150,13 @@ Canon (read on first iteration of a fresh session):
   `is_linked_worktree`, and when wiring is broken in a worktree the
   summary explains that worktrees never inherit the machine-local
   wiring and names `mb skill link --repo .` — flows through to
-  `mb start`, `mb status` ranked actions, and `mb doctor` untouched.
+  `mb start`, `mb status` ranked actions, and `mb doctor` untouched
+  (#845 merged).
+- 2026-06-11: #833 slice — Stripe and Resend are first-class mb connect
+  providers (api_key slot, env-var fallbacks, identity metadata: Stripe
+  `mode` records test-vs-live intent, Resend `sender_domain` makes
+  identity a recorded fact). Roundtrip-tested through SecretStore +
+  `mb connect token`. Next #833 slice: key-shape validation at intake.
   This PR.
 
 ## Next intent

--- a/mb/mb/connect.py
+++ b/mb/mb/connect.py
@@ -106,6 +106,35 @@ PROVIDERS: tuple[Provider, ...] = (
         env_vars=("CLOUDFLARE_API_TOKEN",),
     ),
     Provider(
+        id="stripe",
+        name="Stripe",
+        category="payments",
+        auth="api_key",
+        required_secrets=("api_key",),
+        metadata_fields=("account_id", "mode"),
+        description=(
+            "Stripe payments: checkout, products, customers, and webhook "
+            "configuration. Store the secret or restricted key locally; keys "
+            "never enter chat or committed repo files. Record `mode` metadata "
+            "(test or live) so agents can verify the key matches the intent."
+        ),
+        env_vars=("STRIPE_SECRET_KEY", "STRIPE_API_KEY"),
+    ),
+    Provider(
+        id="resend",
+        name="Resend",
+        category="email",
+        auth="api_key",
+        required_secrets=("api_key",),
+        metadata_fields=("sender_domain", "audience_id"),
+        description=(
+            "Resend transactional and lifecycle email: sending, domains, and "
+            "audiences. The sender domain lives in metadata so agents read "
+            "identity from recorded facts instead of live provider state."
+        ),
+        env_vars=("RESEND_API_KEY",),
+    ),
+    Provider(
         id="postiz",
         name="Postiz",
         category="social",

--- a/mb/tests/test_connect.py
+++ b/mb/tests/test_connect.py
@@ -43,12 +43,20 @@ def test_provider_registry_includes_initial_foundation() -> None:
         "google",
         "meta",
         "cloudflare",
+        "stripe",
+        "resend",
         "postiz",
         "apify",
         "hledger",
         "transcription",
     }.issubset(providers)
     assert "beancount" not in providers
+    assert providers["stripe"]["required_secrets"] == ["api_key"]
+    assert "STRIPE_SECRET_KEY" in providers["stripe"]["env_vars"]
+    assert "mode" in providers["stripe"]["metadata_fields"]
+    assert providers["resend"]["required_secrets"] == ["api_key"]
+    assert "RESEND_API_KEY" in providers["resend"]["env_vars"]
+    assert "sender_domain" in providers["resend"]["metadata_fields"]
     assert providers["cloudflare"]["required_secrets"] == ["api_token"]
     assert providers["meta"]["auth"] == "meta_ads_cli_read_only"
     assert providers["meta"]["required_secrets"] == ["access_token"]
@@ -1649,3 +1657,37 @@ def test_connect_token_rejects_secretless_provider(tmp_path: Path, monkeypatch) 
 
     assert result.exit_code == 2
     assert "stores no secrets" in result.stderr
+
+
+def test_connect_stripe_and_resend_store_and_read_back(tmp_path: Path, monkeypatch) -> None:
+    _local_secret_env(monkeypatch, tmp_path)
+    repo = tmp_path / "biz"
+    repo.mkdir()
+
+    connect_mod.connect_provider(
+        "stripe",
+        repo=repo,
+        token="sk_test_fixture_not_real",
+        metadata_pairs=["mode=test", "account_id=acct_fixture"],
+    )
+    connect_mod.connect_provider(
+        "resend",
+        repo=repo,
+        token="re_fixture_not_real",
+        metadata_pairs=["sender_domain=example.com"],
+    )
+
+    config_text = (repo / ".mb" / "connect.yaml").read_text(encoding="utf-8")
+    assert "sk_test_fixture_not_real" not in config_text
+    assert "re_fixture_not_real" not in config_text
+
+    stripe_token = runner.invoke(app, ["connect", "token", "stripe", "--repo", str(repo)])
+    assert stripe_token.exit_code == 0
+    assert stripe_token.stdout == "sk_test_fixture_not_real\n"
+
+    resend_token = runner.invoke(app, ["connect", "token", "resend", "--repo", str(repo)])
+    assert resend_token.exit_code == 0
+    assert resend_token.stdout == "re_fixture_not_real\n"
+
+    status = connect_mod.status_provider("stripe", repo)
+    assert status["metadata"]["mode"] == "test"


### PR DESCRIPTION
## What

First slice of #833, straight from the mining report's friction #1: the operator reached for `mb connect` for both the money (Stripe) and email (Resend) credential lifecycles, and the fixed provider list forced both outside mb — env files hand-rolled, keychain read raw, agents grepping mb source.

Registry entries only, riding every existing rail (SecretStore, user-scope, `mb connect token`, status/test):

- **stripe**: `api_key` slot, `STRIPE_SECRET_KEY`/`STRIPE_API_KEY` env fallbacks, metadata `account_id` + `mode` — test-vs-live intent becomes a recorded fact agents can check against the key.
- **resend**: `api_key` slot, `RESEND_API_KEY` fallback, metadata `sender_domain` + `audience_id` — sending identity read from facts, not inferred from live provider state.

Not in this slice (next on #833): generic/custom provider entries, key-shape validation at intake (`sk_test_`/`sk_live_`/`re_` prefixes).

## Evidence

- New roundtrip test: connect stripe + resend with fixture keys → keys absent from `.mb/connect.yaml` → `mb connect token` reads both back exactly → `mode` metadata recorded.
- Registry contract test updated. `test_connect.py`: 56 passed. ruff + mypy strict clean.

Refs #833

🤖 Generated with [Claude Code](https://claude.com/claude-code)