### PR TITLE
docs(ads): Google Ads/GTM writes run the provider-mutation contract

### DIFF
--- a/docs/google-ads-gtm-conversion-rubric.md
+++ b/docs/google-ads-gtm-conversion-rubric.md
@@ -32,6 +32,24 @@ Google Ads, GTM, Cloudflare, consent tools, booking tools, Stripe, and CRMs own
 provider state. Main Branch records the durable plan and evidence, but it does
 not become the provider.
 
+### These are provider mutations — run the contract
+
+Publishing a GTM container, creating a Google Ads conversion action, uploading
+offline conversions, and changing budgets or launching a campaign are all
+**provider mutations**. Each runs the five-step contract in
+[provider-mutation-contract.md](provider-mutation-contract.md): read-only
+discovery first, a sanitized plan (provider + object count + risk, no private
+rows), explicit per-surface approval, minimal-scope apply, then verify and a
+private-safe record. Spend, publish, and upload each need their own approval —
+one does not blanket the next. Default to the conservative form: a draft
+container, a staged offline-conversion record, a campaign left paused.
+
+Provider-side automation that needs live Google API access (Ads conversion
+checks, GTM container reads, conversion upload) is operator-gated: it requires
+Google Ads Basic Access and live/sandbox auth, and Main Branch claims no
+provider automation before live smoke evidence exists. Until then the agent
+plans and hands off; the operator does the Google-UI steps.
+
 ## Default Stack
 
 | Layer | Default | When to choose another path |

--- a/docs/provider-mutation-contract.md
+++ b/docs/provider-mutation-contract.md
@@ -84,3 +84,10 @@ the row in the provider.
 mutate a provider. Write surfaces are the ones this contract governs. An agent
 that can read a provider has not been granted permission to write it — the
 write needs its own plan and its own approval, every time.
+
+A worked provider instance lives in
+[google-ads-gtm-conversion-rubric.md](google-ads-gtm-conversion-rubric.md):
+publishing a GTM container, creating a Google Ads conversion action, uploading
+offline conversions, and launching/budget changes are each mutations that run
+this contract, with the live-API automation operator-gated until smoke
+evidence exists.

--- a/mb/tests/test_provider_mutation_contract.py
+++ b/mb/tests/test_provider_mutation_contract.py
@@ -50,3 +50,21 @@ def test_provider_mutation_contract_routed_on_codex_rail() -> None:
     assert "provider-mutation-contract.md" in template
     assert "read-only discovery first" in template
     assert "writing to an external provider" in template
+
+
+def test_google_rubric_ties_to_the_mutation_contract() -> None:
+    """#286: Google Ads/GTM writes are governed by the #656 contract, and the
+    live-API automation is honestly gated (no overclaim before smoke evidence).
+    """
+    rubric = _read("docs/google-ads-gtm-conversion-rubric.md")
+    lowered = " ".join(rubric.lower().split())
+    # The Google surfaces are named as provider mutations under the contract.
+    assert "provider-mutation-contract.md" in rubric
+    assert "provider mutations" in lowered
+    for surface in ("gtm container", "conversion action", "offline conversion"):
+        assert surface in lowered
+    # Honest gating: no automation claim before live smoke evidence.
+    assert "basic access" in lowered
+    assert "no provider automation before live smoke evidence" in lowered
+    # Bidirectional link from the contract to the worked instance.
+    assert "google-ads-gtm-conversion-rubric.md" in _read("docs/provider-mutation-contract.md")


### PR DESCRIPTION
Slice for #286 — the guardrail-clean half. Continues the provider-write-safety cluster.

## What
Ties the existing Google Ads / GTM / conversion rubric to the `#656` provider-mutation contract. Publishing a GTM container, creating a Google Ads conversion action, uploading offline conversions, and budget/launch changes are now explicitly named as **provider mutations** that run the five-step contract (read-only discovery → sanitized plan → per-surface approval → minimal-scope apply → verify + private-safe record), defaulting to the conservative form (draft container, staged upload, **paused** campaign).

Bidirectional cross-links between `google-ads-gtm-conversion-rubric.md` and `provider-mutation-contract.md`; a contract test locks the tie and the gating.

## Honest scope (why not the full automation)
`#286`'s live provider-side automation — Ads conversion-action checks, GTM container reads, conversion upload — needs **Google Ads Basic Access + live/sandbox auth**, and the guardrails forbid claiming provider automation before live smoke evidence exists (graduate-proven-only, §11 validate-against-live-state). So this slice ships the doctrine/gate tie now and the doc states plainly: until smoke evidence exists, the agent **plans and hands off**; the operator does the Google-UI steps.

**The live-automation half of #286 stays open as operator-gated work** (Basic Access is Devon's to enable). Flagged in loop state.

## Evidence
Contract test asserts the rubric names the Google surfaces as mutations under the contract, the Basic-Access / no-overclaim gating, and the bidirectional link. Full `scripts/check.sh` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
