### PR TITLE
feat(status): uncodified_decisions drift — decided, but reality unchanged (#837)

### DIFF
--- a/mb/mb/status.py
+++ b/mb/mb/status.py
@@ -43,6 +43,7 @@ STATUS_SCHEMA_VERSION = "1.0"
 LAST_STATUS_SEEN_RELATIVE_PATH = Path(".mb") / "last-status-seen.json"
 LAST_STATUS_SEEN_GITIGNORE_ENTRY = ".mb/last-status-seen.json"
 STALE_DECISION_DAYS = 14
+UNCODIFIED_DECISION_DAYS = 7
 STALE_RESEARCH_DAYS = 45
 ACTIVE_BET_STATUSES = {"open", "paused"}
 BET_APPETITE_TIERS = {"trivial", "small", "material", "strategic"}
@@ -1174,6 +1175,7 @@ def _brain(repo: Path) -> dict[str, Any]:
     decision_files = _relative_markdown_files(repo, "decisions")
     decisions: list[dict[str, Any]] = []
     stale: list[dict[str, Any]] = []
+    uncodified: list[dict[str, Any]] = []
     today = date.today()
 
     for path in decision_files:
@@ -1188,6 +1190,14 @@ def _brain(repo: Path) -> dict[str, Any]:
                 stale_item = dict(item)
                 stale_item["age_days"] = age_days
                 stale.append(stale_item)
+        # Accepted but never codified: the decision happened, the reference
+        # files it should change did not — decision-vs-implementation drift.
+        if status == "accepted" and decision_date is not None:
+            age_days = (today - decision_date).days
+            if age_days > UNCODIFIED_DECISION_DAYS:
+                uncodified_item = dict(item)
+                uncodified_item["age_days"] = age_days
+                uncodified.append(uncodified_item)
 
     research_files = _relative_markdown_files(repo, "research")
     research: list[dict[str, Any]] = []
@@ -1210,6 +1220,7 @@ def _brain(repo: Path) -> dict[str, Any]:
         "counts": counts,
         "recent_decisions": decisions[:5],
         "stale_decisions": stale[:5],
+        "uncodified_decisions": uncodified[:5],
         "recent_research": research[:5],
         "stale_research": stale_research[:5],
         "bets": bets,
@@ -4023,6 +4034,22 @@ def _drift(report: dict[str, Any]) -> dict[str, Any]:
                 "summary": f"{len(stale_decisions)} proposed/running decision(s) are stale.",
                 "evidence": [item["path"] for item in stale_decisions[:5]],
                 "repair": "Review stale proposed/running decisions in `decisions/`.",
+                "safe_to_share": True,
+            }
+        )
+    uncodified_decisions = report["brain"].get("uncodified_decisions") or []
+    if uncodified_decisions:
+        items.append(
+            {
+                "id": "uncodified_decisions",
+                "severity": "warn",
+                "summary": (
+                    f"{len(uncodified_decisions)} accepted decision(s) were never "
+                    "codified into reference files — decided, but reality unchanged."
+                ),
+                "evidence": [item["path"] for item in uncodified_decisions[:5]],
+                "repair": "Run `/mb-think codify <decision-file>` to apply each, "
+                "then flip its status to codified in the same pass.",
                 "safe_to_share": True,
             }
         )

--- a/mb/tests/fixtures/status/schema-v1-basic.json
+++ b/mb/tests/fixtures/status/schema-v1-basic.json
@@ -26,7 +26,8 @@
       "recent_decisions",
       "recent_research",
       "stale_decisions",
-      "stale_research"
+      "stale_research",
+      "uncodified_decisions"
     ],
     "content_strategy": [
       "counts",

--- a/mb/tests/test_status.py
+++ b/mb/tests/test_status.py
@@ -4009,3 +4009,45 @@ def test_core_propagation_drift_silent_without_active_pushes(tmp_path: Path) -> 
     report = {"repo": str(repo), "brain": {"pushes": {"records": []}}}
 
     assert status_pkg._core_propagation_drift(repo, report) is None
+
+
+def test_uncodified_decisions_drift(tmp_path: Path) -> None:
+    from mb import status as status_pkg
+
+    repo = tmp_path / "biz"
+    decisions = repo / "decisions"
+    decisions.mkdir(parents=True)
+    (decisions / "2026-05-01-old-accepted.md").write_text(
+        "---\ndate: 2026-05-01\nstatus: accepted\n---\n# old accepted\n",
+        encoding="utf-8",
+    )
+    (decisions / "2026-05-01-applied.md").write_text(
+        "---\ndate: 2026-05-01\nstatus: codified\n---\n# applied\n",
+        encoding="utf-8",
+    )
+
+    brain = status_pkg._brain(repo)
+    uncodified = brain["uncodified_decisions"]
+
+    assert len(uncodified) == 1
+    assert uncodified[0]["path"].endswith("2026-05-01-old-accepted.md")
+
+    report = {
+        "brain": brain,
+        "repo": str(repo),
+        "runtime": {},
+        "validation": {},
+        "relationship_health": {},
+        "playbook_health": {},
+        "integrations": {},
+        "measurement": {},
+        "books": {},
+        "topology": {},
+        "since_last_check": {"marker_gitignore": {"ok": True}},
+    }
+    drift = status_pkg._drift(report)
+    by_id = {item["id"]: item for item in drift["items"]}
+
+    assert "uncodified_decisions" in by_id
+    assert "never" in by_id["uncodified_decisions"]["summary"]
+    assert "codify" in by_id["uncodified_decisions"]["repair"]


### PR DESCRIPTION
## What

#837 slice 2: the decision-vs-implementation detector.

- `_brain` now tracks accepted decisions older than 7 days (`UNCODIFIED_DECISION_DAYS`) that never flipped to `codified` — the state meaning "we decided, and the reference files the decision should change were never touched."
- New `uncodified_decisions` drift item (warn): names the files, repairs with `/mb-think codify <file>` + the same-pass status flip (matching the codify-phase contract).
- `brain.uncodified_decisions` rides status facts; golden schema fixture updated.

Remaining on #837: docs-vs-code staleness — engine-side concern largely covered by existing gates; will assess and either slice or close with rationale.

## Evidence

- Test: accepted-and-old flags, codified doesn't; drift item shape + repair asserted.
- `test_status.py`: 101 passed including the golden-schema fixture. ruff + mypy strict clean.

Refs #837

🤖 Generated with [Claude Code](https://claude.com/claude-code)