### PR TITLE
feat(site): mb site check blocks forked-descriptor cross-business leak

### DIFF
--- a/mb/mb/site.py
+++ b/mb/mb/site.py
@@ -130,6 +130,70 @@ def _child_repo_descriptor(child_repo: Path) -> tuple[dict[str, Any], str]:
     return normalized, ""
 
 
+def _descriptor_identity_evidence(
+    child_descriptor: dict[str, Any], business: Path | None
+) -> dict[str, Any] | None:
+    """Verify an inherited descriptor points at the CURRENT business, not a fork.
+
+    A forked site scaffold can carry the previous business's
+    ``.mainbranch/repo.json``, so paid reports render another company's data.
+    When the descriptor's parent identity disagrees with the business this
+    check runs against, that is a cross-business leak — block it. Returns None
+    when there is nothing to verify (no false positives).
+    """
+    if not child_descriptor or business is None:
+        return None
+    parent = child_descriptor.get("parent")
+    parent = parent if isinstance(parent, dict) else {}
+
+    # Strongest signal: the parent's resolved local checkout points elsewhere.
+    resolved = str(parent.get("resolved_local_checkout") or "")
+    if resolved:
+        try:
+            if Path(resolved).resolve() != business:
+                return {
+                    "kind": "descriptor_identity",
+                    "state": "blocked",
+                    "summary": (
+                        "Inherited .mainbranch/repo.json names a different business "
+                        "than this checkout (forked-scaffold leak) — refresh the "
+                        "descriptor for the current business before trusting reports."
+                    ),
+                }
+        except (OSError, ValueError):
+            return None
+
+    # Secondary: parent github identity vs the business's own descriptor.
+    business_descriptor = topology_mod.read_child_descriptor(business)
+    biz_owner = _string_value(business_descriptor.get("github_owner"))
+    biz_repo = _string_value(business_descriptor.get("repo_name"))
+    parent_owner = str(parent.get("github_owner") or "")
+    parent_repo = str(parent.get("repo_name") or "")
+    if biz_owner and biz_repo and parent_owner and parent_repo:
+        if (parent_owner, parent_repo) != (biz_owner, biz_repo):
+            return {
+                "kind": "descriptor_identity",
+                "state": "blocked",
+                "summary": (
+                    f"Inherited descriptor parent is {parent_owner}/{parent_repo}, "
+                    f"but this business is {biz_owner}/{biz_repo} (forked-scaffold "
+                    "leak) — refresh the descriptor before trusting reports."
+                ),
+            }
+        return {
+            "kind": "descriptor_identity",
+            "state": "passed",
+            "summary": "Inherited descriptor points at the current business.",
+        }
+    if resolved:
+        return {
+            "kind": "descriptor_identity",
+            "state": "passed",
+            "summary": "Inherited descriptor's parent checkout matches this business.",
+        }
+    return None
+
+
 def _site_source(site_repo: Path) -> tuple[dict[str, Any], str]:
     source, error = _read_json(site_repo / SOURCE_RELATIVE_PATH)
     if error:
@@ -615,6 +679,10 @@ def check(
                 "summary": f"Child repo descriptor declares role {role}.",
             }
         )
