### PR TITLE
test: runtime-aware discoverability gate — each rail must teach every surface

### DIFF
--- a/mb/mb/_data/templates/AGENTS.md.tmpl
+++ b/mb/mb/_data/templates/AGENTS.md.tmpl
@@ -389,8 +389,13 @@ the operator asks for plumbing.
   credentials -> `mb connect token` (token to stdout for scripts and agents;
   never echo the value). Tools missing from the provider list ->
   `mb connect <id> --custom`. Agents validating their own work in repos with
-  legacy debt -> `mb validate --paths <prefix>`. Lead with the business
-  answer, command second; triggered surfaces stay triggered.
+  legacy debt -> `mb validate --paths <prefix>`. Filing work upstream or in
+  the business repo without leaking private detail -> `mb issue` (privacy-safe
+  GitHub issue drafting). "What should we improve in this repo?" ->
+  `mb suggest` (read-only improvement suggestions). An old repo shape that
+  needs the current structure -> `mb migrate` via the doctor-recommended
+  plan, never hand-moved files. Lead with the business answer, command
+  second; triggered surfaces stay triggered.
 - If readiness is blocked or drift has errors, handle repair before output
   work.
 - Explain two named drift items instead of re-deriving them. A

--- a/mb/tests/test_discoverability.py
+++ b/mb/tests/test_discoverability.py
@@ -1,11 +1,17 @@
-"""Every CLI surface must be reachable from a discovery rail.
+"""Every CLI surface must be reachable from each first-class runtime rail.
 
