### PR TITLE
feat(connect): key-shape validation at intake for Stripe and Resend (#833)

### DIFF
--- a/LOOP-STATE.md
+++ b/LOOP-STATE.md
@@ -156,8 +156,13 @@ Canon (read on first iteration of a fresh session):
   providers (api_key slot, env-var fallbacks, identity metadata: Stripe
   `mode` records test-vs-live intent, Resend `sender_domain` makes
   identity a recorded fact). Roundtrip-tested through SecretStore +
-  `mb connect token`. Next #833 slice: key-shape validation at intake.
-  This PR.
+  `mb connect token` (#846 merged).
+- 2026-06-11: #833 slice 2 — key-shape validation at intake: malformed
+  Stripe/Resend keys refused before storage (error names the expected
+  shape, never echoes the value), and Stripe mode-vs-key cross-check
+  catches mode=live with a TEST key (and vice versa) at connect time —
+  the BOR live-vs-test mixup class, now an intake error. Metadata-only
+  connects still allowed. This PR.
 
 ## Next intent
 

--- a/mb/mb/connect.py
+++ b/mb/mb/connect.py
@@ -69,6 +69,10 @@ class Provider:
     metadata_fields: tuple[str, ...]
     description: str
     env_vars: tuple[str, ...] = ()
+    # Expected prefixes for the primary secret. Empty = no shape check.
+    # Used to refuse malformed credentials at intake without ever echoing
+    # the value itself.
+    key_prefixes: tuple[str, ...] = ()
 
 
 PROVIDERS: tuple[Provider, ...] = (
@@ -119,6 +123,7 @@ PROVIDERS: tuple[Provider, ...] = (
             "(test or live) so agents can verify the key matches the intent."
         ),
         env_vars=("STRIPE_SECRET_KEY", "STRIPE_API_KEY"),
+        key_prefixes=("sk_", "rk_"),
     ),
     Provider(
         id="resend",
@@ -133,6 +138,7 @@ PROVIDERS: tuple[Provider, ...] = (
             "identity from recorded facts instead of live provider state."
         ),
         env_vars=("RESEND_API_KEY",),
+        key_prefixes=("re_",),
     ),
     Provider(
         id="postiz",
@@ -948,6 +954,35 @@ def _meta_setup() -> dict[str, Any]:
     }
 
 
+def _validate_key_shape(provider: Provider, token: str, metadata: dict[str, str]) -> None:
+    """Refuse malformed credentials at intake.
+
+    Error messages must never echo the credential value — only its expected
+    shape and, for Stripe, whether it is a test or live key.
+    """
+    if not token or not provider.key_prefixes:
+        return
+    if not token.startswith(provider.key_prefixes):
+        shapes = ", ".join(f"{prefix}…" for prefix in provider.key_prefixes)
+        slot = provider.required_secrets[0] if provider.required_secrets else "credential"
+        raise ValueError(
+            f"the {provider.name} {slot} does not match the expected key shape "
+            f"({shapes}). Nothing was stored; check the value and reconnect."
+        )
+    if provider.id == "stripe":
+        mode = str(metadata.get("mode") or "").strip().lower()
+        if mode == "live" and token.startswith(("sk_test_", "rk_test_")):
+            raise ValueError(
+                "metadata says mode=live but the key is a Stripe TEST key. "
+                "Nothing was stored; fix the mode or the key and reconnect."
+            )
+        if mode == "test" and token.startswith(("sk_live_", "rk_live_")):
+            raise ValueError(
+                "metadata says mode=test but the key is a Stripe LIVE key. "
+                "Nothing was stored; fix the mode or the key and reconnect."
+            )
+
+
 def connect_provider(
     provider_id: str,
     repo: str | Path = ".",
@@ -965,9 +1000,10 @@ def connect_provider(
     if normalized_scope not in CONNECT_SCOPES:
         raise ValueError("scope must be repo or user")
     target = Path(repo).resolve()
+    metadata = _parse_metadata(metadata_pairs or [])
+    _validate_key_shape(provider, token, metadata)
     config = _read_config(target)
     repo_id = _ensure_repo_id(config, target)
-    metadata = _parse_metadata(metadata_pairs or [])
     store = SecretStore(secret_backend)
 
     secrets: dict[str, dict[str, str]] = {}

--- a/mb/tests/test_connect.py
+++ b/mb/tests/test_connect.py
@@ -1691,3 +1691,88 @@ def test_connect_stripe_and_resend_store_and_read_back(tmp_path: Path, monkeypat
 
     status = connect_mod.status_provider("stripe", repo)
     assert status["metadata"]["mode"] == "test"
+
+
+def test_connect_stripe_refuses_malformed_key_shape(tmp_path: Path, monkeypatch) -> None:
+    _local_secret_env(monkeypatch, tmp_path)
+    repo = tmp_path / "biz"
+    repo.mkdir()
+
+    result = runner.invoke(
+        app,
+        ["connect", "stripe", "--repo", str(repo), "--token", "not-a-stripe-key"],
+    )
+
+    assert result.exit_code == 2
+    assert "expected key shape" in result.stderr
+    assert "not-a-stripe-key" not in result.stderr
+    secret_file = tmp_path / "home" / "secrets" / "connect.json"
+    assert not secret_file.exists() or "not-a-stripe-key" not in secret_file.read_text(
+        encoding="utf-8"
+    )
+
+
+def test_connect_stripe_refuses_mode_key_mismatch(tmp_path: Path, monkeypatch) -> None:
+    _local_secret_env(monkeypatch, tmp_path)
+    repo = tmp_path / "biz"
+    repo.mkdir()
+
+    live_mode_test_key = runner.invoke(
+        app,
+        [
+            "connect",
+            "stripe",
+            "--repo",
+            str(repo),
+            "--token",
+            "sk_test_fixture_not_real",
+            "--metadata",
+            "mode=live",
+        ],
+    )
+    assert live_mode_test_key.exit_code == 2
+    assert "mode=live but the key is a Stripe TEST key" in live_mode_test_key.stderr
+    assert "sk_test_fixture_not_real" not in live_mode_test_key.stderr
+
+    test_mode_live_key = runner.invoke(
+        app,
+        [
+            "connect",
+            "stripe",
+            "--repo",
+            str(repo),
+            "--token",
+            "sk_live_fixture_not_real",
+            "--metadata",
+            "mode=test",
+        ],
+    )
+    assert test_mode_live_key.exit_code == 2
+    assert "mode=test but the key is a Stripe LIVE key" in test_mode_live_key.stderr
+
+
+def test_connect_resend_refuses_malformed_key_shape(tmp_path: Path, monkeypatch) -> None:
+    _local_secret_env(monkeypatch, tmp_path)
+    repo = tmp_path / "biz"
+    repo.mkdir()
+
+    result = runner.invoke(
+        app,
+        ["connect", "resend", "--repo", str(repo), "--token", "sk_wrong_provider"],
+    )
+
+    assert result.exit_code == 2
+    assert "expected key shape" in result.stderr
+    assert "re_…" in result.stderr
+
+
+def test_connect_metadata_only_skips_key_shape_check(tmp_path: Path, monkeypatch) -> None:
+    _local_secret_env(monkeypatch, tmp_path)
+    repo = tmp_path / "biz"
+    repo.mkdir()
+
+    result = connect_mod.connect_provider(
+        "stripe", repo=repo, metadata_pairs=["account_id=acct_fixture"]
+    )
+
+    assert result["ok"] is False or result["status"]["state"] == "missing_secret"


### PR DESCRIPTION
## What

#833 slice 2 (mining friction #1, intake hardening): credentials are now validated at the door.

- `Provider.key_prefixes` — declared shape for the primary secret (stripe: `sk_`/`rk_`; resend: `re_`). Empty tuple = no check, all other providers unchanged.
- Malformed key → `ValueError` before anything is stored; the message names the expected shape and **never echoes the value**. CLI exits 2.
- Stripe mode cross-check: `mode=live` metadata with a `sk_test_`/`rk_test_` key (or `mode=test` with a live key) is refused at connect time — the exact live-vs-test mixup the dogfood business session caught only by agent prefix-checking in production.
- Metadata-only connects (no token yet) skip the shape check, preserving the connect-then-credential flow.

## Evidence

- 4 new tests: malformed Stripe key refused (and absent from the secret store), both mode-mismatch directions refused, Resend wrong-provider key refused, metadata-only connect still works. Error-message assertions confirm the key never appears in output.
- `test_connect.py`: 60 passed. ruff + mypy strict clean.

Refs #833 (remaining: generic/custom provider entries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)