+
+    identity_evidence = _descriptor_identity_evidence(child_descriptor, business)
+    if identity_evidence is not None:
+        evidence.append(identity_evidence)
 
     if site_role in {"site", "offer"}:
         evidence.append(

--- a/mb/tests/test_site.py
+++ b/mb/tests/test_site.py
@@ -672,3 +672,138 @@ def test_site_check_flags_missing_repo_role(tmp_path: Path) -> None:
     role_ev = next(item for item in result["evidence"] if item["kind"] == "repo_role")
     assert role_ev["state"] == "manual"
     assert "no topology role" in role_ev["summary"]
+
+
+def _seed_site_for_identity(site: Path) -> None:
+    _write_conversion(
+        site,
+        {
+            "kind": "lead_form",
+            "url": "https://tally.so/r/example",
+            "render": "link_out",
+            "primary_conversions": ["mb_lead_submit"],
+        },
+    )
+    _write_html(site, events=["mb_cta_click", "mb_form_start", "mb_lead_submit"])
+
+
+def _write_business_descriptor(business: Path, owner: str, repo: str) -> None:
+    (business / ".mainbranch").mkdir(parents=True, exist_ok=True)
+    (business / ".mainbranch" / "repo.json").write_text(
+        json.dumps(
+            {
+                "schema": "mb.child_repo.v0",
+                "role": "business",
+                "display_name": repo,
+                "github_owner": owner,
+                "repo_name": repo,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_site_check_blocks_forked_descriptor_github_identity_leak(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("MB_CONNECT_SECRET_BACKEND", "local-file")
+    monkeypatch.setenv("MAINBRANCH_HOME", str(tmp_path / "home"))
+    business = tmp_path / "business"
+    site = tmp_path / "site"
+    init_run(path=str(business), name="Acme")
+    _write_business_descriptor(business, "acme-co", "acme")
+    site.mkdir()
+    _seed_site_for_identity(site)
+    # Site carries a FORKED descriptor pointing at a different business.
+    (site / ".mainbranch" / "repo.json").write_text(
+        json.dumps(
+            {
+                "schema": "mb.child_repo.v0",
+                "role": "site",
+                "display_name": "Acme site",
+                "parent": {
+                    "display_name": "Previous Co",
+                    "github_owner": "previous-co",
+                    "repo_name": "previous-biz",
+                    "remote": "github:previous-co/previous-biz",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(
+        app, ["site", "check", str(site), "--business-repo", str(business), "--json"]
+    )
+    payload = json.loads(result.stdout)
+    evidence = {item["kind"]: item for item in payload["evidence"]}
+    assert "descriptor_identity" in evidence
+    assert evidence["descriptor_identity"]["state"] == "blocked"
+    assert payload["state"] == "blocked"
+
+
+def test_site_check_passes_descriptor_identity_when_business_matches(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("MB_CONNECT_SECRET_BACKEND", "local-file")
+    monkeypatch.setenv("MAINBRANCH_HOME", str(tmp_path / "home"))
+    business = tmp_path / "business"
+    site = tmp_path / "site"
+    init_run(path=str(business), name="Acme")
+    _write_business_descriptor(business, "acme-co", "acme")
+    site.mkdir()
+    _seed_site_for_identity(site)
+    (site / ".mainbranch" / "repo.json").write_text(
+        json.dumps(
+            {
+                "schema": "mb.child_repo.v0",
+                "role": "site",
+                "display_name": "Acme site",
+                "parent": {
+                    "display_name": "Acme",
+                    "github_owner": "acme-co",
+                    "repo_name": "acme",
+                    "remote": "github:acme-co/acme",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(
+        app, ["site", "check", str(site), "--business-repo", str(business), "--json"]
+    )
+    payload = json.loads(result.stdout)
+    evidence = {item["kind"]: item for item in payload["evidence"]}
+    assert evidence["descriptor_identity"]["state"] == "passed"
+
+
+def test_site_check_blocks_forked_descriptor_parent_path_leak(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("MB_CONNECT_SECRET_BACKEND", "local-file")
+    monkeypatch.setenv("MAINBRANCH_HOME", str(tmp_path / "home"))
+    business = tmp_path / "business"
+    other = tmp_path / "other-business"
+    site = tmp_path / "site"
+    init_run(path=str(business), name="Acme")
+    other.mkdir()
+    site.mkdir()
+    _seed_site_for_identity(site)
+    # parent.local_checkout resolves to a DIFFERENT business than --business-repo.
+    (site / ".mainbranch" / "repo.json").write_text(
+        json.dumps(
+            {
+                "schema": "mb.child_repo.v0",
+                "role": "site",
+                "display_name": "Acme site",
+                "parent": {
+                    "display_name": "Other",
+                    "local_checkout": "../other-business",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(
+        app, ["site", "check", str(site), "--business-repo", str(business), "--json"]
+    )
+    payload = json.loads(result.stdout)
+    evidence = {item["kind"]: item for item in payload["evidence"]}
+    assert evidence["descriptor_identity"]["state"] == "blocked"
+    assert payload["state"] == "blocked"


### PR DESCRIPTION
Slice for #841 — closes the site-integrity cluster (with #840, #887).

## What
`mb site check` now validates that an inherited child descriptor (`.mainbranch/repo.json`) points at the **current** business, not a forked-from one.

`_descriptor_identity_evidence` emits a **blocked** `descriptor_identity` finding when the descriptor's parent disagrees with the business under check:
- **resolved local-checkout path** points at a different directory than `--business-repo`, or
- **github owner/repo** mismatches the business's own descriptor.

A blocked finding routes the overall check to `blocked`, so stale paid reports are never trusted. It returns **nothing when identity can't be verified** — no false positives on repos that simply lack descriptors.

## Why
Live-business mining (rec 27): a forked site scaffold carried the previous business's `.mainbranch/repo.json` / conversion.json, and paid reports rendered **another company's data** before an identity-verification keystone fix. This makes that leak a hard stop at check time.

## Evidence
3 new tests (github-identity leak → blocked, parent-path leak → blocked, matching identity → passed); full `test_site.py` (20) green. New evidence kind inside the existing `mb site check` — no new CLI surface, no discoverability change. Full `scripts/check.sh` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
