### PR TITLE
feat(connect): rotation sweeps sibling keychain refs (#807)

### DIFF
--- a/LOOP-STATE.md
+++ b/LOOP-STATE.md
@@ -202,7 +202,14 @@ Canon (read on first iteration of a fresh session):
   filled from connected providers). Slice 2 (doctor runs the verify
   column) deferred with a whitelist security design commented on #817
   — repo-listed shell commands are an injection surface; only mb-owned
-  commands auto-run. This PR.
+  commands auto-run (#853 merged).
+- 2026-06-12: #807 done — token rotation now sweeps sibling keychain
+  refs: connect with a new credential updates every user-scope ref for
+  that provider across repos/worktrees (per-ref error isolation; rotated
+  + still-stale refs reported, refs are hashes so safe to print; human
+  render warns loudly on any stale survivor). The 2026-06-09
+  three-refs-one-updated failure class is closed for the doctrine path.
+  This PR.
 
 ## Next intent
 
@@ -211,12 +218,11 @@ asking; every slice references its issue and closes it via PR body; new
 findings become issues (LOOP-STATE keeps ordering, issues keep content).
 
 - **Waiting on Devon: pypi environment approval for v0.3.43** (build done,
-  notes synced). Post-publish: verify per docs/post-release-alignment.md.
-- Re-rank priority order against the mining report's leaderboard: top
-  recommendation cluster is credentials (generic provider path + Stripe/
-  Resend first-class, scope manifests, refresh tokens) and verification
-  (provider-write receipts) — both currently mid-list as #807/#817/#656.
-  Proposed next slices: #828 setup-prompt canonicalization (in flight
-  queue), then #804 Stage 2, then the credentials cluster.
+  notes synced). Post-publish: verify per docs/post-release-alignment.md,
+  then hand Devon the Morning Paper plugin-smoke prompt (prompt 3).
+- #817 slice 2: doctor runs the dossier verify column, whitelist-bound
+  (design posted on the issue).
+- Heavy tier, wants Devon's priority call or Stage-1 smoke evidence:
+  #813 pulse, #814 spine, #816 canary, #806 offer graduate, #804 Stage 2.
 - Migrate the BOR daily-brief keychain block to `mb connect token` once
   v0.3.43 publishes (read-only change in the bookedoutroofers repo).

--- a/mb/mb/connect.py
+++ b/mb/mb/connect.py
@@ -1077,6 +1077,11 @@ def connect_provider(
                 entry=providers[provider.id],
             )
         )
