### PR TITLE
feat(spine): mb spine declare / show — the declared contact+event position (#814)

### DIFF
--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -36,6 +36,7 @@ from mb import resolve as resolve_mod
 from mb import similar_bets as similar_bets_mod
 from mb import site as site_mod
 from mb import skill_validate as skill_validate_mod
+from mb import spine as spine_mod
 from mb import start as start_mod
 from mb import status as status_mod
 from mb import suggest as suggest_mod
@@ -141,6 +142,94 @@ canary_app = typer.Typer(
     no_args_is_help=True,
 )
 app.add_typer(canary_app, name="canary")
+
+spine_app = typer.Typer(
+    name="spine",
+    help="Declare and inspect the business's contact+event spine position.",
+    no_args_is_help=True,
+)
+app.add_typer(spine_app, name="spine")
+
+SPINE_LENS_OPTION = typer.Option(
+    [],
+    "--lens",
+    help="Fan-out lens as <store> or <store>:<domain> (repeatable).",
+)
+SPINE_GAP_OPTION = typer.Option(
+    [],
+    "--gap",
+    help="Known event/timeline gap the spine does not hold (repeatable).",
+)
+
+
+@spine_app.command("declare")
+def spine_declare_cmd(
+    store: str = typer.Option(
+        ...,
+        "--store",
+        help="System of record for people (a provider id), or `none`.",
+    ),
+    repo: str = typer.Option(".", "--repo", help="Business repo to declare in."),
+    intentional: bool = typer.Option(
+        False,
+        "--intentional",
+        help="With --store none: declare the no-spine position as deliberate.",
+    ),
+    lenses: list[str] = SPINE_LENS_OPTION,
+    gaps: list[str] = SPINE_GAP_OPTION,
+    revisit: str = typer.Option(
+        "", "--revisit", help="The trigger that should reopen this declaration."
+    ),
+    force: bool = typer.Option(False, "--force", help="Replace an existing declaration."),
+    json_out: bool = typer.Option(False, "--json", help="Machine-readable output."),
+) -> None:
+    """Record which system plays the contact+event spine role (a repo fact)."""
+    try:
+        result = spine_mod.declare(
+            repo,
+            store=store,
+            intentional_none=intentional,
+            lenses=list(lenses),
+            gaps=list(gaps),
+            revisit=revisit,
+            force=force,
+        )
+    except ValueError as exc:
+        typer.echo(f"mb spine declare: {exc}", err=True)
+        raise typer.Exit(2) from exc
+    if json_out:
+        typer.echo(
+            _json_payload(result, command="mb spine declare", schema_name="mainbranch.spine.v1")
+        )
+    else:
+        typer.echo(result["summary"])
+        typer.echo(f"fact: {result['path']}")
+    raise typer.Exit(0 if result["ok"] else 1)
+
+
+@spine_app.command("show")
+def spine_show_cmd(
+    repo: str = typer.Option(".", "--repo", help="Business repo to inspect."),
+    json_out: bool = typer.Option(False, "--json", help="Machine-readable output."),
+) -> None:
+    """Read the declared spine position back as facts."""
+    result = spine_mod.show(repo)
+    if json_out:
+        typer.echo(
+            _json_payload(result, command="mb spine show", schema_name="mainbranch.spine.v1")
+        )
+    else:
+        typer.echo(result["summary"])
+        if result.get("declared"):
+            declaration = result["declaration"]
+            for lens in declaration.get("lenses", []):
+                domain = f" ({lens['domain']})" if lens.get("domain") else ""
+                typer.echo(f"  lens: {lens['store']}{domain}")
+            for gap in declaration.get("known_gaps", []):
+                typer.echo(f"  gap:  {gap}")
+            if declaration.get("revisit_trigger"):
+                typer.echo(f"  revisit when: {declaration['revisit_trigger']}")
+    raise typer.Exit(0 if result["ok"] else 1)
 
 
 @canary_app.command("init")

--- a/mb/mb/spine.py
+++ b/mb/mb/spine.py
@@ -1,0 +1,154 @@
+"""Contact+event spine declaration (`mb spine declare` / `mb spine show`).
+
+The spine is a declared position, not a database to install
+(decisions/2026-06-12-spine-levels.md). A business records which system
+plays the contact+event spine role — or that none does, on purpose — as a
+committed repo fact at ``core/operations/spine.md``. Grading and the owned
+build path ship as later slices; this module is the declare rung.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+SPINE_RELATIVE_PATH = Path("core") / "operations" / "spine.md"
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _parse_lenses(raw: list[str]) -> list[dict[str, str]]:
+    lenses: list[dict[str, str]] = []
+    for item in raw:
+        text = item.strip()
+        if not text:
+            continue
+        store, _, domain = text.partition(":")
+        store = store.strip()
+        if not store:
+            raise ValueError(f"lens {item!r} must be <store> or <store>:<domain>")
+        lenses.append({"store": store, "domain": domain.strip()})
+    return lenses
+
+
+def declare(
+    repo: str | Path = ".",
+    *,
+    store: str,
+    intentional_none: bool = False,
+    lenses: list[str] | None = None,
+    gaps: list[str] | None = None,
+    revisit: str = "",
+    force: bool = False,
+) -> dict[str, Any]:
+    """Write the spine declaration as a committed repo fact."""
+    root = Path(repo).resolve()
+    store_id = store.strip().lower()
+    if not store_id:
+        raise ValueError("store is required; use `none` for an intentional no-spine position")
+    if store_id == "none" and not intentional_none:
+        raise ValueError(
+            "declaring no spine requires --intentional — an undeclared gap and a "
+            "deliberate product stance are different facts"
+        )
+    if store_id != "none" and intentional_none:
+        raise ValueError("--intentional only applies with --store none")
+    path = root / SPINE_RELATIVE_PATH
+    if path.exists() and not force:
+        return {
+            "ok": False,
+            "repo": str(root),
+            "path": str(SPINE_RELATIVE_PATH),
+            "summary": ("a spine declaration already exists; rerun with --force to replace it"),
+        }
+    parsed_lenses = _parse_lenses(lenses or [])
+    frontmatter: dict[str, Any] = {
+        "type": "spine",
+        "store": store_id,
+        "intentional_none": bool(intentional_none),
+        "lenses": parsed_lenses,
+        "known_gaps": [gap.strip() for gap in (gaps or []) if gap.strip()],
+        "revisit_trigger": revisit.strip(),
+        "declared_at": _now(),
+    }
+    if store_id == "none":
+        body = (
+            "# Contact+event spine: none, on purpose\n\n"
+            "This business deliberately holds no person-store. The position is\n"
+            "declared so agents treat it as a stance, not a gap. Revisit when the\n"
+            "trigger below fires.\n"
+        )
+    else:
+        body = (
+            f"# Contact+event spine: {store_id}\n\n"
+            f"`{store_id}` is the system of record for this business's people.\n"
+            "Every other tool is a fan-out lens, never a second source of truth.\n"
+            "Agents read people and events from the spine; sync flows *to* the\n"
+            "lenses (operating-principles §2).\n"
+        )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = "---\n" + yaml.safe_dump(frontmatter, sort_keys=False) + "---\n\n" + body
+    path.write_text(text, encoding="utf-8")
+    return {
+        "ok": True,
+        "repo": str(root),
+        "path": str(SPINE_RELATIVE_PATH),
+        "declaration": frontmatter,
+        "summary": (
+            "spine declared: none (intentional)"
+            if store_id == "none"
+            else f"spine declared: {store_id}"
+            + (f" with {len(parsed_lenses)} lens(es)" if parsed_lenses else "")
+        ),
+    }
+
+
+def show(repo: str | Path = ".") -> dict[str, Any]:
+    """Read the spine declaration back as facts."""
+    root = Path(repo).resolve()
+    path = root / SPINE_RELATIVE_PATH
+    if not path.is_file():
+        return {
+            "ok": False,
+            "declared": False,
+            "repo": str(root),
+            "path": str(SPINE_RELATIVE_PATH),
+            "summary": (
+                "no spine declaration — run `mb spine declare --store <provider>` "
+                "(or `--store none --intentional`)"
+            ),
+        }
+    text = path.read_text(encoding="utf-8")
+    frontmatter: dict[str, Any] = {}
+    if text.startswith("---"):
+        try:
+            end = text.index("\n---", 3)
+            raw = yaml.safe_load(text[3:end].lstrip("\n")) or {}
+            frontmatter = raw if isinstance(raw, dict) else {}
+        except (ValueError, yaml.YAMLError):
+            frontmatter = {}
+    if not frontmatter:
+        return {
+            "ok": False,
+            "declared": False,
+            "repo": str(root),
+            "path": str(SPINE_RELATIVE_PATH),
+            "summary": "spine file exists but its frontmatter is unreadable — re-declare",
+        }
+    return {
+        "ok": True,
+        "declared": True,
+        "repo": str(root),
+        "path": str(SPINE_RELATIVE_PATH),
+        "declaration": frontmatter,
+        "summary": (
+            "spine: none (intentional)"
+            if frontmatter.get("store") == "none"
+            else f"spine: {frontmatter.get('store')}"
+        ),
+    }

--- a/mb/tests/test_spine.py
+++ b/mb/tests/test_spine.py
@@ -1,0 +1,104 @@
+"""``mb spine declare`` / ``mb spine show`` — the declared spine position."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import yaml
+from typer.testing import CliRunner
+
+from mb import spine as spine_mod
+from mb.cli import app
+
+runner = CliRunner()
+
+
+def test_spine_declare_writes_committed_fact(tmp_path: Path) -> None:
+    result = runner.invoke(
+        app,
+        [
+            "spine",
+            "declare",
+            "--store",
+            "shopify",
+            "--repo",
+            str(tmp_path),
+            "--lens",
+            "seguno:email",
+            "--lens",
+            "loox:reviews",
+            "--gap",
+            "person-level web journey",
+            "--revisit",
+            "first unanswerable engagement question",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["declaration"]["store"] == "shopify"
+
+    fact = tmp_path / "core" / "operations" / "spine.md"
+    text = fact.read_text(encoding="utf-8")
+    frontmatter = yaml.safe_load(text[3 : text.index("\n---", 3)])
+    assert frontmatter["type"] == "spine"
+    assert frontmatter["store"] == "shopify"
+    assert frontmatter["lenses"] == [
+        {"store": "seguno", "domain": "email"},
+        {"store": "loox", "domain": "reviews"},
+    ]
+    assert frontmatter["known_gaps"] == ["person-level web journey"]
+    assert "fan-out lens" in text
+
+
+def test_spine_show_roundtrip(tmp_path: Path) -> None:
+    spine_mod.declare(tmp_path, store="stripe", revisit="cross-channel attribution")
+
+    shown = runner.invoke(app, ["spine", "show", "--repo", str(tmp_path), "--json"])
+
+    assert shown.exit_code == 0
+    payload = json.loads(shown.stdout)
+    assert payload["declared"] is True
+    assert payload["declaration"]["store"] == "stripe"
+    assert payload["declaration"]["revisit_trigger"] == "cross-channel attribution"
+
+
+def test_spine_none_requires_intentional(tmp_path: Path) -> None:
+    refused = runner.invoke(app, ["spine", "declare", "--store", "none", "--repo", str(tmp_path)])
+    assert refused.exit_code == 2
+    assert "--intentional" in refused.stderr
+
+    declared = runner.invoke(
+        app,
+        ["spine", "declare", "--store", "none", "--intentional", "--repo", str(tmp_path)],
+    )
+    assert declared.exit_code == 0
+    text = (tmp_path / "core" / "operations" / "spine.md").read_text(encoding="utf-8")
+    assert "none, on purpose" in text
+    assert "stance, not a gap" in text
+
+
+def test_spine_declare_refuses_overwrite_without_force(tmp_path: Path) -> None:
+    spine_mod.declare(tmp_path, store="shopify")
+
+    refused = runner.invoke(
+        app, ["spine", "declare", "--store", "hubspot", "--repo", str(tmp_path)]
+    )
+    assert refused.exit_code == 1
+
+    forced = runner.invoke(
+        app,
+        ["spine", "declare", "--store", "hubspot", "--force", "--repo", str(tmp_path)],
+    )
+    assert forced.exit_code == 0
+    assert spine_mod.show(tmp_path)["declaration"]["store"] == "hubspot"
+
+
+def test_spine_show_undeclared_points_at_declare(tmp_path: Path) -> None:
+    result = runner.invoke(app, ["spine", "show", "--repo", str(tmp_path)])
+
+    assert result.exit_code == 1
+    assert "mb spine declare" in result.stdout


### PR DESCRIPTION
## What

Slice 1 of the spine-levels decision (#862): the declare rung.

- `mb spine declare --store <provider|none> [--lens store:domain]... [--gap text]... [--revisit trigger] [--force]` — writes the committed repo fact `core/operations/spine.md` (frontmatter: store, lenses, known gaps, revisit trigger, declared_at) with operating-principles §2 prose in the body.
- **Intentional-none guard**: `--store none` without `--intentional` is refused — an undeclared gap and a deliberate product stance are different facts (the L0-intentional finding from the validation pass).
- `mb spine show [--json]` — reads the position back as facts; undeclared points at the declare command.
- Existing declaration refuses overwrite without `--force`.

Next slices on #814 per the decision: grading in doctor/status (three dimensions, first unanswerable question, next-level cost), then the owned contact+event schema as the triggered build path.

## Evidence

- 5 tests: declare→fact roundtrip (frontmatter shape, lenses, gaps), show roundtrip, intentional-none guard both directions, force-overwrite behavior, undeclared pointer.
- ruff + mypy strict clean (tests included); smoke-coverage suite green.

Refs #814

🤖 Generated with [Claude Code](https://claude.com/claude-code)