### PR TITLE
feat(doctor): verify the agent-access dossier's provider table (#817)

### DIFF
--- a/mb/mb/doctor.py
+++ b/mb/mb/doctor.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import shutil
 import socket
 import subprocess
@@ -251,6 +252,105 @@ def _section(
         "checks": checks or [],
         "actions": actions or [],
     }
+
+
+DOSSIER_RELATIVE_PATH = Path("core") / "operations" / "agent-access-dossier.md"
+_DOSSIER_VERIFY_RE = re.compile(r"^mb connect test ([a-z0-9][a-z0-9-]{1,30})$")
+
+
+def _dossier_provider_rows(path: Path) -> list[tuple[str, str]]:
+    """Parse (provider, verify) pairs from the dossier's provider table."""
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return []
+    rows: list[tuple[str, str]] = []
+    in_table = False
+    for line in lines:
+        stripped = line.strip()
+        if stripped.lower().startswith("| provider |"):
+            in_table = True
+            continue
+        if not in_table:
+            continue
+        if not stripped.startswith("|"):
+            in_table = False
+            continue
+        cells = [cell.strip() for cell in stripped.strip("|").split("|")]
+        if not cells or set(cells[0]) <= {"-", ":", " "}:
+            continue
+        if len(cells) >= 2 and cells[0]:
+            rows.append((cells[0], cells[-1]))
+    return rows
+
+
+def _dossier_verify_section(repo: Path) -> dict[str, Any]:
+    """Verify the agent-access dossier's provider table.
+
+    Only mb-owned verify commands run, and never through a shell: the
+    provider id is parsed out of the row text and `mb connect test` is
+    called in-process. Anything else in the verify column is surfaced for
+    the operator to run — repo-listed commands are untrusted input.
+    """
+    path = repo / DOSSIER_RELATIVE_PATH
+    if not path.is_file():
+        return _section(
+            "capability-dossier",
+            "Agent Access Dossier",
+            "info",
+            (
+                "no core/operations/agent-access-dossier.md — mb-setup scaffolds "
+                "the capability map for new businesses"
+            ),
+        )
+    rows = _dossier_provider_rows(path)
+    checks: list[dict[str, Any]] = []
+    if not rows:
+        checks.append(
+            {
+                "name": "provider-table",
+                "state": "warn",
+                "summary": "dossier present but no rows found in the provider table",
+            }
+        )
+    for provider_label, verify in rows:
+        command = verify.strip().strip("`").strip()
+        match = _DOSSIER_VERIFY_RE.fullmatch(command)
+        if match:
+            provider_id = match.group(1)
+            try:
+                result = connect_mod.test_provider(provider_id, repo)
+            except ValueError as exc:
+                checks.append(
+                    {"name": provider_label, "state": "warn", "summary": f"verify failed: {exc}"}
+                )
+                continue
+            ok = bool(result.get("ok"))
+            raw_status = result.get("status")
+            status: dict[str, Any] = raw_status if isinstance(raw_status, dict) else {}
+            state_text = str(status.get("state") or ("ready" if ok else "failed"))
+            checks.append(
+                {
+                    "name": provider_label,
+                    "state": "ok" if ok else "warn",
+                    "summary": f"`mb connect test {provider_id}` → {state_text}",
+                }
+            )
+        else:
+            checks.append(
+                {
+                    "name": provider_label,
+                    "state": "info",
+                    "summary": f"operator-run verify (not auto-executed): {command[:80]}",
+                }
+            )
+    return _section(
+        "capability-dossier",
+        "Agent Access Dossier",
+        _max_state([str(check["state"]) for check in checks]) if checks else "ok",
+        "capability map verification — mb-owned verify commands only",
+        checks=checks,
+    )
 
 
 def _unique(values: list[str]) -> list[str]:
@@ -2382,6 +2482,8 @@ def repair_plan(
             ],
         )
     )
+
+    sections.append(_dossier_verify_section(target))
 
     validation = _validation_summary(target, migration_drift_report=migration_drift)
     related_links = related_links_mod.plan(target)

