### PR TITLE
docs(setup): cold-eyes fixes — onboard-then-doctor arc, first checkpoint, local-only respected

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,18 +79,21 @@ this:
 
 ```text
 I want Main Branch: AI business memory I own as files in one folder
-(https://github.com/noontide-co/mainbranch). First read the entire README,
+(https://github.com/noontide-co/mainbranch). First read the entire README (fetch the raw file if your tools summarize),
 then explore the repo enough to understand the architecture (the mb CLI is
 the deterministic control plane; skills are the judgment layer; my business
 lives in its own folder, never in the engine; bets, research, decisions,
 pushes, playbooks, outcomes, and checkpoints are the primitives; writing
 files, publishing, spending, and customer contact stay my call). Then
 interview me briefly about my business, my offer, and my audience. Then:
-install the engine, run `mb doctor` and fix anything it flags, run
-`mb onboard` to create my business folder, seed my core files from the
-interview, and teach me the daily loop — /mb-start to open, /mb-end to
-close. Get me to a business folder with offer, audience, and voice drafted
-and a clean `mb status`, then stop and show me what you set up.
+install the engine, run `mb onboard` to create my business folder,
+then run `mb doctor` inside that folder and fix anything it flags, seed my
+core files from the interview using the templates the folder ships with,
+save the first checkpoint, and teach me the daily loop — /mb-start to
+open, /mb-end to close. If I decline GitHub, treat local-only as a valid
+choice, not something to repair. Get me to a business folder with offer,
+audience, and voice drafted and a clean `mb status`, then stop and show me
+what you set up.
 ```
 
 Prefer to drive it yourself? Everything below is the manual path.

--- a/docs/beginner-setup.md
+++ b/docs/beginner-setup.md
@@ -57,18 +57,21 @@ strongest model with extra reasoning) and paste this:
 
 ```text
 I want Main Branch: AI business memory I own as files in one folder
-(https://github.com/noontide-co/mainbranch). First read the entire README,
+(https://github.com/noontide-co/mainbranch). First read the entire README (fetch the raw file if your tools summarize),
 then explore the repo enough to understand the architecture (the mb CLI is
 the deterministic control plane; skills are the judgment layer; my business
 lives in its own folder, never in the engine; bets, research, decisions,
 pushes, playbooks, outcomes, and checkpoints are the primitives; writing
 files, publishing, spending, and customer contact stay my call). Then
 interview me briefly about my business, my offer, and my audience. Then:
-install the engine, run `mb doctor` and fix anything it flags, run
-`mb onboard` to create my business folder, seed my core files from the
-interview, and teach me the daily loop — /mb-start to open, /mb-end to
-close. Get me to a business folder with offer, audience, and voice drafted
-and a clean `mb status`, then stop and show me what you set up.
+install the engine, run `mb onboard` to create my business folder,
+then run `mb doctor` inside that folder and fix anything it flags, seed my
+core files from the interview using the templates the folder ships with,
+save the first checkpoint, and teach me the daily loop — /mb-start to
+open, /mb-end to close. If I decline GitHub, treat local-only as a valid
+choice, not something to repair. Get me to a business folder with offer,
+audience, and voice drafted and a clean `mb status`, then stop and show me
+what you set up.
 ```
 
 Do not save that prompt as a markdown document. It tells the agent to start

--- a/mb/tests/test_first_run_setup_contract.py
+++ b/mb/tests/test_first_run_setup_contract.py
@@ -31,7 +31,9 @@ def test_beginner_setup_uses_owner_friendly_setup_prompt() -> None:
         # beginner setup). Keep these in lockstep with README.md.
         "I want Main Branch: AI business memory I own as files in one folder",
         "interview me briefly about my business, my offer, and my audience",
-        "run `mb doctor` and fix anything it flags",
+        "then run `mb doctor` inside that folder and fix anything it flags",
+        "save the first checkpoint",
+        "treat local-only as a valid",
         "then stop and show me what you set up",
         # Safety rails stay documented around the prompt.
         "writes are explained and approved first",


### PR DESCRIPTION
## What

The cold-eyes install test ran for the first time (strictly-roleplayed fresh agent, fictional solo-service operator, published 0.3.44, public README only). **Verdict: the front door holds** — first win in ~16 actions, inside the 30-minute target. This PR ships the prompt-side fixes from its friction log:

- **Arc reordered (the near-blocker):** `onboard` first, `doctor` *inside the folder* — the old order made the doctor pass meaningless and invited `repair --apply` writes into whatever cwd the agent happened to be in.
- Seeding step names the shipped templates (non-Claude agents stopped guessing frontmatter).
- First checkpoint made explicit (a clean `mb status` quietly depends on it).
- "If I decline GitHub, treat local-only as a valid choice, not something to repair."
- Raw-fetch hint for summarizing web tools.

Both prompt doors updated in lockstep (byte-identical test holds); contract pins updated. Engine-side findings filed: doctor cwd-guard (the blocker-class one), onboard identity/feedback gaps, status declined-GitHub framing + template surface.

## Evidence

- First-run contract + lockstep + language gates: 12 passed.
- Full friction table (15 items, severities, fixes) in the loop session; what worked is also recorded — wheel self-linking, business-language scaffold, privacy boundaries in onboarding.json, and status demonstrably reading seeded content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)