### PR TITLE
feat(plugin): ship the marketplace manifest — the install rail now exists (#804)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,17 @@
+{
+  "name": "mainbranch",
+  "owner": {
+    "name": "Noontide"
+  },
+  "metadata": {
+    "description": "Main Branch — run a business from markdown files in git, with Claude Code as the operator surface.",
+    "version": "0.3.43"
+  },
+  "plugins": [
+    {
+      "name": "mainbranch",
+      "source": "./",
+      "description": "Main Branch Claude Code skills for running a business from markdown files in git."
+    }
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,6 +189,8 @@ jobs:
             || { echo "::error::bundled reference files missing from wheel"; exit 1; }
           python -m zipfile -l "$wheel" | grep -E '(^|/)mb/_engine/\.claude-plugin/plugin\.json([[:space:]]|$)' \
             || { echo "::error::Claude Code plugin prototype missing from wheel"; exit 1; }
+          python -m zipfile -l "$wheel" | grep -E '(^|/)mb/_engine/\.claude-plugin/marketplace\.json([[:space:]]|$)' \
+            || { echo "::error::plugin marketplace manifest missing from wheel — the install rail needs it"; exit 1; }
 
       - name: Create fresh venv and install the wheel
         # Fresh venv means no repo sources on sys.path — a genuine

--- a/mb/tests/test_smoke_coverage.py
+++ b/mb/tests/test_smoke_coverage.py
@@ -250,3 +250,25 @@ def test_main_help_describes_engine() -> None:
     assert result.exit_code == 0
     txt = result.stdout.lower()
     assert "main branch" in txt or "engine" in txt
+
+
+def test_marketplace_manifest_makes_plugin_installable() -> None:
+    """The marketplace manifest is the install rail; without it,
+    `claude plugin marketplace add` fails (proven in the Stage 1 smoke)."""
+    import json
+    from pathlib import Path
+
+    repo_root = Path(__file__).resolve().parents[2]
+    manifest = json.loads(
+        (repo_root / ".claude-plugin" / "marketplace.json").read_text(encoding="utf-8")
+    )
+    assert manifest["name"] == "mainbranch"
+    plugins = manifest["plugins"]
+    assert len(plugins) == 1
+    assert plugins[0]["name"] == "mainbranch"
+    assert plugins[0]["source"] == "./"
+
+    plugin = json.loads((repo_root / ".claude-plugin" / "plugin.json").read_text(encoding="utf-8"))
+    # Versions travel together; the release preflight checks plugin.json —
+    # the marketplace metadata must not drift from it.
+    assert manifest["metadata"]["version"] == plugin["version"]

--- a/scripts/release-preflight.sh
+++ b/scripts/release-preflight.sh
@@ -20,17 +20,19 @@ expected="${expected#oe-v}"
 pyproject_version="$(sed -n 's/^version = "\(.*\)"$/\1/p' "$ROOT/mb/pyproject.toml" | head -n1)"
 init_version="$(sed -n 's/^__version__ = "\(.*\)"$/\1/p' "$ROOT/mb/mb/__init__.py" | head -n1)"
 plugin_version="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["version"])' "$ROOT/.claude-plugin/plugin.json")"
+marketplace_version="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["metadata"]["version"])' "$ROOT/.claude-plugin/marketplace.json")"
 
 fail=0
 echo "mb/pyproject.toml        version    = $pyproject_version"
 echo "mb/mb/__init__.py        __version__ = $init_version"
 echo ".claude-plugin/plugin.json version  = $plugin_version"
+echo ".claude-plugin/marketplace.json    = $marketplace_version"
 
 if [ -z "$pyproject_version" ] || [ -z "$init_version" ] || [ -z "$plugin_version" ]; then
   echo "release-preflight: could not read all three version strings." >&2
   fail=1
 fi
-if [ "$pyproject_version" != "$init_version" ] || [ "$pyproject_version" != "$plugin_version" ]; then
+if [ "$pyproject_version" != "$init_version" ] || [ "$pyproject_version" != "$plugin_version" ] || [ "$pyproject_version" != "$marketplace_version" ]; then
   echo "release-preflight: version files disagree." >&2
   fail=1
 fi


### PR DESCRIPTION
## What

Stage 1's blocker, fixed: the plugin-first decision (#811) shipped a `plugin.json` but never a `marketplace.json` — so `claude plugin marketplace add` failed on both the repo and the wheel, and the plugin rail was uninstallable. This PR makes the rail real:

- `.claude-plugin/marketplace.json` — minimal manifest (single plugin, source `./`). **Live-verified**: `claude plugin marketplace add <repo-path>` succeeds (and was cleanly removed after).
- Wheel smoke grep for the manifest (setup.py already copies `.claude-plugin/` wholesale, so packaging is automatic — now asserted).
- Smoke-coverage test pinning manifest shape + version lockstep with `plugin.json`.
- `scripts/release-preflight.sh` now checks the marketplace version as a fourth release file.

Stage 1 evidence (full report on #804): `/mb-start` resolves as-is under the plugin (no rename wave); `references/` resolve from the payload; the mb-ads engine-root lens reads are the confirmed silent break to fix before any default flip — that's the next slice.

## Evidence

- Live `marketplace add` success from the repo path.
- `test_smoke_coverage.py`: 21 passed. Release preflight green. ruff + mypy clean.

Refs #804

🤖 Generated with [Claude Code](https://claude.com/claude-code)