### PR TITLE
feat(onboard): budget-band feedback + first-checkpoint Next hint (#880 items 2-3)

### DIFF
--- a/mb/mb/onboard.py
+++ b/mb/mb/onboard.py
@@ -899,6 +899,9 @@ def _next_steps(repo: Path) -> list[str]:
                 "Ask Codex to start this Main Branch business day from read-only mb facts.",
             ]
         )
+    # First checkpoint is the operator's first durable memory; name it
+    # explicitly so a fresh repo's empty-baseline state self-explains (#880).
+    steps.append("Save your first checkpoint once you've made changes: mb checkpoint --plan")
     return steps
 
 
@@ -1237,6 +1240,18 @@ def run(
 
     if not after["git"]:
         warnings.append("Repo is not a git work tree. Run `git init` or `mb doctor` for repair.")
+    # A recorded budget band with no thresholds and no private choice leaves the
+    # MoneyPath checklist silently todo — say what's still missing (#880).
+    if (
+        money_path_inputs.get("monthly_experiment_budget_band")
+        and not _has_threshold_amounts(money_path_inputs)
+        and money_path_inputs.get("threshold_privacy") != "private"
+    ):
+        warnings.append(
+            "Recorded the monthly budget band, but MoneyPath thresholds are still "
+            "open — add trivial/small/material amounts (or pass "
+            "--threshold-privacy private to record that you're keeping them private)."
+        )
     checkpoint_hook = (
         init_result.get("checkpoint_hook")
         if init_result

--- a/mb/tests/test_onboard.py
+++ b/mb/tests/test_onboard.py
@@ -84,7 +84,12 @@ def test_onboard_yes_creates_repo_and_reports_next_steps(tmp_path: Path, monkeyp
     assert result["setup_complete"]["checkpoint_hook_ready"] is True
     assert result["setup_complete"]["claude_code_handoff_ready"] is True
     assert result["setup_complete"]["codex_instructions_present"] is True
-    assert result["next_steps"] == [f"cd {repo.resolve()}", "claude", "/mb-start"]
+    assert result["next_steps"] == [
+        f"cd {repo.resolve()}",
+        "claude",
+        "/mb-start",
+        "Save your first checkpoint once you've made changes: mb checkpoint --plan",
+    ]
     assert any("Claude Code" in warning for warning in result["warnings"])
     assert any(
         "gh auth login" in warning or "GitHub CLI" in warning for warning in result["warnings"]
@@ -112,6 +117,7 @@ def test_onboard_next_steps_offer_global_codex_repair_when_available(
         "mb doctor repair --apply --only codex",
         f"codex -C {repo.resolve()}",
         "Ask Codex to start this Main Branch business day from read-only mb facts.",
+        "Save your first checkpoint once you've made changes: mb checkpoint --plan",
     ]
 
 
@@ -235,7 +241,10 @@ def test_onboard_cli_yes_json_smoke(tmp_path: Path, monkeypatch) -> None:
     payload = json.loads(result.stdout)
     assert payload["ok"] is True
     assert payload["path"] == str(repo.resolve())
-    assert payload["next_steps"][-1] == "/mb-start"
+    assert "/mb-start" in payload["next_steps"]
+    assert payload["next_steps"][-1] == (
+        "Save your first checkpoint once you've made changes: mb checkpoint --plan"
+    )
     assert payload["setup_complete"]["scaffolded"] is True
     assert payload["setup_complete"]["github_requested"] is False
     assert (repo / ".mb" / "onboarding.json").exists()
@@ -1062,3 +1071,54 @@ sys.exit(2)
         check=True,
     )
     assert schema_history.stdout.strip()
+
+
+def test_onboard_budget_band_without_thresholds_warns(tmp_path: Path, monkeypatch) -> None:
+    # #880 item 2: a recorded budget band with no thresholds and no private
+    # choice must say what's still missing, not stay silently todo.
+    monkeypatch.setattr(onboard_mod, "_which", _tool_path)
+    repo = tmp_path / "acme"
+
+    result = onboard_mod.run(
+        path=str(repo),
+        name="Acme Brewing",
+        mode="new",
+        monthly_experiment_budget_band="500-2k",
+    )
+
+    assert any(
+        "MoneyPath thresholds are still" in w and "trivial/small/material" in w
+        for w in result["warnings"]
+    )
+
+
+def test_onboard_budget_band_with_private_choice_is_quiet(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(onboard_mod, "_which", _tool_path)
+    repo = tmp_path / "acme"
+
+    result = onboard_mod.run(
+        path=str(repo),
+        name="Acme Brewing",
+        mode="new",
+        monthly_experiment_budget_band="500-2k",
+        threshold_privacy="private",
+    )
+
+    assert not any("MoneyPath thresholds are still" in w for w in result["warnings"])
+
+
+def test_onboard_budget_band_with_amounts_is_quiet(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(onboard_mod, "_which", _tool_path)
+    repo = tmp_path / "acme"
+
+    result = onboard_mod.run(
+        path=str(repo),
+        name="Acme Brewing",
+        mode="new",
+        monthly_experiment_budget_band="500-2k",
+        trivial_max_amount="50",
+        small_max_amount="200",
+        material_max_amount="1000",
+    )
+
+    assert not any("MoneyPath thresholds are still" in w for w in result["warnings"])


### PR DESCRIPTION
Items 2 + 3b of #880 (cold-eyes onboard findings). Does not close #880 — see note.

## What
- **Item 2 — budget-band feedback.** A recorded monthly budget band with no MoneyPath thresholds and no `--threshold-privacy private` left the checklist silently `todo`. Onboard now warns and names the gap: *"Recorded the monthly budget band, but MoneyPath thresholds are still open — add trivial/small/material amounts (or pass `--threshold-privacy private` ...)."*
- **Item 3b — first-checkpoint hint.** A fresh repo's empty-baseline state never told the operator how to make the first durable memory. `next_steps` now ends with *"Save your first checkpoint once you've made changes: mb checkpoint --plan."*

## Evidence
5 tests: budget warns / private-choice quiet / amounts-present quiet; both `next_steps` shapes (with + without codex); CLI smoke updated. 31 `test_onboard` green; full `scripts/check.sh` green.

## Note on closing #880
Items 1 (#890), 2, 3b, 4 (#908) are now shipped. Item **3a** ("'warn saved baseline' never explains itself") references a status string I could not find in the codebase — likely an operator paraphrase of the empty-baseline state, which item 3b now addresses from the onboard side. Leaving #880 open with a comment so Devon can confirm whether a separate status-side fix is still wanted rather than closing on a guess.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
