### PR TITLE
feat(help): discoverable skills inventory + natural-phrase aliases for pre-publish review (#927)

### DIFF
--- a/.claude/skills/mb-help/SKILL.md
+++ b/.claude/skills/mb-help/SKILL.md
@@ -37,7 +37,8 @@ for repair facts before giving prose-only advice.
 | Error, command not found, MCP, Apify setup, GitHub issue | [troubleshooting.md](references/troubleshooting.md) |
 | Provider readiness, GitHub setup, Cloudflare, Google Workspace, Meta Ads, Apify | [provider-readiness.md](references/provider-readiness.md) |
 | Getting started, setup | Route to `/mb-setup` or `/mb-start` |
-| Which skill, when to use | [skills-guide.md](references/skills-guide.md) |
+| Which skill, when to use, list skills, what skills do I have, skills inventory, what can you do, which skills are we using | [skills-guide.md](references/skills-guide.md) |
+| Pre-publish review, UI pass, design pass, design critique, review the page before publish | Route to `/mb-skill-review` (see [skills-guide.md](references/skills-guide.md)) |
 | Create skill, Notion export, custom | [skills-guide.md](references/skills-guide.md) |
 | Migrate from GPT, ChatGPT | [gpt-migration.md](references/gpt-migration.md) |
 | Reels, TikTok, organic, /mb-organic | [organic-help.md](references/organic-help.md) |

--- a/.claude/skills/mb-help/references/skills-guide.md
+++ b/.claude/skills/mb-help/references/skills-guide.md
@@ -170,15 +170,43 @@ accepts that change.
 ---
 
 ### /mb-help - Get Answers
-**Use when:** Confused, stuck, have questions about Main Branch.
+**Use when:** Confused, stuck, have questions about Main Branch, or want to know what skills you have and when each fires.
 
 **What it does:**
 - Answers questions from documented curriculum
 - Troubleshoots errors
 - Explains concepts
+- Lists your skills and when to use each (this guide)
 - Suggests next skills
 
 **You're using it now.**
+
+---
+
+### /mb-status - Repo Briefing
+**Use when:** You want the deterministic state of the business — readiness, drift, MoneyPath, recent work, connected tools, tasks/proposals — as a standalone read.
+
+**What it does:**
+- Reads `mb status --json --peek` and explains it in business language
+- `/mb-start` reads these same facts internally; reach for `/mb-status` when you only want the briefing
+
+---
+
+### /mb-update - Keep the Engine Current
+**Use when:** Main Branch says an update matters, or you want to check for one.
+
+**What it does:**
+- Checks installed vs latest, applies the package update on approval, refreshes wiring
+- If you run the Claude Code plugin, re-add it and restart so the loaded skills match the new release
+
+---
+
+### /mb-skill-review - Pre-Publish Review (UI / design pass)
+**Use when:** You want a **pre-publish review**, a **UI pass**, a **design pass**, or a **design critique** of a page or copy draft before it ships. This is the built-in review — reach for it instead of a third-party UI-review skill.
+
+**What it does:**
+- Runs the dial-gated Seven Sweeps + auxiliary review gates and returns synthesized findings
+- Called automatically by `/mb-site` at pre-lock and pre-publish; reusable by `/mb-ads` and sales-video work
 
 ---
 
@@ -207,6 +235,12 @@ What do you need?
 │
 ├── Build a landing page or site?
 │   └── /mb-site (lander, minisite, or website)
+│
+├── Review a page/copy before publishing? (UI / design pass)
+│   └── /mb-skill-review
+│
+├── Check or apply an engine update?
+│   └── /mb-update
 │
 ├── Done for the day?
 │   └── /mb-end

--- a/.claude/skills/mb-skill-review/SKILL.md
+++ b/.claude/skills/mb-skill-review/SKILL.md
@@ -2,7 +2,7 @@
 name: mb-skill-review
 tier: skill
 calls: []
-description: "Run dial-gated Seven Sweeps + auxiliary gates against a brief or copy draft. Returns synthesized findings to the operator. Used by /mb-site at pre-lock and pre-publish moments. Reusable by /mb-ads and sales-video workflows."
+description: "Pre-publish review / UI pass / design pass / design critique for a brief or copy draft: runs dial-gated Seven Sweeps + auxiliary gates and returns synthesized findings. Use when: the operator asks for a pre-publish review, a UI pass, a design pass, a design critique, or to review a page before publishing. Called by /mb-site at pre-lock and pre-publish; reusable by /mb-ads and sales-video workflows."
 loops: [reflect]
 ---
 


### PR DESCRIPTION
## What

A second operator couldn't see what skills existed ("which skills are we using when building out the site?") and reached for a third-party UI-review skill because `mb-skill-review`'s "Seven Sweeps + auxiliary gates" framing isn't memorable as "the pre-publish UI review." ([#927](https://github.com/noontide-co/mainbranch/issues/927))

## Fix (parts 1 + 2)

- **`mb-skill-review` SKILL.md** — lead the description with the words operators actually use: **"pre-publish review / UI pass / design pass / design critique"** + an explicit `Use when:`, so the runtime surfaces the built-in review for those phrases instead of jargon. (Confirmed live: it now appears as an available skill under the new description.)
- **`skills-guide.md`** — complete the inventory: add **mb-status, mb-update, mb-skill-review** sections (the guide was missing all three), plus a pre-publish-review branch and an engine-update branch in the Decision Tree. This is the `/mb-help skills` one-pager #927 asked for (it already existed; now it's complete and reachable).
- **`mb-help` SKILL.md** — broaden the skills-listing trigger keywords (*list skills, what skills do I have, skills inventory, what can you do, which skills are we using*) and route the review phrases to `/mb-skill-review`.

## Part 3 — deferred (not built)

The minor Theme-7 item (an `mb start` "what I'm queued on" line) needs a **defined source** before building — assigned issues / open proposals / ranked actions (all already in the status payload) vs. a new pending-request inbox primitive. Building an inbox would be over-engineering for a "minor" observation. I'll note this on #927 and leave it open for that decision.

## Verification

- `scripts/check.sh` green from repo root (skill validate 15/15, operator-docs language gate on the changed mb-help, discoverability gate, runtime-command-references gate — all the new `/mb-*` references are bundled skills).

Refs #927 (parts 1 + 2; part 3 deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
