### PR TITLE
fix(plugin): guard malformed settings.json + doctor plan/apply parity (#929 follow-up)

### DIFF
--- a/mb/mb/doctor.py
+++ b/mb/mb/doctor.py
@@ -85,7 +85,9 @@ REFERENCE_COMPAT_LINKS = {
 STATE_ORDER = {"ok": 0, "info": 1, "warn": 2, "error": 3}
 AUDIENCE_VALUES = frozenset({"mechanical", "operator_decision", "informational"})
 AGENT_REPAIR_SCOPES = frozenset({"claude", "codex"})
-CLAUDE_ACTION_IDS = frozenset({"skill-link", "skill-shadow-repair", "legacy-claude-link-repair"})
+CLAUDE_ACTION_IDS = frozenset(
+    {"skill-link", "plugin-wiring", "skill-shadow-repair", "legacy-claude-link-repair"}
+)
 CODEX_ACTION_IDS = frozenset({"codex-agents-md", "codex-global-skill"})
 AGENT_ACTION_IDS = CLAUDE_ACTION_IDS | CODEX_ACTION_IDS
 AGENT_SECTION_IDS = frozenset({"claude-wiring", "codex-wiring", "git"})
@@ -2502,6 +2504,27 @@ def repair_plan(
                     ".claude/skills/",
                     ".gitignore",
                 ],
+            )
+        )
+    if not engine_mod.plugin_wiring_status(target).get("wired"):
+        # Plan/apply parity: repair_apply writes plugin wiring when unwired
+        # (gated on apply_claude), so the plan must surface it too — otherwise
+        # `--plan` shows nothing while `--apply` writes a tracked file, breaking
+        # the review-before-apply contract precisely on the Stage-3 migration.
+        actions.append(
+            _action(
+                id="plugin-wiring",
+                title="Wire the Main Branch plugin into tracked settings",
+                state="warn",
+                mode="write",
+                command="mb skill link --repo . --plugin --json",
+                safe_to_apply=True,
+                reason=(
+                    "wires the worktree-durable, cross-surface plugin rail (Claude "
+                    "Desktop + CLI + IDEs) so skill discovery survives worktrees; "
+                    "symlinks remain the fallback (decision 2026-06-10, Stage 3)"
+                ),
+                writes=[".claude/settings.json"],
             )
         )
     if int(shadow_report.get("summary", {}).get("repairable", 0) or 0):

