### PR TITLE
fix(checkpoint): missing-prefix rejection enumerates accepted verbs (#881 item 2)

### DIFF
--- a/mb/mb/checkpoint_verbs.py
+++ b/mb/mb/checkpoint_verbs.py
@@ -222,13 +222,15 @@ def validate_subject(message: str) -> dict[str, Any]:
                 )
             )
         elif subject and not prefix:
+            accepted = ", ".join(entry.prefix for entry in registry().values())
             errors.append(
                 _problem(
                     "missing_prefix",
                     "Checkpoint subject must start with an accepted business verb prefix.",
                     (
                         "Use `[verb] object -- result`, for example "
-                        "`[updated] offer.md -- raised price`."
+                        "`[updated] offer.md -- raised price`. Accepted verbs: "
+                        f"{accepted}."
                     ),
                 )
             )

--- a/mb/tests/test_checkpoint.py
+++ b/mb/tests/test_checkpoint.py
@@ -288,6 +288,20 @@ def test_checkpoint_validate_rejects_conventional_commit_type() -> None:
     assert payload["validation"]["parsed"]["verb"] is None
 
 
+def test_checkpoint_missing_prefix_enumerates_accepted_verbs() -> None:
+    # #881 item 2: a plain message must show the accepted verbs, not just the
+    # format. The rejection guidance enumerates the registry prefixes.
+    result = runner.invoke(app, ["checkpoint", "--validate", "fixed the offer", "--json"])
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    missing = next(e for e in payload["validation"]["errors"] if e["code"] == "missing_prefix")
+    assert "Accepted verbs:" in missing["guidance"]
+    # Every registered prefix appears in the enumeration.
+    for entry in verb_registry().values():
+        assert entry.prefix in missing["guidance"]
+
+
 def test_checkpoint_validate_rejects_unknown_bracket_prefix() -> None:
     result = runner.invoke(app, ["checkpoint", "--validate", "[docs] setup guide", "--json"])
 


### PR DESCRIPTION
Item 2 of #881 (cold-eyes operator-respect findings). Items 1 + 3 remain, so this does not close #881.

## What
The checkpoint message gate rejected a plain, prefix-less message (e.g. `fixed the offer`) with only the format example — the operator had to guess which verbs are accepted. The `missing_prefix` error now enumerates the registry prefixes, matching what the `unknown_prefix` path already does:

> Use `[verb] object -- result`, for example `[updated] offer.md -- raised price`. **Accepted verbs: [added], [updated], [decided], [opened], [closed], [drafted], [shipped], [connected], [ran], [fixed].**

## Evidence
1 test asserting every registered prefix appears in the `missing_prefix` guidance; full `test_checkpoint.py` + `scripts/check.sh` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