-Operators never browse the CLI. A surface is discoverable when it appears
-in at least one rail an operator or agent actually touches: a bundled
-skill (mb-start routes, mb-help answers, workers cite), the docs index
-corpus, or an engine-emitted nudge (repair/summary strings in the
-package). A command reachable from none of those is invisible — this
-gate fails the build instead of letting it ship.
+Operators never browse the CLI. A surface is discoverable on a rail when
+that rail's own teaching corpus names it: for Claude Code, the bundled
+skills and docs; for Codex, the generated AGENTS.md template and the
+shared workflow sources its global skills render from. Python string
+literals are not a discovery rail — a surface mentioned only in engine
+source is invisible to operators on both runtimes.
+
+History: the first version of this gate pooled everything into one
+corpus and passed when a surface was taught on ONE rail (or merely
+appeared in .py source). A full cycle of new surfaces shipped Claude-only
+before the 2026-06-12 Codex audit caught it. Per-rail assertion makes
+that class of asymmetry a failing test.
 """
 
 from __future__ import annotations
@@ -16,16 +22,30 @@ from mb.cli import app
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
-# Surfaces that are deliberately agent/engine-internal and are documented
-# where agents actually find them (each entry needs a justification).
+# Engine-internal surfaces, exempt on BOTH rails (justify every entry).
 INTERNAL_ALLOWLIST = {
     # Invoked by mb-think's educational flow through the engine, not named
-    # in prose; covered by the educational content itself.
+    # in operator prose; covered by the educational content itself.
     "educational",
     # Engine-internal resolution helper used by skills' path-resolution
     # reference, which documents the contract rather than the command name.
     "resolve",
 }
+
+# Claude-first surfaces the Codex rail intentionally does not teach yet
+# (Codex support levels: supported daily loop / read_only_planning;
+# justify every entry against docs/compatibility.md).
+CODEX_EXEMPT = {
+    # Fixture-safe creative rails are Claude-skill territory; Codex carries
+    # them as read_only_planning per docs/compatibility.md.
+    "image",
+    "ads",
+    # `mb think` is a redirect stub pointing the operator INTO Claude Code;
+    # Codex has its own Think workflow section in generated AGENTS.md.
+    "think",
+}
+
+MAX_EXEMPTIONS = 6
 
 
 def _cli_surfaces() -> set[str]:
@@ -41,33 +61,53 @@ def _cli_surfaces() -> set[str]:
     return names
 
 
-def _discovery_corpus() -> str:
+def _read_all(patterns: list[str]) -> str:
     chunks: list[str] = []
-    for pattern in (".claude/skills/**/*.md", "docs/*.md", "workflows/**/*.md"):
+    for pattern in patterns:
         for path in REPO_ROOT.glob(pattern):
             if path.is_file():
                 chunks.append(path.read_text(encoding="utf-8", errors="ignore"))
-    for path in (REPO_ROOT / "mb" / "mb").glob("*.py"):
-        chunks.append(path.read_text(encoding="utf-8", errors="ignore"))
     return "\n".join(chunks)
 
 
-def test_every_cli_surface_is_discoverable() -> None:
-    corpus = _discovery_corpus()
-    unreachable = sorted(
+def _claude_corpus() -> str:
+    return _read_all([".claude/skills/**/*.md", "docs/*.md"])
+
+
+def _codex_corpus() -> str:
+    chunks = [_read_all(["workflows/**/*.md"])]
+    template = REPO_ROOT / "mb" / "mb" / "_data" / "templates" / "AGENTS.md.tmpl"
+    chunks.append(template.read_text(encoding="utf-8"))
+    return "\n".join(chunks)
+
+
+def _unreachable(corpus: str, exempt: set[str]) -> list[str]:
+    return sorted(
         name
         for name in _cli_surfaces()
-        if name not in INTERNAL_ALLOWLIST and f"mb {name}" not in corpus
+        if name not in INTERNAL_ALLOWLIST and name not in exempt and f"mb {name}" not in corpus
     )
+
+
+def test_every_cli_surface_is_discoverable_on_claude_rail() -> None:
+    unreachable = _unreachable(_claude_corpus(), set())
     assert unreachable == [], (
-        "CLI surfaces unreachable from every discovery rail (no skill routes "
-        "to them, no doc names them, no engine nudge emits them): "
-        f"{unreachable}. Wire each into mb-start routing, mb-help's "
-        "cli-surfaces map, or a doctor/status repair string — or add to "
-        "INTERNAL_ALLOWLIST with a justification."
+        "CLI surfaces unreachable from the Claude rail (no bundled skill or "
+        f"doc names them): {unreachable}. Wire each into mb-start routing or "
+        "mb-help's cli-surfaces map."
     )
 
 
-def test_allowlist_stays_small_and_justified() -> None:
-    # The allowlist growing silently would gut the gate.
-    assert len(INTERNAL_ALLOWLIST) <= 4
+def test_every_cli_surface_is_discoverable_on_codex_rail() -> None:
+    unreachable = _unreachable(_codex_corpus(), CODEX_EXEMPT)
+    assert unreachable == [], (
+        "CLI surfaces unreachable from the Codex rail (neither the shared "
+        "workflow sources nor AGENTS.md.tmpl name them): "
+        f"{unreachable}. Teach them at the propagation layer (workflow "
+        "Routing Rules + template), or add a justified CODEX_EXEMPT entry."
+    )
+
+
+def test_exemption_lists_stay_small_and_justified() -> None:
+    # Growing allowlists silently would gut the gate.
+    assert len(INTERNAL_ALLOWLIST) + len(CODEX_EXEMPT) <= MAX_EXEMPTIONS


### PR DESCRIPTION
## What

The enforcement half of the Codex rail audit (the teaching half merged as #874): the discoverability gate now asserts **per runtime rail** instead of one pooled corpus.

- Claude rail corpus: bundled skills + docs. Codex rail corpus: shared workflow sources + the generated AGENTS.md template. **Raw `.py` source dropped** — Python string literals are not a discovery rail.
- Running the split immediately surfaced three genuine Codex gaps; this PR teaches them in the template (`mb issue`, `mb suggest`, `mb migrate` with the doctor-plan framing) rather than exempting them.
- Three justified exemptions remain (`image`/`ads` = read_only_planning per the compatibility doc; `think` = a redirect stub whose whole job is pointing into Claude Code), capped at 6 total by the gate's own test.
- The docstring records the history: a full cycle of surfaces shipped Claude-only under the old single-corpus design before the audit caught it. This class of asymmetry now fails CI.

## Evidence

- Both rail tests green after the template additions; gap list empirically derived (the Codex test failed with exactly `['ads','issue','migrate','suggest','think']` before classification).
- 15 passed across discoverability + first-run + language gates; init + runtime-command-reference suites green; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)