### PR TITLE
[update] Ship 0.5 durability release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Main Branch — run a business from markdown files in git, with Claude Code as the operator surface.",
-    "version": "0.4.3"
+    "version": "0.5.0"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mainbranch",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "description": "Main Branch Claude Code skills for running a business from markdown files in git.",
   "author": {
     "name": "Noontide"

--- a/.claude/skills/mb-ads/references/compliance/README.md
+++ b/.claude/skills/mb-ads/references/compliance/README.md
@@ -1,0 +1,99 @@
+# Compliance Reference
+
+Strategic planning resources for compliant advertising.
+
+---
+
+## How This Differs from Lenses
+
+**Lenses** (in `.claude/lenses/`) check individual ads for violations after they're written.
+
+**Compliance references** (this folder) help decide what TYPE of ads to create BEFORE writing them.
+
+```
+PLANNING PHASE                    REVIEW PHASE
+─────────────────                 ─────────────
+compliance/                       lenses/
+├── ftc-scrutiny-categories.md    ├── ftc-compliance.md
+├── angle-playbook.md             ├── meta-policy.md
+├── testimonial-decision-rubric.md├── copy-quality.md
+└── typicality/                   ├── visual-standards.md
+                                  ├── voice-authenticity.md
+                                  └── substantiation.md
+```
+
+---
+
+## Files in This Folder
+
+### Strategic Planning
+
+| File | Purpose | When to Use |
+|------|---------|-------------|
+| `ftc-scrutiny-categories.md` | Which industries get extra FTC attention | Before starting ANY campaign for a client |
+| `angle-playbook.md` | All persuasion angles + rules for each | When planning campaign angles |
+| `testimonial-decision-rubric.md` | When outcome testimonials are worth it | Before deciding to use testimonials |
+
+### Client-Specific Data
+
+| Folder | Purpose | When to Use |
+|--------|---------|-------------|
+| `typicality/` | FTC-required outcome data per client | When using outcome testimonials |
+| `typicality/README.md` | How to collect typicality data | When data is missing |
+| `typicality/{client}-typicality.md` | Client-specific outcome data | During ad review |
+
+---
+
+## Pre-Campaign Checklist
+
+Before creating ads for a client:
+
+### 1. Check FTC Scrutiny Level
+Read `ftc-scrutiny-categories.md`
+- Tier 1 (Max scrutiny): Default to non-outcome angles
+- Tier 2 (High): Outcome testimonials need proper disclosure
+- Tier 3 (Moderate): Standard compliance
+
+### 2. Decide on Angles
+Read `angle-playbook.md`
+- Which angles fit this offer?
+- What are the compliance requirements for each?
+- Which angles to avoid?
+
+### 3. If Using Outcome Testimonials
+Read `testimonial-decision-rubric.md`
+- Score the offer on the rubric
+- If score < 5: Use alternative angles
+- If score >= 5: Check typicality data
+
+### 4. Check Typicality Data
+Look for `typicality/{client}-typicality.md`
+- If exists with data: Use for disclosures
+- If exists but "DATA NEEDED": Block outcome testimonials
+- If doesn't exist: Create file, flag as research task
+
+---
+
+## Adding New Clients
+
+When onboarding a new client:
+
+1. Create `typicality/{client}-typicality.md` using template in `typicality/README.md`
+2. Assess FTC scrutiny tier for their industry
+3. Document what outcome data exists (if any)
+4. Recommend angle strategy based on compliance burden
+
+---
+
+## Quick Reference: Angle by Risk
+
+| Low Compliance Burden | High Compliance Burden |
+|-----------------------|------------------------|
+| Mechanism | Outcome testimonials |
+| Social proof (scale) | Urgency/scarcity |
+| Risk reversal | Pain agitation (Meta) |
+| Community | |
+| Process testimonials | |
+| Curiosity | |
+
+When in doubt, use low-burden angles.

--- a/.claude/skills/mb-ads/references/compliance/angle-playbook.md
+++ b/.claude/skills/mb-ads/references/compliance/angle-playbook.md
@@ -1,0 +1,387 @@
+# Angle Playbook
+
+Persuasion angles for ads, with compliance considerations for each.
+
+---
+
+## Why This Exists
+
+Not every ad needs outcome testimonials. This playbook covers all major persuasion angles, what rules apply to each, and when to use them.
+
+---
+
+## Angle Library Philosophy
+
+**Angles are an evolving library, not a locked set.** New angles emerge from research, mining, and think cycles. The library is additive — every session may surface a new angle or refine an existing one. Positioning should evolve as understanding deepens.
+
+When a new emotional territory, audience insight, or competitive position is discovered through /mb-think, it becomes a candidate for a new angle file in `core/proof/angles/`.
+
+---
+
+## Angle Categories
+
+### 1. OUTCOME TESTIMONIALS
+
+**What it is:** Specific results from real customers (scores, revenue, weight lost)
+
+**Compliance burden:** HIGH
+- FTC typicality disclosure required
+- Must state what AVERAGE user achieves
+- Data collection from ALL users needed
+- Platform restrictions may apply
+
+**When to use:**
+- High-ticket offers where proof is expected
+- Done-for-you services
+- When you have favorable typicality data
+
+**When to avoid:**
+- Regulated categories (credit, health, income)
+- Education/community offers
+- When honest numbers would hurt conversion
+
+**Rules:**
+- ✅ Must have documented consent
+- ✅ Must match offer tier (no high-ticket testimonials for low-ticket)
+- ✅ Must include typicality disclosure near the claim
+- ❌ "Results not typical" alone is insufficient
+- ❌ Cannot audit only wins channel (survivorship bias)
+
+---
+
+### 2. PROCESS TESTIMONIALS
+
+**What it is:** Experience of using the product, not outcomes achieved
+
+**Compliance burden:** LOW
+- No typicality disclosure needed
+- No outcome data required
+
+**Examples:**
+- "The content is well-organized and actionable"
+- "Questions get answered within hours"
+- "I finally understand how this works"
+- "The templates saved me tons of research"
+
+**When to use:**
+- Regulated categories where outcome claims are risky
+- Education/community offers
+- When you don't have typicality data
+
+**Rules:**
+- ✅ Must be genuine (real customer, real experience)
+- ✅ Must have documented consent
+- ❌ Cannot imply outcomes ("I learned so much... and then made $50K")
+
+---
+
+### 3. SOCIAL PROOF (SCALE)
+
+**What it is:** Numbers that demonstrate popularity/trust
+
+**Compliance burden:** LOW
+- Must be accurate and current
+- Source should be documented
+
+**Examples:**
+- "27,800+ members"
+- "500+ 5-star reviews"
+- "Trusted by 10,000 businesses"
+- "Featured in Forbes, Inc, Entrepreneur"
+
+**When to use:**
+- Any offer type
+- Especially effective for low-ticket (reduces perceived risk)
+- Community/membership offers
+
+**Rules:**
+- ✅ Numbers must be accurate and verifiable
+- ✅ Should note date if number changes ("as of Jan 2026")
+- ❌ Cannot suppress negative reviews (must show mix)
+- ❌ Cannot use fake reviews or inflated numbers
+
+**Platform notes:**
+- Meta: Generally safe, no special restrictions
+- FTC: Must be truthful, verifiable
+
+---
+
+### 4. MECHANISM
+
+**What it is:** How the product/service works
+
+**Compliance burden:** LOW
+- Must accurately describe the process
+- No outcome claims = no typicality needed
+
+**Examples:**
+- "AI generates personalized dispute letters"
+- "37 proven email templates"
+- "Weekly live Q&A calls with experts"
+- "Step-by-step video curriculum"
+
+**When to use:**
+- When the "how" is genuinely interesting/unique
+- Education/info products
+- Software/tools
+- When avoiding outcome claims
+
+**Rules:**
+- ✅ Must accurately describe what's included
+- ✅ Can use specificity (numbers, features)
+- ❌ Cannot imply guaranteed outcomes from mechanism
+- ❌ Cannot misrepresent what's actually delivered
+
+**Copywriting note:** Mechanism is most powerful when it's:
+- Novel (they haven't heard this before)
+- Specific (numbers, names, details)
+- Believable (not magic, has logic)
+
+---
+
+### 5. RISK REVERSAL
+
+**What it is:** Reducing perceived risk of purchase
+
+**Compliance burden:** LOW
+- Guarantee terms must be honored
+- Refund policy must be clearly stated
+
+**Examples:**
+- "$5/month, cancel anytime"
+- "30-day money-back guarantee"
+- "Try free for 14 days"
+- "No credit card required"
+
+**When to use:**
+- Low-ticket offers (emphasize low commitment)
+- High-ticket offers (emphasize guarantee)
+- When audience is skeptical
+
+**Rules:**
+- ✅ Must honor stated guarantee
+- ✅ Refund process must be reasonable
+- ❌ Cannot have hidden conditions that make refund impossible
+- ❌ Cannot use fake scarcity with guarantee ("only 2 spots, but also money-back")
+
+---
+
+### 6. AUTHORITY
+
+**What it is:** Credibility markers that establish trust
+
+**Compliance burden:** MEDIUM
+- Press mentions must be accurate
+- Credentials must be real
+- Endorsements require disclosure
+
+**Examples:**
+- "As seen in Forbes, Inc, WSJ"
+- "Dr. [Name], Harvard Medical School"
+- "20 years in the industry"
+- "Certified by [Organization]"
+
+**When to use:**
+- When credibility is in question
+- High-ticket offers
+- Health/financial topics where expertise matters
+
+**Rules:**
+- ✅ Press mentions must be accurate (actually featured, not just quoted)
+- ✅ Credentials must be real and current
+- ✅ Celebrity/influencer endorsements require material connection disclosure
+- ❌ Cannot imply credentials you don't have
+- ❌ Cannot use logos without permission
+
+**Platform notes:**
+- Meta: No unauthorized use of brand logos
+- FTC: Endorsement disclosure required for paid relationships
+
+---
+
+### 7. COMMUNITY/BELONGING
+
+**What it is:** Emphasizing the group/tribe aspect
+
+**Compliance burden:** LOW
+- Must accurately describe community
+
+**Examples:**
+- "Join 27,800 people on the same journey"
+- "Weekly accountability calls"
+- "Private group where questions get answered"
+- "You're not doing this alone"
+
+**When to use:**
+- Membership/community offers
+- When isolation is part of the pain
+- When support is a key differentiator
+
+**Rules:**
+- ✅ Community features must exist as described
+- ✅ Activity level should be accurate ("active" means actually active)
+- ❌ Cannot imply outcomes from community membership
+
+---
+
+### 8. CURIOSITY/INTRIGUE
+
+**What it is:** Creating information gaps that compel clicks
+
+**Compliance burden:** LOW-MEDIUM
+- Must deliver on the curiosity promise
+- Cannot be pure clickbait
+
+**Examples:**
+- "The 609 method banks don't want you to know"
+- "Why 91% of resolutions fail (and what the 9% do differently)"
+- "The counterintuitive approach to [X]"
+- "What I learned after [specific experience]"
+
+**When to use:**
+- Top of funnel awareness
+- When you have genuinely interesting insight
+- Pattern interrupt in crowded feeds
+
+**Rules:**
+- ✅ Must deliver on the implied promise
+- ✅ "Secret" or "loophole" must be real
+- ❌ Cannot be pure clickbait (promise must be fulfilled)
+- ❌ Cannot imply exclusive access to public information
+
+**Copywriting note:** Best curiosity gaps are:
+- Specific (numbers, names)
+- Counterintuitive (challenges assumption)
+- Resolvable (answer exists and you'll deliver it)
+
+---
+
+### 9. PAIN AGITATION
+
+**What it is:** Highlighting the problem before presenting solution
+
+**Compliance burden:** MEDIUM
+- Must avoid Personal Attributes on Meta
+- Cannot be exploitative
+
+**Examples:**
+- "Every January I promise to fix my credit. By March I've given up."
+- "The definition of insanity: doing the same thing expecting different results"
+- "I was tired of seeing everyone else succeed while I stayed stuck"
+
+**When to use:**
+- When audience is problem-aware but not solution-aware
+- Emotional purchases
+- When the pain is widely felt
+
+**Rules:**
+- ✅ Use first-person ("I was struggling") not second-person ("You are struggling")
+- ✅ Can describe common experiences
+- ❌ Meta: Cannot use "You + negative state" (Personal Attributes)
+- ❌ Cannot be exploitative or manipulative of vulnerable states
+
+**Platform notes:**
+- Meta: High rejection risk if using "you" + negative. Use "I" or "they" framing.
+- FTC: Cannot exploit vulnerable populations
+
+---
+
+### 10. URGENCY/SCARCITY
+
+**What it is:** Time or quantity limits that encourage action
+
+**Compliance burden:** HIGH
+- Must be REAL scarcity, not manufactured
+- False urgency is deceptive
+
+**Examples (Real):**
+- "Cohort starts January 15" (actual start date)
+- "Only 20 spots for live calls" (actual capacity limit)
+- "Price increases after beta" (actual planned increase)
+
+**Examples (Fake - AVOID):**
+- "Only 3 spots left" (on evergreen funnel)
+- Countdown timer that resets
+- "Doors closing" when they never close
+
+**When to use:**
+- Launches with real deadlines
+- Capacity-limited offers
+- Genuine price increases
+
+**Rules:**
+- ✅ Scarcity must be real and verifiable
+- ✅ Can reference natural urgency (motivation fading, year ending)
+- ❌ Cannot use fake countdown timers
+- ❌ Cannot claim limited spots on unlimited offers
+- ❌ FTC considers false scarcity deceptive
+
+---
+
+### 11. ENEMY/CONTRAST
+
+**What it is:** Positioning against a named concept (never a person/company) that the audience already fights
+
+**Compliance burden:** LOW
+- Must target concepts, not competitors by name
+- Cannot make comparative claims without substantiation
+
+**Examples:**
+- "Complexity is killing your business. Here's the antidote."
+- "Stop renting your infrastructure. Own it."
+- "If your content sounds like AI wrote it, it might as well not exist."
+- "Screen addiction is the real productivity killer."
+
+**When to use:**
+- Identity-driven offers (community, lifestyle, sovereignty)
+- When audience already feels the enemy but hasn't named it
+- As primary hook for content pillars (each pillar fights one enemy)
+- Pairs naturally with Mechanism or Community angles
+
+**When to avoid:**
+- Naming the enemy could be misread as attacking a specific competitor
+- Highly regulated categories where contrast could imply superiority claims
+
+**Rules:**
+- Enemy is ALWAYS a concept, never a person or company
+- Name it explicitly — vague enemies ("the system") don't land
+- Enemy must be something the audience already feels, not something you invented
+- The solution is your mechanism, not just "not that"
+- Each content pillar should map to one primary enemy
+
+**Copywriting note:** The most powerful enemies are ones the audience already fights but hasn't articulated. When you name their enemy, you become their ally. This is identity creation through contrast.
+
+---
+
+## Angle Selection by Offer Type
+
+| Offer Type | Primary Angles | Avoid |
+|------------|----------------|-------|
+| Low-ticket community ($5-50/mo) | Mechanism, Community, Risk Reversal, Social Proof, Enemy/Contrast | Outcome testimonials (not worth compliance burden) |
+| Mid-ticket course ($200-1000) | Process testimonials, Mechanism, Authority, Curiosity | Fake scarcity |
+| High-ticket coaching ($2K+) | Outcome testimonials (with data), Authority, Risk Reversal | Vague mechanism |
+| DFY service | Outcome testimonials, Case studies, Authority | Process-only testimonials |
+| Software/tool | Mechanism, Social Proof, Risk Reversal | Personal transformation claims |
+
+---
+
+## Platform Quick Reference
+
+| Angle | Meta Risk | FTC Risk |
+|-------|-----------|----------|
+| Outcome testimonials | Medium (if compliant) | HIGH (typicality required) |
+| Process testimonials | Low | Low |
+| Social proof (scale) | Low | Low (if accurate) |
+| Mechanism | Low | Low |
+| Risk reversal | Low | Low (if honored) |
+| Authority | Medium (logo usage) | Medium (endorsement disclosure) |
+| Community | Low | Low |
+| Curiosity | Low | Low (if delivered) |
+| Pain agitation | HIGH (Personal Attributes) | Low |
+| Urgency/scarcity | Low | HIGH (if fake) |
+| Enemy/contrast | Low | Low (if concept-only) |
+
+---
+
+*See also: `testimonial-decision-rubric.md` for outcome testimonial decisions*
+*See also: `ftc-scrutiny-categories.md` for high-risk verticals*

--- a/.claude/skills/mb-ads/references/compliance/ftc-scrutiny-categories.md
+++ b/.claude/skills/mb-ads/references/compliance/ftc-scrutiny-categories.md
@@ -1,0 +1,211 @@
+# FTC High-Scrutiny Categories
+
+Industries and claim types that receive heightened FTC enforcement.
+
+---
+
+## Why This Matters
+
+The FTC applies the "Pfizer Factors" to determine how much substantiation is required. Certain categories automatically require the HIGHEST level of proof due to:
+- Potential for consumer harm
+- History of deceptive practices in the industry
+- Vulnerability of target audience
+
+If your offer falls into these categories, assume maximum compliance burden.
+
+---
+
+## Tier 1: Maximum Scrutiny (Expect Enforcement)
+
+### Health & Weight Loss
+- Weight loss products/programs
+- Dietary supplements
+- Health claims of any kind
+- "Wellness" with implied health benefits
+- Anti-aging claims
+
+**Why:** Direct physical harm potential. History of fraud.
+
+**Requirements:**
+- Competent and reliable scientific evidence
+- Clinical trials for specific health claims
+- No disease treatment claims without FDA approval
+- Typicality disclosures for transformation testimonials
+
+**Recent enforcement:** FTC Health Products Compliance Guidance updated 2023.
+
+---
+
+### Income & Business Opportunity
+- "Make money" offers
+- Business coaching with income claims
+- Affiliate/MLM programs
+- Trading/investing education
+- "Financial freedom" messaging
+
+**Why:** Direct financial harm. Long history of fraud.
+
+**Requirements:**
+- Income disclosures showing what typical participant earns
+- Must include people who earned $0
+- Cannot cherry-pick success stories
+- Earnings claims must be substantiated
+
+**Key case:** FTC v. Lurn Inc. - $11,453/month claims without substantiation.
+
+---
+
+### Credit & Debt
+- Credit repair services
+- Debt relief/consolidation
+- Loan modification
+- Credit monitoring with improvement claims
+
+**Why:** Targets financially vulnerable. Regulated by CROA.
+
+**Requirements:**
+- Cannot guarantee specific outcomes
+- Typicality disclosure for score improvement claims
+- Credit Repair Organizations Act compliance
+- State-level licensing may be required
+
+**Note:** Meta requires "Financial Products and Services" special ad category.
+
+---
+
+## Tier 2: High Scrutiny
+
+### Real Estate & Investment
+- Real estate investing education
+- Stock/crypto trading courses
+- Investment advice (even "educational")
+- Passive income from assets
+
+**Requirements:**
+- Income/return claims need substantiation
+- Past performance disclaimers
+- Typicality for testimonials
+- May require SEC/FINRA compliance
+
+---
+
+### Employment & Career
+- Job placement services
+- Career coaching with salary claims
+- "Get hired" promises
+- Resume services with outcome claims
+
+**Requirements:**
+- Placement rate disclosures
+- Salary claims need data
+- Cannot guarantee employment
+
+---
+
+### Education & Coaching
+- Course completion → outcome claims
+- Certification → career claims
+- Coaching → transformation claims
+
+**Requirements:**
+- Outcome claims need typicality data
+- Completion rates may be relevant
+- Cannot guarantee career outcomes from education
+
+---
+
+## Tier 3: Moderate Scrutiny
+
+### Software & Tools
+- Productivity claims
+- "Save X hours" claims
+- Performance claims
+
+**Generally lower risk** because:
+- Outcomes depend on user effort
+- Less potential for harm
+- Claims often verifiable
+
+**Still required:**
+- Accuracy of feature claims
+- No fake testimonials
+
+---
+
+### Entertainment & Hobbies
+- Gaming
+- Arts & crafts
+- Sports & recreation
+
+**Generally lowest risk** because:
+- Low stakes
+- No health/financial harm potential
+
+---
+
+## Claim Type Scrutiny (Any Industry)
+
+Certain claim TYPES trigger scrutiny regardless of industry:
+
+| Claim Type | Scrutiny Level | Why |
+|------------|----------------|-----|
+| Specific numbers ($X, X lbs, X%) | HIGH | Implies measurement, requires proof |
+| Timeframe claims ("in 6 weeks") | HIGH | Specific performance claim |
+| Comparison claims ("#1", "best") | HIGH | Requires comparative evidence |
+| Testimonials with outcomes | HIGH | Typicality required |
+| "Guaranteed" anything | HIGH | Must honor or face deception claim |
+| "Clinically proven" | MAXIMUM | Requires clinical trial evidence |
+| "Doctor recommended" | HIGH | Must have actual doctor endorsement |
+| Process descriptions | LOW | Describing what's included |
+| Feature lists | LOW | Verifiable facts |
+
+---
+
+## Platform Category Overlap
+
+| FTC Category | Meta Category | Combined Risk |
+|--------------|---------------|---------------|
+| Health/Weight Loss | Special: Health | MAXIMUM |
+| Income/Biz Opp | May trigger restrictions | HIGH |
+| Credit/Debt | Special: Financial Products | MAXIMUM |
+| Real Estate | May trigger restrictions | HIGH |
+| Employment | Special: Employment | HIGH |
+| General education | None | LOWER |
+
+---
+
+## Decision Framework
+
+### If your offer is Tier 1:
+
+1. **Default to non-outcome angles** (mechanism, community, risk reversal)
+2. **If using outcome testimonials:** Budget for proper typicality data collection
+3. **Review all claims** through FTC lens before launch
+4. **Consider legal review** for high-spend campaigns
+5. **Document everything** for potential FTC inquiry
+
+### If your offer is Tier 2:
+
+1. **Outcome testimonials possible** with proper disclosures
+2. **Collect typicality data** if using transformation claims
+3. **Standard review process** through lenses
+
+### If your offer is Tier 3:
+
+1. **Standard compliance** is usually sufficient
+2. **Focus on accuracy** rather than extensive disclosure
+3. **Still avoid fake testimonials** and false claims
+
+---
+
+## Sources
+
+- [FTC Endorsement Guides (2023)](https://www.ftc.gov/business-guidance/resources/ftcs-endorsement-guides-what-people-are-asking)
+- [FTC Health Products Compliance Guidance](https://www.ftc.gov/business-guidance/resources/health-products-compliance-guidance)
+- [Notice of Penalty Offenses (Money-Making)](https://www.ftc.gov/legal-library/browse/penalty-offenses/notice-penalty-offenses-concerning-money-making-opportunities)
+- [Credit Repair Organizations Act](https://www.ftc.gov/legal-library/browse/statutes/credit-repair-organizations-act)
+- [Meta Financial Products Policy](https://transparency.meta.com/policies/ad-standards/restricted-goods-services/financial-services/)
+
+---
+
+*Updated: 2026-01-13*

--- a/.claude/skills/mb-ads/references/compliance/testimonial-decision-rubric.md
+++ b/.claude/skills/mb-ads/references/compliance/testimonial-decision-rubric.md
@@ -1,0 +1,96 @@
+# Testimonial Decision Rubric
+
+When is outcome-based testimonial advertising worth the compliance burden?
+
+---
+
+## The Core Question
+
+Outcome testimonials (Yasmine made $99K, lost 50lbs, etc.) are the most compelling but require:
+- FTC typicality disclosures (what the AVERAGE user achieves)
+- Data collection from ALL users, not just winners
+- Honest numbers that might undermine the testimonial
+
+Sometimes the juice isn't worth the squeeze.
+
+---
+
+## Decision Matrix
+
+| Factor | Outcome-Based Worth It | Avoid Outcome-Based |
+|--------|------------------------|---------------------|
+| **Typical results distribution** | Most users get good results | Only outliers get hero results |
+| **Regulatory scrutiny** | Low (productivity, hobbies) | High (credit, weight loss, income, health) |
+| **Data availability** | Already tracking outcomes | No tracking, would need survey |
+| **Platform restrictions** | No special category | Special ad category required |
+| **Offer type** | Done-for-you service | Education/community |
+| **Price point** | High-ticket (need strong proof) | Low-ticket (low risk) |
+| **Honest disclosure impact** | "Average achieves X" sounds good | "Average achieves nothing" kills ad |
+
+---
+
+## Quick Scoring
+
+Score each factor 0-2:
+- 0 = Avoid outcome testimonials
+- 1 = Could go either way
+- 2 = Outcome testimonials make sense
+
+| Factor | Score |
+|--------|-------|
+| Typical results favorable | /2 |
+| Low regulatory scrutiny | /2 |
+| Data already exists | /2 |
+| No platform restrictions | /2 |
+| DFY service (not education) | /2 |
+| High-ticket offer | /2 |
+| Disclosure helps or neutral | /2 |
+| **Total** | /14 |
+
+**Interpretation:**
+- 10-14: Outcome testimonials recommended
+- 5-9: Consider alternatives, outcome possible with work
+- 0-4: Use alternative angles instead
+
+---
+
+## Red Flags (Avoid Outcome Testimonials)
+
+- Credit repair, debt relief, financial services
+- Weight loss, health transformation
+- Income claims, business opportunity
+- Any Meta special ad category
+- No existing outcome tracking
+- Low-ticket education/community offer
+- Hero results are 10x+ what average achieves
+
+---
+
+## When You MUST Have Outcome Testimonials
+
+Some offers genuinely need outcome proof:
+- High-ticket coaching ($5K+) - buyers need confidence
+- Done-for-you services - results are the product
+- Competitive markets where everyone uses them
+
+If you must use them:
+1. Collect real typicality data (see `typicality/README.md`)
+2. Lead with honest disclosure
+3. Consider landing page disclosure vs in-ad disclosure
+4. Document everything for FTC defense
+
+---
+
+## Alternative: Process Testimonials
+
+Instead of "I made $99K" use:
+- "The content is actionable and organized"
+- "I finally understand how credit works"
+- "The community answered my question in 2 hours"
+- "The templates saved me hours of research"
+
+These require NO typicality disclosures because they don't claim outcomes.
+
+---
+
+*See also: `angle-playbook.md` for full list of persuasion angles*

--- a/.claude/skills/mb-ads/references/lenses/README.md
+++ b/.claude/skills/mb-ads/references/lenses/README.md
@@ -1,0 +1,65 @@
+# Lenses
+
+Quality control reference files for multi-lens ad review.
+
+---
+
+## What Are Lenses?
+
+Lenses are self-contained knowledge bases that define review criteria. Each lens focuses on one domain and provides:
+
+- Core principle (one-sentence philosophy)
+- Actionable checklist with ✅/🔴 examples
+- Red flags to always catch
+- Severity levels (P1/P2/P3)
+- Sources for authority
+
+---
+
+## Available Lenses
+
+| Lens | Focus | Key Question |
+|------|-------|--------------|
+| `ftc-compliance.md` | Federal regulations | Does this violate FTC rules? |
+| `meta-policy.md` | Platform enforcement | Will Meta reject this? |
+| `copy-quality.md` | Direct response effectiveness | Does this follow proven frameworks? |
+| `visual-standards.md` | Visual compliance & impact | Will this pass and stop the scroll? |
+| `voice-authenticity.md` | AI detection & brand voice | Does this sound human and on-brand? |
+| `substantiation.md` | Claims & proof | Is every claim backed by evidence? |
+
+---
+
+## How Agents Use Lenses
+
+1. **Read the lens file** to understand criteria
+2. **Apply checklist** to ad copy/visual
+3. **Flag issues** with severity (P1/P2/P3)
+4. **Cite specific examples** from the lens
+5. **Provide fix suggestions** based on safe alternatives
+
+---
+
+## Severity Definitions
+
+| Level | Meaning | Action |
+|-------|---------|--------|
+| **P1** | Blocks launch | Must fix before shipping |
+| **P2** | Should fix | Fix before launch if possible |
+| **P3** | Nice to have | Improve if time allows |
+
+---
+
+## Adding New Lenses
+
+Each lens file should include:
+
+1. **Core Principle** — One sentence philosophy
+2. **Key Rules** — Specific, actionable criteria
+3. **Checklist** — Pass/fail examples table
+4. **Red Flags** — Patterns to always catch
+5. **Severity** — P1/P2/P3 definitions for this domain
+6. **Sources** — Authority for the rules
+
+---
+
+*Based on Gemini deep research 2026-01-13 and Compound Engineering lens patterns.*

--- a/.claude/skills/mb-ads/references/lenses/copy-quality.md
+++ b/.claude/skills/mb-ads/references/lenses/copy-quality.md
@@ -1,0 +1,142 @@
+# Copy Quality Lens
+
+Review ad copy for direct response effectiveness using named frameworks.
+
+---
+
+## Core Principle
+
+**Compliant does not mean boring.** High-converting copy is possible within compliance constraints by using established frameworks adapted for safety.
+
+---
+
+## Eugene Schwartz: Awareness Levels
+
+Different awareness levels require different approaches. "Problem Aware" is the most dangerous for compliance.
+
+### Unaware Market
+
+**Risk:** Trying to shock with hidden pain ("Do you have gut inflammation?") triggers Personal Attributes.
+
+**Safe pivot:** Use "Story" or "News" angles.
+- Risky: "Do you have hidden gut inflammation?"
+- Safe: "New research reveals why 50% of adults may have gut inflammation."
+
+### Problem Aware Market
+
+**Risk:** Focusing on user's pain ("Is your back pain ruining your sleep?") triggers Personal Attributes.
+
+**Safe pivot:** Externalize the problem as a third party enemy.
+- Risky: "Is your back pain making you miss work?"
+- Safe: "Back pain is the #1 cause of missed work days. Here's the new protocol."
+
+### Solution Aware Market
+
+**Safest territory.** Focus on the unique mechanism.
+- Safe: "The 3-Step 'Inverted Offer' Protocol for scaling agencies."
+
+### Most Aware Market
+
+Direct offers and deals. Safe if urgency is real.
+- Safe: "Open Enrollment for the Tax Academy ends Friday."
+
+---
+
+## Alex Hormozi: Value Equation
+
+Value = (Dream Outcome × Likelihood of Achievement) / (Time Delay × Effort & Sacrifice)
+
+### Compliant Adaptations
+
+| Element | Safe Approach | Unsafe Approach |
+|---------|--------------|-----------------|
+| Dream Outcome | "Build a 7-Figure Asset" | "Become a Millionaire" |
+| Likelihood | "See how 500 students did it" | "Guaranteed to work for you" |
+| Effort | "Templates," "Systems," "Done-for-You" | "Autopilot," "Passive," "No work" |
+
+---
+
+## Sabri Suby: Calling Out the Herd
+
+"Attention Agency Owners" is classic Suby. The danger is what follows.
+
+- Risky: "Attention Agency Owners: Are you tired of being broke and burnt out?"
+- Safe: "Attention Agency Owners: The model for client acquisition has changed."
+
+**Pattern:** Call out the audience, then pivot to external shift (market change, new research) not internal pain.
+
+---
+
+## Banned Word Swap List
+
+| Risky | Safe | Reasoning |
+|-------|------|-----------|
+| "Earn $10,000" | "Scale your revenue" | Avoids income claims |
+| "Passive Income" | "Leveraged income models" | FTC "no effort" trigger |
+| "Financial Freedom" | "Financial clarity / Options" | MLM associations |
+| "Lose weight fast" | "Optimize your routine" | Health policy triggers |
+| "Stop your anxiety" | "Manage daily stress" | Personal Attribute |
+| "Are you..." | "For those who..." | Personal Attribute |
+| "Guaranteed results" | "Proven framework" | Misleading guarantees |
+| "Secret trick" | "Overlooked strategy" | Clickbait/circumvention |
+
+---
+
+## Hook Quality Checklist
+
+| Check | Pass | Fail |
+|-------|------|------|
+| **Specificity** | Names a mechanism, uses numbers | Vague promises |
+| **Pattern interrupt** | Starts in media res | Generic "In today's world..." |
+| **Curiosity gap** | Incomplete loop that compels click | Complete thought, no reason to click |
+| **News value** | New, different, contrarian | Already known, obvious |
+| **Emotional resonance** | Speaks to real felt pain | Academic description of pain |
+
+---
+
+## CTA Quality
+
+| Strong CTA | Weak CTA |
+|------------|----------|
+| Action-specific: "Watch the free training" | Vague: "Learn more" |
+| Low commitment: "See how it works" | High commitment: "Buy now" |
+| Curiosity-driven: "Get the breakdown" | Pressure-driven: "Don't miss out" |
+
+---
+
+## Red Flags (Always Flag)
+
+- Vague, generic promises without mechanism
+- "In today's fast-paced world..." openings
+- All caps, excessive punctuation!!!
+- Claims without specificity
+- CTAs that don't match funnel stage
+
+---
+
+## Severity
+
+| Level | Criteria | Action |
+|-------|----------|--------|
+| **P1 - Blocks** | Hook violates awareness/attributes rules | Rewrite required |
+| **P2 - Fix** | Weak hook, generic copy | Strengthen before launch |
+| **P3 - Note** | Could be more specific | Improve if time |
+
+---
+
+*Source: Eugene Schwartz "Breakthrough Advertising," Alex Hormozi "$100M Offers," Sabri Suby "Sell Like Crazy"*
+
+---
+
+## Enemy-Driven Positioning
+
+When the business has declared named enemies (check `core/voice.md` for a Named Enemies section), verify:
+
+| Check | Pass | Fail |
+|-------|------|------|
+| **Enemy is a concept** | "Complexity is the enemy" | "Company X is the enemy" |
+| **Enemy is named explicitly** | "Screen addiction is stealing your life" | "Things are getting out of hand" |
+| **Enemy connects to pillar** | Copy's enemy matches the content pillar's declared enemy | Random enemy unrelated to the topic |
+| **Solution is mechanism** | "Here's how we fight complexity: [specific approach]" | "Just stop being complex" |
+
+**Severity:** P3 when enemies exist but aren't used. P2 when enemies are used but vaguely. Not flagged when no enemies are declared.

--- a/.claude/skills/mb-ads/references/lenses/ftc-compliance.md
+++ b/.claude/skills/mb-ads/references/lenses/ftc-compliance.md
@@ -1,0 +1,94 @@
+# FTC Compliance Lens
+
+Review ad copy and claims for Federal Trade Commission compliance.
+
+---
+
+## Core Principle
+
+**Disclaimers don't cure deceptive headlines.** If the headline promises wealth, a footer disclaimer saying "results not typical" is legally inadequate. The ad itself must reflect the typical experience.
+
+---
+
+## Notice of Penalty Offenses
+
+The FTC's Notice of Penalty Offenses means advertisers can no longer claim ignorance. Violations carry penalties of **$51,744 per ad, per impression**.
+
+### Education & Coaching Notice
+
+These acts are deceptive *per se*:
+- Misrepresenting employment prospects for graduates
+- Misrepresenting job demand (must be for YOUR graduates, not industry)
+- Highlighting "star students" that imply typical results
+
+### Money-Making Opportunities Notice
+
+These acts are deceptive:
+- Misrepresenting risk or effort required
+- Claims of "passive" income, "autopilot" revenue, "no experience needed"
+- False scarcity (countdown timers, "limited spots" when unlimited)
+
+---
+
+## FTC v. Lurn Case Study (2023-2024)
+
+**What got them:** $2.5M settlement, permanent ban on misleading earnings claims.
+
+| Violation | Why It's a Problem |
+|-----------|-------------------|
+| "Stay-At-Home Millionaire" as program title | Program titles ARE earnings claims |
+| "$11,453 Per Month" specific dollar figure | Specificity implies proof; they had none |
+| Disclaimers in footer | Did not cure deceptive headlines |
+
+---
+
+## Checklist
+
+| Check | Pass Example | Fail Example |
+|-------|--------------|--------------|
+| **Income Typicality** | "Top 1% made $10k. Average makes $0." | "Make $10k/month in 30 days" |
+| **Effort Representation** | "Requires significant time, risk, effort" | "Passive income on autopilot" |
+| **Material Connection** | Superimposed "Paid Ad" in first 3 seconds | Disclosure in "See More" caption |
+| **Urgency & Scarcity** | "Cart closes Friday 5PM" (enforced) | "Only 2 spots left!" (unlimited funnel) |
+| **Program Titles** | "Digital Marketing Course" | "Six-Figure Blueprint Academy" |
+| **Endorsement Honesty** | Verified user sharing real experience | Actor reading script |
+
+---
+
+## Endorsement Rules (2023 Update)
+
+### Clear and Conspicuous Standard
+
+- **Video:** Disclosure superimposed in first 3 seconds, not in "more" text
+- **Audio:** If endorsement is spoken, disclosure must also be spoken
+- **Language:** Use "Ad," "Sponsored," "Paid" — not "Partner" or "Collab"
+
+### Review Integrity
+
+- No "review hijacking" (using high-ticket testimonials for low-ticket offers)
+- No suppressing negative reviews
+- Reviews must fairly represent actual distribution of sentiment
+
+---
+
+## Red Flags (Always Flag)
+
+- Specific dollar amounts without typicality data
+- "Passive," "autopilot," "easy," "fast," "no experience"
+- Before/after with implied typical results
+- Countdown timers on evergreen funnels
+- Program names that imply earnings outcomes
+
+---
+
+## Severity
+
+| Level | Criteria | Action |
+|-------|----------|--------|
+| **P1 - Blocks** | Unsubstantiated income claims, false scarcity | Cannot ship |
+| **P2 - Fix** | Missing disclosures, vague material connections | Fix before launch |
+| **P3 - Note** | Typicality language could be clearer | Improve if time |
+
+---
+
+*Source: FTC.gov, FTC v. Lurn settlement 2024, 2023 Endorsement Guides*

--- a/.claude/skills/mb-ads/references/lenses/meta-policy.md
+++ b/.claude/skills/mb-ads/references/lenses/meta-policy.md
@@ -1,0 +1,180 @@
+# Meta Platform Policy Lens
+
+Review ad copy and visuals for Meta (Facebook/Instagram) automated enforcement triggers.
+
+---
+
+## Core Principle
+
+**Meta's enforcement is algorithmic, not legal.** Even substantiated claims can be rejected if they trigger pattern-matching. Understanding the *mechanism* of triggers is essential.
+
+---
+
+## Personal Attributes Violation
+
+Meta's most common rejection in coaching/health. Users should not feel the platform reveals their intimate data.
+
+### The "You" Trigger
+
+The word "You" + negative state/question = Personal Attributes flag.
+
+| Violation | Why | Safe Pivot |
+|-----------|-----|------------|
+| "Are you struggling with debt?" | Asserts financial status | "Debt relief strategies for families" |
+| "Stop letting anxiety control you" | Asserts mental health | "Overcoming anxiety: A guide" |
+| "Tired of being fat?" | Asserts health/body | "I struggled with weight until..." |
+| "Meet other Christian singles" | Asserts religion | "Meet Christian singles" |
+
+**Pattern:** Shift from Second Person (You) to First Person (I), Third Person (They/Families), or Service focus.
+
+---
+
+## Unrealistic Outcomes
+
+Algorithm flags high-promise claims regardless of substantiation.
+
+### Blacklisted Phrases
+
+- "Financial freedom"
+- "Quit your job"
+- "Laptop lifestyle"
+- "Make 6-figures"
+- "Lose 20 lbs in a week"
+- "Work from home"
+- "Passive income"
+- "Easy money"
+- "Quick cash"
+
+### Visual Triggers
+
+- Before/after images (banned for weight loss, restricted for others)
+- Bank account screenshots with large numbers
+- Dashboards with steep upward graphs
+
+---
+
+## Circumventing Systems (Death Sentence)
+
+This violation leads to **permanent Business Manager ban**. Triggers when AI suspects deception.
+
+### Common Triggers
+
+| Trigger | Why | Avoidance |
+|---------|-----|-----------|
+| Link shorteners (bit.ly) | Looks like cloaking | Direct links only |
+| Unicode obfuscation ("M@ke M0ney") | Demonstrates intent to evade | Standard text |
+| Ad-to-page mismatch | Semantic inconsistency | Matching "scent" |
+| Redirect chains | Looks like cloaking | Clean URL structure |
+
+### False Positive Avoidance
+
+- Link directly to domain, no complex redirects
+- Ensure landing page content matches ad promises
+- No fake UI elements (play buttons, download buttons)
+
+---
+
+## Checklist
+
+| Check | Pass Example | Fail Example |
+|-------|--------------|--------------|
+| **Personal Attributes** | "Weight loss tips for women over 40" | "Are you over 40 struggling to lose weight?" |
+| **Prohibited Keywords** | "Revenue growth," "Scale," "Optimization" | "Financial freedom," "Passive income" |
+| **Before/After** | Lifestyle image of result state | Side-by-side transformation |
+| **Link Integrity** | brand.com/offer | bit.ly → tracker → landing |
+| **Text Obfuscation** | "Make Money" | "M@ke M0ney" |
+| **Button Fakes** | Real video, static image | Fake play button on image |
+
+---
+
+## The "You" Workarounds
+
+| Risky Pattern | Safe Alternative |
+|---------------|-----------------|
+| "Are you..." | "For those who..." |
+| "Your [problem]" | "[Problem] is..." |
+| "Do you have..." | "Many people experience..." |
+| "Stop your..." | "Strategies for managing..." |
+
+---
+
+## Special Ad Categories: Employment
+
+When campaigns target Employment (job training, career services, hiring), Meta applies **stricter Personal Attributes enforcement**. Standard coaching ads that pass normally will fail here.
+
+### What Makes Employment Different
+
+Employment category + Personal Attributes = double scrutiny. The algorithm looks for:
+- Assertions about current job/salary/employment status
+- Language that reveals someone is unemployed, underpaid, or job-seeking
+- Anything that could be discriminatory in hiring contexts
+
+### The "If You've..." Pattern (Critical)
+
+In Employment category, **"If you've..." is functionally equivalent to "You are..."** for Personal Attributes triggers.
+
+| Violation | Why It Fails | Safe Rewrite |
+|-----------|--------------|--------------|
+| "If you've been stuck at £30k..." | "If you've" = "You are" assertion | "DevOps engineers can earn £60k+" |
+| "If you've been rejected after interviews..." | Asserts job-seeking status | "Interview skills that land offers" |
+| "If you've been in IT support for years..." | Asserts current role/tenure | "The path from IT support to DevOps" |
+| "Still getting rejected?" | Asserts interview failure | "Stand out in technical interviews" |
+
+### Salary Mention Rules
+
+| Risk Level | Example | When OK |
+|------------|---------|---------|
+| **HIGH RISK** | "If you're making under £40k..." | Never—asserts current salary |
+| **HIGH RISK** | "Still stuck at £30k?" | Never—asserts + negative state |
+| **MEDIUM RISK** | "Go from £30k to £60k" | Risky—implies current salary |
+| **LOW RISK** | "DevOps roles start at £55k+" | OK as market data |
+| **LOW RISK** | "Senior engineers earn £80k+" | OK as aspiration |
+
+**Safe pattern:** Salary as aspiration or market data, never as current state.
+
+### Employment Category Checklist
+
+| Check | Pass | Fail |
+|-------|------|------|
+| **"If you've..." patterns** | Absent | Present |
+| **Current salary assertion** | "Roles at £60k+" | "If you're earning under £40k" |
+| **Job-seeking status** | "Career advancement" | "Still job hunting?" |
+| **Interview struggles** | "Interview preparation" | "Getting rejected at interviews?" |
+| **Job dissatisfaction** | "Build valuable skills" | "Hate your job?" |
+
+### Employment Severity Upgrade
+
+When Employment category is active, upgrade all Personal Attributes issues by one level:
+- P3 → P2 (monitor → fix before launch)
+- P2 → P1 (fix → blocks launch)
+
+---
+
+## Red Flags (Always Flag)
+
+- Direct "you" + negative state combination
+- Any blacklisted phrase in copy or image text
+- Before/after visual structure
+- Link shorteners or redirect chains
+- Unicode characters in words
+- Fake UI elements
+
+**If Employment Category:**
+- "If you've..." + any employment/salary/job state
+- Salary assertions as pain points (under £X, stuck at $X)
+- Interview failure patterns ("getting rejected", "passed over")
+- Job dissatisfaction ("dead-end job", "hate your boss")
+
+---
+
+## Severity
+
+| Level | Criteria | Action |
+|-------|----------|--------|
+| **P1 - Blocks** | Circumventing systems triggers, fake UI | Cannot ship |
+| **P2 - Fix** | Personal attributes, prohibited keywords | Rewrite before launch |
+| **P3 - Note** | Could be flagged, borderline phrases | Monitor after launch |
+
+---
+
+*Source: Meta Ad Policies, Jon Loomer Digital, Reddit r/FacebookAds practitioner reports*

--- a/.claude/skills/mb-ads/references/lenses/substantiation.md
+++ b/.claude/skills/mb-ads/references/lenses/substantiation.md
@@ -1,0 +1,158 @@
+# Substantiation Lens
+
+Review ad claims for proper evidence and testimonial handling.
+
+---
+
+## Core Principle
+
+**Testimonials ARE claims.** When you publish "I lost 50lbs," YOU are making that claim. You need substantiation.
+
+---
+
+## The Pfizer Factors
+
+FTC uses these factors to determine required level of proof:
+
+| Factor | Higher Proof Needed | Lower Proof Acceptable |
+|--------|--------------------|-----------------------|
+| Type of Product | Health, financial | Entertainment |
+| Type of Claim | Specific ("Lose 10lbs") | General ("Feel better") |
+| Consequences | Physical/financial harm | Low stakes |
+| Cost to Prove | Easy to test | Difficult to test |
+| Industry Standard | Established norms | New category |
+
+---
+
+## Typicality Standard
+
+For earnings/results claims, you need data on the *average* user, not the best user.
+
+### Check Typicality Data First
+
+Before reviewing testimonial ads, check if typicality data exists:
+
+**Location:** `core/proof/typicality.md`
+
+- If file exists and has data → Use that data for disclosure language
+- If file exists but says "DATA NEEDED" → P1 block until data collected
+- If no file exists and outcome testimonials used → P1 block, note typicality data needed
+
+**Critical:** Success stories alone are NOT sufficient. FTC requires outcomes for ALL users who START, not just those who succeed and share results.
+
+### "Results Not Typical" Is Dead
+
+The phrase alone is no longer sufficient protection.
+
+| Wrong | Correct |
+|-------|---------|
+| "Jane made $5k. Results not typical." | "Jane made $5k. Average student makes $0. See disclosure." |
+| "Lost 50lbs. Individual results vary." | "Lost 50lbs. Average participant loses 1-2lbs/week." |
+
+### Disclosure Requirements
+
+- **Proximity:** Must be near the claim, not in footer
+- **Specificity:** Must state what typical IS
+- **Visibility:** Clear and conspicuous, not fine print
+
+---
+
+## Testimonial Rules
+
+### Usable Testimonials
+
+- From actual customers who used the product
+- Reflect a genuine experience
+- Match the offer being sold (same product, same price point)
+- Have documented consent for use
+
+### Unusable Testimonials
+
+- From actors or paid spokespersons (without disclosure)
+- From high-ticket customers used to sell low-ticket offers
+- That imply typical results without typicality data
+- Old testimonials for changed products
+
+### Review Hijacking (Banned)
+
+Cannot use testimonials from one product to sell another.
+
+| Violation | Why |
+|-----------|-----|
+| 1-on-1 coaching testimonials for DIY course | Different support level = different results likelihood |
+| High-ticket program reviews for low-ticket | Material difference in experience |
+| Old product testimonials for updated product | Product may have changed |
+
+---
+
+## Claim Inventory Process
+
+For every ad, inventory all objective claims:
+
+1. **Identify:** Highlight every factual statement
+2. **Categorize:** Result claim? Process claim? Comparison claim?
+3. **Source:** Where's the proof?
+4. **Date:** Is the proof current?
+
+### Example Inventory
+
+| Claim | Type | Source | Status |
+|-------|------|--------|--------|
+| "500 active members" | Fact | CRM data | Verified |
+| "#1 agency" | Comparison | None | Unsubstantiated - remove |
+| "Jane made $5k" | Testimonial | Jane consent doc | Needs typicality disclosure |
+
+---
+
+## Checklist
+
+| Check | Pass | Fail |
+|-------|------|------|
+| **Claim Inventory** | Every claim sourced | Unverified claims |
+| **Testimonial Context** | Average result stated with outlier | "Results not typical" only |
+| **Data Currency** | "Based on 2024 data" | "Based on 2015 data" |
+| **Review Integrity** | Mix of ratings shown | Only 5-star (suppressed negatives) |
+| **Consent** | Documented consent for testimonials | No consent records |
+
+---
+
+## Disclosure Templates
+
+### Earnings Testimonial
+
+```
+"[Name] achieved [result]. The average [customer/student] achieves [typical result].
+Individual results vary based on [factors]. See full income disclosure at [link]."
+```
+
+### Health/Transformation Testimonial
+
+```
+"[Name] experienced [result]. Average participant sees [typical result] over [timeframe].
+Results depend on [factors]. This is not a guarantee."
+```
+
+---
+
+## Red Flags (Always Flag)
+
+- Specific numbers without source
+- "#1" or "best" comparison claims
+- Testimonials without typicality context
+- Old data (2+ years) presented as current
+- Reviews that only show positive (suppressed negatives)
+- High-ticket testimonials selling low-ticket
+
+---
+
+## Severity
+
+| Level | Criteria | Action |
+|-------|----------|--------|
+| **P1 - Blocks** | Unsubstantiated claims, no typicality | Cannot ship |
+| **P2 - Fix** | Missing disclosure, old data | Add disclosure before launch |
+| **P3 - Note** | Disclosure could be clearer | Improve if time |
+
+---
+
+*Source: FTC Substantiation Principles, Thomson Reuters Pfizer Factors analysis, 2023 Endorsement Guides*

--- a/.claude/skills/mb-ads/references/lenses/visual-standards.md
+++ b/.claude/skills/mb-ads/references/lenses/visual-standards.md
@@ -1,0 +1,139 @@
+# Visual Standards Lens
+
+Review ad visuals for platform compliance and thumb-stopping effectiveness.
+
+---
+
+## Core Principle
+
+**Visuals are the first point of rejection.** Meta's algorithm analyzes text via OCR and visual content via computer vision before humans see the ad.
+
+---
+
+## Safe Zones (9:16 Reels/Stories)
+
+The 9:16 format (1080x1920) has UI elements that cover content.
+
+```
+┌─────────────────────┐
+│   TOP 14% DANGER    │  ← Progress bar, account icon
+│                     │
+│ ┌─────────────────┐ │
+│ │  CENTER 1:1     │ │  ← All hooks and disclosures HERE
+│ │  SAFE ZONE      │ │  ← This area extracts as the square version
+│ └─────────────────┘ │
+│                     │
+│  BOTTOM 35% DANGER  │  ← Caption, CTA button, likes
+└─────────────────────┘
+```
+
+**Compliance implication:** Disclosures at bottom are "avoidable" = non-compliant.
+
+### Format Pair: 1:1 + 9:16
+
+Facebook Ads Manager accepts exactly two image uploads per ad: **1:1 (square)** and **9:16 (vertical)**. There is no 4:5 upload option.
+
+**Design strategy:** Design 9:16 first, keep critical content in center 1:1 zone, center-crop for square version. One design → two uploads.
+
+### Technical Specs
+
+- **Square:** 1920×1920 (1:1) — Facebook feed, Instagram feed
+- **Vertical:** 1080×1920 (9:16) — Stories, Reels, full-screen mobile
+- **Safe margin:** 250px from top and bottom edges on 9:16
+- **Critical text:** Must be in center 1:1 zone (visible in both formats)
+
+---
+
+## OCR Triggers
+
+Meta reads text on images. Banned claims in image text trigger rejection.
+
+| Safe Image Text | Flagged Image Text |
+|-----------------|-------------------|
+| "New Strategy Revealed" | "Lose 20lbs Fast" |
+| "Framework Breakdown" | "Make $10k/month" |
+| "Free Training" | "Financial Freedom" |
+
+---
+
+## Visual Patterns (2025)
+
+### Pattern Interrupts
+
+- **Glitch/Flash:** High-contrast, rapid changes. Effect must be smooth (excessive = "Disruptive" flag).
+- **Lo-fi aesthetic:** Native-looking content outperforms polished ads for many audiences.
+
+### Fake Podcast Aesthetic
+
+Popular trend: "Podcast clip" framing builds authority.
+
+**Compliance check:** If guest makes a claim ("I made $1M"), that's an endorsement. Requires superimposed disclaimer *during* that sentence: "Results not typical. Average revenue is $0."
+
+### Green Screen Commentary
+
+Creator talking over screenshot/chart.
+
+**Compliance check:**
+- Background must be truthful (no faked bank statements)
+- No unauthorized logos (CNN, Fox = trademark violation)
+- Source must be visible if showing news article
+
+---
+
+## Prohibited Visual Patterns
+
+| Pattern | Why Banned | Alternative |
+|---------|-----------|-------------|
+| Before/after (weight loss) | Explicitly banned | Result-state lifestyle image |
+| Zoomed body parts | Health policy | Full body in context |
+| Bank account screenshots | "Unrealistic outcomes" | Abstract success imagery |
+| Fake play buttons | Circumventing systems | Real video or static design |
+| Fake UI elements | Deceptive | Clear design language |
+
+---
+
+## Checklist
+
+| Check | Pass | Fail |
+|-------|------|------|
+| **Safe Zones** | Text centered, 250px buffer | Text at edges, covered by UI |
+| **OCR Claims** | Generic text, no promises | Banned phrases in image |
+| **Body Focus** | Full body in context | Zoomed abs, belly, acne |
+| **Button Fakes** | Real video or static | Fake play/download button |
+| **UGC Authenticity** | Real screenshots with source | Doctored images, fake logos |
+
+---
+
+## Disclosure Placement
+
+For endorsements or claims in video:
+
+- **Position:** Superimposed, not in caption
+- **Timing:** Appears during the claim, not after
+- **Size:** Readable, not fine print
+- **Duration:** On screen long enough to read
+
+---
+
+## Red Flags (Always Flag)
+
+- Any before/after structure
+- Text in danger zones (top 14%, bottom 35%)
+- Banned phrases visible in image
+- Fake UI elements anywhere
+- Zoomed body parts
+- Screenshots without visible source
+
+---
+
+## Severity
+
+| Level | Criteria | Action |
+|-------|----------|--------|
+| **P1 - Blocks** | Before/after, fake UI, OCR banned phrases | Cannot ship |
+| **P2 - Fix** | Disclosure placement, safe zone violations | Fix before launch |
+| **P3 - Note** | Could be more thumb-stopping | Improve if time |
+
+---
+
+*Source: Meta Ad Specs 2025, Jon Loomer Safe Zone Templates, usevisuals.com*

--- a/.claude/skills/mb-ads/references/lenses/voice-authenticity.md
+++ b/.claude/skills/mb-ads/references/lenses/voice-authenticity.md
@@ -1,0 +1,129 @@
+# Voice Authenticity Lens
+
+Review ad copy for AI tells and brand voice consistency.
+
+---
+
+## Core Principle
+
+**AI blindness is real.** Generic, robotic copy fails to connect emotionally. Meta's quality algorithms may penalize content that fits the statistical profile of low-quality AI spam.
+
+---
+
+## AI Vocabulary Tells
+
+These words are statistically overrepresented in AI-generated copy:
+
+| AI Word | Human Alternative |
+|---------|-------------------|
+| "delve" | "dig into," "explore" |
+| "tapestry" | (just remove) |
+| "landscape" | "space," "world," "market" |
+| "transformative" | "powerful," "effective" |
+| "game-changer" | "breakthrough," "shift" |
+| "bustling" | (just remove) |
+| "realm" | "space," "area" |
+| "symphony" | (just remove) |
+| "leverage" | "use," "apply" |
+| "paradigm" | "approach," "model" |
+
+---
+
+## AI Structural Tells
+
+### Generic Openings
+
+- **AI:** "In today's fast-paced world of digital marketing..."
+- **Human:** "The biggest mistake I see is..."
+
+### Uniform Paragraphs
+
+- **AI:** Every paragraph same length, starts with transition word
+- **Human:** Short punchy. Fragments. Mixed with longer explanations.
+
+### Passive Voice
+
+- **AI:** "It is important to note that..."
+- **Human:** "Listen close..." / "Here's the thing..."
+
+### Predictable Structure
+
+- **AI:** Problem → Solution → Benefits → CTA (every time)
+- **Human:** Varies based on context, starts in media res
+
+---
+
+## Brand Voice Consistency
+
+The ad voice must match the landing page voice. Mismatch = cognitive dissonance = bounce.
+
+### Voice Archetypes
+
+| Archetype | Ad Signals | Landing Page Must Match |
+|-----------|-----------|------------------------|
+| Best Friend | Casual, emojis, lowercase | Warm, conversational |
+| Authority/Expert | Clinical, precise | Professional, formal |
+| Challenger | Provocative, contrarian | Bold, confident |
+| Mentor | Encouraging, patient | Supportive, educational |
+
+**Test:** Read the ad, then read the landing page. Do they feel like the same person wrote them?
+
+---
+
+## Checklist
+
+| Check | Pass (Human) | Fail (AI) |
+|-------|--------------|-----------|
+| **Vocabulary** | "Let's dig into the details" | "Let's delve into the transformative landscape" |
+| **Sentence Variety** | Short. Long. Fragments mixed. | Uniform length, every paragraph |
+| **Emoji Usage** | 1-2 for emphasis (if casual) | 10+ as bullet points |
+| **Direct Address** | "I've noticed that..." | "It is worth noting that..." |
+| **Opening** | In media res, specific | Context-setting, generic |
+
+---
+
+## Language Bank Check
+
+If the project has a language bank (verbatim customer phrases):
+
+1. Does the ad use actual customer language?
+2. Do the pain points match what customers say?
+3. Is the vocabulary level appropriate for the audience?
+
+**Pattern:** Copy should sound like a customer, not like a marketer.
+
+---
+
+## Tone Matching Rules
+
+| If Ad Is... | Landing Page Must Be... | Red Flag |
+|-------------|------------------------|----------|
+| Hype/Energy | Energetic, fast-paced | Corporate, slow |
+| Professional | Polished, formal | Casual, slangy |
+| Casual | Conversational, warm | Stiff, formal |
+| Provocative | Bold, confident | Safe, hedging |
+
+---
+
+## Red Flags (Always Flag)
+
+- Multiple AI vocabulary words in same paragraph
+- "In today's world of..." opening
+- Passive voice throughout
+- Uniform paragraph structure
+- Ad tone doesn't match landing page
+- Generic pain points not from actual customers
+
+---
+
+## Severity
+
+| Level | Criteria | Action |
+|-------|----------|--------|
+| **P1 - Blocks** | Obvious AI slop, tone mismatch | Rewrite required |
+| **P2 - Fix** | Some AI tells, could be more human | Polish before launch |
+| **P3 - Note** | Minor vocabulary issues | Improve if time |
+
+---
+
+*Source: Medium AI detection research, Embryo AI word lists, Meta quality guidelines*

--- a/.claude/skills/mb-ads/references/mode-review.md
+++ b/.claude/skills/mb-ads/references/mode-review.md
@@ -8,12 +8,12 @@ Review ads through 6 compliance and quality lenses before shipping.
 
 | Lens | Location | What It Checks |
 |------|----------|----------------|
-| FTC Compliance | `<engine>/.claude/lenses/ftc-compliance.md` | Federal regulations, earnings claims |
-| Meta Policy | `<engine>/.claude/lenses/meta-policy.md` | Platform triggers, Personal Attributes |
-| Copy Quality | `<engine>/.claude/lenses/copy-quality.md` | Schwartz, Hormozi, Suby frameworks |
-| Visual Standards | `<engine>/.claude/lenses/visual-standards.md` | Safe zones, OCR, prohibited visuals |
-| Voice Authenticity | `<engine>/.claude/lenses/voice-authenticity.md` | AI tells, brand voice |
-| Substantiation | `<engine>/.claude/lenses/substantiation.md` | Claims inventory, proof matching |
+| FTC Compliance | `references/lenses/ftc-compliance.md` | Federal regulations, earnings claims |
+| Meta Policy | `references/lenses/meta-policy.md` | Platform triggers, Personal Attributes |
+| Copy Quality | `references/lenses/copy-quality.md` | Schwartz, Hormozi, Suby frameworks |
+| Visual Standards | `references/lenses/visual-standards.md` | Safe zones, OCR, prohibited visuals |
+| Voice Authenticity | `references/lenses/voice-authenticity.md` | AI tells, brand voice |
+| Substantiation | `references/lenses/substantiation.md` | Claims inventory, proof matching |
 
 ---
 
@@ -23,7 +23,7 @@ Review ads through 6 compliance and quality lenses before shipping.
 2. Run `mb checkpoint --plan --json`, validate a subject such as `[drafted] {type} ad batch`, and save the pre-review checkpoint only after operator approval.
 3. Spawn 6 parallel Task agents — one per lens. Use `subagent_type: "general-purpose"`. Each agent:
    - Reads the ad batch/copy being reviewed
-   - Reads its assigned lens file from the engine's `lenses/` directory — resolve relative to this skill: `../../lenses/` from the skill's own loaded location (works for symlink, additionalDirectories, and plugin-cache installs; never cwd-relative)
+   - Reads its assigned lens file from this skill's bundled `references/lenses/` directory
    - Evaluates every ad against that lens's checklist
    - Returns P1/P2/P3 findings with specific line references
    - Does NOT fix anything — just reports findings (read-only pattern, no write risk)

--- a/.claude/skills/mb-ads/references/mode-static-ads.md
+++ b/.claude/skills/mb-ads/references/mode-static-ads.md
@@ -39,7 +39,7 @@ Campaign Batch 001
 
 1. Read project context (offer, audience, proof, angles)
 2. Ask for campaign name (required)
-3. Select 5-6 angles for the batch — **reference the engine's `angle-playbook.md` — `../../reference/compliance/angle-playbook.md` relative to this skill's loaded location** for angle types, compliance burden, and selection matrix
+3. Select 5-6 angles for the batch — reference this skill's bundled `references/compliance/angle-playbook.md` for angle types, compliance burden, and selection matrix
 4. **Write ALL image prompts first** (Part 1)
 5. **Write ALL ad copy second** (Part 2)
 6. **Cold traffic language check:** Every hook must pass the 3-second comprehension test — no insider jargon, no assumed context. Translate community language to customer language. See Joel's cold traffic guidance in [one-liner-methodology.md](one-liner-methodology.md).

--- a/.claude/skills/mb-ads/references/post-generation-pipeline.md
+++ b/.claude/skills/mb-ads/references/post-generation-pipeline.md
@@ -47,7 +47,7 @@ Spawn ALL agents in a single message for parallel execution. Use `subagent_type:
 
 Each compliance agent receives:
 - **Ad content inline** (pass the full batch file content in the prompt -- do NOT just give a file path)
-- **Lens file path** (agent reads its assigned lens from the engine's `lenses/` dir — `../../lenses/` relative to this skill's loaded location, never cwd-relative)
+- **Lens file path** (agent reads its assigned lens from this skill's bundled `references/lenses/` directory, never cwd-relative)
 - **Business context** (only what that lens needs):
   - FTC: offer.md, testimonials.md, typicality.md
   - Meta Policy: offer.md

--- a/.claude/skills/mb-ads/references/review-workflow.md
+++ b/.claude/skills/mb-ads/references/review-workflow.md
@@ -25,7 +25,7 @@ Identify what's being reviewed:
 
 Spawn 6 agents, one per lens. Each agent:
 
-1. Reads its lens file from the engine's `lenses/` dir (`../../lenses/` relative to this skill's loaded location)
+1. Reads its lens file from this skill's bundled `references/lenses/` directory
 2. Applies the checklist to the ad content
 3. Returns findings with severity (P1/P2/P3)
 
@@ -174,11 +174,12 @@ mb checkpoint --message "[updated] {type} ad batch after review" --yes
 
 ## Context Files
 
-**From Main Branch engine:**
-- `../../lenses/` (relative to this skill's loaded directory) — the 6 review lenses
-- `../../reference/compliance/` (same resolution) — shared compliance frameworks
+**Bundled with this skill:**
+- `references/lenses/` — the 6 review lenses
+- `references/compliance/` — shared compliance frameworks
 
-Resolve engine paths relative to THIS skill's loaded directory: the engine root is two levels up (`<this-skill-dir>/../../`), so lenses live at `../../lenses/` and compliance frameworks at `../../reference/compliance/`. This works identically for repo symlinks, additionalDirectories, and plugin-cache installs — never resolve them against the business repo's cwd.
+Resolve these paths relative to the `mb-ads` skill directory. Do not resolve them
+against the business repo's cwd or a sibling engine directory.
 
 **From business repo:**
 - `core/proof/testimonials.md` — Available testimonials for substantiation check

--- a/.claude/skills/mb-think/references/gemini-deep-research.md
+++ b/.claude/skills/mb-think/references/gemini-deep-research.md
@@ -14,14 +14,16 @@ When and how to use Gemini for comprehensive research.
 
 **Tested endpoint (Tier 1):**
 ```
-POST https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=$GOOGLE_API_KEY
+POST https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent
+Header: x-goog-api-key: $GOOGLE_API_KEY
 ```
 
 **Response format:** `candidates[].content.parts[].text`
 
 **Tested endpoint (Tier 2):**
 ```
-POST https://generativelanguage.googleapis.com/v1beta/interactions?key=$GOOGLE_API_KEY
+POST https://generativelanguage.googleapis.com/v1beta/interactions
+Header: x-goog-api-key: $GOOGLE_API_KEY
 ```
 
 **Tier 2 REST API verified working:**
@@ -112,7 +114,8 @@ There are THREE different things, often confused:
 
 **Start Deep Research:**
 ```bash
-curl -s "https://generativelanguage.googleapis.com/v1beta/interactions?key=$GOOGLE_API_KEY" \
+curl -s "https://generativelanguage.googleapis.com/v1beta/interactions" \
+  -H "x-goog-api-key: $GOOGLE_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
     "input": "Your research question here",
@@ -134,7 +137,8 @@ curl -s "https://generativelanguage.googleapis.com/v1beta/interactions?key=$GOOG
 
 **Poll for completion:**
 ```bash
-curl -s "https://generativelanguage.googleapis.com/v1beta/interactions/{interaction_id}?key=$GOOGLE_API_KEY"
+curl -s "https://generativelanguage.googleapis.com/v1beta/interactions/{interaction_id}" \
+  -H "x-goog-api-key: $GOOGLE_API_KEY"
 ```
 
 **When complete**, the response includes:

--- a/.claude/skills/mb-think/references/research-architecture.md
+++ b/.claude/skills/mb-think/references/research-architecture.md
@@ -253,12 +253,14 @@ If !GEMINI_AVAILABLE:
 **Tier 2 REST API Example:**
 ```bash
 # Start research (returns interaction ID)
-curl -s "https://generativelanguage.googleapis.com/v1beta/interactions?key=$GOOGLE_API_KEY" \
+curl -s "https://generativelanguage.googleapis.com/v1beta/interactions" \
+  -H "x-goog-api-key: $GOOGLE_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"input": "Your research question", "agent": "deep-research-pro-preview-12-2025", "background": true, "store": true}'
 
 # Poll for completion
-curl -s "https://generativelanguage.googleapis.com/v1beta/interactions/{id}?key=$GOOGLE_API_KEY"
+curl -s "https://generativelanguage.googleapis.com/v1beta/interactions/{id}" \
+  -H "x-goog-api-key: $GOOGLE_API_KEY"
 ```
 
 **Known issues:** Occasional internal server errors during long-running research. If poll returns 500 after ~10min, start a new request.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,48 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-07-08
+
+This release hardens Main Branch's local state writes and runtime repair paths
+so owner-loop setup commands fail loudly instead of silently clobbering local
+agent or provider configuration.
+
+### Added
+
+- Added shared durable-write helpers for atomic text/JSON writes and corrupt
+  JSON detection, then moved core runtime wiring, migration writes, init
+  scaffolding, Codex guidance repair, and provider metadata writes onto those
+  safer paths.
+- `mb migrate` and `mb doctor` now detect business repos with a schema version
+  newer than the installed engine and block write plans instead of preparing a
+  downgrade migration.
+- `AGENTS.md` Codex guidance is now maintained inside a Main Branch managed
+  block, preserving operator-owned notes outside the block during repair.
+- `/mb-ads` now bundles its review lenses and compliance references inside the
+  skill so packaged/global skill copies do not depend on sibling engine
+  directories.
+
+### Changed
+
+- `mb connect` now prefers the Python `keyring` backend over the macOS
+  `security -w` CLI when the backend is set to `auto`; explicit
+  `macos-keychain` selection still uses the macOS CLI.
+- Gemini deep-research examples now pass the API key through the
+  `x-goog-api-key` header instead of a query string.
+
+### Fixed
+
+- `mb skill link` refuses to rewrite corrupt `.claude/settings.local.json`
+  instead of resetting Claude Code permissions from an empty object.
+- `mb connect` refuses to update unreadable or invalid `.mb/connect.yaml` /
+  user-scope metadata, writes provider metadata and local-file secrets
+  atomically, and filters hand-edited secret-looking labels or metadata out of
+  safe-to-share status JSON.
+- `mb init` preserves existing `.gitignore` and `.github/CODEOWNERS` files
+  while still appending Main Branch local wiring ignores when needed.
+- `mb update` uses the currently running `mb` entrypoint for version checks and
+  times out subprocess probes instead of hanging indefinitely.
+
 ## [0.4.3] - 2026-06-30
 
 ### Added

--- a/mb/mb/__init__.py
+++ b/mb/mb/__init__.py
@@ -7,6 +7,6 @@ file stays a thin dispatcher.
 
 from __future__ import annotations
 
-__version__ = "0.4.3"
+__version__ = "0.5.0"
 
 __all__ = ["__version__"]

--- a/mb/mb/cli.py
+++ b/mb/mb/cli.py
@@ -1545,6 +1545,9 @@ def connect_cmd(
             result = connect_mod.list_providers(repo)
         except connect_mod.ConfigBoundaryError as exc:
             _connect_boundary_exit("mb connect", exc)
+        except ValueError as exc:
+            typer.echo(f"mb connect: {exc}", err=True)
+            raise typer.Exit(2) from exc
         if json_out:
             typer.echo(json.dumps(result, indent=2))
         else:
@@ -1555,6 +1558,9 @@ def connect_cmd(
             result = connect_mod.list_providers(repo)
         except connect_mod.ConfigBoundaryError as exc:
             _connect_boundary_exit("mb connect list", exc)
+        except ValueError as exc:
+            typer.echo(f"mb connect list: {exc}", err=True)
+            raise typer.Exit(2) from exc
         if json_out:
             typer.echo(json.dumps(result, indent=2))
         else:
@@ -1565,6 +1571,9 @@ def connect_cmd(
             result = connect_mod.provider_plan(repo)
         except connect_mod.ConfigBoundaryError as exc:
             _connect_boundary_exit("mb connect plan", exc)
+        except ValueError as exc:
+            typer.echo(f"mb connect plan: {exc}", err=True)
+            raise typer.Exit(2) from exc
         if json_out:
             typer.echo(json.dumps(result, indent=2))
         else:
@@ -1593,6 +1602,9 @@ def connect_cmd(
             result = connect_mod.doctor(repo)
         except connect_mod.ConfigBoundaryError as exc:
             _connect_boundary_exit("mb connect doctor", exc)
+        except ValueError as exc:
+            typer.echo(f"mb connect doctor: {exc}", err=True)
+            raise typer.Exit(2) from exc
         if json_out:
             typer.echo(json.dumps(result, indent=2))
         else:

--- a/mb/mb/codex.py
+++ b/mb/mb/codex.py
@@ -20,10 +20,13 @@ from typing import Any
 
 from mb import __version__
 from mb import engine as engine_mod
+from mb.durable import atomic_write_text
 from mb.workflows import WorkflowSource, load_workflow, render_codex_shell
 
 AGENTS_TEMPLATE = "AGENTS.md.tmpl"
 AGENTS_RELATIVE_PATH = "AGENTS.md"
+AGENTS_MANAGED_BEGIN = "<!-- mainbranch:codex-guidance:begin -->"
+AGENTS_MANAGED_END = "<!-- mainbranch:codex-guidance:end -->"
 CODEX_GUIDANCE_SCHEMA = 1
 CODEX_GUIDANCE_MIN_MB = "0.3.43"
 CODEX_SKILL_DIR_RELATIVE_PATH = ".agents/skills/main-branch-owner-loop"
@@ -1732,6 +1735,38 @@ def parse_guidance_metadata(text: str) -> dict[str, str]:
     return pairs
 
 
+def _managed_agents_block(rendered: str) -> str:
+    return f"{AGENTS_MANAGED_BEGIN}\n{rendered.rstrip()}\n{AGENTS_MANAGED_END}\n"
+
+
+def _managed_agents_content(text: str) -> str:
+    start = text.find(AGENTS_MANAGED_BEGIN)
+    if start == -1:
+        return ""
+    body_start = text.find("\n", start)
+    if body_start == -1:
+        return ""
+    end = text.find(AGENTS_MANAGED_END, body_start)
+    if end == -1:
+        return ""
+    return text[body_start + 1 : end].strip() + "\n"
+
+
+def _merge_agents_md(existing: str, rendered: str) -> str:
+    block = _managed_agents_block(rendered)
+    start = existing.find(AGENTS_MANAGED_BEGIN)
+    if start != -1:
+        end = existing.find(AGENTS_MANAGED_END, start)
+        if end != -1:
+            tail_start = end + len(AGENTS_MANAGED_END)
+            return existing[:start] + block.rstrip("\n") + existing[tail_start:]
+    if not existing.strip():
+        return block
+    if parse_guidance_metadata(existing):
+        return block
+    return block + "\n" + existing
+
+
 def _markdown_section(text: str, heading: str) -> str:
     start = text.find(heading)
     if start == -1:
@@ -2998,18 +3033,20 @@ def instructions_status(repo: str | Path) -> dict[str, Any]:
         read_error = str(exc)
     else:
         read_error = ""
-    missing_commands = [command for command in REQUIRED_FACT_COMMANDS if command not in text]
-    approval_ok = "explicit operator approval" in text
-    slash_ok = "Do not pretend Claude Code slash skills work in Codex." in text
+    managed_text = _managed_agents_content(text)
+    status_text = managed_text or text
+    missing_commands = [command for command in REQUIRED_FACT_COMMANDS if command not in status_text]
+    approval_ok = "explicit operator approval" in status_text
+    slash_ok = "Do not pretend Claude Code slash skills work in Codex." in status_text
     missing_lifecycle_guidance = [
-        marker for marker in REQUIRED_LIFECYCLE_GUIDANCE_MARKERS if marker not in text
+        marker for marker in REQUIRED_LIFECYCLE_GUIDANCE_MARKERS if marker not in status_text
     ]
     for heading, markers in REQUIRED_LIFECYCLE_SECTION_MARKERS:
-        section = _markdown_section(text, heading)
+        section = _markdown_section(status_text, heading)
         missing_lifecycle_guidance.extend(marker for marker in markers if marker not in section)
     missing_lifecycle_guidance = list(dict.fromkeys(missing_lifecycle_guidance))
     lifecycle_discovery_ok = bool(exists and not missing_lifecycle_guidance)
-    guidance_metadata = parse_guidance_metadata(text) if exists else {}
+    guidance_metadata = parse_guidance_metadata(status_text) if exists else {}
     expected_template_hash = guidance_template_hash()
     expected_guidance_metadata = guidance_metadata_comment(template_hash=expected_template_hash)
     guidance_schema_ok = guidance_metadata.get("schema") == str(CODEX_GUIDANCE_SCHEMA)
@@ -3033,7 +3070,7 @@ def instructions_status(repo: str | Path) -> dict[str, Any]:
         )
         if (target / relative).exists()
     ]
-    template_match = bool(exists and text == expected)
+    template_match = bool(exists and status_text == expected)
     current = bool(fact_grounding_ok and guidance_metadata_ok and not repo_local_plugin_paths)
     return {
         "ok": current,
@@ -3186,10 +3223,11 @@ def write_agents_md(
     path = agents_path(target)
     rendered = render_agents_md(target, name=name, gh_username=gh_username)
     existing = path.read_text(encoding="utf-8") if path.exists() else ""
-    changed = existing != rendered
+    updated = _merge_agents_md(existing, rendered)
+    changed = existing != updated
     changed_paths: list[str] = []
     if changed:
-        path.write_text(rendered, encoding="utf-8")
+        atomic_write_text(path, updated)
         changed_paths.append(AGENTS_RELATIVE_PATH)
 
     removed_paths = remove_repo_local_codex_plugin_files(target)

--- a/mb/mb/connect.py
+++ b/mb/mb/connect.py
@@ -23,6 +23,8 @@ from typing import Any
 
 import yaml
 
+from mb.durable import atomic_write_text
+
 CONFIG_RELATIVE_PATH = Path(".mb") / "connect.yaml"
 USER_SCOPE_RELATIVE_PATH = Path("connect") / "user-scope.yaml"
 SERVICE_NAME = "mainbranch"
@@ -50,6 +52,10 @@ BEARER_SECRET_RE = re.compile(r"(?i)\bbearer[ \t]+[^\s,;]+")
 
 class ConfigBoundaryError(ValueError):
     """Raised when local connect metadata is outside the selected repo boundary."""
+
+
+class ConfigCorruptError(ValueError):
+    """Raised when local connect metadata cannot be parsed safely."""
 
 
 @dataclass(frozen=True)
@@ -406,6 +412,34 @@ def _safe_identity_metadata(metadata: dict[str, Any]) -> dict[str, str]:
     return recorded
 
 
+def _metadata_key_looks_sensitive(key: str) -> bool:
+    lowered = key.lower().replace("-", "_")
+    return lowered not in SAFE_METADATA_KEYS and any(
+        part in lowered for part in SENSITIVE_KEY_PARTS
+    )
+
+
+def _safe_status_metadata(metadata: dict[str, Any]) -> dict[str, str]:
+    """Filter hand-edited metadata before it enters safe-to-share status JSON."""
+    recorded: dict[str, str] = {}
+    for raw_key, raw_value in metadata.items():
+        key = str(raw_key)
+        if raw_value is None or raw_value == "":
+            continue
+        value = str(raw_value)
+        flagged, _reason = _classify_credential_value(key, value)
+        if flagged or _metadata_key_looks_sensitive(key):
+            continue
+        recorded[key] = value
+    return recorded
+
+
+def _safe_status_label(value: Any) -> str:
+    label = str(value or "")
+    flagged, _reason = _classify_credential_value("account_label", label)
+    return SECRET_REPLACEMENT if flagged else label
+
+
 def _now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
 
@@ -459,10 +493,16 @@ def _read_config(repo: Path) -> dict[str, Any]:
         return _empty_config()
     try:
         raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
-    except (OSError, yaml.YAMLError):
-        raw = {}
+    except (OSError, yaml.YAMLError) as exc:
+        raise ConfigCorruptError(
+            "Refusing to update .mb/connect.yaml because it is unreadable or invalid YAML. "
+            "Fix or move the file, then rerun the command."
+        ) from exc
     if not isinstance(raw, dict):
-        raw = {}
+        raise ConfigCorruptError(
+            "Refusing to update .mb/connect.yaml because it does not contain a YAML object. "
+            "Fix or move the file, then rerun the command."
+        )
     providers = raw.get("providers")
     if not isinstance(providers, dict):
         providers = {}
@@ -563,7 +603,7 @@ def _write_config(repo: Path, config: dict[str, Any]) -> Path:
     # Re-check after creating .mb so a swapped local-state path cannot escape the repo.
     path = _checked_config_path(repo)
     text = yaml.safe_dump(config, sort_keys=False)
-    path.write_text(text, encoding="utf-8")
+    atomic_write_text(path, text)
     return path
 
 
@@ -581,10 +621,16 @@ def _read_user_scope() -> dict[str, Any]:
         return _empty_user_scope()
     try:
         raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
-    except (OSError, yaml.YAMLError):
-        raw = {}
+    except (OSError, yaml.YAMLError) as exc:
+        raise ConfigCorruptError(
+            "Refusing to update connect user-scope metadata because it is unreadable or "
+            "invalid YAML. Fix or move the file, then rerun the command."
+        ) from exc
     if not isinstance(raw, dict):
-        raw = {}
+        raise ConfigCorruptError(
+            "Refusing to update connect user-scope metadata because it does not contain a YAML "
+            "object. Fix or move the file, then rerun the command."
+        )
     repos = raw.get("repos")
     if not isinstance(repos, dict):
         repos = {}
@@ -600,7 +646,7 @@ def _write_user_scope(data: dict[str, Any]) -> Path:
     path.parent.mkdir(parents=True, exist_ok=True)
     with suppress(OSError):
         path.parent.chmod(0o700)
-    path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+    atomic_write_text(path, yaml.safe_dump(data, sort_keys=False))
     with suppress(OSError):
         path.chmod(0o600)
     return path
@@ -842,10 +888,10 @@ def _select_secret_backend() -> str:
     requested = os.environ.get("MB_CONNECT_SECRET_BACKEND", "auto").strip().lower()
     if requested in {"macos-keychain", "keyring", "local-file"}:
         return requested
-    if platform.system() == "Darwin" and shutil.which("security"):
-        return "macos-keychain"
     if _keyring_module() is not None:
         return "keyring"
+    if platform.system() == "Darwin" and shutil.which("security"):
+        return "macos-keychain"
     return "local-file"
 
 
@@ -914,7 +960,7 @@ def _write_local_secrets(data: dict[str, str]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     with suppress(OSError):
         path.parent.chmod(0o700)
-    path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    atomic_write_text(path, json.dumps(data, indent=2, sort_keys=True) + "\n")
     with suppress(OSError):
         path.chmod(0o600)
 
@@ -1230,8 +1276,8 @@ def _unhydrated_status(provider: Provider, entry: dict[str, Any]) -> dict[str, A
         "repair": repair["repair"],
         "repair_command": repair["repair_command"],
         "safe_to_share": True,
-        "account_label": str(entry.get("account_label") or ""),
-        "metadata": metadata,
+        "account_label": _safe_status_label(entry.get("account_label")),
+        "metadata": _safe_status_metadata(metadata),
         "secrets": secrets,
         "last_checked_at": str(entry.get("last_checked_at") or ""),
         "scope": "user",
@@ -1343,8 +1389,8 @@ def status_provider(
             "repair": repair["repair"],
             "repair_command": repair["repair_command"],
             "safe_to_share": True,
-            "account_label": str(raw_entry.get("account_label") or ""),
-            "metadata": meta_metadata,
+            "account_label": _safe_status_label(raw_entry.get("account_label")),
+            "metadata": _safe_status_metadata(meta_metadata),
             "secrets": {
                 "access_token": {"present": secret_present, "ref": ref, "backend": backend}
             },
@@ -1421,8 +1467,8 @@ def status_provider(
         "repair": repair["repair"],
         "repair_command": repair["repair_command"],
         "safe_to_share": True,
-        "account_label": str(entry.get("account_label") or ""),
-        "metadata": metadata,
+        "account_label": _safe_status_label(entry.get("account_label")),
+        "metadata": _safe_status_metadata(metadata),
         "secrets": secrets,
         "last_checked_at": str(entry.get("last_checked_at") or ""),
         "scope": str(entry.get("scope") or "repo"),

--- a/mb/mb/doctor.py
+++ b/mb/mb/doctor.py
@@ -41,7 +41,12 @@ from mb.freshness import (
     package_update_status,
     version_key,
 )
-from mb.migrate import LATEST_SCHEMA_VERSION, pending_migrations, read_schema_version
+from mb.migrate import (
+    LATEST_SCHEMA_VERSION,
+    pending_migrations,
+    read_schema_version,
+    schema_write_blocker,
+)
 from mb.skill_validate import run_all as validate_all_skills
 
 CLOUD_PREFIXES = (
@@ -872,6 +877,14 @@ def _legacy_campaigns_check(repo: Path) -> dict[str, Any]:
 
 def _schema_version_check(repo: Path) -> dict[str, Any]:
     current = read_schema_version(repo)
+    future_blocker = schema_write_blocker(repo)
+    if future_blocker:
+        return {
+            "name": "schema-version",
+            "ok": False,
+            "detail": future_blocker,
+            "severity": "error",
+        }
     pending = pending_migrations(repo)
     if pending:
         names = ", ".join(info.name for info, _module in pending)

--- a/mb/mb/durable.py
+++ b/mb/mb/durable.py
@@ -1,0 +1,86 @@
+"""Small crash-safety helpers for Main Branch state files."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager, suppress
+from pathlib import Path
+from typing import Any
+
+
+class CorruptStateError(ValueError):
+    """Raised when a state file exists but cannot be safely parsed."""
+
+    def __init__(self, path: Path, detail: str) -> None:
+        self.path = path
+        self.detail = detail
+        super().__init__(f"{path} is not valid state: {detail}")
+
+
+def read_json_object(path: Path, *, default: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Read a JSON object, distinguishing missing from corrupt state."""
+    if not path.exists():
+        return {} if default is None else dict(default)
+    raw = path.read_text(encoding="utf-8")
+    if not raw.strip():
+        return {} if default is None else dict(default)
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise CorruptStateError(path, exc.msg) from exc
+    if not isinstance(data, dict):
+        raise CorruptStateError(path, "expected a JSON object")
+    return data
+
+
+def atomic_write_text(path: Path, text: str, *, encoding: str = "utf-8") -> None:
+    """Write text by replacing the target from a same-directory temp file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    mode = path.stat().st_mode & 0o777 if path.exists() else 0o644
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
+    tmp = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding=encoding) as handle:
+            handle.write(text)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(tmp, mode)
+        os.replace(tmp, path)
+    except BaseException:
+        with suppress(OSError):
+            tmp.unlink()
+        raise
+
+
+def atomic_write_json(
+    path: Path,
+    data: Any,
+    *,
+    indent: int = 2,
+    sort_keys: bool = False,
+) -> None:
+    atomic_write_text(path, json.dumps(data, indent=indent, sort_keys=sort_keys) + "\n")
+
+
+@contextmanager
+def state_lock(path: Path, *, timeout: float = 10.0) -> Iterator[None]:
+    """Best-effort interprocess lock using an atomic lock directory."""
+    lock_dir = path.with_name(f".{path.name}.lock")
+    deadline = time.monotonic() + timeout
+    while True:
+        try:
+            lock_dir.mkdir()
+            break
+        except FileExistsError as exc:
+            if time.monotonic() >= deadline:
+                raise TimeoutError(f"timed out waiting for lock {lock_dir}") from exc
+            time.sleep(0.05)
+    try:
+        yield
+    finally:
+        with suppress(OSError):
+            lock_dir.rmdir()

--- a/mb/mb/engine.py
+++ b/mb/mb/engine.py
@@ -28,6 +28,7 @@ from pathlib import Path
 from typing import Any
 
 from mb import __version__
+from mb.durable import CorruptStateError, atomic_write_json, atomic_write_text, read_json_object
 
 SKILL_PREFIX = "mb-"
 PRIMARY_SKILL = "mb-start"
@@ -125,9 +126,11 @@ def skill_path(name: str) -> Path | None:
     return candidate if candidate.is_dir() else None
 
 
-def _read_settings(path: Path) -> dict[str, Any]:
+def _read_settings(path: Path, *, strict: bool = False) -> dict[str, Any]:
     if not path.exists():
         return {}
+    if strict:
+        return read_json_object(path)
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
     except json.JSONDecodeError:
@@ -368,9 +371,19 @@ def is_stale_engine_path(value: str, active_root: Path) -> bool:
     return _is_stale_engine_path(value, active_root)
 
 
-def _write_settings(repo: Path, root: Path) -> tuple[bool, list[str]]:
+def _write_settings(repo: Path, root: Path) -> tuple[bool, list[str], str]:
     settings_path = repo / ".claude" / "settings.local.json"
-    data = _read_settings(settings_path)
+    try:
+        data = _read_settings(settings_path, strict=True)
+    except CorruptStateError as exc:
+        return (
+            False,
+            [],
+            (
+                f"{settings_path} is not valid JSON ({exc.detail}); refused to "
+                "refresh local Claude wiring to avoid clobbering your settings."
+            ),
+        )
     permissions = data.setdefault("permissions", {})
     if not isinstance(permissions, dict):
         permissions = {}
@@ -394,9 +407,8 @@ def _write_settings(repo: Path, root: Path) -> tuple[bool, list[str]]:
     rendered = json.dumps(data, indent=2, sort_keys=True) + "\n"
     changed = not settings_path.exists() or settings_path.read_text(encoding="utf-8") != rendered
     if changed:
-        settings_path.parent.mkdir(parents=True, exist_ok=True)
-        settings_path.write_text(rendered, encoding="utf-8")
-    return changed, removed_stale
+        atomic_write_text(settings_path, rendered)
+    return changed, removed_stale, ""
 
 
 def _append_unique_gitignore(repo: Path, entries: list[str]) -> bool:
@@ -412,7 +424,7 @@ def _append_unique_gitignore(repo: Path, entries: list[str]) -> bool:
     block = [GITIGNORE_HEADER, *to_add]
     if GITIGNORE_HEADER in existing_lines:
         block = to_add
-    gitignore.write_text(existing_text + prefix + "\n".join(block) + "\n", encoding="utf-8")
+    atomic_write_text(gitignore, existing_text + prefix + "\n".join(block) + "\n")
     return True
 
 
@@ -431,7 +443,7 @@ def _remove_gitignore_entries(repo: Path, entries: list[str]) -> bool:
     rendered = "\n".join(kept)
     if rendered:
         rendered += "\n"
-    gitignore.write_text(rendered, encoding="utf-8")
+    atomic_write_text(gitignore, rendered)
     return True
 
 
@@ -701,7 +713,20 @@ def link_skills(repo: str | Path) -> dict[str, Any]:
     skill_link_dir.mkdir(parents=True, exist_ok=True)
 
     created: list[str] = []
-    settings_changed, removed_stale_engine_paths = _write_settings(target, root)
+    settings_changed, removed_stale_engine_paths, settings_error = _write_settings(target, root)
+    if settings_error:
+        return {
+            "ok": False,
+            "repo": str(target),
+            "engine_root": str(root),
+            "created": [],
+            "linked": [],
+            "copied": [],
+            "skipped": [],
+            "removed_legacy": [],
+            "removed_stale_engine_paths": removed_stale_engine_paths,
+            "errors": [settings_error],
+        }
     if settings_changed:
         created.append(".claude/settings.local.json")
 
@@ -1123,7 +1148,7 @@ def write_plugin_wiring(repo: str | Path) -> dict[str, Any]:
         raw = path.read_text(encoding="utf-8")
         if raw.strip():
             try:
-                json.loads(raw)
+                parsed = json.loads(raw)
             except json.JSONDecodeError as exc:
                 return {
                     "ok": False,
@@ -1136,7 +1161,18 @@ def write_plugin_wiring(repo: str | Path) -> dict[str, Any]:
                         "the JSON, then re-run."
                     ),
                 }
-    settings = _read_settings(path)
+            if not isinstance(parsed, dict):
+                return {
+                    "ok": False,
+                    "changed": False,
+                    "settings_path": str(path),
+                    "wiring": plugin_wiring_status(target),
+                    "summary": (
+                        ".claude/settings.json must be a JSON object; refused to write "
+                        "plugin wiring to avoid clobbering your settings."
+                    ),
+                }
+    settings = _read_settings(path, strict=True)
     before = plugin_wiring_status(target)
     marketplaces = settings.setdefault("extraKnownMarketplaces", {})
     if not isinstance(marketplaces, dict):
@@ -1148,8 +1184,7 @@ def write_plugin_wiring(repo: str | Path) -> dict[str, Any]:
         enabled = {}
         settings["enabledPlugins"] = enabled
     enabled[PLUGIN_ENABLE_KEY] = True
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(settings, indent=2) + "\n", encoding="utf-8")
+    atomic_write_json(path, settings)
     after = plugin_wiring_status(target)
     return {
         "ok": after["wired"],

--- a/mb/mb/init.py
+++ b/mb/mb/init.py
@@ -18,6 +18,7 @@ from typing import Any
 from mb import checkpoint as checkpoint_mod
 from mb import codex as codex_mod
 from mb import team as team_mod
+from mb.durable import atomic_write_text
 from mb.engine import link_skills, write_plugin_wiring
 from mb.migrate import LATEST_SCHEMA_VERSION, SCHEMA_MARKER
 
@@ -191,12 +192,12 @@ def run(
         # .gitkeep so empty folders survive git
         keep = d / ".gitkeep"
         if not keep.exists():
-            keep.write_text("", encoding="utf-8")
+            atomic_write_text(keep, "")
             created.append(f"{sub}/.gitkeep")
 
     marker = target / SCHEMA_MARKER
     marker.parent.mkdir(parents=True, exist_ok=True)
-    marker.write_text(LATEST_SCHEMA_VERSION + "\n", encoding="utf-8")
+    atomic_write_text(marker, LATEST_SCHEMA_VERSION + "\n")
     created.append(SCHEMA_MARKER)
 
     mapping = {
@@ -207,12 +208,12 @@ def run(
     }
 
     claude_tmpl = _read_template("CLAUDE.md.tmpl") or _DEFAULT_CLAUDE
-    (target / "CLAUDE.md").write_text(_render(claude_tmpl, mapping), encoding="utf-8")
+    atomic_write_text(target / "CLAUDE.md", _render(claude_tmpl, mapping))
     created.append("CLAUDE.md")
 
     readme_tmpl = _read_template("README.md.tmpl")
     if readme_tmpl:
-        (target / "README.md").write_text(_render(readme_tmpl, mapping), encoding="utf-8")
+        atomic_write_text(target / "README.md", _render(readme_tmpl, mapping))
         created.append("README.md")
 
     agents_result = codex_mod.write_agents_md(
@@ -229,7 +230,7 @@ def run(
         vocabulary_path = target / "core" / "vocabulary.md"
         vocabulary_path.parent.mkdir(parents=True, exist_ok=True)
         if not vocabulary_path.exists():
-            vocabulary_path.write_text(_render(vocabulary_tmpl, mapping), encoding="utf-8")
+            atomic_write_text(vocabulary_path, _render(vocabulary_tmpl, mapping))
             created.append("core/vocabulary.md")
 
     team_tmpl = _read_template("core_team_member.md.tmpl")
@@ -237,18 +238,22 @@ def run(
         owner_path = target / "core" / "team" / f"{owner_slug}.md"
         owner_path.parent.mkdir(parents=True, exist_ok=True)
         if not owner_path.exists():
-            owner_path.write_text(_render(team_tmpl, mapping), encoding="utf-8")
+            atomic_write_text(owner_path, _render(team_tmpl, mapping))
             created.append(f"core/team/{owner_slug}.md")
 
     codeowners_tmpl = _read_template("CODEOWNERS.tmpl") or f"* @{gh_user}\n"
     github_dir = target / ".github"
     github_dir.mkdir(exist_ok=True)
-    (github_dir / "CODEOWNERS").write_text(_render(codeowners_tmpl, mapping), encoding="utf-8")
-    created.append(".github/CODEOWNERS")
+    codeowners_path = github_dir / "CODEOWNERS"
+    if not codeowners_path.exists():
+        atomic_write_text(codeowners_path, _render(codeowners_tmpl, mapping))
+        created.append(".github/CODEOWNERS")
 
     gitignore_tmpl = _read_template(".gitignore.tmpl") or DEFAULT_GITIGNORE
-    (target / ".gitignore").write_text(_render(gitignore_tmpl, mapping), encoding="utf-8")
-    created.append(".gitignore")
+    gitignore_path = target / ".gitignore"
+    if not gitignore_path.exists():
+        atomic_write_text(gitignore_path, _render(gitignore_tmpl, mapping))
+        created.append(".gitignore")
 
     link_result = link_skills(target)
     created.extend(path for path in link_result["created"] if path not in created)

--- a/mb/mb/migrate.py
+++ b/mb/mb/migrate.py
@@ -14,6 +14,7 @@ from typing import Any
 import yaml
 
 from mb import migrations
+from mb.durable import atomic_write_text
 from mb.migrations.base import MigrationInfo, MigrationPlan, PlannedChange
 
 ENVELOPE_SCHEMA = "mb.migrate"
@@ -58,6 +59,31 @@ def read_schema_version(repo: str | Path) -> str:
     return "unknown"
 
 
+def _schema_key(version: str) -> tuple[int, ...] | None:
+    try:
+        return tuple(int(part) for part in version.strip().split("."))
+    except ValueError:
+        return None
+
+
+def is_future_schema_version(version: str) -> bool:
+    current = _schema_key(version)
+    latest = _schema_key(LATEST_SCHEMA_VERSION)
+    if current is None or latest is None:
+        return False
+    return current > latest
+
+
+def schema_write_blocker(repo: str | Path) -> str:
+    version = read_schema_version(repo)
+    if not is_future_schema_version(version):
+        return ""
+    return (
+        f"schema {version} is newer than this engine supports "
+        f"(latest {LATEST_SCHEMA_VERSION}); upgrade Main Branch before writing."
+    )
+
+
 def _migration_dict(info: MigrationInfo) -> dict[str, str]:
     return {
         "id": info.id,
@@ -71,6 +97,8 @@ def _migration_dict(info: MigrationInfo) -> dict[str, str]:
 def pending_migrations(repo: str | Path) -> list[tuple[MigrationInfo, Any]]:
     """Return registered migrations pending for ``repo``."""
     version = read_schema_version(repo)
+    if is_future_schema_version(version):
+        return []
     pending: list[tuple[MigrationInfo, Any]] = []
     version_map = migrations.version_map()
     for info, module in migrations.registered():
@@ -195,6 +223,8 @@ def _backup_hint(plans: list[MigrationPlan]) -> dict[str, Any]:
 
 
 def _next_after_status(result: dict[str, Any]) -> str:
+    if result.get("errors"):
+        return "Upgrade Main Branch before running migrations or repair writes in this repo."
     if result.get("pending"):
         return "Run `mb migrate --check` to preview the migration before applying it."
     return "No layout migration is pending."
@@ -224,10 +254,11 @@ def _next_after_apply(result: dict[str, Any]) -> str:
 
 def _base_envelope(repo: Path, action: str) -> dict[str, Any]:
     pending = pending_migrations(repo)
+    blocker = schema_write_blocker(repo)
     result = {
         "schema": ENVELOPE_SCHEMA,
         "schema_version": ENVELOPE_SCHEMA_VERSION,
-        "ok": True,
+        "ok": not blocker,
         "action": action,
         "repo": str(repo),
         "current_version": read_schema_version(repo),
@@ -236,7 +267,7 @@ def _base_envelope(repo: Path, action: str) -> dict[str, Any]:
         "plan": None,
         "applied": [],
         "backup": None,
-        "errors": [],
+        "errors": [blocker] if blocker else [],
         "next": "",
     }
     result["next"] = _next_after_status(result)
@@ -253,6 +284,18 @@ def check(repo: str | Path = ".", *, include_diff: bool = False) -> dict[str, An
     """Plan pending migrations without writing files."""
     target = Path(repo).resolve()
     result = _base_envelope(target, "check")
+    if result["errors"]:
+        result["plan"] = {
+            "has_changes": False,
+            "migrations": [],
+            "diff_included": include_diff,
+            "diff": "",
+            "privacy_note": "",
+            "errors": list(result["errors"]),
+        }
+        result["backup"] = _backup_hint([])
+        result["next"] = _next_after_check(result)
+        return result
     pending = pending_migrations(target)
     plans = [migrations.plan_for(info, module, target) for info, module in pending]
     _ensure_gitignore_plan(target, plans)
@@ -365,8 +408,7 @@ def _apply_change(repo: Path, change: PlannedChange) -> None:
             path.unlink()
         return
     if change.kind == "write_file":
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(change.content, encoding="utf-8")
+        atomic_write_text(path, change.content)
         return
     if change.kind == "remove_empty_dir":
         if path.is_dir():
@@ -407,9 +449,9 @@ def apply(repo: str | Path = ".") -> dict[str, Any]:
     backup_dir = _backup_path(target, [plan.migration.id for plan in plans])
     backup_dir.mkdir(parents=True, exist_ok=False)
     copied = _backup_existing_paths(target, backup_dir, plans)
-    (backup_dir / "manifest.json").write_text(
+    atomic_write_text(
+        backup_dir / "manifest.json",
         json.dumps({"schema_version": 1, "copied": copied}, indent=2) + "\n",
-        encoding="utf-8",
     )
 
     for plan in plans:
@@ -424,8 +466,7 @@ def apply(repo: str | Path = ".") -> dict[str, Any]:
                 return result
 
     marker = _marker_path(target)
-    marker.parent.mkdir(parents=True, exist_ok=True)
-    marker.write_text(LATEST_SCHEMA_VERSION + "\n", encoding="utf-8")
+    atomic_write_text(marker, LATEST_SCHEMA_VERSION + "\n")
 
     result["ok"] = True
     result["current_version"] = LATEST_SCHEMA_VERSION

--- a/mb/mb/update.py
+++ b/mb/mb/update.py
@@ -6,6 +6,7 @@ import json
 import re
 import shutil
 import subprocess
+import sys
 import urllib.error
 import urllib.request
 from pathlib import Path
@@ -31,16 +32,31 @@ CLONE_UPDATE_COMMAND = ["git", "pull", "--ff-only", "origin", "main"]
 GITHUB_RELEASE_API_URL_TEMPLATE = (
     "https://api.github.com/repos/noontide-co/mainbranch/releases/tags/oe-v{version}"
 )
+COMMAND_TIMEOUT_SECONDS = 120.0
 
 
-def _run_command(args: list[str], *, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(
-        args,
-        cwd=str(cwd) if cwd is not None else None,
-        text=True,
-        capture_output=True,
-        check=False,
-    )
+def _run_command(
+    args: list[str],
+    *,
+    cwd: Path | None = None,
+    timeout: float = COMMAND_TIMEOUT_SECONDS,
+) -> subprocess.CompletedProcess[str]:
+    try:
+        return subprocess.run(
+            args,
+            cwd=str(cwd) if cwd is not None else None,
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as exc:
+        return subprocess.CompletedProcess(
+            args=args,
+            returncode=124,
+            stdout=exc.stdout if isinstance(exc.stdout, str) else "",
+            stderr=f"timed out after {timeout:g}s",
+        )
 
 
 def _engine_version(root: Path | None = None) -> str:
@@ -79,8 +95,15 @@ def _fetch_origin_main(root: Path) -> tuple[bool, str | None]:
     return False, _command_error("git fetch origin main", result)
 
 
-def _version_from_mb_command() -> str | None:
-    result = _run_command(["mb", "--version"])
+def _current_mb_entrypoint() -> str:
+    candidate = Path(sys.argv[0])
+    if candidate.name == "mb" and candidate.exists():
+        return str(candidate)
+    return "mb"
+
+
+def _version_from_mb_command(command: str | None = None) -> str | None:
+    result = _run_command([command or _current_mb_entrypoint(), "--version"])
     if result.returncode != 0:
         return None
     match = re.search(r"\bmb\s+(.+)\s*$", result.stdout.strip())

--- a/mb/pyproject.toml
+++ b/mb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mainbranch"
-version = "0.4.3"
+version = "0.5.0"
 description = "Main Branch engine umbrella - scaffolds, validates, and graphs business-as-files repos. Claude Code first, runtime-agnostic by design."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/mb/tests/test_connect.py
+++ b/mb/tests/test_connect.py
@@ -541,6 +541,35 @@ def test_connect_provider_stores_secret_outside_repo(tmp_path: Path, monkeypatch
     assert stat.S_IMODE(secret_file.stat().st_mode) == 0o600
 
 
+def test_connect_status_filters_hand_edited_secret_like_metadata(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _local_secret_env(monkeypatch, tmp_path)
+    repo = tmp_path / "biz"
+    repo.mkdir()
+    connect_mod.connect_provider(
+        "cloudflare",
+        repo=repo,
+        token="cf-test-token",
+        account_label="Acme CF",
+        metadata_pairs=["account_id=acct_123"],
+    )
+    config_path = repo / ".mb" / "connect.yaml"
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    config["providers"]["cloudflare"]["account_label"] = "sk-live-label-secret"
+    config["providers"]["cloudflare"]["metadata"]["api_key"] = "sk-live-metadata-secret"
+    config["providers"]["cloudflare"]["metadata"]["zone_id"] = "zone_456"
+    config_path.write_text(yaml.safe_dump(config), encoding="utf-8")
+
+    status = connect_mod.status_provider("cloudflare", repo=repo)
+
+    assert status["safe_to_share"] is True
+    assert status["account_label"] == connect_mod.SECRET_REPLACEMENT
+    assert status["metadata"] == {"account_id": "acct_123", "zone_id": "zone_456"}
+    assert "sk-live" not in json.dumps(status)
+    assert "api_key" not in status["metadata"]
+
+
 def test_connect_repo_identity_is_stable_across_worktrees(tmp_path: Path, monkeypatch) -> None:
     _local_secret_env(monkeypatch, tmp_path)
     first = tmp_path / "biz-one"
@@ -1412,6 +1441,25 @@ def test_connect_status_tolerates_malformed_config_version(tmp_path: Path, monke
     assert status_payload["summary"]["configured"] == 0
 
 
+def test_connect_refuses_to_clobber_invalid_yaml_config(tmp_path: Path, monkeypatch) -> None:
+    _local_secret_env(monkeypatch, tmp_path)
+    repo = tmp_path / "biz"
+    repo.mkdir()
+    (repo / ".mb").mkdir()
+    config_path = repo / ".mb" / "connect.yaml"
+    config_path.write_text("version: 1\nproviders: [\n", encoding="utf-8")
+
+    result = runner.invoke(
+        app,
+        ["connect", "cloudflare", "--repo", str(repo), "--token", "cf-test-token", "--json"],
+    )
+
+    assert result.exit_code == 2
+    assert "invalid YAML" in result.stderr
+    assert config_path.read_text(encoding="utf-8") == "version: 1\nproviders: [\n"
+    assert not (tmp_path / "secrets" / "connect.json").exists()
+
+
 def test_connect_status_missing_config_still_reports_empty_state(
     tmp_path: Path, monkeypatch
 ) -> None:
@@ -1578,6 +1626,18 @@ def test_macos_keychain_backend_uses_security(monkeypatch) -> None:
     assert calls
     assert calls[0][:3] == ["security", "add-generic-password", "-a"]
     assert "cf-token" in calls[0]
+
+
+def test_auto_secret_backend_prefers_keyring_over_macos_security(monkeypatch) -> None:
+    class FakeKeyring:
+        pass
+
+    monkeypatch.delenv("MB_CONNECT_SECRET_BACKEND", raising=False)
+    monkeypatch.setattr("mb.connect.platform.system", lambda: "Darwin")
+    monkeypatch.setattr("mb.connect.shutil.which", lambda name: "/usr/bin/security")
+    monkeypatch.setattr(connect_mod, "_keyring_module", lambda: FakeKeyring())
+
+    assert connect_mod._select_secret_backend() == "keyring"
 
 
 def test_connect_token_prints_secret_to_stdout(tmp_path: Path, monkeypatch) -> None:

--- a/mb/tests/test_doctor.py
+++ b/mb/tests/test_doctor.py
@@ -214,6 +214,19 @@ def test_doctor_warns_on_schema_drift(tmp_path: Path) -> None:
     assert "mb migrate --check" in check["detail"]
 
 
+def test_doctor_blocks_future_schema(tmp_path: Path) -> None:
+    repo = tmp_path / "future"
+    (repo / ".mb").mkdir(parents=True)
+    (repo / ".mb" / "schema_version").write_text("9.0\n", encoding="utf-8")
+
+    report = run(path=str(repo))
+
+    check = next(c for c in report["checks"] if c["name"] == "schema-version")
+    assert check["ok"] is False
+    assert check["severity"] == "error"
+    assert "newer than this engine supports" in check["detail"]
+
+
 def test_doctor_json_and_human_output_include_required_update(
     tmp_path: Path, monkeypatch, capsys
 ) -> None:

--- a/mb/tests/test_engine.py
+++ b/mb/tests/test_engine.py
@@ -187,6 +187,25 @@ def test_link_skills_removes_legacy_project_symlink(tmp_path: Path) -> None:
     assert (repo / ".claude" / "skills" / "mb-start" / "SKILL.md").exists()
 
 
+def test_link_skills_refuses_to_clobber_corrupt_local_settings(tmp_path: Path, monkeypatch) -> None:
+    repo = tmp_path / "biz"
+    engine = tmp_path / "engine"
+    _write_skill(engine, "mb-start")
+    settings = repo / ".claude" / "settings.local.json"
+    settings.parent.mkdir(parents=True)
+    settings.write_text("{not json", encoding="utf-8")
+
+    monkeypatch.setattr(engine_mod, "engine_root", lambda: engine)
+    monkeypatch.setattr(engine_mod, "skills_dir", lambda root=None: engine / ".claude" / "skills")
+
+    result = engine_mod.link_skills(repo)
+
+    assert result["ok"] is False
+    assert "not valid JSON" in result["errors"][0]
+    assert settings.read_text(encoding="utf-8") == "{not json"
+    assert not (repo / ".claude" / "skills" / "mb-start").exists()
+
+
 def test_link_skills_removes_retired_project_symlinks_and_gitignore_entries(
     tmp_path: Path, monkeypatch
 ) -> None:

--- a/mb/tests/test_init.py
+++ b/mb/tests/test_init.py
@@ -293,6 +293,40 @@ def test_init_scaffolds_folders(tmp_path: Path) -> None:
     assert codex_mod.instructions_status(target)["ok"] is True
 
 
+def test_init_preserves_existing_gitignore_and_codeowners(tmp_path: Path) -> None:
+    target = tmp_path / "existing"
+    (target / ".github").mkdir(parents=True)
+    (target / ".gitignore").write_text("custom-ignore\n", encoding="utf-8")
+    (target / ".github" / "CODEOWNERS").write_text("* @existing\n", encoding="utf-8")
+
+    result = run(path=str(target), name="Existing Business")
+
+    assert result["status"] == "ok"
+    gitignore = (target / ".gitignore").read_text(encoding="utf-8")
+    assert gitignore.startswith("custom-ignore\n")
+    assert "# Main Branch local Claude wiring" in gitignore
+    assert (target / ".github" / "CODEOWNERS").read_text(encoding="utf-8") == "* @existing\n"
+    assert ".github/CODEOWNERS" not in result["created"]
+
+
+def test_codex_agents_repair_preserves_operator_content(tmp_path: Path) -> None:
+    target = tmp_path / "biz"
+    target.mkdir()
+    (target / "AGENTS.md").write_text(
+        "# Operator Notes\n\nKeep this local note.\n", encoding="utf-8"
+    )
+
+    result = codex_mod.write_agents_md(target, name="Acme")
+
+    text = (target / "AGENTS.md").read_text(encoding="utf-8")
+    assert result["changed"] is True
+    assert text.startswith(codex_mod.AGENTS_MANAGED_BEGIN)
+    assert codex_mod.AGENTS_MANAGED_END in text
+    assert "# Operator Notes\n\nKeep this local note.\n" in text
+    assert "<!-- mainbranch:codex-guidance " in text
+    assert codex_mod.instructions_status(target)["ok"] is True
+
+
 def test_init_defaults_owner_name_without_local_git_identity(
     tmp_path: Path,
     monkeypatch,

--- a/mb/tests/test_migrate.py
+++ b/mb/tests/test_migrate.py
@@ -85,6 +85,35 @@ def test_migrate_status_reports_pending_legacy_schema(tmp_path: Path) -> None:
     assert payload["pending"][0]["name"] == "001_v01_to_v02_path_config"
 
 
+def test_migrate_status_blocks_future_schema(tmp_path: Path) -> None:
+    repo = tmp_path / "future"
+    (repo / ".mb").mkdir(parents=True)
+    (repo / ".mb" / "schema_version").write_text("9.0\n", encoding="utf-8")
+
+    result = runner.invoke(app, ["migrate", "status", "--repo", str(repo), "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False
+    assert payload["current_version"] == "9.0"
+    assert payload["pending"] == []
+    assert "newer than this engine supports" in payload["errors"][0]
+
+
+def test_migrate_check_blocks_future_schema_without_plan(tmp_path: Path) -> None:
+    repo = tmp_path / "future"
+    (repo / ".mb").mkdir(parents=True)
+    (repo / ".mb" / "schema_version").write_text("9.0\n", encoding="utf-8")
+
+    result = runner.invoke(app, ["migrate", "--repo", str(repo), "--check", "--json"])
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False
+    assert payload["plan"]["has_changes"] is False
+    assert "newer than this engine supports" in payload["errors"][0]
+
+
 def test_migrate_check_prints_privacy_safe_summary_when_pending(tmp_path: Path) -> None:
     repo = _legacy_repo(tmp_path)
 

--- a/mb/tests/test_skill_validate.py
+++ b/mb/tests/test_skill_validate.py
@@ -485,6 +485,26 @@ def test_skill_validate_flags_parent_directory_references(
     assert any("outside the skill directory" in error for error in report["files"][0]["errors"])
 
 
+def test_mb_ads_review_references_are_skill_local() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    skill_root = repo_root / ".claude" / "skills" / "mb-ads"
+    text = "\n".join(
+        path.read_text(encoding="utf-8")
+        for path in [
+            skill_root / "references" / "mode-review.md",
+            skill_root / "references" / "review-workflow.md",
+            skill_root / "references" / "mode-static-ads.md",
+            skill_root / "references" / "post-generation-pipeline.md",
+        ]
+    )
+
+    assert "../../lenses" not in text
+    assert "../../reference/compliance" not in text
+    assert "engine's `lenses" not in text
+    assert (skill_root / "references" / "lenses" / "ftc-compliance.md").is_file()
+    assert (skill_root / "references" / "compliance" / "angle-playbook.md").is_file()
+
+
 def test_skill_validate_flags_line_count(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     body = "\n".join(f"line {i}" for i in range(skill_validate_mod.MAX_SKILL_LINES + 1))
     _skill(tmp_path, "mb-alpha", body=body)

--- a/mb/tests/test_update.py
+++ b/mb/tests/test_update.py
@@ -119,6 +119,34 @@ def _codex_repair_completed(args: list[str]) -> subprocess.CompletedProcess[str]
     )
 
 
+def test_run_command_returns_124_on_timeout(monkeypatch: Any) -> None:
+    def fake_run(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        raise subprocess.TimeoutExpired(cmd=args[0], timeout=kwargs["timeout"])
+
+    monkeypatch.setattr("mb.update.subprocess.run", fake_run)
+
+    result = update_mod._run_command(["git", "fetch"], timeout=0.01)
+
+    assert result.returncode == 124
+    assert "timed out after" in result.stderr
+
+
+def test_version_from_mb_command_uses_running_entrypoint(monkeypatch: Any, tmp_path: Path) -> None:
+    mb = tmp_path / "mb"
+    mb.write_text("#!/bin/sh\n", encoding="utf-8")
+    calls: list[list[str]] = []
+
+    def fake_run(args: list[str], *, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+        calls.append(args)
+        return _completed(args, stdout="mb 0.5.0\n")
+
+    monkeypatch.setattr("mb.update.sys.argv", [str(mb), "update"])
+    monkeypatch.setattr(update_mod, "_run_command", fake_run)
+
+    assert update_mod._version_from_mb_command() == "0.5.0"
+    assert calls == [[str(mb), "--version"]]
+
+
 def test_update_check_pipx_does_not_run_commands(monkeypatch: Any, tmp_path: Path) -> None:
     calls: list[list[str]] = []
 


### PR DESCRIPTION
## Summary

Ships Main Branch 0.5.0 as the durability release. This branch turns the session-export findings into product changes across durable writes, corrupt-state guardrails, future schema blocking, safer Codex guidance repair, update command timeouts, safer provider metadata handling, and self-contained bundled ad review references.

## Scope

In:
- Add shared durable write/read helpers and apply them to engine, init, migrate, connect, update, and Codex guidance paths.
- Refuse to clobber corrupt or future-versioned repo/config state.
- Preserve operator-owned `AGENTS.md`, `.gitignore`, and `CODEOWNERS` content while repairing Main Branch-managed sections.
- Prefer Python keyring for automatic secret storage when available.
- Move Gemini API examples to header auth.
- Make `mb-ads` review/compliance references skill-local.
- Bump package, plugin, marketplace, and changelog surfaces to 0.5.0.

Out:
- Retiring Claude project-local symlink fallback. Current public docs and issue context still treat the plugin rail as primary with symlink fallback compatibility; removal needs separate interactive runtime smoke.

## Commits

- `c94a4b2b` `[update] Ship 0.5 durability release`

## Release

Target: `oe-v0.5.0` / PyPI `mainbranch 0.5.0`

No GitHub issue is closed by this PR; this branch is session-export driven release work.

## Success Metric

A 0.5.0 install can onboard, repair, validate, update-check, and run packaged skills without silently overwriting user-owned or corrupt state, and release runtime proxy checks show Main Branch facts are discoverable from a fresh business repo.

## Validation

Level 1 static:
- `scripts/release-preflight.sh oe-v0.5.0`
- `scripts/check.sh`

Level 3 package/install:
- `(cd mb && python3 -m build)`
- fresh venv install from `mb/dist/mainbranch-0.5.0-py3-none-any.whl`
- `mb --version` -> `mb 0.5.0`
- `mb skill list`
- `mb skill validate mb-ads --json`

Level 4 fixture repo:
- `mb onboard --yes --name "Test Business" --path "$tmpdir/test-business" --json`
- `mb doctor --json`
- `mb status --json --peek`
- `mb start --json`
- `mb validate --json`

Level 5 runtime proxy:
- `scripts/claude-runtime-dogfood.py --install-mode wheel --wheel mb/dist/mainbranch-0.5.0-py3-none-any.whl --evidence-dir .agent/release-evidence/0.5.0-wheel-dogfood --cleanup`
- `scripts/claude-runtime-dogfood.py --install-mode wheel --wheel mb/dist/mainbranch-0.5.0-py3-none-any.whl --evidence-dir .agent/release-evidence/0.5.0-prerelease-candidate --run-claude-print --simulation-tier prerelease_candidate --max-budget-usd 0.75 --cleanup`
- `scripts/claude-runtime-dogfood.py --install-mode wheel --wheel mb/dist/mainbranch-0.5.0-py3-none-any.whl --evidence-dir .agent/release-evidence/0.5.0-release-acceptance --run-claude-print --simulation-tier release_acceptance --max-budget-usd 0.75 --cleanup`

Runtime caveat: Claude Code print-mode evidence is proxy evidence, not an interactive TUI smoke. Transcript excerpts were manually reviewed; no release-blocking issues were found.

## Public/Private Boundary

The session export, cold-start note, and release evidence stay in ignored `.agent/` scratch space. This PR commits only public-safe source, tests, changelog, and bundled skill reference material.