### PR TITLE
Release 0.4.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Main Branch — run a business from markdown files in git, with Claude Code as the operator surface.",
-    "version": "0.4.1"
+    "version": "0.4.2"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mainbranch",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Main Branch Claude Code skills for running a business from markdown files in git.",
   "author": {
     "name": "Noontide"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+## [0.4.2] - 2026-06-20
+
+Field thanks to Aneesh for the real-session dogfood that sharpened this one.
+Aneesh, you are an absolute baller.
+
 ### Added
 
 - `mb update` now checks the installed Claude Code Main Branch plugin version
@@ -24,6 +29,7 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 - `mb launch check` now summarizes read-only launch readiness across local app
   stack, Cloudflare/Wrangler deployment, Shopify commerce, Resend/email code,
   smoke scripts, and measurement posture before an agent gives launch advice.
+  (#945)
 
 ## [0.4.1] - 2026-06-20
 

--- a/mb/mb/__init__.py
+++ b/mb/mb/__init__.py
@@ -7,6 +7,6 @@ file stays a thin dispatcher.
 
 from __future__ import annotations
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"
 
 __all__ = ["__version__"]

--- a/mb/pyproject.toml
+++ b/mb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mainbranch"
-version = "0.4.1"
+version = "0.4.2"
 description = "Main Branch engine umbrella - scaffolds, validates, and graphs business-as-files repos. Claude Code first, runtime-agnostic by design."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Prepares Main Branch `0.4.2` release files only:

- bumps `mb/pyproject.toml`, `mb/mb/__init__.py`, `.claude-plugin/plugin.json`, and `.claude-plugin/marketplace.json` to `0.4.2`
- moves the current `[Unreleased]` entries into `## [0.4.2] - 2026-06-20`
- includes a public field-thanks note for Aneesh, whose dogfood shaped this release

Included release payload:

- #923: `mb update` detects stale/disabled/missing Claude Code Main Branch plugin installs and reports repair/restart guidance.
- #926: `mb site check`/status/workflow facts report launch instrumentation for GA4/GTM, Meta Pixel, booking widgets, CRM/form widgets, Shopify/Liquid markup, and form/booking smoke requirements.
- #945: `mb launch check` adds read-only launch readiness across app stack, Cloudflare/Wrangler deploy rail, Shopify commerce, Resend/email code, local smoke scripts, and measurement posture.
- #935/#936 landed before this branch, so the release workflow uses the updated checkout and Linear release actions.

## Release status

Owner waiver recorded on 2026-06-21: the manual plugin-native UI smoke is intentionally deferred until after the package is live. The maintainer will test live and patch if needed.

Why this is a waiver: nested agents could not authoritatively run the true smoke. `claude -p` from inside Claude/Codex hit the known nested-session auth artifact, and standalone Terminal.app automation was unreachable. The deterministic release checks and plugin manifest validation are green, but the real UI smoke still needs a human after publish:

- Claude Desktop, non-engine repo: `/reload-plugins`, `/mainbranch:mb-start`, one other `/mainbranch:mb-*`, and `/mb-start` bridge.
- Standalone Terminal.app, non-engine repo: `/mainbranch:mb-start` and `/mb-start` bridge.
- After PyPI latest is `0.4.2`: update/reinstall the plugin cache, then rerun `mb update --check --json` against the old plugin cache path and confirm the stale-plugin detector behavior.

## Validation

Evidence is local under `.agent/release-evidence/0.4.2/`.

- Level 0 release-file preflight: `PATH=/tmp/mainbranch-review/mb/.venv/bin:$PATH scripts/release-preflight.sh oe-v0.4.2` — runtime: repo venv — exit: 0 — log: `.agent/release-evidence/0.4.2/preflight.out`.
- Level 1 static: `PYTHON=/tmp/mainbranch-review/mb/.venv/bin/python ./scripts/check.sh` — runtime: repo venv Python — exit: 0 — log: `.agent/release-evidence/0.4.2/check.out`.
- Level 3 build: fresh build venv, `(cd mb && /tmp/mainbranch-release-build-0.4.2/bin/python -m build)` — exit: 0 — log: `.agent/release-evidence/0.4.2/build.out`; artifacts: `mainbranch-0.4.2-py3-none-any.whl`, `mainbranch-0.4.2.tar.gz`.
- Level 3 install smoke: fresh venv install of `mb/dist/mainbranch-0.4.2-py3-none-any.whl`, then `mb --version`, `mb skill list`, `mb workflow list --runtime codex --json`, `mb launch check <astro-cloudflare-resend fixture> --business-repo <fixture> --json`, and `mb books check --fixture --json` with normal PATH and hledger-hidden PATH — exit: 0 — log: `.agent/release-evidence/0.4.2/install.out`.
- Plugin manifest validation: `claude plugin validate .`, `claude plugin validate .claude-plugin/marketplace.json`, and `claude plugin validate .claude-plugin/plugin.json` — exit: 0 — log: `.agent/release-evidence/0.4.2/plugin-validate.out` (known root `CLAUDE.md` warning only).
- Plugin stale detector smoke from the pre-#945 release prep remains applicable to #923: direct live probe against real `claude plugin list --json` reported `state: stale`, installed/enabled versions `0.4.0` and `0.4.1`, expected `0.4.2`.
- Level 5 prerelease/release-acceptance harnesses from the pre-#945 release prep passed deterministic fixture checks but hit nested-session `401` in `claude -p`; this is not treated as plugin-native UI proof and is covered by the owner waiver above.

## Public/private boundary

Only release files are committed. Local evidence stays ignored under `.agent/`; no private business transcripts, account data, or secrets are committed.
