### PR TITLE
feat(connect): operator-defined custom providers via --custom (#833)

### DIFF
--- a/LOOP-STATE.md
+++ b/LOOP-STATE.md
@@ -186,7 +186,14 @@ Canon (read on first iteration of a fresh session):
   subagent operating contract (mining rec 19's doctrine home:
   commit-before-return verified, worktree-per-agent, liveness,
   auditor/builder separation, docs-first + stale-doc cleanup).
-  mb-setup points operators at it. This PR.
+  mb-setup points operators at it (#851 merged).
+- 2026-06-11: #833 done — `mb connect <id> --custom` registers
+  operator-named providers (slug-validated, api_key slot) on the same
+  SecretStore/user-scope/token/status/test rails; once connected,
+  reconnect and all read paths work without the flag
+  (`resolve_provider` checks registry → connected customs). Unknown
+  provider error now hints --custom. Closes the DataForSEO-class gap
+  from mining friction #1. This PR.
 
 ## Next intent
 

--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -1109,6 +1109,14 @@ def connect_cmd(
         "--from-env",
         help="Read the provider credential from a known environment variable.",
     ),
+    custom: bool = typer.Option(
+        False,
+        "--custom",
+        help=(
+            "Register an operator-defined provider id (lowercase letters, "
+            "digits, hyphens) with an api_key secret slot."
+        ),
+    ),
     metadata: list[str] = CONNECT_METADATA_OPTION,
     all_providers: bool = typer.Option(
         False,
@@ -1225,7 +1233,10 @@ def connect_cmd(
         raise typer.Exit(2)
 
     try:
-        provider_info = connect_mod.normalize_provider(target)
+        if custom:
+            provider_info = connect_mod.normalize_provider(target, allow_custom=True)
+        else:
+            provider_info = connect_mod.resolve_provider(target, repo)
     except ValueError as exc:
         typer.echo(f"mb connect: {exc}", err=True)
         raise typer.Exit(2) from exc
@@ -1265,6 +1276,7 @@ def connect_cmd(
             account_label=account_label,
             metadata_pairs=metadata,
             scope=scope,
+            custom=custom,
         )
         result["credential_source"] = {
             "type": credential_source if secret_value else "missing",

--- a/mb/mb/connect.py
+++ b/mb/mb/connect.py
@@ -317,15 +317,45 @@ def provider_registry() -> list[dict[str, Any]]:
     ]
 
 
-def normalize_provider(provider_id: str) -> Provider:
+CUSTOM_PROVIDER_RE = re.compile(r"^[a-z0-9][a-z0-9-]{1,30}$")
+
+
+def _custom_provider(provider_id: str) -> Provider:
+    """Synthesize a registry entry for an operator-named provider.
+
+    Custom providers ride every existing rail (SecretStore, user scope,
+    `mb connect token`, status) with a single `api_key` secret slot.
+    """
+    return Provider(
+        id=provider_id,
+        name=provider_id,
+        category="custom",
+        auth="api_key",
+        required_secrets=("api_key",),
+        metadata_fields=(),
+        description="Operator-defined custom provider.",
+    )
+
+
+def normalize_provider(provider_id: str, *, allow_custom: bool = False) -> Provider:
     key = provider_id.strip().lower().replace("_", "-")
     aliases = {"whisper": "transcription", "cloudflare-pages": "cloudflare"}
     key = aliases.get(key, key)
     providers = provider_map()
-    if key not in providers:
-        supported = ", ".join(sorted(providers))
-        raise ValueError(f"unknown provider {provider_id!r}; supported providers: {supported}")
-    return providers[key]
+    if key in providers:
+        return providers[key]
+    if allow_custom:
+        if not CUSTOM_PROVIDER_RE.fullmatch(key):
+            raise ValueError(
+                f"custom provider id {provider_id!r} must be 2-31 chars of "
+                "lowercase letters, digits, and hyphens"
+            )
+        return _custom_provider(key)
+    supported = ", ".join(sorted(providers))
+    raise ValueError(
+        f"unknown provider {provider_id!r}; supported providers: {supported}. "
+        "For an operator-defined provider, rerun with --custom."
+    )
 
 
 def _now() -> str:
@@ -992,10 +1022,15 @@ def connect_provider(
     metadata_pairs: list[str] | None = None,
     secret_backend: str | None = None,
     scope: str = "repo",
+    custom: bool = False,
 ) -> dict[str, Any]:
     """Connect a provider by writing repo metadata and local secrets."""
 
-    provider = normalize_provider(provider_id)
+    if custom:
+        provider = normalize_provider(provider_id, allow_custom=True)
+    else:
+        # Reconnecting an existing custom provider works without the flag.
+        provider = resolve_provider(provider_id, repo)
     normalized_scope = scope.strip().lower().replace("_", "-") or "repo"
     if normalized_scope not in CONNECT_SCOPES:
         raise ValueError("scope must be repo or user")
@@ -1114,6 +1149,27 @@ def _unhydrated_status(provider: Provider, entry: dict[str, Any]) -> dict[str, A
     }
 
 
+def resolve_provider(provider_id: str, repo: str | Path = ".") -> Provider:
+    """Resolve a provider id against the registry, then connected customs.
+
+    Read paths (status, token, test, hydrate) use this so an already
+    connected custom provider keeps working without re-passing --custom.
+    """
+    try:
+        return normalize_provider(provider_id)
+    except ValueError:
+        key = provider_id.strip().lower().replace("_", "-")
+        if CUSTOM_PROVIDER_RE.fullmatch(key):
+            target = Path(repo).resolve()
+            config = _read_config(target)
+            if isinstance(config["providers"].get(key), dict):
+                return _custom_provider(key)
+            repo_id = str(config.get("repo_id") or _repo_identity(target)["repo_id"])
+            if _user_scope_provider_entry(repo_id, key) is not None:
+                return _custom_provider(key)
+        raise
+
+
 def status_provider(
     provider_id: str,
     repo: str | Path = ".",
@@ -1121,7 +1177,7 @@ def status_provider(
     which_func: Which | None = None,
     command_runner: CommandRunner | None = None,
 ) -> dict[str, Any]:
-    provider = normalize_provider(provider_id)
+    provider = resolve_provider(provider_id, repo)
     target = Path(repo).resolve()
     config = _read_config(target)
     identity = _repo_identity(target)
@@ -1311,7 +1367,7 @@ def hydrate(
     providers = raw_providers if isinstance(raw_providers, dict) else {}
     selected_ids: list[str]
     if provider_id:
-        provider = normalize_provider(provider_id)
+        provider = resolve_provider(provider_id, repo)
         selected_ids = [provider.id]
     else:
         selected_ids = sorted(str(key) for key in providers)
@@ -1370,7 +1426,7 @@ def read_token(provider_id: str, repo: str | Path = ".") -> dict[str, Any]:
     Falls back to user scope when the repo config has no entry, so worktrees
     and scheduled tasks resolve the same credential as the primary checkout.
     """
-    provider = normalize_provider(provider_id)
+    provider = resolve_provider(provider_id, repo)
     if not provider.required_secrets:
         raise ValueError(f"provider {provider.id!r} stores no secrets")
     field = provider.required_secrets[0]
@@ -1913,7 +1969,7 @@ def test_provider(
     which_func: Which | None = None,
     command_runner: CommandRunner | None = None,
 ) -> dict[str, Any]:
-    provider = normalize_provider(provider_id)
+    provider = resolve_provider(provider_id, repo)
     target = Path(repo).resolve()
     config = _read_config(target)
     entry = config["providers"].get(provider.id)

--- a/mb/tests/test_connect.py
+++ b/mb/tests/test_connect.py
@@ -1776,3 +1776,68 @@ def test_connect_metadata_only_skips_key_shape_check(tmp_path: Path, monkeypatch
     )
 
     assert result["ok"] is False or result["status"]["state"] == "missing_secret"
+
+
+def test_connect_custom_provider_roundtrip(tmp_path: Path, monkeypatch) -> None:
+    _local_secret_env(monkeypatch, tmp_path)
+    repo = tmp_path / "biz"
+    repo.mkdir()
+
+    result = runner.invoke(
+        app,
+        [
+            "connect",
+            "dataforseo",
+            "--custom",
+            "--repo",
+            str(repo),
+            "--token",
+            "custom-fixture-token",
+        ],
+    )
+    assert result.exit_code == 0
+
+    config_text = (repo / ".mb" / "connect.yaml").read_text(encoding="utf-8")
+    assert "custom-fixture-token" not in config_text
+    assert "dataforseo" in config_text
+
+    token = runner.invoke(app, ["connect", "token", "dataforseo", "--repo", str(repo)])
+    assert token.exit_code == 0
+    assert token.stdout == "custom-fixture-token\n"
+
+    status = connect_mod.status_provider("dataforseo", repo)
+    assert status["provider"] == "dataforseo"
+    assert status["connected"] is True
+
+    reconnect = runner.invoke(
+        app,
+        ["connect", "dataforseo", "--repo", str(repo), "--token", "rotated-fixture-token"],
+    )
+    assert reconnect.exit_code == 0
+    rotated = runner.invoke(app, ["connect", "token", "dataforseo", "--repo", str(repo)])
+    assert rotated.stdout == "rotated-fixture-token\n"
+
+
+def test_connect_unknown_provider_hints_custom(tmp_path: Path, monkeypatch) -> None:
+    _local_secret_env(monkeypatch, tmp_path)
+    repo = tmp_path / "biz"
+    repo.mkdir()
+
+    result = runner.invoke(app, ["connect", "dataforseo", "--repo", str(repo), "--token", "x"])
+
+    assert result.exit_code == 2
+    assert "rerun with --custom" in result.stderr
+
+
+def test_connect_custom_rejects_bad_slug(tmp_path: Path, monkeypatch) -> None:
+    _local_secret_env(monkeypatch, tmp_path)
+    repo = tmp_path / "biz"
+    repo.mkdir()
+
+    result = runner.invoke(
+        app,
+        ["connect", "Bad_Slug!", "--custom", "--repo", str(repo), "--token", "x"],
+    )
+
+    assert result.exit_code == 2
+    assert "lowercase letters, digits, and hyphens" in result.stderr


### PR DESCRIPTION
## What

Final slice of #833 (mining friction #1): credentials for providers outside the registry no longer live outside mb.

- `mb connect <id> --custom` — operator-named provider (slug-validated `^[a-z0-9][a-z0-9-]{1,30}$`), `api_key` secret slot, category `custom`. Same SecretStore backends, user-scope rail, `mb connect token` read path, status/test surfaces.
- `resolve_provider(id, repo)` — registry first, then connected customs (repo config → user scope). All read paths (status/token/test/hydrate) and reconnects work without re-passing `--custom`.
- Unknown-provider error now ends with "For an operator-defined provider, rerun with --custom."

With this, #833's three slices are complete: first-class Stripe/Resend (#846), key-shape + mode intake validation (#847), and the generic path (this PR).

## Evidence

- 3 new tests: full custom roundtrip (connect → token absent from yaml → `mb connect token` read-back → status → reconnect-without-flag → rotated read-back), unknown-provider hint, bad-slug rejection.
- `test_connect.py` 63 passed; + `test_status.py`: 161 passed. ruff + mypy strict clean.

Closes #833

🤖 Generated with [Claude Code](https://claude.com/claude-code)