### PR TITLE
feat(update): surface plugin-rail migration guidance for symlink-era repos (#931)

### DIFF
--- a/mb/mb/update.py
+++ b/mb/mb/update.py
@@ -13,7 +13,7 @@ from typing import Any
 
 from mb import __version__
 from mb import codex as codex_mod
-from mb.engine import bundled_skills, engine_root, install_mode
+from mb.engine import bundled_skills, engine_root, install_mode, plugin_wiring_status
 from mb.freshness import (
     latest_pypi_version as _latest_pypi_version,
 )
@@ -356,6 +356,32 @@ def _add_codex_follow_up(result: dict[str, Any], repo: Path) -> None:
         result["next_actions"].append("Open a fresh Codex thread in the business repo.")
 
 
+def _add_plugin_follow_up(result: dict[str, Any], repo: Path) -> None:
+    """Surface plugin-rail migration guidance for symlink-era repos (#931).
+
+    `mb update` refreshes the symlink wiring but does not write the tracked
+    plugin wiring, so a repo created before the plugin default stays on
+    symlinks even though the plugin is the default cross-surface rail. Name the
+    one-command migration as post-update guidance — never an automatic write.
+    """
+    status = plugin_wiring_status(repo)
+    result["plugin_rail"] = {
+        "wired": status.get("wired", False),
+        "marketplace_known": status.get("marketplace_known", False),
+        "plugin_enabled": status.get("plugin_enabled", False),
+        "settings_path": status.get("settings_path", ""),
+    }
+    if not status.get("wired", False):
+        result["warnings"].append(
+            "This repo is on symlink-only skill wiring. The Main Branch plugin is "
+            "the default cross-surface rail (Claude Desktop and the terminal, and "
+            "it survives git worktrees). Migrate when you're ready with "
+            "`mb skill link --repo . --plugin` (or `mb doctor repair --apply "
+            "--all-agents`), then restart Claude Code."
+        )
+        result["next_actions"].append("mb skill link --repo . --plugin --json")
+
+
 def run(
     repo: str | Path = ".",
     *,
@@ -446,6 +472,7 @@ def run(
                 "source": "not_newer",
             }
         _add_codex_follow_up(result, target_repo)
+        _add_plugin_follow_up(result, target_repo)
         return result
 
     if mode == "pipx":
@@ -516,6 +543,7 @@ def run(
     else:
         result["actions"].append("skipped agent surface refresh")
     _add_codex_follow_up(result, target_repo)
+    _add_plugin_follow_up(result, target_repo)
     return result
 
 

--- a/mb/tests/test_update.py
+++ b/mb/tests/test_update.py
@@ -54,6 +54,22 @@ def codex_adapter_ready(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
 
+@pytest.fixture(autouse=True)
+def plugin_rail_wired(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Default: repo is already on the plugin rail, so the #931 follow-up stays
+    # quiet. Tests that exercise the symlink-era path override this.
+    monkeypatch.setattr(
+        update_mod,
+        "plugin_wiring_status",
+        lambda repo: {
+            "wired": True,
+            "marketplace_known": True,
+            "plugin_enabled": True,
+            "settings_path": str(Path(repo) / ".claude" / "settings.json"),
+        },
+    )
+
+
 def _completed(
     args: list[str],
     *,
@@ -960,3 +976,44 @@ def test_update_render_human_success(capsys: Any) -> None:
 
     assert "updated Main Branch (0.1.2 -> 0.2.0)" in output
     assert "refreshed 4 skill link(s)" in output
+
+
+def test_update_reports_plugin_rail_wired_without_warning(monkeypatch: Any, tmp_path: Path) -> None:
+    # Default fixture: repo already on the plugin rail -> no migration warning.
+    monkeypatch.setattr(update_mod, "install_mode", lambda: "pipx")
+    monkeypatch.setattr(update_mod, "engine_root", lambda: tmp_path / "_engine")
+    monkeypatch.setattr(update_mod, "_latest_pypi_version", lambda: "9.9.9")
+    monkeypatch.setattr(update_mod, "bundled_skills", lambda: ["mb-start", "mb-status"])
+
+    result = update_mod.run(repo=tmp_path / "biz", check=True)
+
+    assert result["plugin_rail"]["wired"] is True
+    assert not any("symlink-only skill wiring" in w for w in result["warnings"])
+    assert "mb skill link --repo . --plugin --json" not in result["next_actions"]
+
+
+def test_update_surfaces_plugin_migration_for_symlink_era_repo(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    # #931: a repo that predates the plugin default stays on symlinks after
+    # `mb update`; the post-update follow-up names the one-command migration.
+    monkeypatch.setattr(
+        update_mod,
+        "plugin_wiring_status",
+        lambda repo: {
+            "wired": False,
+            "marketplace_known": False,
+            "plugin_enabled": False,
+            "settings_path": str(tmp_path / "biz" / ".claude" / "settings.json"),
+        },
+    )
+    monkeypatch.setattr(update_mod, "install_mode", lambda: "pipx")
+    monkeypatch.setattr(update_mod, "engine_root", lambda: tmp_path / "_engine")
+    monkeypatch.setattr(update_mod, "_latest_pypi_version", lambda: "9.9.9")
+    monkeypatch.setattr(update_mod, "bundled_skills", lambda: ["mb-start", "mb-status"])
+
+    result = update_mod.run(repo=tmp_path / "biz", check=True)
+
+    assert result["plugin_rail"]["wired"] is False
+    assert any("symlink-only skill wiring" in w for w in result["warnings"])
+    assert "mb skill link --repo . --plugin --json" in result["next_actions"]


### PR DESCRIPTION
## What

`mb update` refreshes symlink wiring (`mb skill link`, **no `--plugin`**) and runs `doctor repair --only codex` — **neither writes the tracked plugin wiring**. So a repo created before the Stage-3 plugin default ([#929](https://github.com/noontide-co/mainbranch/pull/929)) stays on symlinks after an update. The upgrade population — the people most likely to read the new "plugin is the default rail" guidance ([#930](https://github.com/noontide-co/mainbranch/pull/930)) — never get migrated by the obvious command. ([#931](https://github.com/noontide-co/mainbranch/issues/931))

## Fix

`_add_plugin_follow_up`: after update (both the already-current early return and the did-update path), report a `plugin_rail` status block and, when the repo isn't wired, append a post-update **warning + next action** naming the one-command migration:

```
mb skill link --repo . --plugin      (or: mb doctor repair --apply --all-agents)
```

Guidance only — **never an automatic write**, consistent with the rest of `mb update`'s approval posture. `render_human` already prints `warnings`/`next_actions`, so it surfaces on the human path too.

## Tests

- `test_update`: symlink-era repo → `plugin_rail.wired` False + migration warning + `mb skill link --repo . --plugin --json` in `next_actions`; already-wired repo → no warning. An autouse `plugin_rail_wired` fixture keeps the rest of the suite on the wired (quiet) path.

## Scope

Closes the **un-gated half** of #931. The separate question — should bare `mb doctor repair --apply` (no scope) migrate plugin wiring by default, or is requiring `--all-agents`/`--only claude` correct? — stays on #931 for Devon; this PR doesn't change apply scope.

`scripts/check.sh` green from repo root. Refs #931.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