--- a/mb/mb/engine.py
+++ b/mb/mb/engine.py
@@ -952,6 +952,27 @@ def write_plugin_wiring(repo: str | Path) -> dict[str, Any]:
     """
     target = Path(repo).resolve()
     path = _tracked_settings_path(target)
+    # Never clobber a hand-edited-but-broken settings file. `_read_settings`
+    # returns {} for BOTH "absent" and "unparseable"; writing from {} on the
+    # unparseable case would silently destroy the operator's other keys
+    # (permissions, hooks, ...). Refuse and report instead.
+    if path.exists():
+        raw = path.read_text(encoding="utf-8")
+        if raw.strip():
+            try:
+                json.loads(raw)
+            except json.JSONDecodeError as exc:
+                return {
+                    "ok": False,
+                    "changed": False,
+                    "settings_path": str(path),
+                    "wiring": plugin_wiring_status(target),
+                    "summary": (
+                        f".claude/settings.json is not valid JSON ({exc.msg}); refused "
+                        "to write plugin wiring to avoid clobbering your settings — fix "
+                        "the JSON, then re-run."
+                    ),
+                }
     settings = _read_settings(path)
     before = plugin_wiring_status(target)
     marketplaces = settings.setdefault("extraKnownMarketplaces", {})

--- a/mb/tests/test_doctor.py
+++ b/mb/tests/test_doctor.py
@@ -2062,3 +2062,60 @@ def test_doctor_claude_code_detail_is_path_when_present(tmp_path: Path, monkeypa
     check = next(c for c in report["checks"] if c["name"] == "claude-code")
     assert check["ok"] is True
     assert check["detail"] == "/usr/local/bin/claude"
+
+
+def test_doctor_repair_plan_surfaces_plugin_wiring_on_symlink_era_repo(tmp_path: Path) -> None:
+    # Plan/apply parity: on a symlink-healthy-but-unwired repo, `--plan` must
+    # show the plugin-wiring action that `--apply` would perform — otherwise the
+    # write happens without preview (the contract doctor itself instructs).
+    repo = tmp_path / "biz"
+    init_run(path=str(repo), name="Acme")
+    (repo / ".claude" / "settings.json").unlink()
+    assert engine_mod.plugin_wiring_status(repo)["wired"] is False
+
+    plan = doctor_mod.repair_plan(repo, only="claude")
+    actions = {action["id"]: action for action in plan["actions"]}
+    assert "plugin-wiring" in actions
+    assert actions["plugin-wiring"]["mode"] == "write"
+    assert ".claude/settings.json" in actions["plugin-wiring"]["writes"]
+
+
+def test_doctor_repair_plan_omits_plugin_wiring_when_already_wired(tmp_path: Path) -> None:
+    repo = tmp_path / "biz"
+    init_run(path=str(repo), name="Acme")  # init wires the plugin by default
+    assert engine_mod.plugin_wiring_status(repo)["wired"] is True
+
+    plan = doctor_mod.repair_plan(repo, only="claude")
+    assert "plugin-wiring" not in {action["id"] for action in plan["actions"]}
+
+
+def test_doctor_repair_apply_already_wired_is_noop_for_plugin(tmp_path: Path) -> None:
+    # The `not wired` guard must keep apply from re-firing on an already-wired repo.
+    repo = tmp_path / "biz"
+    init_run(path=str(repo), name="Acme")
+    assert engine_mod.plugin_wiring_status(repo)["wired"] is True
+
+    applied = doctor_mod.repair_apply(repo=repo, only="claude")
+    assert "plugin-wiring" not in {action["id"] for action in applied["applied_actions"]}
+
+
+def test_doctor_repair_apply_plugin_migration_requires_claude_scope(tmp_path: Path) -> None:
+    # Pin the scope contract: only `--only claude` / `--all-agents` migrate the
+    # plugin. Bare `--apply` and `--only codex` do NOT (matching skill-link).
+    # See issue #931 for the UX question this raises.
+    repo = tmp_path / "biz"
+    init_run(path=str(repo), name="Acme")
+    (repo / ".claude" / "settings.json").unlink()
+    assert engine_mod.plugin_wiring_status(repo)["wired"] is False
+
+    codex_only = doctor_mod.repair_apply(repo=repo, only="codex")
+    assert "plugin-wiring" not in {action["id"] for action in codex_only["applied_actions"]}
+    assert engine_mod.plugin_wiring_status(repo)["wired"] is False
+
+    bare = doctor_mod.repair_apply(repo=repo)
+    assert "plugin-wiring" not in {action["id"] for action in bare["applied_actions"]}
+    assert engine_mod.plugin_wiring_status(repo)["wired"] is False
+
+    scoped = doctor_mod.repair_apply(repo=repo, all_agents=True)
+    assert "plugin-wiring" in {action["id"] for action in scoped["applied_actions"]}
+    assert engine_mod.plugin_wiring_status(repo)["wired"] is True

--- a/mb/tests/test_engine.py
+++ b/mb/tests/test_engine.py
@@ -492,6 +492,25 @@ def test_plugin_wiring_preserves_existing_settings(tmp_path: Path) -> None:
     )
 
 
+def test_plugin_wiring_refuses_to_clobber_malformed_settings(tmp_path: Path) -> None:
+    # A hand-edited-but-broken settings file (trailing comma) must NOT be
+    # overwritten — that would silently destroy the operator's other keys.
+    path = tmp_path / ".claude" / "settings.json"
+    path.parent.mkdir(parents=True)
+    malformed = '{\n  "permissions": {"allow": ["Bash(ls:*)"]},\n}\n'
+    path.write_text(malformed, encoding="utf-8")
+
+    result = engine_mod.write_plugin_wiring(tmp_path)
+
+    assert result["ok"] is False
+    assert result["changed"] is False
+    assert "not valid JSON" in result["summary"]
+    # File is untouched: bytes unchanged, no plugin keys injected.
+    assert path.read_text(encoding="utf-8") == malformed
+    assert "enabledPlugins" not in path.read_text(encoding="utf-8")
+    assert engine_mod.plugin_wiring_status(tmp_path)["wired"] is False
+
+
 def test_worktree_summary_mentions_plugin_rail_when_wired(tmp_path: Path) -> None:
     import subprocess
 

--- a/mb/tests/test_init.py
+++ b/mb/tests/test_init.py
@@ -402,6 +402,7 @@ def test_init_wires_plugin_by_default(tmp_path: Path) -> None:
     assert status["plugin_enabled"] is True
     # Tracked settings (committed), not the gitignored local file.
     assert (target / ".claude" / "settings.json").exists()
+    assert ".claude/settings.json" in result["created"]
 
 
 def test_init_already_initialized_backfills_plugin_wiring(tmp_path: Path) -> None:
@@ -414,3 +415,4 @@ def test_init_already_initialized_backfills_plugin_wiring(tmp_path: Path) -> Non
     second = run(path=str(target), name="Acme")
     assert second["status"] == "already-initialized"
     assert engine_mod.plugin_wiring_status(target)["wired"] is True
+    assert ".claude/settings.json" in second["created"]

--- a/mb/tests/test_onboard.py
+++ b/mb/tests/test_onboard.py
@@ -184,6 +184,34 @@ def test_onboard_connect_repairs_existing_initialized_repo(tmp_path: Path, monke
     assert result["skill_wiring"]["ok"] is True
 
 
+def test_onboard_connect_backfills_plugin_wiring(tmp_path: Path, monkeypatch) -> None:
+    # The connect path is how a symlink-era repo gets migrated when the operator
+    # runs `mb onboard` rather than `mb doctor`. Lock that it wires the plugin.
+    from mb import engine as engine_mod
+
+    monkeypatch.setattr(onboard_mod, "_which", _tool_path)
+    repo = tmp_path / "acme"
+    onboard_mod.run(
+        path=str(repo),
+        name="Acme",
+        mode="new",
+        level="power",
+        team_size="solo",
+        business_type="coaching",
+        success_stage="working",
+        desired_outcome="usable core files",
+    )
+    # Simulate symlink-era: drop the tracked plugin wiring.
+    (repo / ".claude" / "settings.json").unlink()
+    assert engine_mod.plugin_wiring_status(repo)["wired"] is False
+
+    result = onboard_mod.run(path=str(repo), name="", mode="connect", level="power")
+
+    assert result["ok"] is True
+    assert engine_mod.plugin_wiring_status(repo)["wired"] is True
+    assert ".claude/settings.json" in result["created"]
+
+
 def test_onboard_connect_missing_repo_routes_to_doctor(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(onboard_mod, "_which", _tool_path)
     repo = tmp_path / "missing"


### PR DESCRIPTION
## What

Two **MAJOR correctness fixes** for the Stage-3 plugin rail ([#929](https://github.com/noontide-co/mainbranch/pull/929)), surfaced by an adversarial multi-agent review of the cumulative 0.4.1 diff, plus the test coverage that locks the migration paths the plugin-first guidance ([#930](https://github.com/noontide-co/mainbranch/pull/930)) routes operators into. Both were confirmed by live repro.

## Fix 1 — `engine.py`: never clobber a malformed `.claude/settings.json` (data loss)

`_read_settings` returns `{}` for **both** "absent" and "unparseable". So a hand-edited-but-broken settings file (e.g. a trailing comma) was silently overwritten by `write_plugin_wiring`, destroying the operator's other keys (`permissions`, hooks, …). Reproduced: `{"permissions": {...},}` came out as just the two plugin keys.

`write_plugin_wiring` now detects the exists-but-unparseable case and **refuses to write** — returns `ok=False` with a "fix the JSON" summary — instead of clobbering. The valid-JSON merge path (and the absent-file create path) are unchanged. Fires on every wiring path: `mb init` (both branches), `mb onboard` connect, `mb doctor repair`.

## Fix 2 — `doctor.py`: plan/apply parity for plugin wiring

`repair_apply` writes plugin wiring on an unwired repo (gated on `apply_claude`), but `repair_plan` never surfaced it — so `repair --plan --only claude` showed nothing while `--apply --only claude` wrote a tracked `.claude/settings.json`. That's a write-without-preview violation, precisely on the Stage-3 migration this feature performs.

`repair_plan` now emits the same `plugin-wiring` action when unwired, and `plugin-wiring` joins `CLAUDE_ACTION_IDS` so it survives scope filtering — making it **mirror `skill-link`'s scoping exactly** (the existing correct pattern: shown in bare/claude/all-agents plans; applied only under `--only claude` / `--all-agents`).

## Tests (each gap was mutation-confirmed regression-invisible)

- `test_engine`: malformed settings.json is refused, the file is byte-for-byte untouched, no plugin keys injected.
- `test_doctor`: plan surfaces `plugin-wiring` on a symlink-era repo; omits it when already wired; apply is a no-op when wired; **migration requires `--only claude` / `--all-agents`** — bare `--apply` and `--only codex` do NOT migrate (pins the contract; the UX question is filed as [#931](https://github.com/noontide-co/mainbranch/issues/931)).
- `test_onboard`: the connect path backfills plugin wiring (`wired` flips False→True, `.claude/settings.json` in `created`).
- `test_init`: `.claude/settings.json` appears in `created` (fresh + already-initialized backfill).

## Verification

- `scripts/check.sh` green from repo root (ruff format + check, mypy, full pytest+coverage ≥79%, `mb skill validate --all`, line gate, docs-naming).
- Full affected suites green: `test_doctor` + `test_engine` + `test_onboard` + `test_init` + `test_json_result` (159 passed).

## Related

Follow-up issues filed from the same review: [#931](https://github.com/noontide-co/mainbranch/issues/931) (`mb update` / bare-apply migration UX), [#932](https://github.com/noontide-co/mainbranch/issues/932) (symlink-era language cleanup).

Refs #929, #930.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
