### PR TITLE
Release 0.4.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Main Branch — run a business from markdown files in git, with Claude Code as the operator surface.",
-    "version": "0.4.0"
+    "version": "0.4.1"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mainbranch",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Main Branch Claude Code skills for running a business from markdown files in git.",
   "author": {
     "name": "Noontide"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-06-20
+
+This release makes the Claude Code plugin the durable default rail while keeping
+the friendly `/mb-*` project-local commands as the operator-facing bridge.
+
+### Added
+
+- `mb update` now surfaces plugin-rail migration guidance for symlink-era repos
+  after package updates, pointing users at `mb skill link --repo . --plugin`
+  when the plugin is not wired. (#938)
+- `/mb-help` and the skills guide now make `mb-status`, `mb-update`, and
+  `mb-skill-review` discoverable; `mb-skill-review` also responds to natural
+  pre-publish/UI/design-review phrases. (#937)
+
 ### Changed
 
 - **The plugin is the default Claude Code rail.** `mb init` and `mb onboard`
@@ -25,6 +39,24 @@ PyPI distribution `mainbranch` tracks the same version sequence.
   in both the Claude Desktop app and the terminal — instead of assuming a
   missing `claude` CLI. Cloud/web Claude sessions cannot load plugins.
   (#930, closes #924)
+- **Hybrid slash-command contract.** User-facing docs keep the friendly
+  `/mb-start` command through the project-local bridge, while release smoke and
+  diagnostics now name the plugin-native `/mainbranch:mb-start` command that
+  proves the plugin itself loaded. (#940)
+- Mid-session "save this progress" language now routes to the lightweight
+  `mb checkpoint` path instead of the full `/mb-end` closeout ceremony. (#934)
+- Beginner-facing references now describe the plugin as the primary Claude Code
+  rail and `settings.local.json` bridge links as the fallback. (#939, closes
+  #932)
+
+### Fixed
+
+- Plugin wiring now refuses to overwrite a malformed-but-nonempty
+  `.claude/settings.json`, avoiding accidental loss of existing Claude
+  permissions, hooks, or user settings. (#933)
+- `mb doctor repair --plan` now previews plugin-wiring migrations before
+  `--apply` writes `.claude/settings.json`, so plan/apply agree for symlink-era
+  repos. (#933)
 
 ## [0.4.0] - 2026-06-14
 

--- a/mb/mb/__init__.py
+++ b/mb/mb/__init__.py
@@ -7,6 +7,6 @@ file stays a thin dispatcher.
 
 from __future__ import annotations
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 
 __all__ = ["__version__"]

--- a/mb/pyproject.toml
+++ b/mb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mainbranch"
-version = "0.4.0"
+version = "0.4.1"
 description = "Main Branch engine umbrella - scaffolds, validates, and graphs business-as-files repos. Claude Code first, runtime-agnostic by design."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

- bump package, `__version__`, plugin manifest, and marketplace manifest to `0.4.1`
- date the `0.4.1` CHANGELOG section and include the complete plugin/default-rail, routing, discoverability, update-guidance, docs, and command-contract slices
- keep `[Unreleased]` empty for the next cycle

## Validation

- Level 0 release preflight: `scripts/release-preflight.sh oe-v0.4.1` — runtime: `mb/.venv/bin/python3` via `PATH` (Python 3.14.5) — exit: 0 — log: `.agent/release-evidence/0.4.1/release-preflight.out` (version files agree; manifest guard passed).
- Level 1 static: `scripts/check.sh` — runtime: `mb/.venv/bin/python3` via `PATH` — exit: 0 — log: `.agent/release-evidence/0.4.1/check.out` (full pytest+coverage, skill validate 15/15, docs/line/language gates).
- Level 3 package/install: `python -m build mb` from dedicated temp build venv + fresh venv wheel install — exit: 0 — logs: `.agent/release-evidence/0.4.1/build.out`, `.agent/release-evidence/0.4.1/install.out` (`mb 0.4.1`; packaged skills list present).
- hledger fixture, base/no-hledger mode: `mb books check --fixture --json` with `PATH` restricted to smoke venv — exit: 0 — log: `.agent/release-evidence/0.4.1/books-fixture-no-hledger.out` (`hledger-missing`, `result_status: ok`).
- hledger fixture, equipped mode: `mb books check --fixture --json` with `/opt/homebrew/bin/hledger` on `PATH` — exit: 0 — log: `.agent/release-evidence/0.4.1/books-fixture-hledger.out` (`fixture-valid`, `result_status: ok`).
- Level 5 prerelease candidate: `scripts/claude-runtime-dogfood.py --install-mode wheel --wheel mb/dist/mainbranch-0.4.1-py3-none-any.whl --run-claude-print --simulation-tier prerelease_candidate --max-budget-usd 0.75` — Claude Code 2.1.170 — exit: 0 — evidence: `.agent/release-evidence/0.4.1/prerelease_candidate/` (11/11 heuristic checks; no harness failures; no read-only `mb` grounding denials; manual transcript skim found no hard failures).
- Level 5 pre-tag release acceptance: same wheel with `--simulation-tier release_acceptance` — Claude Code 2.1.170 — exit: 0 — evidence: `.agent/release-evidence/0.4.1/release_acceptance_pretag/` (10/11 heuristic checks; `loop_routing` reviewed as keyword miss, not behavior; no harness failures; no read-only `mb` grounding denials).
- Supply-chain release checks: no open Dependabot security alerts; `.github/workflows` permission scan unchanged; `pypi` environment has required reviewer protection; open Dependabot #935/#936 are non-security release-workflow bumps intentionally held until after 0.4.1 publishes.

## Pre-publish gate still pending

Rule 7 live plugin-load smoke is **not** covered by this PR. After this release-prep branch lands on `main` and before creating `oe-v0.4.1` / publishing the GitHub Release, run the manual plugin smoke from `docs/release-agent-contract.md`: install/enable the plugin through real Claude Code, confirm plugin-native `/mainbranch:mb-start` and one other `/mainbranch:mb-*` skill in both Desktop and terminal, and separately record whether the legacy bridge `/mb-start` works.
