### PR TITLE
docs(help): frame the plugin as the primary rail in symlink-era guidance (#932)

### DIFF
--- a/.claude/skills/mb-help/references/terminal-basics.md
+++ b/.claude/skills/mb-help/references/terminal-basics.md
@@ -57,7 +57,7 @@ This tells Terminal: "Go to the my-business folder inside GitHub inside Document
 
 **The `~` symbol means "my home folder."**
 
-After running this, you're now "in" your business repo folder. If you type `claude`, Claude starts with access to everything in that folder. Main Branch is linked through `.claude/settings.local.json`, with bridge links as a compatibility fallback for skill discovery.
+After running this, you're now "in" your business repo folder. If you type `claude`, Claude starts with access to everything in that folder. Main Branch loads as a Claude Code plugin — the same plugin works in the Claude Desktop app and the terminal — and a project-local `.claude/settings.local.json` with bridge links is the compatibility fallback for skill discovery.
 
 ---
 
@@ -69,7 +69,7 @@ When someone says "start Claude in your business repo," they mean:
 2. Type `cd ~/Documents/GitHub/[your-business]` and press Enter
 3. Type `claude` and press Enter
 
-Now Claude is running AND it can see all the files in your business repo. Main Branch is linked via `.claude/settings.local.json` (and bridge links when needed).
+Now Claude is running AND it can see all the files in your business repo. Main Branch loads as a Claude Code plugin, with a project-local `.claude/settings.local.json` and bridge links as the fallback.
 
 **Why this matters:** Claude Code can only see files in folders you give it access to. Starting in your business repo means Claude sees your reference files directly. Main Branch is linked by setup so you don't have to wire this manually.
 
@@ -87,7 +87,7 @@ claude
 That's it. Three lines. Copy and paste them if needed.
 
 1. `cd ~/Documents/GitHub/[your-business]` - Go to your business repo folder
-2. `claude` - Start Claude Code (Main Branch linkage comes from `.claude/settings.local.json`)
+2. `claude` - Start Claude Code (Main Branch loads as a plugin; `.claude/settings.local.json` is the fallback)
 3. `/mb-start` - Tell Claude to check your setup and get ready
 
 ---

--- a/.claude/skills/mb-help/references/workspace-setup.md
+++ b/.claude/skills/mb-help/references/workspace-setup.md
@@ -1,5 +1,10 @@
 # Workspace-Isolated Tool Setup
 
+In normal Claude Code — the Claude Desktop app or the terminal — the Main Branch
+plugin handles skill discovery and you do not need this page. It covers
+workspace-isolated tools where the plugin (and the installed package) are not
+reachable, so bridge links and `settings.local.json` file access are the fallback.
+
 Some workspace tools start Claude inside an isolated folder. When that happens,
 Claude may not see the installed Main Branch skills until the workspace has
 local bridge links and `settings.local.json` file access.

--- a/.claude/skills/mb-setup/SKILL.md
+++ b/.claude/skills/mb-setup/SKILL.md
@@ -470,7 +470,7 @@ Once setup is complete, tell the user:
 > claude
 > /mb-start
 > ```
-> Main Branch linkage is managed by setup (`settings.local.json` + compatibility bridge links) — no need to touch the Main Branch package or source-checkout folder.
+> Main Branch loads as a Claude Code plugin (Desktop or terminal); setup also writes a `settings.local.json` + bridge-link fallback — no need to touch the Main Branch package or source-checkout folder.
 >
 > **Key skills to try:**
 > - `/mb-think` — Research topics, make decisions, update reference


### PR DESCRIPTION
## What

With the plugin now the default Claude Code rail ([#929](https://github.com/noontide-co/mainbranch/pull/929)/[#930](https://github.com/noontide-co/mainbranch/pull/930)), several mb-help references still presented project-local `settings.local.json` + bridge links as the **primary** linkage mechanism. Reframe so the plugin leads and symlink wiring is the fallback. ([#932](https://github.com/noontide-co/mainbranch/issues/932))

- **`terminal-basics.md`** — the three "Main Branch is linked through `settings.local.json`" lines now say Main Branch loads as a plugin (Desktop or terminal), with `settings.local.json` + bridge links as the fallback.
- **`mb-setup` SKILL.md** — the linkage note leads with the plugin (in-place reword; file stays at the 500-line gate).
- **`workspace-setup.md`** — a framing line up top: in normal Claude Code the plugin handles discovery; this page is the **workspace-isolated-tool** fallback, where the plugin and the installed package aren't reachable (so bridge links are genuinely the right path there — not rewritten to plugin-first, which would be wrong for that case).

## Scope

Docs-only. Left as-is: `migrating.md` (already acknowledges the plugin rail and frames symlinks as the repair/fallback path) and `system-model.md` (no symlink language). No banned operator-doc terms introduced.

`scripts/check.sh` green from repo root. Closes #932.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
