### PR TITLE
feat(canary): mb canary init — golden-path canary scaffold + alert doctrine (#816)

### DIFF
--- a/mb/mb/canary.py
+++ b/mb/mb/canary.py
@@ -1,0 +1,210 @@
+"""Golden-path canary scaffold (`mb canary init`).
+
+Graduates the canary harness shape proven on a live business: checks return
+``{name, state, surface, detail}``, a cheap tier runs often at near-zero
+cost, an expensive tier runs rarely behind a flag, optional-secret checks
+WARN instead of failing, and every alert is actionable. Check CONTENTS stay
+business-side — the engine ships the harness and the doctrine, never the
+business's invariants.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+SMOKE_TEMPLATE = """#!/usr/bin/env node
+/**
+ * smoke.mjs — golden-path smoke test for this business's money path.
+ *
+ * ONE command. Exits non-zero on ANY hard failure. Prints a PASS/WARN/FAIL
+ * line per check.
+ *
+ * USAGE
+ *   node canary/smoke.mjs              # CHEAP tier only (near $0, run often)
+ *   node canary/smoke.mjs --expensive  # CHEAP + EXPENSIVE tier (run rarely)
+ *   node canary/smoke.mjs --json       # machine-readable summary on stdout
+ *
+ * DOCTRINE (see canary/README.md)
+ *   - Every check guards ONE business invariant no platform synthetic can
+ *     know, with a self-documenting comment: what breaks if it fails.
+ *   - FAIL pages the operator. WARN never pages. Optional-secret checks
+ *     WARN when the secret is absent so the cheap tier stays secret-free.
+ *   - The cheap tier must stay safe to run every few minutes: no sends, no
+ *     spend, no customer-visible side effects.
+ */
+
+const SITE = process.env.CANARY_SITE || "https://example.com"; // TODO: your site
+
+const args = new Set(process.argv.slice(2));
+const EXPENSIVE = args.has("--expensive");
+const JSON_OUT = args.has("--json");
+
+const results = [];
+
+function record(name, state, surface, detail) {
+  results.push({ name, state, surface, detail });
+  if (!JSON_OUT) console.log(`${state.padEnd(4)} ${name} — ${detail}`);
+}
+
+async function fetchWithTimeout(url, opts = {}, ms = 30000) {
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), ms);
+  try {
+    return await fetch(url, { ...opts, signal: ctrl.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CHEAP TIER — each check: guards <invariant>; breaks => <business impact>.
+// ---------------------------------------------------------------------------
+
+// Guards: the site is up. Breaks => every funnel is dark.
+async function checkSiteRoot() {
+  try {
+    const res = await fetchWithTimeout(SITE + "/");
+    record(
+      "site_root",
+      res.ok ? "PASS" : "FAIL",
+      SITE + "/",
+      res.ok ? `HTTP ${res.status}` : `HTTP ${res.status} — site down or erroring`,
+    );
+  } catch (err) {
+    record("site_root", "FAIL", SITE + "/", `unreachable: ${err.name}`);
+  }
+}
+
+// Guards: unknown paths return a REAL 404, not the homepage with 200.
+// Breaks => ad QA, crawler hygiene, and uptime checks can't trust statuses.
+async function checkSite404() {
+  try {
+    const res = await fetchWithTimeout(SITE + "/canary-known-missing-path");
+    record(
+      "site_404",
+      res.status === 404 ? "PASS" : "FAIL",
+      SITE,
+      res.status === 404 ? "real 404 served" : `soft 404: HTTP ${res.status}`,
+    );
+  } catch (err) {
+    record("site_404", "FAIL", SITE, `unreachable: ${err.name}`);
+  }
+}
+
+// TODO: add YOUR money-path checks here. Patterns from a real business:
+//   - a checkout/spend gate rejects requests missing its bot-wall token
+//   - a config endpoint still serves the LIVE tracking/payment ids (a
+//     silent revert to test mode screams instead of quietly failing)
+//   - the lead/contact door validates input and supports a dryRun that
+//     never sends (the canary must stay email-free)
+//   - optional-secret check: read the secret from env; if unset, WARN and
+//     return (soft pass) so the cheap tier needs no secrets.
+
+const CHEAP = [checkSiteRoot, checkSite404];
+
+// ---------------------------------------------------------------------------
+// EXPENSIVE TIER — costs real money or quota; runs only with --expensive.
+// ---------------------------------------------------------------------------
+
+const COSTLY = [
+  // TODO: e.g. one full generation/build against a stable canary slug.
+];
+
+const tiers = EXPENSIVE ? [...CHEAP, ...COSTLY] : CHEAP;
+for (const check of tiers) await check();
+
+const fails = results.filter((r) => r.state === "FAIL");
+const warns = results.filter((r) => r.state === "WARN");
+if (JSON_OUT) {
+  console.log(
+    JSON.stringify(
+      { ok: fails.length === 0, fails: fails.length, warns: warns.length, results },
+      null,
+      2,
+    ),
+  );
+} else {
+  console.log(
+    `\\n${fails.length === 0 ? "PASS" : "FAIL"} — ${results.length} checks, ` +
+      `${fails.length} fail, ${warns.length} warn`,
+  );
+}
+process.exit(fails.length === 0 ? 0 : 1);
+"""
+
+README_TEMPLATE = """# Canary — the golden-path guard
+
+One command proves the money path is alive: `node canary/smoke.mjs`.
+
+## The alert doctrine
+
+- **Every alert is actionable.** A check exists only if its failure names a
+  specific break and a specific fix. No vibes-based monitoring.
+- **FAIL pages the operator. WARN never pages.** WARN is for soft
+  conditions (an optional secret unset, a rate-limit hit) that must be
+  visible without crying wolf.
+- **Checks guard business invariants no platform synthetic can know** —
+  "the checkout gate rejects an untrusted request", "the config endpoint
+  still serves the LIVE payment mode" — not generic uptime, which your
+  platform already watches.
+- **The cheap tier is side-effect-free**: no sends, no spend, no
+  customer-visible writes; safe on a tight schedule. Expensive checks run
+  rarely, behind `--expensive`.
+- **Optional secrets soft-pass.** A check that needs a secret WARNs when
+  the secret is absent, so the cheap tier runs secret-free anywhere.
+
+## Growing up: the scheduled Worker
+
+When the business takes real money, promote this harness to a scheduled
+worker (cron every ~15 min) with:
+
+- an alert throttle (KV-backed) so a sustained break pages once, not every
+  tick;
+- a `/test-alert` route that proves the paging path end to end on demand;
+- a `/simulate-break` route that forces one check to FAIL so you can watch
+  the whole loop (check → throttle → page) before you need it for real.
+
+Keep the checks in one runtime-agnostic module shared by this CLI smoke
+test and the worker, so the two can never drift.
+
+## Adding a check
+
+Copy an existing check. The comment above it must answer: what invariant
+does this guard, and what business impact appears when it breaks? If you
+cannot answer, the check does not belong here.
+"""
+
+
+def init(repo: str | Path = ".", *, force: bool = False) -> dict[str, Any]:
+    """Scaffold canary/smoke.mjs + canary/README.md in a business repo."""
+    root = Path(repo).resolve()
+    canary_dir = root / "canary"
+    smoke_path = canary_dir / "smoke.mjs"
+    readme_path = canary_dir / "README.md"
+    existing = [str(p.relative_to(root)) for p in (smoke_path, readme_path) if p.exists()]
+    if existing and not force:
+        return {
+            "ok": False,
+            "repo": str(root),
+            "written": [],
+            "skipped": existing,
+            "summary": (
+                "canary files already exist; rerun with --force to overwrite "
+                "(your checks live in smoke.mjs — overwriting loses them)"
+            ),
+        }
+    canary_dir.mkdir(parents=True, exist_ok=True)
+    smoke_path.write_text(SMOKE_TEMPLATE, encoding="utf-8")
+    readme_path.write_text(README_TEMPLATE, encoding="utf-8")
+    return {
+        "ok": True,
+        "repo": str(root),
+        "written": [str(smoke_path.relative_to(root)), str(readme_path.relative_to(root))],
+        "skipped": [],
+        "summary": (
+            "canary scaffold written — add your money-path checks to "
+            "canary/smoke.mjs (see canary/README.md for the doctrine), then "
+            "run `node canary/smoke.mjs`"
+        ),
+    }

--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -19,6 +19,7 @@ import typer
 from mb import __version__
 from mb import ads as ads_mod
 from mb import books as books_mod
+from mb import canary as canary_mod
 from mb import checkpoint as checkpoint_mod
 from mb import codex as codex_mod
 from mb import connect as connect_mod
@@ -133,6 +134,37 @@ dashboard_app = typer.Typer(
     no_args_is_help=True,
 )
 app.add_typer(dashboard_app, name="dashboard")
+
+canary_app = typer.Typer(
+    name="canary",
+    help="Golden-path canary scaffold for the business money path.",
+    no_args_is_help=True,
+)
+app.add_typer(canary_app, name="canary")
+
+
+@canary_app.command("init")
+def canary_init_cmd(
+    repo: str = typer.Option(".", "--repo", help="Business repo to scaffold."),
+    force: bool = typer.Option(
+        False, "--force", help="Overwrite existing canary files (loses your checks)."
+    ),
+    json_out: bool = typer.Option(False, "--json", help="Machine-readable output."),
+) -> None:
+    """Scaffold canary/smoke.mjs + canary/README.md (harness + alert doctrine)."""
+    result = canary_mod.init(repo, force=force)
+    if json_out:
+        typer.echo(
+            _json_payload(result, command="mb canary init", schema_name="mainbranch.canary.v1")
+        )
+    else:
+        typer.echo(result["summary"])
+        for path in result["written"]:
+            typer.echo(f"  wrote {path}")
+        for path in result["skipped"]:
+            typer.echo(f"  kept  {path}")
+    raise typer.Exit(0 if result["ok"] else 1)
+
 
 suggest_app = typer.Typer(
     name="suggest",

--- a/mb/tests/test_canary.py
+++ b/mb/tests/test_canary.py
@@ -1,0 +1,68 @@
+"""``mb canary init`` golden-path scaffold."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from mb import canary as canary_mod
+from mb.cli import app
+
+runner = CliRunner()
+
+
+def test_canary_init_scaffolds_harness_and_doctrine(tmp_path: Path) -> None:
+    result = runner.invoke(app, ["canary", "init", "--repo", str(tmp_path), "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert "canary/smoke.mjs" in payload["written"]
+    assert "canary/README.md" in payload["written"]
+
+    smoke = (tmp_path / "canary" / "smoke.mjs").read_text(encoding="utf-8")
+    assert "--expensive" in smoke
+    assert "WARN never pages" in smoke
+    assert "process.exit(fails.length === 0 ? 0 : 1)" in smoke
+
+    readme = (tmp_path / "canary" / "README.md").read_text(encoding="utf-8")
+    assert "FAIL pages the operator. WARN never pages." in readme
+    assert "/test-alert" in readme
+    assert "/simulate-break" in readme
+
+
+def test_canary_init_refuses_overwrite_without_force(tmp_path: Path) -> None:
+    canary_mod.init(tmp_path)
+    marker = "// my custom check\n"
+    smoke = tmp_path / "canary" / "smoke.mjs"
+    smoke.write_text(marker, encoding="utf-8")
+
+    refused = runner.invoke(app, ["canary", "init", "--repo", str(tmp_path)])
+    assert refused.exit_code == 1
+    assert smoke.read_text(encoding="utf-8") == marker
+
+    forced = runner.invoke(app, ["canary", "init", "--repo", str(tmp_path), "--force"])
+    assert forced.exit_code == 0
+    assert "WARN never pages" in smoke.read_text(encoding="utf-8")
+
+
+def test_canary_template_contains_no_business_specifics(tmp_path: Path) -> None:
+    canary_mod.init(tmp_path)
+    for name in ("smoke.mjs", "README.md"):
+        text = (tmp_path / "canary" / name).read_text(encoding="utf-8").lower()
+        for banned in ("booked", "roofer", "noontide", "lbe-", "crandall", "1307884"):
+            assert banned not in text, f"{name} leaks {banned!r}"
+
+
+def test_canary_template_is_valid_node_syntax(tmp_path: Path) -> None:
+    canary_mod.init(tmp_path)
+    proc = subprocess.run(
+        ["node", "--check", str(tmp_path / "canary" / "smoke.mjs")],
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    assert proc.returncode == 0, proc.stderr


### PR DESCRIPTION
## What

#816: every business gets the canary pattern that kept a real money path honest.

- `mb canary init [--repo] [--force] [--json]` scaffolds `canary/smoke.mjs` + `canary/README.md`; refuses overwrite without `--force` (your checks live in smoke.mjs).
- The harness template: `{name, state, surface, detail}` checks, cheap tier (side-effect-free, near-$0, run often) vs `--expensive`, WARN-soft-pass for optional secrets, `--json`, exit non-zero on any FAIL, two generic starter checks (site_root, soft-404 detection) and TODO patterns for money-path checks.
- The README carries the alert doctrine — every alert actionable; FAIL pages, WARN never pages; checks guard business invariants no platform synthetic can know — plus the promotion path to a scheduled worker (KV alert throttle, `/test-alert`, `/simulate-break` proof routes, shared check module so CLI and worker can't drift).
- Templates embedded in `mb/canary.py`: zero package-data wiring, the wheel ships them automatically.

## Evidence

- 4 tests: scaffold + doctrine content, refuse-overwrite/--force behavior, **boundary test** (no business names/ids leak into templates), and `node --check` syntax validation of the emitted harness.
- ruff + mypy strict clean; smoke-coverage suite green.

Closes #816

🤖 Generated with [Claude Code](https://claude.com/claude-code)