### PR TITLE
feat(mb-site): conversion-mechanism gate before page copy

### DIFF
--- a/.claude/skills/mb-site/SKILL.md
+++ b/.claude/skills/mb-site/SKILL.md
@@ -164,6 +164,13 @@ Say `/mb-site` again after compaction, context loss, or switching focus. It relo
 6. When the page, sales video, or lander depends on a weak offer, load
    `.claude/reference/conversion/offer-sharpening.md` and route to `/mb-think`
    before writing page copy from thin claims.
+6a. **Conversion-mechanism gate (before any page copy):** confirm what the
+   visitor does to convert — submit a lead form, book a call, or buy — and
+   specifically whether the operator takes calls. If the operator has not
+   stated it, STOP and ask; never assume a model. Copy is shaped by the
+   mechanism, so it is pinned before drafting (the brief records it; see
+   `mb-skill-brief-draft`). A real business we built lost a full day when an
+   agent invented a call-booking flow the operator never chose.
 7. When the site, blog, wiki, changelog, or launch page depends on content or
    recognition strategy, read `core/content-strategy.md` and relevant
    `core/marketing/` files if present. Owned site content should support the

--- a/.claude/skills/mb-skill-brief-draft/SKILL.md
+++ b/.claude/skills/mb-skill-brief-draft/SKILL.md
@@ -28,6 +28,8 @@ date: YYYY-MM-DD
 slug: <offer-slug>
 status: proposed
 dial: convert | story | brand
+conversion_mechanism: lead_form | book_call | purchase | other
+takes_calls: true | false
 archetype: ...
 audience_current_archetype: ...
 copy_framework_tag: ...
@@ -38,12 +40,24 @@ voice_anchor_lines: {use: [...], avoid: [...]}
 ---
 ```
 
+`conversion_mechanism` and `takes_calls` are operator-stated facts, not guesses — see the gate in Flow step 0.
+
 Plus the body sections: headline + subhead, value prop, mechanism summary, picked supporting pages, conversion endpoint, adjacency map.
 
 ## Flow
 
+0. **Conversion-mechanism gate (before any copy).** Pin what the visitor does
+   to convert — submit a lead form, book a call, buy — and specifically whether
+   the operator takes calls. This is an operator-stated fact: if it is not
+   already recorded (in `offer.md`, a prior decision, or the operator's own
+   words this session), STOP and ask before drafting. Never assume a model —
+   the headline, value prop, and mechanism summary are all shaped by it, so a
+   wrong guess rewrites the whole brief. A real business we built lost a full
+   day when an agent invented a call-booking flow the operator never chose.
+   Record the answer in `conversion_mechanism` + `takes_calls`.
 1. **Read inputs.** Resolve offer/audience/voice; load picked archetype detail file.
-2. **Compose schema header.** Fill in fields from operator picks.
+2. **Compose schema header.** Fill in fields from operator picks, including the
+   gated `conversion_mechanism` + `takes_calls`.
 3. **Draft headline + subhead.** Apply one of the picked formulas. Aim for ≤ 2 lines.
 4. **Draft value prop.** 3 short reasons OR one extended argument. Match the dial.
 5. **Draft mechanism summary.** For the how-it-works page.

--- a/mb/tests/test_conversion_video_routing.py
+++ b/mb/tests/test_conversion_video_routing.py
@@ -113,3 +113,31 @@ def test_operator_help_avoids_retired_data_repo_and_public_conductor_framing() -
                 failures.append(f"{relative}: contains retired phrase {term!r}")
 
     assert failures == []
+
+
+def test_conversion_mechanism_gate_present_on_every_rail() -> None:
+    """#840: page copy must wait on a recorded conversion mechanism, all rails.
+
+    A real business lost a day when an agent invented a call-booking model the
+    operator never chose. The gate must live where copy is drafted (brief-draft),
+    in the Claude router (mb-site), and on the Codex workflow source.
+    """
+    brief = _read(".claude/skills/mb-skill-brief-draft/SKILL.md")
+    site = _read(".claude/skills/mb-site/SKILL.md")
+    workflow = _read("workflows/mb-site/workflow.md")
+
+    # Brief-draft records the mechanism as gated, operator-stated facts.
+    assert "conversion_mechanism" in brief
+    assert "takes_calls" in brief
+    assert "before any copy" in brief.lower()
+
+    for surface in (brief, site, workflow):
+        lowered = surface.lower()
+        # The visitor-action choices the operator must pin.
+        assert "book a call" in lowered or "book_call" in lowered
+        assert "lead form" in lowered or "lead_form" in lowered
+        # Stop-and-ask, never-assume intent.
+        assert "never assume" in lowered
+        assert (
+            "page copy" in lowered or "before drafting" in lowered or "before any copy" in lowered
+        )

--- a/workflows/mb-site/workflow.md
+++ b/workflows/mb-site/workflow.md
@@ -188,7 +188,11 @@ Mode routing:
 2. For `brief`, draft from accepted repo truth: offer, audience, voice, content
    strategy, proof facts, active push, research, decisions, and operator
    constraints. If the offer is thin or claims are unsupported, route to
-   `mb-think` before page copy.
+   `mb-think` before page copy. Conversion-mechanism gate: before drafting any
+   page copy, pin what the visitor does to convert (lead form, book a call, or
+   buy) and whether the operator takes calls. If the operator has not stated
+   it, stop and ask — never assume a model; the headline, value prop, and
+   mechanism copy are all shaped by it. Record it on the brief.
 3. For `build`, propose page structure, sections, copy direction, components,
    and file targets. In Codex, stop at planning and patch-shaped guidance until
    site-build runtime smoke proves writes.


### PR DESCRIPTION
Slice for #840 — #3 in the 2026-06-13 audit-ranked order. Prevents the single biggest dogfood waste.

## What
Page copy now waits on an explicitly recorded **conversion mechanism** — what the visitor does to convert (lead form / book a call / purchase) and specifically whether the operator takes calls. If the operator hasn't stated it, **stop and ask; never assume a model.** Pinned where copy is actually drafted, on every rail:

- **brief-draft** (`mb-skill-brief-draft`): `conversion_mechanism` + `takes_calls` schema-header fields, and a **Flow step 0 gate** that runs before the headline / value-prop / mechanism drafting (steps 3-5). The mechanism shapes all of that copy, so a wrong guess rewrites the whole brief.
- **mb-site SKILL**: step 6a conversion-mechanism gate before page copy.
- **Codex mb-site workflow**: the `brief` routing rule carries the same gate (rail parity).

## Why
Live-business mining, friction #9 (agents inventing decisions): an agent invented a call-based conversion model the operator never chose — the session's biggest single waste, a full day of rework on a real business we built.

## Evidence
New tri-rail contract test asserts the gate, the visitor-action choices, and the never-assume/stop intent survive on brief-draft, mb-site, and the Codex workflow — so a future edit can't silently drop it. Full `scripts/check.sh` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
