### PR TITLE
docs(provider): provider-mutation contract — preview, approve, apply, verify

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -47,6 +47,7 @@ Pick the route that matches what you are doing.
 - [`child-repo-descriptors.md`](child-repo-descriptors.md) — `.mainbranch/repo.json`.
 - [`checks-and-review-model.md`](checks-and-review-model.md) — local + CI + agent checks.
 - [`delivery-truth.md`](delivery-truth.md) — acceptance ≠ delivery: message ids, delivery_state, webhook + reconcile, page on failure.
+- [`provider-mutation-contract.md`](provider-mutation-contract.md) — preview → approve → apply → verify for external-account writes; sanitized plans, minimal scope, no private rows in git.
 - [`operating-principles.md`](operating-principles.md) — the twelve principles, the decision rule, and the subagent operating contract.
 - [`traffic-reconciliation.md`](traffic-reconciliation.md) — counting humans, not crawlers: the three layers, the crawler tell, the recipe.
 - [`claude-code-invocation-contract.md`](claude-code-invocation-contract.md) — supported Claude Code path.

--- a/docs/delivery-truth.md
+++ b/docs/delivery-truth.md
@@ -97,4 +97,7 @@ async function reconcileStale(ceilingMinutes = 30) {
   receipts (issue #656); the delivery state is the receipt.
 
 Related: [checks-and-review-model.md](checks-and-review-model.md) for the
-verify-before-done discipline this belongs to.
+verify-before-done discipline this belongs to, and
+[provider-mutation-contract.md](provider-mutation-contract.md) for the
+preview → approve → apply → verify gate every external-account write runs
+(a send is one such mutation; its delivery receipt is the verify step).

--- a/docs/provider-mutation-contract.md
+++ b/docs/provider-mutation-contract.md
@@ -1,0 +1,86 @@
+# Provider mutation contract: preview, approve, apply, verify
+
+Reading a provider's state and **mutating** a provider's account are different
+surfaces with different trust. A read is recoverable; a write to a CRM, an
+email list, an ad platform, or an account's metadata changes the outside world
+and often cannot be cleanly undone. Main Branch agents move fast from connector
+setup into real external-account writes — updating CRM contacts, smoke-testing
+sends, creating ad drafts — and "be careful" as prose is not a contract.
+
+This page is the engine-side doctrine for any surface that writes to an
+external provider on a business's behalf. It graduated from a live business we
+built, where real CRM records were updated, outbound email was smoke-tested
+through a freshly wired provider, and the operator asked whether the agent
+could build directly in an ad platform — all handled by conversational
+approval, with no deterministic gate underneath.
+
+## The pattern
+
+Every provider mutation runs the same five steps. Never collapse them.
+
+1. **Read-only discovery first.** Establish current provider state with a read
+   before proposing any change. A write you cannot preview, you do not make.
+2. **Build a sanitized mutation plan.** Name the affected provider, the object
+   type, the **count** of objects, and a risk level (`low` / `material` /
+   `irreversible`). The plan describes the change in business terms — "update
+   42 CRM contacts' lifecycle stage", "send 1 smoke email to an owned inbox",
+   "create 1 paused ad draft" — and never embeds private rows, account IDs,
+   customer names, payloads, or tokens. The plan is safe to show and safe to
+   record; the raw data is not.
+3. **Require explicit operator approval.** The operator approves the named
+   plan, not a vague "go ahead." Spend, sends, customer contact, and account
+   changes each need their own approval — one approval does not blanket the
+   next surface. Default to the most conservative form (a paused draft, a
+   dry-run, an owned-inbox smoke test) before anything live.
+4. **Apply with minimal scope.** Use the narrowest credential and the smallest
+   change that satisfies the approved plan. Never widen scope mid-apply; if the
+   apply needs more than the plan named, stop and re-plan.
+5. **Verify and record a private-safe summary.** Confirm the change took
+   (re-read the provider), then write a business-readable record — counts,
+   provider, risk, outcome — with the same sanitization as the plan. When the
+   mutation changes business state, point the operator at a checkpoint or the
+   relevant lane (bet, push, decision). Raw payloads stay out of git.
+
+## Plan / apply example
+
+A CRM lifecycle-stage update, in the contract's language:
+
+```
+mb <provider> plan      # read-only: what would change
+  provider: crm
+  object: contact
+  count: 42
+  change: lifecycle_stage "lead" -> "member" for contacts on the reconciled export
+  risk: material (customer-visible segmentation)
+  scope: contacts.write (no delete, no email)
+  preview: 42 matched, 0 ambiguous, 0 outside the export
+
+# operator reviews the sanitized plan and approves THIS plan
+
+mb <provider> apply --approve   # minimal scope, named change only
+  applied: 42 contacts updated
+  verify: re-read shows 42 at "member", 0 drift
+  record: pushes/<date>/crm-reconcile.md (counts + outcome, no rows)
+  next: mb checkpoint --plan
+```
+
+The same shape holds for an email smoke test (`count: 1`, an owned inbox,
+`risk: low`), an ad draft (`risk: material`, created **paused**, never
+launched without separate spend approval), or a provider metadata update.
+
+## What never enters a public or git artifact
+
+- Tokens or credentials of any kind.
+- Customer rows, contact names, email addresses, or account identifiers.
+- Raw provider payloads or exported member lists.
+
+The plan and the record carry **counts and shapes**, not data. If a number
+can't be reported without a private row attached, report the number and leave
+the row in the provider.
+
+## Read vs write, always separate
+
+`mb connect` read paths (`status`, `doctor`, `identity`, `token`, `test`) never
+mutate a provider. Write surfaces are the ones this contract governs. An agent
+that can read a provider has not been granted permission to write it — the
+write needs its own plan and its own approval, every time.

--- a/mb/mb/_data/templates/AGENTS.md.tmpl
+++ b/mb/mb/_data/templates/AGENTS.md.tmpl
@@ -391,7 +391,12 @@ the operator asks for plumbing.
   `mb dashboard open` (local, read-only, never committed). Scripts that read
   credentials -> `mb connect token` (token to stdout for scripts and agents;
   never echo the value). Tools missing from the provider list ->
-  `mb connect <id> --custom`. Agents validating their own work in repos with
+  `mb connect <id> --custom`. Writing to an external provider (CRM, email
+  send, ads, account metadata) -> the provider-mutation contract: read-only
+  discovery first, a sanitized plan (provider + object count + risk, no
+  private rows), explicit approval, minimal-scope apply, verify + a
+  private-safe record (docs/provider-mutation-contract.md); reads and writes
+  are separate surfaces. Agents validating their own work in repos with
   legacy debt -> `mb validate --paths <prefix>`. Filing work upstream or in
   the business repo without leaking private detail -> `mb issue` (privacy-safe
   GitHub issue drafting). "What should we improve in this repo?" ->

--- a/mb/tests/test_provider_mutation_contract.py
+++ b/mb/tests/test_provider_mutation_contract.py
@@ -1,0 +1,52 @@
+"""#656: the provider-mutation contract is documented, exampled, and routed."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _read(relative: str) -> str:
+    return (REPO_ROOT / relative).read_text(encoding="utf-8")
+
+
+def test_provider_mutation_contract_page_defines_the_five_steps() -> None:
+    doc = _read("docs/provider-mutation-contract.md").lower()
+    # The preview -> approve -> apply -> verify spine.
+    assert "read-only discovery first" in doc
+    assert "mutation plan" in doc
+    assert "explicit operator approval" in doc
+    assert "minimal scope" in doc
+    assert "verify" in doc and "private-safe summary" in doc
+
+
+def test_provider_mutation_contract_has_a_plan_apply_example() -> None:
+    doc = _read("docs/provider-mutation-contract.md").lower()
+    # Acceptance criterion: at least one concrete plan/apply example.
+    assert "plan" in doc and "apply --approve" in doc
+    assert "count: 42" in doc or "count:" in doc
+    assert "risk:" in doc
+
+
+def test_provider_mutation_contract_keeps_private_data_out() -> None:
+    doc = _read("docs/provider-mutation-contract.md").lower()
+    # The secrets/rows-out-of-git rule is explicit.
+    assert "never enter a public or git artifact" in doc or "out of git" in doc
+    assert "tokens" in doc and ("customer rows" in doc or "customer" in doc)
+    # Reads and writes are separated.
+    assert "read vs write" in doc or "read paths" in doc
+
+
+def test_provider_mutation_contract_is_indexed_and_cross_linked() -> None:
+    index = _read("docs/README.md")
+    assert "provider-mutation-contract.md" in index
+    # Sibling doctrine cross-links to it.
+    assert "provider-mutation-contract.md" in _read("docs/delivery-truth.md")
+
+
+def test_provider_mutation_contract_routed_on_codex_rail() -> None:
+    template = " ".join(_read("mb/mb/_data/templates/AGENTS.md.tmpl").lower().split())
+    assert "provider-mutation-contract.md" in template
+    assert "read-only discovery first" in template
+    assert "writing to an external provider" in template


### PR DESCRIPTION
Slice for #656 — first of the second-wave clusters (provider write-safety), protecting the live-money path.

## What
New `docs/provider-mutation-contract.md` — the engine-side doctrine for any surface that **writes** to an external provider (CRM, email send, ads, account metadata). Reading provider state and mutating a provider account are different trust surfaces; the gate was prose convention, never a deterministic contract.

The five-step contract:
1. **Read-only discovery first** — a write you can't preview, you don't make.
2. **Sanitized mutation plan** — names provider + object **count** + risk level; never embeds private rows, account IDs, customer names, payloads, or tokens.
3. **Explicit operator approval** — per surface; spend, sends, and contact each need their own approval. Default to the conservative form (paused draft, dry-run, owned-inbox smoke).
4. **Apply with minimal scope** — narrowest credential, smallest change; never widen mid-apply.
5. **Verify + private-safe record** — re-read to confirm, record counts/outcome (no rows), point at a checkpoint/lane.

Plus a concrete CRM lifecycle plan/apply example, the explicit "what never enters a public or git artifact" rule, and the read-vs-write separation (`mb connect` read paths never mutate).

## Why
Live-business mining: real CRM records updated, outbound email smoke-tested through a fresh provider, ad-platform writes discussed — all on conversational approval, no deterministic gate underneath. Provider writes are trust-critical.

## Where
- Indexed in `docs/README.md`; cross-linked from `delivery-truth.md` (a send is one such mutation, its delivery receipt the verify step).
- Routed on the Codex rail via `AGENTS.md.tmpl` data/ops routing.
- 5-test contract suite locks the doctrine steps, the example, the privacy rule, indexing, and routing.

## Scope
Doctrine + routing this slice (acceptance criteria: contract defined, ≥1 plan/apply example, secrets/rows kept out). A concrete `plan`/`apply` CLI for an mb-owned provider rail is a follow-up where the engine owns the rail.

Full `scripts/check.sh` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
