### PR TITLE
Release 0.4.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Main Branch — run a business from markdown files in git, with Claude Code as the operator surface.",
-    "version": "0.4.2"
+    "version": "0.4.3"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mainbranch",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Main Branch Claude Code skills for running a business from markdown files in git.",
   "author": {
     "name": "Noontide"

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ __pycache__/
 # Local scratch and release evidence; never durable truth.
 # .claude/*.lock is local Claude Code session state (pid, sessionId).
 .agent/
+.agents/
 .context/
 .mb/connect.yaml
 .claude/*.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+### Added
+
+- `mb connect identity` now surfaces safe recorded metadata for connected
+  custom providers, so finance connections such as Mercury can expose role,
+  access level, data domain, and auth state without exposing credentials.
+- Added connection-model docs covering the provider lifecycle, finance-provider
+  boundaries, safe token use from scripts, and follow-up slices for backend
+  diagnostics and rotation ergonomics.
+
 ### Fixed
 
 - `mb connect status --all`, `mb connect doctor`, and `mb connect list` now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+## [0.4.3] - 2026-06-30
+
 ### Added
 
 - `mb connect identity` now surfaces safe recorded metadata for connected

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+### Fixed
+
+- `mb connect status --all`, `mb connect doctor`, and `mb connect list` now
+  include configured custom providers from repo and user scope instead of only
+  looping over the built-in provider registry. Provider-specific
+  `mb connect status <provider> --json` now resolves connected custom
+  providers, and missing custom-provider secrets report a runnable
+  `--custom --token-stdin` repair command.
+
 ## [0.4.2] - 2026-06-20
 
 Field thanks to Aneesh for the real-session dogfood that sharpened this one.

--- a/README.md
+++ b/README.md
@@ -441,7 +441,7 @@ build on it, here is the command list.
 | `mb init` | Quiet scriptable primitive underneath `mb onboard`. |
 | `mb status` | Local-first daily briefing with ranked next actions, MoneyPath readiness, recent activity, GitHub tasks/proposals, updates, and drift. |
 | `mb doctor` | Check environment, repo shape, frontmatter, settings, app setup, provider state, and repair paths. |
-| `mb connect` | Register connected-account metadata/credentials, test health where supported, inspect repair-safe integration status without committing secrets. |
+| `mb connect` | Register connected-account metadata/credentials, test health where supported, inspect repair-safe integration status without committing secrets. See [docs/connect.md](docs/connect.md). |
 | `mb books` | Plain-file bookkeeping setup checks, bookkeeping engine health, safe repair plans, bet exposure, and fake-data sample monthly reporting. |
 | `mb launch check` | Read-only launch readiness across app stack, deploy rail, commerce, email, local smoke scripts, and measurement posture. |
 | `mb site check` | Local paid-traffic measurement readiness: GTM install, dataLayer events, consent posture, Google Ads metadata, approval gates. |

--- a/docs/connect.md
+++ b/docs/connect.md
@@ -37,6 +37,9 @@ to stdout and nothing else. Use it only in pipes or local scripts that need the
 credential; do not paste its output into chat, docs, issues, PRs, or tracked
 files.
 
+The product model behind this surface lives in
+[connection-model.md](connection-model.md).
+
 ## Custom Providers
 
 Use `--custom` when the provider is not in the built-in registry yet. Custom
@@ -66,6 +69,7 @@ mb connect status mercury --json
 mb connect status --all --json
 mb connect doctor --json
 mb connect list --json
+mb connect identity --json
 ```
 
 Read the token for a local importer or scheduled collector:
@@ -73,6 +77,27 @@ Read the token for a local importer or scheduled collector:
 ```bash
 mb connect token mercury
 ```
+
+In a shell script, capture the token without echoing it. Keep shell tracing off
+around secret reads.
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+set +x
+
+token="$(mb connect token mercury)"
+curl --fail --silent --show-error \
+  --header "Authorization: Bearer ${token}" \
+  "https://api.example.invalid/accounts" \
+  > /tmp/mercury-accounts.json
+
+unset token
+```
+
+Do not use `set -x`, `echo "$token"`, committed `.env` files, or logs that
+print request headers. Raw exports should go to a private finance workspace or
+an ignored local staging path, not to a public repo.
 
 If metadata exists but the secret is missing or unreadable, Main Branch reports
 `missing_secret` and gives a reconnect command that includes `--custom`, for
@@ -85,6 +110,36 @@ mb connect mercury --custom --token-stdin
 Reconnecting an already configured custom provider also works without
 `--custom`, but keeping the flag in repair output makes the command safe to
 reuse from a fresh or partially repaired repo.
+
+For rotation, run the same command with the new token:
+
+```bash
+MB_CONNECT_SECRET_BACKEND=macos-keychain \
+  mb connect mercury --custom --token-stdin
+```
+
+Then verify readiness without printing the token:
+
+```bash
+mb connect status mercury --json
+mb connect doctor --json
+mb connect identity --json
+```
+
+Recommended custom metadata for finance providers:
+
+```text
+role=operating_cash_source
+access_level=read_only
+data_domain=banking
+auth_state=api_token
+source_system=mercury
+account_ref=operating-cash
+```
+
+Use `account_ref` as a business-readable handle. Do not commit raw account
+numbers, routing numbers, statements, transaction rows, tax records, or provider
+payloads.
 
 ## User Scope
 

--- a/docs/connect.md
+++ b/docs/connect.md
@@ -1,0 +1,105 @@
+# Connect Providers
+
+`mb connect` records safe provider metadata in the business repo and stores
+credential material outside git.
+
+Use it when a business workflow needs a durable handle to an external account:
+site deploys, ads, email, payment, research, bookkeeping, or a private finance
+source. `mb connect` answers whether the credential is present, whether a safe
+readiness check has passed where supported, and which command repairs the first
+broken step.
+
+## Secret Boundary
+
+Tracked repo metadata may include:
+
+- provider id;
+- account label;
+- non-secret metadata such as account role or token type;
+- secret-store backend name;
+- secret refs.
+
+Tracked repo metadata must not include:
+
+- API tokens, keys, refresh tokens, passwords, or service-account JSON;
+- raw provider exports;
+- account-private finance, customer, member, payroll, legal, or tax data.
+
+By default, Main Branch selects the safest available local secret backend. On
+macOS that is usually Keychain. You can force a backend for setup or testing:
+
+```bash
+MB_CONNECT_SECRET_BACKEND=macos-keychain mb connect cloudflare --token-stdin
+```
+
+`mb connect token <provider>` is the scripted read path. It prints the raw token
+to stdout and nothing else. Use it only in pipes or local scripts that need the
+credential; do not paste its output into chat, docs, issues, PRs, or tracked
+files.
+
+## Custom Providers
+
+Use `--custom` when the provider is not in the built-in registry yet. Custom
+provider ids use lowercase letters, digits, and hyphens. They get one
+`api_key` secret slot and the same status, doctor, list, token, repo-scope, and
+user-scope behavior as built-in providers.
+
+Example: a read-only finance provider token.
+
+```bash
+MB_CONNECT_SECRET_BACKEND=macos-keychain \
+  mb connect mercury \
+    --custom \
+    --token-stdin \
+    --account "Mercury Operating Account" \
+    --metadata role=operating_cash_source \
+    --metadata auth_state=api_token
+```
+
+This writes safe metadata and a secret ref under `.mb/connect.yaml`; the token
+goes to the selected local secret backend.
+
+Check it without printing the token:
+
+```bash
+mb connect status mercury --json
+mb connect status --all --json
+mb connect doctor --json
+mb connect list --json
+```
+
+Read the token for a local importer or scheduled collector:
+
+```bash
+mb connect token mercury
+```
+
+If metadata exists but the secret is missing or unreadable, Main Branch reports
+`missing_secret` and gives a reconnect command that includes `--custom`, for
+example:
+
+```bash
+mb connect mercury --custom --token-stdin
+```
+
+Reconnecting an already configured custom provider also works without
+`--custom`, but keeping the flag in repair output makes the command safe to
+reuse from a fresh or partially repaired repo.
+
+## User Scope
+
+Use user scope when several worktrees for the same business repo should read
+the same credential metadata from local Main Branch state:
+
+```bash
+mb connect mercury --custom --scope user --token-stdin
+```
+
+A fresh worktree can see that user-scoped metadata exists and can hydrate the
+repo-local `.mb/connect.yaml` copy:
+
+```bash
+mb connect hydrate --repo .
+```
+
+Secret material remains outside git in both repo and user scope.

--- a/docs/connection-model.md
+++ b/docs/connection-model.md
@@ -1,0 +1,140 @@
+# Connection Model
+
+Main Branch uses `mb connect` as the durable, secret-safe account handle for
+business tools. The model is deliberately smaller than a native integration:
+record enough setup truth for agents to reason from facts, keep credentials
+outside git, and require separate approval for anything that can change a
+provider account.
+
+Field lesson: using a custom Mercury provider for a bookkeeping migration
+proved the shape. The same pattern should work for Printful, A2X, Xero, bank
+APIs, and niche SaaS tools before Main Branch has native wrappers.
+
+## What worked
+
+- Provider metadata lives in `.mb/connect.yaml`, so setup state is durable and
+  inspectable.
+- Secret values live outside git through `SecretStore` backends such as macOS
+  Keychain, Python keyring, or local file storage.
+- `mb connect token <provider>` gives scripts one narrow credential read path
+  that prints only the token to stdout.
+- `status`, `doctor`, `list`, `identity`, `hygiene`, and `test` give agents
+  facts without copying credentials into chat or workpapers.
+- User scope lets worktrees and scheduled jobs resolve the same credential
+  setup without asking the operator to re-auth every day.
+
+## What failed
+
+- Custom providers were stored correctly but broad list/status/doctor surfaces
+  initially enumerated only the built-in provider registry.
+- Provider-specific status was parsed by the CLI but not handled as a distinct
+  status path.
+- Repair commands for missing custom secrets did not include `--custom`, which
+  made the correct repair easy to miss.
+- Custom providers had no identity schema, so agents could see "connected" but
+  not the safe role of the account, such as `operating_cash_source`.
+- Docs did not show the full finance-token lifecycle or safe script pattern.
+
+## Lifecycle
+
+1. **Declare.** Choose a provider id and record safe intent metadata.
+   Built-ins use the registry; custom providers use `--custom`.
+2. **Store secret.** Store token material through `--token-stdin`,
+   provider-native auth, Keychain, keyring, local secret store, 1Password, or a
+   current-process environment command. Never commit `.env` files or paste raw
+   tokens into docs, issues, logs, or workpapers.
+3. **Smoke test.** Run `mb connect test <provider>` when a safe read-only probe
+   exists. For custom providers without a probe, credential presence can mark
+   local readiness, but it does not prove provider API behavior.
+4. **Record identity metadata.** Record non-secret facts that prevent agents
+   from guessing: role, access level, data domain, auth state, account label,
+   workspace, environment, or provider-specific ids when safe for the repo.
+5. **Use token in scripts.** Scripts call `mb connect token <provider>` and
+   keep stdout in memory or a pipe. They do not echo tokens, enable shell trace,
+   write env files, or commit raw exports.
+6. **Rotate or repair.** Missing or stale secrets report a reconnect command.
+   For custom providers, repair output includes `--custom --token-stdin`.
+7. **Audit and hygiene.** `mb connect doctor`, `mb connect status --all`,
+   `mb connect identity`, and `mb connect hygiene` are the read-only audit
+   surfaces before agents use provider facts.
+
+## Public vs Private
+
+Safe to commit:
+
+- provider id and category;
+- account label when it does not expose a private account number;
+- secret backend name and secret ref;
+- role, access level, data domain, auth state, environment, and source system;
+- validation state, timestamps, and repair commands.
+
+Keep private:
+
+- API keys, access tokens, refresh tokens, passwords, service-account JSON;
+- raw bank, payment, order, customer, member, payroll, tax, or legal exports;
+- full account numbers, routing numbers, card numbers, and private debt terms;
+- provider payloads, workpapers, logs, or scripts that print secret values.
+
+## Finance Providers
+
+Finance and bookkeeping providers are more sensitive than marketing/site
+providers because read access can expose bank balances, customer payments,
+vendor names, debt terms, tax records, and payroll context. Treat finance
+connections as read-only by default and keep raw source data in a restricted
+finance repo, local books vault, or provider export location.
+
+Recommended custom metadata:
+
+```text
+role=operating_cash_source
+access_level=read_only
+data_domain=banking
+auth_state=api_token
+source_system=mercury
+account_ref=operating-cash
+```
+
+Avoid raw bank account numbers in repo metadata. Use a business-readable handle
+such as `operating-cash` and put the exact mapping in the private finance
+workspace if needed.
+
+## Agent Boundary
+
+Agents can do without seeing secrets:
+
+- inspect provider readiness;
+- check whether a secret is present;
+- read safe identity metadata;
+- tell the operator which repair command to run;
+- run approved scripts that consume `mb connect token` without printing it;
+- summarize sanitized import counts and freshness.
+
+Approval-gated every time:
+
+- provider mutation;
+- spend, budget, campaign, or checkout changes;
+- money movement, transfers, bill pay, refunds, or payout changes;
+- emailing, publishing, posting, customer/member contact, or fulfillment writes;
+- exporting raw private records into a shared repo, public issue, PR, log, or
+  model context.
+
+## Implemented Follow-Ups
+
+- Custom providers are included in broad status/list/doctor surfaces.
+- Custom provider tests cover status, list, doctor, token, missing secrets, and
+  user scope.
+- Custom provider identity metadata is surfaced by `mb connect identity`.
+- `docs/connect.md` includes Mercury-style Keychain setup and safe token use.
+
+## Issue-Ready Follow-Ups
+
+- Add explicit secret-backend diagnostics: selected backend, backend
+  availability, Keychain/keyring read failure state, and repair commands.
+- Add `mb connect rotate <provider>` as a clearer alias over reconnecting with
+  `--token-stdin`, including sibling-ref rotation evidence.
+- Add finance-provider metadata validation warnings for raw-looking account
+  numbers, missing `access_level`, and missing `data_domain`.
+- Add optional 1Password command integration for token reads without teaching
+  committed `.env` files.
+- Add native read-only wrappers only after one provider has public-safe smoke
+  evidence and a privacy-bounded output contract.

--- a/mb/mb/__init__.py
+++ b/mb/mb/__init__.py
@@ -7,6 +7,6 @@ file stays a thin dispatcher.
 
 from __future__ import annotations
 
-__version__ = "0.4.2"
+__version__ = "0.4.3"
 
 __all__ = ["__version__"]

--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -1572,11 +1572,19 @@ def connect_cmd(
         raise typer.Exit(0)
     if target == "status":
         try:
-            result = connect_mod.status_all(repo, include_all=all_providers)
+            if provider:
+                result = connect_mod.status_provider(provider, repo)
+            else:
+                result = connect_mod.status_all(repo, include_all=all_providers)
+        except ValueError as exc:
+            typer.echo(f"mb connect status: {exc}", err=True)
+            raise typer.Exit(2) from exc
         except connect_mod.ConfigBoundaryError as exc:
             _connect_boundary_exit("mb connect status", exc)
         if json_out:
             typer.echo(json.dumps(result, indent=2))
+        elif provider:
+            connect_mod.render_provider_status(result)
         else:
             connect_mod.render_status(result)
         raise typer.Exit(0 if result["ok"] else 1)

--- a/mb/mb/connect.py
+++ b/mb/mb/connect.py
@@ -318,6 +318,17 @@ def provider_registry() -> list[dict[str, Any]]:
 
 
 CUSTOM_PROVIDER_RE = re.compile(r"^[a-z0-9][a-z0-9-]{1,30}$")
+CUSTOM_IDENTITY_METADATA_ORDER = (
+    "role",
+    "access_level",
+    "data_domain",
+    "auth_state",
+    "environment",
+    "source_system",
+    "account_ref",
+    "workspace",
+    "tenant_id",
+)
 
 
 def _custom_provider(provider_id: str) -> Provider:
@@ -367,6 +378,32 @@ def _connect_command(provider: Provider, *, token_stdin: bool = False) -> str:
     custom_flag = " --custom" if provider.category == "custom" else ""
     token_flag = " --token-stdin" if token_stdin else ""
     return f"mb connect {provider.id}{custom_flag}{token_flag}"
+
+
+def _safe_identity_metadata(metadata: dict[str, Any]) -> dict[str, str]:
+    """Return custom-provider metadata safe enough for identity diagnostics.
+
+    The output is still operator-facing (`safe_to_share: false`), but this
+    avoids echoing hand-edited secret-like metadata keys if a repo config is
+    malformed.
+    """
+
+    recorded: dict[str, str] = {}
+    for key in CUSTOM_IDENTITY_METADATA_ORDER:
+        value = metadata.get(key)
+        if value is not None and value != "":
+            recorded[key] = str(value)
+    for raw_key, value in metadata.items():
+        key = str(raw_key)
+        lowered = key.lower().replace("-", "_")
+        if key in recorded or value is None or value == "":
+            continue
+        if lowered not in SAFE_METADATA_KEYS and any(
+            part in lowered for part in SENSITIVE_KEY_PARTS
+        ):
+            continue
+        recorded[key] = str(value)
+    return recorded
 
 
 def _now() -> str:
@@ -2728,16 +2765,29 @@ def business_identity(repo: str | Path = ".") -> dict[str, Any]:
         if not item["connected"]:
             continue
         provider = pmap.get(item["provider"])
-        fields = provider.metadata_fields if provider else ()
-        if not fields:
-            continue
         metadata = item.get("metadata") or {}
-        recorded = {field: str(metadata.get(field, "")) for field in fields}
-        missing = [field for field in fields if not recorded[field]]
+        metadata = metadata if isinstance(metadata, dict) else {}
+        if provider:
+            fields = provider.metadata_fields
+            if not fields:
+                continue
+            recorded = {field: str(metadata.get(field, "")) for field in fields}
+            missing = [field for field in fields if not recorded[field]]
+            schema = "registry"
+        elif _is_custom_provider_id(str(item["provider"])):
+            recorded = _safe_identity_metadata(metadata)
+            if not recorded:
+                continue
+            missing = []
+            schema = "custom_metadata"
+        else:
+            continue
         providers_out.append(
             {
                 "provider": item["provider"],
                 "name": item["name"],
+                "custom": provider is None,
+                "identity_schema": schema,
                 "identity": recorded,
                 "missing_fields": missing,
                 "complete": not missing,

--- a/mb/mb/connect.py
+++ b/mb/mb/connect.py
@@ -358,6 +358,17 @@ def normalize_provider(provider_id: str, *, allow_custom: bool = False) -> Provi
     )
 
 
+def _is_custom_provider_id(provider_id: str) -> bool:
+    key = provider_id.strip().lower().replace("_", "-")
+    return key not in provider_map() and bool(CUSTOM_PROVIDER_RE.fullmatch(key))
+
+
+def _connect_command(provider: Provider, *, token_stdin: bool = False) -> str:
+    custom_flag = " --custom" if provider.category == "custom" else ""
+    token_flag = " --token-stdin" if token_stdin else ""
+    return f"mb connect {provider.id}{custom_flag}{token_flag}"
+
+
 def _now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
 
@@ -614,7 +625,7 @@ def _repair(
     if provider.id == "meta":
         return _meta_repair(state, missing)
     missing_fields = ", ".join(missing or provider.required_secrets)
-    connect_command = f"mb connect {provider.id} --token-stdin"
+    connect_command = _connect_command(provider, token_stdin=True)
     if state == "not_connected":
         if provider.required_secrets:
             return {
@@ -1484,6 +1495,7 @@ def read_token(provider_id: str, repo: str | Path = ".") -> dict[str, Any]:
         entry = _user_scope_provider_entry(repo_id, provider.id)
         source = "user"
     if not isinstance(entry, dict):
+        repair_command = _connect_command(provider, token_stdin=True)
         return {
             "ok": False,
             "provider": provider.id,
@@ -1491,10 +1503,11 @@ def read_token(provider_id: str, repo: str | Path = ".") -> dict[str, Any]:
             "source": "",
             "token": "",
             "error": f"{provider.name} is not connected",
-            "repair_command": f"mb connect {provider.id} --token-stdin",
+            "repair_command": repair_command,
         }
     token = _entry_secret_value(entry, field)
     if not token:
+        repair_command = _connect_command(provider, token_stdin=True)
         return {
             "ok": False,
             "provider": provider.id,
@@ -1502,7 +1515,7 @@ def read_token(provider_id: str, repo: str | Path = ".") -> dict[str, Any]:
             "source": source,
             "token": "",
             "error": f"{provider.name} credential is missing or unreadable from the secret store",
-            "repair_command": f"mb connect {provider.id} --token-stdin",
+            "repair_command": repair_command,
         }
     return {
         "ok": True,
@@ -2113,13 +2126,24 @@ def status_all(
     user_repo = _read_user_scope()["repos"].get(repo_id)
     user_repo = user_repo if isinstance(user_repo, dict) else {}
     user_providers = user_repo.get("providers")
-    configured = set(config["providers"].keys())
+    configured = {
+        str(key).strip().lower().replace("_", "-")
+        for key in config["providers"]
+        if str(key).strip()
+    }
     if isinstance(user_providers, dict):
-        configured.update(str(key) for key in user_providers)
+        configured.update(
+            str(key).strip().lower().replace("_", "-") for key in user_providers if str(key).strip()
+        )
     providers = []
     for provider in PROVIDERS:
         if include_all or provider.id in configured:
             providers.append(status_provider(provider.id, target))
+    custom_ids = sorted(
+        provider_id for provider_id in configured if _is_custom_provider_id(provider_id)
+    )
+    for provider_id in custom_ids:
+        providers.append(status_provider(provider_id, target))
     connected = [item for item in providers if item["connected"]]
     broken = [item for item in connected if not item["ok"]]
     unvalidated = [item for item in connected if item["state"] == "unvalidated"]
@@ -2262,11 +2286,40 @@ def list_providers(repo: str | Path = ".") -> dict[str, Any]:
     status = status_all(repo, include_all=True)
     by_id = {item["provider"]: item for item in status["providers"]}
     providers = []
-    for provider in provider_registry():
-        state = by_id[provider["id"]]["state"]
-        guidance = PROVIDER_GUIDANCE.get(provider["id"], {})
-        providers.append({**provider, **guidance, "state": state})
-    return {"ok": True, "providers": providers, "config_path": status["config_path"]}
+    for registry_entry in provider_registry():
+        state = by_id[registry_entry["id"]]["state"]
+        guidance = PROVIDER_GUIDANCE.get(registry_entry["id"], {})
+        providers.append({**registry_entry, **guidance, "state": state, "custom": False})
+    custom_providers = []
+    for item in status["providers"]:
+        if not _is_custom_provider_id(item["provider"]):
+            continue
+        custom_provider = _custom_provider(item["provider"])
+        custom = {
+            "id": custom_provider.id,
+            "name": custom_provider.name,
+            "category": custom_provider.category,
+            "auth": custom_provider.auth,
+            "required_secrets": list(custom_provider.required_secrets),
+            "metadata_fields": list(custom_provider.metadata_fields),
+            "description": custom_provider.description,
+            "env_vars": list(custom_provider.env_vars),
+            "state": item["state"],
+            "custom": True,
+            "connected": bool(item["connected"]),
+            "ready": bool(item["ok"]),
+            "account_label": item.get("account_label", ""),
+            "scope": item.get("scope", "repo"),
+            "repair_command": item.get("repair_command", ""),
+        }
+        providers.append(custom)
+        custom_providers.append(custom)
+    return {
+        "ok": True,
+        "providers": providers,
+        "custom_providers": custom_providers,
+        "config_path": status["config_path"],
+    }
 
 
 def provider_plan(repo: str | Path = ".") -> dict[str, Any]:
@@ -2765,6 +2818,16 @@ def render_status(result: dict[str, Any]) -> None:
         print(f"  {state}  {item['provider']}{label}: {item['state']}")
         if item["repair_command"]:
             print(f"       next: {item['repair_command']}")
+
+
+def render_provider_status(result: dict[str, Any]) -> None:
+    state = "ok" if result["ok"] else "warn"
+    label = f" ({result['account_label']})" if result["account_label"] else ""
+    print(f"mb connect status {result['provider']}{label}: {state} ({result['state']})")
+    if result.get("summary"):
+        print(f"summary: {result['summary']}")
+    if result.get("repair_command"):
+        print(f"next: {result['repair_command']}")
 
 
 def render_doctor(result: dict[str, Any]) -> None:

--- a/mb/pyproject.toml
+++ b/mb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mainbranch"
-version = "0.4.2"
+version = "0.4.3"
 description = "Main Branch engine umbrella - scaffolds, validates, and graphs business-as-files repos. Claude Code first, runtime-agnostic by design."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/mb/tests/test_connect.py
+++ b/mb/tests/test_connect.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import stat
 import sys
@@ -16,6 +17,10 @@ from mb import connect as connect_mod
 from mb.cli import app
 
 runner = CliRunner()
+
+
+def _sha256(value: str) -> str:
+    return hashlib.sha256(value.encode()).hexdigest()
 
 
 def _local_secret_env(monkeypatch, tmp_path: Path) -> None:
@@ -1782,6 +1787,7 @@ def test_connect_custom_provider_roundtrip(tmp_path: Path, monkeypatch) -> None:
     _local_secret_env(monkeypatch, tmp_path)
     repo = tmp_path / "biz"
     repo.mkdir()
+    secret = "custom-fixture-token"
 
     result = runner.invoke(
         app,
@@ -1792,22 +1798,53 @@ def test_connect_custom_provider_roundtrip(tmp_path: Path, monkeypatch) -> None:
             "--repo",
             str(repo),
             "--token",
-            "custom-fixture-token",
+            secret,
         ],
     )
     assert result.exit_code == 0
 
     config_text = (repo / ".mb" / "connect.yaml").read_text(encoding="utf-8")
-    assert "custom-fixture-token" not in config_text
+    assert secret not in config_text
     assert "dataforseo" in config_text
 
     token = runner.invoke(app, ["connect", "token", "dataforseo", "--repo", str(repo)])
     assert token.exit_code == 0
-    assert token.stdout == "custom-fixture-token\n"
+    assert _sha256(token.stdout.strip()) == _sha256(secret)
 
     status = connect_mod.status_provider("dataforseo", repo)
     assert status["provider"] == "dataforseo"
     assert status["connected"] is True
+    assert status["state"] == "unvalidated"
+
+    tested = connect_mod.test_provider("dataforseo", repo)
+    assert tested["ok"] is True
+    assert tested["status"]["state"] == "ready"
+
+    single_status = runner.invoke(
+        app, ["connect", "status", "dataforseo", "--repo", str(repo), "--json"]
+    )
+    assert single_status.exit_code == 0
+    single_status_payload = json.loads(single_status.stdout)
+    assert single_status_payload["provider"] == "dataforseo"
+    assert single_status_payload["state"] == "ready"
+
+    aggregate = connect_mod.status_all(repo, include_all=True)
+    aggregate_by_id = {item["provider"]: item for item in aggregate["providers"]}
+    assert aggregate_by_id["dataforseo"]["state"] == "ready"
+    assert aggregate["summary"]["configured"] == 1
+    assert aggregate["summary"]["healthy"] == 1
+
+    doctor = connect_mod.doctor(repo)
+    checks = {check["name"]: check for check in doctor["checks"]}
+    assert checks["provider:dataforseo"]["state"] == "ready"
+
+    listed = connect_mod.list_providers(repo)
+    listed_by_id = {provider["id"]: provider for provider in listed["providers"]}
+    assert listed_by_id["cloudflare"]["custom"] is False
+    assert listed_by_id["dataforseo"]["custom"] is True
+    assert listed_by_id["dataforseo"]["category"] == "custom"
+    assert listed_by_id["dataforseo"]["state"] == "ready"
+    assert listed["custom_providers"][0]["id"] == "dataforseo"
 
     reconnect = runner.invoke(
         app,
@@ -1815,7 +1852,131 @@ def test_connect_custom_provider_roundtrip(tmp_path: Path, monkeypatch) -> None:
     )
     assert reconnect.exit_code == 0
     rotated = runner.invoke(app, ["connect", "token", "dataforseo", "--repo", str(repo)])
-    assert rotated.stdout == "rotated-fixture-token\n"
+    assert _sha256(rotated.stdout.strip()) == _sha256("rotated-fixture-token")
+
+
+def test_connect_custom_provider_missing_secret_surfaces_repair(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _local_secret_env(monkeypatch, tmp_path)
+    repo = tmp_path / "biz"
+    repo.mkdir()
+    (repo / ".mb").mkdir()
+    (repo / ".mb" / "connect.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "version": 1,
+                "repo_id": "repo",
+                "providers": {
+                    "mercury": {
+                        "provider": "mercury",
+                        "connected": True,
+                        "scope": "repo",
+                        "auth": "api_key",
+                        "secrets": {
+                            "api_key": {
+                                "ref": connect_mod._secret_ref("repo", "mercury", "api_key"),
+                                "backend": "local-file",
+                            }
+                        },
+                        "metadata": {"role": "operating_cash_source"},
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    status = runner.invoke(app, ["connect", "status", "--all", "--repo", str(repo), "--json"])
+    assert status.exit_code == 1
+    status_payload = json.loads(status.stdout)
+    mercury = next(item for item in status_payload["providers"] if item["provider"] == "mercury")
+    assert mercury["state"] == "missing_secret"
+    assert mercury["repair_command"] == "mb connect mercury --custom --token-stdin"
+    assert mercury["secrets"]["api_key"]["present"] is False
+    assert status_payload["summary"]["configured"] == 1
+    assert status_payload["summary"]["needs_repair"] == 1
+
+    single_status = runner.invoke(
+        app, ["connect", "status", "mercury", "--repo", str(repo), "--json"]
+    )
+    assert single_status.exit_code == 1
+    single_status_payload = json.loads(single_status.stdout)
+    assert single_status_payload["provider"] == "mercury"
+    assert single_status_payload["state"] == "missing_secret"
+    assert single_status_payload["repair_command"] == ("mb connect mercury --custom --token-stdin")
+
+    token = runner.invoke(app, ["connect", "token", "mercury", "--repo", str(repo)])
+    assert token.exit_code == 1
+    assert token.stdout == ""
+    assert "missing or unreadable" in token.stderr
+    assert "repair: mb connect mercury --custom --token-stdin" in token.stderr
+
+    doctor = runner.invoke(app, ["connect", "doctor", "--repo", str(repo), "--json"])
+    assert doctor.exit_code == 1
+    doctor_payload = json.loads(doctor.stdout)
+    checks = {check["name"]: check for check in doctor_payload["checks"]}
+    assert checks["provider:mercury"]["state"] == "missing_secret"
+    assert checks["provider:mercury"]["repair_command"] == (
+        "mb connect mercury --custom --token-stdin"
+    )
+
+    listed = runner.invoke(app, ["connect", "list", "--repo", str(repo), "--json"])
+    assert listed.exit_code == 0
+    listed_payload = json.loads(listed.stdout)
+    listed_mercury = next(
+        provider for provider in listed_payload["providers"] if provider["id"] == "mercury"
+    )
+    assert listed_mercury["state"] == "missing_secret"
+    assert listed_mercury["custom"] is True
+
+
+def test_connect_user_scope_custom_provider_hydrates_and_reads(tmp_path: Path, monkeypatch) -> None:
+    _local_secret_env(monkeypatch, tmp_path)
+    canonical = tmp_path / "canonical"
+    disposable = tmp_path / "workspace"
+    canonical.mkdir()
+    disposable.mkdir()
+    secret = "mercury-fixture-token"
+
+    def fake_git(repo: Path, args: list[str]) -> str:
+        if args == ["config", "--get", "remote.origin.url"]:
+            return "git@github.com:acme/business.git"
+        return ""
+
+    monkeypatch.setattr(connect_mod, "_git_output", fake_git)
+
+    connected = connect_mod.connect_provider(
+        "mercury",
+        repo=canonical,
+        token=secret,
+        account_label="Mercury Fixture",
+        metadata_pairs=["role=operating_cash_source"],
+        scope="user",
+        custom=True,
+    )
+    assert connected["scope"] == "user"
+    assert Path(connected["user_scope_path"]).exists()
+    assert secret not in Path(connected["user_scope_path"]).read_text(encoding="utf-8")
+
+    before = connect_mod.status_all(disposable)
+    assert before["summary"]["configured"] == 1
+    assert before["providers"][0]["provider"] == "mercury"
+    assert before["providers"][0]["state"] == "needs_hydration"
+    assert before["providers"][0]["repair_command"] == "mb connect hydrate --repo ."
+
+    token = runner.invoke(app, ["connect", "token", "mercury", "--repo", str(disposable)])
+    assert token.exit_code == 0
+    assert _sha256(token.stdout.strip()) == _sha256(secret)
+
+    hydrated = connect_mod.hydrate(disposable, provider_id="mercury")
+    assert hydrated["ok"] is True
+    assert hydrated["hydrated"] == ["mercury"]
+    assert secret not in (disposable / ".mb" / "connect.yaml").read_text(encoding="utf-8")
+
+    tested = connect_mod.test_provider("mercury", disposable)
+    assert tested["ok"] is True
+    assert tested["status"]["state"] == "ready"
 
 
 def test_connect_unknown_provider_hints_custom(tmp_path: Path, monkeypatch) -> None:

--- a/mb/tests/test_connect.py
+++ b/mb/tests/test_connect.py
@@ -2288,6 +2288,68 @@ def test_identity_cli_json(tmp_path: Path, monkeypatch) -> None:
     assert any(p["provider"] == "meta" for p in payload["providers"])
 
 
+def test_identity_includes_custom_provider_safe_metadata(tmp_path: Path, monkeypatch) -> None:
+    _local_secret_env(monkeypatch, tmp_path)
+    repo = tmp_path / "biz"
+    repo.mkdir()
+    connect_mod.connect_provider(
+        "mercury",
+        repo=repo,
+        token="mercury-fixture-token",
+        account_label="Mercury Fixture",
+        metadata_pairs=[
+            "role=operating_cash_source",
+            "access_level=read_only",
+            "data_domain=banking",
+            "auth_state=api_token",
+        ],
+        custom=True,
+    )
+
+    result = connect_mod.business_identity(repo)
+
+    mercury = next(p for p in result["providers"] if p["provider"] == "mercury")
+    assert mercury["custom"] is True
+    assert mercury["identity_schema"] == "custom_metadata"
+    assert mercury["identity"] == {
+        "role": "operating_cash_source",
+        "access_level": "read_only",
+        "data_domain": "banking",
+        "auth_state": "api_token",
+    }
+    assert mercury["missing_fields"] == []
+    assert mercury["complete"] is True
+    assert "mercury-fixture-token" not in json.dumps(result)
+
+
+def test_identity_suppresses_secret_like_custom_metadata(tmp_path: Path, monkeypatch) -> None:
+    _local_secret_env(monkeypatch, tmp_path)
+    repo = tmp_path / "biz"
+    repo.mkdir()
+    connect_mod.connect_provider(
+        "mercury",
+        repo=repo,
+        token="mercury-fixture-token",
+        metadata_pairs=["role=operating_cash_source"],
+        custom=True,
+    )
+    config_path = repo / ".mb" / "connect.yaml"
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    config["providers"]["mercury"]["metadata"]["api_key"] = "badly-committed-secret"
+    config["providers"]["mercury"]["metadata"]["account_ref"] = "operating-cash"
+    config_path.write_text(yaml.safe_dump(config), encoding="utf-8")
+
+    result = connect_mod.business_identity(repo)
+
+    mercury = next(p for p in result["providers"] if p["provider"] == "mercury")
+    assert mercury["identity"] == {
+        "role": "operating_cash_source",
+        "account_ref": "operating-cash",
+    }
+    assert "badly-committed-secret" not in json.dumps(result)
+    assert "api_key" not in mercury["identity"]
+
+
 def test_hygiene_flags_literal_secret_mixed_with_env_ref(tmp_path: Path) -> None:
     # "${ENV}sk-realsecret" must NOT pass as externalized (false-negative fix).
     home = tmp_path / "home"


### PR DESCRIPTION
## Summary

Release prep for `mainbranch 0.4.3`.

This release makes custom `mb connect` providers first-class across the
readiness surfaces used by agents and scripts, with Awake Happy's Mercury
setup as the motivating fixture.

## In Scope

- Include custom providers in `mb connect status --all`, `doctor`, and `list`.
- Add provider-specific `mb connect status <provider> --json`.
- Make missing custom secrets report `missing_secret` with runnable
  `--custom --token-stdin` repair guidance.
- Surface safe custom-provider identity metadata in `mb connect identity`.
- Document the connection model, provider lifecycle, Mercury-style Keychain
  setup, safe token use, readiness checks, and rotation path.
- Ignore local `.agents/` skill-cache copies.
- Bump package/plugin release files to `0.4.3`.

## Out Of Scope

- Native Mercury, Xero, A2X, Printful, or bank API wrappers.
- Provider-side money movement, spend, publishing, account mutation, or raw
  finance export handling.
- Secret-backend diagnostics beyond the current missing/unreadable state.

## Commits

- `5c40a1ea [fix] Include custom connect providers in status`
- `bbfe70ce [add] Document connect lifecycle and custom identity`
- `262aa5c9 [fix] Ignore local agent skill cache`
- `bd771dff [release] Prepare 0.4.3`

## Success Metric

A bookkeeping agent can inspect `mb connect status --all --json`,
`mb connect doctor --json`, `mb connect list --json`, and
`mb connect identity --json` and know whether a custom Mercury provider is
ready or missing its secret without seeing the token.

## Validation

- Level 0 release preflight:
  `scripts/release-preflight.sh oe-v0.4.3` — runtime: `python3` — exit: `0` —
  log: `.agent/release-evidence/0.4.3/release-preflight.out`.
- Level 1 static:
  `scripts/check.sh` — runtime: `python3` — exit: `0` — log:
  `.agent/release-evidence/0.4.3/check.out`
  (`1095 passed`, coverage `84.37%`, skill validation passed).
- Level 2 focused CLI:
  `pytest tests/test_connect.py -q` — runtime: repo test environment — exit:
  `0` (`83 passed`).
- Level 3 package/install:
  build via `/tmp/mainbranch-0.4.3-build/bin/python -m build`; fresh venv
  install of `mb/dist/mainbranch-0.4.3-py3-none-any.whl`; `mb --version`;
  `mb skill list` — exit: `0` — logs:
  `.agent/release-evidence/0.4.3/build.out`,
  `.agent/release-evidence/0.4.3/install.out`.
- Level 3 package custom-provider smoke:
  installed wheel connected fixture `mercury` custom provider, checked
  `status`, `status --all`, `doctor`, `list`, `identity`, and token read
  without printing the fixture token — exit: `0` — log:
  `.agent/release-evidence/0.4.3/connect-wheel-smoke.out`.
- Level 3 books fixture:
  `mb books check --fixture --json` with hledger available and with hledger
  hidden from `PATH` — both exit: `0`; hledger mode reports `fixture-valid`,
  fallback mode reports `hledger-missing`; logs:
  `.agent/release-evidence/0.4.3/books-fixture-hledger.out`,
  `.agent/release-evidence/0.4.3/books-fixture-no-hledger.out`.
- Level 5 release simulation:
  `scripts/claude-runtime-dogfood.py --install-mode wheel --wheel
  mb/dist/mainbranch-0.4.3-py3-none-any.whl --run-claude-print
  --simulation-tier prerelease_candidate --max-budget-usd 0.75` — exit: `0`;
  deterministic harness passed; Claude print-mode stopped at `mb-start`
  because Claude returned `401 Invalid authentication credentials`; evidence:
  `.agent/release-evidence/0.4.3/prerelease-candidate/`.
- Level 5 release acceptance before tag:
  same wheel with `--simulation-tier release_acceptance` — exit: `0`;
  deterministic harness passed; Claude print-mode had the same `401` auth
  limitation; evidence:
  `.agent/release-evidence/0.4.3/release-acceptance-wheel/`.
- Plugin manifest smoke:
  `claude plugin validate .` — exit: `0` — log:
  `.agent/release-evidence/0.4.3/plugin-validate-root.out`.

## Pre-Publish Notes

- Supply-chain check passed: no runtime dependency addition, no workflow file
  change, Dependabot alerts reported `0`, and the `pypi` environment has a
  required reviewer.
- Direct push to `main` was blocked by branch protection, so this PR is the
  release path.
- Claude Code print-mode and interactive plugin smoke are currently limited by
  local Claude auth returning `401 Invalid authentication credentials`. Before
  publishing, either fix Claude auth and run the manual plugin-load smoke, or
  record an explicit maintainer waiver for that release gate.

## Public / Private Boundary

No credentials, raw finance data, account exports, customer data, private
business records, or fixture tokens are committed. Release evidence stays under
ignored `.agent/`.
