### PR TITLE
feat(pulse): /mb-start and /mb-end read the daily pulse

### DIFF
--- a/.claude/skills/mb-end/SKILL.md
+++ b/.claude/skills/mb-end/SKILL.md
@@ -142,6 +142,12 @@ mb checkpoint --plan --json
 | Push artifacts generated | Status/checkpoint changed files under `pushes/` |
 | Unsaved work | Status dirty-work facts and `mb checkpoint --plan` changed files/blockers |
 
+**Pulse check (skip if no `core/operations/pulse/`):** If today's
+`log/<date>-*-pulse.md` exists, compare its ONE recommended action against
+today's activity — done, moved into a lane (bet/issue/decision), or untouched
+— and say which in the session summary. If the scaffold exists but today's
+paper was never written, note it at close so tomorrow opens with a fresh pulse.
+
 **Multi-offer detection (skip if no `core/offers/` folder — single-offer mode,
 everything reads from `core/`):** Use status/checkpoint file paths under
 `core/offers/` to note which offers changed. If those facts are unavailable,

--- a/.claude/skills/mb-start/SKILL.md
+++ b/.claude/skills/mb-start/SKILL.md
@@ -19,18 +19,17 @@ git terms, checkpoint ids, branch names, `origin`, `ahead`, `behind`, `rebase`,
 and `commit` out of the first response unless the user asks for technical detail
 or the exact command must be shown.
 
-When summarizing repo state, count `pushes/` records and flag `campaigns/`
-only as legacy compatibility. Use `core/vocabulary.md` display words in
-conversation while preserving actual paths in commands.
+When summarizing repo state, count `pushes/` records, flag `campaigns/` as
+legacy only, and use `core/vocabulary.md` display words (real paths in commands).
 
 **CLI facts first:** Once the business repo path is known, run
 `mb status --json --peek` before asking setup or routing questions. Treat JSON
 as source of truth for update severity, readiness, drift, onboarding,
 integrations, GitHub, team, bets, dirty git, since-last-check,
 `content_strategy`, `money_path`, `validation.file_contracts`, and
-`ranked_actions`. Use GitHub activity `author_display` / `author_known` when
-naming people. Parse the full JSON once; do not slice status output with `head`
-or `sed` in the normal path.
+`ranked_actions`. Use GitHub `author_display`/`author_known` when naming
+people. Parse the full JSON once; do not slice status output with `head` or
+`sed`.
 
 **Shared source:** The portable daily start/status workflow contract lives
 in `workflows/mb-start-status/workflow.md`; this skill is its Claude shell.
@@ -90,15 +89,16 @@ before mutating the status marker or doing durable writes.
 **Continuity facts:** Use `since_last_check.journal`, top-level `journal`,
 GitHub activity, and `checkpoint` from status to explain "where we left off."
 Do not run raw `git log` unless status says journal facts are unavailable.
+If `core/operations/pulse/` exists, read today's `log/<date>-*-pulse.md` and
+carry its ONE action into the session open (offer the pulse skill if missing).
 Saving progress: `mb checkpoint --plan --json`, validate, then after approval
 `mb checkpoint --message "..." --yes`.
 
 **Provider facts first:** When setup or routing depends on GitHub, Cloudflare,
 Google/Workspace, Meta Ads, or Apify, read the status `integrations` facts
 first; for a provider choice or repair explanation, run `mb connect plan` or
-`mb connect doctor --json` and use the cited `next_command` /
-`repair_command`. Never ask for tokens or setup in prose before the CLI has
-named the missing step.
+`mb connect doctor --json` and use the cited `next_command`/`repair_command`.
+Never ask for tokens or setup in prose before the CLI names the missing step.
 
 **Paid-traffic facts first:** When routing a paid-traffic minisite, Google Ads,
 GTM, retargeting, or "ready to launch" request, load
@@ -122,10 +122,10 @@ meaning before suggesting file moves.
 
 **Data/ops surface routing:** whose-data questions → `mb spine declare`/
 `show`; money-path-overnight worries (real money flowing unattended) →
-`mb canary init`; "show me the business" → `mb dashboard open`; scripts
-reading credentials → `mb connect token` (never echo values). Full map:
-mb-help `references/cli-surfaces.md` — business answer first; triggered
-surfaces stay triggered.
+`mb canary init`; recurring daily business read → `mb pulse init`; "show me
+the business" → `mb dashboard open`; scripts reading credentials →
+`mb connect token` (never echo values). Full map: mb-help
+`references/cli-surfaces.md` — business answer first; triggered surfaces stay triggered.
 
 **Books/finance routing:** When the user mentions bookkeeping, books, finance,
 accounting, ledgers, statements, P&L, chart of accounts, tax, payroll, hledger,

--- a/workflows/mb-start-status/workflow.md
+++ b/workflows/mb-start-status/workflow.md
@@ -179,7 +179,12 @@ migration. Money-path-overnight worries, once real money or real leads flow
 unattended, route to `mb canary init`. A recurring daily read on the business
 routes to `mb pulse init` (deterministic collectors plus a judgment skill:
 scorecard, anomalies, exactly ONE recommended action, read-only — it consumes
-`mb status` facts rather than re-ranking them). "Show me the business" routes to
+`mb status` facts rather than re-ranking them). When `core/operations/pulse/`
+exists, read today's `log/<date>-*-pulse.md` at session open and carry its ONE
+recommended action alongside the status ranked action; if today's paper is
+missing, offer the repo's pulse run before routing. At session close, say
+whether that action was done, moved into a lane, or untouched.
+"Show me the business" routes to
 `mb dashboard open` (local, read-only, never committed). Scripts that read
 credentials route to `mb connect token` (token to stdout for scripts and
 agents; never echo the value). Tools missing from the provider list route to


### PR DESCRIPTION
Second engine slice of #813, per the operator steer: session skills read the pulse rather than inventing their own morning picture.

## What
- **/mb-start** — Continuity facts: when `core/operations/pulse/` exists, read today's `log/<date>-*-pulse.md` and carry its ONE recommended action into the session open; when today's paper is missing, offer the repo's pulse skill. Data/ops routing also names `mb pulse init`. SKILL.md held at exactly 500/500 lines via wording compressions.
- **/mb-end** — Step 2 pulse check: report whether today's ONE action was done, moved into a lane (bet/issue/decision), or untouched; flag a never-written paper at close so tomorrow opens fresh.
- **Codex parity in the same slice** — the shared workflow source (`workflows/mb-start-status/workflow.md`) carries the same open/close pulse behavior, not just init routing.

## Gate catch worth noting
One line-budget compression broke a phrase the start-router contract test pins (`do not slice status output with \`head\` or \`sed\``) — restored verbatim, budget recovered elsewhere. The pinned-phrase regime works.

## Evidence
Full `scripts/check.sh` green (993 tests), mb-start at 500/500, start-router contract suite passing.

Remaining #813: `mb pulse install` (operator-owned scheduler wrapper), dogfood instantiation on a second business.

🤖 Generated with [Claude Code](https://claude.com/claude-code)