### PR TITLE
feat(doctor): refuse repair-writes outside a recognized business folder (#879)

### DIFF
--- a/mb/mb/doctor.py
+++ b/mb/mb/doctor.py
@@ -35,7 +35,12 @@ from mb import spine as spine_mod
 from mb import topology as topology_mod
 from mb import validate as validate_mod
 from mb.engine import install_mode, link_status
-from mb.freshness import format_update_alert, package_update_status, version_key
+from mb.freshness import (
+    format_update_alert,
+    looks_like_business_repo,
+    package_update_status,
+    version_key,
+)
 from mb.migrate import LATEST_SCHEMA_VERSION, pending_migrations, read_schema_version
 from mb.skill_validate import run_all as validate_all_skills
 
@@ -1971,6 +1976,56 @@ def run(path: str) -> dict[str, Any]:
     }
 
 
+def _not_business_folder_guard(target: Path) -> dict[str, Any] | None:
+    """Refuse doctor writes (and noisy scans) outside a business folder.
+
+    Field-proven failure (cold-eyes install test): pre-onboard doctor in an
+    arbitrary cwd emitted seven folder-shaped warnings, validated stray
+    markdown, and repair --apply would have scaffolded .claude/, AGENTS.md,
+    and .gitignore into whatever directory the agent happened to be in.
+    """
+    markers = (
+        "CLAUDE.md",
+        "AGENTS.md",
+        "core",
+        "decisions",
+        "research",
+        "bets",
+        "pushes",
+        ".mb",
+        ".mainbranch",
+        # Legacy shapes are doctor's migration patients, not junk dirs.
+        "reference",
+        ".vip",
+        "campaigns",
+    )
+    # Partially built or broken business folders are exactly what doctor
+    # repairs — refuse only a directory with no business markers at all.
+    if looks_like_business_repo(target) or any((target / m).exists() for m in markers):
+        return None
+    summary = (
+        "this is not a Main Branch business folder — run `mb onboard` to "
+        "create one (doctor checks and repairs run inside it)"
+    )
+    return {
+        "ok": True,
+        "guard": "not_business_folder",
+        "repo": str(target),
+        "summary": summary,
+        "sections": [
+            _section(
+                "business-folder",
+                "Business Folder",
+                "info",
+                summary,
+            )
+        ],
+        "actions": [],
+        "applied_actions": [],
+        "safe_to_share": True,
+    }
+
+
 def repair_plan(
     repo: str | Path = ".",
     *,
@@ -1985,6 +2040,9 @@ def repair_plan(
     if only and all_agents:
         raise ValueError("--only cannot be combined with --all-agents")
     target = Path(repo).expanduser().resolve()
+    guard = _not_business_folder_guard(target)
+    if guard is not None:
+        return guard
     doctor_report = run(str(target))
     actions: list[dict[str, Any]] = []
     sections: list[dict[str, Any]] = []
@@ -2839,6 +2897,9 @@ def repair_apply(
     if only and all_agents:
         raise ValueError("--only cannot be combined with --all-agents")
     target = Path(repo).expanduser().resolve()
+    guard = _not_business_folder_guard(target)
+    if guard is not None:
+        return guard
     before = repair_plan(target, only=only, all_agents=all_agents)
     applied: list[dict[str, Any]] = []
     apply_non_agent = not only and not all_agents

--- a/mb/mb/doctor.py
+++ b/mb/mb/doctor.py
@@ -1976,7 +1976,7 @@ def run(path: str) -> dict[str, Any]:
     }
 
 
-def _not_business_folder_guard(target: Path) -> dict[str, Any] | None:
+def _not_business_folder_guard(target: Path, *, mode: str = "plan") -> dict[str, Any] | None:
     """Refuse doctor writes (and noisy scans) outside a business folder.
 
     Field-proven failure (cold-eyes install test): pre-onboard doctor in an
@@ -2003,25 +2003,56 @@ def _not_business_folder_guard(target: Path) -> dict[str, Any] | None:
     # repairs — refuse only a directory with no business markers at all.
     if looks_like_business_repo(target) or any((target / m).exists() for m in markers):
         return None
-    summary = (
+    message = (
         "this is not a Main Branch business folder — run `mb onboard` to "
         "create one (doctor checks and repairs run inside it)"
     )
+    # Mirror the full repair payload contract so --json consumers and
+    # render_repair never hit a guard-shaped hole.
     return {
+        "schema": REPAIR_SCHEMA,
+        "schema_version": REPAIR_SCHEMA_VERSION,
         "ok": True,
-        "guard": "not_business_folder",
+        "mode": mode,
+        "only": "",
+        "all_agents": False,
+        # The guard refuses before any write, so even --apply stays read-only.
+        "read_only": True,
         "repo": str(target),
-        "summary": summary,
+        "generated_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "guard": "not_business_folder",
+        "summary": {
+            "ok": 0,
+            "info": 1,
+            "warn": 0,
+            "error": 0,
+            "actions": 0,
+            "write_actions": 0,
+            "safe_apply_actions": 0,
+        },
+        "plan_interpretation": {
+            "state": "not_business_folder",
+            "summary": message,
+            "read_only_plan": True,
+            "nonzero_exit_can_still_include_usable_plan": False,
+            "safe_to_share": True,
+        },
         "sections": [
             _section(
                 "business-folder",
                 "Business Folder",
                 "info",
-                summary,
+                message,
             )
         ],
         "actions": [],
         "applied_actions": [],
+        "post_apply": {
+            "structural_verification": "mb onboard",
+            "validation_frontmatter_debt": "mb onboard",
+            "runtime_smoke_required": message,
+            "git_review": [],
+        },
         "safe_to_share": True,
     }
 
@@ -2040,7 +2071,7 @@ def repair_plan(
     if only and all_agents:
         raise ValueError("--only cannot be combined with --all-agents")
     target = Path(repo).expanduser().resolve()
-    guard = _not_business_folder_guard(target)
+    guard = _not_business_folder_guard(target, mode=mode)
     if guard is not None:
         return guard
     doctor_report = run(str(target))
@@ -2897,7 +2928,7 @@ def repair_apply(
     if only and all_agents:
         raise ValueError("--only cannot be combined with --all-agents")
     target = Path(repo).expanduser().resolve()
-    guard = _not_business_folder_guard(target)
+    guard = _not_business_folder_guard(target, mode="apply")
     if guard is not None:
         return guard
     before = repair_plan(target, only=only, all_agents=all_agents)
@@ -3138,6 +3169,11 @@ def render_repair(report: dict[str, Any]) -> None:
     from rich.console import Console
 
     console = Console()
+    if report.get("guard") == "not_business_folder":
+        console.print("\n[bold]mb doctor repair[/bold]")
+        console.print(f"repo: {report['repo']}\n")
+        console.print(f"  [blue]info[/blue]  {report['plan_interpretation']['summary']}")
+        return
     mode = "read-only plan" if report["read_only"] else "apply summary"
     console.print(f"\n[bold]mb doctor repair[/bold]  {mode}")
     if report.get("only"):

--- a/mb/tests/test_doctor.py
+++ b/mb/tests/test_doctor.py
@@ -1992,13 +1992,18 @@ def test_doctor_guard_refuses_writes_outside_business_folder(tmp_path: Path) -> 
     plan = doctor_mod.repair_plan(tmp_path)
     assert plan["guard"] == "not_business_folder"
     assert plan["actions"] == []
-    assert "mb onboard" in plan["summary"]
+    assert "mb onboard" in plan["plan_interpretation"]["summary"]
+    # Guard payload still honors the repair JSON contract
+    assert plan["schema"] == "mb.doctor.repair"
+    assert plan["schema_version"] == 1
+    assert plan["mode"] == "plan"
     # No phantom validation of stray markdown
     assert len(plan["sections"]) == 1
 
     applied = doctor_mod.repair_apply(tmp_path)
     assert applied["guard"] == "not_business_folder"
     assert applied["applied_actions"] == []
+    assert applied["mode"] == "apply"
     # Nothing scaffolded into the arbitrary cwd
     assert not (tmp_path / ".claude").exists()
     assert not (tmp_path / "AGENTS.md").exists()

--- a/mb/tests/test_doctor.py
+++ b/mb/tests/test_doctor.py
@@ -1720,7 +1720,7 @@ def _topology_section(payload: dict[str, Any]) -> dict[str, Any]:
 
 def test_doctor_topology_drift_section_info_when_no_registry(tmp_path: Path) -> None:
     repo = tmp_path / "no-topology"
-    repo.mkdir()
+    (repo / "core").mkdir(parents=True)  # minimal business marker (doctor guards bare dirs)
 
     payload = doctor_mod.repair_plan(repo=str(repo))
 
@@ -1909,7 +1909,7 @@ def test_doctor_repair_plan_actions_always_carry_audience_and_summary(
     """Every action emitted by repair_plan must have a valid audience and a
     non-empty operator_summary. Locks the contract agents read against."""
     repo = tmp_path / "fresh"
-    repo.mkdir()
+    (repo / "core").mkdir(parents=True)  # minimal business marker (doctor guards bare dirs)
 
     payload = doctor_mod.repair_plan(repo=str(repo))
 
@@ -1984,3 +1984,31 @@ def test_dossier_verify_reports_connected_provider_ok(tmp_path: Path, monkeypatc
     assert apify["name"] == "Apify"
     assert "mb connect test apify" in apify["summary"]
     assert apify["state"] in {"ok", "warn"}
+
+
+def test_doctor_guard_refuses_writes_outside_business_folder(tmp_path: Path) -> None:
+    (tmp_path / "stray-notes.md").write_text("# not a business\n", encoding="utf-8")
+
+    plan = doctor_mod.repair_plan(tmp_path)
+    assert plan["guard"] == "not_business_folder"
+    assert plan["actions"] == []
+    assert "mb onboard" in plan["summary"]
+    # No phantom validation of stray markdown
+    assert len(plan["sections"]) == 1
+
+    applied = doctor_mod.repair_apply(tmp_path)
+    assert applied["guard"] == "not_business_folder"
+    assert applied["applied_actions"] == []
+    # Nothing scaffolded into the arbitrary cwd
+    assert not (tmp_path / ".claude").exists()
+    assert not (tmp_path / "AGENTS.md").exists()
+    assert not (tmp_path / ".gitignore").exists()
+
+
+def test_doctor_guard_passes_business_folders(tmp_path: Path) -> None:
+    repo = tmp_path / "biz"
+    init_run(path=str(repo), name="Acme")
+
+    plan = doctor_mod.repair_plan(repo)
+    assert plan.get("guard") is None
+    assert len(plan["sections"]) > 1


### PR DESCRIPTION
## What

The cold-eyes test's one blocker-class finding, fixed at the engine: `mb doctor` (plan and apply) now guards directories with **no business markers at all** — one info section pointing at `mb onboard`, zero actions, zero writes, zero stray-markdown scanning. The prompt reorder (#882) was the mitigation; this is the guarantee.

Design point from the failures themselves: the first guard draft was too strict and refused doctor's actual patients. The marker list deliberately admits every patient class — fresh scaffolds, partial folders, and **legacy shapes** (`reference/`, `.vip/`, `campaigns/` — migration's whole clientele). Only true junk dirs guard. Two fixtures that depended on the old empty-dir behavior gained a minimal marker; their real subjects are untouched.

## Evidence

- Guard tests: junk dir with a stray `.md` → guard fires, dir provably untouched after `repair --apply`; business folder → full plan unchanged.
- `test_doctor.py`: 78 passed (from 8 failures on the first draft — each one taught the marker list something). ruff + mypy strict clean.

Closes #879

🤖 Generated with [Claude Code](https://claude.com/claude-code)