### PR TITLE
fix(mb-ads): resolve lens + compliance reads relative to the skill, not cwd (#804)

### DIFF
--- a/.claude/skills/mb-ads/references/mode-review.md
+++ b/.claude/skills/mb-ads/references/mode-review.md
@@ -8,12 +8,12 @@ Review ads through 6 compliance and quality lenses before shipping.
 
 | Lens | Location | What It Checks |
 |------|----------|----------------|
-| FTC Compliance | `.claude/lenses/ftc-compliance.md` | Federal regulations, earnings claims |
-| Meta Policy | `.claude/lenses/meta-policy.md` | Platform triggers, Personal Attributes |
-| Copy Quality | `.claude/lenses/copy-quality.md` | Schwartz, Hormozi, Suby frameworks |
-| Visual Standards | `.claude/lenses/visual-standards.md` | Safe zones, OCR, prohibited visuals |
-| Voice Authenticity | `.claude/lenses/voice-authenticity.md` | AI tells, brand voice |
-| Substantiation | `.claude/lenses/substantiation.md` | Claims inventory, proof matching |
+| FTC Compliance | `<engine>/.claude/lenses/ftc-compliance.md` | Federal regulations, earnings claims |
+| Meta Policy | `<engine>/.claude/lenses/meta-policy.md` | Platform triggers, Personal Attributes |
+| Copy Quality | `<engine>/.claude/lenses/copy-quality.md` | Schwartz, Hormozi, Suby frameworks |
+| Visual Standards | `<engine>/.claude/lenses/visual-standards.md` | Safe zones, OCR, prohibited visuals |
+| Voice Authenticity | `<engine>/.claude/lenses/voice-authenticity.md` | AI tells, brand voice |
+| Substantiation | `<engine>/.claude/lenses/substantiation.md` | Claims inventory, proof matching |
 
 ---
 
@@ -23,7 +23,7 @@ Review ads through 6 compliance and quality lenses before shipping.
 2. Run `mb checkpoint --plan --json`, validate a subject such as `[drafted] {type} ad batch`, and save the pre-review checkpoint only after operator approval.
 3. Spawn 6 parallel Task agents — one per lens. Use `subagent_type: "general-purpose"`. Each agent:
    - Reads the ad batch/copy being reviewed
-   - Reads its assigned lens file from `.claude/lenses/`
+   - Reads its assigned lens file from the engine's `lenses/` directory — resolve relative to this skill: `../../lenses/` from the skill's own loaded location (works for symlink, additionalDirectories, and plugin-cache installs; never cwd-relative)
    - Evaluates every ad against that lens's checklist
    - Returns P1/P2/P3 findings with specific line references
    - Does NOT fix anything — just reports findings (read-only pattern, no write risk)

--- a/.claude/skills/mb-ads/references/mode-static-ads.md
+++ b/.claude/skills/mb-ads/references/mode-static-ads.md
@@ -39,7 +39,7 @@ Campaign Batch 001
 
 1. Read project context (offer, audience, proof, angles)
 2. Ask for campaign name (required)
-3. Select 5-6 angles for the batch — **reference `.claude/reference/compliance/angle-playbook.md`** for angle types, compliance burden, and selection matrix
+3. Select 5-6 angles for the batch — **reference the engine's `angle-playbook.md` — `../../reference/compliance/angle-playbook.md` relative to this skill's loaded location** for angle types, compliance burden, and selection matrix
 4. **Write ALL image prompts first** (Part 1)
 5. **Write ALL ad copy second** (Part 2)
 6. **Cold traffic language check:** Every hook must pass the 3-second comprehension test — no insider jargon, no assumed context. Translate community language to customer language. See Joel's cold traffic guidance in [one-liner-methodology.md](one-liner-methodology.md).

--- a/.claude/skills/mb-ads/references/post-generation-pipeline.md
+++ b/.claude/skills/mb-ads/references/post-generation-pipeline.md
@@ -47,7 +47,7 @@ Spawn ALL agents in a single message for parallel execution. Use `subagent_type:
 
 Each compliance agent receives:
 - **Ad content inline** (pass the full batch file content in the prompt -- do NOT just give a file path)
-- **Lens file path** (agent reads its assigned lens from `.claude/lenses/`)
+- **Lens file path** (agent reads its assigned lens from the engine's `lenses/` dir — `../../lenses/` relative to this skill's loaded location, never cwd-relative)
 - **Business context** (only what that lens needs):
   - FTC: offer.md, testimonials.md, typicality.md
   - Meta Policy: offer.md

--- a/.claude/skills/mb-ads/references/review-workflow.md
+++ b/.claude/skills/mb-ads/references/review-workflow.md
@@ -25,7 +25,7 @@ Identify what's being reviewed:
 
 Spawn 6 agents, one per lens. Each agent:
 
-1. Reads its lens file from `.claude/lenses/`
+1. Reads its lens file from the engine's `lenses/` dir (`../../lenses/` relative to this skill's loaded location)
 2. Applies the checklist to the ad content
 3. Returns findings with severity (P1/P2/P3)
 
@@ -175,8 +175,10 @@ mb checkpoint --message "[updated] {type} ad batch after review" --yes
 ## Context Files
 
 **From Main Branch engine:**
-- `.claude/lenses/` — The 6 review lenses
-- `.claude/reference/compliance/` — Shared compliance frameworks
+- `../../lenses/` (relative to this skill's loaded directory) — the 6 review lenses
+- `../../reference/compliance/` (same resolution) — shared compliance frameworks
+
+Resolve engine paths relative to THIS skill's loaded directory: the engine root is two levels up (`<this-skill-dir>/../../`), so lenses live at `../../lenses/` and compliance frameworks at `../../reference/compliance/`. This works identically for repo symlinks, additionalDirectories, and plugin-cache installs — never resolve them against the business repo's cwd.
 
 **From business repo:**
 - `core/proof/testimonials.md` — Available testimonials for substantiation check


### PR DESCRIPTION
## What

The confirmed pre-flip break from the Stage 1 smoke (decision register item 3): mb-ads's four references named `.claude/lenses/` and `.claude/reference/compliance/` as bare paths, which agents resolve against the business repo's cwd — failing under plugin-only access even though the whole tree ships in the payload.

Fix: all four references (mode-review, post-generation-pipeline, review-workflow, mode-static-ads) now instruct **skill-relative resolution** — `../../lenses/` and `../../reference/compliance/` from the skill's own loaded directory, with the explicit never-cwd-relative rule. The relative shape is identical across all three install modes (repo symlinks, additionalDirectories, plugin cache), which the smoke proved works live.

Files stay where they are — no moves, no other-consumer breakage (mb-setup/mb-start mentions are descriptive prose, not read paths).

## Evidence

- `mb skill validate --all`: green. Language gate + smoke-coverage suites green.
- Residual grep: zero bare engine-path read instructions left in mb-ads references.

Refs #804 (remaining there: Stage 2 wiring — tracked-settings plugin enablement + plugin-aware link_status)

🤖 Generated with [Claude Code](https://claude.com/claude-code)