### PR TITLE
docs(mb-think): research-placement contract (#805)

### DIFF
--- a/.claude/skills/mb-think/references/codify-phase.md
+++ b/.claude/skills/mb-think/references/codify-phase.md
@@ -16,7 +16,7 @@ Apply decisions to reference files. Merges research findings and decisions into 
 ## Workflow
 
 1. **Read source** — Decision file or research file
-2. **Identify what changes** — Read the `## What Changes` section (or infer from `## Decision` and `## Consequences` if What Changes is missing). Identify which reference files are affected and what the key changes are.
+2. **Identify what changes** — Read the `## What Changes` section (or infer from `## Decision` and `## Consequences` if What Changes is missing). Identify which reference files are affected and what the key changes are. Durable conclusions always codify **up** into the business repo's `core/`, even when the raw research file lives in a product repo (research lives where its conclusions codify — see the research-phase placement rule).
 3. **Propose edits** — For each affected reference file, read it, then propose the specific update to the user.
 4. **Apply with confirmation** — After user confirms, apply each update. Preserve existing content.
 5. **Atomic finalize pass** — In the SAME edit pass as the final reference file update, flip the source decision from `status: accepted` to `status: codified`. This is the most likely dropped step; treat it as part of the final edit unit, never a follow-up.

--- a/.claude/skills/mb-think/references/research-phase.md
+++ b/.claude/skills/mb-think/references/research-phase.md
@@ -91,6 +91,25 @@ research/YYYY-MM-DD-[offer]-topic-[source].md
 
 This is optional — standard naming without the offer prefix works fine. Use the offer prefix when researching a topic specific to one offer to make it easy to find later.
 
+### Which Repo Gets the Research File
+
+Research lives where its conclusions codify — not where the session happened
+to run:
+
+- Conclusions change `core/` (offer, audience, pricing, positioning, bets) →
+  the **business repo's** `research/`.
+- Conclusions land in one product repo's code or docs → **that product
+  repo's** `research/`.
+- Mixed → default **up** to the business repo, and fold the build-specific
+  notes into the product repo's docs in the same pass.
+
+Quick test: *if we rebuilt the product from scratch tomorrow, would this
+research still matter?* Yes → business repo. No → product repo.
+
+Two invariants hold regardless of where the raw file sits: durable
+conclusions always codify up into the business repo's `core/`, and research
+files carry `offer:` frontmatter in multi-offer repos.
+
 ---
 
 ## Content Strategy Research Routing

--- a/LOOP-STATE.md
+++ b/LOOP-STATE.md
@@ -168,7 +168,12 @@ Canon (read on first iteration of a fresh session):
   webhook fast-path + GET ceiling, page on money-path failure, never
   trust the 200) + channel-agnostic send-function template; suppression
   named as the keystone case. Indexed in docs/README.md, cross-linked
-  to #814/#656. This PR.
+  to #814/#656 (#848 merged).
+- 2026-06-11: #805 done — research-placement contract ("research lives
+  where its conclusions codify") landed in mb-think research-phase +
+  codify-phase references and docs/business-file-contracts.md: codify-up
+  invariant, rebuild-tomorrow test, offer frontmatter in multi-offer
+  repos. This PR.
 
 ## Next intent
 

--- a/docs/business-file-contracts.md
+++ b/docs/business-file-contracts.md
@@ -61,6 +61,25 @@ Every contract should name:
 Contract findings use business language. They should say "your offer does not
 yet tell a qualified buyer what to do next," not "missing H2: CTA."
 
+## Research Placement Across Repos
+
+When a business runs more than one repo (hub plus product/site repos),
+research lives where its conclusions codify — not where the session happened
+to run:
+
+- conclusions change `core/` (offer, audience, pricing, positioning, bets)
+  → the business repo's `research/`;
+- conclusions land in one product repo's code or docs → that product repo's
+  `research/`;
+- mixed → default up to the business repo, folding build notes into the
+  product repo's docs in the same pass.
+
+Quick test: if the product were rebuilt from scratch tomorrow and this
+research still matters, it belongs in the business repo. Durable conclusions
+always codify up into the business repo's `core/` regardless of where the
+raw file sits, and research files carry `offer:` frontmatter in multi-offer
+repos. `/mb-think` applies this contract in its research and codify phases.
+
 ## Current Paths And Legacy Repos
 
 Contracts document current Main Branch paths only: `core/`,


### PR DESCRIPTION
## What

#805: the research-placement contract as engine doctrine, in the three landing spots the issue named:

1. `mb-think` `references/research-phase.md` — new "Which Repo Gets the Research File" section (placement rule, default-up for mixed, rebuild-tomorrow test, the two invariants).
2. `mb-think` `references/codify-phase.md` — codify-up invariant at the identify-what-changes step (durable conclusions reach the business repo's `core/` even when the raw file lives in a product repo).
3. `docs/business-file-contracts.md` — "Research Placement Across Repos" section for the folder-model contract surface.

SKILL.md untouched (496/500 lines; the references are the right depth for this).

## Evidence

- `mb skill validate --all --json`: green.
- Doc-only; docs naming gate covers filenames; no packaged behavior change.

Closes #805

🤖 Generated with [Claude Code](https://claude.com/claude-code)