### PR TITLE
feat(status): core_propagation drift — identity changes that never reached active pushes (#837)

### DIFF
--- a/mb/mb/status.py
+++ b/mb/mb/status.py
@@ -3929,6 +3929,68 @@ def _validation_status(repo: Path, *, cross_refs: bool = True) -> dict[str, Any]
     }
 
 
+def _file_commit_time(repo: Path, rel: str) -> int:
+    """Last-commit unix time for a repo-relative path; 0 when unknown."""
+    result = _run_command(["git", "log", "-1", "--format=%ct", "--", rel], cwd=repo)
+    if not result["ok"]:
+        return 0
+    text = result["stdout"].strip()
+    return int(text) if text.isdigit() else 0
+
+
+def _core_propagation_drift(repo: Path, report: dict[str, Any]) -> dict[str, Any] | None:
+    """Flag identity changes that never propagated to active push records.
+
+    Field-proven failure: offer/audience/voice change lands, and the ad
+    copy, pages, and emails derived from the OLD identity keep running.
+    Within-repo detectable surface: active push records. Cross-repo
+    surfaces (site repos) are out of scope here.
+    """
+    identity_paths = [
+        rel
+        for rel in ("core/offer.md", "core/audience.md", "core/voice.md")
+        if (repo / rel).is_file()
+    ]
+    for pattern in ("core/offers/*/offer.md", "core/offers/*/audience.md"):
+        identity_paths.extend(
+            path.relative_to(repo).as_posix() for path in sorted(repo.glob(pattern))
+        )
+    if not identity_paths:
+        return None
+    push_report = (report.get("brain") or {}).get("pushes") or {}
+    active = [
+        record
+        for record in push_report.get("records", [])
+        if record.get("status") == "active" and not record.get("legacy")
+    ]
+    if not active:
+        return None
+    identity_times = {rel: _file_commit_time(repo, rel) for rel in identity_paths}
+    newest_identity_rel = max(identity_times, key=lambda rel: identity_times[rel])
+    newest_identity_ts = identity_times[newest_identity_rel]
+    derived_paths = [str(record.get("path") or "") for record in active if record.get("path")]
+    newest_derived_ts = max((_file_commit_time(repo, rel) for rel in derived_paths), default=0)
+    if not newest_identity_ts or not newest_derived_ts:
+        return None
+    if newest_identity_ts <= newest_derived_ts:
+        return None
+    return {
+        "id": "core_propagation",
+        "severity": "warn",
+        "summary": (
+            "offer/audience/voice changed after your active push record(s) "
+            "were last updated — derived copy (ads, pages, emails) may still "
+            "carry the old identity."
+        ),
+        "evidence": [newest_identity_rel] + derived_paths[:4],
+        "repair": (
+            "Re-check the active pushes' copy against the updated core files "
+            "and update the push records in the same pass."
+        ),
+        "safe_to_share": True,
+    }
+
+
 def _drift(report: dict[str, Any]) -> dict[str, Any]:
     items: list[dict[str, Any]] = []
     validation = report.get("validation") or {}
@@ -3979,6 +4041,9 @@ def _drift(report: dict[str, Any]) -> dict[str, Any]:
                 "safe_to_share": True,
             }
         )
+    propagation = _core_propagation_drift(Path(str(report.get("repo") or ".")), report)
+    if propagation:
+        items.append(propagation)
     relationship_health = report.get("relationship_health") or {}
     relationship_summary = relationship_health.get("summary") or {}
     if relationship_summary.get("gaps", 0):

--- a/mb/tests/test_status.py
+++ b/mb/tests/test_status.py
@@ -3930,3 +3930,80 @@ def test_git_info_detects_linked_worktree(tmp_path: Path) -> None:
     assert info["default_branch"] == "main"
     assert info["worktree_root"] == str(worktree_path.resolve())
     assert "linked workspace" in info["summary"]
