### PR TITLE
fix(onboard): never scrape the machine's gh login when GitHub was declined

### DIFF
--- a/mb/mb/init.py
+++ b/mb/mb/init.py
@@ -130,8 +130,14 @@ def run(
     *,
     owner_name: str = "",
     owner_github: str = "",
+    infer_github_identity: bool = True,
 ) -> dict[str, Any]:
     """Scaffold ``path`` as a Main Branch business repo.
+
+    ``infer_github_identity`` controls whether the machine's gh login may be
+    probed when no explicit ``owner_github`` is given. Callers that let the
+    operator decline GitHub (onboard) must pass False on decline so a shared
+    machine's logged-in account never lands in the scaffold.
 
     Returns a dict with ``status`` ∈ {ok, already-initialized, error},
     ``path`` (absolute), and ``created`` (list of relative paths created).
@@ -158,13 +164,17 @@ def run(
     if not business_name:
         return {"status": "error", "path": str(target), "error": "empty business name"}
 
-    gh_user = (
-        team_mod.normalize_github_handle(owner_github)
-        or team_mod.normalize_github_handle(_gh_username())
-        or "your-gh-username"
+    explicit_handle = team_mod.normalize_github_handle(owner_github)
+    inferred_handle = (
+        team_mod.normalize_github_handle(_gh_username())
+        if not explicit_handle and infer_github_identity
+        else ""
     )
+    gh_handle = explicit_handle or inferred_handle
+    gh_user = gh_handle or "your-gh-username"
     owner_display_name = _owner_display_name(owner_name)
-    owner_slug = _owner_slug(owner_display_name, gh_user)
+    # No real handle → slug from the owner's name, never from the placeholder.
+    owner_slug = _owner_slug(owner_display_name, gh_handle)
 
     created: list[str] = []
     for sub in DATA_FOLDERS:

--- a/mb/mb/onboard.py
+++ b/mb/mb/onboard.py
@@ -1210,6 +1210,10 @@ def run(
             name=business_name,
             owner_name=owner_name,
             owner_github=owner_github,
+            # Declining GitHub must not scrape the machine's gh login into
+            # the scaffold (cold-eyes finding, #880) — infer only when the
+            # operator actually chose a GitHub path.
+            infer_github_identity=bool(github_repo.strip()),
         )
         created.extend(str(item) for item in init_result.get("created", []))
         if init_result["status"] == "error":

--- a/mb/tests/test_init.py
+++ b/mb/tests/test_init.py
@@ -311,9 +311,58 @@ def test_init_uses_explicit_owner_name_env_override(tmp_path: Path, monkeypatch)
     result = run(path=str(target), name="Acme Brewing")
 
     assert result["status"] == "ok"
-    owner_file = target / "core" / "team" / "your-gh-username.md"
+    # No real handle anywhere → the file slugs from the owner's name, not
+    # from the your-gh-username placeholder.
+    owner_file = target / "core" / "team" / "env-owner.md"
     assert owner_file.exists()
     assert "name: Env Owner" in owner_file.read_text(encoding="utf-8")
+
+
+def test_init_without_github_identity_never_probes_gh(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("MB_OWNER_NAME", "")
+
+    def _explode() -> str:
+        raise AssertionError("gh login probed despite infer_github_identity=False")
+
+    monkeypatch.setattr(init_mod, "_gh_username", _explode)
+    target = tmp_path / "acme"
+
+    result = run(
+        path=str(target),
+        name="Acme Brewing",
+        owner_name="Riley Quinn",
+        infer_github_identity=False,
+    )
+
+    assert result["status"] == "ok"
+    owner_file = target / "core" / "team" / "riley-quinn.md"
+    assert owner_file.exists()
+    text = owner_file.read_text(encoding="utf-8")
+    assert "name: Riley Quinn" in text
+    assert "your-gh-username" in text
+    codeowners = (target / ".github" / "CODEOWNERS").read_text(encoding="utf-8")
+    assert "@your-gh-username" in codeowners
+
+
+def test_init_explicit_owner_github_skips_probe_even_when_inference_off(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(
+        init_mod,
+        "_gh_username",
+        lambda: (_ for _ in ()).throw(AssertionError("probe must not run")),
+    )
+    target = tmp_path / "acme"
+
+    result = run(
+        path=str(target),
+        name="Acme Brewing",
+        owner_github="riley-gh",
+        infer_github_identity=False,
+    )
+
+    assert result["status"] == "ok"
+    assert (target / "core" / "team" / "riley-gh.md").exists()
 
 
 def test_init_idempotent(tmp_path: Path) -> None:

--- a/mb/tests/test_onboard.py
+++ b/mb/tests/test_onboard.py
@@ -115,6 +115,30 @@ def test_onboard_next_steps_offer_global_codex_repair_when_available(
     ]
 
 
+def test_onboard_without_github_never_scrapes_machine_login(tmp_path: Path, monkeypatch) -> None:
+    from mb import init as init_mod
+
+    monkeypatch.setattr(onboard_mod, "_which", _tool_path)
+    monkeypatch.setattr(init_mod, "_gh_username", lambda: "machine-login")
+    repo = tmp_path / "acme"
+
+    result = onboard_mod.run(
+        path=str(repo),
+        name="Acme Brewing",
+        mode="new",
+        owner_name="Riley Quinn",
+    )
+
+    assert result["ok"] is True
+    # The operator declined GitHub (no --github): the machine's gh login
+    # must not appear anywhere in the scaffold (#880, cold-eyes finding).
+    assert not (repo / "core" / "team" / "machine-login.md").exists()
+    assert (repo / "core" / "team" / "riley-quinn.md").exists()
+    for rel in ("CLAUDE.md", "AGENTS.md", ".github/CODEOWNERS", "core/team/riley-quinn.md"):
+        text = (repo / rel).read_text(encoding="utf-8")
+        assert "machine-login" not in text, rel
+
+
 def test_onboard_rerun_is_idempotent(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(onboard_mod, "_which", _tool_path)
     repo = tmp_path / "acme"


### PR DESCRIPTION
Item 1 of #880 (cold-eyes findings — the privacy-flavored one).

## What
- `init.run()` gains `infer_github_identity` (default true, so bare `mb init` behavior is unchanged).
- `mb onboard` passes it as `bool(github_repo)` — the machine's `gh api user` login is probed **only when the operator actually chose a GitHub path**. Declining GitHub no longer stamps the logged-in account into `core/team/<handle>.md`, CODEOWNERS, or templates.
- With no real handle, the owner file slugs from the owner's name (`core/team/riley-quinn.md`) instead of the `your-gh-username` placeholder.
- An explicit `--owner-github` always wins and never triggers a probe.

## Why
Cold-eyes install test: a fresh operator declined GitHub and still got the machine's gh login written into the scaffold — wrong identity on any shared machine.

## Evidence
- New tests: probe forbidden when inference off (asserts the probe never runs), explicit handle skips probe, onboard-without-github leaves no trace of the machine login across CLAUDE.md/AGENTS.md/CODEOWNERS/team file.
- Full `scripts/check.sh` green locally (incl. test_json_result.py).

Remaining #880 items (budget-flag feedback, baseline hint, hook template reconcile) ship as follow-up slices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)