### PR TITLE
release: 0.4.0 — graduate the field-proven engine surfaces

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Main Branch — run a business from markdown files in git, with Claude Code as the operator surface.",
-    "version": "0.3.44"
+    "version": "0.4.0"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mainbranch",
-  "version": "0.3.44",
+  "version": "0.4.0",
   "description": "Main Branch Claude Code skills for running a business from markdown files in git.",
   "author": {
     "name": "Noontide"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,8 +81,8 @@ pytest tests/test_<area>.py -q
 For package/install changes:
 
 ```bash
-(cd mb && python -m build)
-python -m venv /tmp/mainbranch-smoke
+(cd mb && python3 -m build)
+python3 -m venv /tmp/mainbranch-smoke
 /tmp/mainbranch-smoke/bin/pip install mb/dist/*.whl
 /tmp/mainbranch-smoke/bin/mb --version
 /tmp/mainbranch-smoke/bin/mb skill list
@@ -354,8 +354,8 @@ Run when packaging, entrypoints, bundled data, skill discovery, or update paths
 change.
 
 ```bash
-(cd mb && python -m build)
-python -m venv /tmp/mainbranch-smoke
+(cd mb && python3 -m build)
+python3 -m venv /tmp/mainbranch-smoke
 /tmp/mainbranch-smoke/bin/pip install mb/dist/*.whl
 /tmp/mainbranch-smoke/bin/mb --version
 /tmp/mainbranch-smoke/bin/mb skill list

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,74 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-06-14
+
+This release graduates the patterns proven across the live dogfood businesses
+into engine primitives — the daily-pulse observability loop, honest-metric
+lead/creative tracking, provider-write safety, site-integrity gates, and a set
+of cold-eyes onboard fixes.
+
+### Added
+
+- **Daily business pulse** — `mb pulse init` scaffolds deterministic
+  per-source collectors (date in → one JSON object out, honest
+  `{"unavailable": true}` + non-zero exit on failure) plus a repo-local pulse
+  skill (scorecard → anomalies → exactly one recommended action → sub-60-line
+  log). `mb pulse install` emits an operator-owned `run-pulse.sh` wrapper and
+  the cron line to activate it (never enables a schedule itself).
+  `/mb-start` and `/mb-end` now read the day's pulse.
+- **Honest-metric tracking** — `mb leads grade` scores lead eligibility with
+  deterministic checks (plausible email, valid URL, owner answer) and reports
+  ELIGIBLE-lead CPL beside raw CPL so budget calls use the honest number.
+  `mb ledger init` scaffolds the what's-working creative ledger (KEEP/KILL on
+  eligible CPL + downstream event, never raw CPL).
+- **Provider-write safety** — `docs/provider-mutation-contract.md` defines the
+  preview → approve → apply → verify gate for every external-account write;
+  the Google Ads/GTM rubric ties its publish/spend/upload steps to it.
+  `mb production plan` reports the money-taking branch-protection gap (require
+  PR, CI + canary as status checks, block force-push/deletion) and prints the
+  operator-applied `gh` commands.
+- **Credential plane** — `mb connect hygiene` scans agent configs
+  (`~/.claude.json`, project MCP/settings) for plaintext credentials
+  (value-redacted; ISO-date housekeeping fields excluded). `mb connect
+  identity` reads recorded business identity (ad account, pixel, page, sender
+  domain) so agents read identity from facts, not live state.
+- **Inspectable automation** — `mb automation init` scaffolds the steered-loop
+  contract (`loop-state.md`): the loop reads it first, updates it each run,
+  and renders handoffs from it.
+- **mb-site integrity gates** — a conversion-mechanism gate before page copy,
+  a click-ID capture invariant (gclid/gbraid/wbraid/fbclid + 5 UTMs) on
+  lead-capturing scaffolds, and `mb site check` blocks a forked descriptor
+  whose parent points at a different business (cross-business leak).
+
+### Changed
+
+- `mb doctor repair` refuses repair-writes outside a recognized business
+  folder (points marker-free directories at `mb onboard`).
+- `mb onboard` no longer scrapes the machine's GitHub login when GitHub is
+  declined; warns when a budget band is recorded without MoneyPath
+  thresholds; and ends its Next block with the first-checkpoint hint.
+
+### Fixed
+
+- The checkpoint commit-message hook no longer reads as "differs from the
+  current template" when installed via one `mb` entrypoint and checked via
+  another (the baked `MB_BIN` path is normalized before comparison).
+- The checkpoint message gate enumerates the accepted verb prefixes when it
+  rejects a prefix-less subject.
+
+### Known limitations
+
+- The new CLI surfaces run on both runtimes and are routed in the generated
+  `AGENTS.md`, but the Codex workflow support inventory
+  (`mb workflow list --runtime codex`) does not yet enumerate them, and the
+  daily pulse *paper* is written by the Claude `/mb-pulse` skill (Codex can
+  run the deterministic `mb pulse init/install` but has no paper-writing
+  route yet). Codex parity for these is tracked as follow-up work.
+- The discoverability gate verifies top-level commands; it does not yet prove
+  leaf/positional surfaces (`mb pulse install`, `mb connect hygiene`, …).
+  Those are taught manually; teaching the gate to see them is follow-up work.
+
 ## [0.3.44] - 2026-06-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,10 @@ of cold-eyes onboard fixes.
 - The discoverability gate verifies top-level commands; it does not yet prove
   leaf/positional surfaces (`mb pulse install`, `mb connect hygiene`, …).
   Those are taught manually; teaching the gate to see them is follow-up work.
+- Plugin installs do not self-update: `mb update` upgrades the package and
+  refreshes symlink + Codex skills, but a Claude **plugin** install must be
+  re-added/restarted to pick up 0.4.0. Verifying the installed plugin version
+  in `mb update` is follow-up work.
 
 ## [0.3.44] - 2026-06-12
 

--- a/README.md
+++ b/README.md
@@ -55,13 +55,14 @@ It is built for revenue-producing work: sharpening offers, building proof,
 planning launches, writing ads, creating organic content, checking pages,
 tracking bets, and turning what you learn into the next decision.
 
-Open the folder. Run `/mb-start`. Tell the agent what you want help with. Main
-Branch checks what changed, what matters, and what to do next.
+Open the folder. In Claude Code, run `/mb-start`. In Codex, use the global
+`mb-start` skill. Tell the agent what you want help with. Main Branch checks
+what changed, what matters, and what to do next.
 
 | Step | What you do | What happens |
 | --- | --- | --- |
 | **01** | Open the business folder | Your offer, audience, voice, proof, research, bets, pushes, logs, and documents live there. |
-| **02** | Run `/mb-start` | The agent checks current Main Branch facts before giving advice: status, MoneyPath, recent work, connected tools, drift, checkpoints, and next actions. |
+| **02** | Start Main Branch | Claude Code uses `/mb-start`; Codex uses the global `mb-start` skill. The agent checks current Main Branch facts before giving advice: status, MoneyPath, recent work, connected tools, drift, checkpoints, and next actions. |
 | **03** | Pick the next move | The agent routes the work into an offer, bet, decision, push, playbook, research note, outcome, or checkpoint. |
 | **04** | Approve the work | Writing files, publishing, spending, account changes, and customer contact stay your call. |
 | **05** | Keep the lesson | Approved work becomes durable memory for the next session. |
@@ -110,13 +111,14 @@ pipx install mainbranch
 mb onboard --name "My Business" --path my-business
 ```
 
-`mb onboard` creates the folder, prepares Claude Code and Codex, and shows the next step.
-`/mb-start` reads the folder and Main Branch facts, then tells you what to do.
+`mb onboard` creates the folder, prepares Claude Code and Codex, and shows the
+next step. Claude Code uses `/mb-start`; Codex uses the global `mb-start` skill.
+Both read the folder and Main Branch facts before telling you what to do.
 
 ### Daily use
 
 1. Open or select the business folder in Claude Code or Codex.
-2. Run `/mb-start`.
+2. In Claude Code, run `/mb-start`. In Codex, use the global `mb-start` skill.
 3. Tell the agent what you want help with: an offer, page, ad, launch, research
    question, decision, or cleanup.
 
@@ -392,11 +394,13 @@ try, why, by when, and how you will know. An offer is a durable thing you sell.
 A winning bet can graduate into an offer through an accepted decision.
 
 **How do I update?** Type `/mb-update` in Claude Code, or use the global
-`mb-update` skill in Codex.
+`mb-update` skill in Codex. If you installed the Claude Code plugin, update the
+package, re-add the plugin, and restart Claude Code so the loaded skills match
+the new release.
 
 **Can Claude or Codex migrate an old setup for me?** Yes. Open the folder in
 Claude Code or Codex and follow the migration prompt in
-[docs/migrating.md](docs/migrating.md#recommended-let-claude-walk-you-through-it).
+[docs/migrating.md](docs/migrating.md#recommended-let-an-agent-walk-you-through-it).
 
 **Can I edit the skills?** You can. You usually do not need to.
 
@@ -405,7 +409,8 @@ not only memory text. It is a structured folder, health checks, validation,
 graphing, repair paths, connected-tool checks, checkpoints, and agent workflows
 that write approved business artifacts back into files you own.
 
-**I'm stuck.** Type `/mb-start` again.
+**I'm stuck.** In Claude Code, type `/mb-start` again. In Codex, use the global
+`mb-start` skill again.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,8 @@ hosted Main Branch service in the open-source engine.
 
 | Version | Supported |
 |---|---|
-| 0.3.x | Yes |
+| 0.4.x | Yes |
+| 0.3.x | Security fixes only when practical |
 | 0.2.x | Security fixes only when practical |
 | 0.1.x | No |
 | Older versions | No |

--- a/docs/beginner-setup.md
+++ b/docs/beginner-setup.md
@@ -14,7 +14,7 @@ launches, pages, ads, bets, notes, and lessons in files you own.
 Most of this page is one-time setup. After that, your normal flow is simple:
 
 1. Open or select the business folder in Claude Code or Codex.
-2. Run `/mb-start`.
+2. In Claude Code, run `/mb-start`. In Codex, use the global `mb-start` skill.
 3. Tell the agent what you want help with.
 
 You will use a few terminal commands during setup because Main Branch creates
@@ -186,7 +186,7 @@ work, or private ops when access or lifecycle differs. The full model lives in
 
 Open or select the business folder in Claude Code or Codex.
 
-Then run:
+In Claude Code, run:
 
 ```text
 /mb-start
@@ -196,10 +196,12 @@ Then run:
 you into setup, thinking, ads, organic content, site work, bookkeeping checks,
 repairs, updates, or closing a session.
 
+In Codex, use the global `mb-start` skill instead of typing the slash command.
+
 Daily use is:
 
 1. Open or select the business folder in Claude Code or Codex.
-2. Run `/mb-start`.
+2. In Claude Code, run `/mb-start`. In Codex, use the global `mb-start` skill.
 3. Tell the agent what you want help with: an offer, page, ad, launch, research
    question, decision, bookkeeping check, or cleanup.
 
@@ -237,14 +239,20 @@ mb connect plan
 
 ## Updating Main Branch
 
-When Main Branch says an update matters, run this in Claude Code or Codex:
+When Main Branch says an update matters, run this in Claude Code:
 
 ```text
 /mb-update
 ```
 
-`/mb-update` figures out which install you have and runs the right update path.
-`/mb-start` also checks for important updates at the beginning of a session.
+In Codex, use the global `mb-update` skill. The update path figures out which
+install you have and refreshes the supported surfaces it owns. `/mb-start` also
+checks for important updates at the beginning of a Claude Code session.
+
+If you installed Main Branch as a Claude Code plugin, package updates do not
+change the plugin that Claude Code has already loaded. After updating, re-add the
+Main Branch plugin (`claude plugin marketplace add noontide-co/mainbranch`) and
+restart Claude Code.
 
 Power users can run the same update path from a business folder:
 
@@ -271,12 +279,13 @@ through the confirmation-gated migration prompt from that doc.
 Open Claude Code or Codex and paste:
 
 ```text
-I want to migrate my existing Main Branch setup to the current pipx + /mb-start
-workflow. Please run read-only checks first, find my likely business folders,
-show me the exact changes you recommend, and ask before running anything that
-writes files. If an old `reference/` layout is present, run `mb migrate --check`
-first and do not run `mb migrate --apply` until I approve the dry run. Use
-docs/migrating.md as the source of truth.
+I want to migrate my existing Main Branch setup to the current pipx workflow.
+If we are in Claude Code, use `/mb-start` after repair. If we are in Codex, use
+the global `mb-start` skill after repair. Please run read-only checks first,
+find my likely business folders, show me the exact changes you recommend, and
+ask before running anything that writes files. If an old `reference/` layout is
+present, run `mb migrate --check` first and do not run `mb migrate --apply` until
+I approve the dry run. Use docs/migrating.md as the source of truth.
 ```
 
 The agent may ask you to restart in the business folder after it repairs setup.
@@ -286,7 +295,8 @@ That is normal.
 
 ## What you can ask for
 
-You can ask naturally, or use the slash commands when you know them.
+You can ask naturally. In Claude Code, you can also use slash commands when you
+know them. In Codex, use the matching global skill names without the slash.
 
 | Ask for | What Main Branch does |
 | --- | --- |
@@ -330,14 +340,18 @@ For the full list, run `mb --help`.
 
 ## Common issues
 
-**`/mb-start` does not appear:** ask the agent to repair Main Branch setup in
-this folder. Power users can run:
+**`/mb-start` does not appear in Claude Code:** ask the agent to repair Main
+Branch setup in this folder. Power users can run:
 
 ```bash
 mb doctor repair --plan
 ```
 
 Apply only after reviewing the plan.
+
+If you use the Claude Code plugin, re-add the Main Branch plugin and restart
+Claude Code after updating. If you use Codex, start a fresh Codex thread after
+updating so refreshed global skills are loaded.
 
 **I only see `.mb/`, not `.mb-vip/`:** good. `.mb/` is current. `.mb-vip/` was
 old setup language and is not required.
@@ -355,7 +369,8 @@ the URL spelling.
 
 ## Help
 
-- **In Claude Code or Codex:** run `/mb-help` or describe the issue in plain
+- **In Claude Code:** run `/mb-help` or describe the issue in plain English.
+- **In Codex:** use the global `mb-help` skill or describe the issue in plain
   English.
 - **In the community:** post with a screenshot of the exact error.
 - **For contributors:** open an issue at
@@ -368,6 +383,7 @@ the URL spelling.
 
 You do not need to memorize the commands.
 
-Open or select your business folder in Claude Code or Codex, run `/mb-start`,
-and tell the agent what you want help with. Main Branch keeps the useful work in
-files you own so the next session does not start from scratch.
+Open or select your business folder in Claude Code or Codex. In Claude Code, run
+`/mb-start`; in Codex, use the global `mb-start` skill. Then tell the agent what
+you want help with. Main Branch keeps the useful work in files you own so the
+next session does not start from scratch.

--- a/docs/claude-code-runtime-dogfood.md
+++ b/docs/claude-code-runtime-dogfood.md
@@ -91,7 +91,7 @@ first.
 For a wheel smoke:
 
 ```bash
-(cd mb && python -m build)
+(cd mb && python3 -m build)
 scripts/claude-runtime-dogfood.py --install-mode wheel --wheel mb/dist/mainbranch-*.whl
 ```
 

--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -56,10 +56,11 @@ You do **not** need a `.mb-vip/` folder. That name belongs to old clone-based
 setup language and the former internal repo name. The current pipx setup does
 not require a local Main Branch source checkout inside your business repo.
 
-Open Claude Code in the business repo folder, not in an old Main Branch clone.
-If slash commands are missing, ask Claude to repair the skill wiring instead of
-creating a `.mb-vip/` folder. These are the underlying commands Claude or a
-power user may run:
+Open Claude Code or Codex in the business repo folder, not in an old Main Branch
+clone. Claude Code uses slash commands such as `/mb-start`; Codex uses global
+Main Branch skills such as `mb-start`. If skills are missing, ask the agent to
+repair Main Branch setup instead of creating a `.mb-vip/` folder. These are the
+underlying commands an agent or power user may run:
 
 ```bash
 mb update --repo .
@@ -69,15 +70,16 @@ mb doctor
 mb status --peek
 ```
 
-## Recommended: Let Claude Walk You Through It
+## Recommended: Let An Agent Walk You Through It
 
 If you are already using Main Branch and do not want to reason about old
-symlinks, clone paths, or repo shapes, start Claude Code anywhere and paste this
-prompt:
+symlinks, clone paths, plugins, or repo shapes, start Claude Code or Codex
+anywhere and paste this prompt:
 
 ```text
-I want to migrate my existing Main Branch setup to the current pipx + /mb-start
-workflow.
+I want to migrate my existing Main Branch setup to the current pipx workflow.
+If this is Claude Code, use `/mb-start` after repair. If this is Codex, use the
+global `mb-start` skill after repair.
 
 Please go slowly, but treat the Main Branch update as required before repo
 repair. I may be new to Terminal, Git, branches, and GitHub.
@@ -100,7 +102,8 @@ fully, not as optional cleanup.
    updates the tool installed on your computer, not your business files. Should
    I run the update now?"
 3. After I confirm, update Main Branch immediately through the Main Branch
-   update path. If `/mb-update` is available, use it. Otherwise run
+   update path. If `/mb-update` is available in Claude Code, use it. In Codex,
+   use the global `mb-update` skill. Otherwise run
    `mb update --repo <repo>` from the business repo. Only mention raw package
    commands like `pipx upgrade mainbranch` if `mb update` is unavailable because
    the installed version is too old.
@@ -118,10 +121,13 @@ fully, not as optional cleanup.
 9. If you create or switch to a git branch, explain that it is a safe draft copy
    of the work. Do not merge, delete, or rename branches unless I explicitly
    confirm.
-10. If a command says I need to restart Claude, stop and tell me exactly which
-   folder to open next and which slash command to run.
+10. If a command says I need to restart Claude Code, stop and tell me exactly
+   which folder to open next and which slash command to run. If this is Codex,
+   tell me to start a fresh Codex thread in the business folder and use the
+   global `mb-start` skill.
 11. Do not end by giving me a list of internal mb commands to choose from. End
-   with the exact folder to open, the exact `claude` command, and `/mb-start`.
+   with the exact folder to open and the exact next agent step: Claude Code
+   `claude` + `/mb-start`, or Codex + the global `mb-start` skill.
 ```
 
 After the user confirms the update and one repo repair, Claude should get the
@@ -143,6 +149,9 @@ Then restart Claude Code from that business repo and run:
 ```text
 /mb-start
 ```
+
+If you use Codex instead, start a fresh Codex thread from that business repo and
+use the global `mb-start` skill.
 
 This flow is intentionally confirmation-gated. `mb skill link` and
 `mb skill repair --apply` only move stale Main Branch symlinks and broken links
@@ -310,6 +319,11 @@ not keep access to stale Main Branch paths after a clone-to-pipx migration. Duri
 that link step, Main Branch also moves provably stale or broken personal
 symlinks with Main Branch skill names into a timestamped backup.
 
+If you use the Claude Code plugin rail, also re-add the Main Branch plugin after
+updating (`claude plugin marketplace add noontide-co/mainbranch`) and restart
+Claude Code. The symlink repair path remains the fallback and repair path; the
+plugin is the more durable route for fresh Claude Code worktrees.
+
 `mb skill repair --repo .` checks your personal `~/.claude/skills/` directory
 for entries that can beat the project-local Main Branch skills in Claude Code.
 It reports the resolved target for each finding. If the entry is a provably
@@ -348,9 +362,11 @@ mb skill link --repo /path/to/your-business
 mb skill repair --repo /path/to/your-business
 ```
 
-For beginners, Claude should run that sequence after confirmation and translate
-the result into the simple restart flow: open the business folder, run
-`claude`, then type `/mb-start`.
+For beginners, the agent should run that sequence after confirmation and
+translate the result into the simple restart flow: open the business folder, then
+use the right start surface. In Claude Code, run `claude` and type `/mb-start`.
+In Codex, start a fresh thread from the business folder and use the global
+`mb-start` skill.
 
 ## Automated Layout Migration
 

--- a/docs/post-release-alignment.md
+++ b/docs/post-release-alignment.md
@@ -134,8 +134,9 @@ Lanes that can usually run concurrently without merge chaos:
 - **Feature CLI**: one command surface owned by one branch. Do not parallel
   two branches that both touch `mb/<module>.py`, `mb/cli.py`, or shared
   packaged data unless the conflict surface is explicitly enumerated.
-- **Release prep**: only the four release files (`CHANGELOG.md`,
-  `mb/pyproject.toml`, `mb/mb/__init__.py`, `.claude-plugin/plugin.json`).
+- **Release prep**: only release files (`CHANGELOG.md`, `mb/pyproject.toml`,
+  `mb/mb/__init__.py`, `.claude-plugin/plugin.json`,
+  `.claude-plugin/marketplace.json`).
   Anything else is its own branch.
 - **Noontide / business-model**: lives in the operator's business repo, not
   in this engine. Never on the same branch as engine changes.

--- a/docs/release-agent-contract.md
+++ b/docs/release-agent-contract.md
@@ -41,7 +41,9 @@ every version-bearing release file in one pass:
   contains only work intentionally left unreleased;
 - `mb/pyproject.toml` `project.version` matches the release version;
 - `mb/mb/__init__.py` `__version__` matches the release version;
-- `.claude-plugin/plugin.json` `version` matches the release version.
+- `.claude-plugin/plugin.json` `version` matches the release version;
+- `.claude-plugin/marketplace.json` `metadata.version` matches the release
+  version.
 
 All of that is automated:
 
@@ -49,7 +51,7 @@ All of that is automated:
 scripts/release-preflight.sh oe-vX.Y.Z   # or bare X.Y.Z; no arg = files must agree
 ```
 
-The script asserts the three version files agree (and agree with the tag when
+The script asserts the version files agree (and agree with the tag when
 passed), checks `CHANGELOG.md` has the dated section, and runs the targeted
 manifest guard
 (`tests/test_smoke_coverage.py::test_claude_plugin_manifest_points_at_prefixed_skills`).
@@ -165,7 +167,7 @@ items were confirmed, rejected, or routed to follow-up issues.
 ### 4. Release PRs stay release-only.
 
 A release-prep PR commits only files that change because of the release:
-package version sites, the dated CHANGELOG section, and the plugin manifest.
+package version sites, the dated CHANGELOG section, and the plugin manifests.
 Process improvements (this file, the post-release playbook, agent rubric
 updates) belong on their own branch. Process documents drafted *during* a
 release flow are committed *after* the release ships, on a separate branch.

--- a/docs/release-simulations.md
+++ b/docs/release-simulations.md
@@ -147,7 +147,7 @@ scripts/claude-runtime-dogfood.py --install-mode pypi --pypi-version X.Y.Z --run
 For a pre-tag release acceptance run against a release candidate wheel:
 
 ```bash
-(cd mb && python -m build)
+(cd mb && python3 -m build)
 scripts/claude-runtime-dogfood.py --install-mode wheel --wheel mb/dist/mainbranch-*.whl --run-claude-print --simulation-tier release_acceptance --max-budget-usd 0.75
 ```
 

--- a/docs/supply-chain-policy.md
+++ b/docs/supply-chain-policy.md
@@ -85,8 +85,8 @@ human approval over clever automation.
 
 ### Package metadata and dependency surface
 
-- `mb/pyproject.toml` declares three runtime dependencies: `typer`,
-  `pyyaml`, `rich`. Each has a documented floor (`>=`) and no upper
+- `mb/pyproject.toml` declares four runtime dependencies: `openai`, `typer`,
+  `pyyaml`, and `rich`. Each has a documented floor (`>=`) and no upper
   bound. Floors come from the lowest version known to work; upper bounds
   would force premature compatibility breaks.
 - The dev extras (`ruff`, `mypy`, `pytest`, `pytest-cov`,
@@ -120,7 +120,7 @@ human approval over clever automation.
 
 ### No hash-locked install today
 
-- `mb` is a small Typer-shaped CLI with three runtime dependencies.
+- `mb` is a small Typer-shaped CLI with four runtime dependencies.
   Introducing `pip-tools`, `uv`, or `poetry` lockfiles would force a new
   dependency manager on contributors before the surface earns it.
 - This is revisable. If the dependency footprint grows or a specific

--- a/mb/README.md
+++ b/mb/README.md
@@ -2,7 +2,12 @@
 
 Engine umbrella for [Main Branch](https://github.com/noontide-co/mainbranch) — scaffolds, validates, and graphs business-as-files repos.
 
-This package is the Python entry point. Workflows, playbooks, educational content, and consumer-repo templates ship as bundled package data. Today, the day-to-day "do work" surfaces are packaged as Claude Code skills (markdown), invoked from inside Claude Code. The `mb` CLI is runtime-agnostic by design: future adapters should let Codex, Cursor, OpenClaw, Hermes, and local runtimes operate against the same business-as-files repo.
+This package is the Python entry point. Workflows, playbooks, educational
+content, and consumer-repo templates ship as bundled package data. Today, the
+day-to-day "do work" surfaces are Claude Code skills and global Codex `mb-*`
+skills grounded in the same deterministic `mb` facts. The `mb` CLI stays
+runtime-agnostic by design so future adapters can operate against the same
+business-as-files repo.
 
 The source tree keeps the engine payload in one place: repo-root `.claude/`. During sdist/wheel builds, `setup.py` copies that tree into `mb/_engine/.claude/` inside the build artifact so installed wheels can resolve skills, playbooks, reference materials, lenses, and educational prompts without a source checkout.
 
@@ -22,18 +27,23 @@ mb --version
 
 | Command | What it does |
 |---|---|
-| `mb onboard` | Human setup flow. Creates or connects a business repo, explains the local files/git/GitHub model, wires Claude Code skills, verifies discovery, and prints the next `/mb-start` step. Supports `--yes` and `--json` for smoke tests. |
-| `mb init` | Scaffold a new business repo (business folders, CLAUDE.md, CODEOWNERS, `git init`) and wire the bundled Claude Code skill adapter. One question only: business name. |
+| `mb onboard` | Human setup flow. Creates or connects a business repo, explains the local files/git/GitHub model, wires Claude Code and Codex guidance, verifies discovery, and prints the next start step. Supports `--yes` and `--json` for smoke tests. |
+| `mb init` | Scaffold a new business repo (business folders, CLAUDE.md, AGENTS.md, CODEOWNERS, `git init`) and wire bundled runtime guidance. One question only: business name. |
 | `mb doctor` | Diagnostic. Checks Claude Code, gh auth, network, librsvg, runtime wiring, and package freshness. Warns on cloud-backed finance paths and offers educational triage. |
 | `mb status` | Daily briefing. Summarizes repo shape, install/runtime readiness, recent brain files, recent git activity, and GitHub tasks/proposals when `gh` is authenticated. Supports `--json`. |
-| `mb start` | Runtime handoff. Verifies the current business repo, git, Claude Code, and `/mb-start` skill wiring, then prints the exact `claude` command or launches it with `--launch`. Supports `--json`. |
+| `mb start` | Runtime handoff. Verifies the current business repo, git, Claude Code, Codex guidance, and start-skill wiring, then prints the exact next step. Supports `--json`. |
 | `mb validate` | Frontmatter shape check across current business repo folders, with compatibility reads for old migrated surfaces where needed. Exit 1 on any fail. |
 | `mb graph` | Walk linked_research / linked_decisions / supersedes; emit Graphviz DOT to stdout. `--open` shells to `dot` + `open`. |
 | `mb similar-bets` | Find similar past bets and offer outcomes from repo truth. |
 | `mb checkpoint` | Plan or save a business-readable git checkpoint. |
 | `mb update` | Refresh the Main Branch engine according to install mode (`pipx` upgrade or clone `git pull`) and repair skill links. `--check` dry-runs; `--json` emits an envelope. |
+| `mb pulse install` | Install an operator-owned daily pulse wrapper. |
+| `mb leads grade` | Grade lead batches and calculate eligible-lead CPL beside raw CPL. |
+| `mb ledger init` | Create the what's-working creative ledger structure. |
+| `mb automation init` | Create an inspectable steered-loop automation contract. |
+| `mb production plan` | Inspect launch/production readiness without mutating providers or repos. |
 | `mb migrate` | Inspect and apply numbered repo schema migrations. `status`, `--check`, and `--apply` support `--json`; `--check` prints privacy-safe summaries by default, with full diffs behind `--diff`. |
-| `mb connect` | Connect provider credentials without committing secrets, test provider health, and inspect repair-safe integration status. |
+| `mb connect` | Connect provider credentials without committing secrets, test provider health, inspect hygiene/identity, and report repair-safe integration status. |
 | `mb site` | Inspect site readiness for launch-adjacent workflows. |
 | `mb issue` | Draft and open privacy-safe GitHub issues from local friction. |
 | `mb think <topic>` | Print the /mb-think workflow invocation hint for the currently supported runtime. |
@@ -49,9 +59,20 @@ Users on early `0.1.x` installs must bootstrap once with
 repos should run `mb skill link --repo .`, then `mb skill repair --repo .` after
 upgrading.
 
+If you installed Main Branch as a Claude Code plugin, package updates do not
+change the plugin that Claude Code has already loaded. After updating, re-add the
+Main Branch plugin (`claude plugin marketplace add noontide-co/mainbranch`) and
+restart Claude Code.
+
 ## Status
 
-Main Branch is **Claude Code first** with a strong CLI front door: `mb onboard`, `mb status`, `mb start`, and `mb update` are public package surfaces. Runtime compatibility for Codex, Cursor, OpenClaw, Hermes, and local runtimes remains roadmap work. The schema is v1 and will evolve. The runtime boundary decision lives at `decisions/2026-05-01-mb-cli-vs-agent-workflows-boundary.md`; the engine master decision lives at `decisions/2026-04-29-mb-vip-v0-1-0-master.md`.
+Main Branch is **Claude Code first** with supported Codex CLI guidance through
+generated `AGENTS.md` and global `mb-*` skills. `mb onboard`, `mb status`,
+`mb start`, and `mb update` are public package surfaces. Cursor, OpenClaw,
+Hermes, and local runtimes remain roadmap work. The schema is v1 and will
+evolve. The runtime boundary decision lives at
+`decisions/2026-05-01-mb-cli-vs-agent-workflows-boundary.md`; the engine master
+decision lives at `decisions/2026-04-29-mb-vip-v0-1-0-master.md`.
 
 ## License
 

--- a/mb/mb/__init__.py
+++ b/mb/mb/__init__.py
@@ -7,6 +7,6 @@ file stays a thin dispatcher.
 
 from __future__ import annotations
 
-__version__ = "0.3.44"
+__version__ = "0.4.0"
 
 __all__ = ["__version__"]

--- a/mb/mb/_data/templates/AGENTS.md.tmpl
+++ b/mb/mb/_data/templates/AGENTS.md.tmpl
@@ -390,8 +390,12 @@ the operator asks for plumbing.
   "Show me the business" ->
   `mb dashboard open` (local, read-only, never committed). Scripts that read
   credentials -> `mb connect token` (token to stdout for scripts and agents;
-  never echo the value). Tools missing from the provider list ->
-  `mb connect <id> --custom`. Writing to an external provider (CRM, email
+  never echo the value). Plaintext credentials sitting in agent configs ->
+  `mb connect hygiene` (read-only scan; never prints the value). Reading the
+  recorded business identity (ad account, pixel, page, sender domain) instead
+  of inferring it from live state -> `mb connect identity`. Tools missing from
+  the provider list -> `mb connect <id> --custom`. Writing to an external
+  provider (CRM, email
   send, ads, account metadata) -> the provider-mutation contract: read-only
   discovery first, a sanitized plan (provider + object count + risk, no
   private rows), explicit approval, minimal-scope apply, verify + a

--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -438,6 +438,12 @@ def leads_grade_cmd(
     if not isinstance(leads, list):
         typer.echo("mb leads grade: expected a JSON array of lead records", err=True)
         raise typer.Exit(2)
+    if not all(isinstance(item, dict) for item in leads):
+        typer.echo("mb leads grade: each lead must be a JSON object", err=True)
+        raise typer.Exit(2)
+    if spend is not None and spend < 0:
+        typer.echo("mb leads grade: --spend must be zero or positive", err=True)
+        raise typer.Exit(2)
     result = leads_mod.grade_batch(
         leads,
         spend=spend,

--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -8,6 +8,7 @@ because that's the working pattern.
 from __future__ import annotations
 
 import json
+import math
 import os
 import sys
 from datetime import datetime, timezone
@@ -441,8 +442,8 @@ def leads_grade_cmd(
     if not all(isinstance(item, dict) for item in leads):
         typer.echo("mb leads grade: each lead must be a JSON object", err=True)
         raise typer.Exit(2)
-    if spend is not None and spend < 0:
-        typer.echo("mb leads grade: --spend must be zero or positive", err=True)
+    if spend is not None and (not math.isfinite(spend) or spend < 0):
+        typer.echo("mb leads grade: --spend must be a finite, zero-or-positive number", err=True)
         raise typer.Exit(2)
     result = leads_mod.grade_batch(
         leads,

--- a/mb/mb/connect.py
+++ b/mb/mb/connect.py
@@ -2612,8 +2612,10 @@ def scan_credential_hygiene(
         scanned.append(label)
         findings.extend(surface_findings)
 
-    ok = not findings
-    if ok:
+    # A surface that could not be scanned was NOT proven clean — it must not
+    # yield a clean machine verdict (gates/automation read ok + the exit code).
+    ok = not findings and not skipped
+    if not findings:
         summary = f"no plaintext credentials found across {len(scanned)} scanned config surface(s)"
     else:
         summary = (

--- a/mb/mb/connect.py
+++ b/mb/mb/connect.py
@@ -2447,8 +2447,18 @@ _HYGIENE_SECRET_KEY_RE = re.compile(
 # A value that is wholly or partly an env reference (${VAR}, $VAR) is correctly
 # externalized — not a plaintext leak.
 _ENV_REFERENCE_RE = re.compile(r"\$\{?[A-Za-z_][A-Za-z0-9_]*\}?")
+# A value is "externalized" only if it is WHOLLY env reference(s) (optionally a
+# Bearer prefix) — not a literal secret with an env ref tacked on. Matching a
+# bare .search() let "${ENV}sk-realsecret" pass as safe (false negative).
+_ENV_REFERENCE_FULL_RE = re.compile(r"(?i)^(bearer\s+)?(\$\{?[A-Za-z_][A-Za-z0-9_]*\}?)+$")
 _PLACEHOLDER_VALUES = frozenset(
     {"", "changeme", "change-me", "todo", "none", "null", "example", "redacted"}
+)
+# An ISO-8601 date or timestamp is not a secret. Housekeeping fields like
+# `claudeCodeFirstTokenDate` match the secret-named-key heuristic ("Token")
+# but hold a date string — excluding the shape keeps the count honest.
+_ISO_DATETIME_RE = re.compile(
+    r"^\d{4}-\d{2}-\d{2}([T ]\d{2}:\d{2}(:\d{2}(\.\d+)?)?(Z|[+-]\d{2}:?\d{2})?)?$"
 )
 
 # JSON config surfaces scanned by default. TOML surfaces (e.g. ~/.codex/
@@ -2466,8 +2476,13 @@ def _looks_like_env_reference(value: str) -> bool:
     stripped = value.strip()
     if not stripped:
         return False
-    # Whole value is an env ref, or it embeds one (e.g. "Bearer ${FAL_KEY}").
-    return bool(_ENV_REFERENCE_RE.search(stripped))
+    # Safe only if the WHOLE value is env reference(s) (e.g. "Bearer ${FAL_KEY}").
+    # A literal secret mixed with an env ref is NOT safe.
+    return bool(_ENV_REFERENCE_FULL_RE.match(stripped))
+
+
+def _looks_like_iso_datetime(value: str) -> bool:
+    return bool(_ISO_DATETIME_RE.match(value.strip()))
 
 
 def _looks_like_placeholder(value: str) -> bool:
@@ -2496,7 +2511,11 @@ def _classify_credential_value(key: str, value: str) -> tuple[bool, str]:
     """Return (flagged, reason) without ever surfacing the value."""
     if not isinstance(value, str):
         return False, ""
-    if _looks_like_env_reference(value) or _looks_like_placeholder(value):
+    if (
+        _looks_like_env_reference(value)
+        or _looks_like_placeholder(value)
+        or _looks_like_iso_datetime(value)
+    ):
         return False, ""
     prefix = _credential_value_prefix(value)
     if prefix:
@@ -2600,6 +2619,14 @@ def scan_credential_hygiene(
         summary = (
             f"{len(findings)} plaintext credential(s) in agent config — move them "
             "to the keychain/env and reference via ${ENV_VAR}"
+        )
+    # Surface unscannable files loudly — a config that could not be parsed was
+    # NOT proven clean; silence there would be a false all-clear.
+    if skipped:
+        labels = ", ".join(str(item["surface"]) for item in skipped)
+        summary += (
+            f" — WARNING: {len(skipped)} surface(s) could not be scanned "
+            f"(not proven clean): {labels}"
         )
     return {
         "ok": ok,

--- a/mb/mb/leads.py
+++ b/mb/mb/leads.py
@@ -13,6 +13,7 @@ lead dict, and the CLI reads a leads JSON the operator provides.
 
 from __future__ import annotations
 
+import math
 import re
 from typing import Any
 from urllib.parse import urlparse
@@ -105,16 +106,19 @@ def grade_batch(
         for reason in verdict["reasons"]:
             reason_tally[reason] = reason_tally.get(reason, 0) + 1
 
+    # A non-finite spend (nan/inf) would emit invalid JSON constants — treat
+    # it as no spend for the CPL math (the CLI also rejects it up front).
+    spend_value = float(spend) if spend is not None and math.isfinite(float(spend)) else None
     raw_cpl: float | None = None
     eligible_cpl: float | None = None
-    if spend is not None and total:
-        raw_cpl = _round_cents(float(spend) / total)
-    if spend is not None and eligible:
-        eligible_cpl = _round_cents(float(spend) / eligible)
+    if spend_value is not None and total:
+        raw_cpl = _round_cents(spend_value / total)
+    if spend_value is not None and eligible:
+        eligible_cpl = _round_cents(spend_value / eligible)
 
     if total == 0:
         summary = "no leads to grade"
-    elif spend is None:
+    elif spend_value is None:
         summary = f"{eligible}/{total} leads eligible"
     elif eligible == 0:
         summary = (

--- a/mb/mb/leads.py
+++ b/mb/mb/leads.py
@@ -112,7 +112,9 @@ def grade_batch(
     if spend is not None and eligible:
         eligible_cpl = _round_cents(float(spend) / eligible)
 
-    if spend is None:
+    if total == 0:
+        summary = "no leads to grade"
+    elif spend is None:
         summary = f"{eligible}/{total} leads eligible"
     elif eligible == 0:
         summary = (

--- a/mb/mb/production.py
+++ b/mb/mb/production.py
@@ -38,13 +38,19 @@ def _present_flags(protection: dict[str, Any] | None) -> dict[str, bool]:
         return {key: False for key, _ in DESIRED_POSTURE}
     checks = protection.get("required_status_checks") or {}
     contexts: list[Any] = []
+    strict = False
     if isinstance(checks, dict):
         contexts = checks.get("contexts") or checks.get("checks") or []
+        strict = bool(checks.get("strict"))
     has_canary = any("canary" in str(ctx).lower() for ctx in contexts)
+    # A real CI gate is a non-canary required check; the canary alone is not
+    # "CI + canary". And the apply command sets strict=true, so the posture is
+    # only armed when the existing gate is strict too.
+    has_ci = any("canary" not in str(ctx).lower() for ctx in contexts)
     return {
         "required_pull_request": bool(protection.get("required_pull_request_reviews")),
-        # "required" means there is a status-check gate AND the canary is in it.
-        "required_status_checks": bool(contexts) and has_canary,
+        # Armed only when a CI check AND the canary are required, branch-strict.
+        "required_status_checks": has_ci and has_canary and strict,
         "block_force_push": not _allowed(protection, "allow_force_pushes"),
         "block_deletion": not _allowed(protection, "allow_deletions"),
     }

--- a/mb/mb/pulse.py
+++ b/mb/mb/pulse.py
@@ -275,6 +275,7 @@ def init(repo: str | Path = ".", *, slug: str = "", force: bool = False) -> dict
                 "(your collectors keep their own names, so collect-example.sh "
                 "is the only collector at risk)"
             ),
+            "safe_to_share": True,
         }
     collectors_dir.mkdir(parents=True, exist_ok=True)
     skill_path.parent.mkdir(parents=True, exist_ok=True)
@@ -294,4 +295,5 @@ def init(repo: str | Path = ".", *, slug: str = "", force: bool = False) -> dict
             "(see the collectors README for the contract), then run /mb-pulse "
             "for the first paper; `mb pulse install` emits a daily run wrapper"
         ),
+        "safe_to_share": True,
     }

--- a/mb/pyproject.toml
+++ b/mb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mainbranch"
-version = "0.3.44"
+version = "0.4.0"
 description = "Main Branch engine umbrella - scaffolds, validates, and graphs business-as-files repos. Claude Code first, runtime-agnostic by design."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/mb/tests/test_connect.py
+++ b/mb/tests/test_connect.py
@@ -1967,6 +1967,32 @@ def test_hygiene_clean_when_all_externalized(tmp_path: Path) -> None:
     assert "~/.claude.json" in result["surfaces_scanned"]
 
 
+def test_hygiene_ignores_iso_date_housekeeping_fields(tmp_path: Path) -> None:
+    # A secret-named key holding an ISO date (e.g. claudeCodeFirstTokenDate)
+    # is not a credential — it must not inflate the count.
+    home = tmp_path / "home"
+    home.mkdir(parents=True)
+    (home / ".claude.json").write_text(
+        json.dumps(
+            {
+                "claudeCodeFirstTokenDate": "2026-01-15T12:34:56.789Z",
+                "lastTokenRefreshDate": "2026-06-14",
+                "mcpServers": {"real": {"env": {"API_KEY": "sk-live-abc123def456"}}},
+            }
+        ),
+        encoding="utf-8",
+    )
+    repo = tmp_path / "biz"
+    repo.mkdir()
+
+    result = connect_mod.scan_credential_hygiene(repo, home=home)
+    locations = {f["location"] for f in result["findings"]}
+    # The real secret is still caught; the two date fields are not.
+    assert "mcpServers.real.env.API_KEY" in locations
+    assert not any("Date" in loc for loc in locations)
+    assert len(result["findings"]) == 1
+
+
 def test_hygiene_cli_exit_code_and_redaction(tmp_path: Path) -> None:
     home = tmp_path / "home"
     _write_claude_config(home)
@@ -2088,3 +2114,30 @@ def test_identity_cli_json(tmp_path: Path, monkeypatch) -> None:
     payload = json.loads(result.stdout)
     assert payload["safe_to_share"] is False
     assert any(p["provider"] == "meta" for p in payload["providers"])
+
+
+def test_hygiene_flags_literal_secret_mixed_with_env_ref(tmp_path: Path) -> None:
+    # "${ENV}sk-realsecret" must NOT pass as externalized (false-negative fix).
+    home = tmp_path / "home"
+    home.mkdir(parents=True)
+    (home / ".claude.json").write_text(
+        json.dumps({"mcpServers": {"m": {"env": {"API_KEY": "${BASE}sk-live-realsecret999"}}}}),
+        encoding="utf-8",
+    )
+    repo = tmp_path / "biz"
+    repo.mkdir()
+    result = connect_mod.scan_credential_hygiene(repo, home=home)
+    assert result["ok"] is False
+    assert any(f["location"].endswith("API_KEY") for f in result["findings"])
+
+
+def test_hygiene_surfaces_unscannable_files_loudly(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    home.mkdir(parents=True)
+    (home / ".claude.json").write_text("{ not valid json", encoding="utf-8")
+    repo = tmp_path / "biz"
+    repo.mkdir()
+    result = connect_mod.scan_credential_hygiene(repo, home=home)
+    # Skipped surface must be called out, not silently treated as clean.
+    assert "could not be scanned" in result["summary"]
+    assert result["surfaces_skipped"]

--- a/mb/tests/test_connect.py
+++ b/mb/tests/test_connect.py
@@ -2021,15 +2021,26 @@ def test_hygiene_scans_repo_mcp_surface(tmp_path: Path) -> None:
     assert any(f["surface"] == ".mcp.json" for f in result["findings"])
 
 
-def test_hygiene_skips_unparseable_surface(tmp_path: Path) -> None:
+def test_hygiene_unparseable_surface_is_not_a_clean_verdict(tmp_path: Path) -> None:
+    # A surface that could not be scanned must NOT return a clean machine
+    # verdict — gates/automation read ok + the exit code (#911 Codex review).
     home = tmp_path / "home"
     home.mkdir(parents=True)
     (home / ".claude.json").write_text("{ not valid json", encoding="utf-8")
     repo = tmp_path / "biz"
     repo.mkdir()
     result = connect_mod.scan_credential_hygiene(repo, home=home)
-    assert result["ok"] is True
+    assert result["ok"] is False
     assert any(s["reason"] == "not valid JSON" for s in result["surfaces_skipped"])
+
+    import os as _os
+
+    cli = runner.invoke(
+        app,
+        ["connect", "hygiene", "--repo", str(repo), "--json"],
+        env={**_os.environ, "HOME": str(home)},
+    )
+    assert cli.exit_code == 1
 
 
 # --- canonical business identity (mb connect identity) ---------------------

--- a/mb/tests/test_leads.py
+++ b/mb/tests/test_leads.py
@@ -99,3 +99,26 @@ def test_leads_grade_cli_rejects_non_array(tmp_path: Path) -> None:
     bad.write_text(json.dumps({"not": "an array"}), encoding="utf-8")
     result = runner.invoke(app, ["leads", "grade", "--file", str(bad)])
     assert result.exit_code == 2
+
+
+def test_grade_batch_empty_is_not_raw_cpl_none() -> None:
+    result = leads_mod.grade_batch([], spend=40)
+    assert result["total"] == 0
+    assert result["summary"] == "no leads to grade"
+    assert "None" not in result["summary"]
+
+
+def test_leads_grade_cli_rejects_scalar_item(tmp_path: Path) -> None:
+    bad = tmp_path / "bad.json"
+    bad.write_text(json.dumps([{"email": "a@b.co"}, "oops"]), encoding="utf-8")
+    result = runner.invoke(app, ["leads", "grade", "--file", str(bad)])
+    assert result.exit_code == 2
+    assert "must be a JSON object" in result.stderr
+
+
+def test_leads_grade_cli_rejects_negative_spend(tmp_path: Path) -> None:
+    leads_file = tmp_path / "leads.json"
+    leads_file.write_text(json.dumps([{"email": "a@b.co", "owner_answer": "x"}]), encoding="utf-8")
+    result = runner.invoke(app, ["leads", "grade", "--file", str(leads_file), "--spend", "-10"])
+    assert result.exit_code == 2
+    assert "zero or positive" in result.stderr

--- a/mb/tests/test_leads.py
+++ b/mb/tests/test_leads.py
@@ -121,4 +121,21 @@ def test_leads_grade_cli_rejects_negative_spend(tmp_path: Path) -> None:
     leads_file.write_text(json.dumps([{"email": "a@b.co", "owner_answer": "x"}]), encoding="utf-8")
     result = runner.invoke(app, ["leads", "grade", "--file", str(leads_file), "--spend", "-10"])
     assert result.exit_code == 2
-    assert "zero or positive" in result.stderr
+    assert "zero-or-positive" in result.stderr
+
+
+def test_leads_grade_cli_rejects_non_finite_spend(tmp_path: Path) -> None:
+    leads_file = tmp_path / "leads.json"
+    leads_file.write_text(json.dumps([{"email": "a@b.co", "owner_answer": "x"}]), encoding="utf-8")
+    for bad in ("nan", "inf"):
+        result = runner.invoke(app, ["leads", "grade", "--file", str(leads_file), "--spend", bad])
+        assert result.exit_code == 2, bad
+        assert "finite" in result.stderr
+
+
+def test_grade_batch_non_finite_spend_is_not_emitted() -> None:
+    result = leads_mod.grade_batch([{"email": "a@b.co", "owner_answer": "x"}], spend=float("inf"))
+    assert result["raw_cpl"] is None
+    assert result["eligible_cpl"] is None
+    blob = json.dumps(result)
+    assert "Infinity" not in blob and "NaN" not in blob

--- a/mb/tests/test_production.py
+++ b/mb/tests/test_production.py
@@ -76,3 +76,27 @@ def test_production_plan_cli_solo_json() -> None:
     payload = json.loads(result.stdout)
     assert payload["solo_on_main"] is True
     assert payload["safe_to_share"] is True
+
+
+def test_plan_canary_without_ci_check_is_not_armed() -> None:
+    # A canary alone is not "CI + canary" — must not report the posture armed.
+    canary_only = {
+        "required_pull_request_reviews": {"required_approving_review_count": 1},
+        "required_status_checks": {"strict": True, "contexts": ["money-path canary"]},
+        "allow_force_pushes": {"enabled": False},
+        "allow_deletions": {"enabled": False},
+    }
+    result = production_mod.plan("owner/repo", current_protection=canary_only)
+    assert result["ok"] is False
+    assert any("status checks" in m for m in result["missing"])
+
+
+def test_plan_status_checks_require_strict() -> None:
+    not_strict = {
+        "required_pull_request_reviews": {"required_approving_review_count": 1},
+        "required_status_checks": {"strict": False, "contexts": ["ci", "canary"]},
+        "allow_force_pushes": {"enabled": False},
+        "allow_deletions": {"enabled": False},
+    }
+    result = production_mod.plan("owner/repo", current_protection=not_strict)
+    assert any("status checks" in m for m in result["missing"])

--- a/mb/tests/test_pulse.py
+++ b/mb/tests/test_pulse.py
@@ -23,6 +23,8 @@ def test_pulse_init_scaffolds_collectors_and_skill(tmp_path: Path) -> None:
     assert result.exit_code == 0
     payload = json.loads(result.stdout)
     assert payload["ok"] is True
+    # Schema parity with the sibling scaffolds (pulse install, ledger init).
+    assert payload["safe_to_share"] is True
     assert "core/operations/pulse/collectors/README.md" in payload["written"]
     assert "core/operations/pulse/collectors/collect-example.sh" in payload["written"]
     assert ".claude/skills/mb-pulse/SKILL.md" in payload["written"]

--- a/scripts/release-preflight.sh
+++ b/scripts/release-preflight.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Release-file preflight (release-agent-contract.md Rule 0, issue #826).
 #
-# Asserts the three version-bearing release files agree — and agree with the
+# Asserts the version-bearing release files agree — and agree with the
 # release tag when one is passed — then runs the cheapest targeted guard for
 # the plugin manifest. Run this before scripts/check.sh on a release-prep
 # branch; do not spend a 10-minute gate discovering a version mismatch.
@@ -28,8 +28,8 @@ echo "mb/mb/__init__.py        __version__ = $init_version"
 echo ".claude-plugin/plugin.json version  = $plugin_version"
 echo ".claude-plugin/marketplace.json    = $marketplace_version"
 
-if [ -z "$pyproject_version" ] || [ -z "$init_version" ] || [ -z "$plugin_version" ]; then
-  echo "release-preflight: could not read all three version strings." >&2
+if [ -z "$pyproject_version" ] || [ -z "$init_version" ] || [ -z "$plugin_version" ] || [ -z "$marketplace_version" ]; then
+  echo "release-preflight: could not read all version strings." >&2
   fail=1
 fi
 if [ "$pyproject_version" != "$init_version" ] || [ "$pyproject_version" != "$plugin_version" ] || [ "$pyproject_version" != "$marketplace_version" ]; then


### PR DESCRIPTION
**Held review target — do not merge until Devon clears the release.** Tag `oe-v0.4.0` + the PyPI gate come after merge.

Cuts 0.4.0: the 22-commit `oe-v0.3.44..main` delta (≈13 new operator surfaces + mb-site gates + doctrine + fixes), version-bumped and folded with the pre-release review fixes.

## Review trail
- Self pre-release audit (3 finders + adversarial verify): **GO-AFTER-FIXES**, zero code blockers.
- Independent Codex review (`codex exec --sandbox read-only`, adversarial): **GO-AFTER-FIXES**, same main issues.

## Folded the confirmed correctness fixes
- **leads grade** — controlled CLI errors for scalar items + negative spend; empty batch says "no leads to grade" (was "raw CPL None").
- **production plan** — status-check posture armed only with a non-canary CI check **and** a canary **and** branch-strict (was canary-substring alone → false reassurance).
- **connect hygiene** — literal-secret-mixed-with-env-ref no longer passes as safe; unscannable surfaces surfaced loudly; ISO-date housekeeping fields no longer false-positive.
- **pulse init --json** carries `safe_to_share`; **connect hygiene/identity** routed on the Codex rail.

## Deferred to follow-up (documented in CHANGELOG "Known limitations")
- Codex workflow-inventory doesn't yet enumerate the new surfaces; pulse *paper* is Claude-only (`/mb-pulse`). Both run on both rails via `AGENTS.md`.
- Discoverability gate is blind to leaf/positional surfaces.
- `site` descriptor-identity has no business-repo fallback when the repo lacks its own `repo.json`.

Issues filed separately.

## Mechanics
4-file lockstep → 0.4.0, CHANGELOG 0.4.0 section, `release-preflight.sh 0.4.0` ✅, full `scripts/check.sh` ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