+
+
+def test_core_propagation_drift_flags_identity_newer_than_active_push(tmp_path, monkeypatch):
+    import subprocess as sp
+
+    from mb import status as status_pkg
+
+    repo = tmp_path / "biz"
+    (repo / "core").mkdir(parents=True)
+    (repo / "core" / "offer.md").write_text("# offer v2\n", encoding="utf-8")
+    push_dir = repo / "pushes" / "2026-06-01-launch"
+    push_dir.mkdir(parents=True)
+    (push_dir / "push.md").write_text(
+        (
+            "---\ntype: push\nslug: launch\nkind: launch\nstatus: active\n"
+            "health: on-track\nowner: o\naudience: a\noffer: core/offer.md\n"
+            "promise: p\n---\n# launch\n"
+        ),
+        encoding="utf-8",
+    )
+
+    import os
+
+    def git(*args, when=""):
+        env = dict(os.environ)
+        if when:
+            env["GIT_COMMITTER_DATE"] = when
+            env["GIT_AUTHOR_DATE"] = when
+        sp.run(["git", *args], cwd=repo, check=True, capture_output=True, env=env)
+
+    git("init")
+    git("config", "user.email", "t@example.com")
+    git("config", "user.name", "T")
+    git("add", "pushes")
+    git("commit", "-m", "push first", when="2026-06-01T00:00:00")
+    git("add", "core")
+    git("commit", "-m", "identity later", when="2026-06-10T00:00:00")
+
+    report = {
+        "repo": str(repo),
+        "brain": {
+            "pushes": {
+                "records": [
+                    {
+                        "path": "pushes/2026-06-01-launch/push.md",
+                        "status": "active",
+                        "legacy": False,
+                    }
+                ]
+            }
+        },
+    }
+    item = status_pkg._core_propagation_drift(repo, report)
+
+    assert item is not None
+    assert item["id"] == "core_propagation"
+    assert "core/offer.md" in item["evidence"]
+
+    # Touch the push AFTER the identity change: drift clears.
+    (push_dir / "push.md").write_text(
+        (push_dir / "push.md").read_text(encoding="utf-8") + "\nupdated.\n", encoding="utf-8"
+    )
+    git("add", "pushes")
+    git("commit", "-m", "push refreshed", when="2026-06-11T00:00:00")
+    assert status_pkg._core_propagation_drift(repo, report) is None
+
+
+def test_core_propagation_drift_silent_without_active_pushes(tmp_path):
+    from mb import status as status_pkg
+
+    repo = tmp_path / "biz"
+    (repo / "core").mkdir(parents=True)
+    (repo / "core" / "offer.md").write_text("# offer\n", encoding="utf-8")
+
+    report = {"repo": str(repo), "brain": {"pushes": {"records": []}}}
+
+    assert status_pkg._core_propagation_drift(repo, report) is None

--- a/mb/tests/test_status.py
+++ b/mb/tests/test_status.py
@@ -3932,7 +3932,9 @@ def test_git_info_detects_linked_worktree(tmp_path: Path) -> None:
     assert "linked workspace" in info["summary"]
 
 
-def test_core_propagation_drift_flags_identity_newer_than_active_push(tmp_path, monkeypatch):
+def test_core_propagation_drift_flags_identity_newer_than_active_push(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     import subprocess as sp
 
     from mb import status as status_pkg
@@ -3953,7 +3955,7 @@ def test_core_propagation_drift_flags_identity_newer_than_active_push(tmp_path, 
 
     import os
 
-    def git(*args, when=""):
+    def git(*args: str, when: str = "") -> None:
         env = dict(os.environ)
         if when:
             env["GIT_COMMITTER_DATE"] = when
@@ -3997,7 +3999,7 @@ def test_core_propagation_drift_flags_identity_newer_than_active_push(tmp_path, 
     assert status_pkg._core_propagation_drift(repo, report) is None
 
 
-def test_core_propagation_drift_silent_without_active_pushes(tmp_path):
+def test_core_propagation_drift_silent_without_active_pushes(tmp_path: Path) -> None:
     from mb import status as status_pkg
 
     repo = tmp_path / "biz"


### PR DESCRIPTION
## What

First #837 slice (mining friction #5 — stale facts poison every downstream agent): the propagation sweep.

- New `core_propagation` drift item in `mb status`: when the newest identity file (`core/offer.md`, `core/audience.md`, `core/voice.md`, per-offer `offer.md`/`audience.md`) has a last-commit time newer than every **active** push record, drift warns with the changed file + up to 4 stale push paths and the repair.
- Committer-time based (`git log -1 --format=%ct`), so it survives fresh clones; silent when there are no identity files, no active pushes, or times are unknowable; clears the moment the push records are touched after the identity change.
- Rides the existing drift surface — `mb status` consumers, ranked actions, and the dashboard get it for free.

Remaining #837 scope (follow-ups): decision-vs-implementation and docs-vs-code staleness detectors.

## Evidence

- Tests: identity-newer-than-push flags (and clears after the push is refreshed — both directions, with explicit committer dates); silent with no active pushes.
- `test_status.py`: 100 passed. ruff + mypy strict clean.

Refs #837

🤖 Generated with [Claude Code](https://claude.com/claude-code)