### PR TITLE
Clarify Claude plugin command contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,8 +412,9 @@ that write approved business artifacts back into files you own.
 **I'm stuck.** In Claude Code, type `/mb-start` again. In Codex, use the global
 `mb-start` skill again. If `/mb-start` is not found at all, the Main Branch
 plugin may not be installed — add it with `claude plugin marketplace add
-noontide-co/mainbranch`, enable it, and restart Claude Code. The plugin works in
-both the Claude Desktop app and the terminal.
+noontide-co/mainbranch`, enable it, and restart Claude Code. The plugin-native
+diagnostic command is `/mainbranch:mb-start`; the friendly `/mb-start` command
+comes from the project-local bridge Main Branch keeps wired for users.
 
 ---
 

--- a/docs/beginner-setup.md
+++ b/docs/beginner-setup.md
@@ -201,10 +201,12 @@ repairs, updates, or closing a session.
 
 In Codex, use the global `mb-start` skill instead of typing the slash command.
 
-If `/mb-start` does not appear in Claude Code, the Main Branch plugin is not
-installed or enabled yet. Add it with `claude plugin marketplace add
-noontide-co/mainbranch`, enable it, and restart Claude Code from this folder.
-The plugin works in both the Claude Desktop app and the terminal.
+If `/mb-start` does not appear in Claude Code, the Main Branch plugin may not be
+installed or enabled yet, or the project-local bridge may need repair. Add the
+plugin with `claude plugin marketplace add noontide-co/mainbranch`, enable it,
+and restart Claude Code from this folder. The plugin works in both the Claude
+Desktop app and the terminal. For direct plugin diagnostics, use
+`/mainbranch:mb-start`.
 
 Daily use is:
 

--- a/docs/claude-code-invocation-contract.md
+++ b/docs/claude-code-invocation-contract.md
@@ -2,7 +2,7 @@
 
 This is the supported Claude Code invocation contract for Main Branch. It is
 based on Claude Code 2.1.126 runtime smoke from a fresh `mb onboard` business
-repo on May 7, 2026.
+repo on May 7, 2026, plus the Stage 3 plugin rail contract from June 2026.
 
 ## Supported Path
 
@@ -22,7 +22,20 @@ Then type:
 Main Branch skills are Claude Code skills under `.claude/skills/<name>/SKILL.md`.
 `mb onboard`, `mb init`, and `mb skill link --repo .` create project-local
 bridge links such as `.claude/skills/mb-start` in the business repo. Those
-bridge links are the supported slash-command discovery surface.
+bridge links keep the supported, friendly slash-command surface.
+
+Main Branch also wires the Claude Code plugin in tracked `.claude/settings.json`
+so skill distribution survives fresh git worktrees and works across the Claude
+Desktop app and the terminal. Claude Code plugin-native skills are namespaced,
+so the direct plugin smoke command is:
+
+```text
+/mainbranch:mb-start
+```
+
+That command is for release validation and diagnostics. Public setup and support
+docs should still tell users to type `/mb-start` for the daily entrypoint while
+Main Branch keeps the project-local bridge wired.
 
 `.claude/settings.local.json` also points Claude Code at the active Main Branch
 engine through `additionalDirectories`. That setting gives the runtime file
@@ -70,6 +83,12 @@ Then restart Claude Code from the business repo and type `/mb-start` again.
 Claude Code loads skill discovery at session start, so relinking usually
 requires a restart before the slash command appears.
 
+If the plugin itself needs verification, install or refresh it with
+`claude plugin marketplace add noontide-co/mainbranch`, enable it, restart or
+run `/reload-plugins`, and check `/mainbranch:mb-start`. Do not replace the
+user-facing `/mb-start` guidance with the namespaced command unless the bridge
+contract is intentionally removed.
+
 `mb skill link --repo .` creates the project-local bridge links and also moves
 known stale or broken Main Branch personal-skill shadows to backups. If
 `/mb-start` is still missing afterward, run `mb skill repair --repo .` to
@@ -97,3 +116,7 @@ Fresh-repo smoke covered:
   `Unknown command: /mb-start`;
 - relink repair: `mb skill link --repo .` restored the project-local bridge and
   `/mb-start` was recognized again.
+
+Plugin-native command discovery (`/mainbranch:mb-start`) is covered by the
+manual plugin-load release gate in `docs/release-agent-contract.md` whenever a
+release changes plugin wiring, manifests, or plugin-first runtime guidance.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -164,7 +164,7 @@ smoke evidence exist.
 
 | Runtime surface | Status | Invocation | Skill/workflow discovery | Routing and automation | Observability and packaging |
 |---|---|---|---|---|---|
-| Claude Code | Supported | `mb start --repo "$repo"` prints the `claude` handoff; `mb start --launch` may launch after readiness checks. | `mb skill link --repo "$repo"` writes project-local `.claude/skills/mb-*` bridge links and `.claude/settings.local.json`. | Slash commands such as `/mb-start` and `/mb-think` own conversation and judgment; they call deterministic `mb` commands for facts. | `mb doctor`, `mb status --json`, `mb start --json`, `mb skill repair`, and runtime dogfood evidence gate release claims. Skills ship inside the Python package today. |
+| Claude Code | Supported | `mb start --repo "$repo"` prints the `claude` handoff; `mb start --launch` may launch after readiness checks. The normal user command stays `/mb-start` through the project-local bridge. Plugin-native skills are namespaced, so `/mainbranch:mb-start` is the direct plugin smoke command. | `mb init`, `mb onboard`, and scoped Claude repair write the shared plugin wiring in `.claude/settings.json` and keep project-local `.claude/skills/mb-*` bridge links for friendly slash commands. `mb skill link --repo "$repo"` refreshes the bridge fallback and `.claude/settings.local.json`. | Slash skills such as `/mb-start` own conversation and judgment; they call deterministic `mb` commands for facts. Release smoke also proves the namespaced plugin command. | `mb doctor`, `mb status --json`, `mb start --json`, `mb skill repair`, and runtime dogfood evidence gate release claims. The plugin is the durable distribution rail; packaged project-local skill links keep the friendly compatibility command. |
 | Codex CLI | Supported | Can call deterministic `mb` commands as a subprocess when pointed at a business repo. `AGENTS.md` gives Codex the repo bootstrap, and global Main Branch skills give Codex `mb-*` workflow routes. | Fresh `mb onboard` repos include tracked `AGENTS.md`. `mb doctor repair --plan --only codex` / `--apply --only codex` refresh repo guidance and install or repair the global Codex skill bundle. Use `--all-agents` only after reviewing both Claude and Codex surface writes. | Codex `mb-*` skills run `mb status --json --peek`, `mb start --json`, `mb doctor repair --plan --json`, `mb checkpoint --plan --json`, `mb validate --json`, and `mb workflow list --runtime codex --json` as needed, translate facts into business language, and ask before writes. | `mb doctor`, `mb status --json`, `mb start --json`, and `mb workflow list` expose Codex readiness and workflow support. Codex support covers start/status/setup/update/doctor, think/codify, end/checkpoint/save, validate, and workflow discovery. Ads, organic, site, and bet routes remain read-only planning unless their support level says otherwise. Draft/manual playbooks are inventory-only or surfaced behind first-class routes such as `mb-ads`; retired provisional playbook skeletons are not default Codex routes, and stale generated global skill dirs are cleaned up only when Main Branch markers prove ownership. |
 | Cursor | Roadmap | Can call deterministic `mb` commands from terminal/tasks when pointed at a business repo. | No supported Cursor rules/package adapter yet. | No supported Main Branch routing contract. | Needs adapter docs, install/update rules, conflict handling, and smoke evidence. |
 | OpenClaw | Roadmap | Target public runtime surface. It should call `mb` through stable CLI/JSON commands rather than clone-era paths. | No supported OpenClaw adapter yet. | Main Branch should coexist with OpenClaw as the business repo/GitHub memory layer, not replace it. | Needs explicit adapter shape, migration notes, generated-file rules, and smoke evidence. |
@@ -187,7 +187,7 @@ support still requires an adapter and smoke evidence for that runtime.
 |---|---|---|
 | Deterministic CLI facts (`mb status --json`, `mb validate --json`, `mb graph --json`, `mb connect status --json`) | Supported when `mb` is installed and pointed at a business repo. | Callable as packaged CLI subprocesses, but this does not make the hosting runtime supported. |
 | Runtime handoff (`mb start --json`, `mb start --launch`) | Supported for Claude Code handoff and launch readiness. | Codex CLI handoff metadata is supported for global skill readiness: `mb start --json` reports Codex executable, `AGENTS.md`, global skills, and runtime `mb` readiness. `mb` does not launch Codex. |
-| Lifecycle slash skills (`/mb-start`, `/mb-status`, `/mb-setup`, `/mb-update`, `/mb-end`, `/mb-help`) | Supported through Claude Code project-local skill discovery. | Codex supports matching global skills (`mb-start`, `mb-status`, `mb-setup`, `mb-update`, `mb-doctor`, `mb-end`, `mb-help`) grounded in deterministic `mb` facts. |
+| Lifecycle slash skills (`/mb-start`, `/mb-status`, `/mb-setup`, `/mb-update`, `/mb-end`, `/mb-help`) | Supported through the hybrid Claude Code rail: plugin wiring for durability, project-local bridge links for friendly bare slash commands, and namespaced `/mainbranch:mb-*` commands for direct plugin smoke. | Codex supports matching global skills (`mb-start`, `mb-status`, `mb-setup`, `mb-update`, `mb-doctor`, `mb-end`, `mb-help`) grounded in deterministic `mb` facts. |
 | Production slash skills (`/mb-think`, `/mb-ads`, `/mb-organic`, `/mb-site`, `/mb-wiki`, `/mb-bet`) | Supported through Claude Code skills, subject to each skill's provider and workflow limits. Conversion scripts route through the owning workflow instead of a standalone primitive or skill. | Codex supports `mb-think` through shared workflow source and global skills. Ads, organic/newsletter, site, and bet routes now have shared workflow sources and generated global skills, but their Codex support remains read-only planning unless `mb workflow list --runtime codex --json` reports a higher support level. Playbooks are inventory-only or surfaced behind first-class routes such as `mb-ads`; provisional playbook skills are hidden from the default global skill bundle. Wiki and skill-authoring workflows are intentionally unsupported for the current Codex target. |
 | Automation routines | May call CLI commands before handing judgment work to Claude Code. | May call shipped deterministic CLI commands against an explicit repo path. Conversation, retries, routing, and model invocation belong to the runtime adapter, not `mb`. |
 
@@ -285,21 +285,27 @@ mb doctor
 
 ## Known Limits
 
-- Claude Code is supported through project-local slash skills.
+- Claude Code is supported through a hybrid rail: the Main Branch plugin is the
+  durable distribution path, and project-local slash skills keep the friendly
+  `/mb-start` user command. Plugin-native skills use the `mainbranch:`
+  namespace, such as `/mainbranch:mb-start`, and are release-smoked directly.
 - Codex CLI is supported through global Main Branch `mb-*` skills and
   deterministic `mb` facts. Main Branch does not claim all-skill parity, copied Claude skill
   parity, provider writes, publishing, spend, or customer-contact workflows.
 - Windows is experimental.
-- Skills are bundled into the installed Python package, so public users update
-  skills by upgrading `mainbranch`.
+- Skills are distributed through the Claude Code plugin as the primary rail and
+  bundled into the installed Python package for project-local bridge fallback,
+  so public users update both by upgrading `mainbranch` and reloading or
+  restarting Claude Code.
 - The CLI scaffolds, validates, graphs, resolves, and links the current Claude
   Code skill adapter. Most business workflows still happen through Claude Code
   slash commands.
-- Claude Code slash-command discovery depends on project-local
-  `.claude/skills/mb-*` bridge links in the business repo. The
-  `.claude/settings.local.json` `additionalDirectories` entry grants engine
-  file access, but it is not enough by itself for reliable `/mb-start`
-  discovery.
+- Claude Code plugin discovery depends on the shared plugin wiring in
+  `.claude/settings.json`; plugin changes require restart or `/reload-plugins`.
+  The project-local `.claude/skills/mb-*` bridge is intentionally kept so users
+  can type `/mb-start`. The `.claude/settings.local.json` `additionalDirectories`
+  entry grants engine file access, but it is not enough by itself for reliable
+  skill discovery.
 - Cursor, OpenClaw, Hermes, Paperclip-adjacent orchestration, and local
   runtimes remain roadmap surfaces until each has a documented adapter and
   smoke evidence. Codex support is limited to the skill surface above.

--- a/docs/release-agent-contract.md
+++ b/docs/release-agent-contract.md
@@ -221,12 +221,12 @@ guidance that routes operators to the plugin, the release driver must run a
 manual plugin-load smoke before publishing and record it as a validation line:
 
 - `claude plugin marketplace add noontide-co/mainbranch`, enable the plugin,
-  then confirm `/mb-start` (and one other `/mb-*` skill) resolves in **both**
-  the Claude Desktop app **and** the terminal `claude` CLI;
-- record the exact invocation observed — `/mb-start` vs `/mainbranch:mb-start`.
-  If the plugin namespaces skills, the bare-name guidance in `CLAUDE.md`,
-  README, beginner setup, and the skill prose is stale and must be reconciled
-  (or the invocation contract updated) before the tag.
+  then confirm the plugin-native `/mainbranch:mb-start` (and one other
+  `/mainbranch:mb-*` skill) resolves in **both** the Claude Desktop app
+  **and** the terminal `claude` CLI;
+- separately record whether the legacy project-local bridge also exposes
+  `/mb-start`. The bridge is allowed as a compatibility path, but the plugin
+  smoke must prove the namespaced plugin command before the tag.
 
 This is the one true pre-publish gate that lives only here: a green CI run does
 not cover it. "Skipped because no Claude Code build was available" is a valid

--- a/mb/mb/_data/templates/CLAUDE.md.tmpl
+++ b/mb/mb/_data/templates/CLAUDE.md.tmpl
@@ -8,13 +8,13 @@ Main Branch CLI facts are the source of truth for repo health, setup, runtime
 wiring, updates, graph/status signals, provider readiness, and repair paths.
 Main Branch installs as a Claude Code plugin
 (`claude plugin marketplace add noontide-co/mainbranch`, then enable it). The
-plugin is the primary rail: it makes `/mb-start` and the other skills available
-in the Claude Desktop app and the terminal alike, and it survives git
-worktrees. `mb init` and `mb onboard` wire it by default; project-local
-symlinks are the fallback. The normal runtime path is: open this repo in
-Claude Code — the Claude Desktop app, or run `claude` in a terminal — then
-type `/mb-start` inside Claude Code. From the terminal, `mb start --json`
-checks the handoff and `mb start --launch` can open Claude Code when available.
+plugin is the durable cross-surface rail, and `mb init` / `mb onboard` also
+keep the project-local bridge so the normal user command stays `/mb-start`.
+Plugin-native skills are namespaced, so `/mainbranch:mb-start` is the direct
+plugin smoke/diagnostic command. The normal runtime path is: open this repo in
+Claude Code — the Claude Desktop app, or run `claude` in a terminal — then type
+`/mb-start` inside Claude Code. From the terminal, `mb start --json` checks the
+handoff and `mb start --launch` can open Claude Code when available.
 Before giving setup, routing, migration, update, or repair advice, run the
 read-only checks that fit the situation from this business repo:
 
@@ -74,11 +74,12 @@ If `/mb-start` is not discoverable or Claude Code reports `Unknown command:
 /mb-start`, do not improvise from memory. The most common cause is that the
 Main Branch plugin is not installed or enabled — install it with
 `claude plugin marketplace add noontide-co/mainbranch` and enable it (this
-works in the Claude Desktop app and the terminal). If you are in a cloud/web
-session, plugins are unavailable there — use the Claude Desktop app or the
-`claude` CLI. From this business repo, check `mb --version`, run
-`mb start --json` and `mb status --json --peek`, inspect repair options with
-`mb doctor repair --plan`, then ask before running any write/apply command
+works in the Claude Desktop app and the terminal). If you need to prove the
+plugin itself loaded, use the namespaced `/mainbranch:mb-start` command. If you
+are in a cloud/web session, plugins are unavailable there — use the Claude
+Desktop app or the `claude` CLI. From this business repo, check `mb --version`,
+run `mb start --json` and `mb status --json --peek`, inspect repair options
+with `mb doctor repair --plan`, then ask before running any write/apply command
 such as `mb skill link --repo .`, `mb skill repair --repo . --apply`,
 `mb doctor repair --apply`, or `mb update`. After repairing skill wiring, tell
 the operator: "I repaired missing Main Branch start wiring in this business

--- a/mb/mb/engine.py
+++ b/mb/mb/engine.py
@@ -995,7 +995,7 @@ def write_plugin_wiring(repo: str | Path) -> dict[str, Any]:
         "wiring": after,
         "summary": (
             "plugin wiring written to tracked settings — skill discovery now "
-            "survives fresh worktrees (restart or /reload-skills to pick up)"
+            "survives fresh worktrees (restart or /reload-plugins to pick up)"
             if after["wired"]
             else "plugin wiring write did not verify; inspect .claude/settings.json"
         ),

--- a/mb/mb/init.py
+++ b/mb/mb/init.py
@@ -305,13 +305,13 @@ Main Branch CLI facts are the source of truth for repo health, setup, runtime
 wiring, updates, graph/status signals, provider readiness, and repair paths.
 Main Branch installs as a Claude Code plugin
 (`claude plugin marketplace add noontide-co/mainbranch`, then enable it). The
-plugin is the primary rail: it makes `/mb-start` and the other skills available
-in the Claude Desktop app and the terminal alike, and it survives git
-worktrees. `mb init` and `mb onboard` wire it by default; project-local
-symlinks are the fallback. The normal runtime path is: open this repo in
-Claude Code — the Claude Desktop app, or run `claude` in a terminal — then
-type `/mb-start` inside Claude Code. From the terminal, `mb start --json`
-checks the handoff and `mb start --launch` can open Claude Code when available.
+plugin is the durable cross-surface rail, and `mb init` / `mb onboard` also
+keep the project-local bridge so the normal user command stays `/mb-start`.
+Plugin-native skills are namespaced, so `/mainbranch:mb-start` is the direct
+plugin smoke/diagnostic command. The normal runtime path is: open this repo in
+Claude Code — the Claude Desktop app, or run `claude` in a terminal — then type
+`/mb-start` inside Claude Code. From the terminal, `mb start --json` checks the
+handoff and `mb start --launch` can open Claude Code when available.
 Before giving setup, routing, migration, update, or repair advice, run the
 read-only checks that fit the situation from this business repo:
 
@@ -371,11 +371,12 @@ If `/mb-start` is not discoverable or Claude Code reports `Unknown command:
 /mb-start`, do not improvise from memory. The most common cause is that the
 Main Branch plugin is not installed or enabled — install it with
 `claude plugin marketplace add noontide-co/mainbranch` and enable it (this
-works in the Claude Desktop app and the terminal). If you are in a cloud/web
-session, plugins are unavailable there — use the Claude Desktop app or the
-`claude` CLI. From this business repo, check `mb --version`, run
-`mb start --json` and `mb status --json --peek`, inspect repair options with
-`mb doctor repair --plan`, then ask before running any write/apply command
+works in the Claude Desktop app and the terminal). If you need to prove the
+plugin itself loaded, use the namespaced `/mainbranch:mb-start` command. If you
+are in a cloud/web session, plugins are unavailable there — use the Claude
+Desktop app or the `claude` CLI. From this business repo, check `mb --version`,
+run `mb start --json` and `mb status --json --peek`, inspect repair options
+with `mb doctor repair --plan`, then ask before running any write/apply command
 such as `mb skill link --repo .`, `mb skill repair --repo . --apply`,
 `mb doctor repair --apply`, or `mb update`. After repairing skill wiring, tell
 the operator: "I repaired missing Main Branch start wiring in this business

--- a/mb/mb/start.py
+++ b/mb/mb/start.py
@@ -508,7 +508,9 @@ def run(repo: str = ".", launch: bool = False) -> dict[str, Any]:
             "guidance": (
                 "Main Branch runs as a Claude Code plugin (Claude Desktop or the "
                 "terminal) or via the Codex CLI; cloud/web sessions do not support "
-                "plugins. If /mb-start is missing, install the plugin: "
+                "plugins. The normal Claude Code command remains /mb-start via "
+                "the project-local bridge; the direct plugin smoke command is "
+                "/mainbranch:mb-start. If neither appears, install the plugin: "
                 "`claude plugin marketplace add noontide-co/mainbranch`."
             ),
             "skill_wiring": wiring,

--- a/mb/tests/test_engine.py
+++ b/mb/tests/test_engine.py
@@ -449,6 +449,7 @@ def test_plugin_wiring_write_and_status(tmp_path: Path) -> None:
     result = engine_mod.write_plugin_wiring(tmp_path)
     assert result["ok"] is True
     assert result["changed"] is True
+    assert "/reload-plugins" in result["summary"]
 
     settings = json_mod.loads((tmp_path / ".claude" / "settings.json").read_text(encoding="utf-8"))
     assert settings["extraKnownMarketplaces"]["mainbranch"]["source"] == {

--- a/mb/tests/test_init.py
+++ b/mb/tests/test_init.py
@@ -26,9 +26,13 @@ def _assert_claude_md_cli_first_contract(text: str) -> None:
     assert "Main Branch CLI facts are the source of truth" in text
     assert "run `claude`" in text
     assert "`/mb-start` inside Claude Code" in text
-    # Plugin-first, cross-surface framing (Stage 3 / #924): the plugin is the
-    # primary rail and works in Claude Desktop + the terminal.
+    # Hybrid plugin rail (Stage 3 / #924): the plugin is durable across Claude
+    # Desktop + terminal, while the project-local bridge preserves the friendly
+    # `/mb-start` user command.
     assert "claude plugin marketplace add noontide-co/mainbranch" in text
+    assert "normal user command stays `/mb-start`" in text
+    assert "/mainbranch:mb-start" in text
+    assert "plugin smoke/diagnostic command" in text
     assert "Claude Desktop" in text
     assert "mb start --launch" in text
     assert "mb --version" in text

--- a/mb/tests/test_smoke_coverage.py
+++ b/mb/tests/test_smoke_coverage.py
@@ -240,6 +240,9 @@ def test_claude_code_invocation_contract_documents_supported_skill_surface() -> 
     assert "bridge links" in contract
     assert ".claude/skills/mb-start" in contract
     assert "Unknown command: /mb-start" in contract
+    assert "/mainbranch:mb-start" in contract
+    assert "Public setup and support" in contract
+    assert "type `/mb-start`" in contract
     assert "$ARGUMENTS" in contract
     assert "Claude Code Invocation Contract" in compatibility
 

--- a/mb/tests/test_start.py
+++ b/mb/tests/test_start.py
@@ -644,7 +644,8 @@ def test_start_display_command_is_os_aware(tmp_path: Path, monkeypatch) -> None:
 
 def test_start_runtime_guidance_is_plugin_first(tmp_path: Path, monkeypatch) -> None:
     # #924: the handoff payload carries an always-on plugin-first grounding fact
-    # so an agent reading `mb start --json` knows how to make /mb-start appear.
+    # so an agent reading `mb start --json` knows both the user command and the
+    # official plugin smoke command.
     monkeypatch.setattr(start_mod, "_which", _with_claude)
     repo = tmp_path / "acme"
     init_run(path=str(repo), name="Acme")
@@ -653,5 +654,7 @@ def test_start_runtime_guidance_is_plugin_first(tmp_path: Path, monkeypatch) -> 
 
     report = json.loads(result.stdout)
     guidance = report["runtime"]["guidance"]
+    assert "normal Claude Code command remains /mb-start" in guidance
+    assert "/mainbranch:mb-start" in guidance
     assert "claude plugin marketplace add noontide-co/mainbranch" in guidance
     assert "cloud" in guidance.lower()


### PR DESCRIPTION
## Summary
- keep `/mb-start` as the public/user-facing Claude Code command through the project-local bridge
- document `/mainbranch:mb-start` as the official plugin-native smoke/diagnostic command
- update release smoke to prove namespaced plugin loading separately from bridge compatibility
- switch plugin wiring guidance from `/reload-skills` to `/reload-plugins`

## Validation
- `PYTHON=/tmp/mainbranch-review/mb/.venv/bin/python scripts/check.sh`