+    rotated_sibling_refs, stale_sibling_refs = (
+        _sync_sibling_refs(provider, token, current_ref=secrets[required[0]]["ref"])
+        if token and required
+        else ([], [])
+    )
     path = _write_config(target, config)
     status = status_provider(provider.id, target)
     return {
@@ -1089,9 +1094,48 @@ def connect_provider(
         "hydrated": normalized_scope == "user",
         "credential_backend": store.backend,
         "credential_boundary": store.boundary(),
+        "rotated_sibling_refs": rotated_sibling_refs,
+        "stale_sibling_refs": stale_sibling_refs,
         "setup": _meta_setup() if provider.id == "meta" else {},
         "status": status,
     }
+
+
+def _sync_sibling_refs(
+    provider: Provider, token: str, *, current_ref: str
+) -> tuple[list[str], list[str]]:
+    """Rotate every sibling keychain ref for ``provider`` to ``token``.
+
+    A provider connected from several repos (main checkout, worktrees, other
+    business repos) holds one keychain ref per repo id. Rotating from one
+    repo previously updated only that repo's ref; scheduled jobs resolving
+    the others kept the stale token silently. Sibling refs are discovered
+    from user scope; refs are hashes and safe to report — the token never
+    is. Returns (rotated, still_stale) ref lists.
+    """
+    rotated: list[str] = []
+    stale: list[str] = []
+    data = _read_user_scope()
+    for raw_repo in data["repos"].values():
+        repo_entry = raw_repo if isinstance(raw_repo, dict) else {}
+        raw_entries = repo_entry.get("providers")
+        entries: dict[str, Any] = raw_entries if isinstance(raw_entries, dict) else {}
+        raw_entry = entries.get(provider.id)
+        entry = raw_entry if isinstance(raw_entry, dict) else {}
+        stored = entry.get("secrets") if isinstance(entry.get("secrets"), dict) else {}
+        for raw_secret in stored.values() if isinstance(stored, dict) else []:
+            secret = raw_secret if isinstance(raw_secret, dict) else {}
+            ref = str(secret.get("ref") or "")
+            backend = str(secret.get("backend") or "local-file")
+            if not ref or ref == current_ref or ref in rotated or ref in stale:
+                continue
+            try:
+                SecretStore(backend).set(ref, token)
+            except RuntimeError:
+                stale.append(ref)
+            else:
+                rotated.append(ref)
+    return rotated, stale
 
 
 def _secret_statuses(provider: Provider, entry: dict[str, Any]) -> tuple[dict[str, Any], list[str]]:
@@ -2479,6 +2523,19 @@ def render_connect_result(result: dict[str, Any]) -> None:
     if result.get("scope") == "user":
         print(f"user scope: {result['user_scope_path']}")
     print(f"secrets: {result['credential_boundary']}")
+    rotated = result.get("rotated_sibling_refs") or []
+    if rotated:
+        print(
+            f"rotated {len(rotated)} sibling ref(s) to the new credential (other repos/worktrees)"
+        )
+    stale = result.get("stale_sibling_refs") or []
+    if stale:
+        print(
+            f"WARNING: {len(stale)} sibling ref(s) could not be updated "
+            "and still hold the OLD credential:"
+        )
+        for ref in stale:
+            print(f"  - {ref}")
     source = result.get("credential_source") or {}
     if source.get("type") == "env" and source.get("env_var"):
         print(f"credential source: env {source['env_var']}")

--- a/mb/tests/test_connect.py
+++ b/mb/tests/test_connect.py
@@ -1841,3 +1841,43 @@ def test_connect_custom_rejects_bad_slug(tmp_path: Path, monkeypatch) -> None:
 
     assert result.exit_code == 2
     assert "lowercase letters, digits, and hyphens" in result.stderr
+
+
+def test_rotation_syncs_sibling_refs_across_repos(tmp_path: Path, monkeypatch) -> None:
+    _local_secret_env(monkeypatch, tmp_path)
+    repo_a = tmp_path / "biz-a"
+    repo_b = tmp_path / "biz-b"
+    repo_a.mkdir()
+    repo_b.mkdir()
+
+    connect_mod.connect_provider("cloudflare", repo=repo_a, token="cf-old-token", scope="user")
+    connect_mod.connect_provider("cloudflare", repo=repo_b, token="cf-old-token", scope="user")
+
+    result = connect_mod.connect_provider(
+        "cloudflare", repo=repo_a, token="cf-new-token", scope="user"
+    )
+
+    assert len(result["rotated_sibling_refs"]) == 1
+    assert result["stale_sibling_refs"] == []
+    token_b = runner.invoke(app, ["connect", "token", "cloudflare", "--repo", str(repo_b)])
+    assert token_b.exit_code == 0
+    assert token_b.stdout == "cf-new-token\n"
+
+
+def test_rotation_does_not_touch_other_providers(tmp_path: Path, monkeypatch) -> None:
+    _local_secret_env(monkeypatch, tmp_path)
+    repo_a = tmp_path / "biz-a"
+    repo_b = tmp_path / "biz-b"
+    repo_a.mkdir()
+    repo_b.mkdir()
+
+    connect_mod.connect_provider("cloudflare", repo=repo_a, token="cf-token", scope="user")
+    connect_mod.connect_provider("apify", repo=repo_b, token="apify-token", scope="user")
+
+    result = connect_mod.connect_provider(
+        "cloudflare", repo=repo_a, token="cf-rotated", scope="user"
+    )
+
+    assert result["rotated_sibling_refs"] == []
+    token_b = runner.invoke(app, ["connect", "token", "apify", "--repo", str(repo_b)])
+    assert token_b.stdout == "apify-token\n"


### PR DESCRIPTION
## What

#807, the last open credentials-cluster item from the live-business mining report's friction #1: rotating a provider credential now updates every sibling keychain ref, not just the connecting repo's.

- `_sync_sibling_refs()`: discovers all user-scope refs for the provider across repo ids (main checkout, worktrees, other business repos), rotates each to the new token through its own recorded backend. Per-ref error isolation — one unreachable ref doesn't fail the connect or the rest of the sweep.
- Result gains `rotated_sibling_refs` + `stale_sibling_refs` (refs are `mainbranch://hash/provider/field` identifiers — safe to print; the credential never appears).
- Human render: one line on success ("rotated N sibling ref(s)"), loud WARNING listing any ref still holding the old credential.
- Scope: the doctrine path (user-scope connects, which is how agent credentials are stored per the access-dossier doctrine). Repo-only connects in unrelated repos are not centrally discoverable and remain out of scope — noted here rather than silently claimed.

## Evidence

- 2 new tests: two-repo rotation (repo B's `mb connect token` returns the new credential after rotating from repo A), and provider isolation (rotating cloudflare leaves apify's ref untouched).
- `test_connect.py`: 65 passed. ruff + mypy strict clean.

Closes #807

🤖 Generated with [Claude Code](https://claude.com/claude-code)