### PR TITLE
feat(pushes): media_location/media_backend on push frontmatter (#803)

### DIFF
--- a/.claude/skills/mb-ads/SKILL.md
+++ b/.claude/skills/mb-ads/SKILL.md
@@ -111,7 +111,10 @@ The word "campaign" elsewhere in this skill refers to Meta Ads campaigns
 (the provider's term for its object) — not the Main Branch primitive.
 
 When creating `push.md`, include the validator-required frontmatter and fill
-the values from repo truth or operator answers:
+the values from repo truth or operator answers. When finished creative
+already exists outside git (a Drive folder, an export), ask "where do the
+finished files live?" and record `media_location` plus a `media_backend`
+hint (google-drive, r2, local, mb-media):
 
 ```yaml
 ---
@@ -125,31 +128,31 @@ owner: ""
 audience: ""
 offer: core/offers/<offer>/offer.md
 promise: ""
+media_location: ""   # optional — where binary creative lives
+media_backend: ""    # optional hint; requires media_location
 ---
 ```
 
-If the push is tied to a bet, decision, research file, playbook, or outcome,
-add the appropriate typed frontmatter link (`linked_bets`,
-`linked_decisions`, `linked_research`, `linked_playbooks`,
-`linked_outcomes`). Mirror frontmatter links in `## Related links` with
-Markdown relative links, or preview `mb doctor repair --plan` and ask before
-applying the repair. Use the connection decision matrix in
-docs/business-connections.md before adding typed links. Do not infer
-frontmatter links from body-only references.
+If the push ties to a bet, decision, research file, playbook, or outcome,
+add the typed frontmatter link (`linked_bets`, `linked_decisions`,
+`linked_research`, `linked_playbooks`, `linked_outcomes`) and mirror it in
+`## Related links` as Markdown relative links, or preview
+`mb doctor repair --plan` and ask first. Use the connection matrix in
+docs/business-connections.md; never infer links from body-only references.
 
 When an ad-adjacent workflow needs a resource-delivery plan, provider setup
-recipe, launch checklist, or external automation approval record, draft it as
-`pushes/<YYYY-MM-DD-slug>/playbooks/<playbook>.md` with `type: playbook`.
-Treat playbooks as plans and approval records only. Do not publish, schedule,
-DM, reply, mutate ad accounts, or claim a provider is supported unless `mb`
-and a shipped provider adapter prove that path with docs, tests, approval
-gates, and smoke evidence.
+recipe, launch checklist, or external automation approval record, draft it
+as `pushes/<YYYY-MM-DD-slug>/playbooks/<playbook>.md` with `type: playbook`
+— plans and approval records only. Do not publish, schedule, DM, reply,
+mutate ad accounts, or claim a provider is supported unless `mb` and a
+shipped provider adapter prove that path with docs, tests, approval gates,
+and smoke evidence.
 
 ## Step 0: Pre-Flight Readiness
 
-**Before triage, find the business repo, read deterministic Main Branch facts,
-then score ad-specific reference depth only when needed.** This prevents
-generating generic ads from thin reference without duplicating repo-health or
+**Before triage, find the business repo, read deterministic Main Branch
+facts, then score ad-specific reference depth only when needed.** This
+prevents generic ads from thin reference without duplicating repo-health or
 provider checks that `mb` already owns.
 
 ### 0a. Find Business Repo (REQUIRED — do this first)
@@ -158,27 +161,24 @@ provider checks that `mb` already owns.
 
 **CWD-first:** If current Main Branch markers exist in CWD, use it. If CWD looks like an old Main Branch repo, run `mb status --json --peek` and/or `mb doctor repair --plan` before saved config or discovery. Do not write to old repo structure.
 
-If CWD is NOT a business repo:
-
-Run:
+If CWD is NOT a business repo, run:
 
 ```bash
 mb status --json --peek
 ```
 
 - If status identifies a usable business repo, ask the user to confirm it.
-- If status cannot identify a repo, ask: "Which business repo should I use?
-  Give me the path."
+- If status cannot identify one, ask: "Which business repo should I use?"
 - If `/mb-ads` was invoked from `/mb-start`, the repo is already identified —
   use it without asking.
 
 **Always confirm the repo before proceeding.** Never assume.
 
-After the repo is confirmed, run `mb status --json --peek` from that repo. Use
-`readiness`, `drift.items`, `integrations`, `measurement`, and `ranked_actions`
-as the source of truth for setup, stale context, GitHub, provider readiness, and
-repair commands. Only run the direct scoring below for ad-specific creative
-depth when status is unavailable or lacks the needed ad-specific detail.
+After confirming, run `mb status --json --peek` from that repo. Use
+`readiness`, `drift.items`, `integrations`, `measurement`, and
+`ranked_actions` as the source of truth for setup, stale context, GitHub,
+provider readiness, and repair commands. Only run the direct scoring below
+when status is unavailable or lacks the needed ad-specific detail.
 
 When the request depends on a new, thin, or underperforming offer, load
 `.claude/reference/conversion/offer-sharpening.md` before writing hooks or

--- a/LOOP-STATE.md
+++ b/LOOP-STATE.md
@@ -173,7 +173,12 @@ Canon (read on first iteration of a fresh session):
   where its conclusions codify") landed in mb-think research-phase +
   codify-phase references and docs/business-file-contracts.md: codify-up
   invariant, rebuild-tomorrow test, offer frontmatter in multi-offer
-  repos. This PR.
+  repos (#849 merged).
+- 2026-06-11: #803 slice — push frontmatter gains optional
+  media_location + media_backend (pushes.py parses them into facts;
+  validator: non-empty when present, backend requires location; mb-ads
+  push template asks "where do the finished files live?"). Full
+  contract promotion + lock/reconcile semantics stay on #803. This PR.
 
 ## Next intent
 

--- a/mb/mb/pushes.py
+++ b/mb/mb/pushes.py
@@ -140,6 +140,8 @@ def _summarize_record(repo: Path, path: Path, *, legacy: bool) -> dict[str, Any]
         "offer": _string(meta.get("offer")),
         "promise": _string(meta.get("promise")),
         "channels": _strings(meta.get("channels")),
+        "media_location": _string(meta.get("media_location")),
+        "media_backend": _string(meta.get("media_backend")),
         "started": _date_string(meta.get("started")),
         "review_on": _date_string(meta.get("review_on")),
         "date": _record_date(meta, path),

--- a/mb/mb/validate.py
+++ b/mb/mb/validate.py
@@ -559,6 +559,18 @@ def _check_push_frontmatter(path: Path, fm: dict[str, Any], errors: list[str]) -
     promise = fm.get("promise")
     if isinstance(promise, str) and len(promise.strip()) > 140:
         errors.append("promise must be 140 characters or fewer")
+    media_location = fm.get("media_location")
+    if "media_location" in fm and not (isinstance(media_location, str) and media_location.strip()):
+        errors.append("media_location must be a non-empty string when present")
+    if "media_backend" in fm:
+        media_backend = fm.get("media_backend")
+        if not (isinstance(media_backend, str) and media_backend.strip()):
+            errors.append("media_backend must be a non-empty string when present")
+        elif not (isinstance(media_location, str) and media_location.strip()):
+            errors.append(
+                "media_backend is set but media_location is missing — "
+                "record where the finished creative lives"
+            )
     goal = fm.get("goal")
     if "goal" not in fm:
         return

--- a/mb/tests/test_pushes.py
+++ b/mb/tests/test_pushes.py
@@ -1,0 +1,61 @@
+"""Push facts parsing."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from mb import pushes as pushes_mod
+
+
+def _write(path: Path, body: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+
+
+def test_push_facts_include_media_fields(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "pushes" / "2026-06-11-ad-batch" / "push.md",
+        (
+            "---\n"
+            "type: push\n"
+            "slug: ad-batch\n"
+            "kind: launch\n"
+            "status: active\n"
+            "health: on-track\n"
+            "owner: Devon\n"
+            "audience: roofers\n"
+            "offer: core/offers/roofing/offer.md\n"
+            "promise: Booked-out calendar.\n"
+            "media_location: https://drive.google.com/drive/folders/fixture\n"
+            "media_backend: google-drive\n"
+            "---\n"
+            "# Ad batch\n"
+        ),
+    )
+    _write(
+        tmp_path / "pushes" / "2026-06-12-no-media" / "push.md",
+        (
+            "---\n"
+            "type: push\n"
+            "slug: no-media\n"
+            "kind: launch\n"
+            "status: planned\n"
+            "health: unknown\n"
+            "owner: Devon\n"
+            "audience: roofers\n"
+            "offer: core/offers/roofing/offer.md\n"
+            "promise: Booked-out calendar.\n"
+            "---\n"
+            "# No media\n"
+        ),
+    )
+
+    report = pushes_mod.facts(tmp_path)
+    by_slug = {record["slug"]: record for record in report["records"]}
+
+    assert by_slug["ad-batch"]["media_location"] == (
+        "https://drive.google.com/drive/folders/fixture"
+    )
+    assert by_slug["ad-batch"]["media_backend"] == "google-drive"
+    assert by_slug["no-media"]["media_location"] == ""
+    assert by_slug["no-media"]["media_backend"] == ""

--- a/mb/tests/test_validate.py
+++ b/mb/tests/test_validate.py
@@ -2295,3 +2295,37 @@ def test_render_human_collapses_warnings_by_default(tmp_path: Path, capsys) -> N
     verbose_out = capsys.readouterr().out
     # Verbose restores the full per-file detail for power users.
     assert verbose_out.count("2026-04-29-link-") == 40
+
+
+def test_validate_push_media_fields(tmp_path: Path) -> None:
+    base = _push("active")
+
+    with_media = base.replace(
+        "promise: Own the launch memory in git.\n",
+        "promise: Own the launch memory in git.\n"
+        "media_location: https://drive.google.com/drive/folders/fixture\n"
+        "media_backend: google-drive\n",
+    )
+    _write(tmp_path / "pushes" / "2026-05-07-with-media" / "push.md", with_media)
+
+    backend_only = base.replace(
+        "promise: Own the launch memory in git.\n",
+        "promise: Own the launch memory in git.\nmedia_backend: google-drive\n",
+    )
+    _write(tmp_path / "pushes" / "2026-05-08-backend-only" / "push.md", backend_only)
+
+    empty_location = base.replace(
+        "promise: Own the launch memory in git.\n",
+        "promise: Own the launch memory in git.\nmedia_location: ''\n",
+    )
+    _write(tmp_path / "pushes" / "2026-05-09-empty-loc" / "push.md", empty_location)
+
+    report = run(str(tmp_path))
+
+    by_path = {f["path"]: f for f in report["files"]}
+    good = by_path["pushes/2026-05-07-with-media/push.md"]
+    assert good["ok"], good["errors"]
+    backend = by_path["pushes/2026-05-08-backend-only/push.md"]
+    assert any("media_location is missing" in e for e in backend["errors"])
+    empty = by_path["pushes/2026-05-09-empty-loc/push.md"]
+    assert any("media_location must be a non-empty string" in e for e in empty["errors"])


### PR DESCRIPTION
## What

First slice of #803 (dogfooded on the dogfood business 30-image ad batch handoff): pushes can now record where finished binary creative lives, in a typed way.

- `media_location` + `media_backend` optional push frontmatter; `pushes.py` parses both into push facts (status/start/graph/dashboard consumers get them for free).
- Validator rules in `_check_push_frontmatter`: each must be non-empty when present; `media_backend` without `media_location` is an error ("record where the finished creative lives").
- mb-ads push-creation template includes both fields and the capture question ("where do the finished files live?"), with the backend hints (google-drive, r2, local, mb-media). SKILL.md held at exactly 500/500 via prose tightening — no substance dropped.

Remaining on #803: full push file_contract promotion, locked-record/reconcile semantics (per the mining-report evidence comment).

## Evidence

- New `test_pushes.py` (facts include the fields; absent → empty strings) + `test_validate_push_media_fields` (good push passes, backend-only fails, empty location fails).
- `test_pushes.py` + `test_validate.py`: 94 passed. `mb skill validate`: green. ruff + mypy strict clean.

Refs #803

🤖 Generated with [Claude Code](https://claude.com/claude-code)