### PR TITLE
Release 0.5.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Main Branch — run a business from markdown files in git, with Claude Code as the operator surface.",
-    "version": "0.5.0"
+    "version": "0.5.1"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mainbranch",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Main Branch Claude Code skills for running a business from markdown files in git.",
   "author": {
     "name": "Noontide"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,31 @@ PyPI distribution `mainbranch` tracks the same version sequence.
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-07-16
+
+This release makes `mb connect` distinguish an unhealthy local credential
+backend from a genuinely missing provider secret, so a locked or
+password-desynced macOS login Keychain is reported and repaired instead of
+being misread as a missing key.
+
+### Fixed
+
+- `mb connect` now classifies macOS Keychain failures into sanitized reason
+  codes (`keychain_locked`, `keychain_auth_failed`, `keychain_unavailable`)
+  from the `security` exit code and known phrases, and never prints raw
+  `security` output, which can echo the command's own arguments.
+- Credential reads separate an absent secret (Keychain reports item-not-found)
+  from a backend that could not answer; provider status gains a
+  `backend_unavailable` state distinct from `missing_secret`.
+- `mb connect doctor` runs a read-only credential-backend health check before
+  recommending provider reconnection, and the `mb status` briefing leads with a
+  backend failure when one is present. The check is skipped when no provider is
+  connected. Repair guidance recommends unlocking or resyncing the login
+  keychain and warns against resetting it.
+- A `mb connect` attempt that fails on the credential backend now stores
+  nothing and leaves repo metadata unchanged, so it can no longer leave a
+  provider reporting `connected: true` next to a secret that was never stored.
+
 ## [0.5.0] - 2026-07-08
 
 This release hardens Main Branch's local state writes and runtime repair paths

--- a/mb/mb/__init__.py
+++ b/mb/mb/__init__.py
@@ -7,6 +7,6 @@ file stays a thin dispatcher.
 
 from __future__ import annotations
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 
 __all__ = ["__version__"]

--- a/mb/pyproject.toml
+++ b/mb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mainbranch"
-version = "0.5.0"
+version = "0.5.1"
 description = "Main Branch engine umbrella - scaffolds, validates, and graphs business-as-files repos. Claude Code first, runtime-agnostic by design."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Release-only PR for `mainbranch` 0.5.1 (release-agent-contract Rule 4: version sites + dated CHANGELOG only).

Ships the `mb connect` macOS Keychain failure-classification fix from #951 / #952.

## Version files (release-preflight OK)

- `mb/pyproject.toml` → 0.5.1
- `mb/mb/__init__.py` → 0.5.1
- `.claude-plugin/plugin.json` → 0.5.1
- `.claude-plugin/marketplace.json` → 0.5.1
- `CHANGELOG.md` → dated `[0.5.1] - 2026-07-16` section

## Validation

- Level 0 preflight: `scripts/release-preflight.sh 0.5.1` — exit 0 (version files agree, CHANGELOG section present, manifest guard passed).
- Level 1 static: `scripts/check.sh` — runtime: /usr/bin/python3 (3.13.7) — exit 0 — log: `.agent/release-evidence/0.5.1/check.out` (1115 passed, coverage 84.57%).
- Level 3 package: `(cd mb && python3 -m build --wheel)` — exit 0 — `mainbranch-0.5.1-py3-none-any.whl` built — log: `.agent/release-evidence/0.5.1/build.out`.
- Level 5 runtime: `scripts/claude-runtime-dogfood.py --install-mode wheel --wheel mb/dist/mainbranch-0.5.1-py3-none-any.whl --run-claude-print --simulation-tier release_acceptance --max-budget-usd 0.75` — exit 0 — evidence: `.agent/release-evidence/0.5.1/` (summary.json `ok: true`, failures `[]`, warnings `[]`).
  - Print-proxy caveats (not TUI truth, per the harness `proxy_notice`): one `loop_routing` heuristic miss and one benign permission denial (a `cat` of a topology fixture file). Neither touches the `mb connect` credential path this release changes.
- Level 6 hledger: base-install fallback mode exercised by `scripts/check.sh`; the hledger-equipped mode was not run in this environment — non-blocking for a diff that does not touch the books rail.
- Plugin-load smoke (contract Rule 7): the diff does not touch plugin wiring or the marketplace/plugin manifests beyond the mechanical version bump, so a manual plugin-load smoke is not required for this release.

Evidence lives under the gitignored `.agent/release-evidence/0.5.1/`.

After merge: tag `oe-v0.5.1` and publish the GitHub Release to trigger the human-gated PyPI publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)