### PR TITLE
feat(mb-site): click-ID capture invariant on lead-capturing scaffolds

### DIFF
--- a/.claude/skills/mb-site/references/minisite-conversion.md
+++ b/.claude/skills/mb-site/references/minisite-conversion.md
@@ -91,6 +91,28 @@ Custom webhook:
 }
 ```
 
+## Click-ID capture invariant (lead-capturing surfaces)
+
+Operating-principles §6 — own the form, capture the attribution — is enforced
+by scaffold, not by a later audit. Any surface that captures a lead
+(`lead_form`, `custom_webhook`, or any form that posts) MUST snapshot the
+click IDs and campaign params from the landing URL by default, and forward
+them on submit. A real business we built captured `fbclid` + 5 UTMs but ZERO
+Google click IDs, so its first Google clicks were permanently unattributable —
+caught only by a readiness audit, which is exactly the failure this default
+prevents.
+
+Required capture set (snapshot from the querystring on first load, persist
+across navigation, forward on submit):
+
+- **Google click IDs:** `gclid`, `gbraid`, `wbraid`
+- **Meta click ID:** `fbclid`
+- **UTMs (all five):** `utm_source`, `utm_medium`, `utm_campaign`, `utm_term`, `utm_content`
+
+Add `msclkid` (Microsoft) and `ttclid` (TikTok) when those channels are live.
+Capture the params even when no campaign is running yet — the cost of a missing
+column is permanent, unrecoverable attribution loss the day paid traffic starts.
+
 ## Generation Contract
 
 The generation subagent reads `kind`, `render`, and `url`, then renders the home CTA accordingly:
@@ -99,5 +121,11 @@ The generation subagent reads `kind`, `render`, and `url`, then renders the home
 - embedded form;
 - embedded booking iframe;
 - form-POST handler.
+
+For every lead-capturing render, the generated form/handler carries the
+click-ID capture invariant above by default (hidden fields hydrated from the
+landing querystring, forwarded on submit) — never an audit-time retrofit.
+Flagging an existing lead-capturing site that is missing the set is a
+follow-up `/mb-status` check (#887).
 
 After conversion is recorded, move to [`concept-variations.md`](concept-variations.md).

--- a/mb/tests/test_conversion_video_routing.py
+++ b/mb/tests/test_conversion_video_routing.py
@@ -141,3 +141,31 @@ def test_conversion_mechanism_gate_present_on_every_rail() -> None:
         assert (
             "page copy" in lowered or "before drafting" in lowered or "before any copy" in lowered
         )
+
+
+def test_click_id_capture_invariant_present_on_both_rails() -> None:
+    """#887: lead-capturing scaffolds snapshot click IDs + UTMs by default.
+
+    A real business captured fbclid + 5 UTMs but zero Google click IDs, so its
+    first Google clicks were permanently unattributable. The capture set must
+    be a scaffold default on both the Claude lead-capture reference and the
+    Codex workflow — not an audit-time retrofit.
+    """
+    conversion = _read(".claude/skills/mb-site/references/minisite-conversion.md")
+    workflow = _read("workflows/mb-site/workflow.md")
+
+    required = ["gclid", "gbraid", "wbraid", "fbclid"]
+    utms = [
+        "utm_source",
+        "utm_medium",
+        "utm_campaign",
+        "utm_term",
+        "utm_content",
+    ]
+    for surface in (conversion, workflow):
+        lowered = surface.lower()
+        for param in required + utms:
+            assert param in lowered, f"missing {param}"
+        # Tied to the own-the-form principle and a scaffold default, not audit.
+        assert "§6" in surface or "principles" in lowered
+        assert "default" in lowered

--- a/workflows/mb-site/workflow.md
+++ b/workflows/mb-site/workflow.md
@@ -195,7 +195,13 @@ Mode routing:
    mechanism copy are all shaped by it. Record it on the brief.
 3. For `build`, propose page structure, sections, copy direction, components,
    and file targets. In Codex, stop at planning and patch-shaped guidance until
-   site-build runtime smoke proves writes.
+   site-build runtime smoke proves writes. Click-ID capture invariant
+   (operating-principles §6): any lead-capturing surface snapshots the click
+   IDs and campaign params by default — `gclid`, `gbraid`, `wbraid`, `fbclid`,
+   and the five UTMs (`utm_source`/`utm_medium`/`utm_campaign`/`utm_term`/
+   `utm_content`) — hydrated from the landing querystring and forwarded on
+   submit, even before any campaign runs. Missing the set is permanent,
+   unrecoverable attribution loss the day paid traffic starts.
 4. For `preview` and `check`, run or cite `mb site check` and report the
    readiness state exactly: `missing`, `blocked`, `ready_for_preview`,
    `ready_for_operator_review`, or `ready`.


### PR DESCRIPTION
Slice for #887 — #4 in the 2026-06-13 audit-ranked order. Closes a permanent-data-loss class.

## What
Operating-principles §6 (own the form, capture the attribution) is now enforced by **scaffold default**, not by a later readiness audit. Any lead-capturing surface (`lead_form`, `custom_webhook`, any posting form) snapshots the click IDs + campaign params from the landing URL on first load, persists them across navigation, and forwards them on submit:

- **Google:** `gclid`, `gbraid`, `wbraid`
- **Meta:** `fbclid`
- **All five UTMs:** `utm_source`, `utm_medium`, `utm_campaign`, `utm_term`, `utm_content`

(`msclkid`/`ttclid` added when those channels are live.) Captured **even before any campaign runs** — the cost of a missing column is permanent, unrecoverable attribution loss the day paid traffic starts.

## Why
Live-business funnel audit: a real business we built captured `fbclid` + 5 UTMs but **zero** Google click IDs, so its first Google clicks were permanently unattributable — caught only by an audit. This default is exactly what prevents that.

## Where
- `minisite-conversion.md` — the lead-capture authority: a new capture-invariant section + the generation contract now carries it on every lead-capturing render.
- Codex `mb-site` workflow `build` rule — rail parity.
- Two-rail contract test asserts the full capture set + the §6/default framing survive on both surfaces.

## Follow-up (noted on #887)
The `/mb-status` flag for an existing lead-capturing site that is missing the set — a status detector, separate slice.

Full `scripts/check.sh` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