--- a/mb/tests/test_doctor.py
+++ b/mb/tests/test_doctor.py
@@ -1919,3 +1919,68 @@ def test_doctor_repair_plan_actions_always_carry_audience_and_summary(
             f"action {action['id']} has invalid audience: {action['audience']!r}"
         )
         assert action["operator_summary"], f"action {action['id']} has empty operator_summary"
+
+
+def test_dossier_section_absent_is_info(tmp_path: Path) -> None:
+    section = doctor_mod._dossier_verify_section(tmp_path)
+
+    assert section["id"] == "capability-dossier"
+    assert section["state"] == "info"
+    assert "mb-setup scaffolds" in section["summary"]
+
+
+def test_dossier_verify_runs_only_mb_owned_commands(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("MB_CONNECT_SECRET_BACKEND", "local-file")
+    monkeypatch.setenv("MAINBRANCH_HOME", str(tmp_path / "home"))
+    marker = tmp_path / "pwned"
+    dossier = tmp_path / "core" / "operations" / "agent-access-dossier.md"
+    dossier.parent.mkdir(parents=True)
+    dossier.write_text(
+        (
+            "# Agent access dossier\n\n"
+            "## Provider map (verify, don't assume)\n\n"
+            "| Provider | Access level | Storage | Verify |\n"
+            "|---|---|---|---|\n"
+            "| Cloudflare | read | keychain | `mb connect test cloudflare` |\n"
+            f"| Sneaky | full | env | `touch {marker}` |\n"
+            "| Lookalike | full | env | `mb connect test cloudflare; touch pwned2` |\n"
+        ),
+        encoding="utf-8",
+    )
+
+    section = doctor_mod._dossier_verify_section(tmp_path)
+    by_name = {check["name"]: check for check in section["checks"]}
+
+    assert by_name["Cloudflare"]["state"] == "warn"
+    assert "not_connected" in by_name["Cloudflare"]["summary"]
+    assert by_name["Sneaky"]["state"] == "info"
+    assert "not auto-executed" in by_name["Sneaky"]["summary"]
+    assert by_name["Lookalike"]["state"] == "info"
+    assert not marker.exists()
+    assert not (tmp_path / "pwned2").exists()
+
+
+def test_dossier_verify_reports_connected_provider_ok(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("MB_CONNECT_SECRET_BACKEND", "local-file")
+    monkeypatch.setenv("MAINBRANCH_HOME", str(tmp_path / "home"))
+    from mb import connect as connect_mod
+
+    repo = tmp_path
+    connect_mod.connect_provider("apify", repo=repo, token="apify-fixture-token")
+    dossier = repo / "core" / "operations" / "agent-access-dossier.md"
+    dossier.parent.mkdir(parents=True)
+    dossier.write_text(
+        (
+            "| Provider | Access level | Storage | Verify |\n"
+            "|---|---|---|---|\n"
+            "| Apify | research actors | keychain | `mb connect test apify` |\n"
+        ),
+        encoding="utf-8",
+    )
+
+    section = doctor_mod._dossier_verify_section(repo)
+
+    apify = section["checks"][0]
+    assert apify["name"] == "Apify"
+    assert "mb connect test apify" in apify["summary"]
+    assert apify["state"] in {"ok", "warn"}


### PR DESCRIPTION
## What

#817 slice 2 (completing the issue): `mb doctor` now runs the dossier's verify column — under the whitelist bound designed on the issue, because repo-listed shell commands are untrusted input.

- New `capability-dossier` section: parses the provider table from `core/operations/agent-access-dossier.md`.
- **Auto-runs only** rows whose verify command matches `mb connect test <provider>` exactly — and even those never touch a shell: the provider id is parsed out and `connect.test_provider` is called in-process. Result state (ready / not_connected / missing_secret / failed) lands in the check summary.
- Every other verify command → `info` check: "operator-run verify (not auto-executed): `<command>`".
- No dossier → `info` pointer at mb-setup's scaffold (shipped in slice 1).

## Evidence

- 3 new tests, including the injection case: a dossier row carrying `touch <marker>` and a `mb connect test cloudflare; touch pwned2` chain lookalike — both surfaced as operator-run, neither executed, marker files asserted absent.
- `test_doctor.py`: 76 passed. ruff + mypy strict clean.

Closes #817

🤖 Generated with [Claude Code](https://claude.com/claude-code)