### PR TITLE
feat(engine): Stage 2 plugin wiring — worktree-durable skill discovery (#804)

### DIFF
--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -2551,12 +2551,24 @@ def skill_validate_cmd(
 @skill_app.command("link")
 def skill_link_cmd(
     repo: str = typer.Option(".", "--repo", help="Business repo to wire for Claude Code."),
+    plugin: bool = typer.Option(
+        False,
+        "--plugin",
+        help=(
+            "Also write the worktree-durable plugin wiring into tracked "
+            ".claude/settings.json (parallel rail; symlinks still written)."
+        ),
+    ),
     json_out: bool = typer.Option(False, "--json", help="Machine-readable output."),
 ) -> None:
     """Wire bundled skills into a business repo for Claude Code discovery."""
-    from mb.engine import link_skills
+    from mb.engine import link_skills, write_plugin_wiring
 
     result = link_skills(repo)
+    plugin_result: dict[str, Any] | None = None
+    if plugin:
+        plugin_result = write_plugin_wiring(repo)
+        result["plugin_wiring"] = plugin_result
     if json_out:
         typer.echo(json.dumps(result, indent=2))
     else:
@@ -2569,6 +2581,8 @@ def skill_link_cmd(
                 typer.echo(f"  + copied {len(result['copied'])} skill(s)")
             if result["skipped"]:
                 typer.echo(f"  · {len(result['skipped'])} already wired")
+            if plugin_result is not None:
+                typer.echo(f"  + {plugin_result['summary']}")
             typer.echo("")
             typer.echo("you're set — run `claude` and then /mb-start.")
         else:

--- a/mb/mb/engine.py
+++ b/mb/mb/engine.py
@@ -845,8 +845,15 @@ def link_status(repo: str | Path) -> dict[str, Any]:
     else:
         summary = "Missing Main Branch start wiring: " + ", ".join(missing) + "."
 
+    plugin = plugin_wiring_status(target)
+    if missing and plugin["wired"]:
+        summary += (
+            " Tracked plugin wiring is present — once the plugin is active, "
+            "skill discovery survives fresh worktrees without relinking."
+        )
     return {
         "ok": settings_has_engine and start_link_ok and shadow_report["ok"],
+        "plugin": plugin,
         "is_linked_worktree": is_linked_worktree,
         "repo": str(target),
         "engine_root": root_str or None,
@@ -894,3 +901,81 @@ def install_mode() -> str:
     if (root / ".git").exists():
         return "clone"
     return "source"
+
+
+PLUGIN_MARKETPLACE_NAME = "mainbranch"
+PLUGIN_REPO = "noontide-co/mainbranch"
+PLUGIN_ENABLE_KEY = "mainbranch@mainbranch"
+
+
+def _tracked_settings_path(repo: Path) -> Path:
+    return repo / ".claude" / "settings.json"
+
+
+def plugin_wiring_status(repo: str | Path) -> dict[str, Any]:
+    """Report the worktree-durable plugin wiring in tracked settings.
+
+    Stage 2 of the plugin migration (decisions/2026-06-10): plugin
+    enablement written to TRACKED `.claude/settings.json` survives
+    worktrees, unlike the gitignored symlink wiring. Shape verified live
+    against `claude plugin marketplace add` output.
+    """
+    target = Path(repo).resolve()
+    settings = _read_settings(_tracked_settings_path(target))
+    marketplaces = settings.get("extraKnownMarketplaces")
+    marketplace = (
+        marketplaces.get(PLUGIN_MARKETPLACE_NAME) if isinstance(marketplaces, dict) else None
+    )
+    source = (marketplace or {}).get("source") if isinstance(marketplace, dict) else None
+    marketplace_known = bool(
+        isinstance(source, dict)
+        and source.get("source") == "github"
+        and source.get("repo") == PLUGIN_REPO
+    )
+    enabled_plugins = settings.get("enabledPlugins")
+    plugin_enabled = bool(
+        isinstance(enabled_plugins, dict) and enabled_plugins.get(PLUGIN_ENABLE_KEY) is True
+    )
+    return {
+        "marketplace_known": marketplace_known,
+        "plugin_enabled": plugin_enabled,
+        "wired": marketplace_known and plugin_enabled,
+        "settings_path": str(_tracked_settings_path(target)),
+    }
+
+
+def write_plugin_wiring(repo: str | Path) -> dict[str, Any]:
+    """Write the worktree-durable plugin wiring into tracked settings.
+
+    Merges two keys into `.claude/settings.json` (created if absent),
+    preserving everything else in the file. Idempotent.
+    """
+    target = Path(repo).resolve()
+    path = _tracked_settings_path(target)
+    settings = _read_settings(path)
+    before = plugin_wiring_status(target)
+    marketplaces = settings.setdefault("extraKnownMarketplaces", {})
+    if not isinstance(marketplaces, dict):
+        marketplaces = {}
+        settings["extraKnownMarketplaces"] = marketplaces
+    marketplaces[PLUGIN_MARKETPLACE_NAME] = {"source": {"source": "github", "repo": PLUGIN_REPO}}
+    enabled = settings.setdefault("enabledPlugins", {})
+    if not isinstance(enabled, dict):
+        enabled = {}
+        settings["enabledPlugins"] = enabled
+    enabled[PLUGIN_ENABLE_KEY] = True
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(settings, indent=2) + "\n", encoding="utf-8")
+    after = plugin_wiring_status(target)
+    return {
+        "ok": after["wired"],
+        "changed": before != after,
+        "settings_path": str(path),
+        "wiring": after,
+        "summary": (
+            "plugin wiring written to tracked settings — skill discovery now "
+            "survives fresh worktrees (restart or /reload-skills to pick up)"
+            if after["wired"]
+            else "plugin wiring write did not verify; inspect .claude/settings.json"
+        ),
+    }

--- a/mb/tests/test_engine.py
+++ b/mb/tests/test_engine.py
@@ -438,3 +438,81 @@ def test_link_status_explains_worktree_wiring_gap(tmp_path: Path) -> None:
     assert primary["is_linked_worktree"] is False
     if not primary["ok"]:
         assert "worktree" not in primary["summary"]
+
+
+def test_plugin_wiring_write_and_status(tmp_path: Path) -> None:
+    import json as json_mod
+
+    status = engine_mod.plugin_wiring_status(tmp_path)
+    assert status["wired"] is False
+
+    result = engine_mod.write_plugin_wiring(tmp_path)
+    assert result["ok"] is True
+    assert result["changed"] is True
+
+    settings = json_mod.loads((tmp_path / ".claude" / "settings.json").read_text(encoding="utf-8"))
+    assert settings["extraKnownMarketplaces"]["mainbranch"]["source"] == {
+        "source": "github",
+        "repo": "noontide-co/mainbranch",
+    }
+    assert settings["enabledPlugins"]["mainbranch@mainbranch"] is True
+
+    again = engine_mod.write_plugin_wiring(tmp_path)
+    assert again["ok"] is True
+    assert again["changed"] is False  # idempotent
+
+    assert engine_mod.plugin_wiring_status(tmp_path)["wired"] is True
+    assert engine_mod.link_status(tmp_path)["plugin"]["wired"] is True
+
+
+def test_plugin_wiring_preserves_existing_settings(tmp_path: Path) -> None:
+    import json as json_mod
+
+    path = tmp_path / ".claude" / "settings.json"
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        json_mod.dumps(
+            {
+                "permissions": {"allow": ["Bash(ls:*)"]},
+                "extraKnownMarketplaces": {
+                    "other": {"source": {"source": "github", "repo": "a/b"}}
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    engine_mod.write_plugin_wiring(tmp_path)
+
+    settings = json_mod.loads(path.read_text(encoding="utf-8"))
+    assert settings["permissions"]["allow"] == ["Bash(ls:*)"]
+    assert settings["extraKnownMarketplaces"]["other"]["source"]["repo"] == "a/b"
+    assert settings["extraKnownMarketplaces"]["mainbranch"]["source"]["repo"] == (
+        "noontide-co/mainbranch"
+    )
+
+
+def test_worktree_summary_mentions_plugin_rail_when_wired(tmp_path: Path) -> None:
+    import subprocess
+
+    repo = tmp_path / "biz"
+    repo.mkdir()
+
+    def git(*args: str) -> None:
+        subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True, text=True)
+
+    git("init")
+    git("config", "user.email", "t@example.com")
+    git("config", "user.name", "T")
+    engine_mod.write_plugin_wiring(repo)
+    (repo / "README.md").write_text("hi\n", encoding="utf-8")
+    git("add", "-A")
+    git("commit", "-m", "baseline")
+    worktree = repo / ".claude" / "worktrees" / "fresh"
+    git("worktree", "add", "-b", "fresh", str(worktree))
+
+    status = engine_mod.link_status(worktree)
+
+    assert status["ok"] is False  # symlink rail still missing in the worktree
+    assert status["plugin"]["wired"] is True  # tracked wiring carried over
+    assert "survives fresh worktrees" in status["summary"]


### PR DESCRIPTION
## What

Stage 2 of the skills-distribution migration — the slice that makes installs actually durable:

- `engine.write_plugin_wiring(repo)`: merges exactly two keys into **tracked** `.claude/settings.json` — `extraKnownMarketplaces.mainbranch` (GitHub source, shape live-verified against a real `claude plugin marketplace add noontide-co/mainbranch` this morning, settings restored byte-identical after) and `enabledPlugins["mainbranch@mainbranch"]`. Preserves all other settings content; idempotent.
- `mb skill link --plugin`: opt-in parallel rail per the decision — symlinks still written, plugin wiring added.
- `link_status()` gains a `plugin` facts block, and the worktree summary now distinguishes "skills gone, relink every time" from "skills gone here, but the durable rail has you covered once the plugin is active."

GitHub-source chosen over directory-source deliberately: the smoke showed directory sources embed the pipx venv's python-versioned path (breaks on python upgrades); the repo is public and `claude plugin update` becomes the refresh path.

## Evidence

- **The carryover proof in-test**: wiring written in a main checkout is present in a fresh git worktree where the symlink rail is absent.
- Idempotency + existing-settings preservation tests; `test_engine` 18 passed; engine+doctor+start suites 112 passed; ruff + mypy strict clean.

Refs #804 (remaining: onboard/init default wiring + doctor repair migration = Stage 3, after field soak)

🤖 Generated with [Claude Code](https://claude.com/claude-code)