### PR TITLE
feat(doctor): grade the declared contact+event spine position (#814)

### DIFF
--- a/mb/mb/doctor.py
+++ b/mb/mb/doctor.py
@@ -31,6 +31,7 @@ from mb import migrate as migrate_mod
 from mb import migration_lint
 from mb import onboard as onboard_mod
 from mb import related_links as related_links_mod
+from mb import spine as spine_mod
 from mb import topology as topology_mod
 from mb import validate as validate_mod
 from mb.engine import install_mode, link_status
@@ -349,6 +350,124 @@ def _dossier_verify_section(repo: Path) -> dict[str, Any]:
         "Agent Access Dossier",
         _max_state([str(check["state"]) for check in checks]) if checks else "ok",
         "capability map verification — mb-owned verify commands only",
+        checks=checks,
+    )
+
+
+def _spine_section(repo: Path) -> dict[str, Any]:
+    """Grade the declared contact+event spine position.
+
+    Honest grading per decisions/2026-06-12-spine-levels.md: report what
+    the engine can verify (declaration present, store queryable through
+    mb connect) and what the operator declared (timeline gaps, revisit
+    trigger) — never infer a maturity score the facts can't support.
+    """
+    shown = spine_mod.show(repo)
+    if not shown.get("declared"):
+        return _section(
+            "contact-event-spine",
+            "Contact+Event Spine",
+            "info",
+            (
+                "no spine declaration — run `mb spine declare --store <provider>` "
+                "(or `--store none --intentional`) so agents read the position "
+                "from facts instead of guessing"
+            ),
+        )
+    declaration = shown.get("declaration") or {}
+    store = str(declaration.get("store") or "")
+    if store == "none":
+        revisit = str(declaration.get("revisit_trigger") or "")
+        return _section(
+            "contact-event-spine",
+            "Contact+Event Spine",
+            "ok",
+            "none, on purpose — a declared product stance"
+            + (f"; revisit when: {revisit}" if revisit else ""),
+        )
+    checks: list[dict[str, Any]] = []
+    lenses = declaration.get("lenses") or []
+    checks.append(
+        {
+            "name": "declaration",
+            "state": "ok",
+            "summary": f"spine: {store}" + (f", {len(lenses)} fan-out lens(es)" if lenses else ""),
+        }
+    )
+    try:
+        status = connect_mod.status_provider(store, repo)
+    except ValueError:
+        checks.append(
+            {
+                "name": "agent-queryability",
+                "state": "info",
+                "summary": (
+                    f"{store!r} is not an mb connect provider — queryability "
+                    "unverified; connect it (or `mb connect <id> --custom`) so "
+                    "the operator's agent can read the spine from the terminal"
+                ),
+            }
+        )
+    else:
+        if status.get("ok") or str(status.get("state")) in {"unvalidated", "ready"}:
+            checks.append(
+                {
+                    "name": "agent-queryability",
+                    "state": "ok",
+                    "summary": (
+                        f"{store} credentialed via mb connect (state: {status.get('state')})"
+                    ),
+                }
+            )
+        else:
+            checks.append(
+                {
+                    "name": "agent-queryability",
+                    "state": "warn",
+                    "summary": (
+                        f"{store} declared as the spine but not agent-queryable "
+                        f"(state: {status.get('state')}); repair: "
+                        f"{status.get('repair_command') or f'mb connect {store}'}"
+                    ),
+                }
+            )
+    gaps = [str(gap) for gap in declaration.get("known_gaps") or []]
+    if gaps:
+        checks.append(
+            {
+                "name": "timeline-completeness",
+                "state": "info",
+                "summary": (
+                    "declared gap(s) the spine does not hold: "
+                    + "; ".join(gaps[:3])
+                    + " — an owned event log alongside the store is the "
+                    "augmented path (see decisions/2026-06-12-spine-levels.md)"
+                ),
+            }
+        )
+    else:
+        checks.append(
+            {
+                "name": "timeline-completeness",
+                "state": "ok",
+                "summary": "no declared timeline gaps",
+            }
+        )
+    revisit = str(declaration.get("revisit_trigger") or "")
+    checks.append(
+        {
+            "name": "revisit-trigger",
+            "state": "ok" if revisit else "info",
+            "summary": f"revisit when: {revisit}"
+            if revisit
+            else "no revisit trigger declared — name the question that should reopen this",
+        }
+    )
+    return _section(
+        "contact-event-spine",
+        "Contact+Event Spine",
+        _max_state([str(check["state"]) for check in checks]),
+        "declared contact+event spine position and what the engine can verify",
         checks=checks,
     )
 
