### PR TITLE
feat(mb-setup): scaffold the agent-access dossier at setup (#817)

### DIFF
--- a/.claude/skills/mb-setup/SKILL.md
+++ b/.claude/skills/mb-setup/SKILL.md
@@ -345,6 +345,10 @@ Branch engine for current setup patterns. Historical engine builds may still
 contain older compatibility notes under paths that use the word "domain"; treat
 those as migration notes only, not the current product model.
 
+Also scaffold `core/operations/agent-access-dossier.md` from
+`references/templates.md` — the capability map (storage doctrine, provider
+verify table, never-print rules); fill rows from what the operator connects.
+
 ### 7. Draft CLAUDE.md
 
 See `references/claude-md-guide.md` for structure.

--- a/.claude/skills/mb-setup/references/templates.md
+++ b/.claude/skills/mb-setup/references/templates.md
@@ -698,7 +698,7 @@ secret values, ids, or item names.
 
 ## The storage doctrine
 
-1. **Operator's password manager = canonical, OPERATOR-PRESENT ONLY.**
+1. **Operator's password manager = the source of truth, OPERATOR-PRESENT ONLY.**
    Never put it in an automated or scheduled path. Its uses: one-time moves
    into the keychain while the operator is present, and high-sensitivity
    moments where the operator explicitly wants to be in the loop.

--- a/.claude/skills/mb-setup/references/templates.md
+++ b/.claude/skills/mb-setup/references/templates.md
@@ -675,6 +675,59 @@ status: complete
 
 ---
 
+## core/operations/agent-access-dossier.md
+
+The capability map for agents operating this business: which providers an
+agent can reach, where each credential lives, and how to verify access.
+States the MODEL only — never secret values, ids, or item names. Scaffold it
+during setup with the providers the operator names; agents keep the table
+current as access changes (verify dates, scope notes).
+
+```markdown
+---
+type: reference
+status: active
+date: YYYY-MM-DD
+---
+
+# Agent access dossier — what an operating agent can reach, and how
+
+The capability map for agents running this business. States the MODEL
+(which provider, which storage class, how to retrieve and verify) — never
+secret values, ids, or item names.
+
+## The storage doctrine
+
+1. **Operator's password manager = canonical, OPERATOR-PRESENT ONLY.**
+   Never put it in an automated or scheduled path. Its uses: one-time moves
+   into the keychain while the operator is present, and high-sensitivity
+   moments where the operator explicitly wants to be in the loop.
+2. **Keychain via `mb connect` = THE agent path** (reliable, unattended).
+   One-time move from the password manager, piped — never printed. Scripts
+   read back with `mb connect token <provider>`.
+3. **Platform runtime secrets** (e.g. Workers/Pages bindings) are
+   write-only — verify by behavior, not read-back.
+4. **Session env file** for anything that must be exported into a shell.
+
+## Provider map (verify, don't assume — run the check command)
+
+| Provider | Access level | Storage | Verify |
+|---|---|---|---|
+| [provider] | [scopes/level + last-verified date] | [keychain via mb connect / env file / runtime] | [e.g. `mb connect test <provider>`] |
+
+## Operating rules
+
+- **Spend and publish stay human.** Agents may stage work paused/drafted;
+  activation is the operator's click.
+- **Never print a credential.** Pipe values directly into the consumer; no
+  echo, no fallback expansions that reveal the value when set.
+- **One-time moves, durable homes.** A credential needed repeatedly moves
+  to the keychain via `mb connect` once; stop depending on operator-present
+  stores for automated paths.
+```
+
+---
+
 ## README.md
 
 ```markdown

--- a/LOOP-STATE.md
+++ b/LOOP-STATE.md
@@ -193,7 +193,16 @@ Canon (read on first iteration of a fresh session):
   reconnect and all read paths work without the flag
   (`resolve_provider` checks registry → connected customs). Unknown
   provider error now hints --custom. Closes the DataForSEO-class gap
-  from mining friction #1. This PR.
+  from mining friction #1 (#852 merged). Friction-#1 cluster complete.
+- 2026-06-11: consolidation check on main after 22 merges: check.sh
+  exit 0, 949 passed, 0 failed (+26 tests today, zero regressions).
+- 2026-06-11: #817 slice 1 — mb-setup scaffolds
+  core/operations/agent-access-dossier.md (generic capability map:
+  storage doctrine, provider verify table, never-print rules; rows
+  filled from connected providers). Slice 2 (doctor runs the verify
+  column) deferred with a whitelist security design commented on #817
+  — repo-listed shell commands are an injection surface; only mb-owned
+  commands auto-run. This PR.
 
 ## Next intent
 


### PR DESCRIPTION
## What

#817 slice 1: every new business gets the capability map from day one.

- `references/templates.md` gains `core/operations/agent-access-dossier.md` — generalized from the hub original: the storage doctrine (password manager = operator-present only; keychain via `mb connect` = the agent path, read back with `mb connect token`; runtime secrets verify-by-behavior; session env), an empty provider verify table, and the operating rules (spend/publish stay human; never print a credential — including the fallback-expansion leak class; one-time moves to durable homes).
- mb-setup step 6 scaffolds it and fills provider rows from what the operator connects. SKILL.md at exactly 500/500.

**Slice 2 deferred with a security design** (commented on #817): `mb doctor` executing verify commands listed in a repo file is a command-injection surface. Proposed bound: auto-run only whitelisted mb-owned commands (`mb connect test <provider>`); everything else surfaces as "run this yourself."

## Evidence

- `mb skill validate --all --json`: green. Skill-prose + template only; no packaged behavior change beyond the bundled files (wheel packaging of skill references is already covered by the existing smoke).

Refs #817

🤖 Generated with [Claude Code](https://claude.com/claude-code)