### PR TITLE
fix(validate): empty-link crash + guaranteed JSON envelope on failure (#836)

### DIFF
--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -1961,12 +1961,40 @@ def validate_cmd(
 ) -> None:
     """Check frontmatter shape and optional cross-references."""
     target = repo or path
-    report = validate_mod.run(
-        path=target,
-        verbose=verbose,
-        cross_refs=cross_refs,
-        strict=strict,
-    )
+    try:
+        report = validate_mod.run(
+            path=target,
+            verbose=verbose,
+            cross_refs=cross_refs,
+            strict=strict,
+        )
+    except Exception as exc:  # noqa: BLE001 - --json must stay parseable on any failure.
+        # Agents consume this output programmatically; an unhandled traceback
+        # on stdout makes the enforcement plane untrustworthy (operators
+        # route around it). Emit a valid error envelope instead.
+        if json_out:
+            typer.echo(
+                json.dumps(
+                    {
+                        "ok": False,
+                        "error": {
+                            "type": exc.__class__.__name__,
+                            "message": str(exc),
+                        },
+                        "repo": target,
+                        "files": [],
+                        "summary": {"errors": 1, "warnings": 0},
+                    },
+                    indent=2,
+                )
+            )
+        else:
+            typer.echo(
+                f"mb validate: internal error ({exc.__class__.__name__}: {exc}). "
+                "Please report this with the repo shape that triggered it.",
+                err=True,
+            )
+        raise typer.Exit(2) from exc
     if json_out:
         typer.echo(json.dumps(report, indent=2))
     else:

--- a/mb/mb/relationships.py
+++ b/mb/mb/relationships.py
@@ -235,6 +235,10 @@ def markdown_link_target(raw_target: str) -> str:
     """Return the target component from a standard Markdown link destination."""
 
     target = raw_target.strip()
+    if not target:
+        # Empty destinations (`[text]()`) are real in operator repos; they
+        # must surface as findings downstream, never crash the run.
+        return ""
     target = target.split(None, 1)[0].strip()
     if (target.startswith('"') and target.endswith('"')) or (
         target.startswith("'") and target.endswith("'")

--- a/mb/tests/test_validate.py
+++ b/mb/tests/test_validate.py
@@ -2329,3 +2329,38 @@ def test_validate_push_media_fields(tmp_path: Path) -> None:
     assert any("media_location is missing" in e for e in backend["errors"])
     empty = by_path["pushes/2026-05-09-empty-loc/push.md"]
     assert any("media_location must be a non-empty string" in e for e in empty["errors"])
+
+
+def test_cross_refs_survive_empty_markdown_link_destination(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "decisions" / "2026-06-12-ok.md",
+        (
+            "---\ndate: 2026-06-12\nstatus: accepted\n---\n# ok\n\n"
+            "A placeholder [link with empty destination]() should not crash "
+            "the run, and [another](<>) odd shape survives too.\n"
+        ),
+    )
+
+    report = run(str(tmp_path), cross_refs=True)
+
+    assert isinstance(report["ok"], bool)
+
+
+def test_validate_json_stays_parseable_on_internal_error(tmp_path: Path, monkeypatch) -> None:
+    import json as json_mod
+
+    from typer.testing import CliRunner
+
+    from mb import validate as validate_pkg
+    from mb.cli import app as cli_app
+
+    def boom(**kwargs):
+        raise IndexError("synthetic crash")
+
+    monkeypatch.setattr(validate_pkg, "run", boom)
+    result = CliRunner().invoke(cli_app, ["validate", str(tmp_path), "--json"])
+
+    assert result.exit_code == 2
+    payload = json_mod.loads(result.stdout)
+    assert payload["ok"] is False
+    assert payload["error"]["type"] == "IndexError"


### PR DESCRIPTION
## What

Two of #836's three scopes (the third, `--paths` scoping, follows separately):

1. **The cross-refs crash, found and killed.** `markdown_link_target("")` — produced by an empty markdown destination like `[text]()` — raised `IndexError: list index out of range` and took down the whole `--cross-refs` run. Reproduced on a real operating repo before the fix; that repo now validates end-to-end (valid JSON, clean exit 1 with genuine findings).
2. **`--json` is now unconditionally parseable.** Any internal failure emits `{ok: false, error: {type, message}, files: [], summary}` and exits 2, instead of a rich traceback on stdout. The mining report's friction #6 was operators/agents routing around validate the moment it broke — a machine-readable failure mode is the trust floor.

## Evidence

- Regression test: `[text]()` + `[x](<>)` shapes survive `--cross-refs`.
- Envelope test: monkeypatched `run` raising `IndexError` → exit 2, stdout parses, `error.type == "IndexError"`.
- `test_validate.py`: 95 passed. ruff + mypy strict clean.
- Live repro before/after on the repo where the session crash occurred: traceback → valid JSON.

Refs #836

🤖 Generated with [Claude Code](https://claude.com/claude-code)