@@ -2484,6 +2603,7 @@ def repair_plan(
     )
 
     sections.append(_dossier_verify_section(target))
+    sections.append(_spine_section(target))
 
     validation = _validation_summary(target, migration_drift_report=migration_drift)
     related_links = related_links_mod.plan(target)

--- a/mb/tests/test_spine.py
+++ b/mb/tests/test_spine.py
@@ -102,3 +102,60 @@ def test_spine_show_undeclared_points_at_declare(tmp_path: Path) -> None:
 
     assert result.exit_code == 1
     assert "mb spine declare" in result.stdout
+
+
+def test_doctor_spine_section_grades_declared_position(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("MB_CONNECT_SECRET_BACKEND", "local-file")
+    monkeypatch.setenv("MAINBRANCH_HOME", str(tmp_path / "home"))
+    from mb import connect as connect_mod
+    from mb import doctor as doctor_mod
+
+    repo = tmp_path / "biz"
+    repo.mkdir()
+
+    undeclared = doctor_mod._spine_section(repo)
+    assert undeclared["state"] == "info"
+    assert "mb spine declare" in undeclared["summary"]
+
+    connect_mod.connect_provider("shopify", repo=repo, token="shp-fixture", custom=True)
+    spine_mod.declare(
+        repo,
+        store="shopify",
+        lenses=["klaviyo:email"],
+        gaps=["person-level web journey"],
+        revisit="first unanswerable engagement question",
+    )
+    section = doctor_mod._spine_section(repo)
+    by_name = {check["name"]: check for check in section["checks"]}
+
+    assert by_name["declaration"]["state"] == "ok"
+    assert by_name["agent-queryability"]["state"] == "ok"
+    assert by_name["timeline-completeness"]["state"] == "info"
+    assert "owned event log" in by_name["timeline-completeness"]["summary"]
+    assert by_name["revisit-trigger"]["state"] == "ok"
+
+
+def test_doctor_spine_section_intentional_none_is_ok(tmp_path: Path) -> None:
+    from mb import doctor as doctor_mod
+
+    spine_mod.declare(tmp_path, store="none", intentional_none=True, revisit="public launch")
+
+    section = doctor_mod._spine_section(tmp_path)
+
+    assert section["state"] == "ok"
+    assert "on purpose" in section["summary"]
+    assert "public launch" in section["summary"]
+
+
+def test_doctor_spine_section_unconnected_store_warns(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("MB_CONNECT_SECRET_BACKEND", "local-file")
+    monkeypatch.setenv("MAINBRANCH_HOME", str(tmp_path / "home"))
+    from mb import doctor as doctor_mod
+
+    spine_mod.declare(tmp_path, store="cloudflare")
+
+    section = doctor_mod._spine_section(tmp_path)
+    by_name = {check["name"]: check for check in section["checks"]}
+
+    assert by_name["agent-queryability"]["state"] == "warn"
+    assert "not agent-queryable" in by_name["agent-queryability"]["summary"]


### PR DESCRIPTION
## What

Slice 2 of the spine-levels decision (#862): the grading rung.

New `contact-event-spine` doctor section:

- **Undeclared** → info, pointing at `mb spine declare` (agents read position from facts, not guesses).
- **Intentional none** → `ok` — a declared stance with its revisit trigger, never shamed.
- **Declared store** → four honest checks: `declaration` (store + lenses) · `agent-queryability` (connect status; warn + exact repair when the declared spine isn't credentialed; info when the store isn't a connect provider, pointing at `--custom`) · `timeline-completeness` (declared gaps surfaced with the augmented-path pointer to the decision doc) · `revisit-trigger` (named, or info nudge to name one).

Grading reports what's verifiable + what's declared — the three-dimension scoring philosophy from the decision without inventing scores the engine can't verify.

Remaining #814: the owned contact+event schema (slice 3).

## Evidence

- 3 new tests: full declared-store grade card (custom-provider connected → queryability ok; gaps → info with augmented pointer), intentional-none ok with trigger, unconnected-store warn with repair.
- `test_spine.py` + `test_doctor.py`: 84 passed. ruff + mypy strict clean (tests included).

Refs #814

🤖 Generated with [Claude Code](https://claude.com/claude-code)