### PR TITLE
Detect stale Claude plugin during mb update

### DIFF
--- a/.claude/skills/mb-update/SKILL.md
+++ b/.claude/skills/mb-update/SKILL.md
@@ -78,6 +78,12 @@ after repairing links. In `--check --json` output, treat
 `planned_skills_relink_count` as a dry-run preview, not proof that links already
 changed.
 
+If `plugin_rail.install.state` is `stale`, `installed_not_enabled`, `disabled`,
+or `not_installed`, tell the user the Claude Code plugin cache needs attention
+too. Quote the warning, include the plugin repair command from `next_actions`,
+and say to restart Claude Code or run `/reload-plugins` before relying on new
+slash-skill behavior.
+
 ---
 
 ## Step 4: What Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+### Added
+
+- `mb update` now checks the installed Claude Code Main Branch plugin version
+  against the package version and warns when Claude is still loading an older,
+  disabled, or missing plugin cache, with a repair command and restart guidance.
+  (#923)
+
 ## [0.4.1] - 2026-06-20
 
 This release makes the Claude Code plugin the durable default rail while keeping

--- a/docs/release-agent-contract.md
+++ b/docs/release-agent-contract.md
@@ -227,6 +227,11 @@ manual plugin-load smoke before publishing and record it as a validation line:
 - separately record whether the legacy project-local bridge also exposes
   `/mb-start`. The bridge is allowed as a compatibility path, but the plugin
   smoke must prove the namespaced plugin command before the tag.
+- if the release changes plugin update/detection behavior, also smoke an
+  old-version plugin cache: install or leave an older Main Branch plugin
+  enabled, update the package to the release candidate, and confirm
+  `mb update --check --json` reports `plugin_rail.install.state == "stale"`
+  with a repair action before publishing.
 
 This is the one true pre-publish gate that lives only here: a green CI run does
 not cover it. "Skipped because no Claude Code build was available" is a valid

--- a/mb/mb/engine.py
+++ b/mb/mb/engine.py
@@ -906,6 +906,10 @@ def install_mode() -> str:
 PLUGIN_MARKETPLACE_NAME = "mainbranch"
 PLUGIN_REPO = "noontide-co/mainbranch"
 PLUGIN_ENABLE_KEY = "mainbranch@mainbranch"
+PLUGIN_INSTALL_COMMAND = (
+    "claude plugin marketplace update mainbranch && "
+    "claude plugin install mainbranch@mainbranch --scope user"
+)
 
 
 def _tracked_settings_path(repo: Path) -> Path:
@@ -942,6 +946,165 @@ def plugin_wiring_status(repo: str | Path) -> dict[str, Any]:
         "wired": marketplace_known and plugin_enabled,
         "settings_path": str(_tracked_settings_path(target)),
     }
