### PR TITLE
fix(checkpoint): stop false hook-drift when the baked mb path differs (#880 item 4)

### DIFF
--- a/mb/mb/checkpoint.py
+++ b/mb/mb/checkpoint.py
@@ -172,10 +172,26 @@ def _is_managed_hook(text: str) -> bool:
     return HOOK_BEGIN in text and HOOK_END in text
 
 
+def _normalize_hook_for_compare(text: str) -> str:
+    """Blank the baked MB_BIN path so the comparison ignores it.
+
+    The hook bakes ``MB_BIN=<absolute mb path>`` as a fast path, but that path
+    legitimately varies by how mb was invoked (a venv bin, a pipx shim, a
+    `python -m mb` shim). The hook already falls back to `command -v mb` when
+    MB_BIN is not executable, so the path is an optimization, not correctness.
+    Comparing it caused a fresh, healthy hook to read as "differs from the
+    current template" whenever onboard installed it from one entrypoint and a
+    later `mb status` checked it from another (cold-eyes finding, #880).
+    """
+    return re.sub(r"(?m)^MB_BIN=.*$", "MB_BIN=", text)
+
+
 def _hook_state_from_text(text: str, expected: str) -> str:
     if not _is_managed_hook(text):
         return "blocked_existing_hook"
-    return "installed" if text == expected else "broken"
+    if _normalize_hook_for_compare(text) == _normalize_hook_for_compare(expected):
+        return "installed"
+    return "broken"
 
 
 def hook_status(repo: str | Path = ".") -> dict[str, Any]:

--- a/mb/tests/test_checkpoint.py
+++ b/mb/tests/test_checkpoint.py
@@ -832,3 +832,37 @@ def test_checkpoint_status_preserves_legacy_checkpoint_subjects(
     assert payload["ok"] is True
     assert payload["recent"][0]["subject"] == "[checkpoint] Update offer"
     assert payload["recent"][0]["recognized_as"] == "legacy_checkpoint"
+
+
+def test_checkpoint_hook_not_broken_when_mb_path_differs(tmp_path: Path) -> None:
+    # #880: a hook installed from one mb entrypoint (e.g. a venv bin) must not
+    # read as "differs from current template" when checked from another (e.g. a
+    # pipx shim). The baked MB_BIN path varies legitimately; the comparison
+    # must ignore it.
+    repo = tmp_path / "biz"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    hook = repo / ".git" / "hooks" / "commit-msg"
+    hook.parent.mkdir(parents=True, exist_ok=True)
+    # Simulate a healthy hook baked with a DIFFERENT absolute mb path.
+    hook.write_text(checkpoint_mod._hook_body("/some/other/venv/bin/mb"), encoding="utf-8")
+    hook.chmod(0o755)
+
+    status = checkpoint_mod.hook_status(repo)
+    assert status["state"] == "installed", status["summary"]
+    assert status["ok"] is True
+
+
+def test_checkpoint_hook_still_broken_when_logic_differs(tmp_path: Path) -> None:
+    # A genuinely altered hook body (not just the MB_BIN path) still flags.
+    repo = tmp_path / "biz"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    hook = repo / ".git" / "hooks" / "commit-msg"
+    hook.parent.mkdir(parents=True, exist_ok=True)
+    tampered = checkpoint_mod._hook_body("/path/mb").replace("exit 0", "exit 0  # tampered", 1)
+    hook.write_text(tampered, encoding="utf-8")
+    hook.chmod(0o755)
+
+    status = checkpoint_mod.hook_status(repo)
+    assert status["state"] == "broken"


### PR DESCRIPTION
Item 4 of #880 (cold-eyes onboard findings). Items 2-3 remain, so this does not close #880.

## Bug
A fresh scaffold's checkpoint hook read as **"differs from current template"** even though it was healthy — and `onboard` said `ok` while `onboard status` said `todo` minutes apart.

## Root cause
The hook bakes an absolute `MB_BIN=<path>` as a fast path, and `_hook_state_from_text` compared the **whole** hook text. That path legitimately varies by how `mb` was invoked (a venv bin, a pipx shim, `python -m mb`), so a hook installed from one entrypoint flipped to `broken` when checked from another.

## Fix
Normalize the `MB_BIN=` line before the installed-vs-broken equality check. The baked path is an optimization — the hook already falls back to `command -v mb` when `MB_BIN` is not executable — so ignoring it for comparison is correct. A genuinely altered hook body still reads as `broken`.

## Evidence
2 tests (hook baked with a different mb path → `installed`; tampered logic → `broken`); full `test_checkpoint.py` (42) green; full `scripts/check.sh` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