+
+
+def _plugin_entry_summary(entry: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": str(entry.get("id") or ""),
+        "version": str(entry.get("version") or ""),
+        "scope": str(entry.get("scope") or ""),
+        "enabled": entry.get("enabled") is True,
+        "install_path": str(entry.get("installPath") or entry.get("install_path") or ""),
+    }
+
+
+def _run_claude_plugin_list(*, timeout: float = 5.0) -> subprocess.CompletedProcess[str] | None:
+    claude = shutil.which("claude")
+    if not claude:
+        return None
+    try:
+        return subprocess.run(
+            [claude, "plugin", "list", "--json"],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return subprocess.CompletedProcess(
+            args=[claude, "plugin", "list", "--json"],
+            returncode=1,
+            stdout="",
+            stderr="could not run `claude plugin list --json`",
+        )
+
+
+def claude_mainbranch_plugin_status(
+    *, expected_version: str | None = None, timeout: float = 5.0
+) -> dict[str, Any]:
+    """Report the installed Claude Code Main Branch plugin version.
+
+    `mb update` can refresh packaged project-local bridge links, but Claude
+    Code plugin installs are loaded by the runtime and do not self-update just
+    because the `mainbranch` package changed. This probe is best-effort: if
+    Claude Code is not installed or does not support JSON plugin listing, the
+    caller gets an unchecked status instead of a hard failure.
+    """
+    expected = (expected_version or __version__).strip()
+    base: dict[str, Any] = {
+        "checked": False,
+        "ok": False,
+        "state": "unchecked",
+        "expected_version": expected,
+        "installed_version": "",
+        "installed_versions": [],
+        "enabled_versions": [],
+        "entries": [],
+        "command": "claude plugin list --json",
+        "repair": PLUGIN_INSTALL_COMMAND,
+        "summary": "Claude Code plugin version was not checked.",
+    }
+    result = _run_claude_plugin_list(timeout=timeout)
+    if result is None:
+        base.update(
+            {
+                "state": "claude_missing",
+                "summary": "Claude Code CLI is not on PATH; plugin version was not checked.",
+            }
+        )
+        return base
+    base["checked"] = True
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip()
+        base.update(
+            {
+                "state": "error",
+                "summary": detail or "`claude plugin list --json` failed.",
+            }
+        )
+        return base
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        base.update(
+            {"state": "invalid_json", "summary": "Claude plugin list returned invalid JSON."}
+        )
+        return base
+    if not isinstance(payload, list):
+        base.update(
+            {
+                "state": "invalid_json",
+                "summary": "Claude plugin list returned an unexpected JSON shape.",
+            }
+        )
+        return base
+
+    entries = [
+        _plugin_entry_summary(entry)
+        for entry in payload
+        if isinstance(entry, dict) and str(entry.get("id") or "") == PLUGIN_ENABLE_KEY
+    ]
+    installed_versions = sorted({entry["version"] for entry in entries if entry["version"]})
+    enabled_entries = [entry for entry in entries if entry["enabled"]]
+    enabled_versions = sorted({entry["version"] for entry in enabled_entries if entry["version"]})
+    preferred = next(
+        (entry for entry in enabled_entries if expected and entry["version"] == expected),
+        enabled_entries[0] if enabled_entries else (entries[0] if entries else {}),
+    )
+    installed_version = str(preferred.get("version") or "")
+    base.update(
+        {
+            "installed_version": installed_version,
+            "installed_versions": installed_versions,
+            "enabled_versions": enabled_versions,
+            "entries": entries,
+        }
+    )
+    if not entries:
+        base.update(
+            {
+                "state": "not_installed",
+                "summary": "The Main Branch Claude Code plugin is not installed.",
+            }
+        )
+        return base
+    if expected and expected in enabled_versions:
+        base.update(
+            {
+                "ok": True,
+                "state": "current",
+                "summary": f"Main Branch Claude Code plugin is enabled at {expected}.",
+            }
+        )
+        return base
+    if expected and expected in installed_versions:
+        base.update(
+            {
+                "state": "installed_not_enabled",
+                "summary": (
+                    f"Main Branch Claude Code plugin {expected} is installed but not enabled."
+                ),
+            }
+        )
+        return base
+    if enabled_versions:
+        base.update(
+            {
+                "state": "stale",
+                "summary": (
+                    "Main Branch Claude Code plugin is enabled at "
+                    f"{', '.join(enabled_versions)}, expected {expected or 'the current package'}."
+                ),
+            }
+        )
+        return base
+    base.update(
+        {
+            "state": "disabled",
+            "summary": "The Main Branch Claude Code plugin is installed but disabled.",
+        }
+    )
+    return base
 
 
 def write_plugin_wiring(repo: str | Path) -> dict[str, Any]:

--- a/mb/mb/update.py
+++ b/mb/mb/update.py
@@ -13,7 +13,14 @@ from typing import Any
 
 from mb import __version__
 from mb import codex as codex_mod
-from mb.engine import bundled_skills, engine_root, install_mode, plugin_wiring_status
+from mb.engine import (
+    PLUGIN_INSTALL_COMMAND,
+    bundled_skills,
+    claude_mainbranch_plugin_status,
+    engine_root,
+    install_mode,
+    plugin_wiring_status,
+)
 from mb.freshness import (
     latest_pypi_version as _latest_pypi_version,
 )
@@ -365,11 +372,14 @@ def _add_plugin_follow_up(result: dict[str, Any], repo: Path) -> None:
     one-command migration as post-update guidance — never an automatic write.
     """
     status = plugin_wiring_status(repo)
+    expected_version = str(result.get("new_version") or result.get("old_version") or __version__)
+    install = claude_mainbranch_plugin_status(expected_version=expected_version)
     result["plugin_rail"] = {
         "wired": status.get("wired", False),
         "marketplace_known": status.get("marketplace_known", False),
         "plugin_enabled": status.get("plugin_enabled", False),
         "settings_path": status.get("settings_path", ""),
+        "install": install,
     }
     if not status.get("wired", False):
         result["warnings"].append(
@@ -380,6 +390,35 @@ def _add_plugin_follow_up(result: dict[str, Any], repo: Path) -> None:
             "--all-agents`), then restart Claude Code."
         )
         result["next_actions"].append("mb skill link --repo . --plugin --json")
+
+    install_state = str(install.get("state") or "")
+    if install_state in {"stale", "installed_not_enabled", "disabled", "not_installed"}:
+        expected = str(install.get("expected_version") or expected_version)
+        installed = str(install.get("installed_version") or "")
+        if install_state == "stale":
+            message = (
+                "Claude Code is still loading an older Main Branch plugin "
+                f"({installed or 'unknown'}), while this package expects {expected}. "
+                "Update/reinstall the plugin, then restart Claude Code or run "
+                "`/reload-plugins` before relying on slash-skill changes."
+            )
+        elif install_state == "installed_not_enabled":
+            message = (
+                f"Main Branch plugin {expected} is installed in Claude Code but not enabled. "
+                "Enable it, then restart Claude Code or run `/reload-plugins`."
+            )
+        elif install_state == "disabled":
+            message = (
+                "The Main Branch Claude Code plugin is installed but disabled. Enable it, "
+                "then restart Claude Code or run `/reload-plugins`."
+            )
+        else:
+            message = (
+                "The Main Branch Claude Code plugin is not installed. Install it so Claude "
+                "Desktop and the terminal load the updated slash skills."
+            )
+        result["warnings"].append(message)
+        result["next_actions"].append(PLUGIN_INSTALL_COMMAND)
 
 
 def run(

--- a/mb/tests/test_engine.py
+++ b/mb/tests/test_engine.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
 
 from mb import engine as engine_mod
@@ -510,6 +511,123 @@ def test_plugin_wiring_refuses_to_clobber_malformed_settings(tmp_path: Path) -> 
     assert path.read_text(encoding="utf-8") == malformed
     assert "enabledPlugins" not in path.read_text(encoding="utf-8")
     assert engine_mod.plugin_wiring_status(tmp_path)["wired"] is False
+
+
+def test_claude_plugin_status_reports_current_enabled_plugin(monkeypatch) -> None:
+    payload = [
+        {
+            "id": "mainbranch@mainbranch",
+            "version": "0.4.2",
+            "scope": "user",
+            "enabled": True,
+            "installPath": "/tmp/mainbranch/0.4.2",
+        }
+    ]
+
+    monkeypatch.setattr(
+        engine_mod,
+        "_run_claude_plugin_list",
+        lambda timeout=5.0: subprocess.CompletedProcess(
+            ["claude", "plugin", "list", "--json"],
+            0,
+            stdout=json.dumps(payload),
+            stderr="",
+        ),
+    )
+
+    status = engine_mod.claude_mainbranch_plugin_status(expected_version="0.4.2")
+
+    assert status["checked"] is True
+    assert status["ok"] is True
+    assert status["state"] == "current"
+    assert status["installed_version"] == "0.4.2"
+    assert status["enabled_versions"] == ["0.4.2"]
+
+
+def test_claude_plugin_status_reports_stale_enabled_plugin(monkeypatch) -> None:
+    payload = [
+        {
+            "id": "mainbranch@mainbranch",
+            "version": "0.4.1",
+            "scope": "user",
+            "enabled": True,
+            "installPath": "/tmp/mainbranch/0.4.1",
+        }
+    ]
+
+    monkeypatch.setattr(
+        engine_mod,
+        "_run_claude_plugin_list",
+        lambda timeout=5.0: subprocess.CompletedProcess(
+            ["claude", "plugin", "list", "--json"],
+            0,
+            stdout=json.dumps(payload),
+            stderr="",
+        ),
+    )
+
+    status = engine_mod.claude_mainbranch_plugin_status(expected_version="0.4.2")
+
+    assert status["ok"] is False
+    assert status["state"] == "stale"
+    assert status["installed_version"] == "0.4.1"
+    assert "expected 0.4.2" in status["summary"]
+
+
+def test_claude_plugin_status_prefers_current_enabled_among_multiple_scopes(monkeypatch) -> None:
+    payload = [
+        {
+            "id": "mainbranch@mainbranch",
+            "version": "0.4.1",
+            "scope": "project",
+            "enabled": True,
+            "installPath": "/tmp/mainbranch/0.4.1",
+        },
+        {
+            "id": "mainbranch@mainbranch",
+            "version": "0.4.2",
+            "scope": "user",
+            "enabled": True,
+            "installPath": "/tmp/mainbranch/0.4.2",
+        },
+    ]
+
+    monkeypatch.setattr(
+        engine_mod,
+        "_run_claude_plugin_list",
+        lambda timeout=5.0: subprocess.CompletedProcess(
+            ["claude", "plugin", "list", "--json"],
+            0,
+            stdout=json.dumps(payload),
+            stderr="",
+        ),
+    )
+
+    status = engine_mod.claude_mainbranch_plugin_status(expected_version="0.4.2")
+
+    assert status["state"] == "current"
+    assert status["installed_version"] == "0.4.2"
+    assert status["enabled_versions"] == ["0.4.1", "0.4.2"]
+    assert status["installed_versions"] == ["0.4.1", "0.4.2"]
+
+
+def test_claude_plugin_status_reports_not_installed(monkeypatch) -> None:
+    monkeypatch.setattr(
+        engine_mod,
+        "_run_claude_plugin_list",
+        lambda timeout=5.0: subprocess.CompletedProcess(
+            ["claude", "plugin", "list", "--json"],
+            0,
+            stdout=json.dumps([{"id": "other@market", "version": "1.0.0"}]),
+            stderr="",
+        ),
+    )
+
+    status = engine_mod.claude_mainbranch_plugin_status(expected_version="0.4.2")
+
+    assert status["state"] == "not_installed"
+    assert status["entries"] == []
+    assert status["repair"].startswith("claude plugin marketplace update")
 
 
 def test_worktree_summary_mentions_plugin_rail_when_wired(tmp_path: Path) -> None:

--- a/mb/tests/test_update.py
+++ b/mb/tests/test_update.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import shutil
 import subprocess
 from pathlib import Path
 from typing import Any
@@ -12,6 +13,7 @@ from typer.testing import CliRunner
 
 from mb import __version__
 from mb import codex as codex_mod
+from mb import engine as engine_mod
 from mb import update as update_mod
 from mb.cli import app
 
@@ -66,6 +68,23 @@ def plugin_rail_wired(monkeypatch: pytest.MonkeyPatch) -> None:
             "marketplace_known": True,
             "plugin_enabled": True,
             "settings_path": str(Path(repo) / ".claude" / "settings.json"),
+        },
+    )
+    monkeypatch.setattr(
+        update_mod,
+        "claude_mainbranch_plugin_status",
+        lambda *, expected_version=None, timeout=5.0: {
+            "checked": True,
+            "ok": True,
+            "state": "current",
+            "expected_version": expected_version or __version__,
+            "installed_version": expected_version or __version__,
+            "installed_versions": [expected_version or __version__],
+            "enabled_versions": [expected_version or __version__],
+            "entries": [],
+            "command": "claude plugin list --json",
+            "repair": engine_mod.PLUGIN_INSTALL_COMMAND,
+            "summary": "Main Branch Claude Code plugin is enabled.",
         },
     )
 
@@ -1017,3 +1036,87 @@ def test_update_surfaces_plugin_migration_for_symlink_era_repo(
     assert result["plugin_rail"]["wired"] is False
     assert any("symlink-only skill wiring" in w for w in result["warnings"])
     assert "mb skill link --repo . --plugin --json" in result["next_actions"]
+
+
+def test_update_warns_when_installed_claude_plugin_is_stale(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    def fake_run(args: list[str], *, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+        if args == ["pipx", "upgrade", "mainbranch"]:
+            return _completed(args)
+        if args == ["mb", "--version"]:
+            return _completed(args, stdout="mb 0.4.2\n")
+        if args[:3] == ["mb", "skill", "link"]:
+            return _completed(args, stdout=json.dumps({"ok": True, "linked": ["mb-start"]}))
+        if args[:4] == ["mb", "doctor", "repair", "--repo"]:
+            return _codex_repair_completed(args)
+        return _completed(args)
+
+    monkeypatch.setattr(update_mod, "install_mode", lambda: "pipx")
+    monkeypatch.setattr(update_mod, "engine_root", lambda: tmp_path / "_engine")
+    monkeypatch.setattr(shutil, "which", lambda name: "/opt/homebrew/bin/pipx")
+    monkeypatch.setattr(update_mod, "_run_command", fake_run)
+    monkeypatch.setattr(
+        update_mod,
+        "claude_mainbranch_plugin_status",
+        lambda *, expected_version=None, timeout=5.0: {
+            "checked": True,
+            "ok": False,
+            "state": "stale",
+            "expected_version": expected_version,
+            "installed_version": "0.4.1",
+            "installed_versions": ["0.4.1"],
+            "enabled_versions": ["0.4.1"],
+            "entries": [],
+            "command": "claude plugin list --json",
+            "repair": engine_mod.PLUGIN_INSTALL_COMMAND,
+            "summary": "Main Branch Claude Code plugin is enabled at 0.4.1, expected 0.4.2.",
+        },
+    )
+
+    result = update_mod.run(repo=tmp_path / "biz")
+
+    assert result["ok"] is True
+    assert result["new_version"] == "0.4.2"
+    assert result["plugin_rail"]["install"]["state"] == "stale"
+    assert result["plugin_rail"]["install"]["expected_version"] == "0.4.2"
+    assert engine_mod.PLUGIN_INSTALL_COMMAND in result["next_actions"]
+    assert any("older Main Branch plugin" in warning for warning in result["warnings"])
+    assert any("/reload-plugins" in warning for warning in result["warnings"])
+
+
+def test_update_check_uses_planned_version_for_plugin_status(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    expected_versions: list[str | None] = []
+
+    def fake_status(*, expected_version=None, timeout=5.0) -> dict[str, Any]:
+        expected_versions.append(expected_version)
+        return {
+            "checked": True,
+            "ok": False,
+            "state": "stale",
+            "expected_version": expected_version,
+            "installed_version": "0.4.1",
+            "installed_versions": ["0.4.1"],
+            "enabled_versions": ["0.4.1"],
+            "entries": [],
+            "command": "claude plugin list --json",
+            "repair": engine_mod.PLUGIN_INSTALL_COMMAND,
+            "summary": (
+                f"Main Branch Claude Code plugin is enabled at 0.4.1, expected {expected_version}."
+            ),
+        }
+
+    monkeypatch.setattr(update_mod, "install_mode", lambda: "pipx")
+    monkeypatch.setattr(update_mod, "engine_root", lambda: tmp_path / "_engine")
+    monkeypatch.setattr(update_mod, "_latest_pypi_version", lambda: "9.9.9")
+    monkeypatch.setattr(update_mod, "bundled_skills", lambda: ["mb-start", "mb-status"])
+    monkeypatch.setattr(update_mod, "claude_mainbranch_plugin_status", fake_status)
+
+    result = update_mod.run(repo=tmp_path / "biz", check=True)
+
+    assert expected_versions == ["9.9.9"]
+    assert result["plugin_rail"]["install"]["expected_version"] == "9.9.9"
+    assert any("expects 9.9.9" in warning for warning in result["warnings"])
+    assert engine_mod.PLUGIN_INSTALL_COMMAND in result["next_actions"]


### PR DESCRIPTION
## Summary
- add a best-effort `claude plugin list --json` probe for the installed Main Branch Claude Code plugin version
- surface stale/disabled/missing plugin cache warnings from `mb update` with a repair command and restart or `/reload-plugins` guidance
- teach `/mb-update` and the release protocol to preserve this stale-plugin-cache check

Closes #923.

## Validation
- `PATH=/tmp/mainbranch-review/mb/.venv/bin:$PATH python -m pytest mb/tests/test_engine.py mb/tests/test_update.py -q` — 52 passed
- `PATH=/tmp/mainbranch-review/mb/.venv/bin:$PATH python -m ruff check mb/mb/engine.py mb/mb/update.py mb/tests/test_engine.py mb/tests/test_update.py` — passed
- `PATH=/tmp/mainbranch-review/mb/.venv/bin:$PATH scripts/check.sh > .agent/pr-923/check.out 2>&1; ...` — exit 0 (15/15 skill validate, full gate green)